### PR TITLE
copIterator: return context error to avoid return incorrect result on context cancel/timeout

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -750,7 +750,9 @@ func (w *indexIngestBaseWorker) WriteChunk(rs *IndexRecordChunk) (count int, nex
 		failpoint.Return(0, nil, errors.New("mock write local error"))
 	})
 	failpoint.Inject("writeLocalExec", func(_ failpoint.Value) {
-		OperatorCallBackForTest()
+		if rs.Done {
+			OperatorCallBackForTest()
+		}
 	})
 
 	oprStartTime := time.Now()

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -131,14 +131,6 @@ func (e *BaseTaskExecutor) checkBalanceSubtask(ctx context.Context) {
 			e.logger.Error("get subtasks failed", zap.Error(err))
 			continue
 		}
-		if ctx.Err() != nil {
-			// workaround for https://github.com/pingcap/tidb/issues/50089
-			// timeline to trigger this:
-			// 	- this routine runs GetSubtasksByExecIDAndStepAndStates
-			// 	- outer runSubtask finishes and cancel check-context
-			// 	- GetSubtasksByExecIDAndStepAndStates returns with no err and no result
-			return
-		}
 		if len(subtasks) == 0 {
 			e.logger.Info("subtask is scheduled away, cancel running")
 			// cancels runStep, but leave the subtask state unchanged.

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -147,8 +147,6 @@ func colNames2ResultFields(schema *expression.Schema, names []*types.FieldName, 
 // The reason we need update is that chunk with 0 rows indicating we already finished current query, we need prepare for
 // next query.
 // If stmt is not nil and chunk with some rows inside, we simply update last query found rows by the number of row in chunk.
-// as copIterator.recvFromRespCh doesn't handle context cancel/timeout error correctly,
-// we always return ctx.Err() to avoid return incorrect result.
 func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	defer func() {
 		r := recover()

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -169,12 +169,12 @@ func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 		if a.stmt != nil {
 			a.stmt.Ctx.GetSessionVars().LastFoundRows = a.stmt.Ctx.GetSessionVars().StmtCtx.FoundRows()
 		}
-		return errors.Trace(ctx.Err())
+		return nil
 	}
 	if a.stmt != nil {
 		a.stmt.Ctx.GetSessionVars().StmtCtx.AddFoundRows(uint64(numRows))
 	}
-	return errors.Trace(ctx.Err())
+	return nil
 }
 
 // NewChunk create a chunk base on top-level executor's exec.NewFirstChunk().

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -147,6 +147,8 @@ func colNames2ResultFields(schema *expression.Schema, names []*types.FieldName, 
 // The reason we need update is that chunk with 0 rows indicating we already finished current query, we need prepare for
 // next query.
 // If stmt is not nil and chunk with some rows inside, we simply update last query found rows by the number of row in chunk.
+// as copIterator.recvFromRespCh doesn't handle context cancel/timeout error correctly,
+// we always return ctx.Err() to avoid return incorrect result.
 func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	defer func() {
 		r := recover()
@@ -167,12 +169,12 @@ func (a *recordSet) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 		if a.stmt != nil {
 			a.stmt.Ctx.GetSessionVars().LastFoundRows = a.stmt.Ctx.GetSessionVars().StmtCtx.FoundRows()
 		}
-		return nil
+		return errors.Trace(ctx.Err())
 	}
 	if a.stmt != nil {
 		a.stmt.Ctx.GetSessionVars().StmtCtx.AddFoundRows(uint64(numRows))
 	}
-	return nil
+	return errors.Trace(ctx.Err())
 }
 
 // NewChunk create a chunk base on top-level executor's exec.NewFirstChunk().

--- a/pkg/executor/adapter_test.go
+++ b/pkg/executor/adapter_test.go
@@ -15,11 +15,17 @@
 package executor_test
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/executor"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/store/copr"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/util"
 )
 
 func TestFormatSQL(t *testing.T) {
@@ -31,4 +37,31 @@ func TestFormatSQL(t *testing.T) {
 	variable.QueryLogMaxLen.Store(5)
 	val = executor.FormatSQL("aaaaaaaaaaaaaaaaaaaa")
 	require.Equal(t, "aaaaa(len:20)", val.String())
+}
+
+func TestContextCancelWhenReadFromCopIterator(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t values(1)")
+
+	testkit.EnableFailPoint(t, "github.com/pingcap/tidb/pkg/store/copr/CtxCancelBeforeReceive", "return(true)")
+	ctx := context.WithValue(context.Background(), "TestContextCancel", "test")
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer cancelFunc()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx = util.WithInternalSourceType(ctx, "scheduler")
+		rs, err := tk.Session().ExecuteInternal(ctx, "select * from test.t")
+		require.NoError(t, err)
+		_, err2 := session.ResultSetToStringSlice(ctx, tk.Session(), rs)
+		require.ErrorIs(t, err2, context.Canceled)
+	}()
+	<-copr.GlobalSyncChForTest
+	cancelFunc()
+	copr.GlobalSyncChForTest <- struct{}{}
+	wg.Wait()
 }

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -935,7 +935,15 @@ func (sender *copIteratorTaskSender) run(connID uint64) {
 	}
 }
 
+var GlobalSyncChForTest = make(chan struct{})
+
 func (it *copIterator) recvFromRespCh(ctx context.Context, respCh <-chan *copResponse) (resp *copResponse, ok bool, exit bool) {
+	failpoint.Inject("CtxCancelBeforeReceive", func(_ failpoint.Value) {
+		if ctx.Value("TestContextCancel") == "test" {
+			GlobalSyncChForTest <- struct{}{}
+			<-GlobalSyncChForTest
+		}
+	})
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -935,6 +935,7 @@ func (sender *copIteratorTaskSender) run(connID uint64) {
 	}
 }
 
