### PR TITLE
planner: introduce a new fix-control 43817 to control whether to allow the optimizer to evaluate non-correlated sub-queries in advance

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1446,6 +1446,10 @@ func init() {
 	// but the plan package cannot import the executor package because of the dependency cycle.
 	// So we assign a function implemented in the executor package to the plan package to avoid the dependency cycle.
 	plannercore.EvalSubqueryFirstRow = func(ctx context.Context, p base.PhysicalPlan, is infoschema.InfoSchema, pctx planctx.PlanContext) ([]types.Datum, error) {
+		if fixcontrol.GetBoolWithDefault(pctx.GetSessionVars().OptimizerFixControl, fixcontrol.Fix43817, false) {
+			return nil, errors.NewNoStackError("evaluate non-correlated sub-queries during optimization phase is not allowed by fix-control 43817")
+		}
+
 		defer func(begin time.Time) {
 			s := pctx.GetSessionVars()
 			s.StmtCtx.SetSkipPlanCache("query has uncorrelated sub-queries is un-cacheable")

--- a/pkg/planner/core/casetest/BUILD.bazel
+++ b/pkg/planner/core/casetest/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/domain",
         "//pkg/errno",

--- a/pkg/planner/util/fixcontrol/get.go
+++ b/pkg/planner/util/fixcontrol/get.go
@@ -24,6 +24,10 @@ const (
 	// tables (both prepared statments and non-prepared statements)
 	// See #33031
 	Fix33031 uint64 = 33031
+	// Fix43817 controls whether to allow the optimizer to evaluate non-correlated sub-queries during the optimization phase.
+	// If it is not allowed, the optimizer will return a particular error when encountering non-correlated sub-queries.
+	// This fix-control is mainly for Index Advisor.
+	Fix43817 uint64 = 43817
 	// Fix44262 controls whether to allow to use dynamic-mode to access partitioning tables without global-stats (#44262).
 	Fix44262 uint64 = 44262
 	// Fix44389 controls whether to consider non-point ranges of some CNF item when building ranges.

--- a/pkg/planner/util/fixcontrol/get.go
+++ b/pkg/planner/util/fixcontrol/get.go
@@ -24,7 +24,7 @@ const (
 	// tables (both prepared statments and non-prepared statements)
 	// See #33031
 	Fix33031 uint64 = 33031
-	// Fix43817 controls whether to allow the optimizer to evaluate non-correlated sub-queries during the optimization phase.
+	// Fix43817 controls whether to allow optimizer to evaluate non-correlated sub-queries in the optimization phase.
 	// If it is not allowed, the optimizer will return a particular error when encountering non-correlated sub-queries.
 	// This fix-control is mainly for Index Advisor.
 	Fix43817 uint64 = 43817


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43817

Problem Summary: planner: introduce a new fix-control 43817 to control whether to allow the optimizer to evaluate non-correlated sub-queries in advance

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
