### PR TITLE
ebs br: fail backup when no tikv store

### DIFF
--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"io"
 	"os"
 	"sort"
@@ -27,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/config"
 	"github.com/pingcap/tidb/br/pkg/conn"
 	"github.com/pingcap/tidb/br/pkg/conn/util"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/pdutil"
@@ -101,7 +101,7 @@ func RunBackupEBS(c context.Context, g glue.Glue, cfg *BackupConfig) error {
 	storeCount := backupInfo.GetStoreCount()
 	if storeCount == 0 {
 		log.Info("nothing to backup")
-		return errors.Annotate(berrors.ErrInvalidArgument, "store count is 0")
+		return errors.Trace(errors.Annotate(berrors.ErrInvalidArgument, "store count is 0"))
 	}
 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {

--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"io"
 	"os"
 	"sort"
@@ -100,7 +101,7 @@ func RunBackupEBS(c context.Context, g glue.Glue, cfg *BackupConfig) error {
 	storeCount := backupInfo.GetStoreCount()
 	if storeCount == 0 {
 		log.Info("nothing to backup")
-		return nil
+		return errors.Annotate(berrors.ErrInvalidArgument, "store count is 0")
 	}
 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53784 

Problem Summary:

### What changed and how does it work?

If the cluster has 0 tikv replica, we should fail the backup directly.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
