### PR TITLE
domain: make the transaction from `initStatsCtx` blocking gc

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2256,6 +2256,22 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 		},
 		"analyzeJobsCleanupWorker",
 	)
+	go func() {
+		// The initStatsCtx is used to store the internal session for initializing stats,
+		// so we need the gc min start ts calculation to track it as an internal session.
+		// Since the session manager may not be ready at this moment, `infosync.StoreInternalSession` can fail.
+		// we need to retry until the session manager is ready or the init stats completes.
+		for !infosync.StoreInternalSession(initStatsCtx) {
+			waitRetry := time.After(time.Second)
+			select {
+			case <-do.StatsHandle().InitStatsDone:
+				return
+			case <-waitRetry:
+			}
+		}
+		<-do.StatsHandle().InitStatsDone
+		infosync.DeleteInternalSession(initStatsCtx)
+	}()
 	return nil
 }
 

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2256,22 +2256,25 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 		},
 		"analyzeJobsCleanupWorker",
 	)
-	go func() {
-		// The initStatsCtx is used to store the internal session for initializing stats,
-		// so we need the gc min start ts calculation to track it as an internal session.
-		// Since the session manager may not be ready at this moment, `infosync.StoreInternalSession` can fail.
-		// we need to retry until the session manager is ready or the init stats completes.
-		for !infosync.StoreInternalSession(initStatsCtx) {
-			waitRetry := time.After(time.Second)
-			select {
-			case <-do.StatsHandle().InitStatsDone:
-				return
-			case <-waitRetry:
+	do.wg.Run(
+		func() {
+			// The initStatsCtx is used to store the internal session for initializing stats,
+			// so we need the gc min start ts calculation to track it as an internal session.
+			// Since the session manager may not be ready at this moment, `infosync.StoreInternalSession` can fail.
+			// we need to retry until the session manager is ready or the init stats completes.
+			for !infosync.StoreInternalSession(initStatsCtx) {
+				waitRetry := time.After(time.Second)
+				select {
+				case <-do.StatsHandle().InitStatsDone:
+					return
+				case <-waitRetry:
+				}
 			}
-		}
-		<-do.StatsHandle().InitStatsDone
-		infosync.DeleteInternalSession(initStatsCtx)
-	}()
+			<-do.StatsHandle().InitStatsDone
+			infosync.DeleteInternalSession(initStatsCtx)
+		},
+		"RemoveInitStatsFromInternalSessions",
+	)
 	return nil
 }
 

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -1243,16 +1243,18 @@ func ConfigureTiFlashPDForPartitions(accel bool, definitions *[]model.PartitionD
 }
 
 // StoreInternalSession is the entry function for store an internal session to SessionManager.
-func StoreInternalSession(se any) {
+// return whether the session is stored successfully.
+func StoreInternalSession(se any) bool {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
-		return
+		return false
 	}
 	sm := is.GetSessionManager()
 	if sm == nil {
-		return
+		return false
 	}
 	sm.StoreInternalSession(se)
+	return true
 }
 
 // DeleteInternalSession is the entry function for delete an internal session from SessionManager.

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -203,6 +203,7 @@ go_test(
         "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//error",
+        "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//testutils",
         "@com_github_tikv_client_go_v2//tikv",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -102,9 +102,9 @@ func TestInitStatsSessionBlockGC(t *testing.T) {
 			}
 			return false
 		}, 10*time.Second, 10*time.Millisecond, "min_start_ts is not blocked over 1s")
-		dom.Close()
-		require.NoError(t, store.Close())
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStatsLite"))
+		dom.Close()
+		require.NoError(t, store.Close())
 	}
 }

--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -82,11 +82,7 @@ func TestInitStatsSessionBlockGC(t *testing.T) {
 		require.NoError(t, err)
 		dom, err := session.BootstrapSession(store)
 		require.NoError(t, err)
-		defer func() {
-			dom.Close()
-			err := store.Close()
-			require.NoError(t, err)
-		}()
+
 		infoSyncer := dom.InfoSyncer()
 		sv := CreateMockServer(t, store)
 		sv.SetDomain(dom)
@@ -106,6 +102,8 @@ func TestInitStatsSessionBlockGC(t *testing.T) {
 			}
 			return false
 		}, 10*time.Second, 10*time.Millisecond, "min_start_ts is not blocked over 1s")
+		dom.Close()
+		require.NoError(t, store.Close())
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStatsLite"))
 	}

