### PR TITLE
statistics: add comments and remove unnessary check

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1949,6 +1949,7 @@ func (b *PlanBuilder) getMustAnalyzedColumns(tbl *ast.TableName, cols *calcOnceM
 }
 
 func (b *PlanBuilder) getPredicateColumns(tbl *ast.TableName, cols *calcOnceMap) (map[int64]struct{}, error) {
+	// Already calculated in the previous call.
 	if cols.calculated {
 		return cols.data, nil
 	}

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -61,7 +61,7 @@ type StatsUsage interface {
 	// LoadColumnStatsUsage returns all columns' usage information.
 	LoadColumnStatsUsage(loc *time.Location) (map[model.TableItemID]ColStatsTimeInfo, error)
 
-	// GetPredicateColumns returns the IDs of predicate columns, which are the columns whose statistics are needed when generating query plans.
+	// GetPredicateColumns returns IDs of predicate columns, which are the columns whose stats are used(needed) when generating query plans.
 	GetPredicateColumns(tableID int64) ([]int64, error)
 
 	// CollectColumnsInExtendedStats returns IDs of the columns involved in extended stats.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -61,7 +61,7 @@ type StatsUsage interface {
 	// LoadColumnStatsUsage returns all columns' usage information.
 	LoadColumnStatsUsage(loc *time.Location) (map[model.TableItemID]ColStatsTimeInfo, error)
 
-	// GetPredicateColumns returns IDs of predicate columns, which are the columns whose stats are used(needed) when generating query plans.
+	// GetPredicateColumns returns the IDs of predicate columns, which are the columns whose statistics are needed when generating query plans.
 	GetPredicateColumns(tableID int64) ([]int64, error)
 
 	// CollectColumnsInExtendedStats returns IDs of the columns involved in extended stats.

--- a/pkg/statistics/handle/usage/predicate_column.go
+++ b/pkg/statistics/handle/usage/predicate_column.go
@@ -101,8 +101,8 @@ func LoadColumnStatsUsage(sctx sessionctx.Context, loc *time.Location) (map[mode
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			// If `last_used_at` is before the time when `set global enable_column_tracking = 0`, we should ignore it because
-			// `set global enable_column_tracking = 0` indicates all the predicate columns collected before.
+			// If `last_used_at` is before the time when `set global tidb_enable_column_tracking = 0`, we should ignore it because
+			// `set global tidb_enable_column_tracking = 0` indicates all the predicate columns collected before.
 			if disableTime == nil || gt.After(*disableTime) {
 				t := types.NewTime(types.FromGoTime(gt.In(loc)), mysql.TypeTimestamp, types.DefaultFsp)
 				statsUsage.LastUsedAt = &t
@@ -123,7 +123,7 @@ func LoadColumnStatsUsage(sctx sessionctx.Context, loc *time.Location) (map[mode
 
 // GetPredicateColumns returns IDs of predicate columns, which are the columns whose stats are used(needed) when generating query plans.
 func GetPredicateColumns(sctx sessionctx.Context, tableID int64) ([]int64, error) {
-	// This time is the time when `set global enable_column_tracking = 0`.
+	// This time is the time when `set global tidb_enable_column_tracking = 0`.
 	disableTime, err := getDisableColumnTrackingTime(sctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -148,8 +148,8 @@ func GetPredicateColumns(sctx sessionctx.Context, tableID int64) ([]int64, error
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// If `last_used_at` is before the time when `set global enable_column_tracking = 0`, we don't regard the column as predicate column because
-		// `set global enable_column_tracking = 0` indicates all the predicate columns collected before.
+		// If `last_used_at` is before the time when `set global tidb_enable_column_tracking = 0`, we don't regard the column as predicate column because
+		// `set global tidb_enable_column_tracking = 0` indicates all the predicate columns collected before.
 		// TODO: Why do we need to do this? If column tracking is already disabled, we should not collect any column usage.
 		// If this refers to re-enabling column tracking, shouldn't we retain the column usage data from before it was disabled?
 		if disableTime == nil || gt.After(*disableTime) {

--- a/pkg/statistics/handle/usage/predicate_column.go
+++ b/pkg/statistics/handle/usage/predicate_column.go
@@ -139,6 +139,7 @@ func GetPredicateColumns(sctx sessionctx.Context, tableID int64) ([]int64, error
 	columnIDs := make([]int64, 0, len(rows))
 	for _, row := range rows {
 		// Usually, it should not be NULL.
+		// This only happens when the last_used_at is not a valid time.
 		if row.IsNull(1) {
 			continue
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/53567

Problem Summary:

### What changed and how does it work?
1. I added some comments to the GetPredicateColumns function.
2. Remove an unnecessary check, because the column id is always not null. You can find it in the schema:

```sql
	CreateColumnStatsUsageTable = `CREATE TABLE IF NOT EXISTS mysql.column_stats_usage (
		table_id BIGINT(64) NOT NULL,
		column_id BIGINT(64) NOT NULL,
		last_used_at TIMESTAMP,
		last_analyzed_at TIMESTAMP,
		PRIMARY KEY (table_id, column_id) CLUSTERED
	);`
```

3. Added a TODO item to indicate the need to reconsider this design.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
