### PR TITLE
table: memoize TableCommon.getCols

### DIFF
--- a/pkg/table/tables/BUILD.bazel
+++ b/pkg/table/tables/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
     name = "tables_test",
     timeout = "short",
     srcs = [
+        "bench_test.go",
         "cache_test.go",
         "index_test.go",
         "main_test.go",
@@ -106,6 +107,7 @@ go_test(
         "//pkg/util",
         "//pkg/util/codec",
         "//pkg/util/collate",
+        "//pkg/util/context",
         "//pkg/util/mock",
         "//pkg/util/rowcodec",
         "//pkg/util/stmtsummary",

--- a/pkg/table/tables/bench_test.go
+++ b/pkg/table/tables/bench_test.go
@@ -1,0 +1,39 @@
+package tables_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/sessiontxn"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/types"
+	_ "github.com/pingcap/tidb/pkg/util/context"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkAddRecordInPipelinedDML(b *testing.B) {
+	store, dom := testkit.CreateMockStoreAndDomain(b)
+	tk := testkit.NewTestKit(b, store)
+	_, err := tk.Session().Execute(context.Background(), "CREATE TABLE test.t (a int primary key auto_increment, b varchar(255))")
+	require.NoError(b, err)
+	ctx := tk.Session()
+	vars := ctx.GetSessionVars()
+	vars.BulkDMLEnabled = true
+	vars.TxnCtx.EnableMDL = true
+	vars.StmtCtx.InInsertStmt = true
+	require.Nil(b, sessiontxn.NewTxn(context.Background(), tk.Session()))
+	txn, _ := ctx.Txn(true)
+	require.True(b, txn.IsPipelined())
+	tb, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := tb.AddRecord(ctx.GetTableCtx(), types.MakeDatums(i, "test"))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/table/tables/bench_test.go
+++ b/pkg/table/tables/bench_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tables_test
 
 import (

--- a/pkg/table/tables/cache.go
+++ b/pkg/table/tables/cache.go
@@ -119,7 +119,7 @@ func (c *cachedTable) TryReadFromCache(ts uint64, leaseDuration time.Duration) (
 // newCachedTable creates a new CachedTable Instance
 func newCachedTable(tbl *TableCommon) (table.Table, error) {
 	ret := &cachedTable{
-		TableCommon: *tbl,
+		TableCommon: tbl.Copy(),
 		tokenLimit:  make(chan StateRemote, 1),
 	}
 	return ret, nil

--- a/pkg/table/tables/partition.go
+++ b/pkg/table/tables/partition.go
@@ -111,7 +111,7 @@ func newPartitionedTable(tbl *TableCommon, tblInfo *model.TableInfo) (table.Part
 	if pi == nil || len(pi.Definitions) == 0 {
 		return nil, table.ErrUnknownPartition
 	}
-	ret := &partitionedTable{TableCommon: *tbl}
+	ret := &partitionedTable{TableCommon: tbl.Copy()}
 	partitionExpr, err := newPartitionExpr(tblInfo, pi.Type, pi.Expr, pi.Columns, pi.Definitions)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -82,6 +82,21 @@ type TableCommon struct {
 	// recordPrefix and indexPrefix are generated using physicalTableID.
 	recordPrefix kv.Key
 	indexPrefix  kv.Key
+
+	testingKnob
+}
+
+type testingKnob interface {
+	ClearColumnsCache()
+}
+
+// ClearColumnsCache implements testingKnob interface.
+func (t *TableCommon) ClearColumnsCache() {
+	t.publicColumns = nil
+	t.visibleColumns = nil
+	t.hiddenColumns = nil
+	t.writableColumns = nil
+	t.fullHiddenColsAndVisibleColumns = nil
 }
 
 // MockTableFromMeta only serves for test.

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -73,7 +73,7 @@ type TableCommon struct {
 	// TODO: we lazily initialize them because they could possibly consume too much unnecessary
 	//  memory. We can move these initialization to initTableCommon after infoschema v2 is enabled.
 	//
-	// sync.Once is needed to avoid data race because TableCommon may accessed concurrently
+	// sync.Once is needed to avoid data race because TableCommon may be accessed concurrently
 	// They are pointers to support copying TableCommon to CachedTable and PartitionedTable
 	publicColumns                       []*table.Column
 	publicColumnsOnce                   *sync.Once

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -60,43 +60,67 @@ import (
 )
 
 // TableCommon is shared by both Table and partition.
+// NOTE: when copying this struct, use Copy() to clear its columns cache.
 type TableCommon struct {
 	// TODO: Why do we need tableID, when it is already in meta.ID ?
 	tableID int64
 	// physicalTableID is a unique int64 to identify a physical table.
-	physicalTableID                 int64
-	Columns                         []*table.Column
-	publicColumns                   []*table.Column
-	visibleColumns                  []*table.Column
-	hiddenColumns                   []*table.Column
-	writableColumns                 []*table.Column
-	fullHiddenColsAndVisibleColumns []*table.Column
-	indices                         []table.Index
-	meta                            *model.TableInfo
-	allocs                          autoid.Allocators
-	sequence                        *sequenceCommon
-	dependencyColumnOffsets         []int
-	Constraints                     []*table.Constraint
-	writableConstraints             []*table.Constraint
+	physicalTableID int64
+	Columns         []*table.Column
+
+	// column caches
+	//
+	// TODO: we lazily initialize them because they could possibly consume too much unnecessary
+	//  memory. We can move these initialization to initTableCommon after infoschema v2 is enabled.
+	//
+	// sync.Once is needed to avoid data race because TableCommon may accessed concurrently
+	// They are pointers to support copying TableCommon to CachedTable and PartitionedTable
+	publicColumns                       []*table.Column
+	publicColumnsOnce                   *sync.Once
+	visibleColumns                      []*table.Column
+	visibleColumnsOnce                  *sync.Once
+	hiddenColumns                       []*table.Column
+	hiddenColumnsOnce                   *sync.Once
+	writableColumns                     []*table.Column
+	writableColumnsOnce                 *sync.Once
+	fullHiddenColsAndVisibleColumns     []*table.Column
+	fullHiddenColsAndVisibleColumnsOnce *sync.Once
+	writableConstraints                 []*table.Constraint
+	writableConstraintsOnce             *sync.Once
+
+	indices                 []table.Index
+	meta                    *model.TableInfo
+	allocs                  autoid.Allocators
+	sequence                *sequenceCommon
+	dependencyColumnOffsets []int
+	Constraints             []*table.Constraint
 
 	// recordPrefix and indexPrefix are generated using physicalTableID.
 	recordPrefix kv.Key
 	indexPrefix  kv.Key
-
-	testingKnob
-}
-
-type testingKnob interface {
-	ClearColumnsCache()
 }
 
 // ClearColumnsCache implements testingKnob interface.
 func (t *TableCommon) ClearColumnsCache() {
 	t.publicColumns = nil
+	t.publicColumnsOnce = new(sync.Once)
 	t.visibleColumns = nil
+	t.visibleColumnsOnce = new(sync.Once)
 	t.hiddenColumns = nil
+	t.hiddenColumnsOnce = new(sync.Once)
 	t.writableColumns = nil
+	t.writableColumnsOnce = new(sync.Once)
 	t.fullHiddenColsAndVisibleColumns = nil
+	t.fullHiddenColsAndVisibleColumnsOnce = new(sync.Once)
+	t.writableConstraints = nil
+	t.writableConstraintsOnce = new(sync.Once)
+}
+
+// Copy copies a TableCommon struct, and reset its column cache. This is not a deep copy.
+func (t *TableCommon) Copy() TableCommon {
+	newTable := *t
+	newTable.ClearColumnsCache()
+	return newTable
 }
 
 // MockTableFromMeta only serves for test.
@@ -229,6 +253,12 @@ func initTableCommon(t *TableCommon, tblInfo *model.TableInfo, physicalTableID i
 			t.dependencyColumnOffsets = append(t.dependencyColumnOffsets, col.ChangeStateInfo.DependencyColumnOffset)
 		}
 	}
+	t.publicColumnsOnce = new(sync.Once)
+	t.visibleColumnsOnce = new(sync.Once)
+	t.hiddenColumnsOnce = new(sync.Once)
+	t.writableColumnsOnce = new(sync.Once)
+	t.fullHiddenColsAndVisibleColumnsOnce = new(sync.Once)
+	t.writableConstraintsOnce = new(sync.Once)
 }
 
 // initTableIndices initializes the indices of the TableCommon.
@@ -315,41 +345,54 @@ func (t *TableCommon) getCols(mode getColsMode) []*table.Column {
 
 // Cols implements table.Table Cols interface.
 func (t *TableCommon) Cols() []*table.Column {
-	if len(t.publicColumns) == 0 {
-		t.publicColumns = t.getCols(full)
-	}
+	t.publicColumnsOnce.Do(
+		func() {
+			if len(t.publicColumns) == 0 {
+				t.publicColumns = t.getCols(full)
+			}
+		},
+	)
 	return t.publicColumns
 }
 
 // VisibleCols implements table.Table VisibleCols interface.
 func (t *TableCommon) VisibleCols() []*table.Column {
-	if len(t.visibleColumns) == 0 {
-		t.visibleColumns = t.getCols(visible)
-	}
+	t.visibleColumnsOnce.Do(
+		func() {
+			if len(t.visibleColumns) == 0 {
+				t.visibleColumns = t.getCols(visible)
+			}
+		},
+	)
 	return t.visibleColumns
 }
 
 // HiddenCols implements table.Table HiddenCols interface.
 func (t *TableCommon) HiddenCols() []*table.Column {
-	if len(t.hiddenColumns) == 0 {
-		t.hiddenColumns = t.getCols(hidden)
-	}
+	t.hiddenColumnsOnce.Do(
+		func() {
+			if len(t.hiddenColumns) == 0 {
+				t.hiddenColumns = t.getCols(hidden)
+			}
+		},
+	)
 	return t.hiddenColumns
 }
 
 // WritableCols implements table WritableCols interface.
 func (t *TableCommon) WritableCols() []*table.Column {
-	if len(t.writableColumns) > 0 {
-		return t.writableColumns
-	}
-	writableColumns := make([]*table.Column, 0, len(t.Columns))
-	for _, col := range t.Columns {
-		if col.State == model.StateDeleteOnly || col.State == model.StateDeleteReorganization {
-			continue
-		}
-		writableColumns = append(writableColumns, col)
-	}
-	return writableColumns
+	t.writableColumnsOnce.Do(
+		func() {
+			t.writableColumns = make([]*table.Column, 0, len(t.Columns))
+			for _, col := range t.Columns {
+				if col.State == model.StateDeleteOnly || col.State == model.StateDeleteReorganization {
+					continue
+				}
+				t.writableColumns = append(t.writableColumns, col)
+			}
+		},
+	)
+	return t.writableColumns
 }
 
 // DeletableCols implements table DeletableCols interface.
@@ -359,22 +402,22 @@ func (t *TableCommon) DeletableCols() []*table.Column {
 
 // WritableConstraint returns constraints of the table in writable states.
 func (t *TableCommon) WritableConstraint() []*table.Constraint {
-	if len(t.writableConstraints) > 0 {
-		return t.writableConstraints
-	}
 	if t.Constraints == nil {
 		return nil
 	}
-	t.writableConstraints = make([]*table.Constraint, 0, len(t.Constraints))
-	for _, con := range t.Constraints {
-		if !con.Enforced {
-			continue
-		}
-		if con.State == model.StateDeleteOnly || con.State == model.StateDeleteReorganization {
-			continue
-		}
-		t.writableConstraints = append(t.writableConstraints, con)
-	}
+	t.writableConstraintsOnce.Do(
+		func() {
+			t.writableConstraints = make([]*table.Constraint, 0, len(t.Constraints))
+			for _, con := range t.Constraints {
+				if !con.Enforced {
+					continue
+				}
+				if con.State == model.StateDeleteOnly || con.State == model.StateDeleteReorganization {
+					continue
+				}
+				t.writableConstraints = append(t.writableConstraints, con)
+			}
+		})
 	return t.writableConstraints
 }
 
@@ -395,16 +438,14 @@ func (t *TableCommon) CheckRowConstraint(ctx table.MutateContext, rowToCheck []t
 
 // FullHiddenColsAndVisibleCols implements table FullHiddenColsAndVisibleCols interface.
 func (t *TableCommon) FullHiddenColsAndVisibleCols() []*table.Column {
-	if len(t.fullHiddenColsAndVisibleColumns) > 0 {
-		return t.fullHiddenColsAndVisibleColumns
-	}
-
-	t.fullHiddenColsAndVisibleColumns = make([]*table.Column, 0, len(t.Columns))
-	for _, col := range t.Columns {
-		if col.Hidden || col.State == model.StatePublic {
-			t.fullHiddenColsAndVisibleColumns = append(t.fullHiddenColsAndVisibleColumns, col)
+	t.fullHiddenColsAndVisibleColumnsOnce.Do(func() {
+		t.fullHiddenColsAndVisibleColumns = make([]*table.Column, 0, len(t.Columns))
+		for _, col := range t.Columns {
+			if col.Hidden || col.State == model.StatePublic {
+				t.fullHiddenColsAndVisibleColumns = append(t.fullHiddenColsAndVisibleColumns, col)
+			}
 		}
-	}
+	})
 	return t.fullHiddenColsAndVisibleColumns
 }
 

--- a/pkg/table/tables/tables_test.go
+++ b/pkg/table/tables/tables_test.go
@@ -426,7 +426,8 @@ func TestHiddenColumn(t *testing.T) {
 	colInfo[1].Hidden = true
 	colInfo[3].Hidden = true
 	colInfo[5].Hidden = true
-
+	tc := tb.(*tables.TableCommon)
+	tc.ClearColumnsCache()
 	// Basic test
 	cols := tb.VisibleCols()
 	require.NotNil(t, table.FindCol(cols, "a"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53604 

Problem Summary:

`getCols` does duplicated calculation, which wastes CPU time.

### What changed and how does it work?
Memoize this function.

Proportion of time in the microbenchmark of AddRecord (with pipelined DML and ART memdb)

Previous:
<img width="798" alt="image" src="https://github.com/pingcap/tidb/assets/31720476/60900250-032d-4dd3-b049-59a824e70029">


This PR:
<img width="494" alt="image" src="https://github.com/pingcap/tidb/assets/31720476/57bf0a2a-a873-4915-a188-7105df29e361">


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test - micro benchmark + existing test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
