### PR TITLE
planner: fix panic error when subquery + always true predicate in where clause

### DIFF
--- a/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
+++ b/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 32,
+    shard_count = 33,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -1481,3 +1481,29 @@ func TestPointgetIndexChoosen(t *testing.T) {
 		tk.MustQuery("explain format = 'brief' " + ts).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+// Test issue #46962 plan
+func TestAlwaysTruePredicateWithSubquery(t *testing.T) {
+	var (
+		input  []string
+		output []struct {
+			SQL     string
+			Plan    []string
+			Warning []string
+		}
+	)
+	planSuiteData := GetPlanSuiteData()
+	planSuiteData.LoadTestCases(t, &input, &output)
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE t ( a int NOT NULL ,  b int NOT NULL ) `)
+	for i, ts := range input {
+		testdata.OnRecord(func() {
+			output[i].SQL = ts
+			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(ts).Rows())
+		})
+		tk.MustQuery(ts).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_in.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_in.json
@@ -611,5 +611,13 @@
       "select * from t where b=1 and c='1' and d='1';",
       "select * from t where b in (1,2,3) and c in ('1');"
     ]
+  },
+  {
+    "name": "TestAlwaysTruePredicateWithSubquery",
+    "cases" : [
+      "SHOW ERRORS WHERE TRUE = ALL ( SELECT TRUE GROUP BY 1 LIMIT 1 ) IS NULL IS NOT NULL;",
+      "explain select * from t WHERE TRUE = ALL ( SELECT TRUE GROUP BY 1 LIMIT 1 ) IS NULL IS NOT NULL;",
+      "explain select * from t WHERE TRUE = ALL ( SELECT TRUE from t GROUP BY 1 LIMIT 1 ) is null is not null;"
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -3746,5 +3746,43 @@
         "Warning": null
       }
     ]
+  },
+  {
+    "Name": "TestAlwaysTruePredicateWithSubquery",
+    "Cases": [
+      {
+        "SQL": "SHOW ERRORS WHERE TRUE = ALL ( SELECT TRUE GROUP BY 1 LIMIT 1 ) IS NULL IS NOT NULL;",
+        "Plan": null,
+        "Warning": null
+      },
+      {
+        "SQL": "explain select * from t WHERE TRUE = ALL ( SELECT TRUE GROUP BY 1 LIMIT 1 ) IS NULL IS NOT NULL;",
+        "Plan": [
+          "HashJoin_14 10000.00 root  CARTESIAN inner join",
+          "├─StreamAgg_19(Build) 1.00 root  funcs:count(1)->Column#13",
+          "│ └─Limit_22 1.00 root  offset:0, count:1",
+          "│   └─HashAgg_23 1.00 root  group by:1, ",
+          "│     └─TableDual_24 1.00 root  rows:1",
+          "└─TableReader_17(Probe) 10000.00 root  data:TableFullScan_16",
+          "  └─TableFullScan_16 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "explain select * from t WHERE TRUE = ALL ( SELECT TRUE from t GROUP BY 1 LIMIT 1 ) is null is not null;",
+        "Plan": [
+          "HashJoin_14 10000.00 root  CARTESIAN inner join",
+          "├─StreamAgg_19(Build) 1.00 root  funcs:count(1)->Column#16",
+          "│ └─Limit_22 1.00 root  offset:0, count:1",
+          "│   └─HashAgg_27 1.00 root  group by:Column#17, funcs:firstrow(Column#18)->test.t.a, funcs:firstrow(Column#19)->test.t.b, funcs:firstrow(Column#20)->test.t._tidb_rowid",
+          "│     └─TableReader_28 1.00 root  data:HashAgg_23",
+          "│       └─HashAgg_23 1.00 cop[tikv]  group by:1, funcs:firstrow(test.t.a)->Column#18, funcs:firstrow(test.t.b)->Column#19, funcs:firstrow(test.t._tidb_rowid)->Column#20",
+          "│         └─TableFullScan_26 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+          "└─TableReader_17(Probe) 10000.00 root  data:TableFullScan_16",
+          "  └─TableFullScan_16 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      }
+    ]
   }
 ]


### PR DESCRIPTION


### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46962

Problem Summary:

### What changed and how does it work?

Skip the partial agg mode check in the key_build_info when the agg function is empty.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