--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -20,12 +20,14 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/server/internal/util"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 )
 
 func TestUptime(t *testing.T) {
@@ -62,4 +64,49 @@ func TestUptime(t *testing.T) {
 	stats, err := server.Stats(nil)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, stats[upTime].(int64), int64(time.Since(time.Unix(1282967700, 0)).Seconds()))
+}
+
+func TestInitStatsSessionBlockGC(t *testing.T) {
+	origConfig := config.GetGlobalConfig()
+	defer func() {
+		config.StoreGlobalConfig(origConfig)
+	}()
+	newConfig := *origConfig
+	for _, lite := range []bool{false, true} {
+		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats", "pause"))
+		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStatsLite", "pause"))
+		newConfig.Performance.LiteInitStats = lite
+		config.StoreGlobalConfig(&newConfig)
+
+		store, err := mockstore.NewMockStore()
+		require.NoError(t, err)
+		dom, err := session.BootstrapSession(store)
+		require.NoError(t, err)
+		defer func() {
+			dom.Close()
+			err := store.Close()
+			require.NoError(t, err)
+		}()
+		infoSyncer := dom.InfoSyncer()
+		sv := CreateMockServer(t, store)
+		sv.SetDomain(dom)
+		infoSyncer.SetSessionManager(sv)
+		time.Sleep(time.Second)
+		require.Eventually(t, func() bool {
+			now := time.Now()
+			startTSList := sv.GetInternalSessionStartTSList()
+			for _, startTs := range startTSList {
+				if startTs != 0 {
+					startTime := oracle.GetTimeFromTS(startTs)
+					// test pass if the min_start_ts is blocked over 1s.
+					if now.Sub(startTime) > time.Second {
+						return true
+					}
+				}
+			}
+			return false
+		}, 1*time.Second, 10*time.Millisecond, "min_start_ts is not blocked over 1s")
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStatsLite"))
+	}
 }

--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -105,7 +105,7 @@ func TestInitStatsSessionBlockGC(t *testing.T) {
 				}
 			}
 			return false
-		}, 1*time.Second, 10*time.Millisecond, "min_start_ts is not blocked over 1s")
+		}, 10*time.Second, 10*time.Millisecond, "min_start_ts is not blocked over 1s")
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStats"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/beforeInitStatsLite"))
 	}

--- a/pkg/statistics/handle/BUILD.bazel
+++ b/pkg/statistics/handle/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/chunk",
         "//pkg/util/logutil",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -16,6 +16,9 @@ package handle
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -33,8 +36,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
-	"sync"
-	"sync/atomic"
 )
 
 // initStatsStep is the step to load stats by paging.

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -690,6 +691,7 @@ func (h *Handle) InitStatsLite(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return err
 	}
+	failpoint.Inject("beforeInitStatsLite", func() {})
 	cache, err := h.initStatsMeta(is)
 	if err != nil {
 		return errors.Trace(err)
@@ -717,6 +719,7 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return err
 	}
+	failpoint.Inject("beforeInitStats", func() {})
 	cache, err := h.initStatsMeta(is)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -16,10 +16,6 @@ package handle
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
-	"time"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -37,6 +33,8 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
+	"sync"
+	"sync/atomic"
 )
 
 // initStatsStep is the step to load stats by paging.
@@ -691,7 +689,6 @@ func (h *Handle) InitStatsLite(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return err
 	}
-	time.Sleep(30 * time.Minute)
 	cache, err := h.initStatsMeta(is)
 	if err != nil {
 		return errors.Trace(err)
@@ -719,7 +716,6 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return err
 	}
-	time.Sleep(30 * time.Minute)
 	cache, err := h.initStatsMeta(is)
 	if err != nil {
 		return errors.Trace(err)

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
@@ -690,6 +691,7 @@ func (h *Handle) InitStatsLite(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return err
 	}
+	time.Sleep(30 * time.Minute)
 	cache, err := h.initStatsMeta(is)
 	if err != nil {
 		return errors.Trace(err)
@@ -717,6 +719,7 @@ func (h *Handle) InitStats(is infoschema.InfoSchema) (err error) {
 	if err != nil {
 		return err
 	}
+	time.Sleep(30 * time.Minute)
 	cache, err := h.initStatsMeta(is)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53592

Problem Summary:

The `initStatsCtx` is not get from internal session pool, so it's not tracked by min start ts service, thus gc lifetime can overtake it easily.

### What changed and how does it work?

Insert it into tracked session table and it will block gc.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I reproduce the test mentioned in issue, the stats are loaded successfully after 30min.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix a bug that tidb will report gc lifetime too short when tidb bootstrap with slow loading statistics
```
