### PR TITLE
expression: fix the fsp of casting json as datetime/duration

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -518,7 +518,7 @@ func (b *castJSONAsArrayFunctionSig) evalJSON(ctx EvalContext, row chunk.Row) (r
 	return types.CreateBinaryJSON(arrayVals), false, nil
 }
 
-// ConvertJSON2Tp returns a function that can convert JSON to the specified type.
+// ConvertJSON2Tp converts JSON to the specified type.
 func ConvertJSON2Tp(v types.BinaryJSON, targetType *types.FieldType) (any, error) {
 	convertFunc := convertJSON2Tp(targetType.EvalType())
 	if convertFunc == nil {
@@ -560,7 +560,7 @@ func convertJSON2Tp(evalType types.EvalType) func(*stmtctx.StatementContext, typ
 			if (tp.GetType() == mysql.TypeDatetime && item.TypeCode != types.JSONTypeCodeDatetime) || (tp.GetType() == mysql.TypeDate && item.TypeCode != types.JSONTypeCodeDate) {
 				return nil, ErrInvalidJSONForFuncIndex
 			}
-			res := item.GetTime()
+			res := item.GetTimeWithFsp(tp.GetDecimal())
 			res.SetType(tp.GetType())
 			if tp.GetType() == mysql.TypeDate {
 				// Truncate hh:mm:ss part if the type is Date.
@@ -1929,7 +1929,7 @@ func (b *builtinCastJSONAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (res
 
 	switch val.TypeCode {
 	case types.JSONTypeCodeDate, types.JSONTypeCodeDatetime, types.JSONTypeCodeTimestamp:
-		res = val.GetTime()
+		res = val.GetTimeWithFsp(b.tp.GetDecimal())
 		res.SetType(b.tp.GetType())
 		if b.tp.GetType() == mysql.TypeDate {
 			// Truncate hh:mm:ss part if the type is Date.
@@ -1991,7 +1991,7 @@ func (b *builtinCastJSONAsDurationSig) evalDuration(ctx EvalContext, row chunk.R
 
 	switch val.TypeCode {
 	case types.JSONTypeCodeDate, types.JSONTypeCodeDatetime, types.JSONTypeCodeTimestamp:
-		time := val.GetTime()
+		time := val.GetTimeWithFsp(b.tp.GetDecimal())
 		res, err = time.ConvertToDuration()
 		if err != nil {
 			return res, false, err

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -508,7 +508,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 
 		switch val.TypeCode {
 		case types.JSONTypeCodeDate, types.JSONTypeCodeDatetime, types.JSONTypeCodeTimestamp:
-			tm := val.GetTime()
+			tm := val.GetTimeWithFsp(b.tp.GetDecimal())
 			times[i] = tm
 			times[i].SetType(b.tp.GetType())
 			if b.tp.GetType() == mysql.TypeDate {
@@ -1975,7 +1975,7 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 
 		switch val.TypeCode {
 		case types.JSONTypeCodeDate, types.JSONTypeCodeDatetime, types.JSONTypeCodeTimestamp:
-			time := val.GetTime()
+			time := val.GetTimeWithFsp(b.tp.GetDecimal())
 			d, err := time.ConvertToDuration()
 			if err != nil {
 				return err

--- a/pkg/types/json_binary.go
+++ b/pkg/types/json_binary.go
@@ -237,8 +237,16 @@ func (bj BinaryJSON) GetOpaque() Opaque {
 	}
 }
 
-// GetTime gets the time value
+// GetTime gets the time value with default fsp
+//
+// Deprecated: use GetTimeWithFsp instead. The `BinaryJSON` doesn't contain the fsp information, so the caller
+// should always provide the fsp.
 func (bj BinaryJSON) GetTime() Time {
+	return bj.GetTimeWithFsp(DefaultFsp)
+}
+
+// GetTimeWithFsp gets the time value with given fsp
+func (bj BinaryJSON) GetTimeWithFsp(fsp int) Time {
 	coreTime := CoreTime(bj.GetUint64())
 
 	tp := mysql.TypeDate
@@ -248,7 +256,7 @@ func (bj BinaryJSON) GetTime() Time {
 		tp = mysql.TypeTimestamp
 	}
 
-	return NewTime(coreTime, tp, DefaultFsp)
+	return NewTime(coreTime, tp, fsp)
 }
 
 // GetDuration gets the duration value

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -649,3 +649,15 @@ select 1 from t where cast(BINARY vc as json) = '1';
 1
 select 1 from t where cast(BINARY c as json) = '1';
 1
+drop table if exists t;
+create table t (j json);
+insert into t values (cast(cast("2024-10-24 11:11:11.12346" as datetime(6)) as json));
+select cast(j as datetime(6)) from t;
+cast(j as datetime(6))
+2024-10-24 11:11:11.123460
+select cast(j as datetime(3)) from t;
+cast(j as datetime(3))
+2024-10-24 11:11:11.123
+select cast(j as datetime) from t;
+cast(j as datetime)
+2024-10-24 11:11:11

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -393,3 +393,11 @@ select 1 from t where cast(vc as json) = '1';
 select 1 from t where cast(c as json) = '1';
 select 1 from t where cast(BINARY vc as json) = '1';
 select 1 from t where cast(BINARY c as json) = '1';
+
+# TestCastJSONToTimeWithCorrectFsp
+drop table if exists t;
+create table t (j json);
+insert into t values (cast(cast("2024-10-24 11:11:11.12346" as datetime(6)) as json));
+select cast(j as datetime(6)) from t;
+select cast(j as datetime(3)) from t;
+select cast(j as datetime) from t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53352

Problem Summary:

When casting json as datetime/duration, the `fsp` of target type is not obeyed. 

This PR is split from #53363, because #53363 will be held for a while (as long as MySQL didn't confirm the behavior on JSON implicit cast). This one is a pure/simple bug fix, so it can be merged at first.

### What changed and how does it work?

Follow the configuration of the return type to set the correct `fsp`. This PR didn't remove the original `GetTime` function, but just mark it as deprecated, because there are still many usages inside the `json` itself.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that casting json as time or duration will drop the fractional part.
```
