### PR TITLE
ddl: fix ingest job panic when reset engine failed

### DIFF
--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -284,10 +284,8 @@ func (bc *litBackendCtx) unsafeImportAndReset(ei *engineInfo) error {
 	}
 
 	err := resetFn(bc.ctx, ei.uuid)
-	failpoint.Inject("mockResetEngineFailed", func(val failpoint.Value) {
-		if val.(bool) {
-			err = fmt.Errorf("mock failed")
-		}
+	failpoint.Inject("mockResetEngineFailed", func() {
+		err = fmt.Errorf("mock reset engine failed")
 	})
 	if err != nil {
 		logutil.Logger(bc.ctx).Error(LitErrResetEngineFail, zap.Int64("index ID", ei.indexID))

--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -284,9 +284,14 @@ func (bc *litBackendCtx) unsafeImportAndReset(ei *engineInfo) error {
 	}
 
 	err := resetFn(bc.ctx, ei.uuid)
+	failpoint.Inject("mockResetEngineFailed", func(val failpoint.Value) {
+		if val.(bool) {
+			err = fmt.Errorf("mock failed")
+		}
+	})
 	if err != nil {
 		logutil.Logger(bc.ctx).Error(LitErrResetEngineFail, zap.Int64("index ID", ei.indexID))
-		err1 := ei.closedEngine.Cleanup(bc.ctx)
+		err1 := closedEngine.Cleanup(bc.ctx)
 		if err1 != nil {
 			logutil.Logger(ei.ctx).Error(LitErrCleanEngineErr, zap.Error(err1),
 				zap.Int64("job ID", ei.jobID), zap.Int64("index ID", ei.indexID))

--- a/tests/realtikvtest/addindextest4/ingest_test.go
+++ b/tests/realtikvtest/addindextest4/ingest_test.go
@@ -475,7 +475,7 @@ func TestAddIndexBackfillLostUpdate(t *testing.T) {
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionStateBeforeImport"))
 }
 
-func TestAddIndexPreCheckFailed(t *testing.T) {
+func TestAddIndexIngestFailures(t *testing.T) {
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("drop database if exists addindexlit;")
@@ -485,9 +485,16 @@ func TestAddIndexPreCheckFailed(t *testing.T) {
 
 	tk.MustExec("create table t(id int primary key, b int, k int);")
 	tk.MustExec("insert into t values (1, 1, 1);")
+
+	// Test precheck failed.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed", "return"))
 	tk.MustGetErrMsg("alter table t add index idx(b);", "[ddl:8256]Check ingest environment failed: mock error")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed"))
+
+	// Test reset engine failed.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed", "1*return(true)"))
+	tk.MustGetErrMsg("alter table t add index idx(b);", "[0]mock failed")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed"))
 }
 
 func TestAddIndexImportFailed(t *testing.T) {

--- a/tests/realtikvtest/addindextest4/ingest_test.go
+++ b/tests/realtikvtest/addindextest4/ingest_test.go
@@ -491,10 +491,12 @@ func TestAddIndexIngestFailures(t *testing.T) {
 	tk.MustGetErrMsg("alter table t add index idx(b);", "[ddl:8256]Check ingest environment failed: mock error")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed"))
 
+	tk.MustExec(`set global tidb_enable_dist_task=on;`)
 	// Test reset engine failed.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed", "return"))
 	tk.MustGetErrMsg("alter table t add index idx(b);", "[0]mock reset engine failed")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed"))
+	tk.MustExec(`set global tidb_enable_dist_task=off;`)
 }
 
 func TestAddIndexImportFailed(t *testing.T) {

--- a/tests/realtikvtest/addindextest4/ingest_test.go
+++ b/tests/realtikvtest/addindextest4/ingest_test.go
@@ -492,8 +492,8 @@ func TestAddIndexIngestFailures(t *testing.T) {
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed"))
 
 	// Test reset engine failed.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed", "1*return(true)"))
-	tk.MustGetErrMsg("alter table t add index idx(b);", "[0]mock failed")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed", "return"))
+	tk.MustGetErrMsg("alter table t add index idx(b);", "[0]mock reset engine failed")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed"))
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53679

Problem Summary:

`ei.closedEngine` should be empty unless all data has been written and all writers have been closed.

### What changed and how does it work?

Use correct `closedEngine`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