+// GlobalSyncChForTest is a global channel for test.
 var GlobalSyncChForTest = make(chan struct{})
 
 func (it *copIterator) recvFromRespCh(ctx context.Context, respCh <-chan *copResponse) (resp *copResponse, ok bool, exit bool) {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1080,7 +1080,7 @@ func (it *copIterator) Next(ctx context.Context) (kv.ResultSubset, error) {
 		resp, ok, closed = it.recvFromRespCh(ctx, it.respChan)
 		if !ok || closed {
 			it.actionOnExceed.close()
-			return nil, nil
+			return nil, errors.Trace(ctx.Err())
 		}
 		if resp == finCopResp {
 			it.actionOnExceed.destroyTokenIfNeeded(func() {
@@ -1098,8 +1098,8 @@ func (it *copIterator) Next(ctx context.Context) (kv.ResultSubset, error) {
 			task := it.tasks[it.curr]
 			resp, ok, closed = it.recvFromRespCh(ctx, task.respChan)
 			if closed {
-				// Close() is already called, so Next() is invalid.
-				return nil, nil
+				// Close() is called or context cancelled/timeout, so Next() is invalid.
+				return nil, errors.Trace(ctx.Err())
 			}
 			if ok {
 				break

--- a/tests/realtikvtest/addindextest3/operator_test.go
+++ b/tests/realtikvtest/addindextest3/operator_test.go
@@ -17,6 +17,7 @@ package addindextest
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -234,7 +235,7 @@ func TestBackfillOperatorPipelineException(t *testing.T) {
 		{
 			failPointPath:  "github.com/pingcap/tidb/pkg/ddl/scanRecordExec",
 			closeErrMsg:    "context canceled",
-			operatorErrMsg: "",
+			operatorErrMsg: "context canceled",
 		},
 		{
 			failPointPath:  "github.com/pingcap/tidb/pkg/ddl/mockWriteLocalError",
@@ -254,44 +255,62 @@ func TestBackfillOperatorPipelineException(t *testing.T) {
 	}
 
 	for _, tc := range testCase {
-		require.NoError(t, failpoint.Enable(tc.failPointPath, `return`))
-		ctx, cancel := context.WithCancel(context.Background())
-		ddl.OperatorCallBackForTest = func() {
+		t.Run(tc.failPointPath, func(t *testing.T) {
+			require.NoError(t, failpoint.Enable(tc.failPointPath, `return`))
+			defer func() {
+				require.NoError(t, failpoint.Disable(tc.failPointPath))
+			}()
+			ctx, cancel := context.WithCancel(context.Background())
+			if strings.Contains(tc.failPointPath, "writeLocalExec") {
+				var counter atomic.Int32
+				ddl.OperatorCallBackForTest = func() {
+					// we need to want all tableScanWorkers finish scanning, else
+					// fetchTableScanResult will might return context error, and cause
+					// the case fail.
+					// 10 is the table scan task count.
+					counter.Add(1)
+					if counter.Load() == 10 {
+						cancel()
+					}
+				}
+			} else {
+				ddl.OperatorCallBackForTest = func() {
+					cancel()
+				}
+			}
+			opCtx := ddl.NewOperatorCtx(ctx, 1, 1)
+			pipeline, err := ddl.NewAddIndexIngestPipeline(
+				opCtx, store,
+				sessPool,
+				mockBackendCtx,
+				[]ingest.Engine{mockEngine},
+				tk.Session(),
+				1, // job id
+				tbl.(table.PhysicalTable),
+				[]*model.IndexInfo{idxInfo},
+				startKey,
+				endKey,
+				&atomic.Int64{},
+				nil,
+				ddl.NewDDLReorgMeta(tk.Session()),
+				0,
+				2,
+			)
+			require.NoError(t, err)
+			err = pipeline.Execute()
+			require.NoError(t, err)
+			err = pipeline.Close()
+			comment := fmt.Sprintf("case: %s", tc.failPointPath)
+			require.ErrorContains(t, err, tc.closeErrMsg, comment)
+			opCtx.Cancel()
+			if tc.operatorErrMsg == "" {
+				require.NoError(t, opCtx.OperatorErr())
+			} else {
+				require.Error(t, opCtx.OperatorErr())
+				require.Equal(t, tc.operatorErrMsg, opCtx.OperatorErr().Error())
+			}
 			cancel()
-		}
-		opCtx := ddl.NewOperatorCtx(ctx, 1, 1)
-		pipeline, err := ddl.NewAddIndexIngestPipeline(
-			opCtx, store,
-			sessPool,
-			mockBackendCtx,
-			[]ingest.Engine{mockEngine},
-			tk.Session(),
-			1, // job id
-			tbl.(table.PhysicalTable),
-			[]*model.IndexInfo{idxInfo},
-			startKey,
-			endKey,
-			&atomic.Int64{},
-			nil,
-			ddl.NewDDLReorgMeta(tk.Session()),
-			0,
-			2,
-		)
-		require.NoError(t, err)
-		err = pipeline.Execute()
-		require.NoError(t, err)
-		err = pipeline.Close()
-		comment := fmt.Sprintf("case: %s", tc.failPointPath)
-		require.ErrorContains(t, err, tc.closeErrMsg, comment)
-		opCtx.Cancel()
-		if tc.operatorErrMsg == "" {
-			require.NoError(t, opCtx.OperatorErr())
-		} else {
-			require.Error(t, opCtx.OperatorErr())
-			require.Equal(t, tc.operatorErrMsg, opCtx.OperatorErr().Error())
-		}
-		require.NoError(t, failpoint.Disable(tc.failPointPath))
-		cancel()
+		})
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50089

Problem Summary:

### What changed and how does it work?
always return context error when recvFromRespCh return `closed=true`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
