### PR TITLE
statistics: print the process of init stats

### DIFF
--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -698,10 +698,12 @@ func (h *Handle) InitStatsLite(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	statslogutil.StatsLogger().Info("complete to load the meta")
 	err = h.initStatsHistogramsLite(is, cache)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	statslogutil.StatsLogger().Info("complete to load the histogram")
 	h.Replace(cache)
 	return nil
 }

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -351,9 +351,9 @@ func (h *Handle) initStatsHistogramsByPaging(is infoschema.InfoSchema, cache sta
 func (h *Handle) initStatsHistogramsConcurrency(is infoschema.InfoSchema, cache statstypes.StatsCache) error {
 	var maxTid = maxTidRecord.tid.Load()
 	tid := int64(0)
-	ls := initstats.NewRangeWorker(func(task initstats.Task) error {
+	ls := initstats.NewRangeWorker("histogram", func(task initstats.Task) error {
 		return h.initStatsHistogramsByPaging(is, cache, task)
-	})
+	}, uint64(maxTid), uint64(initStatsStep))
 	ls.LoadStats()
 	for tid <= maxTid {
 		ls.SendTask(initstats.Task{
@@ -461,9 +461,9 @@ func (h *Handle) initStatsTopNByPaging(cache statstypes.StatsCache, task initsta
 func (h *Handle) initStatsTopNConcurrency(cache statstypes.StatsCache) error {
 	var maxTid = maxTidRecord.tid.Load()
 	tid := int64(0)
-	ls := initstats.NewRangeWorker(func(task initstats.Task) error {
+	ls := initstats.NewRangeWorker("TopN", func(task initstats.Task) error {
 		return h.initStatsTopNByPaging(cache, task)
-	})
+	}, uint64(maxTid), uint64(initStatsStep))
 	ls.LoadStats()
 	for tid <= maxTid {
 		ls.SendTask(initstats.Task{
@@ -664,9 +664,9 @@ func (h *Handle) initStatsBucketsByPaging(cache statstypes.StatsCache, task init
 func (h *Handle) initStatsBucketsConcurrency(cache statstypes.StatsCache) error {
 	var maxTid = maxTidRecord.tid.Load()
 	tid := int64(0)
-	ls := initstats.NewRangeWorker(func(task initstats.Task) error {
+	ls := initstats.NewRangeWorker("bucket", func(task initstats.Task) error {
 		return h.initStatsBucketsByPaging(cache, task)
-	})
+	}, uint64(maxTid), uint64(initStatsStep))
 	ls.LoadStats()
 	for tid <= maxTid {
 		ls.SendTask(initstats.Task{

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -698,12 +698,12 @@ func (h *Handle) InitStatsLite(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	statslogutil.StatsLogger().Info("complete to load the meta")
+	statslogutil.StatsLogger().Info("complete to load the meta in the lite mode")
 	err = h.initStatsHistogramsLite(is, cache)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	statslogutil.StatsLogger().Info("complete to load the histogram")
+	statslogutil.StatsLogger().Info("complete to load the histogram in the lite mode")
 	h.Replace(cache)
 	return nil
 }

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache"
 	"github.com/pingcap/tidb/pkg/statistics/handle/initstats"
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/types"
@@ -724,11 +725,13 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	statslogutil.StatsLogger().Info("complete to load the meta")
 	if config.GetGlobalConfig().Performance.ConcurrentlyInitStats {
 		err = h.initStatsHistogramsConcurrency(is, cache)
 	} else {
 		err = h.initStatsHistograms(is, cache)
 	}
+	statslogutil.StatsLogger().Info("complete to load the histogram")
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -737,6 +740,7 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 	} else {
 		err = h.initStatsTopN(cache)
 	}
+	statslogutil.StatsLogger().Info("complete to load the topn")
 	if err != nil {
 		return err
 	}
@@ -745,8 +749,10 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 		if err != nil {
 			return err
 		}
+		statslogutil.StatsLogger().Info("complete to load the FM Sketch")
 	}
 	err = h.initStatsBuckets(cache)
+	statslogutil.StatsLogger().Info("complete to load the bucket")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/statistics/handle/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/initstats/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/statistics/handle/logutil",
         "//pkg/util",
         "//pkg/util/logutil",
         "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zapcore",
     ],
 )

--- a/pkg/statistics/handle/initstats/load_stats_page.go
+++ b/pkg/statistics/handle/initstats/load_stats_page.go
@@ -15,10 +15,43 @@
 package initstats
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+var (
+	initSamplerLoggerOnce sync.Once
+	samplerLogger         *zap.Logger
+)
+
+// SingletonStatsSamplerLogger with category "stats" is used to log statistic related messages.
+// It is used to sample the log to avoid too many logs.
+// NOTE: Do not create a new logger for each log, it will cause the sampler not work.
+// Because we need to record the log count with the same level and message in this specific logger.
+// Do not use it to log the message that is not related to statistics.
+func singletonStatsSamplerLogger() *zap.Logger {
+	init := func() {
+		if samplerLogger == nil {
+			// Create a new zapcore sampler with options
+			// This will log the first log entries with the same level and message in 1 minutes and ignore the rest of the logs.
+			sampler := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+				return zapcore.NewSamplerWithOptions(core, time.Minute, 1, 0)
+			})
+			samplerLogger = statslogutil.StatsLogger().WithOptions(sampler)
+		}
+	}
+
+	initSamplerLoggerOnce.Do(init)
+	return samplerLogger
+}
 
 // Task represents the range of the table for loading stats.
 type Task struct {
@@ -28,18 +61,29 @@ type Task struct {
 
 // RangeWorker is used to load stats concurrently by the range of table id.
 type RangeWorker struct {
-	dealFunc func(task Task) error
-	taskChan chan Task
-
-	wg util.WaitGroupWrapper
+	dealFunc        func(task Task) error
+	taskChan        chan Task
+	logger          *zap.Logger
+	taskName        string
+	wg              util.WaitGroupWrapper
+	taskCnt         uint64
+	completeTaskCnt atomic.Uint64
 }
 
 // NewRangeWorker creates a new RangeWorker.
-func NewRangeWorker(dealFunc func(task Task) error) *RangeWorker {
-	return &RangeWorker{
+func NewRangeWorker(taskName string, dealFunc func(task Task) error, maxTid, initStatsStep uint64) *RangeWorker {
+	taskCnt := uint64(1)
+	if maxTid > initStatsStep*2 {
+		taskCnt = maxTid / initStatsStep
+	}
+	worker := &RangeWorker{
+		taskName: taskName,
 		dealFunc: dealFunc,
 		taskChan: make(chan Task, 1),
+		taskCnt:  taskCnt,
 	}
+	worker.logger = singletonStatsSamplerLogger()
+	return worker
 }
 
 // LoadStats loads stats concurrently when to init stats
@@ -56,6 +100,10 @@ func (ls *RangeWorker) loadStats() {
 	for task := range ls.taskChan {
 		if err := ls.dealFunc(task); err != nil {
 			logutil.BgLogger().Error("load stats failed", zap.Error(err))
+		}
+		if ls.logger != nil {
+			completeTaskCnt := ls.completeTaskCnt.Add(1)
+			ls.logger.Info(fmt.Sprintf("load %s [%d/%d]", ls.taskName, completeTaskCnt, ls.taskCnt))
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53564

Problem Summary:

### What changed and how does it work?

it sometimes takes too much time for tidb to init stats. we should print the process info to tell the users.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

if we have several tables, it will print
```
[2024/05/27 18:21:39.093 +08:00] [INFO] [bootstrap.go:734] ["complete to load the histogram"] [category=stats]
[2024/05/27 18:21:39.094 +08:00] [INFO] [bootstrap.go:743] ["complete to load the topn"] [category=stats]
[2024/05/27 18:21:39.097 +08:00] [INFO] [bootstrap.go:755] ["complete to load the bucket"] [category=stats]
[2024/05/27 18:21:39.098 +08:00] [INFO] [domain.go:2318] ["init stats info time"] [lite=false] ["take time"=13.208834ms]
```

But if TiDB has enough tables, it will print.

```
...
[2024/05/27 19:54:10.516 +08:00] [INFO] [load_stats_page.go:83] ["load bucket [1080/2391]"] [category=stats]
[2024/05/27 19:55:10.516 +08:00] [INFO] [load_stats_page.go:83] ["load bucket [1781/2391]"] [category=stats]
...
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
init stats 时显示进度
statistics: print the process of init stats
```
