### PR TITLE
expression: Disallow conv fuction with hybrid type argement to be pushed down to TiKV

### DIFF
--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1456,6 +1456,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	//datetimeColumn := genColumn(mysql.TypeDatetime, 6)
 	binaryStringColumn := genColumn(mysql.TypeString, 7)
 	dateColumn := genColumn(mysql.TypeDate, 8)
+	byteColumn := genColumn(mysql.TypeBit, 9)
 	binaryStringColumn.RetType.SetCollate(charset.CollationBin)
 
 	// Test exprs that cannot be pushed.
@@ -1494,6 +1495,24 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	ctx := mock.NewContext()
 	pushDownCtx := NewPushDownContextFromSessionVars(ctx, ctx.GetSessionVars(), client)
 	pushed, remained := PushDownExprs(pushDownCtx, exprs, kv.TiKV)
+	require.Len(t, pushed, 0)
+	require.Len(t, remained, len(exprs))
+
+	// Test Conv function
+	exprs = exprs[:0]
+	function, err = NewFunction(mock.NewContext(), ast.Conv, types.NewFieldType(mysql.TypeString), stringColumn, intColumn, intColumn)
+	require.NoError(t, err)
+	exprs = append(exprs, function)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiKV)
+	require.Len(t, pushed, len(exprs))
+	require.Len(t, remained, 0)
+	exprs = exprs[:0]
+	castByteAsStringFunc, err := NewFunction(mock.NewContext(), ast.Cast, types.NewFieldType(mysql.TypeString), byteColumn)
+	require.NoError(t, err)
+	function, err = NewFunction(mock.NewContext(), ast.Conv, types.NewFieldType(mysql.TypeString), castByteAsStringFunc, intColumn, intColumn)
+	require.NoError(t, err)
+	exprs = append(exprs, function)
+	pushed, remained = PushDownExprs(pushDownCtx, exprs, kv.TiKV)
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -228,7 +228,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		arg0 := sf.GetArgs()[0]
 		// To be aligned with MySQL, tidb handles hybrid type argument specially, tikv can't be consistent with tidb now.
 		if f, ok := arg0.(*ScalarFunction); ok {
-			if f.FuncName.L == ast.Cast && f.GetArgs()[0].GetType().Hybrid() {
+			if f.FuncName.L == ast.Cast && (f.GetArgs()[0].GetType().Hybrid() || IsBinaryLiteral(f.GetArgs()[0])) {
 				return false
 			}
 		}

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -177,7 +177,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		// Rust use the llvm math functions, which have different precision with Golang/MySQL(cmath)
 		// open the following switchers if we implement them in coprocessor via `cmath`
 		ast.Sin, ast.Asin, ast.Cos, ast.Acos /* ast.Tan */, ast.Atan, ast.Atan2, ast.Cot,
-		ast.Radians, ast.Degrees, ast.Conv, ast.CRC32,
+		ast.Radians, ast.Degrees, ast.CRC32,
 
 		// control flow functions.
 		ast.Case, ast.If, ast.Ifnull, ast.Coalesce,
@@ -221,6 +221,17 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		/*ast.InetNtoa, ast.InetAton, ast.Inet6Ntoa, ast.Inet6Aton, ast.IsIPv4, ast.IsIPv4Compat, ast.IsIPv4Mapped, ast.IsIPv6,*/
 		ast.UUID:
 
+		return true
+	// Rust use the llvm math functions, which have different precision with Golang/MySQL(cmath)
+	// open the following switchers if we implement them in coprocessor via `cmath`
+	case ast.Conv:
+		arg0 := sf.GetArgs()[0]
+		// To be aligned with MySQL, tidb handles hybrid type argument specially, tikv can't be consistent with tidb now.
+		if f, ok := arg0.(*ScalarFunction); ok {
+			if f.FuncName.L == ast.Cast && f.GetArgs()[0].GetType().Hybrid() {
+				return false
+			}
+		}
 		return true
 	case ast.Round:
 		switch sf.Function.PbCode() {

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -226,7 +226,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 	// open the following switchers if we implement them in coprocessor via `cmath`
 	case ast.Conv:
 		arg0 := sf.GetArgs()[0]
-		// To be aligned with MySQL, tidb handles hybrid type argument specially, tikv can't be consistent with tidb now.
+		// To be aligned with MySQL, tidb handles hybrid type argument and binary literal specially, tikv can't be consistent with tidb now.
 		if f, ok := arg0.(*ScalarFunction); ok {
 			if f.FuncName.L == ast.Cast && (f.GetArgs()[0].GetType().Hybrid() || IsBinaryLiteral(f.GetArgs()[0])) {
 				return false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51877

Problem Summary:

### What changed and how does it work?
As described in #51877, such case can't be supported in TiKV side, just disallow it to be pushed down.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
