### PR TITLE
expression,*: remove the session context inside `ParamMarker`

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -163,6 +163,7 @@ nogo(
                "//build/linter/noloopclosure",
                "//build/linter/prealloc",
                "//build/linter/predeclared",
+               "//build/linter/printexpression",
                "//build/linter/unconvert",
                "//build/linter/rowserrcheck",
                "//build/linter/toomanytests",

--- a/build/linter/printexpression/BUILD.bazel
+++ b/build/linter/printexpression/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "printexpression",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/printexpression",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//build/linter/util",
+        "@org_golang_x_tools//go/analysis",
+        "@org_golang_x_tools//go/analysis/passes/inspect",
+        "@org_golang_x_tools//go/ast/inspector",
+    ],
+)
+
+go_test(
+    name = "printexpression_test",
+    timeout = "short",
+    srcs = ["analyzer_test.go"],
+    flaky = True,
+    deps = [
+        ":printexpression",
+        "@org_golang_x_tools//go/analysis/analysistest",
+    ],
+)

--- a/build/linter/printexpression/analyzer.go
+++ b/build/linter/printexpression/analyzer.go
@@ -1,0 +1,150 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printexpression
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/pingcap/tidb/build/linter/util"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer defines the linter for `emptynil` check
+//
+// This linter avoids calling `fmt.Println(expr)` or `fmt.Printf(\"%s\", expr)` directly, because
+// `Expression` doesn't implement `String()` method, so it will print the address or internal state
+// of the expression.
+// It handles the following function call:
+// 1. `fmt.Println(expr)`
+// 2. `fmt.Printf(\"%s\", expr)`
+// 4. `fmt.Sprintf(\"%s\", expr)`
+// 5. `(*Error).GenWithStack/GenWithStackByArgs/FastGen/FastGenByArgs`
+//
+// Every struct which implemented `StringWithCtx` but not implemented `String` cannot be used as an argument.
+var Analyzer = &analysis.Analyzer{
+	Name:     "printexpression",
+	Doc:      `Avoid printing expression directly.`,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+	}
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		expr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return
+		}
+
+		if !funcIsFormat(expr.Fun) {
+			return
+		}
+
+		for _, arg := range expr.Args {
+			if argIsNotAllowed(pass.TypesInfo, arg) {
+				pass.Reportf(arg.Pos(), "avoid printing expression directly. Please use `Expression.StringWithCtx()` to get a string")
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func funcIsFormat(x ast.Expr) bool {
+	switch x := x.(type) {
+	case *ast.SelectorExpr:
+		switch x.Sel.Name {
+		case "Printf", "Sprintf", "Println":
+			if i, ok := x.X.(*ast.Ident); ok {
+				return i.Name == "fmt"
+			}
+			return false
+		case "GenWithStack", "GenWithStackByArgs", "FastGen", "FastGenByArgs":
+			// TODO: check whether the receiver is an `*Error`
+			return true
+		}
+	}
+	return false
+}
+
+func argIsNotAllowed(typInfo *types.Info, x ast.Expr) bool {
+	typ := typInfo.Types[x].Type
+	if typ == nil {
+		return false
+	}
+
+	typWithMethods, ok := elementType(typ).(methodLookup)
+	if !ok {
+		return false
+	}
+
+	return typIsNotAllowed(typWithMethods)
+}
+
+type methodLookup interface {
+	NumMethods() int
+	Method(i int) *types.Func
+	Underlying() types.Type
+}
+
+func typIsNotAllowed(typ methodLookup) bool {
+	implString := false
+	implStringWithCtx := false
+	for i := 0; i < typ.NumMethods(); i++ {
+		method := typ.Method(i)
+		name := method.Name()
+		if name == "String" {
+			implString = true
+		}
+		if name == "StringWithCtx" {
+			implStringWithCtx = true
+		}
+	}
+
+	if implStringWithCtx && !implString {
+		return true
+	}
+
+	// the `Underlying` of an interface is still the interface, so we need to avoid unlimited recursion here.
+	_, typIsIface := typ.(*types.Interface)
+	if iface, underlyingIsIface := typ.Underlying().(*types.Interface); !typIsIface && underlyingIsIface {
+		return typIsNotAllowed(iface)
+	}
+
+	return false
+}
+
+// elementType returns the element type of a pointer or slice recursively.
+func elementType(typ types.Type) types.Type {
+	switch t := typ.(type) {
+	case *types.Pointer:
+		return elementType(t.Elem())
+	case *types.Slice:
+		return elementType(t.Elem())
+	}
+	return typ
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
+	util.SkipAnalyzer(Analyzer)
+}

--- a/build/linter/printexpression/analyzer_test.go
+++ b/build/linter/printexpression/analyzer_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !intest
+
+package printexpression_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/build/linter/printexpression"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TODO: investigate the CI environment and check how to run this test in CI.
+// The CI environment doesn't have `go` executable in $PATH.
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	pkgs := []string{"t", "github.com/pingcap/tidb/pkg/expression"}
+	analysistest.Run(t, testdata, printexpression.Analyzer, pkgs...)
+}

--- a/build/linter/printexpression/testdata/src/github.com/pingcap/tidb/pkg/expression/BUILD.bazel
+++ b/build/linter/printexpression/testdata/src/github.com/pingcap/tidb/pkg/expression/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "expression",
+    srcs = ["expression.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/printexpression/testdata/src/github.com/pingcap/tidb/pkg/expression",
+    visibility = ["//visibility:public"],
+)

--- a/build/linter/printexpression/testdata/src/github.com/pingcap/tidb/pkg/expression/expression.go
+++ b/build/linter/printexpression/testdata/src/github.com/pingcap/tidb/pkg/expression/expression.go
@@ -1,0 +1,53 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"fmt"
+)
+
+// Expression is a test struct.
+type Expression interface {
+	// StringWithCtx method only is not allowed to be printed directly.
+	StringWithCtx()
+}
+
+// Constant is a test struct.
+type Constant struct{}
+
+// StringWithCtx implements the Expression interface.
+func (c *Constant) StringWithCtx() {}
+
+// Column is a test struct
+type Column struct{}
+
+// String implements ExpressionWithString interface.
+func (c *Column) String() {}
+
+// StringWithCtx implements the Expression interface.
+func (c *Column) StringWithCtx() {}
+
+func testFunc() {
+	var expr Expression
+	var con *Constant
+	var conList []*Constant
+
+	var col *Column
+
+	fmt.Println(expr)         // want `avoid printing expression directly.*`
+	fmt.Println(con)          // want `avoid printing expression directly.*`
+	fmt.Printf("%v", conList) // want `avoid printing expression directly.*`
+	fmt.Println(col)
+}

--- a/build/linter/printexpression/testdata/src/t/BUILD.bazel
+++ b/build/linter/printexpression/testdata/src/t/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "t",
+    srcs = ["test_file.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/printexpression/testdata/src/t",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/expression"],
+)

--- a/build/linter/printexpression/testdata/src/t/test_file.go
+++ b/build/linter/printexpression/testdata/src/t/test_file.go
@@ -1,0 +1,52 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package t
+
+import (
+	"fmt"
+
+	"github.com/pingcap/tidb/pkg/expression"
+)
+
+// EmbeddedConstant is a test struct
+type EmbeddedConstant struct {
+	expression.Constant
+}
+
+// String implements ExpressionWithString interface.
+func (e *EmbeddedConstant) String() {}
+
+// ExpressionWithString is a test struct
+type ExpressionWithString interface {
+	expression.Expression
+	String()
+}
+
+func testFunc() {
+	var expr expression.Expression
+	var con *expression.Constant
+	var conList []*expression.Constant
+
+	var exprWithString ExpressionWithString
+	var col *expression.Column
+	var embedded *EmbeddedConstant
+
+	fmt.Println(expr)         // want `avoid printing expression directly.*`
+	fmt.Println(con)          // want `avoid printing expression directly.*`
+	fmt.Printf("%v", conList) // want `avoid printing expression directly.*`
+	fmt.Println(exprWithString)
+	fmt.Println(col)
+	fmt.Println(embedded)
+}

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -69,6 +69,14 @@
       ".*_generated\\.go$": "ignore generated code"
     }
   },
