### PR TITLE
expression, *: Eval param get type with context

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -283,6 +283,7 @@ go_test(
         "//pkg/errctx",
         "//pkg/errno",
         "//pkg/executor",
+        "//pkg/expression",
         "//pkg/infoschema",
         "//pkg/keyspace",
         "//pkg/kv",

--- a/pkg/ddl/bench_test.go
+++ b/pkg/ddl/bench_test.go
@@ -65,7 +65,7 @@ func BenchmarkExtractDatumByOffsets(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ddl.ExtractDatumByOffsetsForTest(row, offsets, c.ExprColumnInfos, handleDataBuf)
+		ddl.ExtractDatumByOffsetsForTest(tk.Session().GetExprCtx().GetEvalCtx(), row, offsets, c.ExprColumnInfos, handleDataBuf)
 	}
 }
 

--- a/pkg/ddl/copr/BUILD.bazel
+++ b/pkg/ddl/copr/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     shard_count = 3,
     deps = [
         "//pkg/expression",
+        "//pkg/expression/contextstatic",
         "//pkg/parser/model",
         "//pkg/parser/mysql",
         "//pkg/types",

--- a/pkg/ddl/copr/copr_ctx.go
+++ b/pkg/ddl/copr/copr_ctx.go
@@ -127,7 +127,7 @@ func NewCopContextBase(
 		return nil, err
 	}
 	hdColOffsets := resolveIndicesForHandle(expColInfos, handleIDs)
-	vColOffsets, vColFts := collectVirtualColumnOffsetsAndTypes(expColInfos)
+	vColOffsets, vColFts := collectVirtualColumnOffsetsAndTypes(exprCtx.GetEvalCtx(), expColInfos)
 
 	return &CopContextBase{
 		TableInfo:                   tblInfo,
@@ -319,13 +319,13 @@ func resolveIndicesForHandle(cols []*expression.Column, handleIDs []int64) []int
 	return offsets
 }
 
-func collectVirtualColumnOffsetsAndTypes(cols []*expression.Column) ([]int, []*types.FieldType) {
+func collectVirtualColumnOffsetsAndTypes(ctx expression.EvalContext, cols []*expression.Column) ([]int, []*types.FieldType) {
 	var offsets []int
 	var fts []*types.FieldType
 	for i, col := range cols {
 		if col.VirtualExpr != nil {
 			offsets = append(offsets, i)
-			fts = append(fts, col.GetType())
+			fts = append(fts, col.GetType(ctx))
 		}
 	}
 	return offsets, fts

--- a/pkg/ddl/copr/copr_ctx_test.go
+++ b/pkg/ddl/copr/copr_ctx_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -200,7 +201,8 @@ func TestCollectVirtualColumnOffsetsAndTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOffsets, gotFt := collectVirtualColumnOffsetsAndTypes(tt.cols)
+			ctx := contextstatic.NewStaticEvalContext()
+			gotOffsets, gotFt := collectVirtualColumnOffsetsAndTypes(ctx, tt.cols)
 			require.Equal(t, gotOffsets, tt.offsets)
 			require.Equal(t, len(gotFt), len(tt.fieldTp))
 			for i, ft := range gotFt {

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -2252,7 +2252,7 @@ func BuildTableInfo(
 				return nil, errors.Trace(err)
 			}
 			// check if the expression is bool type
-			if err := table.IfCheckConstraintExprBoolType(constraintInfo, tbInfo); err != nil {
+			if err := table.IfCheckConstraintExprBoolType(ctx.GetExprCtx().GetEvalCtx(), constraintInfo, tbInfo); err != nil {
 				return nil, err
 			}
 			constraintInfo.ID = allocateConstraintID(tbInfo)
@@ -4890,7 +4890,7 @@ func checkReorgPartitionDefs(ctx sessionctx.Context, action model.ActionType, tb
 				return nil
 			}
 
-			isUnsigned := isPartExprUnsigned(tblInfo)
+			isUnsigned := isPartExprUnsigned(ctx.GetExprCtx().GetEvalCtx(), tblInfo)
 			currentRangeValue, _, err := getRangeValue(ctx.GetExprCtx(), pi.Definitions[lastPartIdx].LessThan[0], isUnsigned)
 			if err != nil {
 				return errors.Trace(err)
@@ -7561,7 +7561,7 @@ func BuildHiddenColumnInfo(ctx sessionctx.Context, indexPartSpecifications []*as
 			Version:             model.CurrLatestColumnInfoVersion,
 			Dependences:         make(map[string]struct{}),
 			Hidden:              true,
-			FieldType:           *expr.GetType(),
+			FieldType:           *expr.GetType(ctx.GetExprCtx().GetEvalCtx()),
 		}
 		// Reset some flag, it may be caused by wrong type infer. But it's not easy to fix them all, so reset them here for safety.
 		colInfo.DelFlag(mysql.PriKeyFlag | mysql.UniqueKeyFlag | mysql.AutoIncrementFlag)
@@ -9405,7 +9405,7 @@ func (d *ddl) CreateCheckConstraint(ctx sessionctx.Context, ti ast.Ident, constr
 		return errors.Trace(err)
 	}
 	// check if the expression is bool type
-	if err := table.IfCheckConstraintExprBoolType(constraintInfo, tblInfo); err != nil {
+	if err := table.IfCheckConstraintExprBoolType(ctx.GetExprCtx().GetEvalCtx(), constraintInfo, tblInfo); err != nil {
 		return err
 	}
 	job := &model.Job{

--- a/pkg/ddl/export_test.go
+++ b/pkg/ddl/export_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/copr"
 	"github.com/pingcap/tidb/pkg/ddl/internal/session"
 	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
@@ -67,11 +68,12 @@ func FetchChunk4Test(copCtx copr.CopContext, tbl table.PhysicalTable, startKey, 
 }
 
 func ConvertRowToHandleAndIndexDatum(
+	ctx expression.EvalContext,
 	handleDataBuf, idxDataBuf []types.Datum,
 	row chunk.Row, copCtx copr.CopContext, idxID int64) (kv.Handle, []types.Datum, error) {
 	c := copCtx.GetBase()
-	idxData := extractDatumByOffsets(row, copCtx.IndexColumnOutputOffsets(idxID), c.ExprColumnInfos, idxDataBuf)
-	handleData := extractDatumByOffsets(row, c.HandleOutputOffsets, c.ExprColumnInfos, handleDataBuf)
+	idxData := extractDatumByOffsets(ctx, row, copCtx.IndexColumnOutputOffsets(idxID), c.ExprColumnInfos, idxDataBuf)
+	handleData := extractDatumByOffsets(ctx, row, c.HandleOutputOffsets, c.ExprColumnInfos, handleDataBuf)
 	handle, err := buildHandle(handleData, c.TableInfo, c.PrimaryKeyInfo, time.Local, errctx.StrictNoWarningContext)
 	return handle, idxData, err
 }

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1746,6 +1746,7 @@ func writeChunkToLocal(
 ) (int, kv.Handle, error) {
 	iter := chunk.NewIterator4Chunk(copChunk)
 	c := copCtx.GetBase()
+	ectx := c.ExprCtx.GetEvalCtx()
 
 	maxIdxColCnt := maxIndexColumnCount(indexes)
 	idxDataBuf := make([]types.Datum, maxIdxColCnt)
@@ -1778,7 +1779,7 @@ func writeChunkToLocal(
 		restoreDataBuf = make([]types.Datum, len(c.HandleOutputOffsets))
 	}
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		handleDataBuf := extractDatumByOffsets(row, c.HandleOutputOffsets, c.ExprColumnInfos, handleDataBuf)
+		handleDataBuf := extractDatumByOffsets(ectx, row, c.HandleOutputOffsets, c.ExprColumnInfos, handleDataBuf)
 		if restore {
 			// restoreDataBuf should not truncate index values.
 			for i, datum := range handleDataBuf {
@@ -1791,7 +1792,7 @@ func writeChunkToLocal(
 		}
 		for i, index := range indexes {
 			idxID := index.Meta().ID
-			idxDataBuf = extractDatumByOffsets(
+			idxDataBuf = extractDatumByOffsets(ectx,
 				row, copCtx.IndexColumnOutputOffsets(idxID), c.ExprColumnInfos, idxDataBuf)
 			idxData := idxDataBuf[:len(index.Meta().Columns)]
 			var rsData []types.Datum

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -369,10 +369,10 @@ func constructTableScanPB(ctx exprctx.BuildContext, tblInfo *model.TableInfo, co
 	return &tipb.Executor{Tp: tipb.ExecType_TypeTableScan, TblScan: tblScan}, err
 }
 
-func extractDatumByOffsets(row chunk.Row, offsets []int, expCols []*expression.Column, buf []types.Datum) []types.Datum {
+func extractDatumByOffsets(ctx expression.EvalContext, row chunk.Row, offsets []int, expCols []*expression.Column, buf []types.Datum) []types.Datum {
 	for i, offset := range offsets {
 		c := expCols[offset]
-		row.DatumWithBuffer(offset, c.GetType(), &buf[i])
+		row.DatumWithBuffer(offset, c.GetType(ctx), &buf[i])
 	}
 	return buf
 }

--- a/pkg/ddl/index_cop_test.go
+++ b/pkg/ddl/index_cop_test.go
@@ -60,7 +60,7 @@ func TestAddIndexFetchRowsFromCoprocessor(t *testing.T) {
 		idxDataBuf := make([]types.Datum, len(idxInfo.Columns))
 
 		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-			handle, idxDatum, err := ddl.ConvertRowToHandleAndIndexDatum(handleDataBuf, idxDataBuf, row, copCtx, idxInfo.ID)
+			handle, idxDatum, err := ddl.ConvertRowToHandleAndIndexDatum(tk.Session().GetExprCtx().GetEvalCtx(), handleDataBuf, idxDataBuf, row, copCtx, idxInfo.ID)
 			require.NoError(t, err)
 			handles = append(handles, handle)
 			copiedIdxDatum := make([]types.Datum, len(idxDatum))

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -100,14 +100,14 @@ func (h *chunkRowHeap) Pop() any {
 
 // NewSortedSelectResults is only for partition table
 // If schema == nil, sort by first few columns.
-func NewSortedSelectResults(selectResult []SelectResult, schema *expression.Schema, byitems []*util.ByItems, memTracker *memory.Tracker) SelectResult {
+func NewSortedSelectResults(ectx expression.EvalContext, selectResult []SelectResult, schema *expression.Schema, byitems []*util.ByItems, memTracker *memory.Tracker) SelectResult {
 	s := &sortedSelectResults{
 		schema:       schema,
 		selectResult: selectResult,
 		byItems:      byitems,
 		memTracker:   memTracker,
 	}
-	s.initCompareFuncs()
+	s.initCompareFuncs(ectx)
 	s.buildKeyColumns()
 	s.heap = &chunkRowHeap{s}
 	s.cachedChunks = make([]*chunk.Chunk, len(selectResult))
@@ -141,10 +141,10 @@ func (ssr *sortedSelectResults) updateCachedChunk(ctx context.Context, idx uint3
 	return nil
 }
 
-func (ssr *sortedSelectResults) initCompareFuncs() {
+func (ssr *sortedSelectResults) initCompareFuncs(ectx expression.EvalContext) {
 	ssr.compareFuncs = make([]chunk.CompareFunc, len(ssr.byItems))
 	for i, item := range ssr.byItems {
-		keyType := item.Expr.GetType()
+		keyType := item.Expr.GetType(ectx)
 		ssr.compareFuncs[i] = chunk.GetCompareFunc(keyType)
 	}
 }

--- a/pkg/executor/aggfuncs/aggfunc_test.go
+++ b/pkg/executor/aggfuncs/aggfunc_test.go
@@ -389,7 +389,7 @@ func testMultiArgsMergePartialResult(t *testing.T, ctx *mock.Context, p multiArg
 			{Expr: args[0], Desc: true},
 		}
 	}
-	ctor := collate.GetCollator(args[0].GetType().GetCollate())
+	ctor := collate.GetCollator(args[0].GetType(ctx).GetCollate())
 	partialDesc, finalDesc := desc.Split([]int{0, 1})
 
 	// build partial func for partial phase.
@@ -684,7 +684,7 @@ func testMultiArgsAggFunc(t *testing.T, ctx *mock.Context, p multiArgsAggTest) {
 			{Expr: args[0], Desc: true},
 		}
 	}
-	ctor := collate.GetCollator(args[0].GetType().GetCollate())
+	ctor := collate.GetCollator(args[0].GetType(ctx).GetCollate())
 	finalFunc := aggfuncs.Build(ctx, desc, 0)
 	finalPr, _ := finalFunc.AllocPartialResult()
 	resultChk := chunk.NewChunkWithCapacity([]*types.FieldType{desc.RetTp}, 1)

--- a/pkg/executor/aggfuncs/builder.go
+++ b/pkg/executor/aggfuncs/builder.go
@@ -37,7 +37,7 @@ type AggFuncBuildContext = exprctx.ExprContext
 func Build(ctx AggFuncBuildContext, aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 	switch aggFuncDesc.Name {
 	case ast.AggFuncCount:
-		return buildCount(aggFuncDesc, ordinal)
+		return buildCount(ctx.GetEvalCtx(), aggFuncDesc, ordinal)
 	case ast.AggFuncSum:
 		return buildSum(ctx, aggFuncDesc, ordinal)
 	case ast.AggFuncAvg:
@@ -103,9 +103,9 @@ func BuildWindowFunctions(ctx AggFuncBuildContext, windowFuncDesc *aggregation.A
 		return buildLag(ctx, windowFuncDesc, ordinal)
 	case ast.AggFuncMax:
 		// The max/min aggFunc using in the window function will using the sliding window algo.
-		return buildMaxMinInWindowFunction(windowFuncDesc, ordinal, true)
+		return buildMaxMinInWindowFunction(ctx, windowFuncDesc, ordinal, true)
 	case ast.AggFuncMin:
-		return buildMaxMinInWindowFunction(windowFuncDesc, ordinal, false)
+		return buildMaxMinInWindowFunction(ctx, windowFuncDesc, ordinal, false)
 	default:
 		return Build(ctx, windowFuncDesc, ordinal)
 	}
@@ -144,9 +144,9 @@ func buildApproxCountDistinct(aggFuncDesc *aggregation.AggFuncDesc, ordinal int)
 	return nil
 }
 
-func getEvalTypeForApproxPercentile(aggFuncDesc *aggregation.AggFuncDesc) types.EvalType {
-	evalType := aggFuncDesc.Args[0].GetType().EvalType()
-	argType := aggFuncDesc.Args[0].GetType().GetType()
+func getEvalTypeForApproxPercentile(ctx expression.EvalContext, aggFuncDesc *aggregation.AggFuncDesc) types.EvalType {
+	evalType := aggFuncDesc.Args[0].GetType(ctx).EvalType()
+	argType := aggFuncDesc.Args[0].GetType(ctx).GetType()
 
 	// Sometimes `mysql.EnumSetAsIntFlag` may be set to true, such as when join,
 	// which is unexpected for `buildApproxPercentile` and `mysql.TypeEnum` and `mysql.TypeSet` will return unexpected `ETInt` here,
@@ -174,7 +174,7 @@ func buildApproxPercentile(sctx AggFuncBuildContext, aggFuncDesc *aggregation.Ag
 
 	base := basePercentile{percent: int(percent), baseAggFunc: baseAggFunc{args: aggFuncDesc.Args, ordinal: ordinal}}
 
-	evalType := getEvalTypeForApproxPercentile(aggFuncDesc)
+	evalType := getEvalTypeForApproxPercentile(sctx.GetEvalCtx(), aggFuncDesc)
 	switch aggFuncDesc.Mode {
 	case aggregation.CompleteMode, aggregation.Partial1Mode, aggregation.FinalMode:
 		switch evalType {
@@ -198,7 +198,7 @@ func buildApproxPercentile(sctx AggFuncBuildContext, aggFuncDesc *aggregation.Ag
 }
 
 // buildCount builds the AggFunc implementation for function "COUNT".
-func buildCount(aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
+func buildCount(ctx expression.EvalContext, aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 	// If mode is DedupMode, we return nil for not implemented.
 	if aggFuncDesc.Mode == aggregation.DedupMode {
 		return nil // not implemented yet.
@@ -220,7 +220,7 @@ func buildCount(aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 			// so they're in exception for now.
 			// TODO: add hashCode method for all evaluate types (decimal, Time, Duration, JSON).
 			// https://github.com/pingcap/tidb/issues/15857
-			switch aggFuncDesc.Args[0].GetType().EvalType() {
+			switch aggFuncDesc.Args[0].GetType(ctx).EvalType() {
 			case types.ETInt:
 				return &countOriginalWithDistinct4Int{baseCount{base}}
 			case types.ETReal:
@@ -238,7 +238,7 @@ func buildCount(aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 
 	switch aggFuncDesc.Mode {
 	case aggregation.CompleteMode, aggregation.Partial1Mode:
-		switch aggFuncDesc.Args[0].GetType().EvalType() {
+		switch aggFuncDesc.Args[0].GetType(ctx).EvalType() {
 		case types.ETInt:
 			return &countOriginal4Int{baseCount{base}}
 		case types.ETReal:
@@ -437,7 +437,7 @@ func buildMaxMin(aggFuncDesc *aggregation.AggFuncDesc, ordinal int, isMax bool) 
 }
 
 // buildMaxMin builds the AggFunc implementation for function "MAX" and "MIN" using by window function.
-func buildMaxMinInWindowFunction(aggFuncDesc *aggregation.AggFuncDesc, ordinal int, isMax bool) AggFunc {
+func buildMaxMinInWindowFunction(ctx AggFuncBuildContext, aggFuncDesc *aggregation.AggFuncDesc, ordinal int, isMax bool) AggFunc {
 	base := buildMaxMin(aggFuncDesc, ordinal, isMax)
 	// build max/min aggFunc for window function using sliding window
 	switch baseAggFunc := base.(type) {
@@ -452,7 +452,7 @@ func buildMaxMinInWindowFunction(aggFuncDesc *aggregation.AggFuncDesc, ordinal i
 	case *maxMin4Decimal:
 		return &maxMin4DecimalSliding{*baseAggFunc, windowInfo{}}
 	case *maxMin4String:
-		return &maxMin4StringSliding{*baseAggFunc, windowInfo{}}
+		return &maxMin4StringSliding{*baseAggFunc, windowInfo{}, baseAggFunc.args[0].GetType(ctx.GetEvalCtx()).GetCollate()}
 	case *maxMin4Time:
 		return &maxMin4TimeSliding{*baseAggFunc, windowInfo{}}
 	case *maxMin4Duration:
@@ -488,12 +488,25 @@ func buildGroupConcat(ctx AggFuncBuildContext, aggFuncDesc *aggregation.AggFuncD
 		}
 		if aggFuncDesc.HasDistinct {
 			if len(aggFuncDesc.OrderByItems) > 0 {
-				return &groupConcatDistinctOrder{base}
+				desc := make([]bool, len(base.byItems))
+				ctors := make([]collate.Collator, 0, len(base.byItems))
+				for i, byItem := range base.byItems {
+					desc[i] = byItem.Desc
+					ctors = append(ctors, collate.GetCollator(byItem.Expr.GetType(ctx.GetEvalCtx()).GetCollate()))
+				}
+				return &groupConcatDistinctOrder{base, ctors, desc}
 			}
 			return &groupConcatDistinct{base}
 		}
 		if len(aggFuncDesc.OrderByItems) > 0 {
-			return &groupConcatOrder{base}
+			desc := make([]bool, len(base.byItems))
+			ctors := make([]collate.Collator, 0, len(base.byItems))
+			for i, byItem := range base.byItems {
+				desc[i] = byItem.Desc
+				ctors = append(ctors, collate.GetCollator(byItem.Expr.GetType(ctx.GetEvalCtx()).GetCollate()))
+			}
+
+			return &groupConcatOrder{base, ctors, desc}
 		}
 		return &groupConcat{base}
 	}

--- a/pkg/executor/aggfuncs/func_count_distinct.go
+++ b/pkg/executor/aggfuncs/func_count_distinct.go
@@ -267,7 +267,7 @@ func (e *countOriginalWithDistinct4String) AppendFinalResult2Chunk(_ AggFuncUpda
 
 func (e *countOriginalWithDistinct4String) UpdatePartialResult(sctx AggFuncUpdateContext, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4CountDistinctString)(pr)
-	collator := collate.GetCollator(e.args[0].GetType().GetCollate())
+	collator := collate.GetCollator(e.args[0].GetType(sctx).GetCollate())
 
 	for _, row := range rowsInGroup {
 		input, isNull, err := e.args[0].EvalString(sctx, row)
@@ -322,7 +322,7 @@ func (e *countOriginalWithDistinct) UpdatePartialResult(sctx AggFuncUpdateContex
 	encodedBytes := make([]byte, 0)
 	collators := make([]collate.Collator, 0, len(e.args))
 	for _, arg := range e.args {
-		collators = append(collators, collate.GetCollator(arg.GetType().GetCollate()))
+		collators = append(collators, collate.GetCollator(arg.GetType(sctx).GetCollate()))
 	}
 	// decimal struct is the biggest type we will use.
 	buf := make([]byte, types.MyDecimalStructSize)
@@ -358,7 +358,7 @@ func evalAndEncode(
 	sctx expression.EvalContext, arg expression.Expression, collator collate.Collator,
 	row chunk.Row, buf, encodedBytes []byte,
 ) (_ []byte, isNull bool, err error) {
-	switch tp := arg.GetType().EvalType(); tp {
+	switch tp := arg.GetType(sctx).EvalType(); tp {
 	case types.ETInt:
 		var val int64
 		val, isNull, err = arg.EvalInt(sctx, row)
@@ -778,7 +778,7 @@ func (e *approxCountDistinctOriginal) UpdatePartialResult(sctx AggFuncUpdateCont
 	buf := make([]byte, types.MyDecimalStructSize)
 	collators := make([]collate.Collator, 0, len(e.args))
 	for _, arg := range e.args {
-		collators = append(collators, collate.GetCollator(arg.GetType().GetCollate()))
+		collators = append(collators, collate.GetCollator(arg.GetType(sctx).GetCollate()))
 	}
 
 	for _, row := range rowsInGroup {

--- a/pkg/executor/aggfuncs/func_json_arrayagg.go
+++ b/pkg/executor/aggfuncs/func_json_arrayagg.go
@@ -69,7 +69,7 @@ func (e *jsonArrayagg) UpdatePartialResult(ctx AggFuncUpdateContext, rowsInGroup
 			return 0, errors.Trace(err)
 		}
 
-		realItem, err := getRealJSONValue(item, e.args[0].GetType())
+		realItem, err := getRealJSONValue(item, e.args[0].GetType(ctx))
 		if err != nil {
 			return 0, errors.Trace(err)
 		}

--- a/pkg/executor/aggfuncs/func_json_objectagg.go
+++ b/pkg/executor/aggfuncs/func_json_objectagg.go
@@ -80,8 +80,8 @@ func (e *jsonObjectAgg) UpdatePartialResult(sctx AggFuncUpdateContext, rowsInGro
 			return 0, types.ErrJSONDocumentNULLKey
 		}
 
-		if e.args[0].GetType().GetCharset() == charset.CharsetBin {
-			return 0, types.ErrInvalidJSONCharset.GenWithStackByArgs(e.args[0].GetType().GetCharset())
+		if e.args[0].GetType(sctx).GetCharset() == charset.CharsetBin {
+			return 0, types.ErrInvalidJSONCharset.GenWithStackByArgs(e.args[0].GetType(sctx).GetCharset())
 		}
 
 		key = strings.Clone(key)
@@ -90,7 +90,7 @@ func (e *jsonObjectAgg) UpdatePartialResult(sctx AggFuncUpdateContext, rowsInGro
 			return 0, errors.Trace(err)
 		}
 
-		realVal, err := getRealJSONValue(value, e.args[1].GetType())
+		realVal, err := getRealJSONValue(value, e.args[1].GetType(sctx))
 		if err != nil {
 			return 0, errors.Trace(err)
 		}

--- a/pkg/executor/aggregate/agg_util.go
+++ b/pkg/executor/aggregate/agg_util.go
@@ -116,7 +116,7 @@ func GetGroupKey(ctx sessionctx.Context, input *chunk.Chunk, groupKey [][]byte, 
 	errCtx := ctx.GetSessionVars().StmtCtx.ErrCtx()
 	exprCtx := ctx.GetExprCtx()
 	for _, item := range groupByItems {
-		tp := item.GetType()
+		tp := item.GetType(ctx.GetExprCtx().GetEvalCtx())
 
 		buf, err := expression.GetColumn(tp.EvalType(), numRows)
 		if err != nil {
@@ -129,7 +129,7 @@ func GetGroupKey(ctx sessionctx.Context, input *chunk.Chunk, groupKey [][]byte, 
 		// Ref to issue #26885.
 		// This check is used to handle invalid enum name same with user defined enum name.
 		// Use enum value as groupKey instead of enum name.
-		if item.GetType().GetType() == mysql.TypeEnum {
+		if item.GetType(ctx.GetExprCtx().GetEvalCtx()).GetType() == mysql.TypeEnum {
 			newTp := *tp
 			newTp.AddFlag(mysql.EnumSetAsIntFlag)
 			tp = &newTp
@@ -140,7 +140,7 @@ func GetGroupKey(ctx sessionctx.Context, input *chunk.Chunk, groupKey [][]byte, 
 			return nil, err
 		}
 		// This check is used to avoid error during the execution of `EncodeDecimal`.
-		if item.GetType().GetType() == mysql.TypeNewDecimal {
+		if item.GetType(ctx.GetExprCtx().GetEvalCtx()).GetType() == mysql.TypeNewDecimal {
 			newTp := *tp
 			newTp.SetFlen(0)
 			tp = &newTp

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -375,7 +375,7 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 			}
 			results = append(results, result)
 		}
-		e.result = distsql.NewSortedSelectResults(results, e.Schema(), e.byItems, e.memTracker)
+		e.result = distsql.NewSortedSelectResults(e.Ctx().GetExprCtx().GetEvalCtx(), results, e.Schema(), e.byItems, e.memTracker)
 	}
 	return nil
 }
@@ -620,7 +620,7 @@ func (e *IndexLookUpExecutor) getRetTpsForIndexReader() []*types.FieldType {
 	var tps []*types.FieldType
 	if len(e.byItems) != 0 {
 		for _, item := range e.byItems {
-			tps = append(tps, item.Expr.GetType())
+			tps = append(tps, item.Expr.GetType(e.Ctx().GetExprCtx().GetEvalCtx()))
 		}
 	}
 	if e.isCommonHandle() {
@@ -719,7 +719,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 		worker.batchSize = min(initBatchSize, worker.maxBatchSize)
 		if len(results) > 1 && len(e.byItems) != 0 {
 			// e.Schema() not the output schema for indexReader, and we put byItems related column at first in `buildIndexReq`, so use nil here.
-			ssr := distsql.NewSortedSelectResults(results, nil, e.byItems, e.memTracker)
+			ssr := distsql.NewSortedSelectResults(e.Ctx().GetExprCtx().GetEvalCtx(), results, nil, e.byItems, e.memTracker)
 			results = []distsql.SelectResult{ssr}
 		}
 		ctx1, cancel := context.WithCancel(ctx)

--- a/pkg/executor/executor_required_rows_test.go
+++ b/pkg/executor/executor_required_rows_test.go
@@ -734,7 +734,7 @@ func buildMergeJoinExec(ctx sessionctx.Context, joinType plannercore.JoinType, i
 
 	j.CompareFuncs = make([]expression.CompareFunc, 0, len(j.LeftJoinKeys))
 	for i := range j.LeftJoinKeys {
-		j.CompareFuncs = append(j.CompareFuncs, expression.GetCmpFunction(nil, j.LeftJoinKeys[i], j.RightJoinKeys[i]))
+		j.CompareFuncs = append(j.CompareFuncs, expression.GetCmpFunction(ctx.GetExprCtx(), j.LeftJoinKeys[i], j.RightJoinKeys[i]))
 	}
 
 	b := newExecutorBuilder(ctx, nil)

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -590,7 +590,7 @@ func (p *Plan) initOptions(ctx context.Context, seCtx sessionctx.Context, option
 	}
 
 	optAsString := func(opt *plannercore.LoadDataOpt) (string, error) {
-		if opt.Value.GetType().GetType() != mysql.TypeVarString {
+		if opt.Value.GetType(seCtx.GetExprCtx().GetEvalCtx()).GetType() != mysql.TypeVarString {
 			return "", exeerrors.ErrInvalidOptionVal.FastGenByArgs(opt.Name)
 		}
 		val, isNull, err2 := opt.Value.EvalString(seCtx.GetExprCtx().GetEvalCtx(), chunk.Row{})
@@ -601,7 +601,7 @@ func (p *Plan) initOptions(ctx context.Context, seCtx sessionctx.Context, option
 	}
 	optAsInt64 := func(opt *plannercore.LoadDataOpt) (int64, error) {
 		// current parser takes integer and bool as mysql.TypeLonglong
-		if opt.Value.GetType().GetType() != mysql.TypeLonglong || mysql.HasIsBooleanFlag(opt.Value.GetType().GetFlag()) {
+		if opt.Value.GetType(seCtx.GetExprCtx().GetEvalCtx()).GetType() != mysql.TypeLonglong || mysql.HasIsBooleanFlag(opt.Value.GetType(seCtx.GetExprCtx().GetEvalCtx()).GetFlag()) {
 			return 0, exeerrors.ErrInvalidOptionVal.FastGenByArgs(opt.Name)
 		}
 		val, isNull, err2 := opt.Value.EvalInt(seCtx.GetExprCtx().GetEvalCtx(), chunk.Row{})

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -922,7 +922,7 @@ ForColumnsTag:
 				idx := expression.FindFieldNameIdxByColName(e.viewOutputNamesMap[tbl.ID], col.Name.L)
 				if idx >= 0 {
 					col1 := e.viewSchemaMap[tbl.ID].Columns[idx]
-					ft = col1.GetType()
+					ft = col1.GetType(sctx.GetExprCtx().GetEvalCtx())
 				}
 			}
 			e.viewMu.RUnlock()

--- a/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
+++ b/pkg/executor/internal/vecgroupchecker/vec_group_checker.go
@@ -160,7 +160,7 @@ func (e *VecGroupChecker) SplitIntoGroups(chk *chunk.Chunk) (isFirstGroupSameAsP
 func (e *VecGroupChecker) getFirstAndLastRowDatum(
 	item expression.Expression, chk *chunk.Chunk, numRows int) (err error) {
 	var firstRowDatum, lastRowDatum types.Datum
-	tp := item.GetType()
+	tp := item.GetType(e.ctx)
 	eType := tp.EvalType()
 	switch eType {
 	case types.ETInt:
@@ -328,7 +328,7 @@ func (e *VecGroupChecker) getFirstAndLastRowDatum(
 // And resolve the rows into groups according to the evaluation results
 func (e *VecGroupChecker) evalGroupItemsAndResolveGroups(
 	item expression.Expression, vecEnabled bool, chk *chunk.Chunk, numRows int) (err error) {
-	tp := item.GetType()
+	tp := item.GetType(e.ctx)
 	eType := tp.EvalType()
 	if e.allocateBuffer == nil {
 		e.allocateBuffer = expression.GetColumn

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -448,7 +448,7 @@ func fillRowChecksum(
 		columnFt[col.ID] = &col.FieldType
 	}
 	tz := sctx.GetSessionVars().TimeZone
-	ft := []*types.FieldType{schema.Columns[checksumColumnIndex].GetType()}
+	ft := []*types.FieldType{schema.Columns[checksumColumnIndex].GetType(sctx.GetExprCtx().GetEvalCtx())}
 	checksumCols := chunk.NewChunkWithCapacity(ft, req.Capacity())
 	for i := start; i < end; i++ {
 		handle, val := handles[i], values[i]

--- a/pkg/executor/select_into.go
+++ b/pkg/executor/select_into.go
@@ -149,7 +149,7 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 				s.lineBuf = append(s.lineBuf, nullTerm...)
 				continue
 			}
-			et := col.GetType().EvalType()
+			et := col.GetType(s.Ctx().GetExprCtx().GetEvalCtx()).EvalType()
 			if (encloseFlag && !encloseOpt) ||
 				(encloseFlag && encloseOpt && s.considerEncloseOpt(et)) {
 				s.lineBuf = append(s.lineBuf, encloseByte)
@@ -158,11 +158,11 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 				s.enclosed = false
 			}
 			s.fieldBuf = s.fieldBuf[:0]
-			switch col.GetType().GetType() {
+			switch col.GetType(s.Ctx().GetExprCtx().GetEvalCtx()).GetType() {
 			case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeYear:
 				s.fieldBuf = strconv.AppendInt(s.fieldBuf, row.GetInt64(j), 10)
 			case mysql.TypeLonglong:
-				if mysql.HasUnsignedFlag(col.GetType().GetFlag()) {
+				if mysql.HasUnsignedFlag(col.GetType(s.Ctx().GetExprCtx().GetEvalCtx()).GetFlag()) {
 					s.fieldBuf = strconv.AppendUint(s.fieldBuf, row.GetUint64(j), 10)
 				} else {
 					s.fieldBuf = strconv.AppendInt(s.fieldBuf, row.GetInt64(j), 10)
@@ -182,7 +182,7 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 			case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
 				s.fieldBuf = append(s.fieldBuf, row.GetTime(j).String()...)
 			case mysql.TypeDuration:
-				s.fieldBuf = append(s.fieldBuf, row.GetDuration(j, col.GetType().GetDecimal()).String()...)
+				s.fieldBuf = append(s.fieldBuf, row.GetDuration(j, col.GetType(s.Ctx().GetExprCtx().GetEvalCtx()).GetDecimal()).String()...)
 			case mysql.TypeEnum:
 				s.fieldBuf = append(s.fieldBuf, row.GetEnum(j).String()...)
 			case mysql.TypeSet:
@@ -191,7 +191,7 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 				s.fieldBuf = append(s.fieldBuf, row.GetJSON(j).String()...)
 			}
 
-			switch col.GetType().EvalType() {
+			switch col.GetType(s.Ctx().GetExprCtx().GetEvalCtx()).EvalType() {
 			case types.ETString, types.ETJson:
 				s.lineBuf = append(s.lineBuf, s.escapeField(s.fieldBuf)...)
 			default:

--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -97,7 +97,7 @@ func (e *SetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 				sessionVars.UnsetUserVar(name)
 			} else {
 				sessionVars.SetUserVarVal(name, value)
-				sessionVars.SetUserVarType(name, v.Expr.GetType())
+				sessionVars.SetUserVarType(name, v.Expr.GetType(sctx.GetExprCtx().GetEvalCtx()))
 			}
 			continue
 		}

--- a/pkg/executor/set_config.go
+++ b/pkg/executor/set_config.go
@@ -187,7 +187,7 @@ func ConvertConfigItem2JSON(ctx sessionctx.Context, key string, val expression.E
 	}
 	isNull := false
 	str := ""
-	switch val.GetType().EvalType() {
+	switch val.GetType(ctx.GetExprCtx().GetEvalCtx()).EvalType() {
 	case types.ETString:
 		var s string
 		s, isNull, err = val.EvalString(ctx.GetExprCtx().GetEvalCtx(), chunk.Row{})
@@ -198,7 +198,7 @@ func ConvertConfigItem2JSON(ctx sessionctx.Context, key string, val expression.E
 		var i int64
 		i, isNull, err = val.EvalInt(ctx.GetExprCtx().GetEvalCtx(), chunk.Row{})
 		if err == nil && !isNull {
-			if mysql.HasIsBooleanFlag(val.GetType().GetFlag()) {
+			if mysql.HasIsBooleanFlag(val.GetType(ctx.GetExprCtx().GetEvalCtx()).GetFlag()) {
 				str = "true"
 				if i == 0 {
 					str = "false"

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -2355,7 +2355,7 @@ func tryFillViewColumnType(ctx context.Context, sctx sessionctx.Context, is info
 		for _, col := range tbl.Columns {
 			idx := expression.FindFieldNameIdxByColName(viewOutputNames, col.Name.L)
 			if idx >= 0 {
-				col.FieldType = *viewSchema.Columns[idx].GetType()
+				col.FieldType = *viewSchema.Columns[idx].GetType(sctx.GetExprCtx().GetEvalCtx())
 			}
 			if col.GetType() == mysql.TypeVarString {
 				col.SetType(mysql.TypeVarchar)

--- a/pkg/executor/sortexec/BUILD.bazel
+++ b/pkg/executor/sortexec/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/executor/internal/exec",
         "//pkg/executor/internal/testutil",
         "//pkg/expression",
+        "//pkg/expression/contextstatic",
         "//pkg/parser/mysql",
         "//pkg/planner/core",
         "//pkg/planner/util",

--- a/pkg/executor/sortexec/sort.go
+++ b/pkg/executor/sortexec/sort.go
@@ -272,7 +272,7 @@ func (e *SortExec) InitInParallelModeForTest() {
 */
 func (e *SortExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	if e.fetched.CompareAndSwap(false, true) {
-		e.initCompareFuncs()
+		e.initCompareFuncs(e.Ctx().GetExprCtx().GetEvalCtx())
 		e.buildKeyColumns()
 		err := e.fetchChunks(ctx)
 		if err != nil {
@@ -753,10 +753,10 @@ func (e *SortExec) fetchChunksFromChild(ctx context.Context) {
 	}
 }
 
-func (e *SortExec) initCompareFuncs() {
+func (e *SortExec) initCompareFuncs(ctx expression.EvalContext) {
 	e.keyCmpFuncs = make([]chunk.CompareFunc, len(e.ByItems))
 	for i := range e.ByItems {
-		keyType := e.ByItems[i].Expr.GetType()
+		keyType := e.ByItems[i].Expr.GetType(ctx)
 		e.keyCmpFuncs[i] = chunk.GetCompareFunc(keyType)
 	}
 }

--- a/pkg/executor/sortexec/sort_spill_test.go
+++ b/pkg/executor/sortexec/sort_spill_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/executor/internal/testutil"
 	"github.com/pingcap/tidb/pkg/executor/sortexec"
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -99,6 +100,8 @@ func (r *resultChecker) initRowPtrs() {
 }
 
 func (r *resultChecker) check(resultChunks []*chunk.Chunk, offset int64, count int64) bool {
+	ctx := contextstatic.NewStaticEvalContext()
+
 	if r.rowPtrs == nil {
 		r.initRowPtrs()
 		sort.Slice(r.rowPtrs, r.keyColumnsLess)
@@ -114,7 +117,7 @@ func (r *resultChecker) check(resultChunks []*chunk.Chunk, offset int64, count i
 	cursor := 0
 	fieldTypes := make([]*types.FieldType, 0)
 	for _, col := range r.schema.Columns {
-		fieldTypes = append(fieldTypes, col.GetType())
+		fieldTypes = append(fieldTypes, col.GetType(ctx))
 	}
 
 	// Check row number

--- a/pkg/executor/sortexec/topn.go
+++ b/pkg/executor/sortexec/topn.go
@@ -261,7 +261,7 @@ func (e *TopNExec) fetchChunks(ctx context.Context) error {
 }
 
 func (e *TopNExec) loadChunksUntilTotalLimit(ctx context.Context) error {
-	e.initCompareFuncs()
+	e.initCompareFuncs(e.Ctx().GetExprCtx().GetEvalCtx())
 	e.buildKeyColumns()
 	e.chkHeap.init(e, e.memTracker, e.Limit.Offset+e.Limit.Count, int(e.Limit.Offset), e.greaterRow, e.RetFieldTypes())
 	for uint64(e.chkHeap.rowChunks.Len()) < e.chkHeap.totalLimit {

--- a/pkg/executor/table_reader.go
+++ b/pkg/executor/table_reader.go
@@ -401,7 +401,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 		if len(results) == 1 {
 			return results[0], nil
 		}
-		return distsql.NewSortedSelectResults(results, e.Schema(), e.byItems, e.memTracker), nil
+		return distsql.NewSortedSelectResults(e.ectx.GetEvalCtx(), results, e.Schema(), e.byItems, e.memTracker), nil
 	}
 
 	kvReq, err := e.buildKVReq(ctx, ranges)

--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -200,6 +200,7 @@ go_test(
         "//pkg/errctx",
         "//pkg/errno",
         "//pkg/expression/context",
+        "//pkg/expression/contextstatic",
         "//pkg/kv",
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -79,11 +79,11 @@ func NewDistAggFunc(expr *tipb.Expr, fieldTps []*types.FieldType, ctx expression
 	case tipb.ExprType_Max:
 		aggF := newAggFunc(ast.AggFuncMax, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
-		return &maxMinFunction{aggFunction: aggF, isMax: true, ctor: collate.GetCollator(args[0].GetType().GetCollate())}, aggF.AggFuncDesc, nil
+		return &maxMinFunction{aggFunction: aggF, isMax: true, ctor: collate.GetCollator(args[0].GetType(ctx.GetEvalCtx()).GetCollate())}, aggF.AggFuncDesc, nil
 	case tipb.ExprType_Min:
 		aggF := newAggFunc(ast.AggFuncMin, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
-		return &maxMinFunction{aggFunction: aggF, ctor: collate.GetCollator(args[0].GetType().GetCollate())}, aggF.AggFuncDesc, nil
+		return &maxMinFunction{aggFunction: aggF, ctor: collate.GetCollator(args[0].GetType(ctx.GetEvalCtx()).GetCollate())}, aggF.AggFuncDesc, nil
 	case tipb.ExprType_First:
 		aggF := newAggFunc(ast.AggFuncFirstRow, args, false)
 		aggF.Mode = AggFunctionMode(*expr.AggFuncMode)
@@ -232,7 +232,7 @@ func IsAllFirstRow(aggFuncs []*AggFuncDesc) bool {
 }
 
 // CheckAggPushDown checks whether an agg function can be pushed to storage.
-func CheckAggPushDown(aggFunc *AggFuncDesc, storeType kv.StoreType) bool {
+func CheckAggPushDown(ctx expression.EvalContext, aggFunc *AggFuncDesc, storeType kv.StoreType) bool {
 	if len(aggFunc.OrderByItems) > 0 && aggFunc.Name != ast.AggFuncGroupConcat {
 		return false
 	}
@@ -242,7 +242,7 @@ func CheckAggPushDown(aggFunc *AggFuncDesc, storeType kv.StoreType) bool {
 	ret := true
 	switch storeType {
 	case kv.TiFlash:
-		ret = CheckAggPushFlash(aggFunc)
+		ret = CheckAggPushFlash(ctx, aggFunc)
 	case kv.TiKV:
 		// TiKV does not support group_concat now
 		ret = aggFunc.Name != ast.AggFuncGroupConcat
@@ -254,9 +254,9 @@ func CheckAggPushDown(aggFunc *AggFuncDesc, storeType kv.StoreType) bool {
 }
 
 // CheckAggPushFlash checks whether an agg function can be pushed to flash storage.
-func CheckAggPushFlash(aggFunc *AggFuncDesc) bool {
+func CheckAggPushFlash(ctx expression.EvalContext, aggFunc *AggFuncDesc) bool {
 	for _, arg := range aggFunc.Args {
-		if arg.GetType().GetType() == mysql.TypeDuration {
+		if arg.GetType(ctx).GetType() == mysql.TypeDuration {
 			return false
 		}
 	}
@@ -265,7 +265,7 @@ func CheckAggPushFlash(aggFunc *AggFuncDesc) bool {
 		return true
 	case ast.AggFuncSum, ast.AggFuncAvg, ast.AggFuncGroupConcat:
 		// Now tiflash doesn't support CastJsonAsReal and CastJsonAsString.
-		return aggFunc.Args[0].GetType().GetType() != mysql.TypeJSON
+		return aggFunc.Args[0].GetType(ctx).GetType() != mysql.TypeJSON
 	}
 	return false
 }

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -94,9 +94,9 @@ func (a *baseFuncDesc) TypeInfer(ctx expression.BuildContext) error {
 	case ast.AggFuncApproxPercentile:
 		return a.typeInfer4ApproxPercentile(ctx.GetEvalCtx())
 	case ast.AggFuncSum:
-		a.typeInfer4Sum()
+		a.typeInfer4Sum(ctx.GetEvalCtx())
 	case ast.AggFuncAvg:
-		a.typeInfer4Avg(ctx.GetEvalCtx().GetDivPrecisionIncrement())
+		a.typeInfer4Avg(ctx.GetEvalCtx())
 	case ast.AggFuncGroupConcat:
 		a.typeInfer4GroupConcat(ctx)
 	case ast.AggFuncMax, ast.AggFuncMin, ast.AggFuncFirstRow,
@@ -158,7 +158,7 @@ func (a *baseFuncDesc) typeInfer4ApproxPercentile(ctx expression.EvalContext) er
 		return fmt.Errorf("Percentage value %d is out of range [1, 100]", percent)
 	}
 
-	switch a.Args[0].GetType().GetType() {
+	switch a.Args[0].GetType(ctx).GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		a.RetTp = types.NewFieldType(mysql.TypeLonglong)
 	case mysql.TypeDouble, mysql.TypeFloat:
@@ -166,14 +166,14 @@ func (a *baseFuncDesc) typeInfer4ApproxPercentile(ctx expression.EvalContext) er
 	case mysql.TypeNewDecimal:
 		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
 		a.RetTp.SetFlen(mysql.MaxDecimalWidth)
-		a.RetTp.SetDecimal(a.Args[0].GetType().GetDecimal())
+		a.RetTp.SetDecimal(a.Args[0].GetType(ctx).GetDecimal())
 		if a.RetTp.GetDecimal() < 0 || a.RetTp.GetDecimal() > mysql.MaxDecimalScale {
 			a.RetTp.SetDecimal(mysql.MaxDecimalScale)
 		}
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeNewDate, mysql.TypeTimestamp:
-		a.RetTp = a.Args[0].GetType().Clone()
+		a.RetTp = a.Args[0].GetType(ctx).Clone()
 	default:
-		a.RetTp = a.Args[0].GetType().Clone()
+		a.RetTp = a.Args[0].GetType(ctx).Clone()
 		a.RetTp.DelFlag(mysql.NotNullFlag)
 	}
 	return nil
@@ -181,22 +181,22 @@ func (a *baseFuncDesc) typeInfer4ApproxPercentile(ctx expression.EvalContext) er
 
 // typeInfer4Sum should return a "decimal", otherwise it returns a "double".
 // Because child returns integer or decimal type.
-func (a *baseFuncDesc) typeInfer4Sum() {
-	switch a.Args[0].GetType().GetType() {
+func (a *baseFuncDesc) typeInfer4Sum(ctx expression.EvalContext) {
+	switch a.Args[0].GetType(ctx).GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
 		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
-		a.RetTp.SetFlenUnderLimit(a.Args[0].GetType().GetFlen() + 21)
+		a.RetTp.SetFlenUnderLimit(a.Args[0].GetType(ctx).GetFlen() + 21)
 		a.RetTp.SetDecimal(0)
-		if a.Args[0].GetType().GetFlen() < 0 {
+		if a.Args[0].GetType(ctx).GetFlen() < 0 {
 			a.RetTp.SetFlen(mysql.MaxDecimalWidth)
 		}
 	case mysql.TypeNewDecimal:
 		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
-		a.RetTp.UpdateFlenAndDecimalUnderLimit(a.Args[0].GetType(), 0, 22)
+		a.RetTp.UpdateFlenAndDecimalUnderLimit(a.Args[0].GetType(ctx), 0, 22)
 	case mysql.TypeDouble, mysql.TypeFloat:
 		a.RetTp = types.NewFieldType(mysql.TypeDouble)
 		a.RetTp.SetFlen(mysql.MaxRealWidth)
-		a.RetTp.SetDecimal(a.Args[0].GetType().GetDecimal())
+		a.RetTp.SetDecimal(a.Args[0].GetType(ctx).GetDecimal())
 	default:
 		a.RetTp = types.NewFieldType(mysql.TypeDouble)
 		a.RetTp.SetFlen(mysql.MaxRealWidth)
@@ -220,20 +220,21 @@ func (a *baseFuncDesc) TypeInfer4FinalCount(finalCountRetType *types.FieldType) 
 
 // typeInfer4Avg should returns a "decimal", otherwise it returns a "double".
 // Because child returns integer or decimal type.
-func (a *baseFuncDesc) typeInfer4Avg(divPrecIncre int) {
-	switch a.Args[0].GetType().GetType() {
+func (a *baseFuncDesc) typeInfer4Avg(ctx expression.EvalContext) {
+	divPrecIncre := ctx.GetDivPrecisionIncrement()
+	switch a.Args[0].GetType(ctx).GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
 		a.RetTp.SetDecimalUnderLimit(divPrecIncre)
-		flen, _ := mysql.GetDefaultFieldLengthAndDecimal(a.Args[0].GetType().GetType())
+		flen, _ := mysql.GetDefaultFieldLengthAndDecimal(a.Args[0].GetType(ctx).GetType())
 		a.RetTp.SetFlenUnderLimit(flen + divPrecIncre)
 	case mysql.TypeYear, mysql.TypeNewDecimal:
 		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
-		a.RetTp.UpdateFlenAndDecimalUnderLimit(a.Args[0].GetType(), divPrecIncre, divPrecIncre)
+		a.RetTp.UpdateFlenAndDecimalUnderLimit(a.Args[0].GetType(ctx), divPrecIncre, divPrecIncre)
 	case mysql.TypeDouble, mysql.TypeFloat:
 		a.RetTp = types.NewFieldType(mysql.TypeDouble)
 		a.RetTp.SetFlen(mysql.MaxRealWidth)
-		a.RetTp.SetDecimal(a.Args[0].GetType().GetDecimal())
+		a.RetTp.SetDecimal(a.Args[0].GetType(ctx).GetDecimal())
 	case mysql.TypeDate, mysql.TypeDuration, mysql.TypeDatetime, mysql.TypeTimestamp:
 		a.RetTp = types.NewFieldType(mysql.TypeDouble)
 		a.RetTp.SetFlen(mysql.MaxRealWidth)
@@ -256,7 +257,7 @@ func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) {
 	a.RetTp.SetDecimal(0)
 	// TODO: a.Args[i] = expression.WrapWithCastAsString(ctx, a.Args[i])
 	for i := 0; i < len(a.Args)-1; i++ {
-		if tp := a.Args[i].GetType(); tp.GetType() == mysql.TypeNewDecimal {
+		if tp := a.Args[i].GetType(ctx.GetEvalCtx()); tp.GetType() == mysql.TypeNewDecimal {
 			a.Args[i] = expression.BuildCastFunction(ctx, a.Args[i], tp)
 		}
 	}
@@ -264,7 +265,7 @@ func (a *baseFuncDesc) typeInfer4GroupConcat(ctx expression.BuildContext) {
 
 func (a *baseFuncDesc) typeInfer4MaxMin(ctx expression.BuildContext) {
 	_, argIsScalaFunc := a.Args[0].(*expression.ScalarFunction)
-	if argIsScalaFunc && a.Args[0].GetType().GetType() == mysql.TypeFloat {
+	if argIsScalaFunc && a.Args[0].GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeFloat {
 		// For scalar function, the result of "float32" is set to the "float64"
 		// field in the "Datum". If we do not wrap a cast-as-double function on a.Args[0],
 		// error would happen when extracting the evaluation of a.Args[0] to a ProjectionExec.
@@ -274,10 +275,10 @@ func (a *baseFuncDesc) typeInfer4MaxMin(ctx expression.BuildContext) {
 		types.SetBinChsClnFlag(tp)
 		a.Args[0] = expression.BuildCastFunction(ctx, a.Args[0], tp)
 	}
-	a.RetTp = a.Args[0].GetType()
+	a.RetTp = a.Args[0].GetType(ctx.GetEvalCtx())
 	if a.Name == ast.AggFuncMax || a.Name == ast.AggFuncMin ||
 		a.Name == ast.WindowFuncLead || a.Name == ast.WindowFuncLag {
-		a.RetTp = a.Args[0].GetType().Clone()
+		a.RetTp = a.Args[0].GetType(ctx.GetEvalCtx()).Clone()
 		a.RetTp.DelFlag(mysql.NotNullFlag)
 	}
 	// issue #13027, #13961
@@ -430,7 +431,7 @@ func (a *baseFuncDesc) WrapCastForAggArgs(ctx expression.BuildContext) {
 		if i == 1 && (a.Name == ast.WindowFuncLead || a.Name == ast.WindowFuncLag || a.Name == ast.WindowFuncNthValue) {
 			continue
 		}
-		if a.Args[i].GetType().GetType() == mysql.TypeNull {
+		if a.Args[i].GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeNull {
 			continue
 		}
 		a.Args[i] = castFunc(ctx, a.Args[i])

--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -226,9 +226,9 @@ func (a *AggFuncDesc) GetAggFunc(ctx expression.AggFuncBuildContext) Aggregation
 	case ast.AggFuncGroupConcat:
 		return &concatFunction{aggFunction: aggFunc, maxLen: ctx.GetGroupConcatMaxLen()}
 	case ast.AggFuncMax:
-		return &maxMinFunction{aggFunction: aggFunc, isMax: true, ctor: collate.GetCollator(a.Args[0].GetType().GetCollate())}
+		return &maxMinFunction{aggFunction: aggFunc, isMax: true, ctor: collate.GetCollator(a.Args[0].GetType(ctx.GetEvalCtx()).GetCollate())}
 	case ast.AggFuncMin:
-		return &maxMinFunction{aggFunction: aggFunc, isMax: false, ctor: collate.GetCollator(a.Args[0].GetType().GetCollate())}
+		return &maxMinFunction{aggFunction: aggFunc, isMax: false, ctor: collate.GetCollator(a.Args[0].GetType(ctx.GetEvalCtx()).GetCollate())}
 	case ast.AggFuncFirstRow:
 		return &firstRowFunction{aggFunction: aggFunc}
 	case ast.AggFuncBitOr:

--- a/pkg/expression/aggregation/window_func.go
+++ b/pkg/expression/aggregation/window_func.go
@@ -66,8 +66,8 @@ func NewWindowFuncDesc(ctx expression.BuildContext, name string, args []expressi
 		base.RetTp.SetFlag(mysql.NotNullFlag)
 	case ast.WindowFuncLead, ast.WindowFuncLag:
 		if len(args) == 3 &&
-			((args[0].GetType().GetFlag() & mysql.NotNullFlag) != 0) &&
-			((args[2].GetType().GetFlag() & mysql.NotNullFlag) != 0) {
+			((args[0].GetType(ctx.GetEvalCtx()).GetFlag() & mysql.NotNullFlag) != 0) &&
+			((args[2].GetType(ctx.GetEvalCtx()).GetFlag() & mysql.NotNullFlag) != 0) {
 			base.RetTp.SetFlag(mysql.NotNullFlag)
 			break
 		}

--- a/pkg/expression/bench_test.go
+++ b/pkg/expression/bench_test.go
@@ -149,7 +149,7 @@ func (h *benchHelper) init() {
 
 	h.outputTypes = make([]*types.FieldType, 0, len(h.exprs))
 	for i := 0; i < len(h.exprs); i++ {
-		h.outputTypes = append(h.outputTypes, h.exprs[i].GetType())
+		h.outputTypes = append(h.outputTypes, h.exprs[i].GetType(h.ctx))
 	}
 
 	h.outputChunk = chunk.NewChunkWithCapacity(h.outputTypes, numRows)
@@ -1293,7 +1293,7 @@ func genVecExprBenchCase(ctx BuildContext, funcName string, testCase vecExprBenc
 		panic(err)
 	}
 
-	output = chunk.New([]*types.FieldType{eType2FieldType(expr.GetType().EvalType())}, testCase.chunkSize, testCase.chunkSize)
+	output = chunk.New([]*types.FieldType{eType2FieldType(expr.GetType(ctx.GetEvalCtx()).EvalType())}, testCase.chunkSize, testCase.chunkSize)
 	return expr, fts, input, output
 }
 
@@ -1313,7 +1313,7 @@ func testVectorizedEvalOneVec(t *testing.T, vecExprCases vecExprBenchCases) {
 			require.NoErrorf(t, evalOneColumn(ctx, expr, it, output2, 0), "func: %v, case: %+v", funcName, testCase)
 
 			c1, c2 := output.Column(0), output2.Column(0)
-			switch expr.GetType().EvalType() {
+			switch expr.GetType(ctx).EvalType() {
 			case types.ETInt:
 				for i := 0; i < input.NumRows(); i++ {
 					require.Equal(t, c1.IsNull(i), c2.IsNull(i), commentf(i))

--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -89,7 +89,7 @@ func (b *baseBuiltinFunc) collator() collate.Collator {
 	return b.ctor
 }
 
-func adjustNullFlagForReturnType(funcName string, args []Expression, bf baseBuiltinFunc) {
+func adjustNullFlagForReturnType(ctx EvalContext, funcName string, args []Expression, bf baseBuiltinFunc) {
 	if functionSetForReturnTypeAlwaysNotNull.Exist(funcName) {
 		bf.tp.AddFlag(mysql.NotNullFlag)
 	} else if functionSetForReturnTypeAlwaysNullable.Exist(funcName) {
@@ -97,7 +97,7 @@ func adjustNullFlagForReturnType(funcName string, args []Expression, bf baseBuil
 	} else if functionSetForReturnTypeNotNullOnNotNull.Exist(funcName) {
 		returnNullable := false
 		for _, arg := range args {
-			if !mysql.HasNotNullFlag(arg.GetType().GetFlag()) {
+			if !mysql.HasNotNullFlag(arg.GetType(ctx).GetFlag()) {
 				returnNullable = true
 				break
 			}
@@ -131,7 +131,7 @@ func newBaseBuiltinFunc(ctx BuildContext, funcName string, args []Expression, tp
 	bf.setCollator(collate.GetCollator(ec.Collation))
 	bf.SetCoercibility(ec.Coer)
 	bf.SetRepertoire(ec.Repe)
-	adjustNullFlagForReturnType(funcName, args, bf)
+	adjustNullFlagForReturnType(ctx.GetEvalCtx(), funcName, args, bf)
 	return bf, nil
 }
 
@@ -218,7 +218,7 @@ func newBaseBuiltinFuncWithTp(ctx BuildContext, funcName string, args []Expressi
 	bf.SetCoercibility(ec.Coer)
 	bf.SetRepertoire(ec.Repe)
 	// note this function must be called after wrap cast function to the args
-	adjustNullFlagForReturnType(funcName, args, bf)
+	adjustNullFlagForReturnType(ctx.GetEvalCtx(), funcName, args, bf)
 	return bf, nil
 }
 
@@ -260,7 +260,7 @@ func newBaseBuiltinFuncWithFieldTypes(ctx BuildContext, funcName string, args []
 		// For decimal/datetime/timestamp/duration types, it is necessary to ensure that decimal are consistent with the output type,
 		// so adding a cast function here.
 		case types.ETDecimal, types.ETDatetime, types.ETTimestamp, types.ETDuration:
-			if !args[i].GetType().Equal(argTps[i]) {
+			if !args[i].GetType(ctx.GetEvalCtx()).Equal(argTps[i]) {
 				args[i] = BuildCastFunction(ctx, args[i], argTps[i])
 			}
 		}
@@ -279,7 +279,7 @@ func newBaseBuiltinFuncWithFieldTypes(ctx BuildContext, funcName string, args []
 	bf.SetCoercibility(ec.Coer)
 	bf.SetRepertoire(ec.Repe)
 	// note this function must be called after wrap cast function to the args
-	adjustNullFlagForReturnType(funcName, args, bf)
+	adjustNullFlagForReturnType(ctx.GetEvalCtx(), funcName, args, bf)
 	return bf, nil
 }
 

--- a/pkg/expression/builtin_arithmetic_test.go
+++ b/pkg/expression/builtin_arithmetic_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/testkit/testutil"
@@ -29,6 +30,7 @@ import (
 )
 
 func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
+	ctx := contextstatic.NewStaticEvalContext()
 	ret := &types.FieldType{}
 	a := &types.FieldType{}
 	a.SetDecimal(1)
@@ -37,25 +39,25 @@ func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
 	b := &types.FieldType{}
 	b.SetDecimal(0)
 	b.SetFlag(2)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, 4, ret.GetFlen())
 
 	b.SetFlen(65)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, mysql.MaxRealWidth, ret.GetFlen())
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, false, false)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, false, false)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, mysql.MaxDecimalWidth, ret.GetFlen())
 
 	b.SetFlen(types.UnspecifiedLength)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, types.UnspecifiedLength, ret.GetFlen())
 
 	b.SetDecimal(types.UnspecifiedLength)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, types.UnspecifiedLength, ret.GetDecimal())
 	require.Equal(t, types.UnspecifiedLength, ret.GetFlen())
 
@@ -68,25 +70,25 @@ func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
 	b.SetDecimal(0)
 	b.SetFlen(2)
 
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, 5, ret.GetFlen())
 
 	b.SetFlen(65)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, mysql.MaxRealWidth, ret.GetFlen())
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, false, true)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, false, true)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, mysql.MaxDecimalWidth, ret.GetFlen())
 
 	b.SetFlen(types.UnspecifiedLength)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, 1, ret.GetDecimal())
 	require.Equal(t, types.UnspecifiedLength, ret.GetFlen())
 
 	b.SetDecimal(types.UnspecifiedLength)
-	setFlenDecimal4RealOrDecimal(ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
+	setFlenDecimal4RealOrDecimal(ctx, ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, types.UnspecifiedLength, ret.GetDecimal())
 	require.Equal(t, types.UnspecifiedLength, ret.GetFlen())
 }

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -384,8 +384,8 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.
 	resulti64s := result.Int64s()
 
 	forceToSigned := sqlMode(ctx).HasNoUnsignedSubtractionMode()
-	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
-	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
+	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
+	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 
 	errType := "BIGINT UNSIGNED"
 	signed := forceToSigned || (!isLHSUnsigned && !isRHSUnsigned)
@@ -583,8 +583,8 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx EvalContext, input
 		num[i] = buf[i].Decimals()
 	}
 
-	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
-	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
+	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
+	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 	isUnsigned := isLHSUnsigned || isRHSUnsigned
 
 	result.ResizeInt64(n, false)
@@ -745,8 +745,8 @@ func (b *builtinArithmeticIntDivideIntSig) vecEvalInt(ctx EvalContext, input *ch
 	rhsI64s := rhsBuf.Int64s()
 	resultI64s := result.Int64s()
 
-	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
-	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
+	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
+	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:
@@ -875,8 +875,8 @@ func (b *builtinArithmeticPlusIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 	rhi64s := rh.Int64s()
 	resulti64s := result.Int64s()
 
-	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
-	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
+	isLHSUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
+	isRHSUnsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1242,7 +1242,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 	for i, c := range cases {
 		// Test wrapping with CastAsInt.
 		intExpr := WrapWithCastAsInt(ctx, c.expr)
-		require.Equal(t, types.ETInt, intExpr.GetType().EvalType())
+		require.Equal(t, types.ETInt, intExpr.GetType(ctx).EvalType())
 		intRes, isNull, err := intExpr.EvalInt(ctx, c.row.ToRow())
 		require.NoErrorf(t, err, "cast[%v]: %#v", i, t)
 		require.Equal(t, false, isNull)
@@ -1250,7 +1250,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 		// Test wrapping with CastAsReal.
 		realExpr := WrapWithCastAsReal(ctx, c.expr)
-		require.Equal(t, types.ETReal, realExpr.GetType().EvalType())
+		require.Equal(t, types.ETReal, realExpr.GetType(ctx).EvalType())
 		realRes, isNull, err := realExpr.EvalReal(ctx, c.row.ToRow())
 		require.NoError(t, err)
 		require.Equal(t, false, isNull)
@@ -1258,7 +1258,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 		// Test wrapping with CastAsDecimal.
 		decExpr := WrapWithCastAsDecimal(ctx, c.expr)
-		require.Equal(t, types.ETDecimal, decExpr.GetType().EvalType())
+		require.Equal(t, types.ETDecimal, decExpr.GetType(ctx).EvalType())
 		decRes, isNull, err := decExpr.EvalDecimal(ctx, c.row.ToRow())
 		require.NoError(t, err, "case[%v]: %#v\n", i, t)
 		require.Equal(t, false, isNull)
@@ -1266,7 +1266,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 		// Test wrapping with CastAsString.
 		strExpr := WrapWithCastAsString(ctx, c.expr)
-		require.True(t, strExpr.GetType().EvalType().IsStringKind())
+		require.True(t, strExpr.GetType(ctx).EvalType().IsStringKind())
 		strRes, isNull, err := strExpr.EvalString(ctx, c.row.ToRow())
 		require.NoError(t, err)
 		require.Equal(t, false, isNull)
@@ -1277,7 +1277,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 	// test cast unsigned int as string.
 	strExpr := WrapWithCastAsString(ctx, unsignedIntExpr)
-	require.True(t, strExpr.GetType().EvalType().IsStringKind())
+	require.True(t, strExpr.GetType(ctx).EvalType().IsStringKind())
 	strRes, isNull, err := strExpr.EvalString(ctx, chunk.MutRowFromDatums([]types.Datum{types.NewUintDatum(math.MaxUint64)}).ToRow())
 	require.NoError(t, err)
 	require.Equal(t, strconv.FormatUint(math.MaxUint64, 10), strRes)
@@ -1290,7 +1290,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 	// test cast unsigned int as decimal.
 	decExpr := WrapWithCastAsDecimal(ctx, unsignedIntExpr)
-	require.Equal(t, types.ETDecimal, decExpr.GetType().EvalType())
+	require.Equal(t, types.ETDecimal, decExpr.GetType(ctx).EvalType())
 	decRes, isNull, err := decExpr.EvalDecimal(ctx, chunk.MutRowFromDatums([]types.Datum{types.NewUintDatum(uint64(1234))}).ToRow())
 	require.NoError(t, err)
 	require.Equal(t, false, isNull)
@@ -1298,7 +1298,7 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 
 	// test cast unsigned int as Time.
 	timeExpr := WrapWithCastAsTime(ctx, unsignedIntExpr, types.NewFieldType(mysql.TypeDatetime))
-	require.Equal(t, mysql.TypeDatetime, timeExpr.GetType().GetType())
+	require.Equal(t, mysql.TypeDatetime, timeExpr.GetType(ctx).GetType())
 	timeRes, isNull, err := timeExpr.EvalTime(ctx, chunk.MutRowFromDatums([]types.Datum{types.NewUintDatum(uint64(curTimeInt))}).ToRow())
 	require.NoError(t, err)
 	require.Equal(t, false, isNull)
@@ -1595,8 +1595,8 @@ func TestCastConstAsDecimalFieldType(t *testing.T) {
 	ctx := createContext(t)
 	for _, tc := range allTestCase {
 		expr := WrapWithCastAsDecimal(ctx, tc.input)
-		require.Equal(t, tc.resultFlen, expr.GetType().GetFlen())
-		require.Equal(t, tc.resultDecimal, expr.GetType().GetDecimal())
+		require.Equal(t, tc.resultFlen, expr.GetType(ctx).GetFlen())
+		require.Equal(t, tc.resultDecimal, expr.GetType(ctx).GetDecimal())
 	}
 }
 

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -105,7 +105,7 @@ func (b *builtinCastIntAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chun
 	rs := result.Float64s()
 
 	hasUnsignedFlag0 := mysql.HasUnsignedFlag(b.tp.GetFlag())
-	hasUnsignedFlag1 := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+	hasUnsignedFlag1 := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
@@ -204,7 +204,7 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 
 	bits := 64
-	if b.args[0].GetType().GetType() == mysql.TypeFloat {
+	if b.args[0].GetType(ctx).GetType() == mysql.TypeFloat {
 		// b.args[0].EvalReal() casts the value from float32 to float64, for example:
 		// float32(208.867) is cast to float64(208.86700439)
 		// If we strconv.FormatFloat the value with 64bits, the result is incorrect!
@@ -334,7 +334,7 @@ func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 	i64s := result.Int64s()
 	var duration types.Duration
 	ds := buf.GoDurations()
-	fsp := b.args[0].GetType().GetDecimal()
+	fsp := b.args[0].GetType(ctx).GetDecimal()
 	isYear := b.tp.GetType() == mysql.TypeYear
 	tc := typeCtx(ctx)
 	for i := 0; i < n; i++ {
@@ -391,7 +391,7 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 			continue
 		}
 
-		if b.args[0].GetType().GetType() == mysql.TypeYear {
+		if b.args[0].GetType(ctx).GetType() == mysql.TypeYear {
 			tm, err = types.ParseTimeFromYear(i64s[i])
 		} else {
 			tm, err = types.ParseTimeFromNum(tc, i64s[i], b.tp.GetType(), fsp)
@@ -704,7 +704,7 @@ func (b *builtinCastIntAsStringSig) vecEvalString(ctx EvalContext, input *chunk.
 		return err
 	}
 
-	tp := b.args[0].GetType()
+	tp := b.args[0].GetType(ctx)
 	isUnsigned := mysql.HasUnsignedFlag(tp.GetFlag())
 	isYearType := tp.GetType() == mysql.TypeYear
 	result.ReserveString(n)
@@ -842,7 +842,7 @@ func (b *builtinCastStringAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.C
 	}
 
 	result.ReserveJSON(n)
-	typ := b.args[0].GetType()
+	typ := b.args[0].GetType(ctx)
 	if types.IsBinaryStr(typ) {
 		var res types.BinaryJSON
 		for i := 0; i < n; i++ {
@@ -860,7 +860,7 @@ func (b *builtinCastStringAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.C
 			}
 
 			res = types.CreateBinaryJSON(types.Opaque{
-				TypeCode: b.args[0].GetType().GetType(),
+				TypeCode: b.args[0].GetType(ctx).GetType(),
 				Buf:      resultBuf,
 			})
 			result.AppendJSON(res)
@@ -942,7 +942,7 @@ func (*builtinCastStringAsIntSig) vectorized() bool {
 
 func (b *builtinCastStringAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	if b.args[0].GetType().Hybrid() || IsBinaryLiteral(b.args[0]) {
+	if b.args[0].GetType(ctx).Hybrid() || IsBinaryLiteral(b.args[0]) {
 		return b.args[0].VecEvalInt(ctx, input, result)
 	}
 
@@ -1059,7 +1059,7 @@ func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 	var duration types.Duration
 	ds := buf.GoDurations()
 	tc, ec := typeCtx(ctx), errCtx(ctx)
-	fsp := b.args[0].GetType().GetDecimal()
+	fsp := b.args[0].GetType(ctx).GetDecimal()
 	if fsp, err = types.CheckFsp(fsp); err != nil {
 		return err
 	}
@@ -1094,7 +1094,7 @@ func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chun
 	}
 
 	isUnsignedTp := mysql.HasUnsignedFlag(b.tp.GetFlag())
-	isUnsignedArgs0 := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+	isUnsignedArgs0 := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 	nums := buf.Int64s()
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf)
@@ -1140,7 +1140,7 @@ func (b *builtinCastIntAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 	}
 	nums := buf.Int64s()
 	result.ReserveJSON(n)
-	if mysql.HasIsBooleanFlag(b.args[0].GetType().GetFlag()) {
+	if mysql.HasIsBooleanFlag(b.args[0].GetType(ctx).GetFlag()) {
 		for i := 0; i < n; i++ {
 			if buf.IsNull(i) {
 				result.AppendNull()
@@ -1148,7 +1148,7 @@ func (b *builtinCastIntAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 				result.AppendJSON(types.CreateBinaryJSON(nums[i] != 0))
 			}
 		}
-	} else if mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()) {
+	} else if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
 		for i := 0; i < n; i++ {
 			if buf.IsNull(i) {
 				result.AppendNull()
@@ -1228,7 +1228,7 @@ func (b *builtinCastDurationAsRealSig) vecEvalReal(ctx EvalContext, input *chunk
 	f64s := result.Float64s()
 
 	var duration types.Duration
-	fsp := b.args[0].GetType().GetDecimal()
+	fsp := b.args[0].GetType(ctx).GetDecimal()
 	if fsp, err = types.CheckFsp(fsp); err != nil {
 		return err
 	}
@@ -1402,7 +1402,7 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(ctx EvalContext, input *c
 	var isNull bool
 	tc := typeCtx(ctx)
 	result.ReserveString(n)
-	fsp := b.args[0].GetType().GetDecimal()
+	fsp := b.args[0].GetType(ctx).GetDecimal()
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -137,8 +137,8 @@ func TestCompare(t *testing.T) {
 		bf, err := funcs[test.funcName].getFunction(ctx, primitiveValsToConstants(ctx, []any{test.arg0, test.arg1}))
 		require.NoError(t, err)
 		args := bf.getArgs()
-		require.Equal(t, test.tp, args[0].GetType().GetType())
-		require.Equal(t, test.tp, args[1].GetType().GetType())
+		require.Equal(t, test.tp, args[0].GetType(ctx).GetType())
+		require.Equal(t, test.tp, args[1].GetType(ctx).GetType())
 		res, err := evalBuiltinFunc(bf, ctx, chunk.Row{})
 		require.NoError(t, err)
 		require.False(t, res.IsNull())
@@ -151,24 +151,24 @@ func TestCompare(t *testing.T) {
 	bf, err := funcs[ast.LT].getFunction(ctx, []Expression{decimalCol, stringCon})
 	require.NoError(t, err)
 	args := bf.getArgs()
-	require.Equal(t, mysql.TypeNewDecimal, args[0].GetType().GetType())
-	require.Equal(t, mysql.TypeNewDecimal, args[1].GetType().GetType())
+	require.Equal(t, mysql.TypeNewDecimal, args[0].GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeNewDecimal, args[1].GetType(ctx).GetType())
 
 	// test <time column> <cmp> <non-time const>
 	timeCol := &Column{RetType: types.NewFieldType(mysql.TypeDatetime)}
 	bf, err = funcs[ast.LT].getFunction(ctx, []Expression{timeCol, stringCon})
 	require.NoError(t, err)
 	args = bf.getArgs()
-	require.Equal(t, mysql.TypeDatetime, args[0].GetType().GetType())
-	require.Equal(t, mysql.TypeDatetime, args[1].GetType().GetType())
+	require.Equal(t, mysql.TypeDatetime, args[0].GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeDatetime, args[1].GetType(ctx).GetType())
 
 	// test <json column> <cmp> <const int expression>
 	jsonCol, intCon := &Column{RetType: types.NewFieldType(mysql.TypeJSON)}, &Constant{RetType: types.NewFieldType(mysql.TypeLong)}
 	bf, err = funcs[ast.LT].getFunction(ctx, []Expression{jsonCol, intCon})
 	require.NoError(t, err)
 	args = bf.getArgs()
-	require.Equal(t, mysql.TypeJSON, args[0].GetType().GetType())
-	require.Equal(t, mysql.TypeJSON, args[1].GetType().GetType())
+	require.Equal(t, mysql.TypeJSON, args[0].GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeJSON, args[1].GetType(ctx).GetType())
 }
 
 func TestCoalesce(t *testing.T) {
@@ -213,7 +213,7 @@ func TestCoalesce(t *testing.T) {
 			if test.isNil {
 				require.Equal(t, types.KindNull, d.Kind())
 			} else {
-				if f.GetType().EvalType() == types.ETDuration {
+				if f.GetType(ctx).EvalType() == types.ETDuration {
 					require.Equal(t, test.expected.(types.Duration).String(), d.GetValue().(types.Duration).String())
 				} else {
 					require.Equal(t, test.expected, d.GetValue())
@@ -425,5 +425,5 @@ func TestIssue46475(t *testing.T) {
 
 	f, err := newFunctionForTest(ctx, ast.Coalesce, primitiveValsToConstants(ctx, args)...)
 	require.NoError(t, err)
-	require.Equal(t, f.GetType().GetType(), mysql.TypeDate)
+	require.Equal(t, f.GetType(ctx).GetType(), mysql.TypeDate)
 }

--- a/pkg/expression/builtin_compare_vec.go
+++ b/pkg/expression/builtin_compare_vec.go
@@ -189,7 +189,7 @@ func (b *builtinGEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	result.ResizeInt64(n, false)
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	result.MergeNulls(buf0, buf1)
 	vecResOfGE(result.Int64s())
 	return nil
@@ -309,7 +309,7 @@ func (b *builtinEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	result.ResizeInt64(n, false)
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	result.MergeNulls(buf0, buf1)
 	vecResOfEQ(result.Int64s())
 	return nil
@@ -341,7 +341,7 @@ func (b *builtinNEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	result.ResizeInt64(n, false)
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	result.MergeNulls(buf0, buf1)
 	vecResOfNE(result.Int64s())
 	return nil
@@ -373,7 +373,7 @@ func (b *builtinGTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	result.ResizeInt64(n, false)
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	result.MergeNulls(buf0, buf1)
 	vecResOfGT(result.Int64s())
 	return nil
@@ -402,7 +402,7 @@ func (b *builtinNullEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	i64s := result.Int64s()
 	for i := 0; i < n; i++ {
 		isNull0 := buf0.IsNull(i)
@@ -436,9 +436,9 @@ func (b *builtinIntervalIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 			continue
 		}
 		if b.hasNullable {
-			idx, err = b.linearSearch(ctx, v, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), b.args[1:], input.GetRow(i))
+			idx, err = b.linearSearch(ctx, v, mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), b.args[1:], input.GetRow(i))
 		} else {
-			idx, err = b.binSearch(ctx, v, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), b.args[1:], input.GetRow(i))
+			idx, err = b.binSearch(ctx, v, mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), b.args[1:], input.GetRow(i))
 		}
 		if err != nil {
 			return err
@@ -511,7 +511,7 @@ func (b *builtinLEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	result.ResizeInt64(n, false)
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	result.MergeNulls(buf0, buf1)
 	vecResOfLE(result.Int64s())
 	return nil
@@ -543,7 +543,7 @@ func (b *builtinLTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	result.ResizeInt64(n, false)
-	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()), buf0, buf1, result)
+	vecCompareInt(mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()), mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()), buf0, buf1, result)
 	result.MergeNulls(buf0, buf1)
 	vecResOfLT(result.Int64s())
 	return nil

--- a/pkg/expression/builtin_encryption.go
+++ b/pkg/expression/builtin_encryption.go
@@ -121,7 +121,7 @@ func (c *aesDecryptFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	bf.tp.SetFlen(args[0].GetType().GetFlen()) // At most.
+	bf.tp.SetFlen(args[0].GetType(ctx.GetEvalCtx()).GetFlen()) // At most.
 	types.SetBinChsClnFlag(bf.tp)
 
 	blockMode := ctx.GetBlockEncryptionMode()
@@ -256,7 +256,7 @@ func (c *aesEncryptFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	bf.tp.SetFlen(aes.BlockSize * (args[0].GetType().GetFlen()/aes.BlockSize + 1)) // At most.
+	bf.tp.SetFlen(aes.BlockSize * (args[0].GetType(ctx.GetEvalCtx()).GetFlen()/aes.BlockSize + 1)) // At most.
 	types.SetBinChsClnFlag(bf.tp)
 
 	blockMode := ctx.GetBlockEncryptionMode()
@@ -389,7 +389,7 @@ func (c *decodeFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 
-	bf.tp.SetFlen(args[0].GetType().GetFlen())
+	bf.tp.SetFlen(args[0].GetType(ctx.GetEvalCtx()).GetFlen())
 	sig := &builtinDecodeSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Decode)
 	return sig, nil
@@ -452,7 +452,7 @@ func (c *encodeFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 
-	bf.tp.SetFlen(args[0].GetType().GetFlen())
+	bf.tp.SetFlen(args[0].GetType(ctx.GetEvalCtx()).GetFlen())
 	sig := &builtinEncodeSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Encode)
 	return sig, nil
@@ -848,7 +848,7 @@ func (c *compressFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err != nil {
 		return nil, err
 	}
-	srcLen := args[0].GetType().GetFlen()
+	srcLen := args[0].GetType(ctx.GetEvalCtx()).GetFlen()
 	compressBound := srcLen + (srcLen >> 12) + (srcLen >> 14) + (srcLen >> 25) + 13
 	if compressBound > mysql.MaxBlobWidth {
 		compressBound = mysql.MaxBlobWidth

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -628,7 +628,7 @@ func (c *benchmarkFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 	// Syntax: BENCHMARK(loop_count, expression)
 	// Define with same eval type of input arg to avoid unnecessary cast function.
-	sameEvalType := args[1].GetType().EvalType()
+	sameEvalType := args[1].GetType(ctx.GetEvalCtx()).EvalType()
 	// constLoopCount is used by VecEvalInt
 	// since non-constant loop count would be different between rows, and cannot be vectorized.
 	var constLoopCount int64
@@ -684,7 +684,7 @@ func (b *builtinBenchmarkSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bo
 	// behavior observed on MySQL 5.7.24.
 	var i int64
 	arg := b.args[1]
-	switch evalType := arg.GetType().EvalType(); evalType {
+	switch evalType := arg.GetType(ctx).EvalType(); evalType {
 	case types.ETInt:
 		for ; i < loopCount; i++ {
 			_, isNull, err = arg.EvalInt(ctx, row)
@@ -752,7 +752,7 @@ func (c *charsetFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	}
 	argsTps := make([]types.EvalType, 0, len(args))
 	for _, arg := range args {
-		argsTps = append(argsTps, arg.GetType().EvalType())
+		argsTps = append(argsTps, arg.GetType(ctx.GetEvalCtx()).EvalType())
 	}
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, argsTps...)
 	if err != nil {
@@ -777,7 +777,7 @@ func (b *builtinCharsetSig) Clone() builtinFunc {
 }
 
 func (b *builtinCharsetSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	return b.args[0].GetType().GetCharset(), false, nil
+	return b.args[0].GetType(ctx).GetCharset(), false, nil
 }
 
 type coercibilityFunctionClass struct {
@@ -788,7 +788,7 @@ func (c *coercibilityFunctionClass) getFunction(ctx BuildContext, args []Express
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, args[0].GetType().EvalType())
+	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, args[0].GetType(ctx.GetEvalCtx()).EvalType())
 	if err != nil {
 		return nil, err
 	}
@@ -821,7 +821,7 @@ func (c *collationFunctionClass) getFunction(ctx BuildContext, args []Expression
 	}
 	argsTps := make([]types.EvalType, 0, len(args))
 	for _, arg := range args {
-		argsTps = append(argsTps, arg.GetType().EvalType())
+		argsTps = append(argsTps, arg.GetType(ctx.GetEvalCtx()).EvalType())
 	}
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, argsTps...)
 	if err != nil {
@@ -846,7 +846,7 @@ func (b *builtinCollationSig) Clone() builtinFunc {
 }
 
 func (b *builtinCollationSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	return b.args[0].GetType().GetCollate(), false, nil
+	return b.args[0].GetType(ctx).GetCollate(), false, nil
 }
 
 type rowCountFunctionClass struct {
@@ -1336,7 +1336,7 @@ func (c *setValFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	sig := &builtinSetValSig{baseBuiltinFunc: bf}
-	bf.tp.SetFlen(args[1].GetType().GetFlen())
+	bf.tp.SetFlen(args[1].GetType(ctx.GetEvalCtx()).GetFlen())
 	return sig, nil
 }
 

--- a/pkg/expression/builtin_info_test.go
+++ b/pkg/expression/builtin_info_test.go
@@ -287,7 +287,7 @@ func TestLastInsertID(t *testing.T) {
 		} else {
 			f, err = newFunctionForTest(ctx, ast.LastInsertId)
 		}
-		tp := f.GetType()
+		tp := f.GetType(ctx)
 		require.NoError(t, err)
 		require.Equal(t, mysql.TypeLonglong, tp.GetType())
 		require.Equal(t, charset.CharsetBin, tp.GetCharset())

--- a/pkg/expression/builtin_info_vec.go
+++ b/pkg/expression/builtin_info_vec.go
@@ -268,7 +268,7 @@ func (b *builtinBenchmarkSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	n := input.NumRows()
 	loopCount := b.constLoopCount
 	arg := b.args[1]
-	evalType := arg.GetType().EvalType()
+	evalType := arg.GetType(ctx).EvalType()
 	buf, err := b.bufAllocator.get()
 	if err != nil {
 		return err

--- a/pkg/expression/builtin_math_test.go
+++ b/pkg/expression/builtin_math_test.go
@@ -591,7 +591,7 @@ func TestConv(t *testing.T) {
 	for _, c := range cases {
 		f, err := newFunctionForTest(ctx, ast.Conv, primitiveValsToConstants(ctx, c.args)...)
 		require.NoError(t, err)
-		tp := f.GetType()
+		tp := f.GetType(ctx)
 		require.Equal(t, mysql.TypeVarString, tp.GetType())
 		require.Equal(t, charset.CharsetUTF8MB4, tp.GetCharset())
 		require.Equal(t, charset.CollationUTF8MB4, tp.GetCollate())

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -769,7 +769,7 @@ func (b *builtinCeilIntToDecSig) vecEvalDecimal(ctx EvalContext, input *chunk.Ch
 
 	i64s := buf.Int64s()
 	d := result.Decimals()
-	isUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+	isUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -805,7 +805,7 @@ func (b *builtinTruncateIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	i64s := result.Int64s()
 	buf64s := buf.Int64s()
 
-	if mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()) {
+	if mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()) {
 		return nil
 	}
 
@@ -849,7 +849,7 @@ func (b *builtinTruncateUintSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	i64s := result.Int64s()
 	buf64s := buf.Int64s()
 
-	if mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag()) {
+	if mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()) {
 		return nil
 	}
 
@@ -1024,7 +1024,7 @@ func (b *builtinFloorIntToDecSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 
 	i64s := buf.Int64s()
 	d := result.Decimals()
-	isUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+	isUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue

--- a/pkg/expression/builtin_miscellaneous.go
+++ b/pkg/expression/builtin_miscellaneous.go
@@ -337,12 +337,12 @@ func (c *anyValueFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, argTp, argTp)
 	if err != nil {
 		return nil, err
 	}
-	ft := args[0].GetType().Clone()
+	ft := args[0].GetType(ctx.GetEvalCtx()).Clone()
 	ft.AddFlag(bf.tp.GetFlag())
 	*bf.tp = *ft
 	var sig builtinFunc
@@ -1145,12 +1145,12 @@ func (c *nameConstFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	argTp := args[1].GetType().EvalType()
+	argTp := args[1].GetType(ctx.GetEvalCtx()).EvalType()
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, argTp, types.ETString, argTp)
 	if err != nil {
 		return nil, err
 	}
-	*bf.tp = *args[1].GetType()
+	*bf.tp = *args[1].GetType(ctx.GetEvalCtx())
 	var sig builtinFunc
 	switch argTp {
 	case types.ETDecimal:

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -450,7 +450,7 @@ func (c *isTrueOrFalseFunctionClass) getFunction(ctx BuildContext, args []Expres
 		return nil, err
 	}
 
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	if argTp == types.ETTimestamp || argTp == types.ETDatetime || argTp == types.ETDuration || argTp == types.ETJson || argTp == types.ETString {
 		argTp = types.ETReal
 	}
@@ -714,7 +714,7 @@ func (c *unaryNotFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	if argTp == types.ETTimestamp || argTp == types.ETDatetime || argTp == types.ETDuration {
 		argTp = types.ETInt
 	} else if argTp == types.ETString {
@@ -837,8 +837,8 @@ type unaryMinusFunctionClass struct {
 	baseFunctionClass
 }
 
-func (c *unaryMinusFunctionClass) handleIntOverflow(arg *Constant) (overflow bool) {
-	if mysql.HasUnsignedFlag(arg.GetType().GetFlag()) {
+func (c *unaryMinusFunctionClass) handleIntOverflow(ctx EvalContext, arg *Constant) (overflow bool) {
+	if mysql.HasUnsignedFlag(arg.GetType(ctx).GetFlag()) {
 		uval := arg.Value.GetUint64()
 		// -math.MinInt64 is 9223372036854775808, so if uval is more than 9223372036854775808, like
 		// 9223372036854775809, -9223372036854775809 is less than math.MinInt64, overflow occurs.
@@ -858,8 +858,8 @@ func (c *unaryMinusFunctionClass) handleIntOverflow(arg *Constant) (overflow boo
 
 // typeInfer infers unaryMinus function return type. when the arg is an int constant and overflow,
 // typerInfer will infers the return type as types.ETDecimal, not types.ETInt.
-func (c *unaryMinusFunctionClass) typeInfer(argExpr Expression) (types.EvalType, bool) {
-	tp := argExpr.GetType().EvalType()
+func (c *unaryMinusFunctionClass) typeInfer(ctx EvalContext, argExpr Expression) (types.EvalType, bool) {
+	tp := argExpr.GetType(ctx).EvalType()
 	if tp != types.ETInt && tp != types.ETDecimal {
 		tp = types.ETReal
 	}
@@ -867,7 +867,7 @@ func (c *unaryMinusFunctionClass) typeInfer(argExpr Expression) (types.EvalType,
 	overflow := false
 	// TODO: Handle float overflow.
 	if arg, ok := argExpr.(*Constant); ok && tp == types.ETInt {
-		overflow = c.handleIntOverflow(arg)
+		overflow = c.handleIntOverflow(ctx, arg)
 		if overflow {
 			tp = types.ETDecimal
 		}
@@ -880,8 +880,8 @@ func (c *unaryMinusFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 
-	argExpr, argExprTp := args[0], args[0].GetType()
-	_, intOverflow := c.typeInfer(argExpr)
+	argExpr, argExprTp := args[0], args[0].GetType(ctx.GetEvalCtx())
+	_, intOverflow := c.typeInfer(ctx.GetEvalCtx(), argExpr)
 
 	var bf baseBuiltinFunc
 	evalType := argExprTp.EvalType()
@@ -956,7 +956,7 @@ func (b *builtinUnaryMinusIntSig) evalInt(ctx EvalContext, row chunk.Row) (res i
 		return val, isNull, err
 	}
 
-	if mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()) {
+	if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
 		uval := uint64(val)
 		if uval > uint64(-math.MinInt64) {
 			return 0, false, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("-%v", uval))
@@ -1012,7 +1012,7 @@ func (c *isNullFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	if argTp == types.ETTimestamp {
 		argTp = types.ETDatetime
 	} else if argTp == types.ETJson {

--- a/pkg/expression/builtin_op_vec.go
+++ b/pkg/expression/builtin_op_vec.go
@@ -551,7 +551,7 @@ func (b *builtinUnaryMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	}
 	n := input.NumRows()
 	args := result.Int64s()
-	if mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()) {
+	if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
 		for i := 0; i < n; i++ {
 			if result.IsNull(i) {
 				continue

--- a/pkg/expression/builtin_op_vec_test.go
+++ b/pkg/expression/builtin_op_vec_test.go
@@ -172,7 +172,7 @@ func TestBuiltinUnaryMinusIntSig(t *testing.T) {
 	input := chunk.NewChunkWithCapacity([]*types.FieldType{ft}, 1024)
 	result := chunk.NewColumn(ft, 1024)
 
-	require.False(t, mysql.HasUnsignedFlag(col0.GetType().GetFlag()))
+	require.False(t, mysql.HasUnsignedFlag(col0.GetType(ctx).GetFlag()))
 	input.AppendInt64(0, 233333)
 	require.NoError(t, vecEvalType(ctx, f, types.ETInt, input, result))
 	require.Equal(t, int64(-233333), result.GetInt64(0))
@@ -183,8 +183,8 @@ func TestBuiltinUnaryMinusIntSig(t *testing.T) {
 	require.NoError(t, vecEvalType(ctx, f, types.ETInt, input, result))
 	require.True(t, result.IsNull(0))
 
-	col0.GetType().AddFlag(mysql.UnsignedFlag)
-	require.True(t, mysql.HasUnsignedFlag(col0.GetType().GetFlag()))
+	col0.GetType(ctx).AddFlag(mysql.UnsignedFlag)
+	require.True(t, mysql.HasUnsignedFlag(col0.GetType(ctx).GetFlag()))
 	input.Reset()
 	input.AppendUint64(0, 233333)
 	require.NoError(t, vecEvalType(ctx, f, types.ETInt, input, result))

--- a/pkg/expression/builtin_other_vec_generated.go
+++ b/pkg/expression/builtin_other_vec_generated.go
@@ -53,7 +53,7 @@ func (b *builtinInIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 			hasNull[i] = true
 		}
 	}
-	isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+	isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 	var compareResult int
 	args := b.args[1:]
 	if len(b.hashSet) != 0 {
@@ -84,7 +84,7 @@ func (b *builtinInIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 		if err := args[j].VecEvalInt(ctx, input, buf1); err != nil {
 			return err
 		}
-		isUnsigned := mysql.HasUnsignedFlag(args[j].GetType().GetFlag())
+		isUnsigned := mysql.HasUnsignedFlag(args[j].GetType(ctx).GetFlag())
 		args1 := buf1.Int64s()
 		buf1.MergeNulls(buf0)
 		for i := 0; i < n; i++ {

--- a/pkg/expression/builtin_regexp.go
+++ b/pkg/expression/builtin_regexp.go
@@ -354,7 +354,7 @@ func (c *regexpSubstrFunctionClass) getFunction(ctx BuildContext, args []Express
 		return nil, err
 	}
 
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	sig := builtinRegexpSubstrFuncSig{
 		regexpBaseFuncSig: regexpBaseFuncSig{baseBuiltinFunc: bf},
@@ -986,7 +986,7 @@ func (c *regexpReplaceFunctionClass) getFunction(ctx BuildContext, args []Expres
 		return nil, ErrRegexp.GenWithStackByArgs(err)
 	}
 
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	sig := builtinRegexpReplaceFuncSig{
 		regexpBaseFuncSig: regexpBaseFuncSig{baseBuiltinFunc: bf},

--- a/pkg/expression/builtin_regexp_test.go
+++ b/pkg/expression/builtin_regexp_test.go
@@ -377,7 +377,7 @@ func TestRegexpSubstr(t *testing.T) {
 			fc := funcs[ast.RegexpSubstr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -426,7 +426,7 @@ func TestRegexpSubstr(t *testing.T) {
 			fc := funcs[ast.RegexpSubstr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -479,7 +479,7 @@ func TestRegexpSubstr(t *testing.T) {
 			fc := funcs[ast.RegexpSubstr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos, tt.occur))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -524,7 +524,7 @@ func TestRegexpSubstr(t *testing.T) {
 			fc := funcs[ast.RegexpSubstr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos, tt.occur, tt.matchType))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -633,7 +633,7 @@ func TestRegexpInStr(t *testing.T) {
 			fc := funcs[ast.RegexpInStr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -681,7 +681,7 @@ func TestRegexpInStr(t *testing.T) {
 			fc := funcs[ast.RegexpInStr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -734,7 +734,7 @@ func TestRegexpInStr(t *testing.T) {
 			fc := funcs[ast.RegexpInStr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos, tt.occurrence))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -781,7 +781,7 @@ func TestRegexpInStr(t *testing.T) {
 			fc := funcs[ast.RegexpInStr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos, tt.occurrence, tt.retOpt))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -828,7 +828,7 @@ func TestRegexpInStr(t *testing.T) {
 			fc := funcs[ast.RegexpInStr]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.pos, tt.occurrence, tt.retOpt, tt.matchType))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -967,7 +967,7 @@ func TestRegexpReplace(t *testing.T) {
 			fc := funcs[ast.RegexpReplace]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.replace))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType(), args[2].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx), args[2].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -1022,7 +1022,7 @@ func TestRegexpReplace(t *testing.T) {
 			fc := funcs[ast.RegexpReplace]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.replace, tt.pos))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType(), args[2].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx), args[2].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -1081,7 +1081,7 @@ func TestRegexpReplace(t *testing.T) {
 			fc := funcs[ast.RegexpReplace]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.replace, tt.pos, tt.occurrence))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType(), args[2].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx), args[2].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}
@@ -1133,7 +1133,7 @@ func TestRegexpReplace(t *testing.T) {
 			fc := funcs[ast.RegexpReplace]
 			expectMatch := tt.match
 			args := datumsToConstants(types.MakeDatums(tt.input, tt.pattern, tt.replace, tt.pos, tt.occurrence, tt.matchType))
-			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(), args[1].GetType(), args[2].GetType())
+			setCharsetAndCollation(charsetAndCollateTp, args[0].GetType(ctx), args[1].GetType(ctx), args[2].GetType(ctx))
 			if charsetAndCollateTp == binaryTpIdx {
 				expectMatch = tt.matchBin
 			}

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -284,7 +284,7 @@ func (c *concatFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	addBinFlag(bf.tp)
 	bf.tp.SetFlen(0)
 	for i := range args {
-		argType := args[i].GetType()
+		argType := args[i].GetType(ctx.GetEvalCtx())
 
 		if argType.GetFlen() < 0 {
 			bf.tp.SetFlen(mysql.MaxBlobWidth)
@@ -353,7 +353,7 @@ func (c *concatWSFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 	addBinFlag(bf.tp)
 	for i := range args {
-		argType := args[i].GetType()
+		argType := args[i].GetType(ctx.GetEvalCtx())
 
 		// skip separator param
 		if i != 0 {
@@ -367,7 +367,7 @@ func (c *concatWSFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 	// add separator
 	sepsLen := len(args) - 2
-	bf.tp.SetFlen(bf.tp.GetFlen() + sepsLen*args[0].GetType().GetFlen())
+	bf.tp.SetFlen(bf.tp.GetFlen() + sepsLen*args[0].GetType(ctx.GetEvalCtx()).GetFlen())
 
 	if bf.tp.GetFlen() >= mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
@@ -449,7 +449,7 @@ func (c *leftFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	if err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(argType) {
@@ -534,7 +534,7 @@ func (c *rightFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(argType) {
@@ -621,7 +621,7 @@ func (c *repeatFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 		return nil, err
 	}
 	bf.tp.SetFlen(mysql.MaxBlobWidth)
-	SetBinFlagOrBinStr(args[0].GetType(), bf.tp)
+	SetBinFlagOrBinStr(args[0].GetType(ctx.GetEvalCtx()), bf.tp)
 	maxAllowedPacket := ctx.GetEvalCtx().GetMaxAllowedPacket()
 	sig := &builtinRepeatSig{bf, maxAllowedPacket}
 	sig.setPbCode(tipb.ScalarFuncSig_Repeat)
@@ -679,7 +679,7 @@ func (c *lowerFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	argTp := args[0].GetType()
+	argTp := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argTp.GetFlen())
 	SetBinFlagOrBinStr(argTp, bf.tp)
 	var sig builtinFunc
@@ -710,7 +710,7 @@ func (b *builtinLowerUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (d stri
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
+	enc := charset.FindEncoding(b.args[0].GetType(ctx).GetCharset())
 	return enc.ToLower(d), false, nil
 }
 
@@ -748,8 +748,8 @@ func (c *reverseFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		return nil, err
 	}
 
-	argTp := args[0].GetType()
-	bf.tp.SetFlen(args[0].GetType().GetFlen())
+	argTp := args[0].GetType(ctx.GetEvalCtx())
+	bf.tp.SetFlen(args[0].GetType(ctx.GetEvalCtx()).GetFlen())
 	addBinFlag(bf.tp)
 	var sig builtinFunc
 	if types.IsBinaryStr(argTp) || types.IsTypeBit(argTp) {
@@ -871,7 +871,7 @@ func (c *upperFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	argTp := args[0].GetType()
+	argTp := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argTp.GetFlen())
 	SetBinFlagOrBinStr(argTp, bf.tp)
 	var sig builtinFunc
@@ -902,7 +902,7 @@ func (b *builtinUpperUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (d stri
 	if isNull || err != nil {
 		return d, isNull, err
 	}
-	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
+	enc := charset.FindEncoding(b.args[0].GetType(ctx).GetCharset())
 	return enc.ToUpper(d), false, nil
 }
 
@@ -989,9 +989,9 @@ func (c *replaceFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	if err != nil {
 		return nil, err
 	}
-	bf.tp.SetFlen(c.fixLength(args))
+	bf.tp.SetFlen(c.fixLength(ctx.GetEvalCtx(), args))
 	for _, a := range args {
-		SetBinFlagOrBinStr(a.GetType(), bf.tp)
+		SetBinFlagOrBinStr(a.GetType(ctx.GetEvalCtx()), bf.tp)
 	}
 	sig := &builtinReplaceSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_Replace)
@@ -999,10 +999,10 @@ func (c *replaceFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 }
 
 // fixLength calculate the flen of the return type.
-func (c *replaceFunctionClass) fixLength(args []Expression) int {
-	charLen := args[0].GetType().GetFlen()
-	oldStrLen := args[1].GetType().GetFlen()
-	diff := args[2].GetType().GetFlen() - oldStrLen
+func (c *replaceFunctionClass) fixLength(ctx EvalContext, args []Expression) int {
+	charLen := args[0].GetType(ctx).GetFlen()
+	oldStrLen := args[1].GetType(ctx).GetFlen()
+	diff := args[2].GetType(ctx).GetFlen() - oldStrLen
 	if diff > 0 && oldStrLen > 0 {
 		charLen += (charLen / oldStrLen) * diff
 	}
@@ -1112,7 +1112,7 @@ func (b *builtinConvertSig) evalString(ctx EvalContext, row chunk.Row) (string, 
 	if isNull || err != nil {
 		return "", true, err
 	}
-	argTp, resultTp := b.args[0].GetType(), b.tp
+	argTp, resultTp := b.args[0].GetType(ctx), b.tp
 	if !charset.IsSupportedEncoding(resultTp.GetCharset()) {
 		return "", false, errUnknownCharacterSet.GenWithStackByArgs(resultTp.GetCharset())
 	}
@@ -1152,7 +1152,7 @@ func (c *substringFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 
@@ -1343,7 +1343,7 @@ func (c *substringIndexFunctionClass) getFunction(ctx BuildContext, args []Expre
 	if err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	sig := &builtinSubstringIndexSig{bf}
@@ -1384,7 +1384,7 @@ func (b *builtinSubstringIndexSig) evalString(ctx EvalContext, row chunk.Row) (d
 		return "", false, nil
 	}
 	// when count > MaxInt64, returns whole string.
-	if count < 0 && mysql.HasUnsignedFlag(b.args[2].GetType().GetFlag()) {
+	if count < 0 && mysql.HasUnsignedFlag(b.args[2].GetType(ctx).GetFlag()) {
 		return str, false, nil
 	}
 
@@ -1603,14 +1603,14 @@ func (c *hexFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		return nil, err
 	}
 
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	switch argTp {
 	case types.ETString, types.ETDatetime, types.ETTimestamp, types.ETDuration, types.ETJson:
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, types.ETString)
 		if err != nil {
 			return nil, err
 		}
-		argFieldTp := args[0].GetType()
+		argFieldTp := args[0].GetType(ctx.GetEvalCtx())
 		// Use UTF8MB4 as default.
 		bf.tp.SetFlen(argFieldTp.GetFlen() * 4 * 2)
 		sig := &builtinHexStrArgSig{bf}
@@ -1621,7 +1621,7 @@ func (c *hexFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		if err != nil {
 			return nil, err
 		}
-		bf.tp.SetFlen(args[0].GetType().GetFlen() * 2)
+		bf.tp.SetFlen(args[0].GetType(ctx.GetEvalCtx()).GetFlen() * 2)
 		charset, collate := ctx.GetCharsetInfo()
 		bf.tp.SetCharset(charset)
 		bf.tp.SetCollate(collate)
@@ -1629,7 +1629,7 @@ func (c *hexFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		sig.setPbCode(tipb.ScalarFuncSig_HexIntArg)
 		return sig, nil
 	default:
-		return nil, errors.Errorf("Hex invalid args, need int or string but get %T", args[0].GetType())
+		return nil, errors.Errorf("Hex invalid args, need int or string but get %T", args[0].GetType(ctx.GetEvalCtx()))
 	}
 }
 
@@ -1686,7 +1686,7 @@ func (c *unhexFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	argEvalTp := argType.EvalType()
 	switch argEvalTp {
 	case types.ETString, types.ETDatetime, types.ETTimestamp, types.ETDuration, types.ETJson:
@@ -1763,7 +1763,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		if err != nil {
 			return nil, err
 		}
-		argType := args[0].GetType()
+		argType := args[0].GetType(ctx.GetEvalCtx())
 		bf.tp.SetFlen(argType.GetFlen())
 		SetBinFlagOrBinStr(argType, bf.tp)
 		sig := &builtinTrim1ArgSig{bf}
@@ -1775,7 +1775,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		if err != nil {
 			return nil, err
 		}
-		argType := args[0].GetType()
+		argType := args[0].GetType(ctx.GetEvalCtx())
 		SetBinFlagOrBinStr(argType, bf.tp)
 		sig := &builtinTrim2ArgsSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_Trim2Args)
@@ -1786,7 +1786,7 @@ func (c *trimFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 		if err != nil {
 			return nil, err
 		}
-		argType := args[0].GetType()
+		argType := args[0].GetType(ctx.GetEvalCtx())
 		bf.tp.SetFlen(argType.GetFlen())
 		SetBinFlagOrBinStr(argType, bf.tp)
 		sig := &builtinTrim3ArgsSig{bf}
@@ -1902,7 +1902,7 @@ func (c *lTrimFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	sig := &builtinLTrimSig{bf}
@@ -1942,7 +1942,7 @@ func (c *rTrimFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
 	sig := &builtinRTrimSig{bf}
@@ -2020,7 +2020,7 @@ func (c *lpadFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	addBinFlag(bf.tp)
 
 	maxAllowedPacket := ctx.GetEvalCtx().GetMaxAllowedPacket()
-	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
+	if types.IsBinaryStr(args[0].GetType(ctx.GetEvalCtx())) || types.IsBinaryStr(args[2].GetType(ctx.GetEvalCtx())) {
 		sig := &builtinLpadSig{bf, maxAllowedPacket}
 		sig.setPbCode(tipb.ScalarFuncSig_Lpad)
 		return sig, nil
@@ -2145,7 +2145,7 @@ func (c *rpadFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	addBinFlag(bf.tp)
 
 	maxAllowedPacket := ctx.GetEvalCtx().GetMaxAllowedPacket()
-	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
+	if types.IsBinaryStr(args[0].GetType(ctx.GetEvalCtx())) || types.IsBinaryStr(args[2].GetType(ctx.GetEvalCtx())) {
 		sig := &builtinRpadSig{bf, maxAllowedPacket}
 		sig.setPbCode(tipb.ScalarFuncSig_Rpad)
 		return sig, nil
@@ -2402,7 +2402,7 @@ func (c *charLengthFunctionClass) getFunction(ctx BuildContext, args []Expressio
 	if err != nil {
 		return nil, err
 	}
-	if types.IsBinaryStr(args[0].GetType()) {
+	if types.IsBinaryStr(args[0].GetType(ctx.GetEvalCtx())) {
 		sig := &builtinCharLengthBinarySig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CharLength)
 		return sig, nil
@@ -2518,7 +2518,7 @@ func (c *fieldFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 
 	isAllString, isAllNumber := true, true
 	for i, length := 0, len(args); i < length; i++ {
-		argTp := args[i].GetType().EvalType()
+		argTp := args[i].GetType(ctx.GetEvalCtx()).EvalType()
 		isAllString = isAllString && (argTp == types.ETString)
 		isAllNumber = isAllNumber && (argTp == types.ETInt)
 	}
@@ -2650,7 +2650,7 @@ func (c *makeSetFunctionClass) getFlen(ctx BuildContext, args []Expression) int 
 		if err == nil && !isNull {
 			for i, length := 1, len(args); i < length; i++ {
 				if (bits & (1 << uint(i-1))) != 0 {
-					flen += args[i].GetType().GetFlen()
+					flen += args[i].GetType(ctx.GetEvalCtx()).GetFlen()
 					count++
 				}
 			}
@@ -2661,7 +2661,7 @@ func (c *makeSetFunctionClass) getFlen(ctx BuildContext, args []Expression) int 
 		}
 	}
 	for i, length := 1, len(args); i < length; i++ {
-		flen += args[i].GetType().GetFlen()
+		flen += args[i].GetType(ctx.GetEvalCtx()).GetFlen()
 	}
 	return flen + len(args) - 1 - 1
 }
@@ -2733,7 +2733,7 @@ func (c *octFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		return nil, err
 	}
 	var sig builtinFunc
-	if IsBinaryLiteral(args[0]) || args[0].GetType().EvalType() == types.ETInt {
+	if IsBinaryLiteral(args[0]) || args[0].GetType(ctx.GetEvalCtx()).EvalType() == types.ETInt {
 		bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, types.ETInt)
 		if err != nil {
 			return nil, err
@@ -2862,7 +2862,7 @@ func (b *builtinOrdSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, er
 	}
 
 	strBytes := hack.Slice(str)
-	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
+	enc := charset.FindEncoding(b.args[0].GetType(ctx).GetCharset())
 	w := len(charset.EncodingUTF8Impl.Peek(strBytes))
 	res, err := enc.Transform(nil, strBytes[:w], charset.OpEncode)
 	if err != nil {
@@ -2895,8 +2895,8 @@ func (c *quoteFunctionClass) getFunction(ctx BuildContext, args []Expression) (b
 	if err != nil {
 		return nil, err
 	}
-	SetBinFlagOrBinStr(args[0].GetType(), bf.tp)
-	bf.tp.SetFlen(2*args[0].GetType().GetFlen() + 2)
+	SetBinFlagOrBinStr(args[0].GetType(ctx.GetEvalCtx()), bf.tp)
+	bf.tp.SetFlen(2*args[0].GetType(ctx.GetEvalCtx()).GetFlen() + 2)
 	if bf.tp.GetFlen() > mysql.MaxBlobWidth {
 		bf.tp.SetFlen(mysql.MaxBlobWidth)
 	}
@@ -3013,7 +3013,7 @@ func (c *eltFunctionClass) getFunction(ctx BuildContext, args []Expression) (bui
 		return nil, err
 	}
 	for _, arg := range args[1:] {
-		argType := arg.GetType()
+		argType := arg.GetType(ctx.GetEvalCtx())
 		if types.IsBinaryStr(argType) {
 			types.SetBinChsClnFlag(bf.tp)
 		}
@@ -3074,13 +3074,13 @@ func (c *exportSetFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	// Calculate the flen as MySQL does.
-	l := args[1].GetType().GetFlen()
-	if args[2].GetType().GetFlen() > l {
-		l = args[2].GetType().GetFlen()
+	l := args[1].GetType(ctx.GetEvalCtx()).GetFlen()
+	if args[2].GetType(ctx.GetEvalCtx()).GetFlen() > l {
+		l = args[2].GetType(ctx.GetEvalCtx()).GetFlen()
 	}
 	sepL := 1
 	if len(args) > 3 {
-		sepL = args[3].GetType().GetFlen()
+		sepL = args[3].GetType(ctx.GetEvalCtx()).GetFlen()
 	}
 	bf.tp.SetFlen((l*64 + sepL*63) * 4)
 	switch len(args) {
@@ -3235,7 +3235,7 @@ func (c *formatFunctionClass) getFunction(ctx BuildContext, args []Expression) (
 	}
 	argTps := make([]types.EvalType, 2, 3)
 	argTps[1] = types.ETInt
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	if argTp == types.ETDecimal || argTp == types.ETInt {
 		argTps[0] = types.ETDecimal
 	} else {
@@ -3271,7 +3271,7 @@ const formatMaxDecimals int64 = 30
 func evalNumDecArgsForFormat(ctx EvalContext, f builtinFunc, row chunk.Row) (string, string, bool, error) {
 	var xStr string
 	arg0, arg1 := f.getArgs()[0], f.getArgs()[1]
-	if arg0.GetType().EvalType() == types.ETDecimal {
+	if arg0.GetType(ctx).EvalType() == types.ETDecimal {
 		x, isNull, err := arg0.EvalDecimal(ctx, row)
 		if isNull || err != nil {
 			return "", "", isNull, err
@@ -3419,10 +3419,10 @@ func (c *fromBase64FunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	// The calculation of flen is the same as MySQL.
-	if args[0].GetType().GetFlen() == types.UnspecifiedLength {
+	if args[0].GetType(ctx.GetEvalCtx()).GetFlen() == types.UnspecifiedLength {
 		bf.tp.SetFlen(types.UnspecifiedLength)
 	} else {
-		bf.tp.SetFlen(args[0].GetType().GetFlen() * 3)
+		bf.tp.SetFlen(args[0].GetType(ctx.GetEvalCtx()).GetFlen() * 3)
 		if bf.tp.GetFlen() > mysql.MaxBlobWidth {
 			bf.tp.SetFlen(mysql.MaxBlobWidth)
 		}
@@ -3501,10 +3501,10 @@ func (c *toBase64FunctionClass) getFunction(ctx BuildContext, args []Expression)
 	bf.tp.SetCharset(charset)
 	bf.tp.SetCollate(collate)
 
-	if bf.args[0].GetType().GetFlen() == types.UnspecifiedLength {
+	if bf.args[0].GetType(ctx.GetEvalCtx()).GetFlen() == types.UnspecifiedLength {
 		bf.tp.SetFlen(types.UnspecifiedLength)
 	} else {
-		bf.tp.SetFlen(base64NeededEncodedLength(bf.args[0].GetType().GetFlen()))
+		bf.tp.SetFlen(base64NeededEncodedLength(bf.args[0].GetType(ctx.GetEvalCtx()).GetFlen()))
 	}
 
 	maxAllowedPacket := ctx.GetEvalCtx().GetMaxAllowedPacket()
@@ -3855,18 +3855,18 @@ type weightStringFunctionClass struct {
 	baseFunctionClass
 }
 
-func (c *weightStringFunctionClass) verifyArgs(args []Expression) (weightStringPadding, int, error) {
+func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expression) (weightStringPadding, int, error) {
 	padding := weightStringPaddingNone
 	l := len(args)
 	if l != 1 && l != 3 {
 		return weightStringPaddingNone, 0, ErrIncorrectParameterCount.GenWithStackByArgs(c.funcName)
 	}
-	if types.IsTypeNumeric(args[0].GetType().GetType()) {
+	if types.IsTypeNumeric(args[0].GetType(ctx).GetType()) {
 		padding = weightStringPaddingNull
 	}
 	length := 0
 	if l == 3 {
-		if args[1].GetType().EvalType() != types.ETString {
+		if args[1].GetType(ctx).EvalType() != types.ETString {
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
 		}
 		c1, ok := args[1].(*Constant)
@@ -3883,7 +3883,7 @@ func (c *weightStringFunctionClass) verifyArgs(args []Expression) (weightStringP
 		default:
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(x, c.funcName)
 		}
-		if args[2].GetType().EvalType() != types.ETInt {
+		if args[2].GetType(ctx).EvalType() != types.ETInt {
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].String(), c.funcName)
 		}
 		c2, ok := args[2].(*Constant)
@@ -3899,7 +3899,7 @@ func (c *weightStringFunctionClass) verifyArgs(args []Expression) (weightStringP
 }
 
 func (c *weightStringFunctionClass) getFunction(ctx BuildContext, args []Expression) (builtinFunc, error) {
-	padding, length, err := c.verifyArgs(args)
+	padding, length, err := c.verifyArgs(ctx.GetEvalCtx(), args)
 	if err != nil {
 		return nil, err
 	}
@@ -3984,7 +3984,7 @@ func (b *builtinWeightStringSig) evalString(ctx EvalContext, row chunk.Row) (str
 			}
 			str += strings.Repeat(" ", b.length-lenRunes)
 		}
-		ctor = collate.GetCollator(b.args[0].GetType().GetCollate())
+		ctor = collate.GetCollator(b.args[0].GetType(ctx).GetCollate())
 	case weightStringPaddingAsBinary:
 		lenStr := len(str)
 		if b.length < lenStr {
@@ -4000,7 +4000,7 @@ func (b *builtinWeightStringSig) evalString(ctx EvalContext, row chunk.Row) (str
 		}
 		ctor = collate.GetCollator(charset.CollationBin)
 	case weightStringPaddingNone:
-		ctor = collate.GetCollator(b.args[0].GetType().GetCollate())
+		ctor = collate.GetCollator(b.args[0].GetType(ctx).GetCollate())
 	default:
 		return "", false, ErrIncorrectType.GenWithStackByArgs(ast.WeightString, string(b.padding))
 	}
@@ -4026,10 +4026,10 @@ func (c *translateFunctionClass) getFunction(ctx BuildContext, args []Expression
 	if err != nil {
 		return nil, err
 	}
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	bf.tp.SetFlen(argType.GetFlen())
 	SetBinFlagOrBinStr(argType, bf.tp)
-	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[1].GetType()) || types.IsBinaryStr(args[2].GetType()) {
+	if types.IsBinaryStr(args[0].GetType(ctx.GetEvalCtx())) || types.IsBinaryStr(args[1].GetType(ctx.GetEvalCtx())) || types.IsBinaryStr(args[2].GetType(ctx.GetEvalCtx())) {
 		sig := &builtinTranslateBinarySig{bf}
 		return sig, nil
 	}

--- a/pkg/expression/builtin_string_test.go
+++ b/pkg/expression/builtin_string_test.go
@@ -779,7 +779,7 @@ func TestReplace(t *testing.T) {
 	for i, c := range cases {
 		f, err := newFunctionForTest(ctx, ast.Replace, primitiveValsToConstants(ctx, c.args)...)
 		require.NoError(t, err)
-		require.Equalf(t, c.flen, f.GetType().GetFlen(), "test %v", i)
+		require.Equalf(t, c.flen, f.GetType(ctx).GetFlen(), "test %v", i)
 		d, err := f.Eval(ctx, chunk.Row{})
 		if c.getErr {
 			require.Error(t, err)
@@ -1090,8 +1090,8 @@ func TestLocate(t *testing.T) {
 	Dtbl2 := tblToDtbl(tbl2)
 	for i, c := range Dtbl2 {
 		exprs := datumsToConstants(c["Args"])
-		types.SetBinChsClnFlag(exprs[0].GetType())
-		types.SetBinChsClnFlag(exprs[1].GetType())
+		types.SetBinChsClnFlag(exprs[0].GetType(ctx))
+		types.SetBinChsClnFlag(exprs[1].GetType(ctx))
 		f, err := instr.getFunction(ctx, exprs)
 		require.NoError(t, err)
 		got, err := evalBuiltinFunc(f, ctx, chunk.Row{})
@@ -1467,7 +1467,7 @@ func TestCharLength(t *testing.T) {
 	for _, v := range tbl {
 		fc := funcs[ast.CharLength]
 		arg := datumsToConstants(types.MakeDatums(v.input))
-		tp := arg[0].GetType()
+		tp := arg[0].GetType(ctx)
 		tp.SetType(mysql.TypeVarString)
 		tp.SetCharset(charset.CharsetBin)
 		tp.SetCollate(charset.CollationBin)

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -53,7 +53,7 @@ func (b *builtinLowerUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 		return err
 	}
 	result.ReserveString(n)
-	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
+	enc := charset.FindEncoding(b.args[0].GetType(ctx).GetCharset())
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -165,7 +165,7 @@ func (b *builtinUpperUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 		return err
 	}
 	result.ReserveString(n)
-	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
+	enc := charset.FindEncoding(b.args[0].GetType(ctx).GetCharset())
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -712,7 +712,7 @@ func (b *builtinConvertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 	if err := b.args[0].VecEvalString(ctx, input, expr); err != nil {
 		return err
 	}
-	argTp, resultTp := b.args[0].GetType(), b.tp
+	argTp, resultTp := b.args[0].GetType(ctx), b.tp
 	result.ReserveString(n)
 	done := vecEvalStringConvertBinary(result, n, expr, argTp, resultTp)
 	if done {
@@ -820,7 +820,7 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx EvalContext, input *chunk.C
 		}
 
 		// when count > MaxInt64, returns whole string.
-		if count < 0 && mysql.HasUnsignedFlag(b.args[2].GetType().GetFlag()) {
+		if count < 0 && mysql.HasUnsignedFlag(b.args[2].GetType(ctx).GetFlag()) {
 			result.AppendString(str)
 			continue
 		}
@@ -1525,7 +1525,7 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 
 	// decimal x
-	if b.args[0].GetType().EvalType() == types.ETDecimal {
+	if b.args[0].GetType(ctx).EvalType() == types.ETDecimal {
 		xBuf, err := b.bufAllocator.get()
 		if err != nil {
 			return err
@@ -2125,7 +2125,7 @@ func (b *builtinOrdSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *
 		return err
 	}
 
-	enc := charset.FindEncoding(b.args[0].GetType().GetCharset())
+	enc := charset.FindEncoding(b.args[0].GetType(ctx).GetCharset())
 	var x [4]byte
 	encBuf := bytes.NewBuffer(x[:])
 	result.ResizeInt64(n, false)
@@ -2706,7 +2706,7 @@ func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	dInt64s := dBuf.Int64s()
 
 	// decimal x
-	if b.args[0].GetType().EvalType() == types.ETDecimal {
+	if b.args[0].GetType(ctx).EvalType() == types.ETDecimal {
 		xBuf, err := b.bufAllocator.get()
 		if err != nil {
 			return err
@@ -3070,7 +3070,7 @@ func (b *builtinTranslateBinarySig) vecEvalString(ctx EvalContext, input *chunk.
 	_, isFromConst := b.args[1].(*Constant)
 	_, isToConst := b.args[2].(*Constant)
 	if isFromConst && isToConst {
-		if !(ExprNotNull(b.args[1]) && ExprNotNull(b.args[2])) {
+		if !(ExprNotNull(ctx, b.args[1]) && ExprNotNull(ctx, b.args[2])) {
 			for i := 0; i < n; i++ {
 				result.AppendNull()
 			}
@@ -3143,7 +3143,7 @@ func (b *builtinTranslateUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	_, isFromConst := b.args[1].(*Constant)
 	_, isToConst := b.args[2].(*Constant)
 	if isFromConst && isToConst {
-		if !(ExprNotNull(b.args[1]) && ExprNotNull(b.args[2])) {
+		if !(ExprNotNull(ctx, b.args[1]) && ExprNotNull(ctx, b.args[2])) {
 			for i := 0; i < n; i++ {
 				result.AppendNull()
 			}

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -411,7 +411,7 @@ func (c *timeDiffFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		return nil, err
 	}
 
-	arg0FieldTp, arg1FieldTp := args[0].GetType(), args[1].GetType()
+	arg0FieldTp, arg1FieldTp := args[0].GetType(ctx.GetEvalCtx()), args[1].GetType(ctx.GetEvalCtx())
 	arg0Tp, arg1Tp := c.getArgEvalTp(arg0FieldTp), c.getArgEvalTp(arg1FieldTp)
 	arg0Dec, err := getExpressionFsp(ctx, args[0])
 	if err != nil {
@@ -773,7 +773,7 @@ func (c *dateFormatFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
-	bf.tp.SetFlen((args[1].GetType().GetFlen() + 1) / 2 * 11)
+	bf.tp.SetFlen((args[1].GetType(ctx.GetEvalCtx()).GetFlen() + 1) / 2 * 11)
 	sig := &builtinDateFormatSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DateFormatSig)
 	return sig, nil
@@ -1651,7 +1651,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx BuildContext, args []Express
 		argTps = append(argTps, types.ETString)
 	}
 
-	arg0Tp := args[0].GetType()
+	arg0Tp := args[0].GetType(ctx.GetEvalCtx())
 	isArg0Str := arg0Tp.EvalType() == types.ETString
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, retTp, argTps...)
 	if err != nil {
@@ -2609,14 +2609,14 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		// extract(day_second from '2001-01-01 02:03:04') = 1020304 // datetime
 		// extract(day_second from 20010101020304) = 1020304 // datetime
 		// extract(day_second from '01 02:03:04') = 260304 // time
-		if args[1].GetType().EvalType() == types.ETDatetime || args[1].GetType().EvalType() == types.ETTimestamp {
+		if args[1].GetType(ctx.GetEvalCtx()).EvalType() == types.ETDatetime || args[1].GetType(ctx.GetEvalCtx()).EvalType() == types.ETTimestamp {
 			bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETString, types.ETDatetime)
 			if err != nil {
 				return nil, err
 			}
 			sig = &builtinExtractDatetimeSig{bf}
 			sig.setPbCode(tipb.ScalarFuncSig_ExtractDatetime)
-		} else if args[1].GetType().EvalType() == types.ETDuration {
+		} else if args[1].GetType(ctx.GetEvalCtx()).EvalType() == types.ETDuration {
 			bf, err = newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETString, types.ETDuration)
 			if err != nil {
 				return nil, err
@@ -2628,7 +2628,7 @@ func (c *extractFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 			if err != nil {
 				return nil, err
 			}
-			bf.args[1].GetType().SetDecimal(int(types.MaxFsp))
+			bf.args[1].GetType(ctx.GetEvalCtx()).SetDecimal(int(types.MaxFsp))
 			sig = &builtinExtractDatetimeFromStringSig{bf}
 			sig.setPbCode(tipb.ScalarFuncSig_ExtractDatetimeFromString)
 		}
@@ -2980,7 +2980,7 @@ func (du *baseDateArithmetical) getIntervalFromInt(ctx EvalContext, args []Expre
 		return "", true, err
 	}
 
-	if mysql.HasUnsignedFlag(args[1].GetType().GetFlag()) {
+	if mysql.HasUnsignedFlag(args[1].GetType(ctx).GetFlag()) {
 		return strconv.FormatUint(uint64(interval), 10), false, nil
 	}
 
@@ -2992,7 +2992,7 @@ func (du *baseDateArithmetical) getIntervalFromReal(ctx EvalContext, args []Expr
 	if isNull || err != nil {
 		return "", true, err
 	}
-	return strconv.FormatFloat(interval, 'f', args[1].GetType().GetDecimal(), 64), false, nil
+	return strconv.FormatFloat(interval, 'f', args[1].GetType(ctx).GetDecimal(), 64), false, nil
 }
 
 func (du *baseDateArithmetical) add(ctx EvalContext, date types.Time, interval, unit string, resultFsp int) (types.Time, bool, error) {
@@ -3423,7 +3423,7 @@ func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, ctx Ev
 
 	result.ReserveString(n)
 	i64s := buf.Int64s()
-	unsigned := mysql.HasUnsignedFlag(b.args[1].GetType().GetFlag())
+	unsigned := mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag())
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -3449,7 +3449,7 @@ func (du *baseDateArithmetical) vecGetIntervalFromReal(b *baseBuiltinFunc, ctx E
 
 	result.ReserveString(n)
 	f64s := buf.Float64s()
-	prec := b.args[1].GetType().GetDecimal()
+	prec := b.args[1].GetType(ctx).GetDecimal()
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
@@ -3574,7 +3574,7 @@ func (c *addSubDateFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 
-	dateEvalTp := args[0].GetType().EvalType()
+	dateEvalTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	// Some special evaluation type treatment.
 	// Note that it could be more elegant if we always evaluate datetime for int, real, decimal and string, by leveraging existing implicit casts.
 	// However, MySQL has a weird behavior for date_add(string, ...), whose result depends on the content of the first argument.
@@ -3588,7 +3588,7 @@ func (c *addSubDateFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		dateEvalTp = types.ETString
 	}
 
-	intervalEvalTp := args[1].GetType().EvalType()
+	intervalEvalTp := args[1].GetType(ctx.GetEvalCtx()).EvalType()
 	if intervalEvalTp == types.ETJson {
 		intervalEvalTp = types.ETString
 	} else if intervalEvalTp != types.ETString && intervalEvalTp != types.ETDecimal && intervalEvalTp != types.ETReal {
@@ -3602,7 +3602,7 @@ func (c *addSubDateFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 	resultTp := mysql.TypeVarString
 	resultEvalTp := types.ETString
-	if args[0].GetType().GetType() == mysql.TypeDate {
+	if args[0].GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeDate {
 		if !types.IsClockUnit(unit) {
 			// First arg is date and unit contains no HMS, return date.
 			resultTp = mysql.TypeDate
@@ -3645,10 +3645,10 @@ func (c *addSubDateFunctionClass) getFunction(ctx BuildContext, args []Expressio
 			if intervalEvalTp == types.ETString || intervalEvalTp == types.ETReal {
 				intervalFsp = types.MaxFsp
 			} else {
-				intervalFsp = mathutil.Min(types.MaxFsp, args[1].GetType().GetDecimal())
+				intervalFsp = mathutil.Min(types.MaxFsp, args[1].GetType(ctx.GetEvalCtx()).GetDecimal())
 			}
 		}
-		resultFsp = mathutil.Min(types.MaxFsp, mathutil.Max(args[0].GetType().GetDecimal(), intervalFsp))
+		resultFsp = mathutil.Min(types.MaxFsp, mathutil.Max(args[0].GetType(ctx.GetEvalCtx()).GetDecimal(), intervalFsp))
 	}
 	switch resultTp {
 	case mysql.TypeDate:
@@ -4148,7 +4148,7 @@ func (c *unixTimestampFunctionClass) getFunction(ctx BuildContext, args []Expres
 		retTp, retDecimal = types.ETInt, 0
 	} else {
 		argTps = []types.EvalType{types.ETDatetime}
-		argType := args[0].GetType()
+		argType := args[0].GetType(ctx.GetEvalCtx())
 		argEvaltp := argType.EvalType()
 		if argEvaltp == types.ETString {
 			// Treat types.ETString as unspecified decimal.
@@ -4355,7 +4355,7 @@ func (c *timestampFunctionClass) getFunction(ctx BuildContext, args []Expression
 		}
 	}
 	isFloat := false
-	switch args[0].GetType().GetType() {
+	switch args[0].GetType(ctx.GetEvalCtx()).GetType() {
 	case mysql.TypeFloat, mysql.TypeDouble, mysql.TypeNewDecimal, mysql.TypeLonglong:
 		isFloat = true
 	}
@@ -4530,7 +4530,7 @@ func getFsp4TimeAddSub(s string) int {
 // getBf4TimeAddSub parses input types, generates baseBuiltinFunc and set related attributes for
 // builtin function 'ADDTIME' and 'SUBTIME'
 func getBf4TimeAddSub(ctx BuildContext, funcName string, args []Expression) (tp1, tp2 *types.FieldType, bf baseBuiltinFunc, err error) {
-	tp1, tp2 = args[0].GetType(), args[1].GetType()
+	tp1, tp2 = args[0].GetType(ctx.GetEvalCtx()), args[1].GetType(ctx.GetEvalCtx())
 	var argTp1, argTp2, retTp types.EvalType
 	switch tp1.GetType() {
 	case mysql.TypeDatetime, mysql.TypeTimestamp:
@@ -4970,7 +4970,7 @@ func (b *builtinAddStringAndStringSig) evalString(ctx EvalContext, row chunk.Row
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg1Type := b.args[1].GetType()
+	arg1Type := b.args[1].GetType(ctx)
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		return "", true, nil
 	}
@@ -5081,11 +5081,11 @@ type convertTzFunctionClass struct {
 func (c *convertTzFunctionClass) getDecimal(ctx BuildContext, arg Expression) int {
 	decimal := types.MaxFsp
 	if dt, isConstant := arg.(*Constant); isConstant {
-		switch arg.GetType().EvalType() {
+		switch arg.GetType(ctx.GetEvalCtx()).EvalType() {
 		case types.ETInt:
 			decimal = 0
 		case types.ETReal, types.ETDecimal:
-			decimal = arg.GetType().GetDecimal()
+			decimal = arg.GetType(ctx.GetEvalCtx()).GetDecimal()
 		case types.ETString:
 			str, isNull, err := dt.EvalString(ctx.GetEvalCtx(), chunk.Row{})
 			if err == nil && !isNull {
@@ -5273,11 +5273,11 @@ func (c *makeTimeFunctionClass) getFunction(ctx BuildContext, args []Expression)
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	tp, decimal := args[2].GetType().EvalType(), 0
+	tp, decimal := args[2].GetType(ctx.GetEvalCtx()).EvalType(), 0
 	switch tp {
 	case types.ETInt:
 	case types.ETReal, types.ETDecimal:
-		decimal = args[2].GetType().GetDecimal()
+		decimal = args[2].GetType(ctx.GetEvalCtx()).GetDecimal()
 		if decimal > 6 || decimal == types.UnspecifiedLength {
 			decimal = 6
 		}
@@ -5355,7 +5355,7 @@ func (b *builtinMakeTimeSig) evalDuration(ctx EvalContext, row chunk.Row) (types
 	if second < 0 || second >= 60 {
 		return dur, true, nil
 	}
-	dur, err = b.makeTime(typeCtx(ctx), hour, minute, second, mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag()))
+	dur, err = b.makeTime(typeCtx(ctx), hour, minute, second, mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()))
 	if err != nil {
 		return dur, true, err
 	}
@@ -5551,7 +5551,7 @@ func (c *secToTimeFunctionClass) getFunction(ctx BuildContext, args []Expression
 		return nil, err
 	}
 	var retFsp int
-	argType := args[0].GetType()
+	argType := args[0].GetType(ctx.GetEvalCtx())
 	argEvalTp := argType.EvalType()
 	if argEvalTp == types.ETString {
 		retFsp = types.UnspecifiedLength
@@ -5840,7 +5840,7 @@ func (b *builtinSubStringAndStringSig) evalString(ctx EvalContext, row chunk.Row
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	arg1Type := b.args[1].GetType()
+	arg1Type := b.args[1].GetType(ctx)
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		return "", true, nil
 	}
@@ -6047,7 +6047,7 @@ func (c *timeFormatFunctionClass) getFunction(ctx BuildContext, args []Expressio
 		return nil, err
 	}
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
-	bf.tp.SetFlen((args[1].GetType().GetFlen() + 1) / 2 * 11)
+	bf.tp.SetFlen((args[1].GetType(ctx.GetEvalCtx()).GetFlen() + 1) / 2 * 11)
 	sig := &builtinTimeFormatSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_TimeFormat)
 	return sig, nil
@@ -6546,7 +6546,7 @@ func getExpressionFsp(ctx BuildContext, expression Expression) (int, error) {
 		return types.GetFsp(str), nil
 	}
 	warpExpr := WrapWithCastAsTime(ctx, expression, types.NewFieldType(mysql.TypeDatetime))
-	return mathutil.Min(warpExpr.GetType().GetDecimal(), types.MaxFsp), nil
+	return mathutil.Min(warpExpr.GetType(ctx.GetEvalCtx()).GetDecimal(), types.MaxFsp), nil
 }
 
 // tidbParseTsoFunctionClass extracts physical time from a tso
@@ -6558,7 +6558,7 @@ func (c *tidbParseTsoFunctionClass) getFunction(ctx BuildContext, args []Express
 	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
-	argTp := args[0].GetType().EvalType()
+	argTp := args[0].GetType(ctx.GetEvalCtx()).EvalType()
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, argTp, types.ETInt)
 	if err != nil {
 		return nil, err

--- a/pkg/expression/builtin_time_test.go
+++ b/pkg/expression/builtin_time_test.go
@@ -796,7 +796,7 @@ func TestTime(t *testing.T) {
 	for _, c := range cases {
 		f, err := newFunctionForTest(ctx, ast.Time, primitiveValsToConstants(ctx, []any{c.args})...)
 		require.NoError(t, err)
-		tp := f.GetType()
+		tp := f.GetType(ctx)
 		require.Equal(t, mysql.TypeDuration, tp.GetType())
 		require.Equal(t, charset.CharsetBin, tp.GetCharset())
 		require.Equal(t, charset.CollationBin, tp.GetCollate())
@@ -1266,7 +1266,7 @@ func TestFromUnixTime(t *testing.T) {
 		if len(c.format) == 0 {
 			constants := datumsToConstants([]types.Datum{timestamp})
 			if !c.isDecimal {
-				constants[0].GetType().SetDecimal(0)
+				constants[0].GetType(ctx).SetDecimal(0)
 			}
 
 			f, err := fc.getFunction(ctx, constants)
@@ -1280,7 +1280,7 @@ func TestFromUnixTime(t *testing.T) {
 			format := types.NewStringDatum(c.format)
 			constants := datumsToConstants([]types.Datum{timestamp, format})
 			if !c.isDecimal {
-				constants[0].GetType().SetDecimal(0)
+				constants[0].GetType(ctx).SetDecimal(0)
 			}
 			f, err := fc.getFunction(ctx, constants)
 			require.NoError(t, err)
@@ -1632,7 +1632,7 @@ func TestTimeDiff(t *testing.T) {
 		preWarningCnt := ctx.GetSessionVars().StmtCtx.WarningCount()
 		f, err := newFunctionForTest(ctx, ast.TimeDiff, primitiveValsToConstants(ctx, c.args)...)
 		require.NoError(t, err)
-		tp := f.GetType()
+		tp := f.GetType(ctx)
 		require.Equal(t, mysql.TypeDuration, tp.GetType())
 		require.Equal(t, charset.CharsetBin, tp.GetCharset())
 		require.Equal(t, charset.CollationBin, tp.GetCollate())
@@ -1873,7 +1873,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 	for _, test := range tests {
 		expr := datumsToConstants([]types.Datum{test.input})
-		expr[0].GetType().SetDecimal(test.inputDecimal)
+		expr[0].GetType(ctx).SetDecimal(test.inputDecimal)
 		resetStmtContext(ctx)
 		f, err := fc.getFunction(ctx, expr)
 		require.NoErrorf(t, err, "%+v", test)
@@ -2265,7 +2265,7 @@ func TestMakeDate(t *testing.T) {
 	for _, c := range cases {
 		f, err := newFunctionForTest(ctx, ast.MakeDate, primitiveValsToConstants(ctx, c.args)...)
 		require.NoError(t, err)
-		tp := f.GetType()
+		tp := f.GetType(ctx)
 		require.Equal(t, mysql.TypeDate, tp.GetType())
 		require.Equal(t, charset.CharsetBin, tp.GetCharset())
 		require.Equal(t, charset.CollationBin, tp.GetCollate())
@@ -2769,7 +2769,7 @@ func TestSecToTime(t *testing.T) {
 	for _, test := range tests {
 		comment := fmt.Sprintf("%+v", test)
 		expr := datumsToConstants([]types.Datum{test.input})
-		expr[0].GetType().SetDecimal(test.inputDecimal)
+		expr[0].GetType(ctx).SetDecimal(test.inputDecimal)
 		f, err := fc.getFunction(ctx, expr)
 		require.NoError(t, err, comment)
 		d, err := evalBuiltinFunc(f, ctx, chunk.Row{})

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -1090,7 +1090,7 @@ func (b *builtinExtractDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	i64s := result.Int64s()
 	durIs := dur.GoDurations()
 	var duration types.Duration
-	duration.Fsp = b.args[1].GetType().GetDecimal()
+	duration.Fsp = b.args[1].GetType(ctx).GetDecimal()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -1447,7 +1447,7 @@ func (b *builtinTimeToSecSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
 	i64s := result.Int64s()
-	fsp := b.args[0].GetType().GetDecimal()
+	fsp := b.args[0].GetType(ctx).GetDecimal()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
@@ -2048,7 +2048,7 @@ func (b *builtinMakeTimeSig) vectorized() bool {
 }
 
 func (b *builtinMakeTimeSig) getVecIntParam(ctx EvalContext, arg Expression, input *chunk.Chunk, col *chunk.Column) (err error) {
-	if arg.GetType().EvalType() == types.ETReal {
+	if arg.GetType(ctx).EvalType() == types.ETReal {
 		err = arg.VecEvalReal(ctx, input, col)
 		if err != nil {
 			return err
@@ -2094,7 +2094,7 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk
 	seconds := secondsBuf.Float64s()
 	durs := result.GoDurations()
 	result.MergeNulls(minutesBuf, secondsBuf)
-	hourUnsignedFlag := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+	hourUnsignedFlag := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -316,7 +316,7 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 		// calculate
 
 		tc := typeCtx(ctx)
-		fsp1 := b.args[1].GetType().GetDecimal()
+		fsp1 := b.args[1].GetType(ctx).GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
 		var isNull bool
@@ -370,7 +370,7 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 		return err
 	}
 
-	arg1Type := b.args[1].GetType()
+	arg1Type := b.args[1].GetType(ctx)
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		result.ReserveString(n)
 		for i := 0; i < n; i++ {
@@ -498,8 +498,8 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 
 		// calculate
 
-		fsp0 := b.args[0].GetType().GetDecimal()
-		fsp1 := b.args[1].GetType().GetDecimal()
+		fsp0 := b.args[0].GetType(ctx).GetDecimal()
+		fsp1 := b.args[1].GetType(ctx).GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Add(arg1Duration)
@@ -576,7 +576,7 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 			return err
 		}
 
-		fsp0 := b.args[0].GetType().GetDecimal()
+		fsp0 := b.args[0].GetType(ctx).GetDecimal()
 
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Add(arg1Duration)
 
@@ -930,7 +930,7 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 		// calculate
 
 		tc := typeCtx(ctx)
-		fsp1 := b.args[1].GetType().GetDecimal()
+		fsp1 := b.args[1].GetType(ctx).GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
 		var isNull bool
@@ -984,7 +984,7 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 		return err
 	}
 
-	arg1Type := b.args[1].GetType()
+	arg1Type := b.args[1].GetType(ctx)
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		result.ReserveString(n)
 		for i := 0; i < n; i++ {
@@ -1112,8 +1112,8 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 
 		// calculate
 
-		fsp0 := b.args[0].GetType().GetDecimal()
-		fsp1 := b.args[1].GetType().GetDecimal()
+		fsp0 := b.args[0].GetType(ctx).GetDecimal()
+		fsp1 := b.args[1].GetType(ctx).GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Sub(arg1Duration)
@@ -1190,7 +1190,7 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 			return err
 		}
 
-		fsp0 := b.args[0].GetType().GetDecimal()
+		fsp0 := b.args[0].GetType(ctx).GetDecimal()
 
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Sub(arg1Duration)
 

--- a/pkg/expression/chunk_executor.go
+++ b/pkg/expression/chunk_executor.go
@@ -116,7 +116,7 @@ func VectorizedExecute(ctx EvalContext, exprs []Expression, iterator *chunk.Iter
 }
 
 func evalOneVec(ctx EvalContext, expr Expression, input *chunk.Chunk, output *chunk.Chunk, colIdx int) error {
-	ft := expr.GetType()
+	ft := expr.GetType(ctx)
 	result := output.Column(colIdx)
 	switch ft.EvalType() {
 	case types.ETInt:
@@ -218,7 +218,7 @@ func evalOneVec(ctx EvalContext, expr Expression, input *chunk.Chunk, output *ch
 }
 
 func evalOneColumn(ctx EvalContext, expr Expression, iterator *chunk.Iterator4Chunk, output *chunk.Chunk, colID int) (err error) {
-	switch fieldType, evalType := expr.GetType(), expr.GetType().EvalType(); evalType {
+	switch fieldType, evalType := expr.GetType(ctx), expr.GetType(ctx).EvalType(); evalType {
 	case types.ETInt:
 		for row := iterator.Begin(); err == nil && row != iterator.End(); row = iterator.Next() {
 			err = executeToInt(ctx, expr, fieldType, row, output, colID)
@@ -252,7 +252,7 @@ func evalOneColumn(ctx EvalContext, expr Expression, iterator *chunk.Iterator4Ch
 }
 
 func evalOneCell(ctx EvalContext, expr Expression, row chunk.Row, output *chunk.Chunk, colID int) (err error) {
-	switch fieldType, evalType := expr.GetType(), expr.GetType().EvalType(); evalType {
+	switch fieldType, evalType := expr.GetType(ctx), expr.GetType(ctx).EvalType(); evalType {
 	case types.ETInt:
 		err = executeToInt(ctx, expr, fieldType, row, output, colID)
 	case types.ETReal:
@@ -472,7 +472,7 @@ func rowBasedFilter(ctx EvalContext, filters []Expression, iterator *chunk.Itera
 	)
 	for _, filter := range filters {
 		isIntType := true
-		if filter.GetType().EvalType() != types.ETInt {
+		if filter.GetType(ctx).EvalType() != types.ETInt {
 			isIntType = false
 		}
 		for row := iterator.Begin(); row != iterator.End(); row = iterator.Next() {

--- a/pkg/expression/collation.go
+++ b/pkg/expression/collation.go
@@ -236,7 +236,7 @@ func deriveCollation(ctx BuildContext, funcName string, args []Expression, retTy
 		ec.Repe = ASCII
 		return ec, nil
 	case ast.In:
-		if args[0].GetType().EvalType() == types.ETString {
+		if args[0].GetType(ctx.GetEvalCtx()).EvalType() == types.ETString {
 			return CheckAndDeriveCollationFromExprs(ctx, funcName, types.ETInt, args...)
 		}
 	case ast.DateFormat, ast.TimeFormat:
@@ -244,7 +244,7 @@ func deriveCollation(ctx BuildContext, funcName string, args []Expression, retTy
 		return &ExprCollation{args[1].Coercibility(), args[1].Repertoire(), charsetInfo, collation}, nil
 	case ast.Cast:
 		// We assume all the cast are implicit.
-		ec = &ExprCollation{args[0].Coercibility(), args[0].Repertoire(), args[0].GetType().GetCharset(), args[0].GetType().GetCollate()}
+		ec = &ExprCollation{args[0].Coercibility(), args[0].Repertoire(), args[0].GetType(ctx.GetEvalCtx()).GetCharset(), args[0].GetType(ctx.GetEvalCtx()).GetCollate()}
 		// Non-string type cast to string type should use @@character_set_connection and @@collation_connection.
 		// String type cast to string type should keep its original charset and collation. It should not happen.
 		if retType == types.ETString && argTps[0] != types.ETString {
@@ -302,13 +302,13 @@ func deriveCollation(ctx BuildContext, funcName string, args []Expression, retTy
 
 // CheckAndDeriveCollationFromExprs derives collation information from these expressions, return error if derives collation error.
 func CheckAndDeriveCollationFromExprs(ctx BuildContext, funcName string, evalType types.EvalType, args ...Expression) (et *ExprCollation, err error) {
-	ec := inferCollation(args...)
+	ec := inferCollation(ctx.GetEvalCtx(), args...)
 	if ec == nil {
-		return nil, illegalMixCollationErr(funcName, args)
+		return nil, illegalMixCollationErr(ctx.GetEvalCtx(), funcName, args)
 	}
 
 	if evalType != types.ETString && ec.Coer == CoercibilityNone {
-		return nil, illegalMixCollationErr(funcName, args)
+		return nil, illegalMixCollationErr(ctx.GetEvalCtx(), funcName, args)
 	}
 
 	if evalType == types.ETString && ec.Coer == CoercibilityNumeric {
@@ -318,10 +318,10 @@ func CheckAndDeriveCollationFromExprs(ctx BuildContext, funcName string, evalTyp
 	}
 
 	if !safeConvert(ctx, ec, args...) {
-		return nil, illegalMixCollationErr(funcName, args)
+		return nil, illegalMixCollationErr(ctx.GetEvalCtx(), funcName, args)
 	}
 
-	return fixStringTypeForMaxLength(funcName, args, ec), nil
+	return fixStringTypeForMaxLength(ctx.GetEvalCtx(), funcName, args, ec), nil
 }
 
 // fixStringTypeForMaxLength changes the type of string from `VARCHAR` to `MEDIUM BLOB` or `LONG BLOB` according to the max length of
@@ -332,27 +332,27 @@ func CheckAndDeriveCollationFromExprs(ctx BuildContext, funcName string, evalTyp
 // TODO: also consider types other than `JSON`. And also think about when it'll become `MEDIUM BLOB`. This function only handles the collation, but
 // not change the type and binary flag.
 // TODO: some function will generate big values, like `repeat` and `space`. They should be handled according to the argument if it's a constant.
-func fixStringTypeForMaxLength(funcName string, args []Expression, ec *ExprCollation) *ExprCollation {
+func fixStringTypeForMaxLength(ctx EvalContext, funcName string, args []Expression, ec *ExprCollation) *ExprCollation {
 	// Be careful that the `args` is not all arguments of the `funcName`. You should check `deriveCollation` function to see which arguments are passed
 	// to the `CheckAndDeriveCollationFromExprs` function, and then passed here.
 	shouldChangeToBin := false
 
 	switch funcName {
 	case ast.Reverse, ast.Lower, ast.Upper, ast.SubstringIndex, ast.Trim, ast.Quote, ast.InsertFunc, ast.Substr, ast.Repeat, ast.Replace:
-		shouldChangeToBin = args[0].GetType().EvalType() == types.ETJson
+		shouldChangeToBin = args[0].GetType(ctx).EvalType() == types.ETJson
 	case ast.Concat, ast.ConcatWS, ast.Elt, ast.MakeSet:
 		for _, arg := range args {
-			if arg.GetType().EvalType() == types.ETJson {
+			if arg.GetType(ctx).EvalType() == types.ETJson {
 				shouldChangeToBin = true
 				break
 			}
 		}
 	case ast.ExportSet:
 		if len(args) >= 2 {
-			shouldChangeToBin = args[0].GetType().EvalType() == types.ETJson || args[1].GetType().EvalType() == types.ETJson
+			shouldChangeToBin = args[0].GetType(ctx).EvalType() == types.ETJson || args[1].GetType(ctx).EvalType() == types.ETJson
 		}
 		if len(args) >= 3 {
-			shouldChangeToBin = shouldChangeToBin || args[2].GetType().EvalType() == types.ETJson
+			shouldChangeToBin = shouldChangeToBin || args[2].GetType(ctx).EvalType() == types.ETJson
 		}
 	}
 
@@ -365,12 +365,12 @@ func fixStringTypeForMaxLength(funcName string, args []Expression, ec *ExprColla
 func safeConvert(ctx BuildContext, ec *ExprCollation, args ...Expression) bool {
 	enc := charset.FindEncodingTakeUTF8AsNoop(ec.Charset)
 	for _, arg := range args {
-		if arg.GetType().GetCharset() == ec.Charset {
+		if arg.GetType(ctx.GetEvalCtx()).GetCharset() == ec.Charset {
 			continue
 		}
 
 		// If value has ASCII repertoire, or it is binary string, just skip it.
-		if arg.Repertoire() == ASCII || types.IsBinaryStr(arg.GetType()) {
+		if arg.Repertoire() == ASCII || types.IsBinaryStr(arg.GetType(ctx.GetEvalCtx())) {
 			continue
 		}
 
@@ -386,7 +386,7 @@ func safeConvert(ctx BuildContext, ec *ExprCollation, args ...Expression) bool {
 				return false
 			}
 		} else {
-			if arg.GetType().GetCollate() != charset.CharsetBin && ec.Charset != charset.CharsetBin && !isUnicodeCollation(ec.Charset) {
+			if arg.GetType(ctx.GetEvalCtx()).GetCollate() != charset.CharsetBin && ec.Charset != charset.CharsetBin && !isUnicodeCollation(ec.Charset) {
 				return false
 			}
 		}
@@ -396,7 +396,7 @@ func safeConvert(ctx BuildContext, ec *ExprCollation, args ...Expression) bool {
 }
 
 // inferCollation infers collation, charset, coercibility and check the legitimacy.
-func inferCollation(exprs ...Expression) *ExprCollation {
+func inferCollation(ctx EvalContext, exprs ...Expression) *ExprCollation {
 	if len(exprs) == 0 {
 		// TODO: see if any function with no arguments could run here.
 		dstCharset, dstCollation := charset.GetDefaultCharsetAndCollate()
@@ -410,22 +410,22 @@ func inferCollation(exprs ...Expression) *ExprCollation {
 
 	repertoire := exprs[0].Repertoire()
 	coercibility := exprs[0].Coercibility()
-	dstCharset, dstCollation := exprs[0].GetType().GetCharset(), exprs[0].GetType().GetCollate()
-	if exprs[0].GetType().EvalType() == types.ETJson {
+	dstCharset, dstCollation := exprs[0].GetType(ctx).GetCharset(), exprs[0].GetType(ctx).GetCollate()
+	if exprs[0].GetType(ctx).EvalType() == types.ETJson {
 		dstCharset, dstCollation = charset.CharsetUTF8MB4, charset.CollationUTF8MB4
-	} else if types.IsTypeBit(exprs[0].GetType()) {
+	} else if types.IsTypeBit(exprs[0].GetType(ctx)) {
 		dstCharset, dstCollation = charset.CharsetBin, charset.CollationBin
 	}
 	unknownCS := false
 
 	// Aggregate arguments one by one, agg(a, b, c) := agg(agg(a, b), c).
 	for _, arg := range exprs[1:] {
-		argCharset, argCollation := arg.GetType().GetCharset(), arg.GetType().GetCollate()
+		argCharset, argCollation := arg.GetType(ctx).GetCharset(), arg.GetType(ctx).GetCollate()
 		// The collation of JSON is always utf8mb4_bin in builtin-func which is same as MySQL
 		// see details https://github.com/pingcap/tidb/issues/31320#issuecomment-1010599311
-		if arg.GetType().EvalType() == types.ETJson {
+		if arg.GetType(ctx).EvalType() == types.ETJson {
 			argCharset, argCollation = charset.CharsetUTF8MB4, charset.CollationUTF8MB4
-		} else if types.IsTypeBit(arg.GetType()) {
+		} else if types.IsTypeBit(arg.GetType(ctx)) {
 			argCharset, argCollation = charset.CharsetBin, charset.CollationBin
 		}
 		// If one of the arguments is binary charset, we allow it can be used with other charsets.
@@ -543,14 +543,14 @@ var (
 	coerString = []string{"EXPLICIT", "NONE", "IMPLICIT", "SYSCONST", "COERCIBLE", "NUMERIC", "IGNORABLE"}
 )
 
-func illegalMixCollationErr(funcName string, args []Expression) error {
+func illegalMixCollationErr(ctx EvalContext, funcName string, args []Expression) error {
 	funcName = GetDisplayName(funcName)
 
 	switch len(args) {
 	case 2:
-		return collate.ErrIllegalMix2Collation.GenWithStackByArgs(args[0].GetType().GetCollate(), coerString[args[0].Coercibility()], args[1].GetType().GetCollate(), coerString[args[1].Coercibility()], funcName)
+		return collate.ErrIllegalMix2Collation.GenWithStackByArgs(args[0].GetType(ctx).GetCollate(), coerString[args[0].Coercibility()], args[1].GetType(ctx).GetCollate(), coerString[args[1].Coercibility()], funcName)
 	case 3:
-		return collate.ErrIllegalMix3Collation.GenWithStackByArgs(args[0].GetType().GetCollate(), coerString[args[0].Coercibility()], args[1].GetType().GetCollate(), coerString[args[1].Coercibility()], args[2].GetType().GetCollate(), coerString[args[2].Coercibility()], funcName)
+		return collate.ErrIllegalMix3Collation.GenWithStackByArgs(args[0].GetType(ctx).GetCollate(), coerString[args[0].Coercibility()], args[1].GetType(ctx).GetCollate(), coerString[args[1].Coercibility()], args[2].GetType(ctx).GetCollate(), coerString[args[2].Coercibility()], funcName)
 	default:
 		return collate.ErrIllegalMixCollation.GenWithStackByArgs(funcName)
 	}

--- a/pkg/expression/collation_test.go
+++ b/pkg/expression/collation_test.go
@@ -218,8 +218,9 @@ func TestInferCollation(t *testing.T) {
 		},
 	}
 
+	ctx := createContext(t)
 	for i, test := range tests {
-		ec := inferCollation(test.exprs...)
+		ec := inferCollation(ctx, test.exprs...)
 		if test.err {
 			require.Nil(t, ec, i)
 		} else {

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -97,7 +97,7 @@ func (col *CorrelatedColumn) EvalInt(ctx EvalContext, row chunk.Row) (int64, boo
 	if col.Data.IsNull() {
 		return 0, true, nil
 	}
-	if col.GetType().Hybrid() {
+	if col.GetType(ctx).Hybrid() {
 		res, err := col.Data.ToInt64(typeCtx(ctx))
 		return res, err != nil, err
 	}
@@ -312,7 +312,7 @@ func (col *Column) VecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk
 func (col *Column) VecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	src := input.Column(col.Index)
-	if col.GetType().GetType() == mysql.TypeFloat {
+	if col.GetType(ctx).GetType() == mysql.TypeFloat {
 		result.ResizeFloat64(n, false)
 		f32s := src.Float32s()
 		f64s := result.Float64s()
@@ -408,7 +408,12 @@ func (col *Column) MarshalJSON() ([]byte, error) {
 }
 
 // GetType implements Expression interface.
-func (col *Column) GetType() *types.FieldType {
+func (col *Column) GetType(_ EvalContext) *types.FieldType {
+	return col.GetStaticType()
+}
+
+// GetStaticType returns the type without considering the context.
+func (col *Column) GetStaticType() *types.FieldType {
 	return col.RetType
 }
 
@@ -424,7 +429,7 @@ func (col *Column) Eval(_ EvalContext, row chunk.Row) (types.Datum, error) {
 
 // EvalInt returns int representation of Column.
 func (col *Column) EvalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
-	if col.GetType().Hybrid() {
+	if col.GetType(ctx).Hybrid() {
 		val := row.GetDatum(col.Index, col.RetType)
 		if val.IsNull() {
 			return 0, true, nil
@@ -447,7 +452,7 @@ func (col *Column) EvalReal(ctx EvalContext, row chunk.Row) (float64, bool, erro
 	if row.IsNull(col.Index) {
 		return 0, true, nil
 	}
-	if col.GetType().GetType() == mysql.TypeFloat {
+	if col.GetType(ctx).GetType() == mysql.TypeFloat {
 		return float64(row.GetFloat32(col.Index)), false, nil
 	}
 	return row.GetFloat64(col.Index), false, nil
@@ -460,7 +465,7 @@ func (col *Column) EvalString(ctx EvalContext, row chunk.Row) (string, bool, err
 	}
 
 	// Specially handle the ENUM/SET/BIT input value.
-	if col.GetType().Hybrid() {
+	if col.GetType(ctx).Hybrid() {
 		val := row.GetDatum(col.Index, col.RetType)
 		res, err := val.ToString()
 		return res, err != nil, err

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -19,6 +19,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
@@ -129,6 +130,7 @@ type Constant struct {
 
 // ParamMarker indicates param provided by COM_STMT_EXECUTE.
 type ParamMarker struct {
+	ctx   variable.SessionVarsProvider
 	order int
 }
 
@@ -137,11 +139,17 @@ func (d *ParamMarker) GetUserVar(ctx EvalContext) types.Datum {
 	return ctx.GetParamValue(d.order)
 }
 
+func (d *ParamMarker) getUserVarWithInternalCtx() types.Datum {
+	// TODO: remove this function in the future
+	sessionVars := d.ctx.GetSessionVars()
+	return sessionVars.PlanCacheParams.GetParamValue(d.order)
+}
+
 // String implements fmt.Stringer interface.
 func (c *Constant) String() string {
 	if c.ParamMarker != nil {
-		// TODO: use a more meaningful value to represent the param marker.
-		return "?"
+		dt := c.ParamMarker.getUserVarWithInternalCtx()
+		c.Value.SetValue(dt.GetValue(), c.RetType)
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.String()
 	}
@@ -160,14 +168,13 @@ func (c *Constant) Clone() Expression {
 }
 
 // GetType implements Expression interface.
-func (c *Constant) GetType() *types.FieldType {
+func (c *Constant) GetType(ctx EvalContext) *types.FieldType {
 	if c.ParamMarker != nil {
 		// GetType() may be called in multi-threaded context, e.g, in building inner executors of IndexJoin,
 		// so it should avoid data race. We achieve this by returning different FieldType pointer for each call.
 		tp := types.NewFieldType(mysql.TypeUnspecified)
-		// dt := c.ParamMarker.GetUserVar(ctx)
-		// types.InferParamTypeFromDatum(&dt, tp)
-		// TODO: fix GetType
+		dt := c.ParamMarker.GetUserVar(ctx)
+		types.InferParamTypeFromDatum(&dt, tp)
 		return tp
 	}
 	return c.RetType
@@ -263,7 +270,7 @@ func (c *Constant) Eval(ctx EvalContext, row chunk.Row) (types.Datum, error) {
 				}
 				return val, nil
 			}
-			if err := c.adjustDecimal(dt.GetMysqlDecimal()); err != nil {
+			if err := c.adjustDecimal(ctx, dt.GetMysqlDecimal()); err != nil {
 				return dt, err
 			}
 		}
@@ -281,12 +288,12 @@ func (c *Constant) EvalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) 
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return 0, true, nil
 	} else if dt.Kind() == types.KindBinaryLiteral {
 		val, err := dt.GetBinaryLiteral().ToInt(typeCtx(ctx))
 		return int64(val), err != nil, err
-	} else if c.GetType().Hybrid() || dt.Kind() == types.KindString {
+	} else if c.GetType(ctx).Hybrid() || dt.Kind() == types.KindString {
 		res, err := dt.ToInt64(typeCtx(ctx))
 		return res, false, err
 	} else if dt.Kind() == types.KindMysqlBit {
@@ -305,10 +312,10 @@ func (c *Constant) EvalReal(ctx EvalContext, row chunk.Row) (float64, bool, erro
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return 0, true, nil
 	}
-	if c.GetType().Hybrid() || dt.Kind() == types.KindBinaryLiteral || dt.Kind() == types.KindString {
+	if c.GetType(ctx).Hybrid() || dt.Kind() == types.KindBinaryLiteral || dt.Kind() == types.KindString {
 		res, err := dt.ToFloat64(typeCtx(ctx))
 		return res, false, err
 	}
@@ -324,7 +331,7 @@ func (c *Constant) EvalString(ctx EvalContext, row chunk.Row) (string, bool, err
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return "", true, nil
 	}
 	res, err := dt.ToString()
@@ -340,24 +347,24 @@ func (c *Constant) EvalDecimal(ctx EvalContext, row chunk.Row) (*types.MyDecimal
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return nil, true, nil
 	}
 	res, err := dt.ToDecimal(typeCtx(ctx))
 	if err != nil {
 		return nil, false, err
 	}
-	if err := c.adjustDecimal(res); err != nil {
+	if err := c.adjustDecimal(ctx, res); err != nil {
 		return nil, false, err
 	}
 	return res, false, nil
 }
 
-func (c *Constant) adjustDecimal(d *types.MyDecimal) error {
+func (c *Constant) adjustDecimal(ctx EvalContext, d *types.MyDecimal) error {
 	// Decimal Value's precision and frac may be modified during plan building.
 	_, frac := d.PrecisionAndFrac()
-	if frac < c.GetType().GetDecimal() {
-		return d.Round(d, c.GetType().GetDecimal(), types.ModeHalfUp)
+	if frac < c.GetType(ctx).GetDecimal() {
+		return d.Round(d, c.GetType(ctx).GetDecimal(), types.ModeHalfUp)
 	}
 	return nil
 }
@@ -371,7 +378,7 @@ func (c *Constant) EvalTime(ctx EvalContext, row chunk.Row) (val types.Time, isN
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return types.ZeroTime, true, nil
 	}
 	return dt.GetMysqlTime(), false, nil
@@ -386,7 +393,7 @@ func (c *Constant) EvalDuration(ctx EvalContext, row chunk.Row) (val types.Durat
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return types.Duration{}, true, nil
 	}
 	return dt.GetMysqlDuration(), false, nil
@@ -401,7 +408,7 @@ func (c *Constant) EvalJSON(ctx EvalContext, row chunk.Row) (types.BinaryJSON, b
 	if !lazy {
 		dt = c.Value
 	}
-	if c.GetType().GetType() == mysql.TypeNull || dt.IsNull() {
+	if c.GetType(ctx).GetType() == mysql.TypeNull || dt.IsNull() {
 		return types.BinaryJSON{}, true, nil
 	}
 	return dt.GetMysqlJSON(), false, nil

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -41,9 +41,9 @@ func FoldConstant(ctx BuildContext, expr Expression) Expression {
 	// keep the original coercibility, charset, collation and repertoire values after folding
 	e.SetCoercibility(expr.Coercibility())
 
-	charset, collate := expr.GetType().GetCharset(), expr.GetType().GetCollate()
-	e.GetType().SetCharset(charset)
-	e.GetType().SetCollate(collate)
+	charset, collate := expr.GetType(ctx.GetEvalCtx()).GetCharset(), expr.GetType(ctx.GetEvalCtx()).GetCollate()
+	e.GetType(ctx.GetEvalCtx()).SetCharset(charset)
+	e.GetType(ctx.GetEvalCtx()).SetCollate(collate)
 	e.SetRepertoire(expr.Repertoire())
 	return e
 }
@@ -65,7 +65,7 @@ func isNullHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool) {
 		}
 		return &Constant{Value: value, RetType: expr.RetType}, false
 	}
-	if mysql.HasNotNullFlag(arg0.GetType().GetFlag()) {
+	if mysql.HasNotNullFlag(arg0.GetType(ctx.GetEvalCtx()).GetFlag()) {
 		return NewZero(), false
 	}
 	return expr, false
@@ -105,8 +105,8 @@ func ifNullFoldHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool
 			// See https://github.com/pingcap/tidb/issues/51765. If the first argument can
 			// be folded into NULL, the collation of IFNULL should be the same as the second
 			// arguments.
-			expr.GetType().SetCharset(args[1].GetType().GetCharset())
-			expr.GetType().SetCollate(args[1].GetType().GetCollate())
+			expr.GetType(ctx.GetEvalCtx()).SetCharset(args[1].GetType(ctx.GetEvalCtx()).GetCharset())
+			expr.GetType(ctx.GetEvalCtx()).SetCollate(args[1].GetType(ctx.GetEvalCtx()).GetCollate())
 
 			return foldedExpr, isConstant
 		}
@@ -137,7 +137,7 @@ func caseWhenHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool) 
 			foldedExpr, isDeferred := foldConstant(ctx, args[i+1])
 			isDeferredConst = isDeferredConst || isDeferred
 			if _, isConst := foldedExpr.(*Constant); isConst {
-				foldedExpr.GetType().SetDecimal(expr.GetType().GetDecimal())
+				foldedExpr.GetType(ctx.GetEvalCtx()).SetDecimal(expr.GetType(ctx.GetEvalCtx()).GetDecimal())
 				return foldedExpr, isDeferredConst
 			}
 			return foldedExpr, isDeferredConst
@@ -150,7 +150,7 @@ func caseWhenHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool) 
 		foldedExpr, isDeferred := foldConstant(ctx, args[l-1])
 		isDeferredConst = isDeferredConst || isDeferred
 		if _, isConst := foldedExpr.(*Constant); isConst {
-			foldedExpr.GetType().SetDecimal(expr.GetType().GetDecimal())
+			foldedExpr.GetType(ctx.GetEvalCtx()).SetDecimal(expr.GetType(ctx.GetEvalCtx()).GetDecimal())
 			return foldedExpr, isDeferredConst
 		}
 		return foldedExpr, isDeferredConst
@@ -204,7 +204,7 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 					constArgs[i] = NewOne()
 				}
 			}
-			dummyScalarFunc, err := NewFunctionBase(ctx, x.FuncName.L, x.GetType(), constArgs...)
+			dummyScalarFunc, err := NewFunctionBase(ctx, x.FuncName.L, x.GetType(ctx.GetEvalCtx()), constArgs...)
 			if err != nil {
 				return expr, isDeferredConst
 			}

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -251,7 +251,7 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 	case *Constant:
 		if x.ParamMarker != nil {
 			return &Constant{
-				Value:        x.ParamMarker.GetUserVar(),
+				Value:        x.ParamMarker.GetUserVar(ctx.GetEvalCtx()),
 				RetType:      x.RetType,
 				DeferredExpr: x.DeferredExpr,
 				ParamMarker:  x.ParamMarker,

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -336,31 +336,31 @@ func TestDeferredParamNotNull(t *testing.T) {
 		types.NewMysqlBitDatum([]byte{1}),
 		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	)
-	cstInt := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
-	cstDec := &Constant{ParamMarker: &ParamMarker{order: 1}, RetType: newDecimalFieldType()}
-	cstTime := &Constant{ParamMarker: &ParamMarker{order: 2}, RetType: newDateFieldType()}
-	cstDuration := &Constant{ParamMarker: &ParamMarker{order: 3}, RetType: newDurFieldType()}
-	cstJSON := &Constant{ParamMarker: &ParamMarker{order: 4}, RetType: newJSONFieldType()}
-	cstBytes := &Constant{ParamMarker: &ParamMarker{order: 6}, RetType: newBlobFieldType()}
-	cstBinary := &Constant{ParamMarker: &ParamMarker{order: 5}, RetType: newBinaryLiteralFieldType()}
-	cstFloat32 := &Constant{ParamMarker: &ParamMarker{order: 7}, RetType: newFloatFieldType()}
-	cstFloat64 := &Constant{ParamMarker: &ParamMarker{order: 8}, RetType: newFloatFieldType()}
-	cstUint := &Constant{ParamMarker: &ParamMarker{order: 9}, RetType: newIntFieldType()}
-	cstBit := &Constant{ParamMarker: &ParamMarker{order: 10}, RetType: newBinaryLiteralFieldType()}
-	cstEnum := &Constant{ParamMarker: &ParamMarker{order: 11}, RetType: newEnumFieldType()}
+	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
+	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
+	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
+	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
+	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
 
-	require.Equal(t, mysql.TypeVarString, cstJSON.GetType().GetType())
-	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType().GetType())
-	require.Equal(t, mysql.TypeLonglong, cstInt.GetType().GetType())
-	require.Equal(t, mysql.TypeLonglong, cstUint.GetType().GetType())
-	require.Equal(t, mysql.TypeTimestamp, cstTime.GetType().GetType())
-	require.Equal(t, mysql.TypeDuration, cstDuration.GetType().GetType())
-	require.Equal(t, mysql.TypeBlob, cstBytes.GetType().GetType())
-	require.Equal(t, mysql.TypeVarString, cstBinary.GetType().GetType())
-	require.Equal(t, mysql.TypeVarString, cstBit.GetType().GetType())
-	require.Equal(t, mysql.TypeFloat, cstFloat32.GetType().GetType())
-	require.Equal(t, mysql.TypeDouble, cstFloat64.GetType().GetType())
-	require.Equal(t, mysql.TypeEnum, cstEnum.GetType().GetType())
+	require.Equal(t, mysql.TypeVarString, cstJSON.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeLonglong, cstInt.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeLonglong, cstUint.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeTimestamp, cstTime.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeDuration, cstDuration.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeBlob, cstBytes.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeVarString, cstBinary.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeVarString, cstBit.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeFloat, cstFloat32.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeDouble, cstFloat64.GetType(ctx).GetType())
+	require.Equal(t, mysql.TypeEnum, cstEnum.GetType(ctx).GetType())
 
 	d, _, err := cstInt.EvalInt(ctx, chunk.Row{})
 	require.NoError(t, err)
@@ -519,9 +519,9 @@ func TestVectorizedConstant(t *testing.T) {
 func TestGetTypeThreadSafe(t *testing.T) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(1))
-	con := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newStringFieldType()}
-	ft1 := con.GetType()
-	ft2 := con.GetType()
+	con := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newStringFieldType()}
+	ft1 := con.GetType(ctx)
+	ft2 := con.GetType(ctx)
 	require.NotSame(t, ft1, ft2)
 }
 

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -336,18 +336,18 @@ func TestDeferredParamNotNull(t *testing.T) {
 		types.NewMysqlBitDatum([]byte{1}),
 		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	)
-	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
-	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
-	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
-	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
-	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
-	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
-	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
-	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
-	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
-	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
-	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
-	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
+	cstInt := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newIntFieldType()}
+	cstDec := &Constant{ParamMarker: &ParamMarker{order: 1}, RetType: newDecimalFieldType()}
+	cstTime := &Constant{ParamMarker: &ParamMarker{order: 2}, RetType: newDateFieldType()}
+	cstDuration := &Constant{ParamMarker: &ParamMarker{order: 3}, RetType: newDurFieldType()}
+	cstJSON := &Constant{ParamMarker: &ParamMarker{order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{order: 11}, RetType: newEnumFieldType()}
 
 	require.Equal(t, mysql.TypeVarString, cstJSON.GetType().GetType())
 	require.Equal(t, mysql.TypeNewDecimal, cstDec.GetType().GetType())
@@ -519,7 +519,7 @@ func TestVectorizedConstant(t *testing.T) {
 func TestGetTypeThreadSafe(t *testing.T) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(1))
-	con := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newStringFieldType()}
+	con := &Constant{ParamMarker: &ParamMarker{order: 0}, RetType: newStringFieldType()}
 	ft1 := con.GetType()
 	ft2 := con.GetType()
 	require.NotSame(t, ft1, ft2)

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -82,6 +82,8 @@ type EvalContext interface {
 	GetOptionalPropSet() OptionalEvalPropKeySet
 	// GetOptionalPropProvider gets the optional property provider by key
 	GetOptionalPropProvider(OptionalEvalPropKey) (OptionalEvalPropProvider, bool)
+	// GetParamValue returns the value of the parameter by index.
+	GetParamValue(idx int) types.Datum
 }
 
 // BuildContext is used to build an expression

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -273,6 +273,11 @@ func (ctx *SessionEvalContext) RequestDynamicVerification(privName string, grant
 	return checker.RequestDynamicVerification(ctx.sctx.GetSessionVars().ActiveRoles, privName, grantable)
 }
 
+// GetParamValue returns the value of the parameter by index.
+func (ctx *SessionEvalContext) GetParamValue(idx int) types.Datum {
+	return ctx.sctx.GetSessionVars().PlanCacheParams.GetParamValue(idx)
+}
+
 func getStmtTimestamp(ctx sessionctx.Context) (time.Time, error) {
 	if ctx != nil {
 		staleTSO, err := ctx.GetSessionVars().StmtCtx.GetStaleTSO()

--- a/pkg/expression/contextstatic/BUILD.bazel
+++ b/pkg/expression/contextstatic/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":contextstatic"],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/errctx",
         "//pkg/expression/context",

--- a/pkg/expression/contextstatic/evalctx_test.go
+++ b/pkg/expression/contextstatic/evalctx_test.go
@@ -427,3 +427,25 @@ func TestUpdateStaticEvalContext(t *testing.T) {
 	require.Greater(t, ctx3.CtxID(), ctx2.CtxID())
 	checkOptionsStaticEvalCtx(t, ctx3, optState)
 }
+
+func TestParamList(t *testing.T) {
+	paramList := variable.NewPlanCacheParamList()
+	paramList.Append(types.NewDatum(1))
+	paramList.Append(types.NewDatum(2))
+	paramList.Append(types.NewDatum(3))
+	ctx := NewStaticEvalContext(
+		WithParamList(paramList),
+	)
+	for i := 0; i < 3; i++ {
+		val := ctx.GetParamValue(i)
+		require.Equal(t, int64(i+1), val.GetInt64())
+	}
+
+	// after reset the paramList and append new one, the value is still persisted
+	paramList.Reset()
+	paramList.Append(types.NewDatum(4))
+	for i := 0; i < 3; i++ {
+		val := ctx.GetParamValue(i)
+		require.Equal(t, int64(i+1), val.GetInt64())
+	}
+}

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -93,7 +93,7 @@ func primitiveValsToConstants(ctx BuildContext, args []any) []Expression {
 	cons := datumsToConstants(types.MakeDatums(args...))
 	char, col := ctx.GetCharsetInfo()
 	for i, arg := range args {
-		types.DefaultTypeForValue(arg, cons[i].GetType(), char, col)
+		types.DefaultTypeForValue(arg, cons[i].GetType(ctx.GetEvalCtx()), char, col)
 	}
 	return cons
 }

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -96,7 +96,7 @@ func (pc PbConverter) ExprToPB(expr Expression) *tipb.Expr {
 }
 
 func (pc PbConverter) conOrCorColToPBExpr(expr Expression) *tipb.Expr {
-	ft := expr.GetType()
+	ft := expr.GetType(pc.ctx)
 	d, err := expr.Eval(pc.ctx, chunk.Row{})
 	if err != nil {
 		logutil.BgLogger().Error("eval constant or correlated column", zap.String("expression", expr.ExplainInfo(pc.ctx)), zap.Error(err))
@@ -214,7 +214,7 @@ func (pc PbConverter) columnToPBExpr(column *Column, checkType bool) *tipb.Expr 
 		return nil
 	}
 	if checkType {
-		switch column.GetType().GetType() {
+		switch column.GetType(pc.ctx).GetType() {
 		case mysql.TypeBit:
 			if !IsPushDownEnabled(ast.TypeStr(mysql.TypeBit), kv.TiKV) {
 				return nil
@@ -257,7 +257,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	}
 
 	// Check whether this function can be pushed.
-	if !canFuncBePushed(expr, kv.UnSpecified) {
+	if !canFuncBePushed(pc.ctx, expr, kv.UnSpecified) {
 		return nil
 	}
 

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -197,7 +197,7 @@ type Expression interface {
 	EvalJSON(ctx EvalContext, row chunk.Row) (val types.BinaryJSON, isNull bool, err error)
 
 	// GetType gets the type that the expression returns.
-	GetType() *types.FieldType
+	GetType(ctx EvalContext) *types.FieldType
 
 	// Clone copies an expression totally.
 	Clone() Expression
@@ -289,13 +289,13 @@ func IsEQCondFromIn(expr Expression) bool {
 }
 
 // ExprNotNull checks if an expression is possible to be null.
-func ExprNotNull(expr Expression) bool {
+func ExprNotNull(ctx EvalContext, expr Expression) bool {
 	if c, ok := expr.(*Constant); ok {
 		return !c.Value.IsNull()
 	}
 	// For ScalarFunction, the result would not be correct until we support maintaining
 	// NotNull flag for it.
-	return mysql.HasNotNullFlag(expr.GetType().GetFlag())
+	return mysql.HasNotNullFlag(expr.GetType(ctx).GetFlag())
 }
 
 // EvalBool evaluates expression list to a boolean value. The first returned value
@@ -401,7 +401,7 @@ func VecEvalBool(ctx EvalContext, vecEnabled bool, exprList CNFExprs, input *chu
 	isZero := allocZeroSlice(n)
 	defer deallocateZeroSlice(isZero)
 	for _, expr := range exprList {
-		tp := expr.GetType()
+		tp := expr.GetType(ctx)
 		eType := tp.EvalType()
 		if CanImplicitEvalReal(expr) {
 			eType = types.ETReal
@@ -635,7 +635,7 @@ func EvalExpr(ctx EvalContext, vecEnabled bool, expr Expression, evalType types.
 		case types.ETDecimal:
 			err = expr.VecEvalDecimal(ctx, input, result)
 		default:
-			err = fmt.Errorf("invalid eval type %v", expr.GetType().EvalType())
+			err = fmt.Errorf("invalid eval type %v", expr.GetType(ctx).EvalType())
 		}
 	} else {
 		ind, n := 0, input.NumRows()
@@ -743,7 +743,7 @@ func EvalExpr(ctx EvalContext, vecEnabled bool, expr Expression, evalType types.
 				ind++
 			}
 		default:
-			err = fmt.Errorf("invalid eval type %v", expr.GetType().EvalType())
+			err = fmt.Errorf("invalid eval type %v", expr.GetType(ctx).EvalType())
 		}
 	}
 	return
@@ -1092,7 +1092,7 @@ func IsBinaryLiteral(expr Expression) bool {
 // The `wrapForInt` indicates whether we need to wrapIsTrue for non-logical Expression with int type.
 // TODO: remove this function. ScalarFunction should be newed in one place.
 func wrapWithIsTrue(ctx BuildContext, keepNull bool, arg Expression, wrapForInt bool) (Expression, error) {
-	if arg.GetType().EvalType() == types.ETInt {
+	if arg.GetType(ctx.GetEvalCtx()).EvalType() == types.ETInt {
 		if !wrapForInt {
 			return arg, nil
 		}
@@ -1150,12 +1150,12 @@ func wrapWithIsTrue(ctx BuildContext, keepNull bool, arg Expression, wrapForInt 
 // +----------------------+
 // The expected `decimal` and `length` of the outer cast_as_double need to be
 // propagated to the inner div.
-func PropagateType(evalType types.EvalType, args ...Expression) {
+func PropagateType(ctx EvalContext, evalType types.EvalType, args ...Expression) {
 	switch evalType {
 	case types.ETReal:
 		expr := args[0]
-		oldFlen, oldDecimal := expr.GetType().GetFlen(), expr.GetType().GetDecimal()
-		newFlen, newDecimal := setDataTypeDouble(expr.GetType().GetDecimal())
+		oldFlen, oldDecimal := expr.GetType(ctx).GetFlen(), expr.GetType(ctx).GetDecimal()
+		newFlen, newDecimal := setDataTypeDouble(expr.GetType(ctx).GetDecimal())
 		// For float(M,D), double(M,D) or decimal(M,D), M must be >= D.
 		if newFlen < newDecimal {
 			newFlen = oldFlen - oldDecimal + newDecimal
@@ -1171,7 +1171,7 @@ func PropagateType(evalType types.EvalType, args ...Expression) {
 				newCol.(*CorrelatedColumn).RetType = col.RetType.Clone()
 				args[0] = newCol
 			}
-			if args[0].GetType().GetType() == mysql.TypeNewDecimal {
+			if args[0].GetType(ctx).GetType() == mysql.TypeNewDecimal {
 				if newDecimal > mysql.MaxDecimalScale {
 					newDecimal = mysql.MaxDecimalScale
 				}
@@ -1191,8 +1191,8 @@ func PropagateType(evalType types.EvalType, args ...Expression) {
 					}
 				}
 			}
-			args[0].GetType().SetFlenUnderLimit(newFlen)
-			args[0].GetType().SetDecimalUnderLimit(newDecimal)
+			args[0].GetType(ctx).SetFlenUnderLimit(newFlen)
+			args[0].GetType(ctx).SetDecimalUnderLimit(newDecimal)
 		}
 	}
 }

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -68,7 +68,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	res := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
-	param.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
+	param.ParamMarker = &ParamMarker{order: 0}
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -68,7 +68,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	res := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
-	param.ParamMarker = &ParamMarker{order: 0}
+	param.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)
@@ -268,9 +268,9 @@ func TestEvalExpr(t *testing.T) {
 		colBuf2 := chunk.NewColumn(ft, 1024)
 		var err error
 		require.True(t, colExpr.Vectorized())
-		err = EvalExpr(ctx, false, colExpr, colExpr.GetType().EvalType(), input, colBuf)
+		err = EvalExpr(ctx, false, colExpr, colExpr.GetType(ctx).EvalType(), input, colBuf)
 		require.NoError(t, err)
-		err = EvalExpr(ctx, true, colExpr, colExpr.GetType().EvalType(), input, colBuf2)
+		err = EvalExpr(ctx, true, colExpr, colExpr.GetType(ctx).EvalType(), input, colBuf2)
 		require.NoError(t, err)
 		for j := 0; j < 1024; j++ {
 			isNull := colBuf.IsNull(j)

--- a/pkg/expression/generator/other_vec.go
+++ b/pkg/expression/generator/other_vec.go
@@ -147,7 +147,7 @@ func (b *{{.SigName}}) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *c
 	}
 	{{- end }}
 	{{- if $InputInt }}
-		isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType().GetFlag())
+		isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag())
 	{{- end }}
 	var compareResult int
 	args := b.args[1:]
@@ -219,7 +219,7 @@ func (b *{{.SigName}}) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *c
 			return err
 		}
 		{{- if $InputInt }}
-			isUnsigned := mysql.HasUnsignedFlag(args[j].GetType().GetFlag())
+			isUnsigned := mysql.HasUnsignedFlag(args[j].GetType(ctx).GetFlag())
 		{{- end }}
 		{{- if $InputFixed }}
 			args1 := buf1.{{.Input.TypeNameInColumn}}s()

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -107,7 +107,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 {{ end }}
 
 {{ if or (eq .SigName "builtinAddStringAndStringSig") (eq .SigName "builtinSubStringAndStringSig") }}
-	arg1Type := b.args[1].GetType()
+	arg1Type := b.args[1].GetType(ctx)
 	if mysql.HasBinaryFlag(arg1Type.GetFlag()) {
 		result.Reserve{{ .Output.TypeNameInColumn }}(n)
 		for i := 0; i < n; i++ {
@@ -232,7 +232,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 		{{ end }}
 	{{ else if or (eq .SigName "builtinAddStringAndDurationSig") (eq .SigName "builtinSubStringAndDurationSig") }}
 		tc := typeCtx(ctx)
-		fsp1 := b.args[1].GetType().GetDecimal()
+		fsp1 := b.args[1].GetType(ctx).GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		var output string
 		var isNull bool
@@ -299,8 +299,8 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 			}
 		}
 	{{ else if or (eq .SigName "builtinAddDateAndDurationSig") (eq .SigName "builtinSubDateAndDurationSig") }}
-		fsp0 := b.args[0].GetType().GetDecimal()
-		fsp1 := b.args[1].GetType().GetDecimal()
+		fsp0 := b.args[0].GetType(ctx).GetDecimal()
+		fsp1 := b.args[1].GetType(ctx).GetDecimal()
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
 		{{ if eq $.FuncName "AddTime" }}
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Add(arg1Duration)
@@ -313,7 +313,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 		output := sum.String()
 	{{ else if or (eq .SigName "builtinAddDateAndStringSig") (eq .SigName "builtinSubDateAndStringSig") }}
 		{{ template "ConvertStringToDuration" . }}
-		fsp0 := b.args[0].GetType().GetDecimal()
+		fsp0 := b.args[0].GetType(ctx).GetDecimal()
 		{{ if eq $.FuncName "AddTime" }}
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Add(arg1Duration)
 		{{ else }}

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -42,7 +42,7 @@ var DefaultExprPushDownBlacklist *atomic.Value
 // This is for plan cache, when the push-down black list is updated, we invalid all cached plans to avoid error.
 var ExprPushDownBlackListReloadTimeStamp *atomic.Int64
 
-func canFuncBePushed(sf *ScalarFunction, storeType kv.StoreType) bool {
+func canFuncBePushed(ctx EvalContext, sf *ScalarFunction, storeType kv.StoreType) bool {
 	// Use the failpoint to control whether to push down an expression in the integration test.
 	// Push down all expression if the `failpoint expression` is `all`, otherwise, check
 	// whether scalar function's name is contained in the enabled expression list (e.g.`ne,eq,lt`).
@@ -65,13 +65,13 @@ func canFuncBePushed(sf *ScalarFunction, storeType kv.StoreType) bool {
 
 	switch storeType {
 	case kv.TiFlash:
-		ret = scalarExprSupportedByFlash(sf)
+		ret = scalarExprSupportedByFlash(ctx, sf)
 	case kv.TiKV:
-		ret = scalarExprSupportedByTiKV(sf)
+		ret = scalarExprSupportedByTiKV(ctx, sf)
 	case kv.TiDB:
-		ret = scalarExprSupportedByTiDB(sf)
+		ret = scalarExprSupportedByTiDB(ctx, sf)
 	case kv.UnSpecified:
-		ret = scalarExprSupportedByTiDB(sf) || scalarExprSupportedByTiKV(sf) || scalarExprSupportedByFlash(sf)
+		ret = scalarExprSupportedByTiDB(ctx, sf) || scalarExprSupportedByTiKV(ctx, sf) || scalarExprSupportedByFlash(ctx, sf)
 	}
 
 	if ret {
@@ -85,7 +85,7 @@ func canFuncBePushed(sf *ScalarFunction, storeType kv.StoreType) bool {
 func canScalarFuncPushDown(ctx PushDownContext, scalarFunc *ScalarFunction, storeType kv.StoreType) bool {
 	pbCode := scalarFunc.Function.PbCode()
 	// Check whether this function can be pushed.
-	if unspecified := pbCode <= tipb.ScalarFuncSig_Unspecified; unspecified || !canFuncBePushed(scalarFunc, storeType) {
+	if unspecified := pbCode <= tipb.ScalarFuncSig_Unspecified; unspecified || !canFuncBePushed(ctx.EvalCtx(), scalarFunc, storeType) {
 		if unspecified {
 			failpoint.Inject("PanicIfPbCodeUnspecified", func() {
 				panic(errors.Errorf("unspecified PbCode: %T", scalarFunc.Function))
@@ -122,17 +122,17 @@ func canScalarFuncPushDown(ctx PushDownContext, scalarFunc *ScalarFunction, stor
 func canExprPushDown(ctx PushDownContext, expr Expression, storeType kv.StoreType, canEnumPush bool) bool {
 	pc := ctx.PbConverter()
 	if storeType == kv.TiFlash {
-		switch expr.GetType().GetType() {
+		switch expr.GetType(ctx.EvalCtx()).GetType() {
 		case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet, mysql.TypeGeometry, mysql.TypeUnspecified:
-			if expr.GetType().GetType() == mysql.TypeEnum && canEnumPush {
+			if expr.GetType(ctx.EvalCtx()).GetType() == mysql.TypeEnum && canEnumPush {
 				break
 			}
-			warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType().GetType()) + "'.")
+			warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType(ctx.EvalCtx()).GetType()) + "'.")
 			ctx.AppendWarning(warnErr)
 			return false
 		case mysql.TypeNewDecimal:
-			if !expr.GetType().IsDecimalValid() {
-				warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType().GetFlen()) + "','" + strconv.Itoa(expr.GetType().GetDecimal()) + "').")
+			if !expr.GetType(ctx.EvalCtx()).IsDecimalValid() {
+				warnErr := errors.NewNoStackError("Expression about '" + expr.String() + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetFlen()) + "','" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetDecimal()) + "').")
 				ctx.AppendWarning(warnErr)
 				return false
 			}
@@ -151,13 +151,13 @@ func canExprPushDown(ctx PushDownContext, expr Expression, storeType kv.StoreTyp
 	return false
 }
 
-func scalarExprSupportedByTiDB(function *ScalarFunction) bool {
+func scalarExprSupportedByTiDB(ctx EvalContext, function *ScalarFunction) bool {
 	// TiDB can support all functions, but TiPB may not include some functions.
-	return scalarExprSupportedByTiKV(function) || scalarExprSupportedByFlash(function)
+	return scalarExprSupportedByTiKV(ctx, function) || scalarExprSupportedByFlash(ctx, function)
 }
 
 // supported functions tracked by https://github.com/tikv/tikv/issues/5751
-func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
+func scalarExprSupportedByTiKV(ctx EvalContext, sf *ScalarFunction) bool {
 	switch sf.FuncName.L {
 	case
 		// op functions.
@@ -228,7 +228,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		arg0 := sf.GetArgs()[0]
 		// To be aligned with MySQL, tidb handles hybrid type argument and binary literal specially, tikv can't be consistent with tidb now.
 		if f, ok := arg0.(*ScalarFunction); ok {
-			if f.FuncName.L == ast.Cast && (f.GetArgs()[0].GetType().Hybrid() || IsBinaryLiteral(f.GetArgs()[0])) {
+			if f.FuncName.L == ast.Cast && (f.GetArgs()[0].GetType(ctx).Hybrid() || IsBinaryLiteral(f.GetArgs()[0])) {
 				return false
 			}
 		}
@@ -255,7 +255,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 	return false
 }
 
-func scalarExprSupportedByFlash(function *ScalarFunction) bool {
+func scalarExprSupportedByFlash(ctx EvalContext, function *ScalarFunction) bool {
 	switch function.FuncName.L {
 	case ast.Floor, ast.Ceil, ast.Ceiling:
 		switch function.Function.PbCode() {
@@ -312,7 +312,7 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 			return true
 		}
 	case ast.Cast:
-		sourceType := function.GetArgs()[0].GetType()
+		sourceType := function.GetArgs()[0].GetType(ctx)
 		retType := function.RetType
 		switch function.Function.PbCode() {
 		case tipb.ScalarFuncSig_CastDecimalAsInt, tipb.ScalarFuncSig_CastIntAsInt, tipb.ScalarFuncSig_CastRealAsInt, tipb.ScalarFuncSig_CastTimeAsInt,
@@ -332,7 +332,7 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		case tipb.ScalarFuncSig_CastDecimalAsTime, tipb.ScalarFuncSig_CastIntAsTime, tipb.ScalarFuncSig_CastRealAsTime, tipb.ScalarFuncSig_CastTimeAsTime,
 			tipb.ScalarFuncSig_CastStringAsTime /*, tipb.ScalarFuncSig_CastDurationAsTime, tipb.ScalarFuncSig_CastJsonAsTime*/ :
 			// ban the function of casting year type as time type pushing down to tiflash because of https://github.com/pingcap/tidb/issues/26215
-			return function.GetArgs()[0].GetType().GetType() != mysql.TypeYear
+			return function.GetArgs()[0].GetType(ctx).GetType() != mysql.TypeYear
 		case tipb.ScalarFuncSig_CastTimeAsDuration:
 			return retType.GetType() == mysql.TypeDuration
 		case tipb.ScalarFuncSig_CastIntAsJson, tipb.ScalarFuncSig_CastRealAsJson, tipb.ScalarFuncSig_CastDecimalAsJson, tipb.ScalarFuncSig_CastStringAsJson,

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -148,7 +148,7 @@ func (sf *ScalarFunction) MarshalJSON() ([]byte, error) {
 
 // typeInferForNull infers the NULL constants field type and set the field type
 // of NULL constant same as other non-null operands.
-func typeInferForNull(args []Expression) {
+func typeInferForNull(ctx EvalContext, args []Expression) {
 	if len(args) < 2 {
 		return
 	}
@@ -162,7 +162,7 @@ func typeInferForNull(args []Expression) {
 	for i := len(args) - 1; i >= 0; i-- {
 		isNullArg := isNull(args[i])
 		if !isNullArg && retFieldTp == nil {
-			retFieldTp = args[i].GetType()
+			retFieldTp = args[i].GetType(ctx)
 		}
 		hasNullArg = hasNullArg || isNullArg
 		// Break if there are both NULL and non-NULL expression
@@ -175,8 +175,8 @@ func typeInferForNull(args []Expression) {
 	}
 	for _, arg := range args {
 		if isNull(arg) {
-			*arg.GetType() = *retFieldTp
-			arg.GetType().DelFlag(mysql.NotNullFlag) // Remove NotNullFlag of NullConst
+			*arg.GetType(ctx) = *retFieldTp
+			arg.GetType(ctx).DelFlag(mysql.NotNullFlag) // Remove NotNullFlag of NullConst
 		}
 	}
 }
@@ -245,7 +245,7 @@ func newFunctionImpl(ctx BuildContext, fold int, funcName string, retType *types
 		// For example, expression ('abc', 1) = (null, 0). Null's type should be STRING, not INT.
 		// The type infer happens when converting the expression to ('abc' = null) and (1 = 0).
 	default:
-		typeInferForNull(funcArgs)
+		typeInferForNull(ctx.GetEvalCtx(), funcArgs)
 	}
 
 	f, err := fc.getFunction(ctx, funcArgs)
@@ -346,7 +346,12 @@ func (sf *ScalarFunction) Clone() Expression {
 }
 
 // GetType implements Expression interface.
-func (sf *ScalarFunction) GetType() *types.FieldType {
+func (sf *ScalarFunction) GetType(_ EvalContext) *types.FieldType {
+	return sf.GetStaticType()
+}
+
+// GetStaticType returns the static type of the scalar function.
+func (sf *ScalarFunction) GetStaticType() *types.FieldType {
 	return sf.RetType
 }
 
@@ -420,7 +425,7 @@ func (sf *ScalarFunction) Eval(ctx EvalContext, row chunk.Row) (d types.Datum, e
 		isNull bool
 	)
 	intest.AssertNotNil(ctx)
-	switch tp, evalType := sf.GetType(), sf.GetType().EvalType(); evalType {
+	switch tp, evalType := sf.GetType(ctx), sf.GetType(ctx).EvalType(); evalType {
 	case types.ETInt:
 		var intRes int64
 		intRes, isNull, err = sf.EvalInt(ctx, row)

--- a/pkg/expression/scalar_function_test.go
+++ b/pkg/expression/scalar_function_test.go
@@ -130,7 +130,9 @@ func TestIssue23309(t *testing.T) {
 	v, err := sf.GetArgs()[1].Eval(mock.NewContext(), chunk.Row{})
 	require.NoError(t, err)
 	require.True(t, v.IsNull())
-	require.False(t, mysql.HasNotNullFlag(sf.GetArgs()[1].GetType().GetFlag()))
+
+	ctx := createContext(t)
+	require.False(t, mysql.HasNotNullFlag(sf.GetArgs()[1].GetType(ctx).GetFlag()))
 }
 
 func TestScalarFuncs2Exprs(t *testing.T) {

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1172,7 +1172,6 @@ func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMark
 	if useCache || needParam {
 		value.ParamMarker = &ParamMarker{
 			order: v.Order,
-			ctx:   ctx,
 		}
 	}
 	return value, nil
@@ -1394,7 +1393,7 @@ func GetUint64FromConstant(ctx EvalContext, expr Expression) (uint64, bool, bool
 	}
 	dt := con.Value
 	if con.ParamMarker != nil {
-		dt = con.ParamMarker.GetUserVar()
+		dt = con.ParamMarker.GetUserVar(ctx)
 	} else if con.DeferredExpr != nil {
 		var err error
 		dt, err = con.DeferredExpr.Eval(ctx, chunk.Row{})

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -462,7 +462,7 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 					e.(*ScalarFunction).Function.getArgs()[0] = newArg
 				}
 				e.SetCoercibility(v.Coercibility())
-				e.GetType().SetFlag(flag)
+				e.GetType(ctx.GetEvalCtx()).SetFlag(flag)
 				return true, false, e
 			}
 			return false, false, v
@@ -496,11 +496,11 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 					return false, failed, v
 				}
 				if oldCollEt.Collation == newCollEt.Collation {
-					if newFuncExpr.GetType().GetCollate() == arg.GetType().GetCollate() && newFuncExpr.Coercibility() == arg.Coercibility() {
+					if newFuncExpr.GetType(ctx.GetEvalCtx()).GetCollate() == arg.GetType(ctx.GetEvalCtx()).GetCollate() && newFuncExpr.Coercibility() == arg.Coercibility() {
 						// It's safe to use the new expression, otherwise some cases in projection push-down will be wrong.
 						changed = true
 					} else {
-						changed = checkCollationStrictness(oldCollEt.Collation, newFuncExpr.GetType().GetCollate())
+						changed = checkCollationStrictness(oldCollEt.Collation, newFuncExpr.GetType(ctx.GetEvalCtx()).GetCollate())
 					}
 				}
 			}
@@ -605,7 +605,7 @@ func SubstituteCorCol2Constant(ctx BuildContext, expr Expression) (Expression, e
 			if err != nil {
 				return nil, err
 			}
-			return &Constant{Value: val, RetType: x.GetType()}, nil
+			return &Constant{Value: val, RetType: x.GetType(ctx.GetEvalCtx())}, nil
 		}
 		var (
 			err   error
@@ -617,15 +617,15 @@ func SubstituteCorCol2Constant(ctx BuildContext, expr Expression) (Expression, e
 			newSf = x.Clone()
 			newSf.(*ScalarFunction).GetArgs()[0] = newArgs[0]
 		} else {
-			newSf, err = NewFunction(ctx, x.FuncName.L, x.GetType(), newArgs...)
+			newSf, err = NewFunction(ctx, x.FuncName.L, x.GetType(ctx.GetEvalCtx()), newArgs...)
 		}
 		return newSf, err
 	case *CorrelatedColumn:
-		return &Constant{Value: *x.Data, RetType: x.GetType()}, nil
+		return &Constant{Value: *x.Data, RetType: x.GetType(ctx.GetEvalCtx())}, nil
 	case *Constant:
 		if x.DeferredExpr != nil {
 			newExpr := FoldConstant(ctx, x)
-			return &Constant{Value: newExpr.(*Constant).Value, RetType: x.GetType()}, nil
+			return &Constant{Value: newExpr.(*Constant).Value, RetType: x.GetType(ctx.GetEvalCtx())}, nil
 		}
 	}
 	return expr, nil
@@ -887,13 +887,13 @@ func pushNotAcrossExpr(ctx BuildContext, expr Expression, not bool) (_ Expressio
 			return childExpr, true
 		case ast.LT, ast.GE, ast.GT, ast.LE, ast.EQ, ast.NE:
 			if not {
-				return NewFunctionInternal(ctx, oppositeOp[f.FuncName.L], f.GetType(), f.GetArgs()...), true
+				return NewFunctionInternal(ctx, oppositeOp[f.FuncName.L], f.GetType(ctx.GetEvalCtx()), f.GetArgs()...), true
 			}
 			newArgs, changed := pushNotAcrossArgs(ctx, f.GetArgs(), false)
 			if !changed {
 				return f, false
 			}
-			return NewFunctionInternal(ctx, f.FuncName.L, f.GetType(), newArgs...), true
+			return NewFunctionInternal(ctx, f.FuncName.L, f.GetType(ctx.GetEvalCtx()), newArgs...), true
 		case ast.LogicAnd, ast.LogicOr:
 			var (
 				newArgs []Expression
@@ -910,7 +910,7 @@ func pushNotAcrossExpr(ctx BuildContext, expr Expression, not bool) (_ Expressio
 			if !changed {
 				return f, false
 			}
-			return NewFunctionInternal(ctx, funcName, f.GetType(), newArgs...), true
+			return NewFunctionInternal(ctx, funcName, f.GetType(ctx.GetEvalCtx()), newArgs...), true
 		}
 	}
 	if not {
@@ -1150,7 +1150,7 @@ func PopRowFirstArg(ctx BuildContext, e Expression) (ret Expression, err error) 
 		if len(args) == 2 {
 			return args[1], nil
 		}
-		ret, err = NewFunction(ctx, ast.RowFunc, f.GetType(), args[1:]...)
+		ret, err = NewFunction(ctx, ast.RowFunc, f.GetType(ctx.GetEvalCtx()), args[1:]...)
 		return ret, err
 	}
 	return
@@ -1172,6 +1172,7 @@ func ParamMarkerExpression(ctx variable.SessionVarsProvider, v *driver.ParamMark
 	if useCache || needParam {
 		value.ParamMarker = &ParamMarker{
 			order: v.Order,
+			ctx:   ctx,
 		}
 	}
 	return value, nil
@@ -1203,14 +1204,14 @@ func (pc *ParamMarkerInPrepareChecker) Leave(in ast.Node) (out ast.Node, ok bool
 // it. Moreover, Column.RetType refers to the infoschema, if we modify it, data
 // race may happen if another goroutine read from the infoschema at the same
 // time.
-func DisableParseJSONFlag4Expr(expr Expression) {
+func DisableParseJSONFlag4Expr(ctx EvalContext, expr Expression) {
 	if _, isColumn := expr.(*Column); isColumn {
 		return
 	}
 	if _, isCorCol := expr.(*CorrelatedColumn); isCorCol {
 		return
 	}
-	expr.GetType().SetFlag(expr.GetType().GetFlag() & ^mysql.ParseToJSONFlag)
+	expr.GetType(ctx).SetFlag(expr.GetType(ctx).GetFlag() & ^mysql.ParseToJSONFlag)
 }
 
 // ConstructPositionExpr constructs PositionExpr with the given ParamMarkerExpr.

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -182,7 +182,7 @@ func TestGetUint64FromConstant(t *testing.T) {
 	require.Equal(t, uint64(1), num)
 
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewUintDatum(100))
-	con.ParamMarker = &ParamMarker{order: 0}
+	con.ParamMarker = &ParamMarker{ctx: ctx, order: 0}
 	num, _, _ = GetUint64FromConstant(ctx, con)
 	require.Equal(t, uint64(100), num)
 }
@@ -351,7 +351,7 @@ func TestHashGroupKey(t *testing.T) {
 			bufs[j] = bufs[j][:0]
 		}
 		var err error
-		err = EvalExpr(ctx, ctx.GetSessionVars().EnableVectorizedExpression, colExpr, colExpr.GetType().EvalType(), input, colBuf)
+		err = EvalExpr(ctx, ctx.GetSessionVars().EnableVectorizedExpression, colExpr, colExpr.GetType(ctx).EvalType(), input, colBuf)
 		require.NoError(t, err)
 		bufs, err = codec.HashGroupKey(sc.TimeZone(), 1024, colBuf, bufs, ft)
 		require.NoError(t, err)
@@ -376,21 +376,22 @@ func isLogicOrFunction(e Expression) bool {
 
 func TestDisableParseJSONFlag4Expr(t *testing.T) {
 	var expr Expression
+	ctx := createContext(t)
 	expr = &Column{RetType: newIntFieldType()}
-	ft := expr.GetType()
+	ft := expr.GetType(ctx)
 	ft.AddFlag(mysql.ParseToJSONFlag)
-	DisableParseJSONFlag4Expr(expr)
+	DisableParseJSONFlag4Expr(ctx, expr)
 	require.True(t, mysql.HasParseToJSONFlag(ft.GetFlag()))
 
 	expr = &CorrelatedColumn{Column: Column{RetType: newIntFieldType()}}
-	ft = expr.GetType()
+	ft = expr.GetType(ctx)
 	ft.AddFlag(mysql.ParseToJSONFlag)
-	DisableParseJSONFlag4Expr(expr)
+	DisableParseJSONFlag4Expr(ctx, expr)
 	require.True(t, mysql.HasParseToJSONFlag(ft.GetFlag()))
 	expr = &ScalarFunction{RetType: newIntFieldType()}
-	ft = expr.GetType()
+	ft = expr.GetType(ctx)
 	ft.AddFlag(mysql.ParseToJSONFlag)
-	DisableParseJSONFlag4Expr(expr)
+	DisableParseJSONFlag4Expr(ctx, expr)
 	require.False(t, mysql.HasParseToJSONFlag(ft.GetFlag()))
 }
 
@@ -567,7 +568,7 @@ func (m *MockExpr) EvalJSON(ctx EvalContext, row chunk.Row) (val types.BinaryJSO
 	}
 	return types.BinaryJSON{}, m.i == nil, m.err
 }
-func (m *MockExpr) GetType() *types.FieldType                         { return m.t }
+func (m *MockExpr) GetType(_ EvalContext) *types.FieldType            { return m.t }
 func (m *MockExpr) Clone() Expression                                 { return nil }
 func (m *MockExpr) Equal(ctx EvalContext, e Expression) bool          { return false }
 func (m *MockExpr) IsCorrelated() bool                                { return false }

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -182,7 +182,7 @@ func TestGetUint64FromConstant(t *testing.T) {
 	require.Equal(t, uint64(1), num)
 
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewUintDatum(100))
-	con.ParamMarker = &ParamMarker{order: 0, ctx: ctx}
+	con.ParamMarker = &ParamMarker{order: 0}
 	num, _, _ = GetUint64FromConstant(ctx, con)
 	require.Equal(t, uint64(100), num)
 }

--- a/pkg/planner/cardinality/row_size.go
+++ b/pkg/planner/cardinality/row_size.go
@@ -92,7 +92,7 @@ func GetAvgRowSize(ctx context.PlanContext, coll *statistics.HistColl, cols []*e
 func GetAvgRowSizeDataInDiskByRows(coll *statistics.HistColl, cols []*expression.Column) (size float64) {
 	if coll.Pseudo || len(coll.Columns) == 0 || coll.RealtimeCount == 0 {
 		for _, col := range cols {
-			size += float64(chunk.EstimateTypeWidth(col.GetType()))
+			size += float64(chunk.EstimateTypeWidth(col.GetStaticType()))
 		}
 	} else {
 		for _, col := range cols {
@@ -100,7 +100,7 @@ func GetAvgRowSizeDataInDiskByRows(coll *statistics.HistColl, cols []*expression
 			// Normally this would not happen, it is for compatibility with old version stats which
 			// does not include TotColSize.
 			if !ok || (!colHist.IsHandle && colHist.TotColSize == 0 && (colHist.NullCount != coll.RealtimeCount)) {
-				size += float64(chunk.EstimateTypeWidth(col.GetType()))
+				size += float64(chunk.EstimateTypeWidth(col.GetStaticType()))
 				continue
 			}
 			size += AvgColSizeDataInDiskByRows(colHist, coll.RealtimeCount)

--- a/pkg/planner/cascades/transformation_rules.go
+++ b/pkg/planner/cascades/transformation_rules.go
@@ -1603,6 +1603,7 @@ func (r *EliminateSingleMaxMin) Match(expr *memo.ExprIter) bool {
 // It will transform `max/min->X` to `max/min->top1->sel->X`.
 func (r *EliminateSingleMaxMin) OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error) {
 	agg := old.GetExpr().ExprNode.(*plannercore.LogicalAggregation)
+	ectx := agg.SCtx().GetExprCtx().GetEvalCtx()
 	childGroup := old.GetExpr().Children[0]
 	ctx := agg.SCtx()
 	f := agg.AggFuncs[0]
@@ -1610,7 +1611,7 @@ func (r *EliminateSingleMaxMin) OnTransform(old *memo.ExprIter) (newExprs []*mem
 	// If there's no column in f.GetArgs()[0], we still need limit and read data from real table because the result should be NULL if the input is empty.
 	if len(expression.ExtractColumns(f.Args[0])) > 0 {
 		// If it can be NULL, we need to filter NULL out first.
-		if !mysql.HasNotNullFlag(f.Args[0].GetType().GetFlag()) {
+		if !mysql.HasNotNullFlag(f.Args[0].GetType(ectx).GetFlag()) {
 			sel := plannercore.LogicalSelection{}.Init(ctx, agg.QueryBlockOffset())
 			isNullFunc := expression.NewFunctionInternal(ctx.GetExprCtx(), ast.IsNull, types.NewFieldType(mysql.TypeTiny), f.Args[0])
 			notNullFunc := expression.NewFunctionInternal(ctx.GetExprCtx(), ast.UnaryNot, types.NewFieldType(mysql.TypeTiny), isNullFunc)
@@ -2247,6 +2248,7 @@ func (*InjectProjectionBelowTopN) Match(expr *memo.ExprIter) bool {
 // It will convert `TopN -> X` to `Projection -> TopN -> Projection -> X`.
 func (*InjectProjectionBelowTopN) OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error) {
 	topN := old.GetExpr().ExprNode.(*plannercore.LogicalTopN)
+	ectx := topN.SCtx().GetExprCtx().GetEvalCtx()
 	oldTopNSchema := old.GetExpr().Schema()
 
 	// Construct top Projection.
@@ -2276,7 +2278,7 @@ func (*InjectProjectionBelowTopN) OnTransform(old *memo.ExprIter) (newExprs []*m
 		bottomProjExprs = append(bottomProjExprs, itemExpr)
 		newCol := &expression.Column{
 			UniqueID: topN.SCtx().GetSessionVars().AllocPlanColumnID(),
-			RetType:  itemExpr.GetType(),
+			RetType:  itemExpr.GetType(ectx),
 		}
 		bottomProjSchema = append(bottomProjSchema, newCol)
 		newByItems = append(newByItems, &util.ByItems{Expr: newCol, Desc: item.Desc})
@@ -2337,6 +2339,7 @@ func (*InjectProjectionBelowAgg) Match(expr *memo.ExprIter) bool {
 // It will convert `Agg -> X` to `Agg -> Proj -> X`.
 func (*InjectProjectionBelowAgg) OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error) {
 	agg := old.GetExpr().ExprNode.(*plannercore.LogicalAggregation)
+	ectx := agg.SCtx().GetExprCtx().GetEvalCtx()
 
 	hasScalarFunc := false
 	copyFuncs := make([]*aggregation.AggFuncDesc, 0, len(agg.AggFuncs))
@@ -2374,7 +2377,7 @@ func (*InjectProjectionBelowAgg) OnTransform(old *memo.ExprIter) (newExprs []*me
 				projExprs = append(projExprs, expr)
 				newArg := &expression.Column{
 					UniqueID: agg.SCtx().GetSessionVars().AllocPlanColumnID(),
-					RetType:  arg.GetType(),
+					RetType:  arg.GetType(ectx),
 				}
 				projSchemaCols = append(projSchemaCols, newArg)
 				f.Args[i] = newArg
@@ -2395,7 +2398,7 @@ func (*InjectProjectionBelowAgg) OnTransform(old *memo.ExprIter) (newExprs []*me
 			projExprs = append(projExprs, expr)
 			newArg := &expression.Column{
 				UniqueID: agg.SCtx().GetSessionVars().AllocPlanColumnID(),
-				RetType:  item.GetType(),
+				RetType:  item.GetType(ectx),
 			}
 			projSchemaCols = append(projSchemaCols, newArg)
 			newGroupByItems[i] = newArg

--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "//pkg/domain",
         "//pkg/expression",
         "//pkg/expression/aggregation",
+        "//pkg/expression/contextstatic",
         "//pkg/parser/ast",
         "//pkg/parser/model",
         "//pkg/parser/mysql",

--- a/pkg/planner/core/casetest/rule/rule_inject_extra_projection_test.go
+++ b/pkg/planner/core/casetest/rule/rule_inject_extra_projection_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
+	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/util/coreusage"
@@ -28,6 +29,8 @@ import (
 )
 
 func TestWrapCastForAggFuncs(t *testing.T) {
+	ctx := contextstatic.NewStaticEvalContext()
+
 	aggNames := []string{ast.AggFuncSum}
 	modes := []aggregation.AggFunctionMode{aggregation.CompleteMode,
 		aggregation.FinalMode, aggregation.Partial1Mode, aggregation.Partial1Mode}
@@ -59,9 +62,9 @@ func TestWrapCastForAggFuncs(t *testing.T) {
 	coreusage.WrapCastForAggFuncs(mock.NewContext(), aggFuncs)
 	for i := range aggFuncs {
 		if aggFuncs[i].Mode != aggregation.FinalMode && aggFuncs[i].Mode != aggregation.Partial2Mode {
-			require.Equal(t, aggFuncs[i].Args[0].GetType().GetType(), aggFuncs[i].RetTp.GetType())
+			require.Equal(t, aggFuncs[i].Args[0].GetType(ctx).GetType(), aggFuncs[i].RetTp.GetType())
 		} else {
-			require.Equal(t, orgAggFuncs[i].Args[0].GetType().GetType(), aggFuncs[i].Args[0].GetType().GetType())
+			require.Equal(t, orgAggFuncs[i].Args[0].GetType(ctx).GetType(), aggFuncs[i].Args[0].GetType(ctx).GetType())
 		}
 	}
 }

--- a/pkg/planner/core/debugtrace.go
+++ b/pkg/planner/core/debugtrace.go
@@ -106,7 +106,7 @@ func DebugTraceReceivedCommand(s base.PlanContext, cmd byte, stmtNode ast.StmtNo
 	if len(binaryParams) > 0 {
 		execInfo.BinaryParamsInfo = make([]binaryParamInfo, len(binaryParams))
 		for i, param := range binaryParams {
-			execInfo.BinaryParamsInfo[i].Type = param.GetType().String()
+			execInfo.BinaryParamsInfo[i].Type = param.GetType(s.GetExprCtx().GetEvalCtx()).String()
 			execInfo.BinaryParamsInfo[i].Value = param.String()
 		}
 	}

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1665,7 +1665,7 @@ func (ijHelper *indexJoinBuildHelper) resetContextForIndex(innerKeys []*expressi
 				if err != nil {
 					logutil.BgLogger().Error("Unexpected error happened during constructing index join", zap.Stack("stack"))
 				}
-				if !collate.CompatibleCollate(idxCol.GetType().GetCollate(), et.Collation) {
+				if !collate.CompatibleCollate(idxCol.GetStaticType().GetCollate(), et.Collation) {
 					ijHelper.curIdxOff2KeyOff[i] = -1
 				}
 			}
@@ -2946,7 +2946,7 @@ func (lw *LogicalWindow) GetPartitionKeys() []*property.MPPPartitionColumn {
 	for _, item := range lw.PartitionBy {
 		partitionByCols = append(partitionByCols, &property.MPPPartitionColumn{
 			Col:       item.Col,
-			CollateID: property.GetCollateIDByNameForPartition(item.Col.GetType().GetCollate()),
+			CollateID: property.GetCollateIDByNameForPartition(item.Col.GetStaticType().GetCollate()),
 		})
 	}
 
@@ -2956,8 +2956,8 @@ func (lw *LogicalWindow) GetPartitionKeys() []*property.MPPPartitionColumn {
 // Duration vs Datetime is invalid comparison as TiFlash can't handle it so far.
 func (lw *LogicalWindow) checkComparisonForTiFlash(frameBound *FrameBound) bool {
 	if len(frameBound.CompareCols) > 0 {
-		orderByEvalType := lw.OrderBy[0].Col.GetType().EvalType()
-		calFuncEvalType := frameBound.CalcFuncs[0].GetType().EvalType()
+		orderByEvalType := lw.OrderBy[0].Col.GetStaticType().EvalType()
+		calFuncEvalType := frameBound.CalcFuncs[0].GetType(lw.SCtx().GetExprCtx().GetEvalCtx()).EvalType()
 
 		if orderByEvalType == types.ETDuration && (calFuncEvalType == types.ETDatetime || calFuncEvalType == types.ETTimestamp) {
 			return false

--- a/pkg/planner/core/expression_test.go
+++ b/pkg/planner/core/expression_test.go
@@ -479,11 +479,11 @@ func TestBuildExpression(t *testing.T) {
 	// WithCastExprTo
 	expr, err = buildExpr(t, ctx, "1+2+3")
 	require.NoError(t, err)
-	require.Equal(t, mysql.TypeLonglong, expr.GetType().GetType())
+	require.Equal(t, mysql.TypeLonglong, expr.GetType(ctx).GetType())
 	castTo := types.NewFieldType(mysql.TypeVarchar)
 	expr, err = buildExpr(t, ctx, "1+2+3", expression.WithCastExprTo(castTo))
 	require.NoError(t, err)
-	require.Equal(t, mysql.TypeVarchar, expr.GetType().GetType())
+	require.Equal(t, mysql.TypeVarchar, expr.GetType(ctx).GetType())
 	v, err := expr.Eval(ctx, chunk.Row{})
 	require.NoError(t, err)
 	require.Equal(t, types.KindString, v.Kind())

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1884,14 +1884,15 @@ func (ds *DataSource) indexCoveringColumn(column *expression.Column, indexColumn
 	if column.ID == model.ExtraHandleID || column.ID == model.ExtraPhysTblID {
 		return true
 	}
-	coveredByPlainIndex := isIndexColsCoveringCol(ds.SCtx().GetExprCtx().GetEvalCtx(), column, indexColumns, idxColLens, ignoreLen)
-	coveredByClusteredIndex := isIndexColsCoveringCol(ds.SCtx().GetExprCtx().GetEvalCtx(), column, ds.commonHandleCols, ds.commonHandleLens, ignoreLen)
+	evalCtx := ds.SCtx().GetExprCtx().GetEvalCtx()
+	coveredByPlainIndex := isIndexColsCoveringCol(evalCtx, column, indexColumns, idxColLens, ignoreLen)
+	coveredByClusteredIndex := isIndexColsCoveringCol(evalCtx, column, ds.commonHandleCols, ds.commonHandleLens, ignoreLen)
 	if !coveredByPlainIndex && !coveredByClusteredIndex {
 		return false
 	}
 	isClusteredNewCollationIdx := collate.NewCollationEnabled() &&
-		column.GetType().EvalType() == types.ETString &&
-		!mysql.HasBinaryFlag(column.GetType().GetFlag())
+		column.GetType(evalCtx).EvalType() == types.ETString &&
+		!mysql.HasBinaryFlag(column.GetType(evalCtx).GetFlag())
 	if !coveredByPlainIndex && coveredByClusteredIndex && isClusteredNewCollationIdx && ds.table.Meta().CommonHandleVersion == 0 {
 		return false
 	}

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -161,7 +161,7 @@ func TestImplicitCastNotNullFlag(t *testing.T) {
 	p, err = logicalOptimize(context.TODO(), flagPredicatePushDown|flagJoinReOrder|flagPrunColumns|flagEliminateProjection, p.(base.LogicalPlan))
 	require.NoError(t, err)
 	// AggFuncs[0] is count; AggFuncs[1] is bit_and, args[0] is return type of the implicit cast
-	castNotNullFlag := (p.(*LogicalProjection).Children()[0].(*LogicalSelection).Children()[0].(*LogicalAggregation).AggFuncs[1].Args[0].GetType().GetFlag()) & mysql.NotNullFlag
+	castNotNullFlag := (p.(*LogicalProjection).Children()[0].(*LogicalSelection).Children()[0].(*LogicalAggregation).AggFuncs[1].Args[0].GetType(s.ctx.GetExprCtx().GetEvalCtx()).GetFlag()) & mysql.NotNullFlag
 	var nullableFlag uint = 0
 	require.Equal(t, nullableFlag, castNotNullFlag)
 }
@@ -180,7 +180,7 @@ func TestEliminateProjectionUnderUnion(t *testing.T) {
 	require.NoError(t, err)
 	// after folding constants, the null flag should keep the same with the old one's (i.e., the schema's).
 	schemaNullFlag := p.(*LogicalProjection).Children()[0].(*LogicalJoin).Children()[1].Children()[1].(*LogicalProjection).schema.Columns[0].RetType.GetFlag() & mysql.NotNullFlag
-	exprNullFlag := p.(*LogicalProjection).Children()[0].(*LogicalJoin).Children()[1].Children()[1].(*LogicalProjection).Exprs[0].GetType().GetFlag() & mysql.NotNullFlag
+	exprNullFlag := p.(*LogicalProjection).Children()[0].(*LogicalJoin).Children()[1].Children()[1].(*LogicalProjection).Exprs[0].GetType(s.ctx.GetExprCtx().GetEvalCtx()).GetFlag() & mysql.NotNullFlag
 	require.Equal(t, exprNullFlag, schemaNullFlag)
 }
 

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -55,7 +55,7 @@ type extractHelper struct {
 	isLower map[string]bool
 }
 
-func (extractHelper) extractColInConsExpr(extractCols map[int64]*types.FieldName, expr *expression.ScalarFunction) (string, []types.Datum) {
+func (extractHelper) extractColInConsExpr(ctx base.PlanContext, extractCols map[int64]*types.FieldName, expr *expression.ScalarFunction) (string, []types.Datum) {
 	args := expr.GetArgs()
 	col, isCol := args[0].(*expression.Column)
 	if !isCol {
@@ -75,14 +75,14 @@ func (extractHelper) extractColInConsExpr(extractCols map[int64]*types.FieldName
 		}
 		v := constant.Value
 		if constant.ParamMarker != nil {
-			v = constant.ParamMarker.GetUserVar()
+			v = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
 		}
 		results = append(results, v)
 	}
 	return name.ColName.L, results
 }
 
-func (helper *extractHelper) extractColBinaryOpConsExpr(extractCols map[int64]*types.FieldName, supportLower bool, expr *expression.ScalarFunction) (string, []types.Datum) {
+func (helper *extractHelper) extractColBinaryOpConsExpr(ctx base.PlanContext, extractCols map[int64]*types.FieldName, supportLower bool, expr *expression.ScalarFunction) (string, []types.Datum) {
 	args := expr.GetArgs()
 	var col *expression.Column
 	var colIdx int
@@ -157,14 +157,14 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(extractCols map[int64]*t
 	}
 	v := constant.Value
 	if constant.ParamMarker != nil {
-		v = constant.ParamMarker.GetUserVar()
+		v = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
 	}
 	return name.ColName.L, []types.Datum{v}
 }
 
 // extract the OR expression, e.g:
 // SELECT * FROM t1 WHERE c1='a' OR c1='b' OR c1='c'
-func (helper *extractHelper) extractColOrExpr(extractCols map[int64]*types.FieldName, supportLower bool, expr *expression.ScalarFunction) (string, []types.Datum) {
+func (helper *extractHelper) extractColOrExpr(ctx base.PlanContext, extractCols map[int64]*types.FieldName, supportLower bool, expr *expression.ScalarFunction) (string, []types.Datum) {
 	args := expr.GetArgs()
 	lhs, ok := args[0].(*expression.ScalarFunction)
 	if !ok {
@@ -178,11 +178,11 @@ func (helper *extractHelper) extractColOrExpr(extractCols map[int64]*types.Field
 	var extract = func(extractCols map[int64]*types.FieldName, fn *expression.ScalarFunction) (string, []types.Datum) {
 		switch helper.getStringFunctionName(fn) {
 		case ast.EQ:
-			return helper.extractColBinaryOpConsExpr(extractCols, supportLower, fn)
+			return helper.extractColBinaryOpConsExpr(ctx, extractCols, supportLower, fn)
 		case ast.LogicOr:
-			return helper.extractColOrExpr(extractCols, supportLower, fn)
+			return helper.extractColOrExpr(ctx, extractCols, supportLower, fn)
 		case ast.In:
-			return helper.extractColInConsExpr(extractCols, fn)
+			return helper.extractColInConsExpr(ctx, extractCols, fn)
 		default:
 			return "", nil
 		}
@@ -237,6 +237,7 @@ func (extractHelper) mergeWithLower(lhs set.StringSet, datums []types.Datum, toL
 }
 
 func (helper *extractHelper) extractColWithLower(
+	ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
@@ -263,9 +264,9 @@ func (helper *extractHelper) extractColWithLower(
 		var datums []types.Datum // the memory of datums should not be reused, they will be put into result.
 		switch helper.getStringFunctionName(fn) {
 		case ast.EQ:
-			colName, datums = helper.extractColBinaryOpConsExpr(extractCols, true, fn)
+			colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, true, fn)
 		case ast.In:
-			colName, datums = helper.extractColInConsExpr(extractCols, fn)
+			colName, datums = helper.extractColInConsExpr(ctx, extractCols, fn)
 		case ast.LogicOr:
 			// disable predicate pushdown for case like `lower(c1) = xx or c1 = yy`
 			colName, datums = "", nil
@@ -290,6 +291,7 @@ func (helper *extractHelper) extractColWithLower(
 }
 
 func (helper *extractHelper) extractCol(
+	ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
@@ -318,11 +320,11 @@ func (helper *extractHelper) extractCol(
 		var datums []types.Datum // the memory of datums should not be reused, they will be put into result.
 		switch helper.getStringFunctionName(fn) {
 		case ast.EQ:
-			colName, datums = helper.extractColBinaryOpConsExpr(extractCols, false, fn)
+			colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, false, fn)
 		case ast.In:
-			colName, datums = helper.extractColInConsExpr(extractCols, fn)
+			colName, datums = helper.extractColInConsExpr(ctx, extractCols, fn)
 		case ast.LogicOr:
-			colName, datums = helper.extractColOrExpr(extractCols, false, fn)
+			colName, datums = helper.extractColOrExpr(ctx, extractCols, false, fn)
 		}
 		if colName == extractColName {
 			result = helper.merge(result, datums, valueToLower)
@@ -344,6 +346,7 @@ func (helper *extractHelper) extractCol(
 // SELECT * FROM t WHERE c LIKE '%a%' AND c REGEXP '.*xxx.*'
 // SELECT * FROM t WHERE c LIKE '%a%' OR c REGEXP '.*xxx.*'
 func (helper extractHelper) extractLikePatternCol(
+	ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
@@ -377,9 +380,9 @@ func (helper extractHelper) extractLikePatternCol(
 		// e.g:
 		// SELECT * FROM t WHERE c LIKE '%a%' OR c LIKE '%b%'
 		if fn.FuncName.L == ast.LogicOr && !toLower {
-			canBuildPattern, pattern = helper.extractOrLikePattern(fn, extractColName, extractCols, needLike2Regexp)
+			canBuildPattern, pattern = helper.extractOrLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
 		} else {
-			canBuildPattern, pattern = helper.extractLikePattern(fn, extractColName, extractCols, needLike2Regexp)
+			canBuildPattern, pattern = helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
 		}
 		if canBuildPattern && toLower {
 			pattern = strings.ToLower(pattern)
@@ -394,6 +397,7 @@ func (helper extractHelper) extractLikePatternCol(
 }
 
 func (helper extractHelper) extractOrLikePattern(
+	ctx base.PlanContext,
 	orFunc *expression.ScalarFunction,
 	extractColName string,
 	extractCols map[int64]*types.FieldName,
@@ -414,7 +418,7 @@ func (helper extractHelper) extractOrLikePattern(
 			return false, ""
 		}
 
-		ok, partPattern := helper.extractLikePattern(fn, extractColName, extractCols, needLike2Regexp)
+		ok, partPattern := helper.extractLikePattern(ctx, fn, extractColName, extractCols, needLike2Regexp)
 		if !ok {
 			return false, ""
 		}
@@ -424,6 +428,7 @@ func (helper extractHelper) extractOrLikePattern(
 }
 
 func (helper extractHelper) extractLikePattern(
+	ctx base.PlanContext,
 	fn *expression.ScalarFunction,
 	extractColName string,
 	extractCols map[int64]*types.FieldName,
@@ -436,7 +441,7 @@ func (helper extractHelper) extractLikePattern(
 	var datums []types.Datum
 	switch fn.FuncName.L {
 	case ast.EQ, ast.Like, ast.Ilike, ast.Regexp, ast.RegexpLike:
-		colName, datums = helper.extractColBinaryOpConsExpr(extractCols, false, fn)
+		colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, false, fn)
 	}
 	if colName != extractColName {
 		return false, ""
@@ -542,7 +547,7 @@ func (helper extractHelper) extractTimeRange(
 		fnName := helper.getTimeFunctionName(fn)
 		switch fnName {
 		case ast.GT, ast.GE, ast.LT, ast.LE, ast.EQ:
-			colName, datums = helper.extractColBinaryOpConsExpr(extractCols, false, fn)
+			colName, datums = helper.extractColBinaryOpConsExpr(ctx, extractCols, false, fn)
 		}
 
 		if colName == extractColName {
@@ -629,6 +634,7 @@ func (extractHelper) parseUint64(uint64Set set.StringSet) []uint64 {
 }
 
 func (helper extractHelper) extractCols(
+	ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
@@ -643,7 +649,7 @@ func (helper extractHelper) extractCols(
 			continue
 		}
 		var values set.StringSet
-		remained, skipRequest, values = helper.extractCol(schema, names, remained, name.ColName.L, valueToLower)
+		remained, skipRequest, values = helper.extractCol(ctx, schema, names, remained, name.ColName.L, valueToLower)
 		if skipRequest {
 			return nil, true, nil
 		}
@@ -701,13 +707,13 @@ type ClusterTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *ClusterTableExtractor) Extract(_ base.PlanContext,
+func (e *ClusterTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) []expression.Expression {
-	remained, typeSkipRequest, nodeTypes := e.extractCol(schema, names, predicates, "type", true)
-	remained, addrSkipRequest, instances := e.extractCol(schema, names, remained, "instance", false)
+	remained, typeSkipRequest, nodeTypes := e.extractCol(ctx, schema, names, predicates, "type", true)
+	remained, addrSkipRequest, instances := e.extractCol(ctx, schema, names, remained, "instance", false)
 	e.SkipRequest = typeSkipRequest || addrSkipRequest
 	e.NodeTypes = nodeTypes
 	e.Instances = instances
@@ -774,9 +780,9 @@ func (e *ClusterLogTableExtractor) Extract(ctx base.PlanContext,
 	predicates []expression.Expression,
 ) []expression.Expression {
 	// Extract the `type/instance` columns
-	remained, typeSkipRequest, nodeTypes := e.extractCol(schema, names, predicates, "type", true)
-	remained, addrSkipRequest, instances := e.extractCol(schema, names, remained, "instance", false)
-	remained, levlSkipRequest, logLevels := e.extractCol(schema, names, remained, "level", true)
+	remained, typeSkipRequest, nodeTypes := e.extractCol(ctx, schema, names, predicates, "type", true)
+	remained, addrSkipRequest, instances := e.extractCol(ctx, schema, names, remained, "instance", false)
+	remained, levlSkipRequest, logLevels := e.extractCol(ctx, schema, names, remained, "level", true)
 	e.SkipRequest = typeSkipRequest || addrSkipRequest || levlSkipRequest
 	e.NodeTypes = nodeTypes
 	e.Instances = instances
@@ -799,7 +805,7 @@ func (e *ClusterLogTableExtractor) Extract(ctx base.PlanContext,
 		return nil
 	}
 
-	remained, patterns := e.extractLikePatternCol(schema, names, remained, "message", false, true)
+	remained, patterns := e.extractLikePatternCol(ctx, schema, names, remained, "message", false, true)
 	e.Patterns = patterns
 	return remained
 }
@@ -889,9 +895,9 @@ func (e *HotRegionsHistoryTableExtractor) Extract(ctx base.PlanContext,
 	predicates []expression.Expression,
 ) []expression.Expression {
 	// Extract the `region_id/store_id/peer_id` columns
-	remained, regionIDSkipRequest, regionIDs := e.extractCol(schema, names, predicates, "region_id", false)
-	remained, storeIDSkipRequest, storeIDs := e.extractCol(schema, names, remained, "store_id", false)
-	remained, peerIDSkipRequest, peerIDs := e.extractCol(schema, names, remained, "peer_id", false)
+	remained, regionIDSkipRequest, regionIDs := e.extractCol(ctx, schema, names, predicates, "region_id", false)
+	remained, storeIDSkipRequest, storeIDs := e.extractCol(ctx, schema, names, remained, "store_id", false)
+	remained, peerIDSkipRequest, peerIDs := e.extractCol(ctx, schema, names, remained, "peer_id", false)
 	e.RegionIDs, e.StoreIDs, e.PeerIDs = e.parseUint64(regionIDs), e.parseUint64(storeIDs), e.parseUint64(peerIDs)
 	e.SkipRequest = regionIDSkipRequest || storeIDSkipRequest || peerIDSkipRequest
 	if e.SkipRequest {
@@ -899,8 +905,8 @@ func (e *HotRegionsHistoryTableExtractor) Extract(ctx base.PlanContext,
 	}
 
 	// Extract the is_learner/is_leader columns
-	remained, isLearnerSkipRequest, isLearners := e.extractCol(schema, names, remained, "is_learner", false)
-	remained, isLeaderSkipRequest, isLeaders := e.extractCol(schema, names, remained, "is_leader", false)
+	remained, isLearnerSkipRequest, isLearners := e.extractCol(ctx, schema, names, remained, "is_learner", false)
+	remained, isLeaderSkipRequest, isLeaders := e.extractCol(ctx, schema, names, remained, "is_leader", false)
 	isLearnersUint64, isLeadersUint64 := e.parseUint64(isLearners), e.parseUint64(isLeaders)
 	e.SkipRequest = isLearnerSkipRequest || isLeaderSkipRequest
 	if e.SkipRequest {
@@ -911,7 +917,7 @@ func (e *HotRegionsHistoryTableExtractor) Extract(ctx base.PlanContext,
 	e.IsLeaders = e.convertToBoolSlice(isLeadersUint64)
 
 	// Extract the `type` column
-	remained, typeSkipRequest, types := e.extractCol(schema, names, remained, "type", false)
+	remained, typeSkipRequest, types := e.extractCol(ctx, schema, names, remained, "type", false)
 	e.HotRegionTypes = types
 	e.SkipRequest = typeSkipRequest
 	if e.SkipRequest {
@@ -1009,7 +1015,7 @@ func (e *MetricTableExtractor) Extract(ctx base.PlanContext,
 	predicates []expression.Expression,
 ) []expression.Expression {
 	// Extract the `quantile` columns
-	remained, skipRequest, quantileSet := e.extractCol(schema, names, predicates, "quantile", true)
+	remained, skipRequest, quantileSet := e.extractCol(ctx, schema, names, predicates, "quantile", true)
 	e.Quantiles = e.parseQuantiles(quantileSet)
 	e.SkipRequest = skipRequest
 	if e.SkipRequest {
@@ -1025,7 +1031,7 @@ func (e *MetricTableExtractor) Extract(ctx base.PlanContext,
 	}
 
 	excludeCols := set.NewStringSet("quantile", "time", "value")
-	_, skipRequest, extractCols := e.extractCols(schema, names, remained, excludeCols, false)
+	_, skipRequest, extractCols := e.extractCols(ctx, schema, names, remained, excludeCols, false)
 	e.SkipRequest = skipRequest
 	if e.SkipRequest {
 		return nil
@@ -1105,14 +1111,14 @@ type MetricSummaryTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *MetricSummaryTableExtractor) Extract(_ base.PlanContext,
+func (e *MetricSummaryTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
 	//nolint: ineffassign
-	remained, quantileSkip, quantiles := e.extractCol(schema, names, predicates, "quantile", false)
-	remained, metricsNameSkip, metricsNames := e.extractCol(schema, names, predicates, "metrics_name", true)
+	remained, quantileSkip, quantiles := e.extractCol(ctx, schema, names, predicates, "quantile", false)
+	remained, metricsNameSkip, metricsNames := e.extractCol(ctx, schema, names, predicates, "metrics_name", true)
 	e.SkipRequest = quantileSkip || metricsNameSkip
 	e.Quantiles = e.parseQuantiles(quantiles)
 	e.MetricsNames = metricsNames
@@ -1138,14 +1144,14 @@ type InspectionResultTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *InspectionResultTableExtractor) Extract(_ base.PlanContext,
+func (e *InspectionResultTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
 	// Extract the `rule/item` columns
-	remained, ruleSkip, rules := e.extractCol(schema, names, predicates, "rule", true)
-	remained, itemSkip, items := e.extractCol(schema, names, remained, "item", true)
+	remained, ruleSkip, rules := e.extractCol(ctx, schema, names, predicates, "rule", true)
+	remained, itemSkip, items := e.extractCol(ctx, schema, names, remained, "item", true)
 	e.SkipInspection = ruleSkip || itemSkip
 	e.Rules = rules
 	e.Items = items
@@ -1176,17 +1182,17 @@ type InspectionSummaryTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *InspectionSummaryTableExtractor) Extract(_ base.PlanContext,
+func (e *InspectionSummaryTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
 	// Extract the `rule` columns
-	_, ruleSkip, rules := e.extractCol(schema, names, predicates, "rule", true)
+	_, ruleSkip, rules := e.extractCol(ctx, schema, names, predicates, "rule", true)
 	// Extract the `metric_name` columns
-	_, metricNameSkip, metricNames := e.extractCol(schema, names, predicates, "metrics_name", true)
+	_, metricNameSkip, metricNames := e.extractCol(ctx, schema, names, predicates, "metrics_name", true)
 	// Extract the `quantile` columns
-	remained, quantileSkip, quantileSet := e.extractCol(schema, names, predicates, "quantile", false)
+	remained, quantileSkip, quantileSet := e.extractCol(ctx, schema, names, predicates, "quantile", false)
 	e.SkipInspection = ruleSkip || quantileSkip || metricNameSkip
 	e.Rules = rules
 	e.Quantiles = e.parseQuantiles(quantileSet)
@@ -1235,13 +1241,13 @@ type InspectionRuleTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *InspectionRuleTableExtractor) Extract(_ base.PlanContext,
+func (e *InspectionRuleTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
 	// Extract the `type` columns
-	remained, tpSkip, tps := e.extractCol(schema, names, predicates, "type", true)
+	remained, tpSkip, tps := e.extractCol(ctx, schema, names, predicates, "type", true)
 	e.SkipRequest = tpSkip
 	e.Types = tps
 	return remained
@@ -1383,15 +1389,15 @@ type TableStorageStatsExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface.
-func (e *TableStorageStatsExtractor) Extract(_ base.PlanContext,
+func (e *TableStorageStatsExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) []expression.Expression {
 	// Extract the `table_schema` columns.
-	remained, schemaSkip, tableSchema := e.extractCol(schema, names, predicates, "table_schema", true)
+	remained, schemaSkip, tableSchema := e.extractCol(ctx, schema, names, predicates, "table_schema", true)
 	// Extract the `table_name` columns.
-	remained, tableSkip, tableName := e.extractCol(schema, names, remained, "table_name", true)
+	remained, tableSkip, tableName := e.extractCol(ctx, schema, names, remained, "table_name", true)
 	e.SkipRequest = schemaSkip || tableSkip
 	if e.SkipRequest {
 		return nil
@@ -1456,17 +1462,17 @@ type TiFlashSystemTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *TiFlashSystemTableExtractor) Extract(_ base.PlanContext,
+func (e *TiFlashSystemTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) []expression.Expression {
 	// Extract the `tiflash_instance` columns.
-	remained, instanceSkip, tiflashInstances := e.extractCol(schema, names, predicates, "tiflash_instance", false)
+	remained, instanceSkip, tiflashInstances := e.extractCol(ctx, schema, names, predicates, "tiflash_instance", false)
 	// Extract the `tidb_database` columns.
-	remained, databaseSkip, tidbDatabases := e.extractCol(schema, names, remained, "tidb_database", true)
+	remained, databaseSkip, tidbDatabases := e.extractCol(ctx, schema, names, remained, "tidb_database", true)
 	// Extract the `tidb_table` columns.
-	remained, tableSkip, tidbTables := e.extractCol(schema, names, remained, "tidb_table", true)
+	remained, tableSkip, tidbTables := e.extractCol(ctx, schema, names, remained, "tidb_table", true)
 	e.SkipRequest = instanceSkip || databaseSkip || tableSkip
 	if e.SkipRequest {
 		return nil
@@ -1525,7 +1531,7 @@ func (e *StatementsSummaryExtractor) Extract(sctx base.PlanContext,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
 	// Extract the `digest` column
-	remained, skip, digests := e.extractCol(schema, names, predicates, "digest", false)
+	remained, skip, digests := e.extractCol(sctx, schema, names, predicates, "digest", false)
 	if skip {
 		e.SkipRequest = true
 		return nil
@@ -1622,14 +1628,14 @@ type TikvRegionPeersExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *TikvRegionPeersExtractor) Extract(_ base.PlanContext,
+func (e *TikvRegionPeersExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) []expression.Expression {
 	// Extract the `region_id/store_id` columns.
-	remained, regionIDSkipRequest, regionIDs := e.extractCol(schema, names, predicates, "region_id", false)
-	remained, storeIDSkipRequest, storeIDs := e.extractCol(schema, names, remained, "store_id", false)
+	remained, regionIDSkipRequest, regionIDs := e.extractCol(ctx, schema, names, predicates, "region_id", false)
+	remained, storeIDSkipRequest, storeIDs := e.extractCol(ctx, schema, names, remained, "store_id", false)
 	e.RegionIDs, e.StoreIDs = e.parseUint64(regionIDs), e.parseUint64(storeIDs)
 
 	e.SkipRequest = regionIDSkipRequest || storeIDSkipRequest
@@ -1681,21 +1687,21 @@ type ColumnsTableExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *ColumnsTableExtractor) Extract(_ base.PlanContext,
+func (e *ColumnsTableExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
-	remained, tableSchemaSkipRequest, tableSchema := e.extractCol(schema, names, predicates, "table_schema", true)
-	remained, tableNameSkipRequest, tableName := e.extractCol(schema, names, remained, "table_name", true)
-	remained, columnNameSkipRequest, columnName := e.extractCol(schema, names, remained, "column_name", true)
+	remained, tableSchemaSkipRequest, tableSchema := e.extractCol(ctx, schema, names, predicates, "table_schema", true)
+	remained, tableNameSkipRequest, tableName := e.extractCol(ctx, schema, names, remained, "table_name", true)
+	remained, columnNameSkipRequest, columnName := e.extractCol(ctx, schema, names, remained, "column_name", true)
 	e.SkipRequest = columnNameSkipRequest || tableSchemaSkipRequest || tableNameSkipRequest
 	if e.SkipRequest {
 		return
 	}
-	remained, tableSchemaPatterns := e.extractLikePatternCol(schema, names, remained, "table_schema", true, false)
-	remained, tableNamePatterns := e.extractLikePatternCol(schema, names, remained, "table_name", true, false)
-	remained, columnNamePatterns := e.extractLikePatternCol(schema, names, remained, "column_name", true, false)
+	remained, tableSchemaPatterns := e.extractLikePatternCol(ctx, schema, names, remained, "table_schema", true, false)
+	remained, tableNamePatterns := e.extractLikePatternCol(ctx, schema, names, remained, "table_name", true, false)
+	remained, columnNamePatterns := e.extractLikePatternCol(ctx, schema, names, remained, "column_name", true, false)
 
 	e.ColumnName = columnName
 	e.TableName = tableName
@@ -1745,12 +1751,12 @@ type TiKVRegionStatusExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *TiKVRegionStatusExtractor) Extract(_ base.PlanContext,
+func (e *TiKVRegionStatusExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
 ) (remained []expression.Expression) {
-	remained, _, tableIDSet := e.extractCol(schema, names, predicates, "table_id", true)
+	remained, _, tableIDSet := e.extractCol(ctx, schema, names, predicates, "table_id", true)
 	if tableIDSet.Count() < 1 {
 		return predicates
 	}
@@ -1800,7 +1806,7 @@ type InfoSchemaTablesExtractor struct {
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
-func (e *InfoSchemaTablesExtractor) Extract(_ base.PlanContext,
+func (e *InfoSchemaTablesExtractor) Extract(ctx base.PlanContext,
 	schema *expression.Schema,
 	names []*types.FieldName,
 	predicates []expression.Expression,
@@ -1810,11 +1816,11 @@ func (e *InfoSchemaTablesExtractor) Extract(_ base.PlanContext,
 	e.ColPredicates = make(map[string]set.StringSet)
 	remained = predicates
 	for _, colName := range e.colNames {
-		remained, e.SkipRequest, resultSet = e.extractColWithLower(schema, names, remained, colName)
+		remained, e.SkipRequest, resultSet = e.extractColWithLower(ctx, schema, names, remained, colName)
 		if e.SkipRequest {
 			break
 		}
-		remained, e.SkipRequest, resultSet1 = e.extractCol(schema, names, remained, colName, true)
+		remained, e.SkipRequest, resultSet1 = e.extractCol(ctx, schema, names, remained, colName, true)
 		if e.SkipRequest {
 			break
 		}

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -319,7 +319,7 @@ func TestHandleFineGrainedShuffle(t *testing.T) {
 	var partitionCols = make([]*property.MPPPartitionColumn, 0, 1)
 	partitionCols = append(partitionCols, &property.MPPPartitionColumn{
 		Col:       col0,
-		CollateID: property.GetCollateIDByNameForPartition(col0.GetType().GetCollate()),
+		CollateID: property.GetCollateIDByNameForPartition(col0.GetType(sctx).GetCollate()),
 	})
 
 	// HashAgg(x) <- ExchangeReceiver <- ExchangeSender

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -736,7 +736,7 @@ func parseParamTypes(sctx sessionctx.Context, params []expression.Expression) (p
 	paramTypes = make([]*types.FieldType, 0, len(params))
 	for _, param := range params {
 		if c, ok := param.(*expression.Constant); ok { // from binary protocol
-			paramTypes = append(paramTypes, c.GetType())
+			paramTypes = append(paramTypes, c.GetType(sctx.GetExprCtx().GetEvalCtx()))
 			continue
 		}
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -639,7 +639,7 @@ func (b *PlanBuilder) buildDo(ctx context.Context, v *ast.DoStmt) (base.Plan, er
 		proj.Exprs = append(proj.Exprs, expr)
 		schema.Append(&expression.Column{
 			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
-			RetType:  expr.GetType(),
+			RetType:  expr.GetType(b.ctx.GetExprCtx().GetEvalCtx()),
 		})
 	}
 	proj.SetChildren(p)
@@ -692,7 +692,7 @@ func (b *PlanBuilder) buildSet(ctx context.Context, v *ast.SetStmt) (base.Plan, 
 				}
 				constant := &expression.Constant{
 					Value:   row[0],
-					RetType: assign.Expr.GetType(),
+					RetType: assign.Expr.GetType(b.ctx.GetExprCtx().GetEvalCtx()),
 				}
 				assign.Expr = constant
 			}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1996,7 +1996,7 @@ func buildOrderedList(ctx base.PlanContext, plan base.Plan, list []*ast.Assignme
 		if err != nil {
 			return nil, true
 		}
-		expr = expression.BuildCastFunction(ctx.GetExprCtx(), expr, col.GetType())
+		expr = expression.BuildCastFunction(ctx.GetExprCtx(), expr, col.GetStaticType())
 		if allAssignmentsAreConstant {
 			_, isConst := expr.(*expression.Constant)
 			allAssignmentsAreConstant = isConst

--- a/pkg/planner/core/resolve_indices.go
+++ b/pkg/planner/core/resolve_indices.go
@@ -95,7 +95,7 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 			return err
 		}
 		p.RightJoinKeys[i] = rArg.(*expression.Column)
-		p.EqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetType(), lArg, rArg).(*expression.ScalarFunction)
+		p.EqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetStaticType(), lArg, rArg).(*expression.ScalarFunction)
 	}
 	for i, fun := range p.NAEqualConditions {
 		lArg, err := fun.GetArgs()[0].ResolveIndices(lSchema)
@@ -108,7 +108,7 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 			return err
 		}
 		p.RightNAJoinKeys[i] = rArg.(*expression.Column)
-		p.NAEqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetType(), lArg, rArg).(*expression.ScalarFunction)
+		p.NAEqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetStaticType(), lArg, rArg).(*expression.ScalarFunction)
 	}
 	for i, expr := range p.LeftConditions {
 		p.LeftConditions[i], err = expr.ResolveIndices(lSchema)

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -619,12 +619,13 @@ func (a *aggregationPushDownSolver) aggPushDown(p base.LogicalPlan, opt *optimiz
 						}
 					}
 				}
+				ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 				for i, funcsArgs := range oldAggFuncsArgs {
 					if !noSideEffects {
 						break
 					}
 					for j := range funcsArgs {
-						if oldAggFuncsArgs[i][j].GetType().EvalType() != newAggFuncsArgs[i][j].GetType().EvalType() {
+						if oldAggFuncsArgs[i][j].GetType(ectx).EvalType() != newAggFuncsArgs[i][j].GetType(ectx).EvalType() {
 							noSideEffects = false
 							break
 						}
@@ -634,7 +635,7 @@ func (a *aggregationPushDownSolver) aggPushDown(p base.LogicalPlan, opt *optimiz
 							continue
 						}
 						// substitution happened, check the eval type compatibility.
-						if oldAggOrderItems[i][j].Expr.GetType().EvalType() != newAggOrderItems[i][j].Expr.GetType().EvalType() {
+						if oldAggOrderItems[i][j].Expr.GetType(ectx).EvalType() != newAggOrderItems[i][j].Expr.GetType(ectx).EvalType() {
 							noSideEffects = false
 							break
 						}

--- a/pkg/planner/core/rule_aggregation_skew_rewrite.go
+++ b/pkg/planner/core/rule_aggregation_skew_rewrite.go
@@ -224,8 +224,8 @@ func (a *skewDistinctAggRewriter) rewriteSkewDistinctAgg(agg *LogicalAggregation
 
 	// wrap sum() with cast function to keep output data type same
 	for _, index := range cntIndexes {
-		exprType := proj.Exprs[index].GetType()
-		targetType := agg.schema.Columns[index].GetType()
+		exprType := proj.Exprs[index].GetType(agg.SCtx().GetExprCtx().GetEvalCtx())
+		targetType := agg.schema.Columns[index].GetStaticType()
 		if !exprType.Equal(targetType) {
 			proj.Exprs[index] = expression.BuildCastFunction(agg.SCtx().GetExprCtx(), proj.Exprs[index], targetType)
 		}

--- a/pkg/planner/core/rule_build_key_info.go
+++ b/pkg/planner/core/rule_build_key_info.go
@@ -160,7 +160,7 @@ func (p *LogicalProjection) buildSchemaByExprs(selfSchema *expression.Schema) *e
 			// If the expression is not a column, we add a column to occupy the position.
 			schema.Append(&expression.Column{
 				UniqueID: p.SCtx().GetSessionVars().AllocPlanColumnID(),
-				RetType:  expr.GetType(),
+				RetType:  expr.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 			})
 		}
 	}

--- a/pkg/planner/core/rule_column_pruning.go
+++ b/pkg/planner/core/rule_column_pruning.go
@@ -250,7 +250,7 @@ func pruneByItems(p base.LogicalPlan, old []*util.ByItems, opt *optimizetrace.Lo
 					pruned = false
 					byItems = append(byItems, byItem)
 				}
-			} else if byItem.Expr.GetType().GetType() != mysql.TypeNull {
+			} else if byItem.Expr.GetType(p.SCtx().GetExprCtx().GetEvalCtx()).GetType() != mysql.TypeNull {
 				pruned = false
 				parentUsedCols = append(parentUsedCols, cols...)
 				byItems = append(byItems, byItem)
@@ -687,11 +687,11 @@ func addConstOneForEmptyProjection(p base.LogicalPlan) {
 	constOne := expression.NewOne()
 	proj.schema.Append(&expression.Column{
 		UniqueID: proj.SCtx().GetSessionVars().AllocPlanColumnID(),
-		RetType:  constOne.GetType(),
+		RetType:  constOne.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 	})
 	proj.Exprs = append(proj.Exprs, &expression.Constant{
 		Value:   constOne.Value,
-		RetType: constOne.GetType(),
+		RetType: constOne.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 	})
 }
 

--- a/pkg/planner/core/rule_constant_propagation.go
+++ b/pkg/planner/core/rule_constant_propagation.go
@@ -173,7 +173,7 @@ func (selection *LogicalSelection) PullUpConstantPredicates() []expression.Expre
 	var result []expression.Expression
 	for _, candidatePredicate := range selection.Conditions {
 		// the candidate predicate should be a constant and compare predicate
-		match := validCompareConstantPredicate(candidatePredicate)
+		match := validCompareConstantPredicate(selection.SCtx().GetExprCtx().GetEvalCtx(), candidatePredicate)
 		if match {
 			result = append(result, candidatePredicate)
 		}
@@ -220,7 +220,7 @@ func (projection *LogicalProjection) PullUpConstantPredicates() []expression.Exp
 // validComparePredicate checks if the predicate is an expression like [column '>'|'>='|'<'|'<='|'=' constant].
 // return param1: return true, if the predicate is a compare constant predicate.
 // return param2: return the column side of predicate.
-func validCompareConstantPredicate(candidatePredicate expression.Expression) bool {
+func validCompareConstantPredicate(ctx expression.EvalContext, candidatePredicate expression.Expression) bool {
 	scalarFunction, ok := candidatePredicate.(*expression.ScalarFunction)
 	if !ok {
 		return false
@@ -230,9 +230,9 @@ func validCompareConstantPredicate(candidatePredicate expression.Expression) boo
 		scalarFunction.FuncName.L != ast.EQ {
 		return false
 	}
-	column, _ := expression.ValidCompareConstantPredicateHelper(scalarFunction, true)
+	column, _ := expression.ValidCompareConstantPredicateHelper(ctx, scalarFunction, true)
 	if column == nil {
-		column, _ = expression.ValidCompareConstantPredicateHelper(scalarFunction, false)
+		column, _ = expression.ValidCompareConstantPredicateHelper(ctx, scalarFunction, false)
 	}
 	if column == nil {
 		return false

--- a/pkg/planner/core/rule_eliminate_projection.go
+++ b/pkg/planner/core/rule_eliminate_projection.go
@@ -218,7 +218,7 @@ func (pe *projectionEliminator) eliminate(p base.LogicalPlan, replace map[string
 				proj.Exprs[i] = ReplaceColumnOfExpr(proj.Exprs[i], child, child.Schema())
 				foldedExpr := expression.FoldConstant(ctx.GetExprCtx(), proj.Exprs[i])
 				// the folded expr should have the same null flag with the original expr, especially for the projection under union, so forcing it here.
-				foldedExpr.GetType().SetFlag((foldedExpr.GetType().GetFlag() & ^mysql.NotNullFlag) | (proj.Exprs[i].GetType().GetFlag() & mysql.NotNullFlag))
+				foldedExpr.GetType(ctx.GetExprCtx().GetEvalCtx()).SetFlag((foldedExpr.GetType(ctx.GetExprCtx().GetEvalCtx()).GetFlag() & ^mysql.NotNullFlag) | (proj.Exprs[i].GetType(ctx.GetExprCtx().GetEvalCtx()).GetFlag() & mysql.NotNullFlag))
 				proj.Exprs[i] = foldedExpr
 			}
 			p.Children()[0] = child.Children()[0]

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -69,6 +69,7 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 	if ds.preferStoreType&h.PreferTiFlash != 0 {
 		return
 	}
+	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	for _, p := range ds.possibleAccessPaths {
 		if p.IsTablePath() {
 			continue
@@ -78,7 +79,7 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 			if colInfo.IsGenerated() && !colInfo.GeneratedStored {
 				s := ds.schema.Columns
 				col := expression.ColInfo2Col(s, colInfo)
-				if col != nil && col.GetType().PartialEqual(col.VirtualExpr.GetType(), lp.SCtx().GetSessionVars().EnableUnsafeSubstitute) {
+				if col != nil && col.GetType(ectx).PartialEqual(col.VirtualExpr.GetType(ectx), lp.SCtx().GetSessionVars().EnableUnsafeSubstitute) {
 					exprToColumn[col.VirtualExpr] = col
 				}
 			}
@@ -88,7 +89,8 @@ func collectGenerateColumn(lp base.LogicalPlan, exprToColumn ExprColumnMap) {
 
 func tryToSubstituteExpr(expr *expression.Expression, lp base.LogicalPlan, candidateExpr expression.Expression, tp types.EvalType, schema *expression.Schema, col *expression.Column, opt *optimizetrace.LogicalOptimizeOp) bool {
 	changed := false
-	if (*expr).Equal(lp.SCtx().GetExprCtx().GetEvalCtx(), candidateExpr) && candidateExpr.GetType().EvalType() == tp &&
+	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
+	if (*expr).Equal(ectx, candidateExpr) && candidateExpr.GetType(ectx).EvalType() == tp &&
 		schema.ColumnIndex(col) != -1 {
 		*expr = col
 		appendSubstituteColumnStep(lp, candidateExpr, col, opt)
@@ -134,22 +136,23 @@ func substituteExpression(cond expression.Expression, lp base.LogicalPlan, exprT
 	}()
 	var expr *expression.Expression
 	var tp types.EvalType
+	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	switch sf.FuncName.L {
 	case ast.EQ, ast.LT, ast.LE, ast.GT, ast.GE:
 		for candidateExpr, column := range exprToColumn {
-			collectChanged(tryToSubstituteExpr(&sf.GetArgs()[1], lp, candidateExpr, sf.GetArgs()[0].GetType().EvalType(), schema, column, opt))
+			collectChanged(tryToSubstituteExpr(&sf.GetArgs()[1], lp, candidateExpr, sf.GetArgs()[0].GetType(ectx).EvalType(), schema, column, opt))
 		}
 		for candidateExpr, column := range exprToColumn {
-			collectChanged(tryToSubstituteExpr(&sf.GetArgs()[0], lp, candidateExpr, sf.GetArgs()[1].GetType().EvalType(), schema, column, opt))
+			collectChanged(tryToSubstituteExpr(&sf.GetArgs()[0], lp, candidateExpr, sf.GetArgs()[1].GetType(ectx).EvalType(), schema, column, opt))
 		}
 	case ast.In:
 		expr = &sf.GetArgs()[0]
-		tp = sf.GetArgs()[1].GetType().EvalType()
+		tp = sf.GetArgs()[1].GetType(ectx).EvalType()
 		canSubstitute := true
 		// Can only substitute if all the operands on the right-hand
 		// side are the same type.
 		for i := 1; i < len(sf.GetArgs()); i++ {
-			if sf.GetArgs()[i].GetType().EvalType() != tp {
+			if sf.GetArgs()[i].GetType(ectx).EvalType() != tp {
 				canSubstitute = false
 				break
 			}
@@ -161,7 +164,7 @@ func substituteExpression(cond expression.Expression, lp base.LogicalPlan, exprT
 		}
 	case ast.Like:
 		expr = &sf.GetArgs()[0]
-		tp = sf.GetArgs()[1].GetType().EvalType()
+		tp = sf.GetArgs()[1].GetType(ectx).EvalType()
 		for candidateExpr, column := range exprToColumn {
 			collectChanged(tryToSubstituteExpr(expr, lp, candidateExpr, tp, schema, column, opt))
 		}
@@ -176,6 +179,7 @@ func substituteExpression(cond expression.Expression, lp base.LogicalPlan, exprT
 
 func (gc *gcSubstituter) substitute(ctx context.Context, lp base.LogicalPlan, exprToColumn ExprColumnMap, opt *optimizetrace.LogicalOptimizeOp) base.LogicalPlan {
 	var tp types.EvalType
+	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	switch x := lp.(type) {
 	case *LogicalSelection:
 		for _, cond := range x.Conditions {
@@ -183,14 +187,14 @@ func (gc *gcSubstituter) substitute(ctx context.Context, lp base.LogicalPlan, ex
 		}
 	case *LogicalProjection:
 		for i := range x.Exprs {
-			tp = x.Exprs[i].GetType().EvalType()
+			tp = x.Exprs[i].GetType(ectx).EvalType()
 			for candidateExpr, column := range exprToColumn {
 				tryToSubstituteExpr(&x.Exprs[i], lp, candidateExpr, tp, x.Children()[0].Schema(), column, opt)
 			}
 		}
 	case *LogicalSort:
 		for i := range x.ByItems {
-			tp = x.ByItems[i].Expr.GetType().EvalType()
+			tp = x.ByItems[i].Expr.GetType(ectx).EvalType()
 			for candidateExpr, column := range exprToColumn {
 				tryToSubstituteExpr(&x.ByItems[i].Expr, lp, candidateExpr, tp, x.Schema(), column, opt)
 			}
@@ -198,9 +202,9 @@ func (gc *gcSubstituter) substitute(ctx context.Context, lp base.LogicalPlan, ex
 	case *LogicalAggregation:
 		for _, aggFunc := range x.AggFuncs {
 			for i := 0; i < len(aggFunc.Args); i++ {
-				tp = aggFunc.Args[i].GetType().EvalType()
+				tp = aggFunc.Args[i].GetType(ectx).EvalType()
 				for candidateExpr, column := range exprToColumn {
-					if aggFunc.Args[i].Equal(lp.SCtx().GetExprCtx().GetEvalCtx(), candidateExpr) && candidateExpr.GetType().EvalType() == tp &&
+					if aggFunc.Args[i].Equal(lp.SCtx().GetExprCtx().GetEvalCtx(), candidateExpr) && candidateExpr.GetType(ectx).EvalType() == tp &&
 						x.Schema().ColumnIndex(column) != -1 {
 						aggFunc.Args[i] = column
 						appendSubstituteColumnStep(lp, candidateExpr, column, opt)
@@ -209,9 +213,9 @@ func (gc *gcSubstituter) substitute(ctx context.Context, lp base.LogicalPlan, ex
 			}
 		}
 		for i := 0; i < len(x.GroupByItems); i++ {
-			tp = x.GroupByItems[i].GetType().EvalType()
+			tp = x.GroupByItems[i].GetType(ectx).EvalType()
 			for candidateExpr, column := range exprToColumn {
-				if x.GroupByItems[i].Equal(lp.SCtx().GetExprCtx().GetEvalCtx(), candidateExpr) && candidateExpr.GetType().EvalType() == tp &&
+				if x.GroupByItems[i].Equal(lp.SCtx().GetExprCtx().GetEvalCtx(), candidateExpr) && candidateExpr.GetType(ectx).EvalType() == tp &&
 					x.Schema().ColumnIndex(column) != -1 {
 					x.GroupByItems[i] = column
 					appendSubstituteColumnStep(lp, candidateExpr, column, opt)

--- a/pkg/planner/core/rule_inject_extra_projection.go
+++ b/pkg/planner/core/rule_inject_extra_projection.go
@@ -139,6 +139,7 @@ func InjectProjBelowAgg(aggPlan base.PhysicalPlan, aggFuncs []*aggregation.AggFu
 	projExprs := make([]expression.Expression, 0, cap(projSchemaCols))
 	cursor := 0
 
+	ectx := aggPlan.SCtx().GetExprCtx().GetEvalCtx()
 	for _, f := range aggFuncs {
 		for i, arg := range f.Args {
 			if _, isCnst := arg.(*expression.Constant); isCnst {
@@ -147,7 +148,7 @@ func InjectProjBelowAgg(aggPlan base.PhysicalPlan, aggFuncs []*aggregation.AggFu
 			projExprs = append(projExprs, arg)
 			newArg := &expression.Column{
 				UniqueID: aggPlan.SCtx().GetSessionVars().AllocPlanColumnID(),
-				RetType:  arg.GetType(),
+				RetType:  arg.GetType(ectx),
 				Index:    cursor,
 			}
 			projSchemaCols = append(projSchemaCols, newArg)
@@ -161,7 +162,7 @@ func InjectProjBelowAgg(aggPlan base.PhysicalPlan, aggFuncs []*aggregation.AggFu
 			projExprs = append(projExprs, byItem.Expr)
 			newArg := &expression.Column{
 				UniqueID: aggPlan.SCtx().GetSessionVars().AllocPlanColumnID(),
-				RetType:  byItem.Expr.GetType(),
+				RetType:  byItem.Expr.GetType(ectx),
 				Index:    cursor,
 			}
 			projSchemaCols = append(projSchemaCols, newArg)
@@ -177,7 +178,7 @@ func InjectProjBelowAgg(aggPlan base.PhysicalPlan, aggFuncs []*aggregation.AggFu
 		projExprs = append(projExprs, item)
 		newArg := &expression.Column{
 			UniqueID: aggPlan.SCtx().GetSessionVars().AllocPlanColumnID(),
-			RetType:  item.GetType(),
+			RetType:  item.GetType(ectx),
 			Index:    cursor,
 		}
 		projSchemaCols = append(projSchemaCols, newArg)
@@ -246,7 +247,7 @@ func InjectProjBelowSort(p base.PhysicalPlan, orderByItems []*util.ByItems) base
 		bottomProjExprs = append(bottomProjExprs, itemExpr)
 		newArg := &expression.Column{
 			UniqueID: p.SCtx().GetSessionVars().AllocPlanColumnID(),
-			RetType:  itemExpr.GetType(),
+			RetType:  itemExpr.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 			Index:    len(bottomProjSchemaCols),
 		}
 		bottomProjSchemaCols = append(bottomProjSchemaCols, newArg)
@@ -297,7 +298,7 @@ func TurnNominalSortIntoProj(p base.PhysicalPlan, onlyColumn bool, orderByItems 
 		bottomProjExprs = append(bottomProjExprs, itemExpr)
 		newArg := &expression.Column{
 			UniqueID: p.SCtx().GetSessionVars().AllocPlanColumnID(),
-			RetType:  itemExpr.GetType(),
+			RetType:  itemExpr.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 			Index:    len(bottomProjSchemaCols),
 		}
 		bottomProjSchemaCols = append(bottomProjSchemaCols, newArg)

--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -513,7 +513,7 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 				rightNode, leftNode = leftPlan, rightPlan
 				usedEdges = append(usedEdges, edge)
 			} else {
-				newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(), rCol, lCol).(*expression.ScalarFunction)
+				newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetStaticType(), rCol, lCol).(*expression.ScalarFunction)
 
 				// after creating the new EQ function, the 2 args might not be column anymore, for example `sf=sf(cast(col))`,
 				// which breaks the assumption that join eq keys must be `col=col`, to handle this, inject 2 projections.
@@ -527,7 +527,7 @@ func (s *baseSingleGroupJoinOrderSolver) checkConnection(leftPlan, rightPlan bas
 						rightPlan, lCol = s.injectExpr(rightPlan, newSf.GetArgs()[1])
 					}
 					leftNode, rightNode = leftPlan, rightPlan
-					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetType(),
+					newSf = expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.GetStaticType(),
 						rCol, lCol).(*expression.ScalarFunction)
 				}
 				usedEdges = append(usedEdges, newSf)

--- a/pkg/planner/core/rule_join_reorder_dp.go
+++ b/pkg/planner/core/rule_join_reorder_dp.go
@@ -249,7 +249,7 @@ func (s *joinReorderDPSolver) newJoinWithEdge(leftPlan, rightPlan base.LogicalPl
 		if leftPlan.Schema().Contains(lCol) {
 			eqConds = append(eqConds, edge.edge)
 		} else {
-			newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.edge.GetType(), rCol, lCol).(*expression.ScalarFunction)
+			newSf := expression.NewFunctionInternal(s.ctx.GetExprCtx(), ast.EQ, edge.edge.GetStaticType(), rCol, lCol).(*expression.ScalarFunction)
 			eqConds = append(eqConds, newSf)
 		}
 	}

--- a/pkg/planner/core/rule_max_min_eliminate.go
+++ b/pkg/planner/core/rule_max_min_eliminate.go
@@ -183,7 +183,7 @@ func (*maxMinEliminator) eliminateSingleMaxMin(agg *LogicalAggregation, opt *opt
 	// If there's no column in f.GetArgs()[0], we still need limit and read data from real table because the result should be NULL if the input is empty.
 	if len(expression.ExtractColumns(f.Args[0])) > 0 {
 		// If it can be NULL, we need to filter NULL out first.
-		if !mysql.HasNotNullFlag(f.Args[0].GetType().GetFlag()) {
+		if !mysql.HasNotNullFlag(f.Args[0].GetType(ctx.GetExprCtx().GetEvalCtx()).GetFlag()) {
 			sel = LogicalSelection{}.Init(ctx, agg.QueryBlockOffset())
 			isNullFunc := expression.NewFunctionInternal(ctx.GetExprCtx(), ast.IsNull, types.NewFieldType(mysql.TypeTiny), f.Args[0])
 			notNullFunc := expression.NewFunctionInternal(ctx.GetExprCtx(), ast.UnaryNot, types.NewFieldType(mysql.TypeTiny), isNullFunc)

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -1027,7 +1027,7 @@ func (s *partitionProcessor) pruneRangePartition(ctx base.PlanContext, pi *model
 	pruner := rangePruner{
 		lessThan: lessThanDataInt{
 			data:     partExpr.ForRangePruning.LessThan,
-			unsigned: mysql.HasUnsignedFlag(col.GetType().GetFlag()),
+			unsigned: mysql.HasUnsignedFlag(col.GetStaticType().GetFlag()),
 			maxvalue: partExpr.ForRangePruning.MaxValue,
 		},
 		col:        col,
@@ -1161,7 +1161,7 @@ func minCmp(ctx base.PlanContext, lowVal []types.Datum, columnsPruner *rangeColu
 							return false
 						}
 					} else {
-						if con.Value.GetInt64() == types.IntergerSignedLowerBound(col.GetType().GetType()) {
+						if con.Value.GetInt64() == types.IntergerSignedLowerBound(col.GetStaticType().GetType()) {
 							return false
 						}
 					}
@@ -1422,10 +1422,10 @@ func partitionRangeForInExpr(sctx base.PlanContext, args []expression.Expression
 			// replace fn(col) to fn(const)
 			partFnConst := replaceColumnWithConst(pruner.partFn, constExpr)
 			val, _, err = partFnConst.EvalInt(sctx.GetExprCtx().GetEvalCtx(), chunk.Row{})
-			unsigned = mysql.HasUnsignedFlag(partFnConst.GetType().GetFlag())
+			unsigned = mysql.HasUnsignedFlag(partFnConst.GetStaticType().GetFlag())
 		} else {
 			val, _, err = constExpr.EvalInt(sctx.GetExprCtx().GetEvalCtx(), chunk.Row{})
-			unsigned = mysql.HasUnsignedFlag(constExpr.GetType().GetFlag())
+			unsigned = mysql.HasUnsignedFlag(constExpr.GetType(sctx.GetExprCtx().GetEvalCtx()).GetFlag())
 		}
 		if err != nil {
 			return pruner.fullRange()
@@ -1543,7 +1543,7 @@ func (p *rangePruner) extractDataForPrune(sctx base.PlanContext, expr expression
 	c, isNull, err := constExpr.EvalInt(sctx.GetExprCtx().GetEvalCtx(), chunk.Row{})
 	if err == nil && !isNull {
 		ret.c = c
-		ret.unsigned = mysql.HasUnsignedFlag(constExpr.GetType().GetFlag())
+		ret.unsigned = mysql.HasUnsignedFlag(constExpr.GetType(sctx.GetExprCtx().GetEvalCtx()).GetFlag())
 		return ret, true
 	}
 	return ret, false

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -346,14 +346,14 @@ func (p *LogicalProjection) appendExpr(expr expression.Expression) *expression.C
 
 	col := &expression.Column{
 		UniqueID: p.SCtx().GetSessionVars().AllocPlanColumnID(),
-		RetType:  expr.GetType().Clone(),
+		RetType:  expr.GetType(p.SCtx().GetExprCtx().GetEvalCtx()).Clone(),
 	}
 	col.SetCoercibility(expr.Coercibility())
 	col.SetRepertoire(expr.Repertoire())
 	p.schema.Append(col)
 	// reset ParseToJSONFlag in order to keep the flag away from json column
-	if col.GetType().GetType() == mysql.TypeJSON {
-		col.GetType().DelFlag(mysql.ParseToJSONFlag)
+	if col.GetStaticType().GetType() == mysql.TypeJSON {
+		col.GetStaticType().DelFlag(mysql.ParseToJSONFlag)
 	}
 	return col
 }

--- a/pkg/planner/core/runtime_filter_generator.go
+++ b/pkg/planner/core/runtime_filter_generator.go
@@ -208,14 +208,14 @@ func (*RuntimeFilterGenerator) matchEQPredicate(eqPredicate *expression.ScalarFu
 		return false
 	}
 	// match data type
-	srcColumnType := srcColumn.GetType().GetType()
+	srcColumnType := srcColumn.GetStaticType().GetType()
 	if srcColumnType == mysql.TypeJSON || srcColumnType == mysql.TypeBlob ||
 		srcColumnType == mysql.TypeLongBlob || srcColumnType == mysql.TypeMediumBlob ||
-		srcColumnType == mysql.TypeTinyBlob || srcColumn.GetType().Hybrid() || srcColumn.GetType().IsArray() {
+		srcColumnType == mysql.TypeTinyBlob || srcColumn.GetStaticType().Hybrid() || srcColumn.GetStaticType().IsArray() {
 		logutil.BgLogger().Debug("Src column type does not match RF pattern",
 			zap.String("EQPredicate", eqPredicate.String()),
 			zap.String("SrcColumn", srcColumn.String()),
-			zap.String("SrcColumnType", srcColumn.GetType().String()))
+			zap.String("SrcColumnType", srcColumn.GetStaticType().String()))
 		return false
 	}
 	return true

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -151,7 +151,7 @@ func (*ScalarSubQueryExpr) EvalJSON(_ expression.EvalContext, _ chunk.Row) (val 
 }
 
 // GetType implements the Expression interface.
-func (s *ScalarSubQueryExpr) GetType() *types.FieldType {
+func (s *ScalarSubQueryExpr) GetType(_ expression.EvalContext) *types.FieldType {
 	return s.RetType
 }
 

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -50,7 +50,8 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 			newArgs := make([]expression.Expression, 0, 2)
 			newArgs = append(newArgs, expr.GetArgs()[0])
 			newArgs = append(newArgs, arg)
-			eQCondition, err := expression.NewFunction(ctx.GetExprCtx(), ast.EQ, expr.GetType(), newArgs...)
+			eQCondition, err := expression.NewFunction(ctx.GetExprCtx(), ast.EQ,
+				expr.GetType(ctx.GetExprCtx().GetEvalCtx()), newArgs...)
 			if err != nil {
 				return false
 			}

--- a/pkg/store/mockstore/mockcopr/cop_handler_dag.go
+++ b/pkg/store/mockstore/mockcopr/cop_handler_dag.go
@@ -385,7 +385,7 @@ func (h coprHandler) buildStreamAgg(ctx *dagContext, executor *tipb.Executor) (*
 	}
 	groupByCollators := make([]collate.Collator, 0, len(groupBys))
 	for _, expr := range groupBys {
-		groupByCollators = append(groupByCollators, collate.GetCollator(expr.GetType().GetCollate()))
+		groupByCollators = append(groupByCollators, collate.GetCollator(expr.GetType(ctx.evalCtx.sctx.GetExprCtx().GetEvalCtx()).GetCollate()))
 	}
 
 	return &streamAggExec{

--- a/pkg/store/mockstore/unistore/cophandler/mpp.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp.go
@@ -464,7 +464,7 @@ func (b *mppExecBuilder) buildMPPProj(proj *tipb.Projection) (*projExec, error) 
 			return nil, errors.Trace(err)
 		}
 		e.exprs = append(e.exprs, expr)
-		e.fieldTypes = append(e.fieldTypes, expr.GetType())
+		e.fieldTypes = append(e.fieldTypes, expr.GetType(b.sctx.GetExprCtx().GetEvalCtx()))
 	}
 	return e, nil
 }

--- a/pkg/table/constraint.go
+++ b/pkg/table/constraint.go
@@ -233,12 +233,12 @@ func hasSpecifiedCol(cols []model.CIStr, col model.CIStr) bool {
 }
 
 // IfCheckConstraintExprBoolType checks whether the check expression is bool type
-func IfCheckConstraintExprBoolType(info *model.ConstraintInfo, tableInfo *model.TableInfo) error {
+func IfCheckConstraintExprBoolType(ctx expression.EvalContext, info *model.ConstraintInfo, tableInfo *model.TableInfo) error {
 	cons, err := ToConstraint(info, tableInfo)
 	if err != nil {
 		return err
 	}
-	if !mysql.HasIsBooleanFlag(cons.ConstraintExpr.GetType().GetFlag()) {
+	if !mysql.HasIsBooleanFlag(cons.ConstraintExpr.GetType(ctx).GetFlag()) {
 		return dbterror.ErrNonBooleanExprForCheckConstraint.GenWithStackByArgs(cons.Name)
 	}
 	return nil

--- a/pkg/util/ranger/checker.go
+++ b/pkg/util/ranger/checker.go
@@ -31,7 +31,7 @@ type conditionChecker struct {
 }
 
 func (c *conditionChecker) isFullLengthColumn() bool {
-	return c.length == types.UnspecifiedLength || c.length == c.checkerCol.GetType().GetFlen()
+	return c.length == types.UnspecifiedLength || c.length == c.checkerCol.GetType(c.ctx).GetFlen()
 }
 
 // check returns two values, isAccessCond and shouldReserve.
@@ -66,7 +66,7 @@ func (c *conditionChecker) checkScalarFunction(scalar *expression.ScalarFunction
 		if _, ok := scalar.GetArgs()[0].(*expression.Constant); ok {
 			if c.matchColumn(scalar.GetArgs()[1]) {
 				// Checks whether the scalar function is calculated use the collation compatible with the column.
-				if scalar.GetArgs()[1].GetType().EvalType() == types.ETString && !collate.CompatibleCollate(scalar.GetArgs()[1].GetType().GetCollate(), collation) {
+				if scalar.GetArgs()[1].GetType(c.ctx).EvalType() == types.ETString && !collate.CompatibleCollate(scalar.GetArgs()[1].GetType(c.ctx).GetCollate(), collation) {
 					return false, true
 				}
 				isFullLength := c.isFullLengthColumn()
@@ -79,7 +79,7 @@ func (c *conditionChecker) checkScalarFunction(scalar *expression.ScalarFunction
 		if _, ok := scalar.GetArgs()[1].(*expression.Constant); ok {
 			if c.matchColumn(scalar.GetArgs()[0]) {
 				// Checks whether the scalar function is calculated use the collation compatible with the column.
-				if scalar.GetArgs()[0].GetType().EvalType() == types.ETString && !collate.CompatibleCollate(scalar.GetArgs()[0].GetType().GetCollate(), collation) {
+				if scalar.GetArgs()[0].GetType(c.ctx).EvalType() == types.ETString && !collate.CompatibleCollate(scalar.GetArgs()[0].GetType(c.ctx).GetCollate(), collation) {
 					return false, true
 				}
 				isFullLength := c.isFullLengthColumn()
@@ -120,7 +120,7 @@ func (c *conditionChecker) checkScalarFunction(scalar *expression.ScalarFunction
 		if !c.matchColumn(scalar.GetArgs()[0]) {
 			return false, true
 		}
-		if scalar.GetArgs()[0].GetType().EvalType() == types.ETString && !collate.CompatibleCollate(scalar.GetArgs()[0].GetType().GetCollate(), collation) {
+		if scalar.GetArgs()[0].GetType(c.ctx).EvalType() == types.ETString && !collate.CompatibleCollate(scalar.GetArgs()[0].GetType(c.ctx).GetCollate(), collation) {
 			return false, true
 		}
 		for _, v := range scalar.GetArgs()[1:] {
@@ -140,7 +140,7 @@ func (c *conditionChecker) checkScalarFunction(scalar *expression.ScalarFunction
 
 func (c *conditionChecker) checkLikeFunc(scalar *expression.ScalarFunction) (isAccessCond, shouldReserve bool) {
 	_, collation := scalar.CharsetAndCollation()
-	if !collate.CompatibleCollate(scalar.GetArgs()[0].GetType().GetCollate(), collation) {
+	if !collate.CompatibleCollate(scalar.GetArgs()[0].GetType(c.ctx).GetCollate(), collation) {
 		return false, true
 	}
 	if !c.matchColumn(scalar.GetArgs()[0]) {
@@ -185,7 +185,7 @@ func (c *conditionChecker) checkLikeFunc(scalar *expression.ScalarFunction) (isA
 		if patternStr[i] == '%' {
 			// We currently do not support using `enum like 'xxx%'` to build range
 			// see https://github.com/pingcap/tidb/issues/27130 for more details
-			if scalar.GetArgs()[0].GetType().GetType() == mysql.TypeEnum {
+			if scalar.GetArgs()[0].GetType(c.ctx).GetType() == mysql.TypeEnum {
 				return false, true
 			}
 			if i != len(patternStr)-1 {
@@ -196,7 +196,7 @@ func (c *conditionChecker) checkLikeFunc(scalar *expression.ScalarFunction) (isA
 		if patternStr[i] == '_' {
 			// We currently do not support using `enum like 'xxx_'` to build range
 			// see https://github.com/pingcap/tidb/issues/27130 for more details
-			if scalar.GetArgs()[0].GetType().GetType() == mysql.TypeEnum {
+			if scalar.GetArgs()[0].GetType(c.ctx).GetType() == mysql.TypeEnum {
 				return false, true
 			}
 			likeFuncReserve = true

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -631,8 +631,8 @@ func ExtractEqAndInCondition(sctx *rangerctx.RangerContext, conditions []express
 		}
 		// Multiple Eq/In conditions for one column in CNF, apply intersection on them
 		// Lazily compute the points for the previously visited Eq/In
-		newTp := newFieldType(cols[offset].GetType())
-		collator := collate.GetCollator(cols[offset].GetType().GetCollate())
+		newTp := newFieldType(cols[offset].GetType(sctx.ExprCtx.GetEvalCtx()))
+		collator := collate.GetCollator(cols[offset].GetType(sctx.ExprCtx.GetEvalCtx()).GetCollate())
 		if mergedAccesses[offset] == nil {
 			mergedAccesses[offset] = accesses[offset]
 			// Note that this is a relatively special usage of build(). We will restore the points back to Expression for
@@ -704,7 +704,7 @@ func ExtractEqAndInCondition(sctx *rangerctx.RangerContext, conditions []express
 		// However, please notice that if you're implementing this, please (1) set StatementContext.OptimDependOnMutableConst to true,
 		// or (2) don't do this optimization when StatementContext.UseCache is true. That's because this plan is affected by
 		// flen of user variable, we cannot cache this plan.
-		isFullLength := lengths[i] == types.UnspecifiedLength || lengths[i] == cols[i].GetType().GetFlen()
+		isFullLength := lengths[i] == types.UnspecifiedLength || lengths[i] == cols[i].GetType(sctx.ExprCtx.GetEvalCtx()).GetFlen()
 		if !isFullLength {
 			filters = append(filters, cond)
 		}

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -329,7 +329,7 @@ func (r *builder) buildFromBinOp(
 			value.SetString(value.GetString(), col.RetType.GetCollate())
 		}
 		// If nulleq with null value, values.ToInt64 will return err
-		if col.GetType().GetType() == mysql.TypeYear && !value.IsNull() {
+		if col.GetType(r.sctx.ExprCtx.GetEvalCtx()).GetType() == mysql.TypeYear && !value.IsNull() {
 			// Convert the out-of-range uint number to int and then let the following logic can handle it correctly.
 			// Since the max value of year is 2155, `col op MaxUint` should have the same result with `col op MaxInt`.
 			if value.Kind() == types.KindUint64 && value.GetUint64() > math.MaxInt64 {
@@ -657,7 +657,7 @@ func (r *builder) buildFromIn(
 	list := expr.GetArgs()[1:]
 	rangePoints := make([]*point, 0, len(list)*2)
 	hasNull := false
-	ft := expr.GetArgs()[0].GetType()
+	ft := expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx())
 	colCollate := ft.GetCollate()
 	tc := r.sctx.TypeCtx
 	evalCtx := r.sctx.ExprCtx.GetEvalCtx()
@@ -676,11 +676,11 @@ func (r *builder) buildFromIn(
 			hasNull = true
 			continue
 		}
-		if expr.GetArgs()[0].GetType().GetType() == mysql.TypeEnum {
+		if expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetType() == mysql.TypeEnum {
 			switch dt.Kind() {
 			case types.KindString, types.KindBytes, types.KindBinaryLiteral:
 				// Can't use ConvertTo directly, since we shouldn't convert numerical string to Enum in select stmt.
-				targetType := expr.GetArgs()[0].GetType()
+				targetType := expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx())
 				enum, parseErr := types.ParseEnumName(targetType.GetElems(), dt.GetString(), targetType.GetCollate())
 				if parseErr == nil {
 					dt.SetMysqlEnum(enum, targetType.GetCollate())
@@ -688,7 +688,7 @@ func (r *builder) buildFromIn(
 					err = parseErr
 				}
 			default:
-				dt, err = dt.ConvertTo(tc, expr.GetArgs()[0].GetType())
+				dt, err = dt.ConvertTo(tc, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
 			}
 
 			if err != nil {
@@ -696,15 +696,15 @@ func (r *builder) buildFromIn(
 				continue
 			}
 		}
-		if expr.GetArgs()[0].GetType().GetType() == mysql.TypeYear {
-			dt, err = dt.ConvertToMysqlYear(tc, expr.GetArgs()[0].GetType())
+		if expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetType() == mysql.TypeYear {
+			dt, err = dt.ConvertToMysqlYear(tc, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
 			if err != nil {
 				// in (..., an impossible value (not valid year), ...), the range is empty, so skip it.
 				continue
 			}
 		}
-		if expr.GetArgs()[0].GetType().EvalType() == types.ETString && (dt.Kind() == types.KindString || dt.Kind() == types.KindBinaryLiteral) {
-			dt.SetString(dt.GetString(), expr.GetArgs()[0].GetType().GetCollate()) // refine the string like what we did in builder.buildFromBinOp
+		if expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).EvalType() == types.ETString && (dt.Kind() == types.KindString || dt.Kind() == types.KindBinaryLiteral) {
+			dt.SetString(dt.GetString(), expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetCollate()) // refine the string like what we did in builder.buildFromBinOp
 		}
 		var startValue, endValue types.Datum
 		dt.Copy(&startValue)
@@ -752,11 +752,11 @@ func (r *builder) newBuildFromPatternLike(
 	convertToSortKey bool,
 ) []*point {
 	_, collation := expr.CharsetAndCollation()
-	if !collate.CompatibleCollate(expr.GetArgs()[0].GetType().GetCollate(), collation) {
+	if !collate.CompatibleCollate(expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()).GetCollate(), collation) {
 		return getFullRange()
 	}
 	pdt, err := expr.GetArgs()[1].(*expression.Constant).Eval(r.sctx.ExprCtx.GetEvalCtx(), chunk.Row{})
-	tpOfPattern := expr.GetArgs()[0].GetType()
+	tpOfPattern := expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx())
 	if err != nil {
 		r.err = errors.Trace(err)
 		return getFullRange()
@@ -951,7 +951,7 @@ func (r *builder) buildFromNot(
 		// Append the interval (last element, max value].
 		retRangePoints = append(retRangePoints, &point{value: previousValue, start: true, excl: true})
 		retRangePoints = append(retRangePoints, &point{value: types.MaxValueDatum()})
-		cutPrefixForPoints(retRangePoints, prefixLen, expr.GetArgs()[0].GetType())
+		cutPrefixForPoints(retRangePoints, prefixLen, expr.GetArgs()[0].GetType(r.sctx.ExprCtx.GetEvalCtx()))
 		if convertToSortKey {
 			var err error
 			retRangePoints, err = pointsConvertToSortKey(r.sctx, retRangePoints, newTp)

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -732,7 +732,7 @@ func newFieldType(tp *types.FieldType) *types.FieldType {
 func points2EqOrInCond(ctx expression.BuildContext, points []*point, col *expression.Column) expression.Expression {
 	// len(points) cannot be 0 here, since we impose early termination in ExtractEqAndInCondition
 	// Constant and Column args should have same RetType, simply get from first arg
-	retType := col.GetType()
+	retType := col.GetType(ctx.GetEvalCtx())
 	args := make([]expression.Expression, 0, len(points)/2)
 	args = append(args, col)
 	for i := 0; i < len(points); i = i + 2 {
@@ -746,7 +746,7 @@ func points2EqOrInCond(ctx expression.BuildContext, points []*point, col *expres
 	if len(args) > 2 {
 		funcName = ast.In
 	}
-	return expression.NewFunctionInternal(ctx, funcName, col.GetType(), args...)
+	return expression.NewFunctionInternal(ctx, funcName, col.GetType(ctx.GetEvalCtx()), args...)
 }
 
 // RangesToString print a list of Ranges into a string which can appear in an SQL as a condition.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53653

Problem Summary:

Ref https://github.com/pingcap/tidb/issues/53533 and https://github.com/pingcap/tidb/pull/53534. This PR splits the first commit of #53534  to make it easier to review.

The goal is to remove the `sessionctx.Session` inside the `Constant`. Instead, we should pass the session context through argument, especially for function `String()` and `GetType()`. This PR modifies the `GetType()` part. To make sure this patch can work standalone, the internal session in `Constant` is not removed yet. It'll be removed in https://github.com/pingcap/tidb/pull/53534 (which is ready, but is too long to review).

### What changed and how does it work?

This PR adds an argument `EvalType` to the method `GetType` in `Expression`, so that in the future, the 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
  > This refactor should be covered by existing tests. It shouldn't change any logic.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
