### PR TITLE
statistics: add counter for sync load's backgroud tasks

### DIFF
--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -16563,7 +16563,7 @@
               "refId": "B",
               "step": 30
             },
-                        {
+            {
               "exemplar": true,
               "expr": "sum(increase(tidb_statistics_sync_load_dedup_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
               "format": "time_series",

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -16548,7 +16548,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "sync-load",
+              "legendFormat": "total sync-load",
               "refId": "A",
               "step": 30
             },
@@ -16561,6 +16561,16 @@
               "intervalFactor": 2,
               "legendFormat": "timeout",
               "refId": "B",
+              "step": 30
+            },
+                        {
+              "exemplar": true,
+              "expr": "sum(increase(tidb_statistics_sync_load_dedup_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (type)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "dedup sync-load",
+              "refId": "C",
               "step": 30
             }
           ],

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -150,6 +150,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(HandleJobHistogram)
 	prometheus.MustRegister(SyncLoadCounter)
 	prometheus.MustRegister(SyncLoadTimeoutCounter)
+	prometheus.MustRegister(SyncLoadDedupCounter)
 	prometheus.MustRegister(SyncLoadHistogram)
 	prometheus.MustRegister(ReadStatsHistogram)
 	prometheus.MustRegister(JobsGauge)

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -26,6 +26,7 @@ var (
 	PseudoEstimation          *prometheus.CounterVec
 	SyncLoadCounter           prometheus.Counter
 	SyncLoadTimeoutCounter    prometheus.Counter
+	SyncLoadDedupCounter      prometheus.Counter
 	SyncLoadHistogram         prometheus.Histogram
 	ReadStatsHistogram        prometheus.Histogram
 	StatsCacheCounter         *prometheus.CounterVec
@@ -89,6 +90,13 @@ func InitStatsMetrics() {
 			Subsystem: "statistics",
 			Name:      "sync_load_timeout_total",
 			Help:      "Counter of sync load timeout.",
+		})
+	SyncLoadDedupCounter = NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "statistics",
+			Name:      "sync_load_dedup_total",
+			Help:      "Counter of deduplicated sync load.",
 		})
 
 	SyncLoadHistogram = NewHistogram(


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

The original counter doesn't show the real QPS of the sync load.

### What changed and how does it work?

Add one inside the singleflight.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
