### PR TITLE
planner: remove some restrictions for global index

### DIFF
--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -156,13 +156,6 @@ func (ds *DataSource) generateNormalIndexPartialPaths4DNF(
 			// the entire index merge is not valid anymore.
 			return nil, false, usedMap
 		}
-		// prune out global indexes.
-		itemPaths = slices.DeleteFunc(itemPaths, func(path *util.AccessPath) bool {
-			if path.Index != nil && path.Index.Global {
-				return true
-			}
-			return false
-		})
 		partialPath := buildIndexMergePartialPath(itemPaths)
 		if partialPath == nil {
 			// for this dnf item, we couldn't generate an index merge partial path.
@@ -889,9 +882,6 @@ func (ds *DataSource) generateIndexMerge4ComposedIndex(normalPathCnt int, indexM
 	var mvIndexPathCnt int
 	candidateAccessPaths := make([]*util.AccessPath, 0, len(ds.possibleAccessPaths))
 	for idx := 0; idx < normalPathCnt; idx++ {
-		if ds.possibleAccessPaths[idx].Index != nil && ds.possibleAccessPaths[idx].Index.Global {
-			continue
-		}
 		if (ds.possibleAccessPaths[idx].IsTablePath() &&
 			!ds.isInIndexMergeHints("primary")) ||
 			(!ds.possibleAccessPaths[idx].IsTablePath() &&

--- a/tests/integrationtest/r/globalindex/multi_valued_index.result
+++ b/tests/integrationtest/r/globalindex/multi_valued_index.result
@@ -1,0 +1,55 @@
+set tidb_enable_global_index = true;
+CREATE TABLE `customers` (
+`id` bigint(20),
+`name` char(10) DEFAULT NULL,
+`custinfo` json DEFAULT NULL,
+KEY idx(`id`),
+UNIQUE KEY `zips` ((cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array)))
+) PARTITION BY HASH (`id`) PARTITIONS 5;
+INSERT INTO customers VALUES (1, 'pingcap', '{"zipcode": [1,2]}');
+INSERT INTO customers VALUES (2, 'pingcap', '{"zipcode": [2,3]}');
+Error 1062 (23000): Duplicate entry '2' for key 'customers.zips'
+INSERT INTO customers VALUES (2, 'pingcap', '{"zipcode": [3,3,4]}');
+INSERT INTO customers VALUES (3, 'pingcap', '{"zipcode": [5,6]}');
+explain select * from customers where (1 member of (custinfo->'$.zipcode'));
+id	estRows	task	access object	operator info
+IndexMerge_11	1.00	root	partition:all	type: union
+├─IndexRangeScan_8(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+└─TableRowIDScan_10(Probe)	1.00	cop[tikv]	table:customers	keep order:false, stats:pseudo
+select * from customers where (1 member of (custinfo->'$.zipcode'));
+id	name	custinfo
+1	pingcap	{"zipcode": [1, 2]}
+explain select * from customers where json_overlaps("[1, 3, 7, 10]", custinfo->'$.zipcode');
+id	estRows	task	access object	operator info
+Selection_5	3.20	root		json_overlaps(cast("[1, 3, 7, 10]", json BINARY), json_extract(globalindex__multi_valued_index.customers.custinfo, "$.zipcode"))
+└─IndexMerge_17	4.00	root	partition:all	type: union
+  ├─IndexRangeScan_8(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+  ├─IndexRangeScan_10(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[3,3], keep order:false, stats:pseudo
+  ├─IndexRangeScan_12(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[7,7], keep order:false, stats:pseudo
+  ├─IndexRangeScan_14(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[10,10], keep order:false, stats:pseudo
+  └─TableRowIDScan_16(Probe)	4.00	cop[tikv]	table:customers	keep order:false, stats:pseudo
+select * from customers where json_overlaps("[1, 3, 7, 10]", custinfo->'$.zipcode');
+id	name	custinfo
+1	pingcap	{"zipcode": [1, 2]}
+2	pingcap	{"zipcode": [3, 3, 4]}
+explain select * from customers where json_overlaps("[1, 6, 10]", custinfo->'$.zipcode') and id > 1;
+id	estRows	task	access object	operator info
+Selection_5	2.40	root		json_overlaps(cast("[1, 6, 10]", json BINARY), json_extract(globalindex__multi_valued_index.customers.custinfo, "$.zipcode"))
+└─IndexMerge_20	1.00	root	partition:all	type: union
+  ├─IndexRangeScan_12(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+  ├─IndexRangeScan_14(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[6,6], keep order:false, stats:pseudo
+  ├─IndexRangeScan_16(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[10,10], keep order:false, stats:pseudo
+  └─Selection_19(Probe)	1.00	cop[tikv]		gt(globalindex__multi_valued_index.customers.id, 1)
+    └─TableRowIDScan_18	3.00	cop[tikv]	table:customers	keep order:false, stats:pseudo
+select * from customers where json_overlaps("[1, 6, 10]", custinfo->'$.zipcode') and id > 1;
+id	name	custinfo
+3	pingcap	{"zipcode": [5, 6]}
+explain select /*+ USE_INDEX_MERGE(customers, idx, zips) */* from customers where (1 member of (custinfo->'$.zipcode')) and id > 0;
+id	estRows	task	access object	operator info
+IndexMerge_9	0.33	root	partition:all	type: intersection
+├─IndexRangeScan_5(Build)	3333.33	cop[tikv]	table:customers, index:idx(id)	range:(0,+inf], keep order:false, stats:pseudo
+├─IndexRangeScan_6(Build)	1.00	cop[tikv]	table:customers, index:zips(cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array))	range:[1,1], keep order:false, stats:pseudo
+└─TableRowIDScan_8(Probe)	0.33	cop[tikv]	table:customers	keep order:false, stats:pseudo
+select /*+ USE_INDEX_MERGE(customers, idx, zips) */* from customers where (1 member of (custinfo->'$.zipcode')) and id > 0;
+id	name	custinfo
+1	pingcap	{"zipcode": [1, 2]}

--- a/tests/integrationtest/t/globalindex/multi_valued_index.test
+++ b/tests/integrationtest/t/globalindex/multi_valued_index.test
@@ -1,0 +1,28 @@
+set tidb_enable_global_index = true;
+CREATE TABLE `customers` (
+  `id` bigint(20),
+  `name` char(10) DEFAULT NULL,
+  `custinfo` json DEFAULT NULL,
+  KEY idx(`id`),
+  UNIQUE KEY `zips` ((cast(json_extract(`custinfo`, _utf8'$.zipcode') as unsigned array)))
+) PARTITION BY HASH (`id`) PARTITIONS 5;
+
+INSERT INTO customers VALUES (1, 'pingcap', '{"zipcode": [1,2]}');
+--error 1062
+INSERT INTO customers VALUES (2, 'pingcap', '{"zipcode": [2,3]}');
+INSERT INTO customers VALUES (2, 'pingcap', '{"zipcode": [3,3,4]}');
+INSERT INTO customers VALUES (3, 'pingcap', '{"zipcode": [5,6]}');
+
+explain select * from customers where (1 member of (custinfo->'$.zipcode'));
+select * from customers where (1 member of (custinfo->'$.zipcode'));
+
+explain select * from customers where json_overlaps("[1, 3, 7, 10]", custinfo->'$.zipcode');
+--sorted_result
+select * from customers where json_overlaps("[1, 3, 7, 10]", custinfo->'$.zipcode');
+
+explain select * from customers where json_overlaps("[1, 6, 10]", custinfo->'$.zipcode') and id > 1;
+--sorted_result
+select * from customers where json_overlaps("[1, 6, 10]", custinfo->'$.zipcode') and id > 1;
+
+explain select /*+ USE_INDEX_MERGE(customers, idx, zips) */* from customers where (1 member of (custinfo->'$.zipcode')) and id > 0;
+select /*+ USE_INDEX_MERGE(customers, idx, zips) */* from customers where (1 member of (custinfo->'$.zipcode')) and id > 0;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #45133

Problem Summary: Add some test cases for the case where the global index is also a multi-valued index. 

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
