### PR TITLE
expression: fail `ColumnSubstituteImpl` if creating function returns error

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -519,7 +519,11 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 			}
 		}
 		if substituted {
-			return true, hasFail, NewFunctionInternal(ctx, v.FuncName.L, v.RetType, refExprArr.Result()...)
+			newFunc, err := NewFunction(ctx, v.FuncName.L, v.RetType, refExprArr.Result()...)
+			if err != nil {
+				return true, true, v
+			}
+			return true, hasFail, newFunc
 		}
 	}
 	return false, false, expr

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -4305,3 +4305,10 @@ id
 2
 drop table sys.t;
 set tidb_isolation_read_engines=DEFAULT;
+drop table if exists t;
+create table t (col TEXT);
+select 1 from (select t.col as c0, 46578369 as c1 from t) as t where
+case when (
+t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
+) then 1 else 2 end;
+1

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2369,3 +2369,11 @@ set tidb_isolation_read_engines='tiflash';
 select * from sys.t;
 drop table sys.t;
 set tidb_isolation_read_engines=DEFAULT;
+
+# TestIssue53580
+drop table if exists t;
+create table t (col TEXT);
+select 1 from (select t.col as c0, 46578369 as c1 from t) as t where
+  case when (
+    t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
+  ) then 1 else 2 end;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53580, close #53582, close #53603, close #53594

Problem Summary:

The following `ColumnSubstituteImpl` will fail if it returns `nil` for a function argument.

### What changed and how does it work?

This PR makes the `ColumnSubstituteImpl` fail if the `NewFunction` returns an error. I traced back the change in `ColumnSubstituteImpl` function. Maybe the only reason why `NewFunctionInternal` is used here is that the developers were quite confident that it'll not return an error, and at that time the `ColumnSubstituteImpl` function didn't return the second value to indicate whether it successes or not.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the planner will panic if the predicates have error after column substitution.
```
