### PR TITLE
executor: sync deletable columns to binlog when remove record

### DIFF
--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -172,6 +172,7 @@ func onAddColumn(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error)
 	case model.StateWriteReorganization:
 		// reorganization -> public
 		// Adjust table column offset.
+		failpoint.InjectCall("onAddColumnStateWriteReorg")
 		offset, err := LocateOffsetToMove(columnInfo.Offset, pos, tblInfo)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -271,6 +272,7 @@ func onDropColumn(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 		}
 	case model.StateWriteOnly:
 		// write only -> delete only
+		failpoint.InjectCall("onDropColumnStateWriteOnly")
 		colInfo.State = model.StateDeleteOnly
 		tblInfo.MoveColumnInfo(colInfo.Offset, len(tblInfo.Columns)-1)
 		if len(idxInfos) > 0 {

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -426,6 +426,7 @@ go_test(
         "//pkg/testkit",
         "//pkg/testkit/external",
         "//pkg/testkit/testdata",
+        "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testmain",
         "//pkg/testkit/testsetup",
         "//pkg/types",

--- a/pkg/executor/executor_txn_test.go
+++ b/pkg/executor/executor_txn_test.go
@@ -18,12 +18,15 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
 )
 
@@ -693,4 +696,41 @@ func TestSavepointWithBinlog(t *testing.T) {
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 1"))
 	tk.MustExec("commit")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 1"))
+}
+
+func TestColumnNotMatchError(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.Session().GetSessionVars().BinlogClient = binloginfo.MockPumpsClient(&testkit.MockPumpClient{})
+	tk.MustExec("set @@global.tidb_enable_metadata_lock=0")
+	tk.MustExec("use test")
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+	tk.MustExec("create table t(id int primary key, a int)")
+	tk.MustExec("insert into t values(1, 2)")
+
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onAddColumnStateWriteReorg", func() {
+		tk.MustExec("begin;")
+	})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		tk2.MustExec("alter table t add column wait_notify int")
+		wg.Done()
+	}()
+	wg.Wait()
+	tk.MustExec("delete from t where id=1")
+	tk.MustGetErrCode("commit", errno.ErrInfoSchemaChanged)
+
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onDropColumnStateWriteOnly", func() {
+		tk.MustExec("begin;")
+	})
+	wg.Add(1)
+	go func() {
+		tk2.MustExec("alter table t drop column wait_notify")
+		wg.Done()
+	}()
+	wg.Wait()
+	tk.MustExec("delete from t where id=1")
+	tk.MustGetErrCode("commit", errno.ErrInfoSchemaChanged)
 }

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1403,21 +1403,6 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 	return err
 }
 
-func projectPublicColData(t *TableCommon, deletableData []types.Datum) (publicData []types.Datum, colIDs []int64) {
-	publicColLen := len(t.Cols())
-	publicData = make([]types.Datum, 0, publicColLen)
-	colIDs = make([]int64, 0, publicColLen+1)
-	deletableCols := t.DeletableCols()
-	for i, d := range deletableData {
-		dCol := deletableCols[i]
-		if dCol.State == model.StatePublic {
-			publicData = append(publicData, d)
-			colIDs = append(colIDs, dCol.ID)
-		}
-	}
-	return publicData, colIDs
-}
-
 func (t *TableCommon) addInsertBinlog(ctx table.MutateContext, h kv.Handle, row []types.Datum, colIDs []int64) error {
 	mutation := t.getMutation(ctx)
 	handleData, err := h.Data()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53133

Problem Summary:

Previously, when TiDB writes delete records to binlog, column count of schema and data mismatch. This is because only public columns are selected, while data includes all deletable columns.

### What changed and how does it work?

Make schema use all deletable columns.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
  1. deploy two TiDB clusters, and start pump & drainer.
  2. modify upstream TiDB code:
  ```diff
  diff --git a/pkg/config/config.toml.example b/pkg/config/config.toml.example
  index c1438a9e85..b73828367d 100644
  --- a/pkg/config/config.toml.example
  +++ b/pkg/config/config.toml.example
  @@ -416,7 +416,7 @@ capacity-mb = 1000.0
   # enable to write binlog.
   # NOTE: If binlog is enabled with Kafka (e.g. arbiter cluster),
   # txn-total-size-limit should be less than 1073741824(1G) because this is the maximum size that can be handled by Kafka.
  -enable = false
  +enable = true
   
   # WriteTimeout specifies how long it will wait for writing binlog to pump.
   write-timeout = "15s"
  diff --git a/pkg/ddl/column.go b/pkg/ddl/column.go
  index 206b64d513..1727ba4c44 100644
  --- a/pkg/ddl/column.go
  +++ b/pkg/ddl/column.go
  @@ -173,6 +173,7 @@ func onAddColumn(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error)
                  // reorganization -> public
                  // Adjust table column offset.
                  failpoint.InjectCall("onAddColumnStateWriteReorg")
  +               time.Sleep(20 * time.Second)
                  offset, err := LocateOffsetToMove(columnInfo.Offset, pos, tblInfo)
                  if err != nil {
                          return ver, errors.Trace(err)
  ```
  3. execute SQL at upstream:
  ```
  -- session 1
  CREATE TABLE `t` (
    `a` int(11) DEFAULT NULL,
    `b` int(11) DEFAULT NULL,
    `c` int(11) DEFAULT NULL,
  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
  insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 3);
  alter table t add column d int default 3;
  ```
  ```
  -- session 2
  delete from t where a = 1;
  ```
  4. execute SQL at downstream:
  ```
  mysql> select * from t;
  +------+------+------+------+
  | a    | b    | c    | d    |
  +------+------+------+------+
  |    3 |    3 |    3 |    3 |
  |    2 |    2 |    2 |    3 |
  +------+------+------+------+
  2 rows in set (0.00 sec)
  ```
  Even if we synchronize a 4-columns row to binlog, drainer can handle it correctly by decoding necessary(public) columns:
  https://github.com/pingcap/tidb-binlog/blob/6fba4f883a0c6c7e0d68b3b8aef1a53d9454b273/drainer/translator/mysql.go#L88-L90
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
