### PR TITLE
br: fix Log Backup unexpected paused when adding a already long-running task

### DIFF
--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 30,
+    shard_count = 32,
     deps = [
         ":streamhelper",
         "//br/pkg/errors",

--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 29,
+    shard_count = 30,
     deps = [
         ":streamhelper",
         "//br/pkg/errors",

--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 28,
+    shard_count = 29,
     deps = [
         ":streamhelper",
         "//br/pkg/errors",

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -426,7 +426,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		c.setCheckpoints(spans.Sorted(spans.NewFullWith(e.Ranges, 0)))
 		globalCheckpointTs,ok := c.env.GetGlobalCheckpointForTask(ctx, c.task.Name)
 		if ok != nil {
-			log.Warn("failed to get global checkpoint", zap.String("category", "log backup advancer"))
+			log.Warn("Advancer failed to get global checkpoint")
 			globalCheckpointTs = 0
 		}
 		if globalCheckpointTs < c.task.StartTs {

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -424,7 +424,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		c.task = e.Info
 		c.taskRange = spans.Collapse(len(e.Ranges), func(i int) kv.KeyRange { return e.Ranges[i] })
 		c.setCheckpoints(spans.Sorted(spans.NewFullWith(e.Ranges, 0)))
-		globalCheckpointTs,ok := c.env.GetGlobalCheckpointForTask(ctx, c.task.Name)
+		globalCheckpointTs, ok := c.env.GetGlobalCheckpointForTask(ctx, c.task.Name)
 		if ok != nil {
 			log.Warn("Advancer failed to get global checkpoint")
 			globalCheckpointTs = 0

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -415,7 +415,8 @@ func (c *CheckpointAdvancer) setCheckpoints(cps *spans.ValueSortedFull) {
 	c.checkpointsMu.Unlock()
 }
 
-func (c *CheckpointAdvancer) GetGlobalCheckpointWithRetry(ctx context.Context, maxRetry uint, interval time.Duration) (uint64, error) {
+func (c *CheckpointAdvancer) GetGlobalCheckpointWithRetry(
+	ctx context.Context, maxRetry uint, interval time.Duration) (uint64, error) {
 	var globalCheckpointTs uint64
 	var err error
 	var i uint = 0

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -425,6 +425,10 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		c.taskRange = spans.Collapse(len(e.Ranges), func(i int) kv.KeyRange { return e.Ranges[i] })
 		c.setCheckpoints(spans.Sorted(spans.NewFullWith(e.Ranges, 0)))
 		globalCheckpointTs, err := c.env.GetGlobalCheckpointForTask(ctx, e.Name)
+		if globalCheckpointTs < c.task.StartTs {
+			globalCheckpointTs = c.task.StartTs
+		}
+		log.Info("get global checkpoint", zap.Uint64("checkpoint", globalCheckpointTs))
 		if err != nil {
 			log.Error("failed to get global checkpoint, skipping.", logutil.ShortError(err))
 			return err

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -415,6 +415,24 @@ func (c *CheckpointAdvancer) setCheckpoints(cps *spans.ValueSortedFull) {
 	c.checkpointsMu.Unlock()
 }
 
+func (c *CheckpointAdvancer) GetGlobalCheckpointWithRetry(ctx context.Context, maxRetry uint, interval time.Duration) (uint64, error) {
+	var globalCheckpointTs uint64
+	var err error
+	var i uint = 0
+	for ; i < maxRetry; i++ {
+		globalCheckpointTs, err = c.env.GetGlobalCheckpointForTask(ctx, c.task.Name)
+		if err == nil {
+			break
+		}
+		time.Sleep(interval)
+	}
+
+	if globalCheckpointTs < c.task.StartTs {
+		globalCheckpointTs = c.task.StartTs
+	}
+	return globalCheckpointTs, err
+}
+
 func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error {
 	c.taskMu.Lock()
 	defer c.taskMu.Unlock()
@@ -424,16 +442,12 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		c.task = e.Info
 		c.taskRange = spans.Collapse(len(e.Ranges), func(i int) kv.KeyRange { return e.Ranges[i] })
 		c.setCheckpoints(spans.Sorted(spans.NewFullWith(e.Ranges, 0)))
-		globalCheckpointTs, ok := c.env.GetGlobalCheckpointForTask(ctx, c.task.Name)
-		if ok != nil {
-			log.Warn("Advancer failed to get global checkpoint")
-			globalCheckpointTs = 0
-		}
-		if globalCheckpointTs < c.task.StartTs {
-			globalCheckpointTs = c.task.StartTs
+		globalCheckpointTs, err := c.GetGlobalCheckpointWithRetry(ctx, 3, 100*time.Millisecond)
+		if err != nil {
+			log.Warn("failed to get global checkpoint, skipping.", logutil.ShortError(err))
 		}
 		c.lastCheckpoint = newCheckpointWithTS(globalCheckpointTs)
-		p, err := c.env.BlockGCUntil(ctx, c.task.StartTs)
+		p, err := c.env.BlockGCUntil(ctx, globalCheckpointTs)
 		if err != nil {
 			log.Warn("failed to upload service GC safepoint, skipping.", logutil.ShortError(err))
 		}

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -425,14 +425,14 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		c.taskRange = spans.Collapse(len(e.Ranges), func(i int) kv.KeyRange { return e.Ranges[i] })
 		c.setCheckpoints(spans.Sorted(spans.NewFullWith(e.Ranges, 0)))
 		globalCheckpointTs, err := c.env.GetGlobalCheckpointForTask(ctx, e.Name)
-		if globalCheckpointTs < c.task.StartTs {
-			globalCheckpointTs = c.task.StartTs
-		}
-		log.Info("get global checkpoint", zap.Uint64("checkpoint", globalCheckpointTs))
 		if err != nil {
 			log.Error("failed to get global checkpoint, skipping.", logutil.ShortError(err))
 			return err
 		}
+		if globalCheckpointTs < c.task.StartTs {
+			globalCheckpointTs = c.task.StartTs
+		}
+		log.Info("get global checkpoint", zap.Uint64("checkpoint", globalCheckpointTs))
 		c.lastCheckpoint = newCheckpointWithTS(globalCheckpointTs)
 		p, err := c.env.BlockGCUntil(ctx, globalCheckpointTs)
 		if err != nil {

--- a/br/pkg/streamhelper/advancer_env.go
+++ b/br/pkg/streamhelper/advancer_env.go
@@ -172,6 +172,8 @@ type StreamMeta interface {
 	Begin(ctx context.Context, ch chan<- TaskEvent) error
 	// UploadV3GlobalCheckpointForTask uploads the global checkpoint to the meta store.
 	UploadV3GlobalCheckpointForTask(ctx context.Context, taskName string, checkpoint uint64) error
+	// GetGlobalCheckpointForTask gets the global checkpoint from the meta store.
+	GetGlobalCheckpointForTask(ctx context.Context, taskName string) (uint64, error)
 	// ClearV3GlobalCheckpointForTask clears the global checkpoint to the meta store.
 	ClearV3GlobalCheckpointForTask(ctx context.Context, taskName string) error
 	PauseTask(ctx context.Context, taskName string) error

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -584,9 +584,11 @@ func TestAddTaskWithLaggedStartTS(t *testing.T) {
 		c.CheckPointLagLimit = 1 * time.Minute
 	})
 	c.advanceClusterTimeBy(5 * time.Minute)
-	c.advanceCheckpointBy(5 * time.Minute)
-	env.advanceCheckpointBy(0 * time.Minute)
+	c.advanceCheckpointBy(0 * time.Minute)
+	env.advanceCheckpointBy(5 * time.Minute)
 	adv.StartTaskListener(ctx)
+	require.NoError(t, adv.OnTick(ctx))
+	require.NoError(t, adv.OnTick(ctx))
 	require.NoError(t, adv.OnTick(ctx))
 }
 

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	backup "github.com/pingcap/kvproto/pkg/brpb"
 	logbackup "github.com/pingcap/kvproto/pkg/logbackuppb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/streamhelper"
@@ -20,9 +21,11 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
 	"go.uber.org/atomic"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -171,7 +174,7 @@ func TestOneStoreFailure(t *testing.T) {
 	c.splitAndScatter(splitKeys...)
 	c.flushAll()
 
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 	require.NoError(t, adv.OnTick(ctx))
@@ -195,7 +198,7 @@ func TestGCServiceSafePoint(t *testing.T) {
 	c := createFakeCluster(t, 4, true)
 	ctx := context.Background()
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
@@ -221,7 +224,8 @@ func TestTaskRanges(t *testing.T) {
 	c.splitAndScatter("0001", "0002", "0012", "0034", "0048")
 	c.advanceCheckpoints()
 	c.flushAllExcept("0000", "0049")
-	env := &testEnv{fakeCluster: c, testCtx: t, ranges: []kv.KeyRange{{StartKey: []byte("0002"), EndKey: []byte("0048")}}}
+	env := newTestEnv(c, t)
+	env.ranges = []kv.KeyRange{{StartKey: []byte("0002"), EndKey: []byte("0048")}}
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 
@@ -238,7 +242,8 @@ func TestTaskRangesWithSplit(t *testing.T) {
 	c.splitAndScatter("0012", "0034", "0048")
 	c.advanceCheckpoints()
 	c.flushAllExcept("0049")
-	env := &testEnv{fakeCluster: c, testCtx: t, ranges: []kv.KeyRange{{StartKey: []byte("0002"), EndKey: []byte("0048")}}}
+	env := newTestEnv(c, t)
+	env.ranges = []kv.KeyRange{{StartKey: []byte("0002"), EndKey: []byte("0048")}}
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 
@@ -281,7 +286,7 @@ func TestClearCache(t *testing.T) {
 		}
 		s.clientMu.Unlock()
 	}
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 	var err error
@@ -312,7 +317,7 @@ func TestBlocked(t *testing.T) {
 		marked = true
 	}
 	req.True(marked, "failed to mark the cluster: ")
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 	adv.UpdateConfigWith(func(c *config.Config) {
@@ -343,7 +348,7 @@ func TestResolveLock(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
 	minCheckpoint := c.advanceCheckpoints()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 
 	lockRegion := c.findRegionByKey([]byte("01"))
 	allLocks := []*txnlock.Lock{
@@ -409,7 +414,7 @@ func TestOwnerDropped(t *testing.T) {
 	c := createFakeCluster(t, 4, false)
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	installSubscribeSupport(c)
-	env := &testEnv{testCtx: t, fakeCluster: c}
+	env := newTestEnv(c, t)
 	fp := "github.com/pingcap/tidb/br/pkg/streamhelper/get_subscriber"
 	defer func() {
 		if t.Failed() {
@@ -445,10 +450,7 @@ func TestRemoveTaskAndFlush(t *testing.T) {
 	ctx := context.Background()
 	c := createFakeCluster(t, 4, true)
 	installSubscribeSupport(c)
-	env := &testEnv{
-		fakeCluster: c,
-		testCtx:     t,
-	}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 	adv.SpawnSubscriptionHandler(ctx)
@@ -473,11 +475,29 @@ func TestEnableCheckPointLimit(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+
+	env := newTestEnv(c, t)
+	rngs := env.ranges
+	if len(rngs) == 0 {
+		rngs = []kv.KeyRange{{}}
+	}
+	env.task = streamhelper.TaskEvent{
+		Type: streamhelper.EventAdd,
+		Name: "whole",
+		Info: &backup.StreamBackupTaskInfo{
+			Name:    "whole",
+			StartTs: oracle.GoTimeToTS(oracle.GetTimeFromTS(0).Add(1 * time.Minute)),
+		},
+		Ranges: rngs,
+	}
+	log.Info("Start Time:", zap.Uint64("StartTs", env.task.Info.StartTs))
+
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.UpdateConfigWith(func(c *config.Config) {
 		c.CheckPointLagLimit = 1 * time.Minute
 	})
+	c.advanceClusterTimeBy(1 * time.Minute)
+	c.advanceCheckpointBy(1 * time.Minute)
 	adv.StartTaskListener(ctx)
 	for i := 0; i < 5; i++ {
 		c.advanceClusterTimeBy(30 * time.Second)
@@ -494,13 +514,28 @@ func TestCheckPointLagged(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+
+	env := newTestEnv(c, t)
+	rngs := env.ranges
+	if len(rngs) == 0 {
+		rngs = []kv.KeyRange{{}}
+	}
+	env.task = streamhelper.TaskEvent{
+		Type: streamhelper.EventAdd,
+		Name: "whole",
+		Info: &backup.StreamBackupTaskInfo{
+			Name:    "whole",
+			StartTs: oracle.GoTimeToTS(oracle.GetTimeFromTS(0).Add(1 * time.Minute)),
+		},
+		Ranges: rngs,
+	}
+
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.UpdateConfigWith(func(c *config.Config) {
 		c.CheckPointLagLimit = 1 * time.Minute
 	})
 	adv.StartTaskListener(ctx)
-	c.advanceClusterTimeBy(1 * time.Minute)
+	c.advanceClusterTimeBy(2 * time.Minute)
 	require.NoError(t, adv.OnTick(ctx))
 	c.advanceClusterTimeBy(1 * time.Minute)
 	require.ErrorContains(t, adv.OnTick(ctx), "lagged too large")
@@ -510,6 +545,7 @@ func TestCheckPointLagged(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+// If the paused task are manually resumed, it should run normally
 func TestCheckPointResume(t *testing.T) {
 	c := createFakeCluster(t, 4, false)
 	defer func() {
@@ -518,7 +554,7 @@ func TestCheckPointResume(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.UpdateConfigWith(func(c *config.Config) {
 		c.CheckPointLagLimit = 1 * time.Minute
@@ -550,7 +586,7 @@ func TestUnregisterAfterPause(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.UpdateConfigWith(func(c *config.Config) {
 		c.CheckPointLagLimit = 1 * time.Minute
@@ -570,7 +606,8 @@ func TestUnregisterAfterPause(t *testing.T) {
 	}, 5*time.Second, 300*time.Millisecond)
 }
 
-func TestAddTaskWithLaggedStartTS(t *testing.T) {
+// If the start ts is *NOT* lagged, even both the cluster and pd are lagged, the task should run normally.
+func TestAddTaskWithLongRunTask0(t *testing.T) {
 	c := createFakeCluster(t, 4, false)
 	defer func() {
 		fmt.Println(c)
@@ -578,46 +615,154 @@ func TestAddTaskWithLaggedStartTS(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
-	adv := streamhelper.NewCheckpointAdvancer(env)
-	adv.UpdateConfigWith(func(c *config.Config) {
-		c.CheckPointLagLimit = 1 * time.Minute
-	})
-	c.advanceClusterTimeBy(5 * time.Minute)
-	env.advanceCheckpointBy(5 * time.Minute)
-	// Global checkpoint lagged
-	c.advanceCheckpointBy(0 * time.Minute)
-	adv.StartTaskListener(ctx)
-	// Try update checkpoint
-	require.NoError(t, adv.OnTick(ctx))
-	// Verify no err raised
-	require.NoError(t, adv.OnTick(ctx))
-	require.NoError(t, adv.OnTick(ctx))
-}
 
-func TestAddTaskWithLaggedStartTSFailed(t *testing.T) {
-	c := createFakeCluster(t, 4, false)
-	defer func() {
-		fmt.Println(c)
-	}()
-	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
+	rngs := env.ranges
+	if len(rngs) == 0 {
+		rngs = []kv.KeyRange{{}}
+	}
+	env.task = streamhelper.TaskEvent{
+		Type: streamhelper.EventAdd,
+		Name: "whole",
+		Info: &backup.StreamBackupTaskInfo{
+			Name:    "whole",
+			StartTs: oracle.GoTimeToTS(oracle.GetTimeFromTS(0).Add(2 * time.Minute)),
+		},
+		Ranges: rngs,
+	}
+
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.UpdateConfigWith(func(c *config.Config) {
 		c.CheckPointLagLimit = 1 * time.Minute
 	})
-	c.advanceClusterTimeBy(5 * time.Minute)
-	env.advanceCheckpointBy(5 * time.Minute)
-	// Global checkpoint lagged
-	c.advanceCheckpointBy(0 * time.Minute)
+	c.advanceClusterTimeBy(3 * time.Minute)
+	c.advanceCheckpointBy(1 * time.Minute)
+	env.advanceCheckpointBy(1 * time.Minute)
 	env.mockPDConnectionError()
 	adv.StartTaskListener(ctx)
 	// Try update checkpoint
 	require.NoError(t, adv.OnTick(ctx))
 	// Verify no err raised
 	require.NoError(t, adv.OnTick(ctx))
+}
+
+// If the start ts is lagged, as long as cluster has advanced, the task should run normally.
+func TestAddTaskWithLongRunTask1(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	defer func() {
+		fmt.Println(c)
+	}()
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := newTestEnv(c, t)
+	rngs := env.ranges
+	if len(rngs) == 0 {
+		rngs = []kv.KeyRange{{}}
+	}
+	env.task = streamhelper.TaskEvent{
+		Type: streamhelper.EventAdd,
+		Name: "whole",
+		Info: &backup.StreamBackupTaskInfo{
+			Name:    "whole",
+			StartTs: oracle.GoTimeToTS(oracle.GetTimeFromTS(0).Add(1 * time.Minute)),
+		},
+		Ranges: rngs,
+	}
+
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.Config) {
+		c.CheckPointLagLimit = 1 * time.Minute
+	})
+	c.advanceClusterTimeBy(3 * time.Minute)
+	c.advanceCheckpointBy(2 * time.Minute)
+	env.advanceCheckpointBy(1 * time.Minute)
+	adv.StartTaskListener(ctx)
+	// Try update checkpoint
+	require.NoError(t, adv.OnTick(ctx))
+	// Verify no err raised
+	require.NoError(t, adv.OnTick(ctx))
+}
+
+// If the start ts is lagged, as long as pd stored the advanced checkpoint, the task should run normally.
+// Also, temporary connection error won't affect the task.
+func TestAddTaskWithLongRunTask2(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	defer func() {
+		fmt.Println(c)
+	}()
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := newTestEnv(c, t)
+	rngs := env.ranges
+	if len(rngs) == 0 {
+		rngs = []kv.KeyRange{{}}
+	}
+	env.task = streamhelper.TaskEvent{
+		Type: streamhelper.EventAdd,
+		Name: "whole",
+		Info: &backup.StreamBackupTaskInfo{
+			Name:    "whole",
+			StartTs: oracle.GoTimeToTS(oracle.GetTimeFromTS(0).Add(1 * time.Minute)),
+		},
+		Ranges: rngs,
+	}
+
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.Config) {
+		c.CheckPointLagLimit = 1 * time.Minute
+	})
+	c.advanceClusterTimeBy(3 * time.Minute)
+	c.advanceCheckpointBy(1 * time.Minute)
+	env.advanceCheckpointBy(2 * time.Minute)
+	env.mockPDConnectionError()
+	adv.StartTaskListener(ctx)
+	// Try update checkpoint
+	require.NoError(t, adv.OnTick(ctx))
+	// Verify no err raised
+	require.NoError(t, adv.OnTick(ctx))
+}
+
+// If the start ts, pd, and cluster checkpoint are all lagged, the task should pause.
+func TestAddTaskWithLongRunTask3(t *testing.T) {
+	c := createFakeCluster(t, 4, false)
+	defer func() {
+		fmt.Println(c)
+	}()
+	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := newTestEnv(c, t)
+	rngs := env.ranges
+	if len(rngs) == 0 {
+		rngs = []kv.KeyRange{{}}
+	}
+	env.task = streamhelper.TaskEvent{
+		Type: streamhelper.EventAdd,
+		Name: "whole",
+		Info: &backup.StreamBackupTaskInfo{
+			Name:    "whole",
+			StartTs: oracle.GoTimeToTS(oracle.GetTimeFromTS(0).Add(1 * time.Minute)),
+		},
+		Ranges: rngs,
+	}
+
+	adv := streamhelper.NewCheckpointAdvancer(env)
+	adv.UpdateConfigWith(func(c *config.Config) {
+		c.CheckPointLagLimit = 1 * time.Minute
+	})
+	c.advanceClusterTimeBy(3 * time.Minute)
+	c.advanceCheckpointBy(1 * time.Minute)
+	env.advanceCheckpointBy(1 * time.Minute)
+	env.mockPDConnectionError()
+	adv.StartTaskListener(ctx)
+	// Try update checkpoint
+	require.NoError(t, adv.OnTick(ctx))
+	// Verify no err raised
 	require.NoError(t, adv.OnTick(ctx))
 }
 
@@ -626,7 +771,7 @@ func TestOwnershipLost(t *testing.T) {
 	c.splitAndScatter(manyRegions(0, 10240)...)
 	installSubscribeSupport(c)
 	ctx, cancel := context.WithCancel(context.Background())
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.OnStart(ctx)
 	adv.OnBecomeOwner(ctx)
@@ -647,7 +792,7 @@ func TestSubscriptionPanic(t *testing.T) {
 	c.splitAndScatter(manyRegions(0, 20)...)
 	installSubscribeSupport(c)
 	ctx, cancel := context.WithCancel(context.Background())
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.OnStart(ctx)
 	adv.OnBecomeOwner(ctx)

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -226,6 +226,7 @@ func TestTaskRanges(t *testing.T) {
 	c.flushAllExcept("0000", "0049")
 	env := newTestEnv(c, t)
 	env.ranges = []kv.KeyRange{{StartKey: []byte("0002"), EndKey: []byte("0048")}}
+	env.task.Ranges = env.ranges
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 
@@ -244,6 +245,7 @@ func TestTaskRangesWithSplit(t *testing.T) {
 	c.flushAllExcept("0049")
 	env := newTestEnv(c, t)
 	env.ranges = []kv.KeyRange{{StartKey: []byte("0002"), EndKey: []byte("0048")}}
+	env.task.Ranges = env.ranges
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -41,7 +41,7 @@ func TestBasic(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx := context.Background()
 	minCheckpoint := c.advanceCheckpoints()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	coll := streamhelper.NewClusterCollector(ctx, env)
 	err := adv.GetCheckpointInRange(ctx, []byte{}, []byte{}, coll)
@@ -60,7 +60,7 @@ func TestTick(t *testing.T) {
 	c.splitAndScatter("01", "02", "022", "023", "033", "04", "043")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 	require.NoError(t, adv.OnTick(ctx))
@@ -82,7 +82,7 @@ func TestWithFailure(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	adv.StartTaskListener(ctx)
 	require.NoError(t, adv.OnTick(ctx))
@@ -133,7 +133,7 @@ func TestCollectorFailure(t *testing.T) {
 	}
 	c.splitAndScatter(splitKeys...)
 
-	env := &testEnv{fakeCluster: c, testCtx: t}
+	env := newTestEnv(c, t)
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	coll := streamhelper.NewClusterCollector(ctx, env)
 

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -612,8 +612,7 @@ func TestAddTaskWithLaggedStartTSFailed(t *testing.T) {
 	env.advanceCheckpointBy(5 * time.Minute)
 	// Global checkpoint lagged
 	c.advanceCheckpointBy(0 * time.Minute)
-	// PD lost connection and will resume after some time
-	env.mockPDConnectionError(500 * time.Millisecond)
+	env.mockPDConnectionError()
 	adv.StartTaskListener(ctx)
 	// Try update checkpoint
 	require.NoError(t, adv.OnTick(ctx))

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -763,9 +763,12 @@ func TestAddTaskWithLongRunTask3(t *testing.T) {
 	env.mockPDConnectionError()
 	adv.StartTaskListener(ctx)
 	// Try update checkpoint
-	require.NoError(t, adv.OnTick(ctx))
-	// Verify no err raised
-	require.NoError(t, adv.OnTick(ctx))
+	require.ErrorContains(t, adv.OnTick(ctx), "lagged too large")
+	// Verify no err raised after paused
+	require.Eventually(t, func() bool {
+		err := adv.OnTick(ctx)
+		return err == nil
+	}, 5*time.Second, 300*time.Millisecond)
 }
 
 func TestOwnershipLost(t *testing.T) {

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -714,6 +714,13 @@ func (t *testEnv) getCheckpoint() uint64 {
 	return t.checkpoint
 }
 
+func (t *testEnv) advanceCheckpointBy(duration time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.checkpoint = oracle.GoTimeToTS(oracle.GetTimeFromTS(t.checkpoint).Add(duration))
+}
+
 func (t *testEnv) unregisterTask() {
 	t.taskCh <- streamhelper.TaskEvent{
 		Type: streamhelper.EventDel,

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -680,7 +680,7 @@ func (t *testEnv) UploadV3GlobalCheckpointForTask(ctx context.Context, _ string,
 }
 
 func (t *testEnv) GetGlobalCheckpointForTask(ctx context.Context, taskName string) (uint64, error) {
-	return t.checkpoint,nil
+	return t.checkpoint, nil
 }
 
 func (t *testEnv) ClearV3GlobalCheckpointForTask(ctx context.Context, taskName string) error {

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -679,6 +679,10 @@ func (t *testEnv) UploadV3GlobalCheckpointForTask(ctx context.Context, _ string,
 	return nil
 }
 
+func (t *testEnv) GetGlobalCheckpointForTask(ctx context.Context, taskName string) (uint64, error) {
+	return t.checkpoint,nil
+}
+
 func (t *testEnv) ClearV3GlobalCheckpointForTask(ctx context.Context, taskName string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -680,16 +680,20 @@ func (t *testEnv) UploadV3GlobalCheckpointForTask(ctx context.Context, _ string,
 	return nil
 }
 
-func (t *testEnv) mockPDConnectionError(duration time.Duration) {
+func (t *testEnv) mockPDConnectionError() {
 	t.pdDisconnected = true
-	go func() {
-		time.Sleep(duration)
-		t.pdDisconnected = false
-	}()
+}
+
+func (t *testEnv) connectPD() bool {
+	if !t.pdDisconnected {
+		return true
+	}
+	t.pdDisconnected = false
+	return false
 }
 
 func (t *testEnv) GetGlobalCheckpointForTask(ctx context.Context, taskName string) (uint64, error) {
-	if t.pdDisconnected {
+	if !t.connectPD() {
 		return 0, status.Error(codes.Unavailable, "pd disconnected")
 	}
 	return t.checkpoint, nil

--- a/br/pkg/streamhelper/basic_lib_for_test.go
+++ b/br/pkg/streamhelper/basic_lib_for_test.go
@@ -640,7 +640,7 @@ func (f *fakeCluster) String() string {
 type testEnv struct {
 	*fakeCluster
 	checkpoint     uint64
-	pdDisconnected bool
+	pdDisconnected atomic.Bool
 	testCtx        *testing.T
 	ranges         []kv.KeyRange
 	taskCh         chan<- streamhelper.TaskEvent
@@ -681,14 +681,14 @@ func (t *testEnv) UploadV3GlobalCheckpointForTask(ctx context.Context, _ string,
 }
 
 func (t *testEnv) mockPDConnectionError() {
-	t.pdDisconnected = true
+	t.pdDisconnected.Store(true)
 }
 
 func (t *testEnv) connectPD() bool {
-	if !t.pdDisconnected {
+	if !t.pdDisconnected.Load() {
 		return true
 	}
-	t.pdDisconnected = false
+	t.pdDisconnected.Store(false)
 	return false
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53561

Problem Summary:

### What changed and how does it work?

Now, advancer will sync checkpoint with pd when adding a new task

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix Log Backup unexpected paused when adding a long-run task
```