+  "printexpression": {
+    "exclude_files": {
+      "pkg/parser/parser.go": "parser/parser.go code",
+      "external/": "no need to vet third party code",
+      ".*_generated\\.go$": "ignore generated code",
+      "build/linter/printexpression/testdata/": "ignore test code"
+    }
+  },
   "printf": {
     "exclude_files": {
       "pkg/parser/parser.go": "parser/parser.go code",

--- a/pkg/ddl/copr/copr_ctx.go
+++ b/pkg/ddl/copr/copr_ctx.go
@@ -19,7 +19,6 @@ import (
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
 	"github.com/pingcap/tidb/pkg/expression"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
-
 	// make sure mock.MockInfoschema is initialized to make sure the test pass
 	_ "github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"

--- a/pkg/ddl/copr/copr_ctx.go
+++ b/pkg/ddl/copr/copr_ctx.go
@@ -19,6 +19,7 @@ import (
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
 	"github.com/pingcap/tidb/pkg/expression"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
+
 	// make sure mock.MockInfoschema is initialized to make sure the test pass
 	_ "github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -809,9 +809,13 @@ func (p *Plan) initParameters(plan *plannercore.ImportInto) error {
 		setClause = sb.String()
 	}
 	optionMap := make(map[string]any, len(plan.Options))
+	var evalCtx expression.EvalContext
+	if plan.SCtx() != nil {
+		evalCtx = plan.SCtx().GetExprCtx().GetEvalCtx()
+	}
 	for _, opt := range plan.Options {
 		if opt.Value != nil {
-			val := opt.Value.String()
+			val := opt.Value.StringWithCtx(evalCtx)
 			if opt.Name == cloudStorageURIOption {
 				val = ast.RedactURL(val)
 			}

--- a/pkg/executor/importer/table_import_testkit_test.go
+++ b/pkg/executor/importer/table_import_testkit_test.go
@@ -82,7 +82,7 @@ func TestImportFromSelectCleanup(t *testing.T) {
 	require.True(t, ok)
 	table, err := do.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
-	plan, err := importer.NewImportPlan(ctx, tk.Session(), &plannercore.ImportInto{
+	plan, err := importer.NewImportPlan(ctx, tk.Session(), plannercore.ImportInto{
 		Table: &ast.TableName{
 			Name: model.NewCIStr("t"),
 			DBInfo: &model.DBInfo{
@@ -91,7 +91,7 @@ func TestImportFromSelectCleanup(t *testing.T) {
 			},
 		},
 		SelectPlan: &plannercore.PhysicalSelection{},
-	}, table)
+	}.Init(tk.Session().GetPlanCtx()), table)
 	require.NoError(t, err)
 	controller, err := importer.NewLoadDataController(plan, table, &importer.ASTArgs{})
 	require.NoError(t, err)

--- a/pkg/expression/aggregation/agg_to_pb.go
+++ b/pkg/expression/aggregation/agg_to_pb.go
@@ -107,7 +107,7 @@ func AggFuncToPBExpr(ctx expression.PushDownContext, aggFunc *AggFuncDesc, store
 	for _, arg := range aggFunc.Args {
 		pbArg := pc.ExprToPB(arg)
 		if pbArg == nil {
-			return nil, errors.New(aggFunc.String() + " can't be converted to PB.")
+			return nil, errors.New(aggFunc.StringWithCtx(ctx.EvalCtx()) + " can't be converted to PB.")
 		}
 		children = append(children, pbArg)
 	}
@@ -121,7 +121,7 @@ func AggFuncToPBExpr(ctx expression.PushDownContext, aggFunc *AggFuncDesc, store
 		for _, arg := range aggFunc.OrderByItems {
 			pbArg := expression.SortByItemToPB(ctx.EvalCtx(), client, arg.Expr, arg.Desc)
 			if pbArg == nil {
-				return nil, errors.New(aggFunc.String() + " can't be converted to PB.")
+				return nil, errors.New(aggFunc.StringWithCtx(ctx.EvalCtx()) + " can't be converted to PB.")
 			}
 			orderBy = append(orderBy, pbArg)
 		}

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -71,7 +71,7 @@ func (a *baseFuncDesc) clone() *baseFuncDesc {
 }
 
 // StringWithCtx returns the string within given context.
-func (a *baseFuncDesc) StringWithCtx(ctx expression.EvalContext) string {
+func (a *baseFuncDesc) StringWithCtx(ctx expression.ParamValues) string {
 	buffer := bytes.NewBufferString(a.Name)
 	buffer.WriteString("(")
 	for i, arg := range a.Args {

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -70,12 +70,12 @@ func (a *baseFuncDesc) clone() *baseFuncDesc {
 	return &clone
 }
 
-// String implements the fmt.Stringer interface.
-func (a *baseFuncDesc) String() string {
+// StringWithCtx returns the string within given context.
+func (a *baseFuncDesc) StringWithCtx(ctx expression.EvalContext) string {
 	buffer := bytes.NewBufferString(a.Name)
 	buffer.WriteString("(")
 	for i, arg := range a.Args {
-		buffer.WriteString(arg.String())
+		buffer.WriteString(arg.StringWithCtx(ctx))
 		if i+1 != len(a.Args) {
 			buffer.WriteString(", ")
 		}
@@ -149,7 +149,7 @@ func (a *baseFuncDesc) typeInfer4ApproxPercentile(ctx expression.EvalContext) er
 	}
 	percent, isNull, err := a.Args[1].EvalInt(ctx, chunk.Row{})
 	if err != nil {
-		return fmt.Errorf("APPROX_PERCENTILE: Invalid argument %s", a.Args[1].String())
+		return fmt.Errorf("APPROX_PERCENTILE: Invalid argument %s", a.Args[1].StringWithCtx(ctx))
 	}
 	if percent <= 0 || percent > 100 || isNull {
 		if isNull {

--- a/pkg/expression/aggregation/concat.go
+++ b/pkg/expression/aggregation/concat.go
@@ -104,7 +104,7 @@ func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		}
 		evalCtx.Buffer.Truncate(i)
 		if !cf.truncated {
-			sc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(cf.Args[0].String()))
+			sc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(cf.Args[0].StringWithCtx(evalCtx.Ctx)))
 		}
 		cf.truncated = true
 	}

--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -59,15 +59,15 @@ func NewAggFuncDescForWindowFunc(ctx expression.BuildContext, desc *WindowFuncDe
 	return &AggFuncDesc{baseFuncDesc: baseFuncDesc{desc.Name, desc.Args, desc.RetTp}, HasDistinct: hasDistinct}, nil
 }
 
-// String implements the fmt.Stringer interface.
-func (a *AggFuncDesc) String() string {
+// StringWithCtx returns the string representation within given ctx.
+func (a *AggFuncDesc) StringWithCtx(ctx expression.EvalContext) string {
 	buffer := bytes.NewBufferString(a.Name)
 	buffer.WriteString("(")
 	if a.HasDistinct {
 		buffer.WriteString("distinct ")
 	}
 	for i, arg := range a.Args {
-		buffer.WriteString(arg.String())
+		buffer.WriteString(arg.StringWithCtx(ctx))
 		if i+1 != len(a.Args) {
 			buffer.WriteString(", ")
 		}
@@ -76,7 +76,7 @@ func (a *AggFuncDesc) String() string {
 		buffer.WriteString(" order by ")
 	}
 	for i, arg := range a.OrderByItems {
-		buffer.WriteString(arg.String())
+		buffer.WriteString(arg.StringWithCtx(ctx))
 		if i+1 != len(a.OrderByItems) {
 			buffer.WriteString(", ")
 		}

--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -60,7 +60,7 @@ func NewAggFuncDescForWindowFunc(ctx expression.BuildContext, desc *WindowFuncDe
 }
 
 // StringWithCtx returns the string representation within given ctx.
-func (a *AggFuncDesc) StringWithCtx(ctx expression.EvalContext) string {
+func (a *AggFuncDesc) StringWithCtx(ctx expression.ParamValues) string {
 	buffer := bytes.NewBufferString(a.Name)
 	buffer.WriteString("(")
 	if a.HasDistinct {

--- a/pkg/expression/bench_test.go
+++ b/pkg/expression/bench_test.go
@@ -1371,11 +1371,11 @@ func testVectorizedEvalOneVec(t *testing.T, vecExprCases vecExprBenchCases) {
 // benchmarkVectorizedEvalOneVec is used to get the effect of
 // using the vectorized expression evaluations during projection
 func benchmarkVectorizedEvalOneVec(b *testing.B, vecExprCases vecExprBenchCases) {
-	ctx := mock.NewContext()
+	ctx := createContext(b)
 	for funcName, testCases := range vecExprCases {
 		for _, testCase := range testCases {
 			expr, _, input, output := genVecExprBenchCase(ctx, funcName, testCase)
-			exprName := expr.String()
+			exprName := expr.StringWithCtx(ctx)
 			if sf, ok := expr.(*ScalarFunction); ok {
 				exprName = fmt.Sprintf("%v", reflect.TypeOf(sf.Function))
 				tmp := strings.Split(exprName, ".")

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -225,25 +225,25 @@ func (s *builtinArithmeticPlusIntSig) evalInt(ctx EvalContext, row chunk.Row) (v
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:
 		if uint64(a) > math.MaxUint64-uint64(b) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 	case isLHSUnsigned && !isRHSUnsigned:
 		if b < 0 && uint64(-b) > uint64(a) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 		if b > 0 && uint64(a) > math.MaxUint64-uint64(b) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 	case !isLHSUnsigned && isRHSUnsigned:
 		if a < 0 && uint64(-a) > uint64(b) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 		if a > 0 && uint64(b) > math.MaxUint64-uint64(a) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 	case !isLHSUnsigned && !isRHSUnsigned:
 		if (a > 0 && b > math.MaxInt64-a) || (a < 0 && b < math.MinInt64-a) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 	}
 
@@ -273,7 +273,7 @@ func (s *builtinArithmeticPlusDecimalSig) evalDecimal(ctx EvalContext, row chunk
 	err = types.DecimalAdd(a, b, c)
 	if err != nil {
 		if err == types.ErrOverflow {
-			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 		return nil, true, err
 	}
@@ -303,7 +303,7 @@ func (s *builtinArithmeticPlusRealSig) evalReal(ctx EvalContext, row chunk.Row) 
 		return 0, true, nil
 	}
 	if !mathutil.IsFinite(a + b) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return a + b, false, nil
 }
@@ -368,7 +368,7 @@ func (s *builtinArithmeticMinusRealSig) evalReal(ctx EvalContext, row chunk.Row)
 		return 0, isNull, err
 	}
 	if !mathutil.IsFinite(a - b) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return a - b, false, nil
 }
@@ -396,7 +396,7 @@ func (s *builtinArithmeticMinusDecimalSig) evalDecimal(ctx EvalContext, row chun
 	err = types.DecimalSub(a, b, c)
 	if err != nil {
 		if err == types.ErrOverflow {
-			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", s.args[0].String(), s.args[1].String()))
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 		return nil, true, err
 	}
@@ -434,7 +434,7 @@ func (s *builtinArithmeticMinusIntSig) evalInt(ctx EvalContext, row chunk.Row) (
 	}
 	overflow := s.overflowCheck(isLHSUnsigned, isRHSUnsigned, signed, a, b)
 	if overflow {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 
 	return a - b, false, nil
@@ -578,7 +578,7 @@ func (s *builtinArithmeticMultiplyRealSig) evalReal(ctx EvalContext, row chunk.R
 	}
 	result := a * b
 	if math.IsInf(result, 0) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return result, false, nil
 }
@@ -596,7 +596,7 @@ func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(ctx EvalContext, row c
 	err = types.DecimalMul(a, b, c)
 	if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
 		if err == types.ErrOverflow {
-			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", s.args[0].String(), s.args[1].String()))
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 		return nil, true, err
 	}
@@ -616,7 +616,7 @@ func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(ctx EvalContext, row c
 	unsignedB := uint64(b)
 	result := unsignedA * unsignedB
 	if unsignedA != 0 && result/unsignedA != unsignedB {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return int64(result), false, nil
 }
@@ -632,7 +632,7 @@ func (s *builtinArithmeticMultiplyIntSig) evalInt(ctx EvalContext, row chunk.Row
 	}
 	result := a * b
 	if (a != 0 && result/a != b) || (result == math.MinInt64 && a == -1) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return result, false, nil
 }
@@ -697,7 +697,7 @@ func (s *builtinArithmeticDivideRealSig) evalReal(ctx EvalContext, row chunk.Row
 	}
 	result := a / b
 	if math.IsInf(result, 0) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", s.args[0].String(), s.args[1].String()))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return result, false, nil
 }
@@ -726,7 +726,7 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(ctx EvalContext, row chu
 			err = c.Round(c, s.baseBuiltinFunc.tp.GetDecimal(), types.ModeHalfUp)
 		}
 	} else if err == types.ErrOverflow {
-		err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", s.args[0].String(), s.args[1].String()))
+		err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 	}
 	return c, false, err
 }
@@ -857,14 +857,14 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(ctx EvalContext, row chun
 				ret = int64(0)
 				return ret, false, nil
 			}
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s DIV %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s DIV %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 		ret = int64(val)
 	} else {
 		ret, err = c.ToInt()
 		// err returned by ToInt may be ErrTruncated or ErrOverflow, only handle ErrOverflow, ignore ErrTruncated.
 		if err == types.ErrOverflow {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s DIV %s)", s.args[0].String(), s.args[1].String()))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s DIV %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
 		}
 	}
 

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -53,7 +53,7 @@ func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(ctx EvalContext, input *c
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 	}
 	return nil
@@ -106,7 +106,7 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx EvalContext, inpu
 				}
 			}
 		} else if err == types.ErrOverflow {
-			return types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		} else {
 			return err
 		}
@@ -313,7 +313,7 @@ func (b *builtinArithmeticMinusRealSig) vecEvalReal(ctx EvalContext, input *chun
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 		x[i] = x[i] - y[i]
 	}
@@ -348,7 +348,7 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(ctx EvalContext, input
 		}
 		if err = types.DecimalSub(&x[i], &y[i], &to); err != nil {
 			if err == types.ErrOverflow {
-				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", b.args[0].String(), b.args[1].String()))
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 			}
 			return err
 		}
@@ -400,7 +400,7 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 
 		resulti64s[i] = lh - rh
@@ -514,7 +514,7 @@ func (b *builtinArithmeticPlusRealSig) vecEvalReal(ctx EvalContext, input *chunk
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 		x[i] = x[i] + y[i]
 	}
@@ -550,7 +550,7 @@ func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(ctx EvalContext, in
 		err = types.DecimalMul(&x[i], &y[i], &to)
 		if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
 			if err == types.ErrOverflow {
-				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 			}
 			return err
 		}
@@ -668,7 +668,7 @@ func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(ctx EvalContext, input *chu
 				continue
 			}
 			result.SetNull(i, true)
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 
 		x[i] = tmp
@@ -712,7 +712,7 @@ func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx EvalContext, input *chu
 
 		x[i] = x[i] / y[i]
 		if math.IsInf(x[i], 0) {
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 	}
 	return nil
@@ -880,17 +880,17 @@ func (b *builtinArithmeticPlusIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:
-		err = b.plusUU(result, lhi64s, rhi64s, resulti64s)
+		err = b.plusUU(ctx, result, lhi64s, rhi64s, resulti64s)
 	case isLHSUnsigned && !isRHSUnsigned:
-		err = b.plusUS(result, lhi64s, rhi64s, resulti64s)
+		err = b.plusUS(ctx, result, lhi64s, rhi64s, resulti64s)
 	case !isLHSUnsigned && isRHSUnsigned:
-		err = b.plusSU(result, lhi64s, rhi64s, resulti64s)
+		err = b.plusSU(ctx, result, lhi64s, rhi64s, resulti64s)
 	case !isLHSUnsigned && !isRHSUnsigned:
-		err = b.plusSS(result, lhi64s, rhi64s, resulti64s)
+		err = b.plusSS(ctx, result, lhi64s, rhi64s, resulti64s)
 	}
 	return err
 }
-func (b *builtinArithmeticPlusIntSig) plusUU(result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
+func (b *builtinArithmeticPlusIntSig) plusUU(ctx EvalContext, result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
 	for i := 0; i < len(lhi64s); i++ {
 		lh, rh := lhi64s[i], rhi64s[i]
 
@@ -898,7 +898,7 @@ func (b *builtinArithmeticPlusIntSig) plusUU(result *chunk.Column, lhi64s, rhi64
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -906,7 +906,7 @@ func (b *builtinArithmeticPlusIntSig) plusUU(result *chunk.Column, lhi64s, rhi64
 	return nil
 }
 
-func (b *builtinArithmeticPlusIntSig) plusUS(result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
+func (b *builtinArithmeticPlusIntSig) plusUS(ctx EvalContext, result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
 	for i := 0; i < len(lhi64s); i++ {
 		lh, rh := lhi64s[i], rhi64s[i]
 
@@ -914,13 +914,13 @@ func (b *builtinArithmeticPlusIntSig) plusUS(result *chunk.Column, lhi64s, rhi64
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 		if rh > 0 && uint64(lh) > math.MaxUint64-uint64(rh) {
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -928,7 +928,7 @@ func (b *builtinArithmeticPlusIntSig) plusUS(result *chunk.Column, lhi64s, rhi64
 	return nil
 }
 
-func (b *builtinArithmeticPlusIntSig) plusSU(result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
+func (b *builtinArithmeticPlusIntSig) plusSU(ctx EvalContext, result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
 	for i := 0; i < len(lhi64s); i++ {
 		lh, rh := lhi64s[i], rhi64s[i]
 
@@ -936,20 +936,20 @@ func (b *builtinArithmeticPlusIntSig) plusSU(result *chunk.Column, lhi64s, rhi64
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 		if lh > 0 && uint64(rh) > math.MaxUint64-uint64(lh) {
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 
 		resulti64s[i] = lh + rh
 	}
 	return nil
 }
-func (b *builtinArithmeticPlusIntSig) plusSS(result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
+func (b *builtinArithmeticPlusIntSig) plusSS(ctx EvalContext, result *chunk.Column, lhi64s, rhi64s, resulti64s []int64) error {
 	for i := 0; i < len(lhi64s); i++ {
 		lh, rh := lhi64s[i], rhi64s[i]
 
@@ -957,7 +957,7 @@ func (b *builtinArithmeticPlusIntSig) plusSS(result *chunk.Column, lhi64s, rhi64
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -993,7 +993,7 @@ func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 		}
 		if err = types.DecimalAdd(&x[i], &y[i], to); err != nil {
 			if err == types.ErrOverflow {
-				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 			}
 			return err
 		}
@@ -1031,7 +1031,7 @@ func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(ctx EvalContext, in
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
 		}
 		x[i] = res
 	}

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1011,7 +1011,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 	if !b.inUnion || val >= 0 {
 		err = res.FromFloat64(val)
 		if types.ErrOverflow.Equal(err) {
-			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
+			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0].StringWithCtx(ctx))
 			err = ec.HandleErrorWithAlias(err, err, warnErr)
 		} else if types.ErrTruncated.Equal(err) {
 			// This behavior is consistent with MySQL.

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1446,7 +1446,7 @@ func TestWrapWithCastAsString(t *testing.T) {
 	}
 
 	expr := BuildCastFunction(ctx, &Constant{RetType: types.NewFieldType(mysql.TypeEnum)}, types.NewFieldType(mysql.TypeVarString))
-	require.NotContains(t, expr.String(), "to_binary")
+	require.NotContains(t, expr.StringWithCtx(ctx), "to_binary")
 }
 
 func TestWrapWithCastAsJSON(t *testing.T) {

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -916,7 +916,7 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 		if !b.inUnion || bufreal[i] >= 0 {
 			if err = resdecimal[i].FromFloat64(bufreal[i]); err != nil {
 				if types.ErrOverflow.Equal(err) {
-					warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0])
+					warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0].StringWithCtx(ctx))
 					err = ec.HandleErrorWithAlias(err, err, warnErr)
 				} else if types.ErrTruncated.Equal(err) {
 					// This behavior is consistent with MySQL.

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1535,7 +1535,7 @@ func allowCmpArgsRefining4PlanCache(ctx BuildContext, args []Expression) (allowR
 		exprType := args[1-conIdx].GetType(ctx.GetEvalCtx())
 		exprEvalType := exprType.EvalType()
 		if exprType.GetType() == mysql.TypeYear {
-			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].String()))
+			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].StringWithCtx(ctx.GetEvalCtx())))
 			return true
 		}
 
@@ -1544,7 +1544,7 @@ func allowCmpArgsRefining4PlanCache(ctx BuildContext, args []Expression) (allowR
 		conEvalType := args[conIdx].GetType(ctx.GetEvalCtx()).EvalType()
 		if exprEvalType == types.ETInt &&
 			(conEvalType == types.ETString || conEvalType == types.ETReal || conEvalType == types.ETDecimal) {
-			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].String()))
+			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].StringWithCtx(ctx.GetEvalCtx())))
 			return true
 		}
 
@@ -1553,7 +1553,7 @@ func allowCmpArgsRefining4PlanCache(ctx BuildContext, args []Expression) (allowR
 		// see https://github.com/pingcap/tidb/issues/38361 for more details
 		_, exprIsCon := args[1-conIdx].(*Constant)
 		if !exprIsCon && matchRefineRule3Pattern(conEvalType, exprType) {
-			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to datetime", args[conIdx].String()))
+			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to datetime", args[conIdx].StringWithCtx(ctx.GetEvalCtx())))
 			return true
 		}
 	}

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -73,7 +73,7 @@ func TestCompareFunctionWithRefine(t *testing.T) {
 	for _, test := range tests {
 		f, err := ParseSimpleExpr(ctx, test.exprStr, WithTableInfo("", tblInfo))
 		require.NoError(t, err)
-		require.Equal(t, test.result, f.String())
+		require.Equal(t, test.result, f.StringWithCtx(ctx))
 	}
 }
 

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -1739,7 +1739,7 @@ func (b *builtinExpSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool,
 	}
 	exp := math.Exp(val)
 	if math.IsInf(exp, 0) || math.IsNaN(exp) {
-		s := fmt.Sprintf("exp(%s)", b.args[0].String())
+		s := fmt.Sprintf("exp(%s)", b.args[0].StringWithCtx(ctx))
 		return 0, false, types.ErrOverflow.GenWithStackByArgs("DOUBLE", s)
 	}
 	return exp, false, nil

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -290,7 +290,7 @@ func (b *builtinExpSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result 
 		}
 		exp := math.Exp(f64s[i])
 		if math.IsInf(exp, 0) || math.IsNaN(exp) {
-			s := fmt.Sprintf("exp(%s)", b.args[0].String())
+			s := fmt.Sprintf("exp(%s)", b.args[0].StringWithCtx(ctx))
 			if err := types.ErrOverflow.GenWithStackByArgs("DOUBLE", s); err != nil {
 				return err
 			}

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -2311,7 +2311,7 @@ func (c *charFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	// The last argument represents the charset name after "using".
 	if _, ok := args[len(args)-1].(*Constant); !ok {
 		// If we got there, there must be something wrong in other places.
-		logutil.BgLogger().Warn(fmt.Sprintf("The last argument in char function must be constant, but got %T", args[len(args)-1]))
+		logutil.BgLogger().Warn(fmt.Sprintf("The last argument in char function must be constant, but got %T", args[len(args)-1].StringWithCtx(ctx.GetEvalCtx())))
 		return nil, errIncorrectArgs
 	}
 	charsetName, isNull, err := args[len(args)-1].EvalString(ctx.GetEvalCtx(), chunk.Row{})
@@ -3867,11 +3867,11 @@ func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expressio
 	length := 0
 	if l == 3 {
 		if args[1].GetType(ctx).EvalType() != types.ETString {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx), c.funcName)
 		}
 		c1, ok := args[1].(*Constant)
 		if !ok {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx), c.funcName)
 		}
 		switch x := c1.Value.GetString(); x {
 		case "CHAR":
@@ -3884,15 +3884,15 @@ func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expressio
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(x, c.funcName)
 		}
 		if args[2].GetType(ctx).EvalType() != types.ETInt {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].String(), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].StringWithCtx(ctx), c.funcName)
 		}
 		c2, ok := args[2].(*Constant)
 		if !ok {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx), c.funcName)
 		}
 		length = int(c2.Value.GetInt64())
 		if length == 0 {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].String(), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].StringWithCtx(ctx), c.funcName)
 		}
 	}
 	return padding, length, nil

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/errors"
+	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -389,7 +390,7 @@ func (col *Column) VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chun
 const columnPrefix = "Column#"
 
 // StringWithCtx implements Expression interface.
-func (col *Column) StringWithCtx(ctx EvalContext) string {
+func (col *Column) StringWithCtx(ctx ParamValues) string {
 	return col.String()
 }
 
@@ -398,7 +399,7 @@ func (col *Column) String() string {
 	if col.IsHidden && col.VirtualExpr != nil {
 		// A hidden column without virtual expression indicates it's a stored type.
 		// a virtual column should be able to be stringified without context.
-		return col.VirtualExpr.StringWithCtx(nil)
+		return col.VirtualExpr.StringWithCtx(exprctx.EmptyParamValues)
 	}
 	if col.OrigName != "" {
 		return col.OrigName

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -388,11 +388,17 @@ func (col *Column) VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chun
 
 const columnPrefix = "Column#"
 
+// StringWithCtx implements Expression interface.
+func (col *Column) StringWithCtx(ctx EvalContext) string {
+	return col.String()
+}
+
 // String implements Stringer interface.
 func (col *Column) String() string {
 	if col.IsHidden && col.VirtualExpr != nil {
 		// A hidden column without virtual expression indicates it's a stored type.
-		return col.VirtualExpr.String()
+		// a virtual column should be able to be stringified without context.
+		return col.VirtualExpr.StringWithCtx(nil)
 	}
 	if col.OrigName != "" {
 		return col.OrigName

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -19,7 +19,6 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
@@ -130,7 +129,6 @@ type Constant struct {
 
 // ParamMarker indicates param provided by COM_STMT_EXECUTE.
 type ParamMarker struct {
-	ctx   variable.SessionVarsProvider
 	order int
 }
 
@@ -139,17 +137,11 @@ func (d *ParamMarker) GetUserVar(ctx EvalContext) types.Datum {
 	return ctx.GetParamValue(d.order)
 }
 
-func (d *ParamMarker) getUserVarWithInternalCtx() types.Datum {
-	// TODO: remove this function in the future
-	sessionVars := d.ctx.GetSessionVars()
-	return sessionVars.PlanCacheParams.GetParamValue(d.order)
-}
-
 // String implements fmt.Stringer interface.
 func (c *Constant) String() string {
 	if c.ParamMarker != nil {
-		dt := c.ParamMarker.getUserVarWithInternalCtx()
-		c.Value.SetValue(dt.GetValue(), c.RetType)
+		// TODO: use a more meaningful value to represent the param marker.
+		return "?"
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.String()
 	}

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -336,18 +336,18 @@ func TestDeferredParamNotNull(t *testing.T) {
 		types.NewMysqlBitDatum([]byte{1}),
 		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	)
-	cstInt := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
-	cstDec := &Constant{ParamMarker: &ParamMarker{order: 1}, RetType: newDecimalFieldType()}
-	cstTime := &Constant{ParamMarker: &ParamMarker{order: 2}, RetType: newDateFieldType()}
-	cstDuration := &Constant{ParamMarker: &ParamMarker{order: 3}, RetType: newDurFieldType()}
-	cstJSON := &Constant{ParamMarker: &ParamMarker{order: 4}, RetType: newJSONFieldType()}
-	cstBytes := &Constant{ParamMarker: &ParamMarker{order: 6}, RetType: newBlobFieldType()}
-	cstBinary := &Constant{ParamMarker: &ParamMarker{order: 5}, RetType: newBinaryLiteralFieldType()}
-	cstFloat32 := &Constant{ParamMarker: &ParamMarker{order: 7}, RetType: newFloatFieldType()}
-	cstFloat64 := &Constant{ParamMarker: &ParamMarker{order: 8}, RetType: newFloatFieldType()}
-	cstUint := &Constant{ParamMarker: &ParamMarker{order: 9}, RetType: newIntFieldType()}
-	cstBit := &Constant{ParamMarker: &ParamMarker{order: 10}, RetType: newBinaryLiteralFieldType()}
-	cstEnum := &Constant{ParamMarker: &ParamMarker{order: 11}, RetType: newEnumFieldType()}
+	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
+	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
+	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
+	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
+	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
 
 	require.Equal(t, mysql.TypeVarString, cstJSON.GetType(ctx).GetType())
 	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType(ctx).GetType())

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -336,18 +336,18 @@ func TestDeferredParamNotNull(t *testing.T) {
 		types.NewMysqlBitDatum([]byte{1}),
 		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	)
-	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
-	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
-	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
-	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
-	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
-	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
-	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
-	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
-	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
-	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
-	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
-	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
+	cstInt := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
+	cstDec := &Constant{ParamMarker: &ParamMarker{order: 1}, RetType: newDecimalFieldType()}
+	cstTime := &Constant{ParamMarker: &ParamMarker{order: 2}, RetType: newDateFieldType()}
+	cstDuration := &Constant{ParamMarker: &ParamMarker{order: 3}, RetType: newDurFieldType()}
+	cstJSON := &Constant{ParamMarker: &ParamMarker{order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{order: 11}, RetType: newEnumFieldType()}
 
 	require.Equal(t, mysql.TypeVarString, cstJSON.GetType(ctx).GetType())
 	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType(ctx).GetType())
@@ -519,7 +519,7 @@ func TestVectorizedConstant(t *testing.T) {
 func TestGetTypeThreadSafe(t *testing.T) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(1))
-	con := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newStringFieldType()}
+	con := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newStringFieldType()}
 	ft1 := con.GetType(ctx)
 	ft2 := con.GetType(ctx)
 	require.NotSame(t, ft1, ft2)

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -185,7 +185,7 @@ func TestConstantPropagation(t *testing.T) {
 			newConds := solver.PropagateConstant(ctx, conds)
 			var result []string
 			for _, v := range newConds {
-				result = append(result, v.String())
+				result = append(result, v.StringWithCtx(ctx))
 			}
 			sort.Strings(result)
 			require.Equalf(t, tt.result, strings.Join(result, ", "), "different for expr %s", tt.conditions)
@@ -253,7 +253,7 @@ func TestConstantFolding(t *testing.T) {
 			require.True(t, ctx.IsInNullRejectCheck())
 		}
 		newConds := FoldConstant(ctx, expr)
-		require.Equalf(t, tt.result, newConds.String(), "different for expr %s", tt.condition)
+		require.Equalf(t, tt.result, newConds.StringWithCtx(ctx.GetEvalCtx()), "different for expr %s", tt.condition)
 	}
 }
 
@@ -315,7 +315,7 @@ func TestConstantFoldingCharsetConvert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		newConds := FoldConstant(ctx, tt.condition)
-		require.Equalf(t, tt.result, newConds.String(), "different for expr %s", tt.condition)
+		require.Equalf(t, tt.result, newConds.StringWithCtx(ctx), "different for expr %s", tt.condition)
 	}
 }
 
@@ -336,18 +336,18 @@ func TestDeferredParamNotNull(t *testing.T) {
 		types.NewMysqlBitDatum([]byte{1}),
 		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	)
-	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
-	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
-	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
-	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
-	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
-	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
-	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
-	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
-	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
-	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
-	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
-	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
+	cstInt := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
+	cstDec := &Constant{ParamMarker: &ParamMarker{order: 1}, RetType: newDecimalFieldType()}
+	cstTime := &Constant{ParamMarker: &ParamMarker{order: 2}, RetType: newDateFieldType()}
+	cstDuration := &Constant{ParamMarker: &ParamMarker{order: 3}, RetType: newDurFieldType()}
+	cstJSON := &Constant{ParamMarker: &ParamMarker{order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{order: 11}, RetType: newEnumFieldType()}
 
 	require.Equal(t, mysql.TypeVarString, cstJSON.GetType(ctx).GetType())
 	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType(ctx).GetType())

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -25,6 +25,9 @@ import (
 	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
+// ParamValues is used to store the values of params in context
+type ParamValues = context.ParamValues
+
 // EvalContext is used to evaluate an expression
 type EvalContext = context.EvalContext
 
@@ -118,5 +121,5 @@ func (ctx *assertionEvalContext) GetOptionalPropProvider(key OptionalEvalPropKey
 type StringerWithCtx interface {
 	// StringWithCtx returns the string representation of the expression with context.
 	// NOTE: any implementation of `StringWithCtx` should not panic if the context is nil.
-	StringWithCtx(ctx EvalContext) string
+	StringWithCtx(ctx ParamValues) string
 }

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -113,3 +113,10 @@ func (ctx *assertionEvalContext) GetOptionalPropProvider(key OptionalEvalPropKey
 	)
 	return ctx.EvalContext.GetOptionalPropProvider(key)
 }
+
+// StringerWithCtx is the interface for expressions that can be stringified with context.
+type StringerWithCtx interface {
+	// StringWithCtx returns the string representation of the expression with context.
+	// NOTE: any implementation of `StringWithCtx` should not panic if the context is nil.
+	StringWithCtx(ctx EvalContext) string
+}

--- a/pkg/expression/context/BUILD.bazel
+++ b/pkg/expression/context/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "context.go",
         "optional.go",
+        "param.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/expression/context",
     visibility = ["//visibility:public"],
@@ -16,6 +17,7 @@ go_library(
         "//pkg/util/context",
         "//pkg/util/intest",
         "//pkg/util/mathutil",
+        "@com_github_pingcap_errors//:errors",
     ],
 )
 

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -53,6 +53,7 @@ func (a *SimplePlanColumnIDAllocator) AllocPlanColumnID() int64 {
 // EvalContext is used to evaluate an expression
 type EvalContext interface {
 	contextutil.WarnHandler
+	ParamValues
 	// CtxID indicates the id of the context.
 	CtxID() uint64
 	// SQLMode returns the sql mode
@@ -82,8 +83,6 @@ type EvalContext interface {
 	GetOptionalPropSet() OptionalEvalPropKeySet
 	// GetOptionalPropProvider gets the optional property provider by key
 	GetOptionalPropProvider(OptionalEvalPropKey) (OptionalEvalPropProvider, bool)
-	// GetParamValue returns the value of the parameter by index.
-	GetParamValue(idx int) types.Datum
 }
 
 // BuildContext is used to build an expression

--- a/pkg/expression/context/param.go
+++ b/pkg/expression/context/param.go
@@ -1,0 +1,39 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/types"
+)
+
+// ErrParamIndexExceedParamCounts describes the error that the index exceed the count of all params
+var ErrParamIndexExceedParamCounts = errors.New("Param index exceed param counts")
+
+// ParamValues is a readonly interface to return param
+type ParamValues interface {
+	// GetParamValue returns the value of the parameter by index.
+	GetParamValue(idx int) (types.Datum, error)
+}
+
+// EmptyParamValues is the `ParamValues` which contains nothing
+var EmptyParamValues ParamValues = &emptyParamValues{}
+
+type emptyParamValues struct{}
+
+// GetParamValue always returns the `ErrParamIndexExceedParamCounts` for any index
+func (e *emptyParamValues) GetParamValue(idx int) (types.Datum, error) {
+	return types.Datum{}, ErrParamIndexExceedParamCounts
+}

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -279,8 +279,12 @@ func (ctx *SessionEvalContext) RequestDynamicVerification(privName string, grant
 }
 
 // GetParamValue returns the value of the parameter by index.
-func (ctx *SessionEvalContext) GetParamValue(idx int) types.Datum {
-	return ctx.sctx.GetSessionVars().PlanCacheParams.GetParamValue(idx)
+func (ctx *SessionEvalContext) GetParamValue(idx int) (types.Datum, error) {
+	params := ctx.sctx.GetSessionVars().PlanCacheParams.AllParamValues()
+	if idx >= len(params) {
+		return types.Datum{}, exprctx.ErrParamIndexExceedParamCounts
+	}
+	return params[idx], nil
 }
 
 func getStmtTimestamp(ctx sessionctx.Context) (time.Time, error) {

--- a/pkg/expression/contextstatic/evalctx.go
+++ b/pkg/expression/contextstatic/evalctx.go
@@ -375,9 +375,9 @@ func (ctx *StaticEvalContext) Apply(opt ...StaticEvalCtxOption) *StaticEvalConte
 }
 
 // GetParamValue returns the value of the parameter by index.
-func (ctx *StaticEvalContext) GetParamValue(idx int) types.Datum {
+func (ctx *StaticEvalContext) GetParamValue(idx int) (types.Datum, error) {
 	if idx < 0 || idx >= len(ctx.paramList) {
-		return types.Datum{}
+		return types.Datum{}, exprctx.ErrParamIndexExceedParamCounts
 	}
-	return ctx.paramList[idx]
+	return ctx.paramList[idx], nil
 }

--- a/pkg/expression/contextstatic/evalctx_test.go
+++ b/pkg/expression/contextstatic/evalctx_test.go
@@ -437,7 +437,8 @@ func TestParamList(t *testing.T) {
 		WithParamList(paramList),
 	)
 	for i := 0; i < 3; i++ {
-		val := ctx.GetParamValue(i)
+		val, err := ctx.GetParamValue(i)
+		require.NoError(t, err)
 		require.Equal(t, int64(i+1), val.GetInt64())
 	}
 
@@ -445,7 +446,8 @@ func TestParamList(t *testing.T) {
 	paramList.Reset()
 	paramList.Append(types.NewDatum(4))
 	for i := 0; i < 3; i++ {
-		val := ctx.GetParamValue(i)
+		val, err := ctx.GetParamValue(i)
+		require.NoError(t, err)
 		require.Equal(t, int64(i+1), val.GetInt64())
 	}
 }

--- a/pkg/expression/explain.go
+++ b/pkg/expression/explain.go
@@ -105,7 +105,7 @@ func (expr *ScalarFunction) ExplainNormalizedInfo4InList() string {
 }
 
 // ColumnExplainInfo returns the explained info for column.
-func (col *Column) ColumnExplainInfo(ctx EvalContext, normalized bool) string {
+func (col *Column) ColumnExplainInfo(ctx ParamValues, normalized bool) string {
 	if normalized {
 		return col.ColumnExplainInfoNormalized()
 	}

--- a/pkg/expression/explain.go
+++ b/pkg/expression/explain.go
@@ -105,29 +105,34 @@ func (expr *ScalarFunction) ExplainNormalizedInfo4InList() string {
 }
 
 // ColumnExplainInfo returns the explained info for column.
-func (col *Column) ColumnExplainInfo(normalized bool) string {
+func (col *Column) ColumnExplainInfo(ctx EvalContext, normalized bool) string {
 	if normalized {
-		if col.OrigName != "" {
-			return col.OrigName
-		}
-		return "?"
+		return col.ColumnExplainInfoNormalized()
 	}
-	return col.String()
+	return col.StringWithCtx(ctx)
+}
+
+// ColumnExplainInfoNormalized returns the normalized explained info for column.
+func (col *Column) ColumnExplainInfoNormalized() string {
+	if col.OrigName != "" {
+		return col.OrigName
+	}
+	return "?"
 }
 
 // ExplainInfo implements the Expression interface.
 func (col *Column) ExplainInfo(ctx EvalContext) string {
-	return col.ColumnExplainInfo(false)
+	return col.ColumnExplainInfo(ctx, false)
 }
 
 // ExplainNormalizedInfo implements the Expression interface.
 func (col *Column) ExplainNormalizedInfo() string {
-	return col.ColumnExplainInfo(true)
+	return col.ColumnExplainInfoNormalized()
 }
 
 // ExplainNormalizedInfo4InList implements the Expression interface.
 func (col *Column) ExplainNormalizedInfo4InList() string {
-	return col.ColumnExplainInfo(true)
+	return col.ColumnExplainInfoNormalized()
 }
 
 // ExplainInfo implements the Expression interface.
@@ -161,19 +166,19 @@ func (expr *Constant) format(dt types.Datum) string {
 }
 
 // ExplainExpressionList generates explain information for a list of expressions.
-func ExplainExpressionList(exprs []Expression, schema *Schema) string {
+func ExplainExpressionList(ctx EvalContext, exprs []Expression, schema *Schema) string {
 	builder := &strings.Builder{}
 	for i, expr := range exprs {
 		switch expr.(type) {
 		case *Column, *CorrelatedColumn:
-			builder.WriteString(expr.String())
-			if expr.String() != schema.Columns[i].String() {
+			builder.WriteString(expr.StringWithCtx(ctx))
+			if expr.StringWithCtx(ctx) != schema.Columns[i].StringWithCtx(ctx) {
 				// simple col projected again with another uniqueID without origin name.
 				builder.WriteString("->")
-				builder.WriteString(schema.Columns[i].String())
+				builder.WriteString(schema.Columns[i].StringWithCtx(ctx))
 			}
 		case *Constant:
-			v := expr.String()
+			v := expr.StringWithCtx(ctx)
 			length := 64
 			if len(v) < length {
 				builder.WriteString(v)
@@ -182,11 +187,11 @@ func ExplainExpressionList(exprs []Expression, schema *Schema) string {
 				fmt.Fprintf(builder, "(len:%d)", len(v))
 			}
 			builder.WriteString("->")
-			builder.WriteString(schema.Columns[i].String())
+			builder.WriteString(schema.Columns[i].StringWithCtx(ctx))
 		default:
-			builder.WriteString(expr.String())
+			builder.WriteString(expr.StringWithCtx(ctx))
 			builder.WriteString("->")
-			builder.WriteString(schema.Columns[i].String())
+			builder.WriteString(schema.Columns[i].StringWithCtx(ctx))
 		}
 		if i+1 < len(exprs) {
 			builder.WriteString(", ")

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -39,7 +39,7 @@ func ExpressionsToPBList(ctx EvalContext, exprs []Expression, client kv.Client) 
 	for _, expr := range exprs {
 		v := pc.ExprToPB(expr)
 		if v == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr)
+			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr.StringWithCtx(ctx))
 		}
 		pbExpr = append(pbExpr, v)
 	}
@@ -58,7 +58,7 @@ func ProjectionExpressionsToPBList(ctx EvalContext, exprs []Expression, client k
 			v = pc.ExprToPB(expr)
 		}
 		if v == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr)
+			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr.StringWithCtx(ctx))
 		}
 		pbExpr = append(pbExpr, v)
 	}

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -16,6 +16,7 @@ package expression
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -164,7 +165,6 @@ const (
 
 // Expression represents all scalar expression in SQL.
 type Expression interface {
-	fmt.Stringer
 	VecExpr
 	CollationInfo
 
@@ -250,6 +250,8 @@ type Expression interface {
 
 	// MemoryUsage return the memory usage of Expression
 	MemoryUsage() int64
+
+	StringerWithCtx
 }
 
 // CNFExprs stands for a CNF expression.
@@ -864,7 +866,7 @@ func SplitDNFItems(onExpr Expression) []Expression {
 // If the Expression is a non-constant value, it means the result is unknown.
 func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression) Expression {
 	if MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
-		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.String()))
+		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx())))
 	}
 	if ctx.IsInNullRejectCheck() {
 		expr, _ = evaluateExprWithNullInNullRejectCheck(ctx, schema, expr)
@@ -1225,4 +1227,19 @@ func Args2Expressions4Test(args ...any) []Expression {
 		exprs[i] = &Constant{Value: d, RetType: ft}
 	}
 	return exprs
+}
+
+// StringifyExpressionsWithCtx turns a slice of expressions into string
+func StringifyExpressionsWithCtx(ctx EvalContext, exprs []Expression) string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i, expr := range exprs {
+		sb.WriteString(expr.StringWithCtx(ctx))
+
+		if i != len(exprs)-1 {
+			sb.WriteString(" ")
+		}
+	}
+	sb.WriteString("]")
+	return sb.String()
 }

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -68,7 +68,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	res := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
-	param.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
+	param.ParamMarker = &ParamMarker{order: 0}
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -68,7 +68,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	res := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
-	param.ParamMarker = &ParamMarker{order: 0}
+	param.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)

--- a/pkg/expression/grouping_sets.go
+++ b/pkg/expression/grouping_sets.go
@@ -261,15 +261,15 @@ func (gs GroupingSet) Clone() GroupingSet {
 	return gc
 }
 
-// String is used to output a string which simply described current grouping set.
-func (gs GroupingSet) String() string {
+// StringWithCtx is used to output a string which simply described current grouping set.
+func (gs GroupingSet) StringWithCtx(ctx EvalContext) string {
 	var str strings.Builder
 	str.WriteString("{")
 	for i, one := range gs {
 		if i != 0 {
 			str.WriteString(",")
 		}
-		str.WriteString(one.String())
+		str.WriteString(one.StringWithCtx(ctx))
 	}
 	str.WriteString("}")
 	return str.String()
@@ -319,15 +319,15 @@ func (gss GroupingSets) AllSetsColIDs() *intset.FastIntSet {
 	return &res
 }
 
-// String is used to output a string which simply described current grouping sets.
-func (gss GroupingSets) String() string {
+// StringWithCtx is used to output a string which simply described current grouping sets.
+func (gss GroupingSets) StringWithCtx(ctx EvalContext) string {
 	var str strings.Builder
 	str.WriteString("[")
 	for i, gs := range gss {
 		if i != 0 {
 			str.WriteString(",")
 		}
-		str.WriteString(gs.String())
+		str.WriteString(gs.StringWithCtx(ctx))
 	}
 	str.WriteString("]")
 	return str.String()
@@ -388,15 +388,15 @@ func (g GroupingExprs) Clone() GroupingExprs {
 	return gc
 }
 
-// String is used to output a string which simply described current grouping expressions.
-func (g GroupingExprs) String() string {
+// StringWithCtx is used to output a string which simply described current grouping expressions.
+func (g GroupingExprs) StringWithCtx(ctx EvalContext) string {
 	var str strings.Builder
 	str.WriteString("<")
 	for i, one := range g {
 		if i != 0 {
 			str.WriteString(",")
 		}
-		str.WriteString(one.String())
+		str.WriteString(one.StringWithCtx(ctx))
 	}
 	str.WriteString(">")
 	return str.String()

--- a/pkg/expression/grouping_sets.go
+++ b/pkg/expression/grouping_sets.go
@@ -262,7 +262,7 @@ func (gs GroupingSet) Clone() GroupingSet {
 }
 
 // StringWithCtx is used to output a string which simply described current grouping set.
-func (gs GroupingSet) StringWithCtx(ctx EvalContext) string {
+func (gs GroupingSet) StringWithCtx(ctx ParamValues) string {
 	var str strings.Builder
 	str.WriteString("{")
 	for i, one := range gs {
@@ -320,7 +320,7 @@ func (gss GroupingSets) AllSetsColIDs() *intset.FastIntSet {
 }
 
 // StringWithCtx is used to output a string which simply described current grouping sets.
-func (gss GroupingSets) StringWithCtx(ctx EvalContext) string {
+func (gss GroupingSets) StringWithCtx(ctx ParamValues) string {
 	var str strings.Builder
 	str.WriteString("[")
 	for i, gs := range gss {
@@ -389,7 +389,7 @@ func (g GroupingExprs) Clone() GroupingExprs {
 }
 
 // StringWithCtx is used to output a string which simply described current grouping expressions.
-func (g GroupingExprs) StringWithCtx(ctx EvalContext) string {
+func (g GroupingExprs) StringWithCtx(ctx ParamValues) string {
 	var str strings.Builder
 	str.WriteString("<")
 	for i, one := range g {

--- a/pkg/expression/grouping_sets_test.go
+++ b/pkg/expression/grouping_sets_test.go
@@ -17,6 +17,7 @@ package expression
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -310,6 +311,8 @@ func TestGroupingSetsMergeUnitTest(t *testing.T) {
 
 func TestDistinctGroupingSets(t *testing.T) {
 	defer view.Stop()
+	ctx := contextstatic.NewStaticEvalContext()
+
 	// premise: every grouping item in grouping sets should be a col.
 	a := &Column{
 		UniqueID: 1,
@@ -352,9 +355,9 @@ func TestDistinctGroupingSets(t *testing.T) {
 	rawRollupExprs = []Expression{a, b, b, c}
 	deduplicateExprs, pos = DeduplicateGbyExpression(rawRollupExprs)
 	require.Equal(t, len(deduplicateExprs), 3)
-	require.Equal(t, deduplicateExprs[0].String(), "Column#1")
-	require.Equal(t, deduplicateExprs[1].String(), "Column#2")
-	require.Equal(t, deduplicateExprs[2].String(), "Column#3")
+	require.Equal(t, deduplicateExprs[0].StringWithCtx(ctx), "Column#1")
+	require.Equal(t, deduplicateExprs[1].StringWithCtx(ctx), "Column#2")
+	require.Equal(t, deduplicateExprs[2].StringWithCtx(ctx), "Column#3")
 	deduplicateColumns := make([]*Column, 0, len(deduplicateExprs))
 	for _, one := range deduplicateExprs {
 		deduplicateColumns = append(deduplicateColumns, one.(*Column))
@@ -372,10 +375,10 @@ func TestDistinctGroupingSets(t *testing.T) {
 	// so that why restore gby expression according to their pos is necessary.
 	restoreGbyExpressions := RestoreGbyExpression(deduplicateColumns, pos)
 	require.Equal(t, len(restoreGbyExpressions), 4)
-	require.Equal(t, restoreGbyExpressions[0].String(), "Column#1")
-	require.Equal(t, restoreGbyExpressions[1].String(), "Column#2")
-	require.Equal(t, restoreGbyExpressions[2].String(), "Column#2")
-	require.Equal(t, restoreGbyExpressions[3].String(), "Column#3")
+	require.Equal(t, restoreGbyExpressions[0].StringWithCtx(ctx), "Column#1")
+	require.Equal(t, restoreGbyExpressions[1].StringWithCtx(ctx), "Column#2")
+	require.Equal(t, restoreGbyExpressions[2].StringWithCtx(ctx), "Column#2")
+	require.Equal(t, restoreGbyExpressions[3].StringWithCtx(ctx), "Column#3")
 
 	// rollup grouping sets (build grouping sets on the restored gby expression, because all the
 	// complicated expressions have been projected as simple columns at this time).

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -127,12 +127,12 @@ func canExprPushDown(ctx PushDownContext, expr Expression, storeType kv.StoreTyp
 			if expr.GetType(ctx.EvalCtx()).GetType() == mysql.TypeEnum && canEnumPush {
 				break
 			}
-			warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType(ctx.EvalCtx()).GetType()) + "'.")
+			warnErr := errors.NewNoStackError("Expression about '" + expr.StringWithCtx(ctx.EvalCtx()) + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType(ctx.EvalCtx()).GetType()) + "'.")
 			ctx.AppendWarning(warnErr)
 			return false
 		case mysql.TypeNewDecimal:
 			if !expr.GetType(ctx.EvalCtx()).IsDecimalValid() {
-				warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetFlen()) + "','" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetDecimal()) + "').")
+				warnErr := errors.NewNoStackError("Expression about '" + expr.StringWithCtx(ctx.EvalCtx()) + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetFlen()) + "','" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetDecimal()) + "').")
 				ctx.AppendWarning(warnErr)
 				return false
 			}

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -426,6 +426,7 @@ func TestFilterExtractFromDNF(t *testing.T) {
 	for _, tt := range tests {
 		sql := "select * from t where " + tt.exprStr
 		sctx := tk.Session()
+		ectx := sctx.GetExprCtx().GetEvalCtx()
 		stmts, err := session.Parse(sctx, sql)
 		require.NoError(t, err, "error %v, for expr %s", err, tt.exprStr)
 		require.Len(t, stmts, 1)
@@ -443,7 +444,7 @@ func TestFilterExtractFromDNF(t *testing.T) {
 		sort.Slice(afterFunc, func(i, j int) bool {
 			return bytes.Compare(afterFunc[i].HashCode(), afterFunc[j].HashCode()) < 0
 		})
-		require.Equal(t, fmt.Sprintf("%s", afterFunc), tt.result, "wrong result for expr: %s", tt.exprStr)
+		require.Equal(t, expression.StringifyExpressionsWithCtx(ectx, afterFunc), tt.result, "wrong result for expr: %s", tt.exprStr)
 	}
 }
 

--- a/pkg/expression/main_test.go
+++ b/pkg/expression/main_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, opts...)
 }
 
-func createContext(t *testing.T) *mock.Context {
+func createContext(t testing.TB) *mock.Context {
 	ctx := mock.NewContext()
 	sqlMode, err := mysql.GetSQLMode(mysql.DefaultSQLMode)
 	require.NoError(t, err)

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/errors"
+	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -119,7 +120,7 @@ func (sf *ScalarFunction) Vectorized() bool {
 }
 
 // StringWithCtx implements Expression interface.
-func (sf *ScalarFunction) StringWithCtx(ctx EvalContext) string {
+func (sf *ScalarFunction) StringWithCtx(ctx ParamValues) string {
 	var buffer bytes.Buffer
 	fmt.Fprintf(&buffer, "%s(", sf.FuncName.L)
 	switch sf.FuncName.L {
@@ -143,25 +144,7 @@ func (sf *ScalarFunction) StringWithCtx(ctx EvalContext) string {
 
 // String returns the string representation of the function
 func (sf *ScalarFunction) String() string {
-	var buffer bytes.Buffer
-	fmt.Fprintf(&buffer, "%s(", sf.FuncName.L)
-	switch sf.FuncName.L {
-	case ast.Cast:
-		for _, arg := range sf.GetArgs() {
-			buffer.WriteString(arg.StringWithCtx(nil))
-			buffer.WriteString(", ")
-			buffer.WriteString(sf.RetType.String())
-		}
-	default:
-		for i, arg := range sf.GetArgs() {
-			buffer.WriteString(arg.StringWithCtx(nil))
-			if i+1 != len(sf.GetArgs()) {
-				buffer.WriteString(", ")
-			}
-		}
-	}
-	buffer.WriteString(")")
-	return buffer.String()
+	return sf.StringWithCtx(exprctx.EmptyParamValues)
 }
 
 // typeInferForNull infers the NULL constants field type and set the field type

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -118,20 +118,20 @@ func (sf *ScalarFunction) Vectorized() bool {
 	return sf.Function.vectorized() && sf.Function.isChildrenVectorized()
 }
 
-// String implements fmt.Stringer interface.
-func (sf *ScalarFunction) String() string {
+// StringWithCtx implements Expression interface.
+func (sf *ScalarFunction) StringWithCtx(ctx EvalContext) string {
 	var buffer bytes.Buffer
 	fmt.Fprintf(&buffer, "%s(", sf.FuncName.L)
 	switch sf.FuncName.L {
 	case ast.Cast:
 		for _, arg := range sf.GetArgs() {
-			buffer.WriteString(arg.String())
+			buffer.WriteString(arg.StringWithCtx(ctx))
 			buffer.WriteString(", ")
 			buffer.WriteString(sf.RetType.String())
 		}
 	default:
 		for i, arg := range sf.GetArgs() {
-			buffer.WriteString(arg.String())
+			buffer.WriteString(arg.StringWithCtx(ctx))
 			if i+1 != len(sf.GetArgs()) {
 				buffer.WriteString(", ")
 			}
@@ -141,9 +141,27 @@ func (sf *ScalarFunction) String() string {
 	return buffer.String()
 }
 
-// MarshalJSON implements json.Marshaler interface.
-func (sf *ScalarFunction) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%q", sf)), nil
+// String returns the string representation of the function
+func (sf *ScalarFunction) String() string {
+	var buffer bytes.Buffer
+	fmt.Fprintf(&buffer, "%s(", sf.FuncName.L)
+	switch sf.FuncName.L {
+	case ast.Cast:
+		for _, arg := range sf.GetArgs() {
+			buffer.WriteString(arg.StringWithCtx(nil))
+			buffer.WriteString(", ")
+			buffer.WriteString(sf.RetType.String())
+		}
+	default:
+		for i, arg := range sf.GetArgs() {
+			buffer.WriteString(arg.StringWithCtx(nil))
+			if i+1 != len(sf.GetArgs()) {
+				buffer.WriteString(", ")
+			}
+		}
+	}
+	buffer.WriteString(")")
+	return buffer.String()
 }
 
 // typeInferForNull infers the NULL constants field type and set the field type

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1204,6 +1204,7 @@ func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMark
 	if useCache || needParam {
 		value.ParamMarker = &ParamMarker{
 			order: v.Order,
+			ctx:   ctx,
 		}
 	}
 	return value, nil

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1204,7 +1204,6 @@ func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMark
 	if useCache || needParam {
 		value.ParamMarker = &ParamMarker{
 			order: v.Order,
-			ctx:   ctx,
 		}
 	}
 	return value, nil

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1013,12 +1013,12 @@ func containOuterNot(expr Expression, not bool) bool {
 }
 
 // Contains tests if `exprs` contains `e`.
-func Contains(exprs []Expression, e Expression) bool {
+func Contains(ectx EvalContext, exprs []Expression, e Expression) bool {
 	for _, expr := range exprs {
 		// Check string equivalence if one of the expressions is a clone.
 		sameString := false
 		if e != nil && expr != nil {
-			sameString = (e.String() == expr.String())
+			sameString = (e.StringWithCtx(ectx) == expr.StringWithCtx(ectx))
 		}
 		if e == expr || sameString {
 			return true
@@ -1204,7 +1204,6 @@ func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMark
 	if useCache || needParam {
 		value.ParamMarker = &ParamMarker{
 			order: v.Order,
-			ctx:   ctx,
 		}
 	}
 	return value, nil
@@ -1859,7 +1858,7 @@ func (r *SQLDigestTextRetriever) RetrieveGlobal(ctx context.Context, exec contex
 // to make it better for display and debug, it also escapes the string to corresponding golang string literal,
 // which means using \t, \n, \x??, \u????, ... to represent newline, control character, non-printable character,
 // invalid utf-8 bytes and so on.
-func ExprsToStringsForDisplay(exprs []Expression) []string {
+func ExprsToStringsForDisplay(ctx EvalContext, exprs []Expression) []string {
 	strs := make([]string, len(exprs))
 	for i, cond := range exprs {
 		quote := `"`
@@ -1867,7 +1866,7 @@ func ExprsToStringsForDisplay(exprs []Expression) []string {
 		// so we trim the \" prefix and suffix here.
 		strs[i] = strings.TrimSuffix(
 			strings.TrimPrefix(
-				strconv.Quote(cond.String()),
+				strconv.Quote(cond.StringWithCtx(ctx)),
 				quote),
 			quote)
 	}

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1425,7 +1425,12 @@ func GetUint64FromConstant(ctx EvalContext, expr Expression) (uint64, bool, bool
 	}
 	dt := con.Value
 	if con.ParamMarker != nil {
-		dt = con.ParamMarker.GetUserVar(ctx)
+		var err error
+		dt, err = con.ParamMarker.GetUserVar(ctx)
+		if err != nil {
+			logutil.BgLogger().Warn("get param failed", zap.Error(err))
+			return 0, false, false
+		}
 	} else if con.DeferredExpr != nil {
 		var err error
 		dt, err = con.DeferredExpr.Eval(ctx, chunk.Row{})

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -182,7 +182,7 @@ func TestGetUint64FromConstant(t *testing.T) {
 	require.Equal(t, uint64(1), num)
 
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewUintDatum(100))
-	con.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
+	con.ParamMarker = &ParamMarker{order: 0}
 	num, _, _ = GetUint64FromConstant(ctx, con)
 	require.Equal(t, uint64(100), num)
 }

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -182,7 +182,7 @@ func TestGetUint64FromConstant(t *testing.T) {
 	require.Equal(t, uint64(1), num)
 
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewUintDatum(100))
-	con.ParamMarker = &ParamMarker{order: 0}
+	con.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
 	num, _, _ = GetUint64FromConstant(ctx, con)
 	require.Equal(t, uint64(100), num)
 }

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -182,7 +182,7 @@ func TestGetUint64FromConstant(t *testing.T) {
 	require.Equal(t, uint64(1), num)
 
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewUintDatum(100))
-	con.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
+	con.ParamMarker = &ParamMarker{order: 0}
 	num, _, _ = GetUint64FromConstant(ctx, con)
 	require.Equal(t, uint64(100), num)
 }
@@ -558,8 +558,12 @@ func (m *MockExpr) VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chun
 	return nil
 }
 
-func (m *MockExpr) String() string               { return "" }
-func (m *MockExpr) MarshalJSON() ([]byte, error) { return nil, nil }
+<<<<<<< Updated upstream
+func (m *MockExpr) StringWithCtx(EvalContext) string { return "" }
+func (m *MockExpr) MarshalJSON() ([]byte, error)     { return nil, nil }
+=======
+func (m *MockExpr) StringWithCtx(ParamValues) string { return "" }
+>>>>>>> Stashed changes
 func (m *MockExpr) Eval(ctx EvalContext, row chunk.Row) (types.Datum, error) {
 	return types.NewDatum(m.i), m.err
 }

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -558,12 +558,7 @@ func (m *MockExpr) VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chun
 	return nil
 }
 
-<<<<<<< Updated upstream
-func (m *MockExpr) StringWithCtx(EvalContext) string { return "" }
-func (m *MockExpr) MarshalJSON() ([]byte, error)     { return nil, nil }
-=======
 func (m *MockExpr) StringWithCtx(ParamValues) string { return "" }
->>>>>>> Stashed changes
 func (m *MockExpr) Eval(ctx EvalContext, row chunk.Row) (types.Datum, error) {
 	return types.NewDatum(m.i), m.err
 }

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -60,7 +60,7 @@ func Selectivity(
 	var exprStrs []string
 	if ctx.GetSessionVars().StmtCtx.EnableOptimizerDebugTrace {
 		debugtrace.EnterContextCommon(ctx)
-		exprStrs = expression.ExprsToStringsForDisplay(exprs)
+		exprStrs = expression.ExprsToStringsForDisplay(ctx.GetExprCtx().GetEvalCtx(), exprs)
 		debugtrace.RecordAnyValuesWithNames(ctx, "Input Expressions", exprStrs)
 		defer func() {
 			debugtrace.RecordAnyValuesWithNames(ctx, "Result", result)
@@ -111,7 +111,7 @@ func Selectivity(
 			sel = 1.0 / pseudoEqualRate
 		}
 		if sc.EnableOptimizerDebugTrace {
-			debugtrace.RecordAnyValuesWithNames(ctx, "Expression", expr.String(), "Selectivity", sel)
+			debugtrace.RecordAnyValuesWithNames(ctx, "Expression", expr.StringWithCtx(ctx.GetExprCtx().GetEvalCtx()), "Selectivity", sel)
 		}
 		ret *= sel
 	}

--- a/pkg/planner/cardinality/trace.go
+++ b/pkg/planner/cardinality/trace.go
@@ -95,7 +95,7 @@ func exprToString(ctx expression.EvalContext, e expression.Expression) (string, 
 		buffer.WriteString(")")
 		return buffer.String(), nil
 	case *expression.Column:
-		return expr.String(), nil
+		return expr.StringWithCtx(ctx), nil
 	case *expression.CorrelatedColumn:
 		return "", errors.New("tracing for correlated columns not supported now")
 	case *expression.Constant:

--- a/pkg/planner/cascades/stringer.go
+++ b/pkg/planner/cascades/stringer.go
@@ -19,18 +19,19 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/memo"
 )
 
 // ToString stringifies a Group Tree.
-func ToString(g *memo.Group) []string {
+func ToString(ctx expression.EvalContext, g *memo.Group) []string {
 	idMap := make(map[*memo.Group]int)
 	idMap[g] = 0
-	return toString(g, idMap, map[*memo.Group]struct{}{}, []string{})
+	return toString(ctx, g, idMap, map[*memo.Group]struct{}{}, []string{})
 }
 
 // toString recursively stringifies a Group Tree using a preorder traversal method.
-func toString(g *memo.Group, idMap map[*memo.Group]int, visited map[*memo.Group]struct{}, strs []string) []string {
+func toString(ctx expression.EvalContext, g *memo.Group, idMap map[*memo.Group]int, visited map[*memo.Group]struct{}, strs []string) []string {
 	if _, exists := visited[g]; exists {
 		return strs
 	}
@@ -45,12 +46,12 @@ func toString(g *memo.Group, idMap map[*memo.Group]int, visited map[*memo.Group]
 		}
 	}
 	// Visit self first.
-	strs = append(strs, groupToString(g, idMap)...)
+	strs = append(strs, groupToString(ctx, g, idMap)...)
 	// Visit children then.
 	for item := g.Equivalents.Front(); item != nil; item = item.Next() {
 		expr := item.Value.(*memo.GroupExpr)
 		for _, childGroup := range expr.Children {
-			strs = toString(childGroup, idMap, visited, strs)
+			strs = toString(ctx, childGroup, idMap, visited, strs)
 		}
 	}
 	return strs
@@ -62,11 +63,11 @@ func toString(g *memo.Group, idMap map[*memo.Group]int, visited map[*memo.Group]
 //
 //	Selection_4 input:[Group#2], eq(Column#13, Column#2), gt(Column#1, 10)
 //	Projection_15 input:Group#3 Column#1, Column#2
-func groupToString(g *memo.Group, idMap map[*memo.Group]int) []string {
+func groupToString(ctx expression.EvalContext, g *memo.Group, idMap map[*memo.Group]int) []string {
 	schema := g.Prop.Schema
 	colStrs := make([]string, 0, len(schema.Columns))
 	for _, col := range schema.Columns {
-		colStrs = append(colStrs, col.String())
+		colStrs = append(colStrs, col.StringWithCtx(ctx))
 	}
 
 	groupLine := bytes.NewBufferString("")
@@ -77,7 +78,7 @@ func groupToString(g *memo.Group, idMap map[*memo.Group]int) []string {
 		for _, key := range schema.Keys {
 			ukColStrs := make([]string, 0, len(key))
 			for _, col := range key {
-				ukColStrs = append(ukColStrs, col.String())
+				ukColStrs = append(ukColStrs, col.StringWithCtx(ctx))
 			}
 			ukStrs = append(ukStrs, strings.Join(ukColStrs, ","))
 		}

--- a/pkg/planner/cascades/stringer_test.go
+++ b/pkg/planner/cascades/stringer_test.go
@@ -78,8 +78,8 @@ func TestGroupStringer(t *testing.T) {
 		group.BuildKeyInfo()
 		testdata.OnRecord(func() {
 			output[i].SQL = sql
-			output[i].Result = ToString(group)
+			output[i].Result = ToString(ctx.GetEvalCtx(), group)
 		})
-		require.Equalf(t, output[i].Result, ToString(group), "case:%v, sql:%s", i, sql)
+		require.Equalf(t, output[i].Result, ToString(ctx.GetEvalCtx(), group), "case:%v, sql:%s", i, sql)
 	}
 }

--- a/pkg/planner/cascades/transformation_rules_test.go
+++ b/pkg/planner/cascades/transformation_rules_test.go
@@ -60,9 +60,9 @@ func testGroupToString(t *testing.T, input []string, output []struct {
 		require.NoError(t, err)
 		testdata.OnRecord(func() {
 			output[i].SQL = sql
-			output[i].Result = ToString(group)
+			output[i].Result = ToString(ctx, group)
 		})
-		require.Equalf(t, output[i].Result, ToString(group), "case:%v, sql:%s", i, sql)
+		require.Equalf(t, output[i].Result, ToString(ctx, group), "case:%v, sql:%s", i, sql)
 	}
 }
 
@@ -115,9 +115,9 @@ func TestAggPushDownGather(t *testing.T) {
 		group.BuildKeyInfo()
 		testdata.OnRecord(func() {
 			output[i].SQL = sql
-			output[i].Result = ToString(group)
+			output[i].Result = ToString(ctx, group)
 		})
-		require.Equalf(t, output[i].Result, ToString(group), "case:%v, sql:%s", i, sql)
+		require.Equalf(t, output[i].Result, ToString(ctx, group), "case:%v, sql:%s", i, sql)
 	}
 }
 

--- a/pkg/planner/core/debugtrace.go
+++ b/pkg/planner/core/debugtrace.go
@@ -107,7 +107,7 @@ func DebugTraceReceivedCommand(s base.PlanContext, cmd byte, stmtNode ast.StmtNo
 		execInfo.BinaryParamsInfo = make([]binaryParamInfo, len(binaryParams))
 		for i, param := range binaryParams {
 			execInfo.BinaryParamsInfo[i].Type = param.GetType(s.GetExprCtx().GetEvalCtx()).String()
-			execInfo.BinaryParamsInfo[i].Value = param.String()
+			execInfo.BinaryParamsInfo[i].Value = param.StringWithCtx(s.GetExprCtx().GetEvalCtx())
 		}
 	}
 }
@@ -235,18 +235,18 @@ type accessPathForDebugTrace struct {
 	CountAfterIndex  float64
 }
 
-func convertAccessPathForDebugTrace(path *util.AccessPath, out *accessPathForDebugTrace) {
+func convertAccessPathForDebugTrace(ctx expression.EvalContext, path *util.AccessPath, out *accessPathForDebugTrace) {
 	if path.Index != nil {
 		out.IndexName = path.Index.Name.O
 	}
-	out.AccessConditions = expression.ExprsToStringsForDisplay(path.AccessConds)
-	out.IndexFilters = expression.ExprsToStringsForDisplay(path.IndexFilters)
-	out.TableFilters = expression.ExprsToStringsForDisplay(path.TableFilters)
+	out.AccessConditions = expression.ExprsToStringsForDisplay(ctx, path.AccessConds)
+	out.IndexFilters = expression.ExprsToStringsForDisplay(ctx, path.IndexFilters)
+	out.TableFilters = expression.ExprsToStringsForDisplay(ctx, path.TableFilters)
 	out.CountAfterAccess = path.CountAfterAccess
 	out.CountAfterIndex = path.CountAfterIndex
 	out.PartialPaths = make([]accessPathForDebugTrace, len(path.PartialIndexPaths))
 	for i, partialPath := range path.PartialIndexPaths {
-		convertAccessPathForDebugTrace(partialPath, &out.PartialPaths[i])
+		convertAccessPathForDebugTrace(ctx, partialPath, &out.PartialPaths[i])
 	}
 }
 
@@ -254,7 +254,7 @@ func debugTraceAccessPaths(s base.PlanContext, paths []*util.AccessPath) {
 	root := debugtrace.GetOrInitDebugTraceRoot(s)
 	traceInfo := make([]accessPathForDebugTrace, len(paths))
 	for i, partialPath := range paths {
-		convertAccessPathForDebugTrace(partialPath, &traceInfo[i])
+		convertAccessPathForDebugTrace(s.GetExprCtx().GetEvalCtx(), partialPath, &traceInfo[i])
 	}
 	root.AppendStepWithNameToCurrentContext(traceInfo, "Access paths")
 }

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -882,7 +882,7 @@ func (p *LogicalJoin) buildIndexJoinInner2TableScan(
 			if i != 0 {
 				buffer.WriteString(" ")
 			}
-			buffer.WriteString(key.String())
+			buffer.WriteString(key.StringWithCtx(p.SCtx().GetExprCtx().GetEvalCtx()))
 		}
 		buffer.WriteString("]")
 		rangeInfo := buffer.String()
@@ -1012,13 +1012,14 @@ func (ijHelper *indexJoinBuildHelper) buildRangeDecidedByInformation(idxCols []*
 		}
 		fmt.Fprintf(buffer, "eq(%v, %v)", idxCols[idxOff], outerJoinKeys[keyOff])
 	}
+	ectx := ijHelper.join.SCtx().GetExprCtx().GetEvalCtx()
 	for _, access := range ijHelper.chosenAccess {
 		if !isFirst {
 			buffer.WriteString(" ")
 		} else {
 			isFirst = false
 		}
-		fmt.Fprintf(buffer, "%v", access)
+		fmt.Fprintf(buffer, "%v", access.StringWithCtx(ectx))
 	}
 	buffer.WriteString("]")
 	return buffer.String()
@@ -1799,7 +1800,8 @@ func (ijHelper *indexJoinBuildHelper) updateByTemplateRangeResult(tempRangeRes *
 		ijHelper.curIdxOff2KeyOff[i] = -1
 	}
 	newAccesses = accesses[:tempRangeRes.eqAndInCntInRange]
-	newRemained = ranger.AppendConditionsIfNotExist(remained, accesses[tempRangeRes.eqAndInCntInRange:])
+	newRemained = ranger.AppendConditionsIfNotExist(ijHelper.innerPlan.SCtx().GetExprCtx().GetEvalCtx(),
+		remained, accesses[tempRangeRes.eqAndInCntInRange:])
 	return
 }
 
@@ -1821,7 +1823,7 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(path *util.AccessPath
 		return false, nil
 	}
 	accesses = append(accesses, notKeyEqAndIn...)
-	remained = ranger.AppendConditionsIfNotExist(remained, remainedEqAndIn)
+	remained = ranger.AppendConditionsIfNotExist(innerPlan.SCtx().GetExprCtx().GetEvalCtx(), remained, remainedEqAndIn)
 	lastColPos := matchedKeyCnt + len(notKeyEqAndIn)
 	// There should be some equal conditions. But we don't need that there must be some join key in accesses here.
 	// A more strict check is applied later.
@@ -3202,6 +3204,19 @@ func getEnforcedStreamAggs(la *LogicalAggregation, prop *property.PhysicalProper
 		enforcedAggs = append(enforcedAggs, agg)
 	}
 	return enforcedAggs
+}
+
+func (la *LogicalAggregation) distinctArgsMeetsProperty() bool {
+	for _, aggFunc := range la.AggFuncs {
+		if aggFunc.HasDistinct {
+			for _, distinctArg := range aggFunc.Args {
+				if !expression.Contains(la.SCtx().GetExprCtx().GetEvalCtx(), la.GroupByItems, distinctArg) {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 func getStreamAggs(lp base.LogicalPlan, prop *property.PhysicalProperty) []base.PhysicalPlan {

--- a/pkg/planner/core/exhaust_physical_plans_test.go
+++ b/pkg/planner/core/exhaust_physical_plans_test.go
@@ -204,10 +204,11 @@ func testAnalyzeLookUpFilters(t *testing.T, testCtx *indexJoinContext, testCase 
 	if testCase.rebuildMode {
 		require.Equal(t, testCase.ranges, fmt.Sprintf("%v", helper.chosenRanges.Range()), msgAndArgs)
 	} else {
-		require.Equal(t, testCase.accesses, fmt.Sprintf("%v", helper.chosenAccess), msgAndArgs)
+		ectx := ctx.GetExprCtx().GetEvalCtx()
+		require.Equal(t, testCase.accesses, expression.StringifyExpressionsWithCtx(ectx, helper.chosenAccess), msgAndArgs)
 		require.Equal(t, testCase.ranges, fmt.Sprintf("%v", helper.chosenRanges.Range()), msgAndArgs)
 		require.Equal(t, testCase.idxOff2KeyOff, fmt.Sprintf("%v", helper.idxOff2KeyOff), msgAndArgs)
-		require.Equal(t, testCase.remained, fmt.Sprintf("%v", helper.chosenRemained), msgAndArgs)
+		require.Equal(t, testCase.remained, expression.StringifyExpressionsWithCtx(ectx, helper.chosenRemained), msgAndArgs)
 		require.Equal(t, testCase.compareFilters, fmt.Sprintf("%v", helper.lastColManager), msgAndArgs)
 	}
 	return helper

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1898,7 +1898,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 					if c.GetType(er.sctx.GetEvalCtx()).EvalType() == types.ETInt {
 						continue // no need to refine it
 					}
-					er.sctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", c.String()))
+					er.sctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", c.StringWithCtx(er.sctx.GetEvalCtx())))
 					if err := expression.RemoveMutableConst(er.sctx, []expression.Expression{c}); err != nil {
 						er.err = err
 						return

--- a/pkg/planner/core/indexmerge_test.go
+++ b/pkg/planner/core/indexmerge_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -29,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getIndexMergePathDigest(paths []*util.AccessPath, startIndex int) string {
+func getIndexMergePathDigest(ctx expression.EvalContext, paths []*util.AccessPath, startIndex int) string {
 	if len(paths) == startIndex {
 		return "[]"
 	}
@@ -59,7 +60,7 @@ func getIndexMergePathDigest(paths []*util.AccessPath, startIndex int) string {
 			if j > 0 {
 				idxMergeDisgest += ","
 			}
-			idxMergeDisgest += path.TableFilters[j].String()
+			idxMergeDisgest += path.TableFilters[j].StringWithCtx(ctx)
 		}
 		idxMergeDisgest += "]}"
 	}
@@ -111,7 +112,7 @@ func TestIndexMergePathGeneration(t *testing.T) {
 		idxMergeStartIndex := len(ds.PossibleAccessPaths)
 		_, err = lp.RecursiveDeriveStats(nil)
 		require.NoError(t, err)
-		result := getIndexMergePathDigest(ds.PossibleAccessPaths, idxMergeStartIndex)
+		result := getIndexMergePathDigest(sctx.GetExprCtx().GetEvalCtx(), ds.PossibleAccessPaths, idxMergeStartIndex)
 		testdata.OnRecord(func() {
 			output[i] = result
 		})

--- a/pkg/planner/core/logical_aggregation.go
+++ b/pkg/planner/core/logical_aggregation.go
@@ -593,7 +593,7 @@ func (la *LogicalAggregation) DistinctArgsMeetsProperty() bool {
 	for _, aggFunc := range la.AggFuncs {
 		if aggFunc.HasDistinct {
 			for _, distinctArg := range aggFunc.Args {
-				if !expression.Contains(la.GroupByItems, distinctArg) {
+				if !expression.Contains(la.SCtx().GetExprCtx().GetEvalCtx(), la.GroupByItems, distinctArg) {
 					return false
 				}
 			}

--- a/pkg/planner/core/logical_limit.go
+++ b/pkg/planner/core/logical_limit.go
@@ -48,9 +48,10 @@ func (p LogicalLimit) Init(ctx base.PlanContext, offset int) *LogicalLimit {
 
 // ExplainInfo implements Plan interface.
 func (p *LogicalLimit) ExplainInfo() string {
+	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	buffer := bytes.NewBufferString("")
 	if len(p.GetPartitionBy()) > 0 {
-		buffer = explainPartitionBy(buffer, p.GetPartitionBy(), false)
+		buffer = explainPartitionBy(ectx, buffer, p.GetPartitionBy(), false)
 		fmt.Fprintf(buffer, ", offset:%v, count:%v", p.Offset, p.Count)
 	} else {
 		fmt.Fprintf(buffer, "offset:%v, count:%v", p.Offset, p.Count)

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -197,6 +197,7 @@ func TestJoinPredicatePushDown(t *testing.T) {
 	s := createPlannerSuite()
 	defer s.Close()
 	ctx := context.Background()
+	ectx := s.ctx.GetExprCtx().GetEvalCtx()
 	for i, ca := range input {
 		comment := fmt.Sprintf("for %s", ca)
 		stmt, err := s.p.ParseOneStmt(ca, "", "")
@@ -213,8 +214,8 @@ func TestJoinPredicatePushDown(t *testing.T) {
 		require.True(t, ok, comment)
 		rightPlan, ok := join.Children()[1].(*DataSource)
 		require.True(t, ok, comment)
-		leftCond := fmt.Sprintf("%s", leftPlan.PushedDownConds)
-		rightCond := fmt.Sprintf("%s", rightPlan.PushedDownConds)
+		leftCond := expression.StringifyExpressionsWithCtx(ectx, leftPlan.PushedDownConds)
+		rightCond := expression.StringifyExpressionsWithCtx(ectx, rightPlan.PushedDownConds)
 		testdata.OnRecord(func() {
 			output[i].Left, output[i].Right = leftCond, rightCond
 		})
@@ -237,6 +238,7 @@ func TestOuterWherePredicatePushDown(t *testing.T) {
 	s := createPlannerSuite()
 	defer s.Close()
 	ctx := context.Background()
+	ectx := s.ctx.GetExprCtx().GetEvalCtx()
 	for i, ca := range input {
 		comment := fmt.Sprintf("for %s", ca)
 		stmt, err := s.p.ParseOneStmt(ca, "", "")
@@ -249,7 +251,7 @@ func TestOuterWherePredicatePushDown(t *testing.T) {
 		require.True(t, ok, comment)
 		selection, ok := proj.Children()[0].(*LogicalSelection)
 		require.True(t, ok, comment)
-		selCond := fmt.Sprintf("%s", selection.Conditions)
+		selCond := expression.StringifyExpressionsWithCtx(ectx, selection.Conditions)
 		testdata.OnRecord(func() {
 			output[i].Sel = selCond
 		})
@@ -260,8 +262,8 @@ func TestOuterWherePredicatePushDown(t *testing.T) {
 		require.True(t, ok, comment)
 		rightPlan, ok := join.Children()[1].(*DataSource)
 		require.True(t, ok, comment)
-		leftCond := fmt.Sprintf("%s", leftPlan.PushedDownConds)
-		rightCond := fmt.Sprintf("%s", rightPlan.PushedDownConds)
+		leftCond := expression.StringifyExpressionsWithCtx(ectx, leftPlan.PushedDownConds)
+		rightCond := expression.StringifyExpressionsWithCtx(ectx, rightPlan.PushedDownConds)
 		testdata.OnRecord(func() {
 			output[i].Left, output[i].Right = leftCond, rightCond
 		})
@@ -352,6 +354,7 @@ func TestDeriveNotNullConds(t *testing.T) {
 	s := createPlannerSuite()
 	defer s.Close()
 	ctx := context.Background()
+	ectx := s.ctx.GetExprCtx().GetEvalCtx()
 	for i, ca := range input {
 		comment := fmt.Sprintf("for %s", ca)
 		stmt, err := s.p.ParseOneStmt(ca, "", "")
@@ -367,8 +370,8 @@ func TestDeriveNotNullConds(t *testing.T) {
 		join := p.(base.LogicalPlan).Children()[0].(*LogicalJoin)
 		left := join.Children()[0].(*DataSource)
 		right := join.Children()[1].(*DataSource)
-		leftConds := fmt.Sprintf("%s", left.PushedDownConds)
-		rightConds := fmt.Sprintf("%s", right.PushedDownConds)
+		leftConds := expression.StringifyExpressionsWithCtx(ectx, left.PushedDownConds)
+		rightConds := expression.StringifyExpressionsWithCtx(ectx, right.PushedDownConds)
 		testdata.OnRecord(func() {
 			output[i].Left, output[i].Right = leftConds, rightConds
 		})
@@ -478,7 +481,7 @@ func TestDupRandJoinCondsPushDown(t *testing.T) {
 	require.True(t, ok, comment)
 	leftPlan, ok := join.Children()[0].(*LogicalSelection)
 	require.True(t, ok, comment)
-	leftCond := fmt.Sprintf("%s", leftPlan.Conditions)
+	leftCond := expression.StringifyExpressionsWithCtx(s.ctx.GetExprCtx().GetEvalCtx(), leftPlan.Conditions)
 	// Condition with mutable function cannot be de-duplicated when push down join conds.
 	require.Equal(t, "[gt(cast(test.t.a, double BINARY), rand()) gt(cast(test.t.a, double BINARY), rand())]", leftCond, comment)
 }
@@ -774,6 +777,7 @@ func TestAllocID(t *testing.T) {
 }
 
 func checkDataSourceCols(p base.LogicalPlan, t *testing.T, ans map[int][]string, comment string) {
+	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	switch v := p.(type) {
 	case *DataSource, *LogicalUnionAll, *LogicalLimit:
 		testdata.OnRecord(func() {
@@ -784,9 +788,9 @@ func checkDataSourceCols(p base.LogicalPlan, t *testing.T, ans map[int][]string,
 		require.Equal(t, len(colList), len(p.Schema().Columns), comment)
 		for i, col := range p.Schema().Columns {
 			testdata.OnRecord(func() {
-				colList[i] = col.String()
+				colList[i] = col.StringWithCtx(ectx)
 			})
-			require.Equal(t, colList[i], col.String(), comment)
+			require.Equal(t, colList[i], col.StringWithCtx(ectx), comment)
 		}
 	}
 	for _, child := range p.Children() {
@@ -795,6 +799,7 @@ func checkDataSourceCols(p base.LogicalPlan, t *testing.T, ans map[int][]string,
 }
 
 func checkOrderByItems(p base.LogicalPlan, t *testing.T, colList *[]string, comment string) {
+	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	switch p := p.(type) {
 	case *LogicalSort:
 		testdata.OnRecord(func() {
@@ -802,9 +807,9 @@ func checkOrderByItems(p base.LogicalPlan, t *testing.T, colList *[]string, comm
 		})
 		for i, col := range p.ByItems {
 			testdata.OnRecord(func() {
-				(*colList)[i] = col.String()
+				(*colList)[i] = col.StringWithCtx(ectx)
 			})
-			s := col.String()
+			s := col.StringWithCtx(ectx)
 			require.Equal(t, (*colList)[i], s, comment)
 		}
 	}
@@ -1010,6 +1015,7 @@ func TestValidate(t *testing.T) {
 }
 
 func checkUniqueKeys(p base.LogicalPlan, t *testing.T, ans map[int][][]string, sql string) {
+	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	testdata.OnRecord(func() {
 		ans[p.ID()] = make([][]string, len(p.Schema().Keys))
 	})
@@ -1023,9 +1029,9 @@ func checkUniqueKeys(p base.LogicalPlan, t *testing.T, ans map[int][][]string, s
 		require.Equal(t, len(keyList[i]), len(p.Schema().Keys[i]), fmt.Sprintf("for %s, %v %v, the number of column doesn't match", sql, p.ID(), keyList[i]))
 		for j := range keyList[i] {
 			testdata.OnRecord(func() {
-				keyList[i][j] = p.Schema().Keys[i][j].String()
+				keyList[i][j] = p.Schema().Keys[i][j].StringWithCtx(ectx)
 			})
-			require.Equal(t, keyList[i][j], p.Schema().Keys[i][j].String(), fmt.Sprintf("for %s, %v %v, column dosen't match", sql, p.ID(), keyList[i]))
+			require.Equal(t, keyList[i][j], p.Schema().Keys[i][j].StringWithCtx(ectx), fmt.Sprintf("for %s, %v %v, column dosen't match", sql, p.ID(), keyList[i]))
 		}
 	}
 	testdata.OnRecord(func() {
@@ -2348,11 +2354,11 @@ func TestRollupExpand(t *testing.T) {
 	require.Equal(t, builder.currentBlockExpand.LevelExprs != nil, true)
 	require.Equal(t, len(builder.currentBlockExpand.LevelExprs), 3)
 	// for grouping set {}: gid = '00' = 0
-	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[0], expand.Schema()), "test.t.a, <nil>->Column#13, <nil>->Column#14, 0->gid")
+	require.Equal(t, expression.ExplainExpressionList(s.ctx.GetExprCtx().GetEvalCtx(), expand.LevelExprs[0], expand.Schema()), "test.t.a, <nil>->Column#13, <nil>->Column#14, 0->gid")
 	// for grouping set {a}: gid = '01' = 1
-	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[1], expand.Schema()), "test.t.a, Column#13, <nil>->Column#14, 1->gid")
+	require.Equal(t, expression.ExplainExpressionList(s.ctx.GetExprCtx().GetEvalCtx(), expand.LevelExprs[1], expand.Schema()), "test.t.a, Column#13, <nil>->Column#14, 1->gid")
 	// for grouping set {a,b}: gid = '11' = 3
-	require.Equal(t, expression.ExplainExpressionList(expand.LevelExprs[2], expand.Schema()), "test.t.a, Column#13, Column#14, 3->gid")
+	require.Equal(t, expression.ExplainExpressionList(s.ctx.GetExprCtx().GetEvalCtx(), expand.LevelExprs[2], expand.Schema()), "test.t.a, Column#13, Column#14, 3->gid")
 
 	require.Equal(t, expand.Schema().Len(), 4)
 	// source column a should be kept as real.

--- a/pkg/planner/core/logical_top_n.go
+++ b/pkg/planner/core/logical_top_n.go
@@ -49,8 +49,9 @@ func (lt LogicalTopN) Init(ctx base.PlanContext, offset int) *LogicalTopN {
 
 // ExplainInfo implements Plan interface.
 func (lt *LogicalTopN) ExplainInfo() string {
+	ectx := lt.SCtx().GetExprCtx().GetEvalCtx()
 	buffer := bytes.NewBufferString("")
-	buffer = explainPartitionBy(buffer, lt.GetPartitionBy(), false)
+	buffer = explainPartitionBy(ectx, buffer, lt.GetPartitionBy(), false)
 	if len(lt.GetPartitionBy()) > 0 && len(lt.ByItems) > 0 {
 		buffer.WriteString("order by ")
 	}

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tidb/pkg/util/set"
@@ -75,7 +76,13 @@ func (extractHelper) extractColInConsExpr(ctx base.PlanContext, extractCols map[
 		}
 		v := constant.Value
 		if constant.ParamMarker != nil {
-			v = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
+			var err error
+			v, err = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
+			intest.AssertNoError(err, "fail to get param")
+			if err != nil {
+				logutil.BgLogger().Warn("fail to get param", zap.Error(err))
+				return "", nil
+			}
 		}
 		results = append(results, v)
 	}
@@ -157,7 +164,13 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(ctx base.PlanContext, ex
 	}
 	v := constant.Value
 	if constant.ParamMarker != nil {
-		v = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
+		var err error
+		v, err = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
+		intest.AssertNoError(err, "fail to get param")
+		if err != nil {
+			logutil.BgLogger().Warn("fail to get param", zap.Error(err))
+			return "", nil
+		}
 	}
 	return name.ColName.L, []types.Datum{v}
 }

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -515,5 +515,5 @@ func TestPhysicalTableScanExtractCorrelatedCols(t *testing.T) {
 	// make sure the correlated columns are extracted correctly
 	correlated := ts.ExtractCorrelatedCols()
 	require.Equal(t, 1, len(correlated))
-	require.Equal(t, "test.t2.company_no", correlated[0].String())
+	require.Equal(t, "test.t2.company_no", correlated[0].StringWithCtx(tk.Session().GetExprCtx().GetEvalCtx()))
 }

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -665,15 +665,16 @@ func isSafePointGetPath4PlanCacheScenario3(path *util.AccessPath) bool {
 
 // parseParamTypes get parameters' types in PREPARE statement
 func parseParamTypes(sctx sessionctx.Context, params []expression.Expression) (paramTypes []*types.FieldType) {
+	ectx := sctx.GetExprCtx().GetEvalCtx()
 	paramTypes = make([]*types.FieldType, 0, len(params))
 	for _, param := range params {
 		if c, ok := param.(*expression.Constant); ok { // from binary protocol
-			paramTypes = append(paramTypes, c.GetType(sctx.GetExprCtx().GetEvalCtx()))
+			paramTypes = append(paramTypes, c.GetType(ectx))
 			continue
 		}
 
 		// from text protocol, there must be a GetVar function
-		name := param.(*expression.ScalarFunction).GetArgs()[0].String()
+		name := param.(*expression.ScalarFunction).GetArgs()[0].StringWithCtx(ectx)
 		tp, ok := sctx.GetSessionVars().GetUserVarType(name)
 		if !ok {
 			tp = types.NewFieldType(mysql.TypeNull)

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -687,13 +687,14 @@ func (*aggregationPushDownSolver) name() string {
 
 func appendAggPushDownAcrossJoinTraceStep(oldAgg, newAgg *LogicalAggregation, aggFuncs []*aggregation.AggFuncDesc, join *LogicalJoin,
 	childIdx int, opt *optimizetrace.LogicalOptimizeOp) {
+	evalCtx := oldAgg.SCtx().GetExprCtx().GetEvalCtx()
 	reason := func() string {
 		buffer := bytes.NewBufferString(fmt.Sprintf("%v_%v's functions[", oldAgg.TP(), oldAgg.ID()))
 		for i, aggFunc := range aggFuncs {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(aggFunc.String())
+			buffer.WriteString(aggFunc.StringWithCtx(evalCtx))
 		}
 		buffer.WriteString("] are decomposable with join")
 		return buffer.String()
@@ -712,13 +713,14 @@ func appendAggPushDownAcrossJoinTraceStep(oldAgg, newAgg *LogicalAggregation, ag
 }
 
 func appendAggPushDownAcrossProjTraceStep(agg *LogicalAggregation, proj *LogicalProjection, opt *optimizetrace.LogicalOptimizeOp) {
+	evalCtx := agg.SCtx().GetExprCtx().GetEvalCtx()
 	action := func() string {
 		buffer := bytes.NewBufferString(fmt.Sprintf("%v_%v is eliminated, and %v_%v's functions changed into[", proj.TP(), proj.ID(), agg.TP(), agg.ID()))
 		for i, aggFunc := range agg.AggFuncs {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(aggFunc.String())
+			buffer.WriteString(aggFunc.StringWithCtx(evalCtx))
 		}
 		buffer.WriteString("]")
 		return buffer.String()
@@ -730,13 +732,14 @@ func appendAggPushDownAcrossProjTraceStep(agg *LogicalAggregation, proj *Logical
 }
 
 func appendAggPushDownAcrossUnionTraceStep(union *LogicalUnionAll, agg *LogicalAggregation, opt *optimizetrace.LogicalOptimizeOp) {
+	evalCtx := union.SCtx().GetExprCtx().GetEvalCtx()
 	reason := func() string {
 		buffer := bytes.NewBufferString(fmt.Sprintf("%v_%v functions[", agg.TP(), agg.ID()))
 		for i, aggFunc := range agg.AggFuncs {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(aggFunc.String())
+			buffer.WriteString(aggFunc.StringWithCtx(evalCtx))
 		}
 		fmt.Fprintf(buffer, "] are decomposable with %v_%v", union.TP(), union.ID())
 		return buffer.String()

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -525,27 +525,29 @@ func appendAddProjTraceStep(p *LogicalApply, proj *LogicalProjection, opt *optim
 func appendModifyAggTraceStep(outerPlan base.LogicalPlan, p *LogicalApply, agg *LogicalAggregation, sel *LogicalSelection,
 	appendedGroupByCols *expression.Schema, appendedAggFuncs []*aggregation.AggFuncDesc,
 	eqCondWithCorCol []*expression.ScalarFunction, opt *optimizetrace.LogicalOptimizeOp) {
+	evalCtx := outerPlan.SCtx().GetExprCtx().GetEvalCtx()
+
 	action := func() string {
 		buffer := bytes.NewBufferString(fmt.Sprintf("%v_%v's groupby items added [", agg.TP(), agg.ID()))
 		for i, col := range appendedGroupByCols.Columns {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(col.String())
+			buffer.WriteString(col.StringWithCtx(evalCtx))
 		}
 		buffer.WriteString("], and functions added [")
 		for i, f := range appendedAggFuncs {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(f.String())
+			buffer.WriteString(f.StringWithCtx(evalCtx))
 		}
 		fmt.Fprintf(buffer, "], and %v_%v's conditions added [", p.TP(), p.ID())
 		for i, cond := range eqCondWithCorCol {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.String())
+			buffer.WriteString(cond.StringWithCtx(evalCtx))
 		}
 		buffer.WriteString("]")
 		return buffer.String()
@@ -556,7 +558,7 @@ func appendModifyAggTraceStep(outerPlan base.LogicalPlan, p *LogicalApply, agg *
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.String())
+			buffer.WriteString(cond.StringWithCtx(evalCtx))
 		}
 		fmt.Fprintf(buffer, "] are correlated to %v_%v and pulled up as %v_%v's join key",
 			outerPlan.TP(), outerPlan.ID(), p.TP(), p.ID())

--- a/pkg/planner/core/rule_eliminate_projection.go
+++ b/pkg/planner/core/rule_eliminate_projection.go
@@ -314,6 +314,7 @@ func (*projectionEliminator) name() string {
 }
 
 func appendDupProjEliminateTraceStep(parent, child *LogicalProjection, opt *optimizetrace.LogicalOptimizeOp) {
+	ectx := parent.SCtx().GetExprCtx().GetEvalCtx()
 	action := func() string {
 		buffer := bytes.NewBufferString(
 			fmt.Sprintf("%v_%v is eliminated, %v_%v's expressions changed into[", child.TP(), child.ID(), parent.TP(), parent.ID()))
@@ -321,7 +322,7 @@ func appendDupProjEliminateTraceStep(parent, child *LogicalProjection, opt *opti
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(expr.String())
+			buffer.WriteString(expr.StringWithCtx(ectx))
 		}
 		buffer.WriteString("]")
 		return buffer.String()

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -101,12 +101,13 @@ func tryToSubstituteExpr(expr *expression.Expression, lp base.LogicalPlan, candi
 
 func appendSubstituteColumnStep(lp base.LogicalPlan, candidateExpr expression.Expression, col *expression.Column, opt *optimizetrace.LogicalOptimizeOp) {
 	reason := func() string { return "" }
+	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	action := func() string {
 		buffer := bytes.NewBufferString("expression:")
-		buffer.WriteString(candidateExpr.String())
+		buffer.WriteString(candidateExpr.StringWithCtx(ectx))
 		buffer.WriteString(" substituted by")
 		buffer.WriteString(" column:")
-		buffer.WriteString(col.String())
+		buffer.WriteString(col.StringWithCtx(ectx))
 		return buffer.String()
 	}
 	opt.AppendStepToCurrent(lp.ID(), lp.TP(), reason, action)

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -259,20 +259,21 @@ func (*outerJoinEliminator) name() string {
 
 func appendOuterJoinEliminateTraceStep(join *LogicalJoin, outerPlan base.LogicalPlan, parentCols []*expression.Column,
 	innerJoinKeys *expression.Schema, opt *optimizetrace.LogicalOptimizeOp) {
+	ectx := join.SCtx().GetExprCtx().GetEvalCtx()
 	reason := func() string {
 		buffer := bytes.NewBufferString("The columns[")
 		for i, col := range parentCols {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(col.String())
+			buffer.WriteString(col.StringWithCtx(ectx))
 		}
 		buffer.WriteString("] are from outer table, and the inner join keys[")
 		for i, key := range innerJoinKeys.Columns {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(key.String())
+			buffer.WriteString(key.StringWithCtx(ectx))
 		}
 		buffer.WriteString("] are unique")
 		return buffer.String()
@@ -284,13 +285,14 @@ func appendOuterJoinEliminateTraceStep(join *LogicalJoin, outerPlan base.Logical
 }
 
 func appendOuterJoinEliminateAggregationTraceStep(join *LogicalJoin, outerPlan base.LogicalPlan, aggCols []*expression.Column, opt *optimizetrace.LogicalOptimizeOp) {
+	ectx := join.SCtx().GetExprCtx().GetEvalCtx()
 	reason := func() string {
 		buffer := bytes.NewBufferString("The columns[")
 		for i, col := range aggCols {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(col.String())
+			buffer.WriteString(col.StringWithCtx(ectx))
 		}
 		buffer.WriteString("] in agg are from outer table, and the agg functions are duplicate agnostic")
 		return buffer.String()

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -490,7 +490,9 @@ func (*partitionProcessor) reconstructTableColNames(ds *DataSource) ([]*types.Fi
 			})
 			continue
 		}
-		return nil, errors.Trace(fmt.Errorf("information of column %v is not found", colExpr.String()))
+
+		ectx := ds.SCtx().GetExprCtx().GetEvalCtx()
+		return nil, errors.Trace(fmt.Errorf("information of column %v is not found", colExpr.StringWithCtx(ectx)))
 	}
 	return names, nil
 }

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -600,13 +600,14 @@ func appendTableDualTraceStep(replaced base.LogicalPlan, dual base.LogicalPlan, 
 	action := func() string {
 		return fmt.Sprintf("%v_%v is replaced by %v_%v", replaced.TP(), replaced.ID(), dual.TP(), dual.ID())
 	}
+	ectx := replaced.SCtx().GetExprCtx().GetEvalCtx()
 	reason := func() string {
 		buffer := bytes.NewBufferString("The conditions[")
 		for i, cond := range conditions {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.String())
+			buffer.WriteString(cond.StringWithCtx(ectx))
 		}
 		buffer.WriteString("] are constant false or null")
 		return buffer.String()
@@ -622,13 +623,14 @@ func appendSelectionPredicatePushDownTraceStep(p *LogicalSelection, conditions [
 		return ""
 	}
 	if len(conditions) > 0 {
+		evalCtx := p.SCtx().GetExprCtx().GetEvalCtx()
 		reason = func() string {
 			buffer := bytes.NewBufferString("The conditions[")
 			for i, cond := range conditions {
 				if i > 0 {
 					buffer.WriteString(",")
 				}
-				buffer.WriteString(cond.String())
+				buffer.WriteString(cond.StringWithCtx(evalCtx))
 			}
 			fmt.Fprintf(buffer, "] in %v_%v are pushed down", p.TP(), p.ID())
 			return buffer.String()
@@ -641,6 +643,7 @@ func appendDataSourcePredicatePushDownTraceStep(ds *DataSource, opt *optimizetra
 	if len(ds.PushedDownConds) < 1 {
 		return
 	}
+	ectx := ds.SCtx().GetExprCtx().GetEvalCtx()
 	reason := func() string {
 		return ""
 	}
@@ -650,7 +653,7 @@ func appendDataSourcePredicatePushDownTraceStep(ds *DataSource, opt *optimizetra
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.String())
+			buffer.WriteString(cond.StringWithCtx(ectx))
 		}
 		fmt.Fprintf(buffer, "] are pushed down across %v_%v", ds.TP(), ds.ID())
 		return buffer.String()

--- a/pkg/planner/core/rule_topn_push_down.go
+++ b/pkg/planner/core/rule_topn_push_down.go
@@ -183,6 +183,7 @@ func appendTopNPushDownTraceStep(parent base.LogicalPlan, child base.LogicalPlan
 }
 
 func appendTopNPushDownJoinTraceStep(p *LogicalJoin, topN *LogicalTopN, idx int, opt *optimizetrace.LogicalOptimizeOp) {
+	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	action := func() string {
 		buffer := bytes.NewBufferString(fmt.Sprintf("%v_%v is added and pushed into %v_%v's ",
 			topN.TP(), topN.ID(), p.TP(), p.ID()))
@@ -200,7 +201,7 @@ func appendTopNPushDownJoinTraceStep(p *LogicalJoin, topN *LogicalTopN, idx int,
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(item.String())
+			buffer.WriteString(item.StringWithCtx(ectx))
 		}
 		buffer.WriteString("] contained in ")
 		if idx == 0 {
@@ -215,13 +216,14 @@ func appendTopNPushDownJoinTraceStep(p *LogicalJoin, topN *LogicalTopN, idx int,
 }
 
 func appendSortPassByItemsTraceStep(sort *LogicalSort, topN *LogicalTopN, opt *optimizetrace.LogicalOptimizeOp) {
+	ectx := sort.SCtx().GetExprCtx().GetEvalCtx()
 	action := func() string {
 		buffer := bytes.NewBufferString(fmt.Sprintf("%v_%v passes ByItems[", sort.TP(), sort.ID()))
 		for i, item := range sort.ByItems {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(item.String())
+			buffer.WriteString(item.StringWithCtx(ectx))
 		}
 		fmt.Fprintf(buffer, "] to %v_%v", topN.TP(), topN.ID())
 		return buffer.String()

--- a/pkg/planner/core/runtime_filter.go
+++ b/pkg/planner/core/runtime_filter.go
@@ -216,12 +216,13 @@ func RuntimeFilterListToPB(ctx *base.BuildPBContext, runtimeFilterList []*Runtim
 
 // ToPB convert runtime filter to PB
 func (rf *RuntimeFilter) ToPB(ctx *base.BuildPBContext, client kv.Client) (*tipb.RuntimeFilter, error) {
-	pc := expression.NewPBConverter(client, ctx.GetExprCtx().GetEvalCtx())
+	ectx := ctx.GetExprCtx().GetEvalCtx()
+	pc := expression.NewPBConverter(client, ectx)
 	srcExprListPB := make([]*tipb.Expr, 0, len(rf.srcExprList))
 	for _, srcExpr := range rf.srcExprList {
 		srcExprPB := pc.ExprToPB(srcExpr)
 		if srcExprPB == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform src expr %s to pb in runtime filter", srcExpr.String())
+			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform src expr %s to pb in runtime filter", srcExpr.StringWithCtx(ectx))
 		}
 		srcExprListPB = append(srcExprListPB, srcExprPB)
 	}
@@ -229,7 +230,7 @@ func (rf *RuntimeFilter) ToPB(ctx *base.BuildPBContext, client kv.Client) (*tipb
 	for _, targetExpr := range rf.targetExprList {
 		targetExprPB := pc.ExprToPB(targetExpr)
 		if targetExprPB == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform target expr %s to pb in runtime filter", targetExpr.String())
+			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform target expr %s to pb in runtime filter", targetExpr.StringWithCtx(ectx))
 		}
 		targetExprListPB = append(targetExprListPB, targetExprPB)
 	}

--- a/pkg/planner/core/tiflash_selection_late_materialization.go
+++ b/pkg/planner/core/tiflash_selection_late_materialization.go
@@ -217,7 +217,7 @@ func withHeavyCostFunctionForTiFlashPrefetch(cond expression.Expression) bool {
 func removeSpecificExprsFromSelection(physicalSelection *PhysicalSelection, exprs []expression.Expression) {
 	conditions := physicalSelection.Conditions
 	for i := len(conditions) - 1; i >= 0; i-- {
-		if expression.Contains(exprs, conditions[i]) {
+		if expression.Contains(physicalSelection.SCtx().GetExprCtx().GetEvalCtx(), exprs, conditions[i]) {
 			conditions = append(conditions[:i], conditions[i+1:]...)
 		}
 	}

--- a/pkg/planner/util/byitem.go
+++ b/pkg/planner/util/byitem.go
@@ -29,7 +29,7 @@ type ByItems struct {
 }
 
 // StringWithCtx implements expression.StringerWithCtx interface.
-func (by *ByItems) StringWithCtx(ctx expression.EvalContext) string {
+func (by *ByItems) StringWithCtx(ctx expression.ParamValues) string {
 	if by.Desc {
 		return fmt.Sprintf("%s true", by.Expr.StringWithCtx(ctx))
 	}

--- a/pkg/planner/util/byitem.go
+++ b/pkg/planner/util/byitem.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/util/size"
@@ -27,12 +28,12 @@ type ByItems struct {
 	Desc bool
 }
 
-// String implements fmt.Stringer interface.
-func (by *ByItems) String() string {
+// StringWithCtx implements expression.StringerWithCtx interface.
+func (by *ByItems) StringWithCtx(ctx expression.EvalContext) string {
 	if by.Desc {
-		return fmt.Sprintf("%s true", by.Expr)
+		return fmt.Sprintf("%s true", by.Expr.StringWithCtx(ctx))
 	}
-	return by.Expr.String()
+	return by.Expr.StringWithCtx(ctx)
 }
 
 // Clone makes a copy of ByItems.
@@ -56,4 +57,18 @@ func (by *ByItems) MemoryUsage() (sum int64) {
 		sum += by.Expr.MemoryUsage()
 	}
 	return sum
+}
+
+// StringifyByItemsWithCtx is used to print ByItems slice.
+func StringifyByItemsWithCtx(ctx expression.EvalContext, byItems []*ByItems) string {
+	sb := strings.Builder{}
+	sb.WriteString("[")
+	for i, item := range byItems {
+		sb.WriteString(item.StringWithCtx(ctx))
+		if i != len(byItems)-1 {
+			sb.WriteString(" ")
+		}
+	}
+	sb.WriteString("]")
+	return sb.String()
 }

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -48,8 +48,8 @@ type HandleCols interface {
 	ResolveIndices(schema *expression.Schema) (HandleCols, error)
 	// IsInt returns if the HandleCols is a single int column.
 	IsInt() bool
-	// String implements the fmt.Stringer interface.
-	String() string
+	// StringWithCtx implements the expression.StringerWithCtx interface.
+	StringWithCtx(ctx expression.EvalContext) string
 	// GetCol gets the column by idx.
 	GetCol(idx int) *expression.Column
 	// NumCols returns the number of columns.
@@ -161,15 +161,15 @@ func (cb *CommonHandleCols) NumCols() int {
 	return len(cb.columns)
 }
 
-// String implements the kv.HandleCols interface.
-func (cb *CommonHandleCols) String() string {
+// StringWithCtx implements the kv.HandleCols interface.
+func (cb *CommonHandleCols) StringWithCtx(ctx expression.EvalContext) string {
 	b := new(strings.Builder)
 	b.WriteByte('[')
 	for i, col := range cb.columns {
 		if i != 0 {
 			b.WriteByte(',')
 		}
-		b.WriteString(col.ColumnExplainInfo(false))
+		b.WriteString(col.ColumnExplainInfo(ctx, false))
 	}
 	b.WriteByte(']')
 	return b.String()
@@ -283,9 +283,9 @@ func (*IntHandleCols) IsInt() bool {
 	return true
 }
 
-// String implements the kv.HandleCols interface.
-func (ib *IntHandleCols) String() string {
-	return ib.col.ColumnExplainInfo(false)
+// StringWithCtx implements the kv.HandleCols interface.
+func (ib *IntHandleCols) StringWithCtx(ctx expression.EvalContext) string {
+	return ib.col.ColumnExplainInfo(ctx, false)
 }
 
 // GetCol implements the kv.HandleCols interface.

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -33,6 +33,8 @@ import (
 
 // HandleCols is the interface that holds handle columns.
 type HandleCols interface {
+	expression.StringerWithCtx
+
 	// BuildHandle builds a Handle from a row.
 	BuildHandle(row chunk.Row) (kv.Handle, error)
 	// BuildHandleByDatums builds a Handle from a datum slice.
@@ -48,8 +50,6 @@ type HandleCols interface {
 	ResolveIndices(schema *expression.Schema) (HandleCols, error)
 	// IsInt returns if the HandleCols is a single int column.
 	IsInt() bool
-	// StringWithCtx implements the expression.StringerWithCtx interface.
-	StringWithCtx(ctx expression.EvalContext) string
 	// GetCol gets the column by idx.
 	GetCol(idx int) *expression.Column
 	// NumCols returns the number of columns.
@@ -162,7 +162,7 @@ func (cb *CommonHandleCols) NumCols() int {
 }
 
 // StringWithCtx implements the kv.HandleCols interface.
-func (cb *CommonHandleCols) StringWithCtx(ctx expression.EvalContext) string {
+func (cb *CommonHandleCols) StringWithCtx(ctx expression.ParamValues) string {
 	b := new(strings.Builder)
 	b.WriteByte('[')
 	for i, col := range cb.columns {
@@ -284,7 +284,7 @@ func (*IntHandleCols) IsInt() bool {
 }
 
 // StringWithCtx implements the kv.HandleCols interface.
-func (ib *IntHandleCols) StringWithCtx(ctx expression.EvalContext) string {
+func (ib *IntHandleCols) StringWithCtx(ctx expression.ParamValues) string {
 	return ib.col.ColumnExplainInfo(ctx, false)
 }
 

--- a/pkg/planner/util/optimizetrace/logicaltrace/logical_tracer.go
+++ b/pkg/planner/util/optimizetrace/logicaltrace/logical_tracer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 )
 
-func appendItemPruneTraceStep(p base.LogicalPlan, itemType string, prunedObjects []fmt.Stringer,
+func appendItemPruneTraceStep(p base.LogicalPlan, itemType string, prunedObjects []expression.StringerWithCtx,
 	opt *optimizetrace.LogicalOptimizeOp) {
 	if len(prunedObjects) < 1 {
 		return
@@ -36,7 +36,7 @@ func appendItemPruneTraceStep(p base.LogicalPlan, itemType string, prunedObjects
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(item.String())
+			buffer.WriteString(item.StringWithCtx(p.SCtx().GetExprCtx().GetEvalCtx()))
 		}
 		buffer.WriteString("] have been pruned")
 		return buffer.String()
@@ -53,7 +53,7 @@ func AppendColumnPruneTraceStep(p base.LogicalPlan, prunedColumns []*expression.
 	if len(prunedColumns) < 1 {
 		return
 	}
-	s := make([]fmt.Stringer, 0, len(prunedColumns))
+	s := make([]expression.StringerWithCtx, 0, len(prunedColumns))
 	for _, item := range prunedColumns {
 		s = append(s, item)
 	}
@@ -66,7 +66,7 @@ func AppendFunctionPruneTraceStep(p base.LogicalPlan, prunedFunctions []*aggrega
 	if len(prunedFunctions) < 1 {
 		return
 	}
-	s := make([]fmt.Stringer, 0, len(prunedFunctions))
+	s := make([]expression.StringerWithCtx, 0, len(prunedFunctions))
 	for _, item := range prunedFunctions {
 		s = append(s, item)
 	}
@@ -79,7 +79,7 @@ func AppendByItemsPruneTraceStep(p base.LogicalPlan, prunedByItems []*util.ByIte
 	if len(prunedByItems) < 1 {
 		return
 	}
-	s := make([]fmt.Stringer, 0, len(prunedByItems))
+	s := make([]expression.StringerWithCtx, 0, len(prunedByItems))
 	for _, item := range prunedByItems {
 		s = append(s, item)
 	}
@@ -92,7 +92,7 @@ func AppendGroupByItemsPruneTraceStep(p base.LogicalPlan, prunedGroupByItems []e
 	if len(prunedGroupByItems) < 1 {
 		return
 	}
-	s := make([]fmt.Stringer, 0, len(prunedGroupByItems))
+	s := make([]expression.StringerWithCtx, 0, len(prunedGroupByItems))
 	for _, item := range prunedGroupByItems {
 		s = append(s, item)
 	}

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -260,7 +260,7 @@ func TestGeneratePartitionExpr(t *testing.T) {
 		"1",
 	}
 	for i, expr := range pe.UpperBounds {
-		require.Equal(t, upperBounds[i], expr.String())
+		require.Equal(t, upperBounds[i], expr.StringWithCtx(tk.Session().GetExprCtx().GetEvalCtx()))
 	}
 }
 

--- a/pkg/util/ranger/BUILD.bazel
+++ b/pkg/util/ranger/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/config",
         "//pkg/domain",
         "//pkg/expression",
+        "//pkg/expression/contextstatic",
         "//pkg/parser/ast",
         "//pkg/parser/model",
         "//pkg/parser/mysql",

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -322,7 +322,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		return nil, err
 	}
 	if len(remainedConds) > 0 {
-		filterConds = removeConditions(filterConds, remainedConds)
+		filterConds = removeConditions(d.sctx.ExprCtx.GetEvalCtx(), filterConds, remainedConds)
 		newConditions = append(newConditions, remainedConds...)
 	}
 	for ; eqCount < len(accessConds); eqCount++ {
@@ -431,7 +431,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 					d.sctx.RecordRangeFallback(d.rangeMaxSize)
 					res.RemainedConds = append(res.RemainedConds, tailRes.AccessConds...)
 					// Some conditions may be in both tailRes.AccessConds and tailRes.RemainedConds so we call AppendConditionsIfNotExist here.
-					res.RemainedConds = AppendConditionsIfNotExist(res.RemainedConds, tailRes.RemainedConds)
+					res.RemainedConds = AppendConditionsIfNotExist(d.sctx.ExprCtx.GetEvalCtx(), res.RemainedConds, tailRes.RemainedConds)
 					return res, nil
 				}
 				res.Ranges = newRanges
@@ -461,7 +461,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		// [10, 10] [30, 30] exceeds range mem limit, we add `a = 10 or a = 30` back to RemainedConds, which is actually
 		// unnecessary because `(a = 10 and b = 20) or (a = 30 and b = 40)` is already in RemainedConds.
 		// TODO: we will optimize it later.
-		res.RemainedConds = AppendConditionsIfNotExist(res.RemainedConds, remainedConds)
+		res.RemainedConds = AppendConditionsIfNotExist(d.sctx.ExprCtx.GetEvalCtx(), res.RemainedConds, remainedConds)
 		res.Ranges = ranges
 		// Choosing between point ranges and bestCNF is needed since bestCNF does not cover the intersection
 		// of all conjuncts. Even when we add support for intersection, it could be turned off by a flag or it could be
@@ -473,7 +473,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 			// Apply optimization if bestCNFItemRes is a proper subset of point ranges.
 			if bestCNFIsSubset && !pointRangeIsSubset {
 				// Update final result and just update: Ranges, AccessConds and RemainedConds
-				res.RemainedConds = removeConditions(res.RemainedConds, bestCNFItemRes.rangeResult.AccessConds)
+				res.RemainedConds = removeConditions(d.sctx.ExprCtx.GetEvalCtx(), res.RemainedConds, bestCNFItemRes.rangeResult.AccessConds)
 				res.Ranges = bestCNFItemRes.rangeResult.Ranges
 				res.AccessConds = bestCNFItemRes.rangeResult.AccessConds
 			}
@@ -726,7 +726,7 @@ func ExtractEqAndInCondition(sctx *rangerctx.RangerContext, conditions []express
 		}
 	}
 	// We should remove all accessConds, so that they will not be added to filter conditions.
-	newConditions = removeConditions(newConditions, accesses)
+	newConditions = removeConditions(sctx.ExprCtx.GetEvalCtx(), newConditions, accesses)
 	return accesses, filters, newConditions, columnValues, false
 }
 
@@ -992,10 +992,10 @@ func DetachSimpleCondAndBuildRangeForIndex(sctx *rangerctx.RangerContext, condit
 	return res.Ranges, res.AccessConds, err
 }
 
-func removeConditions(conditions, condsToRemove []expression.Expression) []expression.Expression {
+func removeConditions(ectx expression.EvalContext, conditions, condsToRemove []expression.Expression) []expression.Expression {
 	filterConds := make([]expression.Expression, 0, len(conditions))
 	for _, cond := range conditions {
-		if !expression.Contains(condsToRemove, cond) {
+		if !expression.Contains(ectx, condsToRemove, cond) {
 			filterConds = append(filterConds, cond)
 		}
 	}
@@ -1003,10 +1003,10 @@ func removeConditions(conditions, condsToRemove []expression.Expression) []expre
 }
 
 // AppendConditionsIfNotExist appends conditions if they are absent.
-func AppendConditionsIfNotExist(conditions, condsToAppend []expression.Expression) []expression.Expression {
+func AppendConditionsIfNotExist(ectx expression.EvalContext, conditions, condsToAppend []expression.Expression) []expression.Expression {
 	shouldAppend := make([]expression.Expression, 0, len(condsToAppend))
 	for _, cond := range condsToAppend {
-		if !expression.Contains(conditions, cond) {
+		if !expression.Contains(ectx, conditions, cond) {
 			shouldAppend = append(shouldAppend, cond)
 		}
 	}
@@ -1274,7 +1274,7 @@ func AddExpr4EqAndInCondition(sctx *rangerctx.RangerContext, conditions []expres
 	// remove the accesses from newConditions
 	newConditions := make([]expression.Expression, 0, len(conditions))
 	newConditions = append(newConditions, conditions...)
-	newConditions = removeConditions(newConditions, accesses)
+	newConditions = removeConditions(sctx.ExprCtx.GetEvalCtx(), newConditions, accesses)
 
 	// add Gc condition for accesses and return new condition to newAccesses
 	newAccesses, err := AddGcColumnCond(sctx, cols, accesses, columnValues)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -664,12 +664,12 @@ func (r *builder) buildFromIn(
 	for _, e := range list {
 		v, ok := e.(*expression.Constant)
 		if !ok {
-			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not constant", e)
+			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not constant", e.StringWithCtx(evalCtx))
 			return getFullRange(), hasNull
 		}
 		dt, err := v.Eval(evalCtx, chunk.Row{})
 		if err != nil {
-			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not evaluated", e)
+			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not evaluated", e.StringWithCtx(evalCtx))
 			return getFullRange(), hasNull
 		}
 		if dt.IsNull() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53533

Problem Summary:

Previously, the code stores a reference to the session context in `ParamMarker`. It convenient for re-using the expression in the plan cache inside a single session. However, it blocks us from achieving the following goals:

1. We cannot evaluate the expression whiling the params on session is changing. It will happen if we enabled lazy-cursor fetch.
2. The plan cache cannot be re-used across different sessions, because the expression will always reference to the session on which it's cached.

This PR depends on #53922 now.

### What changed and how does it work?

1. Remove the session context inside `ParamMarker`, and pass it through argument.
2. Add `EvalContext` argument for `GetType` and `GetUserVar`.
4. Add a new method `StringWithCtx` to stringify the expression with a given context.

It's also fine to use the `StringWithCtx` with `nil` argument directly, but it'll print `?` for the params.

The biggest challenge is that the `String` is implicitly used in many places: like formatter and error / warnings. I wrote a linter to detect all the cases, you can find it in `/build/linter/printexpression`. It ensures that all struct/interface (and the reference/slice of them) which implements `StringWithCtx` but doesn't implement `String` cannot be used as an argument of format function.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
