### PR TITLE
infoschema: fix issue of information schema cache miss cause by schema version gap (#53445)

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3703,8 +3703,8 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:M0DudF9JLF1GbmdoxM7LK8pNaiLAReHihdk5nwnB8pg=",
-        version = "v2.0.4-0.20240125040124-4c64e5d5d57d",
+        sum = "h1:NXhdhxU4dibxCmMChAOpyBXzuqi2VKp17nSx1HUg4HU=",
+        version = "v2.0.4-0.20240521070200-f9fbc4c8f578",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -137,7 +137,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	}
 	stmtStats.RegisterStats(2, s1)
 	stats = stmtStats.GetRootStats(2)
-	expect = "cop_task: {num: 2, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 1s, tot_wait: 1s, rpc_num: 1, rpc_time: 1s, copr_cache_hit_ratio: 0.00, distsql_concurrency: 15}, backoff{RegionMiss: 1ms}"
+	expect = "cop_task: {num: 2, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 1s, tot_wait: 1s, copr_cache_hit_ratio: 0.00, distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:1, total_time:1s}}, backoff{RegionMiss: 1ms}"
 	require.Equal(t, expect, stats.String())
 	// Test for idempotence.
 	require.Equal(t, expect, stats.String())

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -380,6 +380,8 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 		if diff == nil {
 			// Empty diff means the txn of generating schema version is committed, but the txn of `runDDLJob` is not or fail.
 			// It is safe to skip the empty diff because the infoschema is new enough and consistent.
+			logutil.BgLogger().Info("diff load InfoSchema get empty schema diff", zap.Int64("version", usedVersion))
+			do.infoCache.InsertEmptySchemaVersion(usedVersion)
 			continue
 		}
 		diffs = append(diffs, diff)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -217,7 +217,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 	// 3. There are less 100 diffs.
 	startTime := time.Now()
 	if currentSchemaVersion != 0 && neededSchemaVersion > currentSchemaVersion && neededSchemaVersion-currentSchemaVersion < 100 {
-		is, relatedChanges, err := do.tryLoadSchemaDiffs(m, currentSchemaVersion, neededSchemaVersion)
+		is, relatedChanges, diffTypes, err := do.tryLoadSchemaDiffs(m, currentSchemaVersion, neededSchemaVersion)
 		if err == nil {
 			loadSchemaDurationLoadDiff.Observe(time.Since(startTime).Seconds())
 			do.infoCache.Insert(is, uint64(schemaTs))
@@ -226,7 +226,8 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 				zap.Int64("neededSchemaVersion", neededSchemaVersion),
 				zap.Duration("start time", time.Since(startTime)),
 				zap.Int64s("phyTblIDs", relatedChanges.PhyTblIDS),
-				zap.Uint64s("actionTypes", relatedChanges.ActionTypes))
+				zap.Uint64s("actionTypes", relatedChanges.ActionTypes),
+				zap.Strings("diffTypes", diffTypes))
 			return is, false, currentSchemaVersion, relatedChanges, nil
 		}
 		// We can fall back to full load, don't need to return the error.
