### PR TITLE
ddl: Regenerating AutoIDs for _tidb_rowid during Reorganize Partition

### DIFF
--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -3386,11 +3386,7 @@ func (w *reorgPartitionWorker) fetchRowColVals(txn kv.Transaction, taskRange reo
 				stmtCtx := w.sessCtx.GetSessionVars().StmtCtx
 				if stmtCtx.BaseRowID >= stmtCtx.MaxRowID {
 					// TODO: Which autoid allocator to use?
-					ids := uint64(1)
-					cacheIDs := w.batchCnt - len(w.rowRecords)
-					if cacheIDs > 1 {
-						ids = uint64(cacheIDs)
-					}
+					ids := uint64(max(1, w.batchCnt - len(w.rowRecords)))
 					// Keep using the original table's allocator
 					stmtCtx.BaseRowID, stmtCtx.MaxRowID, err = tables.AllocHandleIDs(w.ctx, w.tblCtx, w.reorgedTbl, ids)
 					if err != nil {

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2676,6 +2676,8 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 	})
 
 	// Set both tables to the maximum auto IDs between normal table and partitioned table.
+	// TODO: Fix the issue of big transactions during EXCHANGE PARTITION with AutoID.
+	// Similar to https://github.com/pingcap/tidb/issues/46904
 	newAutoIDs := meta.AutoIDGroup{
 		RowID:       mathutil.Max(ptAutoIDs.RowID, ntAutoIDs.RowID),
 		IncrementID: mathutil.Max(ptAutoIDs.IncrementID, ntAutoIDs.IncrementID),
@@ -3355,8 +3357,6 @@ func (w *reorgPartitionWorker) fetchRowColVals(txn kv.Transaction, taskRange reo
 				return false, nil
 			}
 
-			// TODO: Extend for normal tables
-			// TODO: Extend for REMOVE PARTITIONING
 			_, err := w.rowDecoder.DecodeTheExistedColumnMap(w.exprCtx, handle, rawRow, sysTZ, w.rowMap)
 			if err != nil {
 				return false, errors.Trace(err)
@@ -3374,9 +3374,35 @@ func (w *reorgPartitionWorker) fetchRowColVals(txn kv.Transaction, taskRange reo
 			if err != nil {
 				return false, errors.Trace(err)
 			}
-			pid := p.GetPhysicalID()
-			newKey := tablecodec.EncodeTablePrefix(pid)
-			newKey = append(newKey, recordKey[len(newKey):]...)
+			var newKey kv.Key
+			if w.reorgedTbl.Meta().PKIsHandle || w.reorgedTbl.Meta().IsCommonHandle {
+				pid := p.GetPhysicalID()
+				newKey = tablecodec.EncodeTablePrefix(pid)
+				newKey = append(newKey, recordKey[len(newKey):]...)
+			} else {
+				// Non-clustered table / not unique _tidb_rowid for the whole table
+				// Generate new _tidb_rowid if exists.
+				// Due to EXCHANGE PARTITION, the existing _tidb_rowid may collide between partitions!
+				stmtCtx := w.sessCtx.GetSessionVars().StmtCtx
+				if stmtCtx.BaseRowID >= stmtCtx.MaxRowID {
+					// TODO: Which autoid allocator to use?
+					ids := uint64(1)
+					cacheIDs := w.batchCnt - len(w.rowRecords)
+					if cacheIDs > 1 {
+						ids = uint64(cacheIDs)
+					}
+					// Keep using the original table's allocator
+					stmtCtx.BaseRowID, stmtCtx.MaxRowID, err = tables.AllocHandleIDs(w.ctx, w.tblCtx, w.reorgedTbl, ids)
+					if err != nil {
+						return false, errors.Trace(err)
+					}
+				}
+				recordID, err := tables.AllocHandle(w.ctx, w.tblCtx, w.reorgedTbl)
+				if err != nil {
+					return false, errors.Trace(err)
+				}
+				newKey = tablecodec.EncodeRecordKey(p.RecordPrefix(), recordID)
+			}
 			w.rowRecords = append(w.rowRecords, &rowRecord{
 				key: newKey, vals: rawRow,
 			})

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -3386,7 +3386,7 @@ func (w *reorgPartitionWorker) fetchRowColVals(txn kv.Transaction, taskRange reo
 				stmtCtx := w.sessCtx.GetSessionVars().StmtCtx
 				if stmtCtx.BaseRowID >= stmtCtx.MaxRowID {
 					// TODO: Which autoid allocator to use?
-					ids := uint64(max(1, w.batchCnt - len(w.rowRecords)))
+					ids := uint64(max(1, w.batchCnt-len(w.rowRecords)))
 					// Keep using the original table's allocator
 					stmtCtx.BaseRowID, stmtCtx.MaxRowID, err = tables.AllocHandleIDs(w.ctx, w.tblCtx, w.reorgedTbl, ids)
 					if err != nil {

--- a/pkg/ddl/reorg_partition_test.go
+++ b/pkg/ddl/reorg_partition_test.go
@@ -581,3 +581,35 @@ func TestReorgPartitionRollback(t *testing.T) {
 	require.NoError(t, err)
 	noNewTablesAfter(t, tk, ctx, tbl)
 }
+
+func TestExchangePartitionRowID(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (id int not null, store_id int not null )  partition by range (store_id) (partition p0 values less than (6), partition p1 values less than (11), partition p2 values less than (16), partition p3 values less than (21) )`)
+	tk.MustExec(`create table t1(id int not null, store_id int not null)`)
+	tk.MustExec(`insert into t values (1, 1)`)
+	tk.MustExec(`insert into t values (2, 17)`)
+	tk.MustExec(`insert into t1 values (0, 18)`)
+	tk.MustExec(`alter table t exchange partition p3 with table t1`)
+	tk.MustExec(`alter table t remove partitioning`)
+	tk.MustQuery(`select * from t`).Sort().Check(testkit.Rows("0 18", "1 1"))
+	tk.MustQuery(`select *,_tidb_rowid from t`).Sort().Check(testkit.Rows("0 18 5257", "1 1 5001"))
+}
+
+func TestExchangeReorganizePartitionRowID(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (id int not null, store_id int not null )  partition by range (store_id) (partition p0 values less than (6), partition p1 values less than (11), partition p2 values less than (16), partition p3 values less than (21) )`)
+	tk.MustExec(`create table t1(id int not null, store_id int not null)`)
+	tk.MustExec(`insert into t values (1, 1)`)
+	tk.MustExec(`insert into t values (2, 17)`)
+	tk.MustExec(`insert into t1 values (0, 18)`)
+	tk.MustExec(`alter table t exchange partition p3 with table t1`)
+	tk.MustQuery(`select *, _tidb_rowid from t`).Sort().Check(testkit.Rows("0 18 1", "1 1 1"))
+	tk.MustQuery(`select *, _tidb_rowid from t1`).Sort().Check(testkit.Rows("2 17 2"))
+	tk.MustExec(`alter table t reorganize partition p0, p1, p2, p3 into (partition pMax values less than (maxvalue))`)
+	tk.MustQuery(`select * from t`).Sort().Check(testkit.Rows("0 18", "1 1"))
+	tk.MustQuery(`select *,_tidb_rowid from t`).Sort().Check(testkit.Rows("0 18 5257", "1 1 5001"))
+}

--- a/pkg/ddl/tests/partition/db_partition_test.go
+++ b/pkg/ddl/tests/partition/db_partition_test.go
@@ -3270,7 +3270,7 @@ func TestRemovePartitioningAutoIDs(t *testing.T) {
 	//waitFor(4, "t", "public")
 	//tk2.MustExec(`commit`)
 	// TODO: Investigate and fix, but it is also related to https://github.com/pingcap/tidb/issues/46904
-	require.ErrorContains(t, <-alterChan, "[kv:1062]Duplicate entry '26' for key 't.PRIMARY'")
+	require.ErrorContains(t, <-alterChan, "[kv:1062]Duplicate entry '31' for key 't.PRIMARY'")
 	tk3.MustQuery(`select _tidb_rowid, a, b from t`).Sort().Check(testkit.Rows(
 		"13 11 11", "14 2 2", "15 12 12", "17 16 18",
 		"19 18 4", "21 20 5", "23 22 6", "25 24 7", "27 26 8", "30 29 9",

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1758,6 +1758,8 @@ func AllocHandle(ctx context.Context, mctx table.MutateContext, t table.Table) (
 	return kv.IntHandle(rowID), err
 }
 
+// AllocHandleIDs allocates n handle ids (_tidb_rowid), and caches the range
+// in the table.MutateContext.
 func AllocHandleIDs(ctx context.Context, mctx table.MutateContext, t table.Table, n uint64) (int64, int64, error) {
 	meta := t.Meta()
 	base, maxID, err := t.Allocators(mctx).Get(autoid.RowIDAllocType).Alloc(ctx, n, 1, 1)

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -947,7 +947,7 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 			// Make the IDs continuous benefit for the performance of TiKV.
 			sessVars := sctx.GetSessionVars()
 			stmtCtx := sessVars.StmtCtx
-			stmtCtx.BaseRowID, stmtCtx.MaxRowID, err = allocHandleIDs(ctx, sctx, t, uint64(opt.ReserveAutoID))
+			stmtCtx.BaseRowID, stmtCtx.MaxRowID, err = AllocHandleIDs(ctx, sctx, t, uint64(opt.ReserveAutoID))
 			if err != nil {
 				return nil, err
 			}
@@ -1754,11 +1754,11 @@ func AllocHandle(ctx context.Context, mctx table.MutateContext, t table.Table) (
 		}
 	}
 
-	_, rowID, err := allocHandleIDs(ctx, mctx, t, 1)
+	_, rowID, err := AllocHandleIDs(ctx, mctx, t, 1)
 	return kv.IntHandle(rowID), err
 }
 
-func allocHandleIDs(ctx context.Context, mctx table.MutateContext, t table.Table, n uint64) (int64, int64, error) {
+func AllocHandleIDs(ctx context.Context, mctx table.MutateContext, t table.Table, n uint64) (int64, int64, error) {
 	meta := t.Meta()
 	base, maxID, err := t.Allocators(mctx).Get(autoid.RowIDAllocType).Alloc(ctx, n, 1, 1)
 	if err != nil {

--- a/tests/integrationtest/r/ddl/db_partition.result
+++ b/tests/integrationtest/r/ddl/db_partition.result
@@ -3311,3 +3311,44 @@ Error 1731 (HY000): Non matching attribute 'global index: b' between partition a
 drop database partition_exchange;
 use ddl__db_partition;
 set tidb_enable_global_index=default;
+# 53385
+drop table if exists t,t1;
+create table t (id int not null, store_id int not null )  partition by range (store_id) (partition p0 values less than (6), partition p1 values less than (11), partition p2 values less than (16), partition p3 values less than (21));
+create table t1(id int not null, store_id int not null);
+insert into t values (1, 1);
+insert into t values (2, 17);
+insert into t1 values (0, 18);
+alter table t exchange partition p3 with table t1;
+alter table t remove partitioning;
+select * from t;
+id	store_id
+0	18
+1	1
+select *,_tidb_rowid from t;
+id	store_id	_tidb_rowid
+0	18	30257
+1	1	30001
+drop table t, t1;
+create table t (id int not null, store_id int not null )  partition by range (store_id) (partition p0 values less than (6), partition p1 values less than (11), partition p2 values less than (16), partition p3 values less than (21));
+create table t1(id int not null, store_id int not null);
+insert into t values (1, 1);
+insert into t values (2, 17);
+insert into t1 values (0, 18);
+alter table t exchange partition p3 with table t1;
+select *, _tidb_rowid from t;
+id	store_id	_tidb_rowid
+0	18	1
+1	1	1
+select *, _tidb_rowid from t1;
+id	store_id	_tidb_rowid
+2	17	2
+alter table t reorganize partition p0, p1, p2, p3 into (partition pMax values less than (maxvalue));
+select * from t;
+id	store_id
+0	18
+1	1
+select *,_tidb_rowid from t;
+id	store_id	_tidb_rowid
+0	18	30257
+1	1	30001
+drop table t, t1;

--- a/tests/integrationtest/t/ddl/db_partition.test
+++ b/tests/integrationtest/t/ddl/db_partition.test
@@ -2280,3 +2280,33 @@ drop database partition_exchange;
 use ddl__db_partition;
 set tidb_enable_global_index=default;
 
+--echo # 53385
+drop table if exists t,t1;
+create table t (id int not null, store_id int not null )  partition by range (store_id) (partition p0 values less than (6), partition p1 values less than (11), partition p2 values less than (16), partition p3 values less than (21));
+create table t1(id int not null, store_id int not null);
+insert into t values (1, 1);
+insert into t values (2, 17);
+insert into t1 values (0, 18);
+alter table t exchange partition p3 with table t1;
+alter table t remove partitioning;
+--sorted_result
+select * from t;
+--sorted_result
+select *,_tidb_rowid from t;
+drop table t, t1;
+create table t (id int not null, store_id int not null )  partition by range (store_id) (partition p0 values less than (6), partition p1 values less than (11), partition p2 values less than (16), partition p3 values less than (21));
+create table t1(id int not null, store_id int not null);
+insert into t values (1, 1);
+insert into t values (2, 17);
+insert into t1 values (0, 18);
+alter table t exchange partition p3 with table t1;
+--sorted_result
+select *, _tidb_rowid from t;
+--sorted_result
+select *, _tidb_rowid from t1;
+alter table t reorganize partition p0, p1, p2, p3 into (partition pMax values less than (maxvalue));
+--sorted_result
+select * from t;
+--sorted_result
+select *,_tidb_rowid from t;
+drop table t, t1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
When EXCHANGE PARTITION is used, the _tidb_rowid from the exchanged table, may conflict with rows in other partitions, which can collide during REORGANIZE PARTITION or REMOVE PARTITIONING since they keep the _tidb_rowid but will be placed in the same physical partition/table.

Solution:
Generate new _tidb_rowid for each row during the data reorganization phase.

Issue Number: close #53385

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
