### PR TITLE
ddl: remove useless code in `adjustWorkerSize`

### DIFF
--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -276,8 +276,6 @@ func (b *txnBackfillScheduler) adjustWorkerSize() error {
 			runner = newBackfillWorker(b.ctx, tmpIdxWorker)
 			worker = tmpIdxWorker
 		case typeUpdateColumnWorker:
-			// Setting InCreateOrAlterStmt tells the difference between SELECT casting and ALTER COLUMN casting.
-			sessCtx.GetSessionVars().StmtCtx.InCreateOrAlterStmt = true
 			sessCtx.GetSessionVars().StmtCtx.SetTypeFlags(
 				sessCtx.GetSessionVars().StmtCtx.TypeFlags().
 					WithIgnoreZeroDateErr(!reorgInfo.ReorgMeta.SQLMode.HasStrictMode()))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53388

Problem Summary:

This line seems useless now:

https://github.com/pingcap/tidb/blob/afd23434dc558f00514dd7cc0295807002b69e16/pkg/ddl/backfilling_scheduler.go#L280

This line is first introduced in PR #25728, and [this line]( https://github.com/pingcap/tidb/pull/25728/files#diff-1bbc7833321782b3a22a842b6237974b6a60cb07b49b246b85552ab5e915ed6eR624 )  disallows 0 value when altering a column from integer to time.

However, after PR #47794, it seems not necessary because [this change](https://github.com/pingcap/tidb/pull/47794/files#diff-cedde52f04eef8a5117a506a088e41a878c00e147d529fcda309d834c966a010R220) does the same work.

Currently, `InCreateOrAlterStmt` is only read by `ResetContextOfStmt` which will never be called in DDL worker. So we can remove this line safely.

### What changed and how does it work?

Remove `sessCtx.GetSessionVars().StmtCtx.InCreateOrAlterStmt = true` because it is useless now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > Just run regression test TestCastFromZeroIntToTimeError

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