@@ -369,13 +370,13 @@ func (do *Domain) fetchSchemasWithTables(schemas []*model.DBInfo, m *meta.Meta, 
 // Return true if the schema is loaded successfully.
 // Return false if the schema can not be loaded by schema diff, then we need to do full load.
 // The second returned value is the delta updated table and partition IDs.
-func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (infoschema.InfoSchema, *transaction.RelatedSchemaChange, error) {
+func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64) (infoschema.InfoSchema, *transaction.RelatedSchemaChange, []string, error) {
 	var diffs []*model.SchemaDiff
 	for usedVersion < newVersion {
 		usedVersion++
 		diff, err := m.GetSchemaDiff(usedVersion)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if diff == nil {
 			// Empty diff means the txn of generating schema version is committed, but the txn of `runDDLJob` is not or fail.
@@ -390,14 +391,16 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 	builder.SetDeltaUpdateBundles()
 	phyTblIDs := make([]int64, 0, len(diffs))
 	actions := make([]uint64, 0, len(diffs))
+	diffTypes := make([]string, 0, len(diffs))
 	for _, diff := range diffs {
 		IDs, err := builder.ApplyDiff(m, diff)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if canSkipSchemaCheckerDDL(diff.Type) {
 			continue
 		}
+		diffTypes = append(diffTypes, diff.Type.String())
 		phyTblIDs = append(phyTblIDs, IDs...)
 		for i := 0; i < len(IDs); i++ {
 			actions = append(actions, uint64(1<<diff.Type))
@@ -408,7 +411,7 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 	relatedChange := transaction.RelatedSchemaChange{}
 	relatedChange.PhyTblIDS = phyTblIDs
 	relatedChange.ActionTypes = actions
-	return is, &relatedChange, nil
+	return is, &relatedChange, diffTypes, nil
 }
 
 func canSkipSchemaCheckerDDL(tp model.ActionType) bool {

--- a/infoschema/cache.go
+++ b/infoschema/cache.go
@@ -40,6 +40,9 @@ type InfoCache struct {
 	mu sync.RWMutex
 	// cache is sorted by both SchemaVersion and timestamp in descending order, assume they have same order
 	cache []schemaAndTimestamp
+
+	// emptySchemaVersions stores schema version which has no schema_diff.
+	emptySchemaVersions map[int64]struct{}
 }
 
 type schemaAndTimestamp struct {
@@ -50,7 +53,8 @@ type schemaAndTimestamp struct {
 // NewCache creates a new InfoCache.
 func NewCache(capacity int) *InfoCache {
 	return &InfoCache{
-		cache: make([]schemaAndTimestamp, 0, capacity),
+		cache:               make([]schemaAndTimestamp, 0, capacity),
+		emptySchemaVersions: make(map[int64]struct{}),
 	}
 }
 
@@ -102,6 +106,11 @@ func (h *InfoCache) Len() int {
 	return len(h.cache)
 }
 
+// GetEmptySchemaVersions returns emptySchemaVersions, exports for testing.
+func (h *InfoCache) GetEmptySchemaVersions() map[int64]struct{} {
+	return h.emptySchemaVersions
+}
+
 func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	logutil.BgLogger().Debug("SCHEMA CACHE get schema", zap.Uint64("timestamp", ts))
 	// search one by one instead of binary search, because the timestamp of a schema could be 0
@@ -115,8 +124,32 @@ func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 		if i == 0 {
 			return is.infoschema, true
 		}
-		if h.cache[i-1].infoschema.SchemaMetaVersion() == is.infoschema.SchemaMetaVersion()+1 && uint64(h.cache[i-1].timestamp) > ts {
-			return is.infoschema, true
+
+		if uint64(h.cache[i-1].timestamp) > ts {
+			// The first condition is to make sure the cache[i-1].timestamp > ts >= cache[i].timestamp, then the current schema is suitable for ts.
+			lastVersion := h.cache[i-1].infoschema.SchemaMetaVersion()
+			currentVersion := is.infoschema.SchemaMetaVersion()
+			if lastVersion == currentVersion+1 {
+				// This condition is to make sure the schema version is continuous. If last(cache[i-1]) schema-version is 10,
+				// but current(cache[i]) schema-version is not 9, then current schema may not suitable for ts.
+				return is.infoschema, true
+			}
+			if lastVersion > currentVersion {
+				found := true
+				for ver := currentVersion + 1; ver < lastVersion; ver++ {
+					_, ok := h.emptySchemaVersions[ver]
+					if !ok {
+						found = false
+						break
+					}
+				}
+				if found {
+					// This condition is to make sure the schema version is continuous. If last(cache[i-1]) schema-version is 10, and
+					// current(cache[i]) schema-version is 8, then there is a gap exist, and if all the gap version can be found in cache.emptySchemaVersions
+					// which means those gap versions don't have schema info, then current schema is also suitable for ts.
+					return is.infoschema, true
+				}
+			}
 		}
 		break
 	}
@@ -224,4 +257,26 @@ func (h *InfoCache) Insert(is InfoSchema, schemaTS uint64) bool {
 	}
 
 	return true
+}
+
+// InsertEmptySchemaVersion inserts empty schema version into a map. If exceeded the cache capacity, remove the oldest version.
+func (h *InfoCache) InsertEmptySchemaVersion(version int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.emptySchemaVersions[version] = struct{}{}
+	if len(h.emptySchemaVersions) > cap(h.cache) {
+		// remove oldest version.
+		versions := make([]int64, 0, len(h.emptySchemaVersions))
+		for ver := range h.emptySchemaVersions {
+			versions = append(versions, ver)
+		}
+		sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+		for _, ver := range versions {
+			delete(h.emptySchemaVersions, ver)
+			if len(h.emptySchemaVersions) <= cap(h.cache) {
+				break
+			}
+		}
+	}
 }

--- a/infoschema/cache_test.go
+++ b/infoschema/cache_test.go
@@ -290,4 +290,51 @@ func TestCacheWithSchemaTsZero(t *testing.T) {
 	checkFn(1, 84, false)
 	checkFn(85, 100, true)
 	require.Equal(t, 16, ic.Size())
+
+	// Test cache with schema version hole, which is cause by schema version doesn't has related schema-diff.
+	ic = infoschema.NewCache(16)
+	require.NotNil(t, ic)
+	for i := 1; i <= 8; i++ {
+		ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, int64(i)), uint64(i))
+	}
+	checkFn(1, 10, true)
+	// mock for schema version hole, schema-version 9 is missing.
+	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 10), 10)
+	checkFn(1, 7, true)
+	// without empty schema version map, get snapshot by ts 8, 9 will both failed.
+	checkFn(8, 9, false)
+	checkFn(10, 10, true)
+	// add empty schema version 9.
+	ic.InsertEmptySchemaVersion(9)
+	// after set empty schema version, get snapshot by ts 8, 9 will both success.
+	checkFn(1, 8, true)
+	checkFn(10, 10, true)
+	is := ic.GetBySnapshotTS(uint64(9))
+	require.NotNil(t, is)
+	// since schema version 9 is empty, so get by ts 9 will get schema which version is 8.
+	require.Equal(t, int64(8), is.SchemaMetaVersion())
+}
+
+func TestCacheEmptySchemaVersion(t *testing.T) {
+	ic := infoschema.NewCache(16)
+	require.NotNil(t, ic)
+	require.Equal(t, 0, len(ic.GetEmptySchemaVersions()))
+	for i := 0; i < 16; i++ {
+		ic.InsertEmptySchemaVersion(int64(i))
+	}
+	emptyVersions := ic.GetEmptySchemaVersions()
+	require.Equal(t, 16, len(emptyVersions))
+	for i := 0; i < 16; i++ {
+		_, ok := emptyVersions[int64(i)]
+		require.True(t, ok)
+	}
+	for i := 16; i < 20; i++ {
+		ic.InsertEmptySchemaVersion(int64(i))
+	}
+	emptyVersions = ic.GetEmptySchemaVersions()
+	require.Equal(t, 16, len(emptyVersions))
+	for i := 4; i < 20; i++ {
+		_, ok := emptyVersions[int64(i)]
+		require.True(t, ok)
+	}
 }

--- a/tests/realtikvtest/sessiontest/session_fail_test.go
+++ b/tests/realtikvtest/sessiontest/session_fail_test.go
@@ -254,7 +254,7 @@ func TestTiKVClientReadTimeout(t *testing.T) {
 	rows = tk.MustQuery("explain analyze select /*+ set_var(tikv_client_read_timeout=1) */ * from t as of timestamp(@stale_read_ts_var) where b > 1").Rows()
 	require.Len(t, rows, 3)
 	explain = fmt.Sprintf("%v", rows[0])
-	require.Regexp(t, ".*TableReader.* root  time:.*, loops:.* cop_task: {num: 1, .*num_rpc:(3|4).*", explain)
+	require.Regexp(t, ".*TableReader.* root  time:.*, loops:.* cop_task: {num: 1, .*num_rpc:(3|4|5).*", explain)
 
 	// Test for tikv_client_read_timeout session variable.
 	tk.MustExec("set @@tikv_client_read_timeout=1;")
@@ -282,5 +282,5 @@ func TestTiKVClientReadTimeout(t *testing.T) {
 	rows = tk.MustQuery("explain analyze select * from t as of timestamp(@stale_read_ts_var) where b > 1").Rows()
 	require.Len(t, rows, 3)
 	explain = fmt.Sprintf("%v", rows[0])
-	require.Regexp(t, ".*TableReader.* root  time:.*, loops:.* cop_task: {num: 1, *num_rpc:(3|4).*", explain)
+	require.Regexp(t, ".*TableReader.* root  time:.*, loops:.* cop_task: {num: 1, .*num_rpc:(3|4|5).*", explain)
 }

--- a/util/logutil/BUILD.bazel
+++ b/util/logutil/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@com_github_opentracing_opentracing_go//log",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_log//:log",
+        "@com_github_tikv_client_go_v2//tikv",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//buffer",
         "@org_uber_go_zap//zapcore",


### PR DESCRIPTION
Cherry-pick #53445  #47810 

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53428

Problem Summary: fix issue of information schema cache miss cause by schema version gap

### What changed and how does it work?

#### before this PR

When DDL has empty schema version, will cause cache miss, then stale-read query need to load snapshot schema from TiKV.

<img width="1454" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/32411733-9e38-4bf5-9b9e-b0287af18f31">


```sql
[2024/05/23 06:15:10.546 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6760] [neededSchemaVersion=6762] ["start time"=2.583049ms] [gotSchemaVersion=6762] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:15:17.869 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6763] [neededSchemaVersion=6765] ["start time"=2.040666ms] [gotSchemaVersion=6765] [phyTblIDs="[10496]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:15:18.051 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6765] [neededSchemaVersion=6767] ["start time"=4.321375ms] [gotSchemaVersion=6767] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:15:18.245 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6767] [neededSchemaVersion=6769] ["start time"=3.01603ms] [gotSchemaVersion=6769] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
```

### This PR

When DDL has empty schema version, this PR won't have schema cache miss, then won't cause many load snapshot schema operation.

<img width="1445" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/7d34a3c9-aa04-453b-87c5-51d369b04b43">

```log
[2024/05/23 06:23:45.209 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6777] [neededSchemaVersion=6779] ["start time"=5.409896ms] [gotSchemaVersion=6779] [phyTblIDs="[10502]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:45.458 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6779] [neededSchemaVersion=6781] ["start time"=2.711853ms] [gotSchemaVersion=6781] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:45.650 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6781] [neededSchemaVersion=6783] ["start time"=1.910751ms] [gotSchemaVersion=6783] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:49.173 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6784] [neededSchemaVersion=6786] ["start time"=2.511772ms] [gotSchemaVersion=6786] [phyTblIDs="[10505]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:49.372 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6786] [neededSchemaVersion=6788] ["start time"=2.768253ms] [gotSchemaVersion=6788] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:49.590 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6788] [neededSchemaVersion=6790] ["start time"=4.466332ms] [gotSchemaVersion=6790] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:53.670 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6791] [neededSchemaVersion=6793] ["start time"=799.389µs] [gotSchemaVersion=6793] [phyTblIDs="[10508]"] [actionTypes="[4]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:53.872 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6793] [neededSchemaVersion=6795] ["start time"=1.025364ms] [gotSchemaVersion=6795] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
[2024/05/23 06:23:54.090 +00:00] [INFO] [domain.go:287] ["diff load InfoSchema success"] [currentSchemaVersion=6795] [neededSchemaVersion=6797] ["start time"=3.549838ms] [gotSchemaVersion=6797] [phyTblIDs="[]"] [actionTypes="[]"] [diffTypes="[\"drop table\"]"]
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

