### PR TITLE
infoschema: fix issue of load multiple schema diff at a time will cause information schema cache miss

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -488,6 +488,8 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 			// then the TiKV which store schema will become the hot spot.
 			schemaTs, err := do.getTimestampForSchemaVersionWithNonEmptyDiff(m, diff.Version, startTS)
 			if err == nil {
+				// Use `BuildWithoutUpdateBundles` here to avoid `updateInfoSchemaBundles`,
+				// because `builder.Build` will do it later.
 				latestIS := builder.BuildWithoutUpdateBundles(schemaTs)
 				// create a copy of the latest info schema.
 				builder, err := infoschema.NewBuilder(do, do.sysFacHack, do.infoCache.Data).InitWithOldInfoSchema(latestIS)

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 17,
+    shard_count = 18,
     deps = [
         "//pkg/config",
         "//pkg/ddl/schematracker",

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -1016,4 +1017,53 @@ func TestRenameMultiTables(t *testing.T) {
 	tk.MustExec("drop database rename1")
 	tk.MustExec("drop database rename2")
 	tk.MustExec("drop database rename3")
+}
+
+func TestSchemaCacheWithConcurrentDDL(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t, mockstore.WithDDLChecker())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			if i == 0 {
+				tk.MustExec("set @@global.tidb_schema_version_cache_limit = 255")
+			}
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					tableName := fmt.Sprintf("t%d", i)
+					tk.MustExec("drop table if exists " + tableName)
+					tk.MustExec(fmt.Sprintf("create table %s (a int, b int)", tableName))
+					tk.MustExec(fmt.Sprintf("alter table %s add index idx(a)", tableName))
+				}
+			}
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				versions := dom.InfoCache().GetAllSchemaVersions()
+				for i := 0; i < len(versions)-1; i++ {
+					// Following check use to make sure all schema versions are continuous,
+					// if not, it means some schema versions are missing, then stale-raed query will meet schema cache miss,
+					// then load snapshot schema from TiKV, then the TiKV which store schema will become the hot point.
+					require.Equal(t, versions[i], versions[i+1]+1, fmt.Sprintf("all versions: %v", versions))
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
+	}()
+	wg.Wait()
 }

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -1058,7 +1058,7 @@ func TestSchemaCacheWithConcurrentDDL(t *testing.T) {
 				for i := 0; i < len(versions)-1; i++ {
 					// Following check use to make sure all schema versions are continuous,
 					// if not, it means some schema versions are missing, then stale-raed query will meet schema cache miss,
-					// then load snapshot schema from TiKV, then the TiKV which store schema will become the hot point.
+					// then load snapshot schema from TiKV, then the TiKV which store schema will become the hot spot.
 					require.Equal(t, versions[i], versions[i+1]+1, fmt.Sprintf("all versions: %v", versions))
 				}
 				time.Sleep(50 * time.Millisecond)

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -790,6 +790,15 @@ func (b *Builder) Build(schemaTS uint64) InfoSchema {
 	return b.infoSchema
 }
 
+// BuildWithoutUpdateBundles builds and returns the built infoschema without updateInfoSchemaBundles.
+func (b *Builder) BuildWithoutUpdateBundles(schemaTS uint64) InfoSchema {
+	if b.enableV2 {
+		b.infoschemaV2.ts = schemaTS
+		return &b.infoschemaV2
+	}
+	return b.infoSchema
+}
+
 // InitWithOldInfoSchema initializes an empty new InfoSchema by copies all the data from old InfoSchema.
 func (b *Builder) InitWithOldInfoSchema(oldSchema InfoSchema) (*Builder, error) {
 	// Do not mix infoschema v1 and infoschema v2 building, this can simplify the logic.

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -109,6 +109,17 @@ func (h *InfoCache) GetEmptySchemaVersions() map[int64]struct{} {
 	return h.emptySchemaVersions
 }
 
+// GetAllSchemaVersions returns all schema versions in the cache. It's exported for test.
+func (h *InfoCache) GetAllSchemaVersions() []int64 {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	versions := make([]int64, 0, len(h.cache))
+	for _, v := range h.cache {
+		versions = append(versions, v.infoschema.SchemaMetaVersion())
+	}
+	return versions
+}
+
 func (h *InfoCache) getSchemaByTimestampNoLock(ts uint64) (InfoSchema, bool) {
 	logutil.BgLogger().Debug("SCHEMA CACHE get schema", zap.Uint64("timestamp", ts))
 	// search one by one instead of binary search, because the timestamp of a schema could be 0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53428

Problem Summary:  This PR fix the situation mentioned https://github.com/pingcap/tidb/issues/53428#issuecomment-2123740603

fix issue of load multiple schema diff at a time will cause information schema cache miss, then may cause stale-read query  latency 10x spike.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
