### PR TITLE
statistics: clean up dropped predicate columns stats usage

### DIFF
--- a/pkg/statistics/handle/usage/BUILD.bazel
+++ b/pkg/statistics/handle/usage/BUILD.bazel
@@ -35,10 +35,12 @@ go_test(
     timeout = "short",
     srcs = [
         "index_usage_integration_test.go",
+        "predicate_column_test.go",
         "session_stats_collect_test.go",
     ],
     embed = [":usage"],
     flaky = True,
+    shard_count = 3,
     deps = [
         "//pkg/infoschema",
         "//pkg/parser/model",

--- a/pkg/statistics/handle/usage/predicate_column_test.go
+++ b/pkg/statistics/handle/usage/predicate_column_test.go
@@ -52,6 +52,5 @@ func TestCleanupPredicateColumns(t *testing.T) {
 	require.NoError(t, err)
 	columns, err := h.GetPredicateColumns(tbl.Meta().ID)
 	require.NoError(t, err)
-	// FIXME: cleanup predicate columns.
-	require.Len(t, columns, 2)
+	require.Len(t, columns, 1)
 }

--- a/pkg/statistics/handle/usage/predicate_column_test.go
+++ b/pkg/statistics/handle/usage/predicate_column_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupPredicateColumns(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	// Create table and select data with predicate.
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
+	// Enable column tracking.
+	tk.MustExec("set global tidb_enable_column_tracking = 1")
+	tk.MustQuery("select * from t where a > 1").Check(testkit.Rows("2 2", "3 3"))
+	tk.MustQuery("select * from t where b > 1").Check(testkit.Rows("2 2", "3 3"))
+
+	// Dump the statistics usage.
+	h := dom.StatsHandle()
+	err := h.DumpColStatsUsageToKV()
+	require.NoError(t, err)
+
+	// Check the statistics usage.
+	rows := tk.MustQuery("select * from mysql.column_stats_usage").Rows()
+	require.Len(t, rows, 2)
+
+	// Drop column b.
+	tk.MustExec("alter table t drop column b")
+	// Get table ID.
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	columns, err := h.GetPredicateColumns(tbl.Meta().ID)
+	require.NoError(t, err)
+	// FIXME: cleanup predicate columns.
+	require.Len(t, columns, 2)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/53567


Problem Summary:

We need to clean up the outdated predicate columns that have been dropped from the schema.
Otherwise, we will attempt to analyze non-existent columns.

### What changed and how does it work?

1. Added a test case to verify current behavior.
2. Added a new function to clean up the non-existent columns before we get the predicate columns.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
