### PR TITLE
planner: fix small regression caused by #53094

### DIFF
--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -130,7 +130,6 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 		if exec, isExec := finalPlan.(*plannercore.Execute); isExec {
 			if pointPlan, isPointPlan := exec.Plan.(*plannercore.PointGetPlan); isPointPlan {
 				stmt.PsStmt, stmt.Plan = preparedObj, pointPlan // notify to re-use the cached plan
-				stmtCtx.SetPlanDigest(preparedObj.NormalizedPlan, preparedObj.PlanDigest)
 			}
 		}
 	}

--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -130,6 +130,7 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 		if exec, isExec := finalPlan.(*plannercore.Execute); isExec {
 			if pointPlan, isPointPlan := exec.Plan.(*plannercore.PointGetPlan); isPointPlan {
 				stmt.PsStmt, stmt.Plan = preparedObj, pointPlan // notify to re-use the cached plan
+				stmtCtx.SetPlanDigest(preparedObj.NormalizedPlan, preparedObj.PlanDigest)
 			}
 		}
 	}

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -238,14 +238,9 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 	return generateNewPlan(ctx, sctx, isNonPrepared, is, stmt, cacheKey, latestSchemaVersion, bindSQL, matchOpts)
 }
 
-func adjustCachedPlan(
-	sctx sessionctx.Context,
-	cachedVal *PlanCacheValue,
-	isNonPrepared bool,
-	cacheKey kvcache.Key,
-	bindSQL string,
-	is infoschema.InfoSchema, stmt *PlanCacheStmt) (
-	base.Plan, []*types.FieldName, bool, error) {
+func adjustCachedPlan(sctx sessionctx.Context, cachedVal *PlanCacheValue, isNonPrepared bool,
+	cacheKey kvcache.Key, bindSQL string, is infoschema.InfoSchema, stmt *PlanCacheStmt) (base.Plan,
+	[]*types.FieldName, bool, error) {
 	sessVars := sctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
 	if err := checkPreparedPriv(sctx, stmt, is); err != nil {

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -215,30 +215,39 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 		}
 	}
 
-	matchOpts, err := GetMatchOpts(sctx, is, stmt, params)
-	if err != nil {
-		return nil, nil, err
-	}
+	var matchOpts *utilpc.PlanCacheMatchOpts
 	if stmtCtx.UseCache() {
-		if plan, names, ok, err := getCachedPlan(sctx, isNonPrepared, cacheKey, bindSQL, is, stmt, matchOpts); err != nil || ok {
-			return plan, names, err
+		var cacheVal kvcache.Value
+		var hit bool
+		if stmt.PointGet.Executor != nil { // if it's PointGet Plan, no need to use MatchOpts
+			cacheVal, hit = sctx.GetSessionPlanCache().Get(cacheKey, nil)
+		} else {
+			matchOpts = GetMatchOpts(sctx, is, stmt, params)
+			cacheVal, hit = sctx.GetSessionPlanCache().Get(cacheKey, matchOpts)
 		}
+		if hit {
+			if plan, names, ok, err := adjustCachedPlan(sctx, cacheVal.(*PlanCacheValue), isNonPrepared, cacheKey, bindSQL, is, stmt); err != nil || ok {
+				return plan, names, err
+			}
+		}
+	}
+	if matchOpts == nil {
+		matchOpts = GetMatchOpts(sctx, is, stmt, params)
 	}
 
 	return generateNewPlan(ctx, sctx, isNonPrepared, is, stmt, cacheKey, latestSchemaVersion, bindSQL, matchOpts)
 }
 
-func getCachedPlan(sctx sessionctx.Context, isNonPrepared bool, cacheKey kvcache.Key, bindSQL string,
-	is infoschema.InfoSchema, stmt *PlanCacheStmt, matchOpts *utilpc.PlanCacheMatchOpts) (base.Plan,
-	[]*types.FieldName, bool, error) {
+func adjustCachedPlan(
+	sctx sessionctx.Context,
+	cachedVal *PlanCacheValue,
+	isNonPrepared bool,
+	cacheKey kvcache.Key,
+	bindSQL string,
+	is infoschema.InfoSchema, stmt *PlanCacheStmt) (
+	base.Plan, []*types.FieldName, bool, error) {
 	sessVars := sctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
-
-	candidate, exist := sctx.GetSessionPlanCache().Get(cacheKey, matchOpts)
-	if !exist {
-		return nil, nil, false, nil
-	}
-	cachedVal := candidate.(*PlanCacheValue)
 	if err := checkPreparedPriv(sctx, stmt, is); err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/planner/core/plan_cache_lru.go
+++ b/pkg/planner/core/plan_cache_lru.go
@@ -253,6 +253,10 @@ func (l *LRUPlanCache) memoryControl() {
 // PickPlanFromBucket pick one plan from bucket
 func (l *LRUPlanCache) pickFromBucket(bucket map[*list.Element]struct{}, matchOpts *utilpc.PlanCacheMatchOpts) (*list.Element, bool) {
 	for k := range bucket {
+		if matchOpts == nil { // for PointGet Plan
+			return k, true
+		}
+
 		plan := k.Value.(*planCacheEntry).PlanValue.(*PlanCacheValue)
 		// check param types' compatibility
 		ok1 := checkTypesCompatibility4PC(plan.matchOpts.ParamTypes, matchOpts.ParamTypes)

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -559,7 +559,7 @@ func GetPreparedStmt(stmt *ast.ExecuteStmt, vars *variable.SessionVars) (*PlanCa
 
 // GetMatchOpts get options to fetch plan or generate new plan
 // we can add more options here
-func GetMatchOpts(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt, params []expression.Expression) (*utilpc.PlanCacheMatchOpts, error) {
+func GetMatchOpts(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt, params []expression.Expression) *utilpc.PlanCacheMatchOpts {
 	var statsVerHash uint64
 	var limitOffsetAndCount []uint64
 
@@ -606,7 +606,7 @@ func GetMatchOpts(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanC
 		StatsVersionHash:    statsVerHash,
 		ParamTypes:          parseParamTypes(sctx, params),
 		ForeignKeyChecks:    sctx.GetSessionVars().ForeignKeyChecks,
-	}, nil
+	}
 }
 
 // CheckTypesCompatibility4PC compares FieldSlice with []*types.FieldType


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50618

Problem Summary: planner: fix small regression caused by #53094

### What changed and how does it work?

BenchmarkPreparedPointGet: `7020 ns/op` --> `6528 ns/op`

Skip `GetMatchOpts` and `checkPreparedPriv` for cached point-get plans

<img width="853" alt="image" src="https://github.com/pingcap/tidb/assets/7499936/236ec853-6eb6-439d-ae30-500caee98542">


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
