### PR TITLE
domain: fix unstable test TestRepairTable

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -283,8 +283,10 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 		is, relatedChanges, diffTypes, err := do.tryLoadSchemaDiffs(m, currentSchemaVersion, neededSchemaVersion, startTS)
 		if err == nil {
 			infoschema_metrics.LoadSchemaDurationLoadDiff.Observe(time.Since(startTime).Seconds())
+			isV2, _ := infoschema.IsV2(is)
 			do.infoCache.Insert(is, schemaTs)
 			logutil.BgLogger().Info("diff load InfoSchema success",
+				zap.Bool("isV2", isV2),
 				zap.Int64("currentSchemaVersion", currentSchemaVersion),
 				zap.Int64("neededSchemaVersion", neededSchemaVersion),
 				zap.Duration("start time", time.Since(startTime)),
@@ -436,7 +438,15 @@ func (*Domain) fetchSchemasWithTables(schemas []*model.DBInfo, m *meta.Meta, don
 			infoschema.ConvertCharsetCollateToLowerCaseIfNeed(tbl)
 			// Check whether the table is in repair mode.
 			if domainutil.RepairInfo.InRepairMode() && domainutil.RepairInfo.CheckAndFetchRepairedTable(di, tbl) {
-				continue
+				if tbl.State == model.StatePublic {
+					// If the state is public, it means that the DDL job is done, but the table
+					// haven't been deleted from the repair table list.
+					// Since the repairment is done and table is visible, we should load it.
+				} else {
+					// Do not load it because we are reparing the table and the table info could be `bad`
+					// before repair is done.
+					continue
+				}
 			}
 			di.Tables = append(di.Tables, tbl)
 		}

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -438,7 +438,7 @@ func (*Domain) fetchSchemasWithTables(schemas []*model.DBInfo, m *meta.Meta, don
 			infoschema.ConvertCharsetCollateToLowerCaseIfNeed(tbl)
 			// Check whether the table is in repair mode.
 			if domainutil.RepairInfo.InRepairMode() && domainutil.RepairInfo.CheckAndFetchRepairedTable(di, tbl) {
-				if !tbl.State == model.StatePublic {
+				if tbl.State != model.StatePublic {
 					// Do not load it because we are reparing the table and the table info could be `bad`
 					// before repair is done.
 					continue

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -438,15 +438,14 @@ func (*Domain) fetchSchemasWithTables(schemas []*model.DBInfo, m *meta.Meta, don
 			infoschema.ConvertCharsetCollateToLowerCaseIfNeed(tbl)
 			// Check whether the table is in repair mode.
 			if domainutil.RepairInfo.InRepairMode() && domainutil.RepairInfo.CheckAndFetchRepairedTable(di, tbl) {
-				if tbl.State == model.StatePublic {
-					// If the state is public, it means that the DDL job is done, but the table
-					// haven't been deleted from the repair table list.
-					// Since the repairment is done and table is visible, we should load it.
-				} else {
+				if !tbl.State == model.StatePublic {
 					// Do not load it because we are reparing the table and the table info could be `bad`
 					// before repair is done.
 					continue
 				}
+				// If the state is public, it means that the DDL job is done, but the table
+				// haven't been deleted from the repair table list.
+				// Since the repairment is done and table is visible, we should load it.
 			}
 			di.Tables = append(di.Tables, tbl)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53667 

Problem Summary:

### What changed and how does it work?

The DDL of 'admin repair table' works like this:

- create a list of tables been repairing
- ddl owner publish the ddl job
- ddl worker receive ddl job, execute onRepairTable function
- repairment done, update the table info, set the DDL state to public
- remove the table from repair table list

After we set the DDL state to public, and just before the table been removed from the list,
If we trigger a full reload of infoschema, we will goto this line:

https://github.com/pingcap/tidb/blob/22c41d0e0c86ddb98dd029d49a2df038d7ac42bf/pkg/domain/domain.go#L437-L440

And tidb will skip loading this table. (but the table is public, the repairment is done in fact)

In the past, the full reload in not triggered so the bug is not exposed.
After we adding infoschema v2 to our CI, the v1 -> v2 switch could trigger a full reload, and expose this bug.


### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test

After this fix, the unit test TestRepairTable become stable.

- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
