### PR TITLE
txn: save unnecessary calls to newMemBuffer

### DIFF
--- a/pkg/store/driver/txn/txn_driver.go
+++ b/pkg/store/driver/txn/txn_driver.go
@@ -50,6 +50,7 @@ type tikvTxn struct {
 	// columnMapsCache is a cache used for the mutation checker
 	columnMapsCache    any
 	isCommitterWorking atomic.Bool
+	memBuffer          *memBuffer
 }
 
 // NewTiKVTxn returns a new Transaction.
@@ -61,7 +62,10 @@ func NewTiKVTxn(txn *tikv.KVTxn) kv.Transaction {
 	totalLimit := kv.TxnTotalSizeLimit.Load()
 	txn.GetUnionStore().SetEntrySizeLimit(entryLimit, totalLimit)
 
-	return &tikvTxn{txn, make(map[int64]*model.TableInfo), nil, nil, atomic.Bool{}}
+	return &tikvTxn{
+		txn, make(map[int64]*model.TableInfo), nil, nil, atomic.Bool{},
+		newMemBuffer(txn.GetMemBuffer(), txn.IsPipelined()),
+	}
 }
 
 func (txn *tikvTxn) GetTableInfo(id int64) *model.TableInfo {
@@ -210,7 +214,10 @@ func (txn *tikvTxn) Set(k kv.Key, v []byte) error {
 }
 
 func (txn *tikvTxn) GetMemBuffer() kv.MemBuffer {
-	return newMemBuffer(txn.KVTxn.GetMemBuffer(), txn.IsPipelined())
+	if txn.memBuffer == nil {
+		txn.memBuffer = newMemBuffer(txn.KVTxn.GetMemBuffer(), txn.IsPipelined())
+	}
+	return txn.memBuffer
 }
 
 func (txn *tikvTxn) SetOption(opt int, val any) {

--- a/pkg/store/driver/txn/unionstore_driver.go
+++ b/pkg/store/driver/txn/unionstore_driver.go
@@ -29,7 +29,7 @@ type memBuffer struct {
 	isPipelinedDML bool
 }
 
-func newMemBuffer(m tikv.MemBuffer, isPipelinedDML bool) kv.MemBuffer {
+func newMemBuffer(m tikv.MemBuffer, isPipelinedDML bool) *memBuffer {
 	if m == nil {
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53714

Problem Summary:

`GetMemBuffer` takes too much time.
<img width="687" alt="image" src="https://github.com/pingcap/tidb/assets/31720476/214f9199-9b8e-4bb5-8b47-1d9cc20132f5">

### What changed and how does it work?

Cache the result of `newMemBuffer`, instead of creating a new one each time when `GetMemBuffer` is called.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - Simple fix
  > - Covered by many existing tests
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
