### PR TITLE
ddl: change finishedWritingNeedImport to importStarted

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -593,7 +593,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(
 	}
 	defer scheduler.close(true)
 	if lit, ok := scheduler.(*ingestBackfillScheduler); ok {
-		if lit.finishedWritingNeedImport() {
+		if lit.importStarted() {
 			return nil
 		}
 	}

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -370,13 +370,13 @@ func newIngestBackfillScheduler(
 	}, nil
 }
 
-func (b *ingestBackfillScheduler) finishedWritingNeedImport() bool {
+func (b *ingestBackfillScheduler) importStarted() bool {
 	job := b.reorgInfo.Job
 	bc, ok := ingest.LitBackCtxMgr.Load(job.ID)
 	if !ok {
 		return false
 	}
-	return bc.FinishedWritingNeedImport()
+	return bc.ImportStarted()
 }
 
 func (b *ingestBackfillScheduler) setupWorkers() error {

--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -59,11 +59,11 @@ type BackendCtx interface {
 	// TODO(lance6716): refine the interface to let caller don't need to pass the
 	// indexID, and unify with CollectRemoteDuplicateRows.
 	FinishImport(indexID int64, unique bool, tbl table.Table) error
-	// FinishedWritingNeedImport returns true only when all the engines are finished
-	// writing and only need import. Considering the calling usage of FinishImport,
-	// it will return true after a successful call of FinishImport and may return
-	// true after a failed call of FinishImport.
-	FinishedWritingNeedImport() bool
+	// ImportStarted returns true only when all the engines are finished writing and
+	// import is started by FinishImport. Considering the calling usage of
+	// FinishImport, it will return true after a successful call of FinishImport and
+	// may return true after a failed call of FinishImport.
+	ImportStarted() bool
 
 	CollectRemoteDuplicateRows(indexID int64, tbl table.Table) error
 	FlushController

--- a/pkg/ddl/ingest/engine_mgr.go
+++ b/pkg/ddl/ingest/engine_mgr.go
@@ -111,13 +111,13 @@ func (bc *litBackendCtx) UnregisterEngines() {
 	bc.memRoot.Release(numIdx * (structSizeEngineInfo + engineCacheSize))
 }
 
-// FinishedWritingNeedImport implements BackendCtx.
-func (bc *litBackendCtx) FinishedWritingNeedImport() bool {
+// ImportStarted implements BackendCtx.
+func (bc *litBackendCtx) ImportStarted() bool {
 	if len(bc.engines) == 0 {
 		return false
 	}
 	for _, ei := range bc.engines {
-		if ei.closedEngine != nil {
+		if ei.openedEngine == nil {
 			return true
 		}
 	}

--- a/pkg/ddl/ingest/mock.go
+++ b/pkg/ddl/ingest/mock.go
@@ -119,8 +119,8 @@ func (*MockBackendCtx) UnregisterEngines() {
 	logutil.DDLIngestLogger().Info("mock backend ctx unregister")
 }
 
-// FinishedWritingNeedImport implements BackendCtx interface.
-func (*MockBackendCtx) FinishedWritingNeedImport() bool {
+// ImportStarted implements BackendCtx interface.
+func (*MockBackendCtx) ImportStarted() bool {
 	return false
 }
 

--- a/tests/realtikvtest/addindextest4/ingest_test.go
+++ b/tests/realtikvtest/addindextest4/ingest_test.go
@@ -376,6 +376,7 @@ func TestAddIndexFinishImportError(t *testing.T) {
 	tk.MustExec("create database addindexlit;")
 	tk.MustExec("use addindexlit;")
 	tk.MustExec(`set global tidb_ddl_enable_fast_reorg=on;`)
+	tk.MustExec("set global tidb_enable_dist_task = off;")
 
 	tk.MustExec("create table t (a int primary key, b int);")
 	for i := 0; i < 4; i++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53641

Problem Summary:

### What changed and how does it work?

in the old code, `finishedWritingNeedImport` checks `closedEngine != nil` which stands for "there's a pending engine to be imported". Now it checks `openedEngine == nil` which stands for "all writing of this engine is finished". The difference is if retry happens after importing engine is finished, `closedEngine` is assigned to nil, and old `finishedWritingNeedImport` returns `false` but `importStarted` returns `true`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
