### PR TITLE
(DNM) expression: remove ctx from `ParamMarker`

### DIFF
--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -251,7 +251,7 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 	case *Constant:
 		if x.ParamMarker != nil {
 			return &Constant{
-				Value:        x.ParamMarker.GetUserVar(),
+				Value:        x.Value,
 				RetType:      x.RetType,
 				DeferredExpr: x.DeferredExpr,
 				ParamMarker:  x.ParamMarker,

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -336,18 +336,18 @@ func TestDeferredParamNotNull(t *testing.T) {
 		types.NewMysqlBitDatum([]byte{1}),
 		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	)
-	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
-	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
-	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
-	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
-	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
-	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
-	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
-	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
-	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
-	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
-	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
-	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
+	cstInt := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
+	cstDec := &Constant{ParamMarker: &ParamMarker{order: 1}, RetType: newDecimalFieldType()}
+	cstTime := &Constant{ParamMarker: &ParamMarker{order: 2}, RetType: newDateFieldType()}
+	cstDuration := &Constant{ParamMarker: &ParamMarker{order: 3}, RetType: newDurFieldType()}
+	cstJSON := &Constant{ParamMarker: &ParamMarker{order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{order: 11}, RetType: newEnumFieldType()}
 
 	require.Equal(t, mysql.TypeVarString, cstJSON.GetType().GetType())
 	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType().GetType())
@@ -519,7 +519,7 @@ func TestVectorizedConstant(t *testing.T) {
 func TestGetTypeThreadSafe(t *testing.T) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(1))
-	con := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newStringFieldType()}
+	con := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newStringFieldType()}
 	ft1 := con.GetType()
 	ft2 := con.GetType()
 	require.NotSame(t, ft1, ft2)

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -69,7 +69,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	res := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
-	param.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
+	param.ParamMarker = &ParamMarker{order: 0}
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1172,7 +1172,6 @@ func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMark
 	if useCache || needParam {
 		value.ParamMarker = &ParamMarker{
 			order: v.Order,
-			ctx:   ctx,
 		}
 	}
 	return value, nil
@@ -1393,9 +1392,7 @@ func GetUint64FromConstant(ctx EvalContext, expr Expression) (uint64, bool, bool
 		return 0, false, false
 	}
 	dt := con.Value
-	if con.ParamMarker != nil {
-		dt = con.ParamMarker.GetUserVar()
-	} else if con.DeferredExpr != nil {
+	if con.DeferredExpr != nil {
 		var err error
 		dt, err = con.DeferredExpr.Eval(ctx, chunk.Row{})
 		if err != nil {

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -182,7 +182,7 @@ func TestGetUint64FromConstant(t *testing.T) {
 	require.Equal(t, uint64(1), num)
 
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewUintDatum(100))
-	con.ParamMarker = &ParamMarker{order: 0, ctx: ctx}
+	con.ParamMarker = &ParamMarker{order: 0}
 	num, _, _ = GetUint64FromConstant(ctx, con)
 	require.Equal(t, uint64(100), num)
 }

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -74,9 +74,6 @@ func (extractHelper) extractColInConsExpr(extractCols map[int64]*types.FieldName
 			return "", nil
 		}
 		v := constant.Value
-		if constant.ParamMarker != nil {
-			v = constant.ParamMarker.GetUserVar()
-		}
 		results = append(results, v)
 	}
 	return name.ColName.L, results
@@ -156,9 +153,6 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(extractCols map[int64]*t
 		return "", nil
 	}
 	v := constant.Value
-	if constant.ParamMarker != nil {
-		v = constant.ParamMarker.GetUserVar()
-	}
 	return name.ColName.L, []types.Datum{v}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53485

Problem Summary:

As every execution will set the correct `Constant.Value`, there is no need to read the value from session context again.

### What changed and how does it work?

Remove the `ctx` field from `ParamMarker`. Remove the `GetUserVar` function, and use `Constant.Value` as a replacement.

### Check List

TODO

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
