### PR TITLE
test: fix flaky test TestSyncJobSchemaVerLoop

### DIFF
--- a/pkg/ddl/syncer/syncer.go
+++ b/pkg/ddl/syncer/syncer.go
@@ -434,6 +434,7 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx context.Context, jobID i
 			case <-notifyCh:
 				return nil
 			case <-ctx.Done():
+				item.clearMatchFn()
 				return errors.Trace(ctx.Err())
 			case <-time.After(time.Second):
 				item.clearMatchFn()

--- a/pkg/ddl/syncer/syncer_nokit_test.go
+++ b/pkg/ddl/syncer/syncer_nokit_test.go
@@ -188,6 +188,4 @@ func TestSyncJobSchemaVerLoop(t *testing.T) {
 
 	cancel()
 	wg.Wait()
-
-	require.Zero(t, jobNodeVersionCnt())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53508

Problem Summary:

### What changed and how does it work?
the `require.Zero(t, jobNodeVersionCnt())` check might fail if the loop  cancelled before it receive the last DELETE event. it does not affect the correctness, so remove it.
see https://tiprow.hawkingrei.com/view/gs/pingcapprow/pr-logs/pull/pingcap_tidb/53489/fast_test_tiprow/1793524686622035968
```
    syncer_nokit_test.go:192: 
        	Error Trace:	pkg/ddl/syncer/syncer_nokit_test.go:192
        	Error:      	Should be zero, but was 1
        	Test:       	TestSyncJobSchemaVerLoop
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
