### PR TITLE
planner: fix column evaluator can not detect input's column-ref and thus swapping and destroying later column ref projection logic

### DIFF
--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -121,10 +121,9 @@ func (e *columnEvaluator) mergeInputIdxToOutputIdxes(input *chunk.Chunk, inputId
 	newInputIdxToOutputIdxes := make(map[int][]int, len(inputIdxToOutputIdxes))
 	for inputIdx := range inputIdxToOutputIdxes {
 		originalRootIdx := originalDJSet.FindRoot(inputIdx)
-		if _, ok := newInputIdxToOutputIdxes[originalRootIdx]; !ok {
-			newInputIdxToOutputIdxes[originalRootIdx] = []int{}
-		}
-		newInputIdxToOutputIdxes[originalRootIdx] = append(newInputIdxToOutputIdxes[originalRootIdx], inputIdxToOutputIdxes[inputIdx]...)
+		mergedOutputIdxes := newInputIdxToOutputIdxes[originalRootIdx]
+		mergedOutputIdxes = append(mergedOutputIdxes, inputIdxToOutputIdxes[inputIdx]...)
+		newInputIdxToOutputIdxes[originalRootIdx] = mergedOutputIdxes
 	}
 	e.mergedInputIdxToOutputIdxes = newInputIdxToOutputIdxes
 }

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -103,7 +103,7 @@ func (e *columnEvaluator) mergeInputIdxToOutputIdxes(input *chunk.Chunk, inputId
 			}
 		}
 	}
-	// step2: convert inputIdxToOutputIdxes into disJoint set.
+	// step2: link items inside inputIdxToOutputIdxes with originalDisJoint set.
 	// since originDJSet covers offset 0 to input.NumCols(), it may overlap with the output indexes.
 	newInputIdxToOutputIdxes := make(map[int][]int, len(inputIdxToOutputIdxes))
 	for inputIdx := range inputIdxToOutputIdxes {
@@ -113,13 +113,11 @@ func (e *columnEvaluator) mergeInputIdxToOutputIdxes(input *chunk.Chunk, inputId
 		if _, ok := newInputIdxToOutputIdxes[originalRootIdx]; !ok {
 			newInputIdxToOutputIdxes[originalRootIdx] = []int{}
 		}
-		for _, outputIdx := range inputIdxToOutputIdxes[inputIdx] {
-			// eg: assuming A and B are in the same set of originalDJSet, and root is A.
-			// if inputIdxToOutputIdxes[A]=[0,1], A is in the same set of B
-			// and inputIdxToOutputIdxes[B]=[2,3], and we will get
-			// newInputIdxToOutputIdxes[A] = [0,1,2,3]
-			newInputIdxToOutputIdxes[originalRootIdx] = append(newInputIdxToOutputIdxes[originalRootIdx], outputIdx)
-		}
+		// eg: assuming A and B are in the same set of originalDJSet, and root is A.
+		// if inputIdxToOutputIdxes[A]=[0,1], A is in the same set of B
+		// and inputIdxToOutputIdxes[B]=[2,3], and we will get
+		// newInputIdxToOutputIdxes[A] = [0,1,2,3]
+		newInputIdxToOutputIdxes[originalRootIdx] = append(newInputIdxToOutputIdxes[originalRootIdx], inputIdxToOutputIdxes[inputIdx]...)
 	}
 	e.mergedInputIdxToOutputIdxes = newInputIdxToOutputIdxes
 }

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/disjointset"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 type columnEvaluator struct {
@@ -120,10 +121,13 @@ func (e *columnEvaluator) mergeInputIdxToOutputIdxes(input *chunk.Chunk, inputId
 	// Merge inputIdxToOutputIdxes based on the detected column references.
 	newInputIdxToOutputIdxes := make(map[int][]int, len(inputIdxToOutputIdxes))
 	for inputIdx := range inputIdxToOutputIdxes {
+		// Root idx is internal offset, not the right column index.
 		originalRootIdx := originalDJSet.FindRoot(inputIdx)
-		mergedOutputIdxes := newInputIdxToOutputIdxes[originalRootIdx]
+		originalVal, ok := originalDJSet.FindVal(originalRootIdx)
+		intest.Assert(ok)
+		mergedOutputIdxes := newInputIdxToOutputIdxes[originalVal]
 		mergedOutputIdxes = append(mergedOutputIdxes, inputIdxToOutputIdxes[inputIdx]...)
-		newInputIdxToOutputIdxes[originalRootIdx] = mergedOutputIdxes
+		newInputIdxToOutputIdxes[originalVal] = mergedOutputIdxes
 	}
 	e.mergedInputIdxToOutputIdxes = newInputIdxToOutputIdxes
 }

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -58,25 +58,26 @@ func (e *columnEvaluator) run(ctx EvalContext, input, output *chunk.Chunk) error
 //
 // This column 'a' is used in the first projection (proj1) to create two columns a1 and a2, both referencing 'a':
 //
-//                         proj1
-//                        /     \
-//                       /       \
-//                      /         \
-//        a1 (addr: 0xe)           a2 (addr: 0xe)
-//        /                         \
-//       /                           \
-//      /                             \
-//     proj2                          proj2
-//     /     \                       /     \
-//    /       \                     /       \
-//   a3        a4                  a3        a4
+//	                      proj1
+//	                     /     \
+//	                    /       \
+//	                   /         \
+//	     a1 (addr: 0xe)           a2 (addr: 0xe)
+//	     /                         \
+//	    /                           \
+//	   /                             \
+//	  proj2                          proj2
+//	  /     \                       /     \
+//	 /       \                     /       \
+//	a3        a4                  a5        a6
+//
 // (addr: 0xe) (addr: 0xe)      (addr: 0xe) (addr: 0xe)
 //
 // Here, a1 and a2 share the same address (0xe), indicating they reference the same data from the original 'a'.
 //
 // When moving to the second projection (proj2), the system tries to project these columns further:
 // - The first set (left side) consists of a3 and a4, derived from a1, both retaining the address (0xe).
-// - The second set (right side) consists of a3 and a4, derived from a2, also starting with address (0xe).
+// - The second set (right side) consists of a5 and a6, derived from a2, also starting with address (0xe).
 //
 // When proj1 is complete, the output chunk contains two columns [a1, a2], both derived from the single column 'a' from the scan.
 // Since both a1 and a2 are column references with the same address (0xe), they are treated as referencing the same data.
@@ -91,48 +92,38 @@ func (e *columnEvaluator) run(ctx EvalContext, input, output *chunk.Chunk) error
 // proj1:          a1 (addr: invalid)             a2 (addr: invalid)
 //
 // This can lead to issues in proj2, where further operations on these columns may be unsafe:
-// 
-// proj2:   a3 (addr: 0xe) a4 (addr: 0xe)   a3 (addr: ???) a4 (addr: ???)
+//
+// proj2:   a3 (addr: 0xe) a4 (addr: 0xe)   a5 (addr: ???) a6 (addr: ???)
 //
 // Therefore, it's crucial to identify and merge the original column references early, ensuring
 // the final inputIdxToOutputIdxes mapping accurately reflects the shared origins of the data.
 // For instance, <0, [0,1,2,3]> indicates that the 0th input column (original 'a') is referenced
 // by all four output columns in the final output.
-
+//
+// mergeInputIdxToOutputIdxes merges inputIdxToOutputIdxes based on detected column references.
+// This ensures that columns with the same reference are correctly handled in the output chunk.
 func (e *columnEvaluator) mergeInputIdxToOutputIdxes(input *chunk.Chunk, inputIdxToOutputIdxes map[int][]int) {
-	// step1: we should detect the self column-ref inside input chunk.
-	// we use the generic set rather than single int set to leverage the value mapping.
-	// the original column ref inside may not be too much, give size 4 here rather input.NumCols().
 	originalDJSet := disjointset.NewSet[int](4)
 	flag := make([]bool, input.NumCols())
-	// we can only detect the self column-ref inside input chunk by address equal.
+	// Detect self column-references inside the input chunk by comparing column addresses
 	for i := 0; i < input.NumCols(); i++ {
 		if flag[i] {
 			continue
 		}
-		for j := i; j < input.NumCols(); j++ {
+		for j := i + 1; j < input.NumCols(); j++ {
 			if input.Column(i) == input.Column(j) {
-				// mark referred column to avoid successive detection.
 				flag[j] = true
-				// make j union ref i.
 				originalDJSet.Union(i, j)
 			}
 		}
 	}
-	// step2: link items inside inputIdxToOutputIdxes with originalDisJoint set.
-	// since originDJSet covers offset 0 to input.NumCols(), it may overlap with the output indexes.
+	// Merge inputIdxToOutputIdxes based on the detected column references.
 	newInputIdxToOutputIdxes := make(map[int][]int, len(inputIdxToOutputIdxes))
 	for inputIdx := range inputIdxToOutputIdxes {
-		// if originIdx is in originalDJSet, find the root.
-		originalRootIdx := originalDJSet.FindRootForV(inputIdx)
-		// initialize the map item if not exist.
+		originalRootIdx := originalDJSet.FindRoot(inputIdx)
 		if _, ok := newInputIdxToOutputIdxes[originalRootIdx]; !ok {
 			newInputIdxToOutputIdxes[originalRootIdx] = []int{}
 		}
-		// eg: assuming A and B are in the same set of originalDJSet, and root is A.
-		// if inputIdxToOutputIdxes[A]=[0,1], A is in the same set of B
-		// and inputIdxToOutputIdxes[B]=[2,3], and we will get
-		// newInputIdxToOutputIdxes[A] = [0,1,2,3]
 		newInputIdxToOutputIdxes[originalRootIdx] = append(newInputIdxToOutputIdxes[originalRootIdx], inputIdxToOutputIdxes[inputIdx]...)
 	}
 	e.mergedInputIdxToOutputIdxes = newInputIdxToOutputIdxes

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -15,11 +15,12 @@
 package expression
 
 import (
+	"sync/atomic"
+
 	"github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/disjointset"
 	"github.com/pingcap/tidb/pkg/util/intest"
-	"sync/atomic"
 )
 
 type columnEvaluator struct {

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -694,7 +694,7 @@ func TestMergeInputIdxToOutputIdxes(t *testing.T) {
 	require.Equal(t, output.Column(2), output.Column(3))
 	require.Equal(t, output.GetRow(0).GetInt64(0), int64(99))
 
-	require.Equal(t, len(columnEval.mergedInputIdxToOutputIdxes), 1)
-	slices.Sort(columnEval.mergedInputIdxToOutputIdxes[0])
-	require.Equal(t, columnEval.mergedInputIdxToOutputIdxes[0], []int{0, 1, 2, 3})
+	require.Equal(t, len(*columnEval.mergedInputIdxToOutputIdxes.Load()), 1)
+	slices.Sort((*columnEval.mergedInputIdxToOutputIdxes.Load())[0])
+	require.Equal(t, (*columnEval.mergedInputIdxToOutputIdxes.Load())[0], []int{0, 1, 2, 3})
 }

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -677,9 +677,6 @@ func (c *Column) GetDuration(rowID int, fillFsp int) types.Duration {
 }
 
 func (c *Column) getNameValue(rowID int) (string, uint64) {
-	if rowID+1 >= len(c.offsets) {
-		fmt.Println(1)
-	}
 	start, end := c.offsets[rowID], c.offsets[rowID+1]
 	if start == end {
 		return "", 0

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -677,6 +677,9 @@ func (c *Column) GetDuration(rowID int, fillFsp int) types.Duration {
 }
 
 func (c *Column) getNameValue(rowID int) (string, uint64) {
+	if rowID+1 >= len(c.offsets) {
+		fmt.Println(1)
+	}
 	start, end := c.offsets[rowID], c.offsets[rowID+1]
 	if start == end {
 		return "", 0

--- a/pkg/util/disjointset/int_set.go
+++ b/pkg/util/disjointset/int_set.go
@@ -40,7 +40,7 @@ func (m *SimpleIntSet) FindRoot(a int) int {
 	if a == m.parent[a] {
 		return a
 	}
-	// path short compression
+	// Path compression, which leads the time complexity to the inverse Ackermann function.
 	m.parent[a] = m.FindRoot(m.parent[a])
 	return m.parent[a]
 }

--- a/pkg/util/disjointset/int_set.go
+++ b/pkg/util/disjointset/int_set.go
@@ -40,6 +40,7 @@ func (m *SimpleIntSet) FindRoot(a int) int {
 	if a == m.parent[a] {
 		return a
 	}
+	// path short compression
 	m.parent[a] = m.FindRoot(m.parent[a])
 	return m.parent[a]
 }

--- a/pkg/util/disjointset/set.go
+++ b/pkg/util/disjointset/set.go
@@ -33,6 +33,7 @@ func NewSet[T comparable](size int) *Set[T] {
 		tailIdx: 0,
 	}
 }
+
 func (s *Set[T]) findRootOriginalVal(a T) int {
 	idx, ok := s.val2Idx[a]
 	if !ok {
@@ -47,6 +48,7 @@ func (s *Set[T]) findRootOriginalVal(a T) int {
 // findRoot is an internal implementation. Call it inside findRootOriginalVal.
 func (s *Set[T]) findRoot(a int) int {
 	if s.parent[a] != a {
+		// path short compression
 		s.parent[a] = s.findRoot(s.parent[a])
 	}
 	return s.parent[a]
@@ -61,7 +63,14 @@ func (s *Set[T]) InSameGroup(a, b T) bool {
 func (s *Set[T]) Union(a, b T) {
 	rootA := s.findRootOriginalVal(a)
 	rootB := s.findRootOriginalVal(b)
+	// take b as successor, respect the rootA as the root of the new set.
 	if rootA != rootB {
-		s.parent[rootA] = rootB
+		s.parent[rootB] = rootA
 	}
+}
+
+// FindRootForV finds the root of the set that contains a.
+func (s *Set[T]) FindRootForV(a T) int {
+	// if a is not in the set, assign a new index to it.
+	return s.findRootOriginalVal(a)
 }

--- a/pkg/util/disjointset/set.go
+++ b/pkg/util/disjointset/set.go
@@ -22,6 +22,7 @@ package disjointset
 type Set[T comparable] struct {
 	parent  []int
 	val2Idx map[T]int
+	idx2Val map[int]T
 	tailIdx int
 }
 
@@ -30,6 +31,7 @@ func NewSet[T comparable](size int) *Set[T] {
 	return &Set[T]{
 		parent:  make([]int, 0, size),
 		val2Idx: make(map[T]int, size),
+		idx2Val: make(map[int]T, size),
 		tailIdx: 0,
 	}
 }
@@ -40,6 +42,7 @@ func (s *Set[T]) findRootOriginalVal(a T) int {
 		s.parent = append(s.parent, s.tailIdx)
 		s.val2Idx[a] = s.tailIdx
 		s.tailIdx++
+		s.idx2Val[s.tailIdx-1] = a
 		return s.tailIdx - 1
 	}
 	return s.findRootInternal(idx)
@@ -73,4 +76,12 @@ func (s *Set[T]) Union(a, b T) {
 func (s *Set[T]) FindRoot(a T) int {
 	// if a is not in the set, assign a new index to it.
 	return s.findRootOriginalVal(a)
+}
+
+func (s *Set[T]) FindVal(idx int) (T, bool) {
+	if v, ok := s.idx2Val[s.findRootInternal(idx)]; ok {
+		return v, true
+	} else {
+		return v, false
+	}
 }

--- a/pkg/util/disjointset/set.go
+++ b/pkg/util/disjointset/set.go
@@ -42,14 +42,14 @@ func (s *Set[T]) findRootOriginalVal(a T) int {
 		s.tailIdx++
 		return s.tailIdx - 1
 	}
-	return s.findRoot(idx)
+	return s.findRootInternal(idx)
 }
 
 // findRoot is an internal implementation. Call it inside findRootOriginalVal.
-func (s *Set[T]) findRoot(a int) int {
+func (s *Set[T]) findRootInternal(a int) int {
 	if s.parent[a] != a {
 		// Path compression, which leads the time complexity to the inverse Ackermann function.
-		s.parent[a] = s.findRoot(s.parent[a])
+		s.parent[a] = s.findRootInternal(s.parent[a])
 	}
 	return s.parent[a]
 }
@@ -69,8 +69,8 @@ func (s *Set[T]) Union(a, b T) {
 	}
 }
 
-// FindRootForV finds the root of the set that contains a.
-func (s *Set[T]) FindRootForV(a T) int {
+// FindRoot finds the root of the set that contains a.
+func (s *Set[T]) FindRoot(a T) int {
 	// if a is not in the set, assign a new index to it.
 	return s.findRootOriginalVal(a)
 }

--- a/pkg/util/disjointset/set.go
+++ b/pkg/util/disjointset/set.go
@@ -48,7 +48,7 @@ func (s *Set[T]) findRootOriginalVal(a T) int {
 // findRoot is an internal implementation. Call it inside findRootOriginalVal.
 func (s *Set[T]) findRoot(a int) int {
 	if s.parent[a] != a {
-		// path short compression
+		// Path compression, which leads the time complexity to the inverse Ackermann function.
 		s.parent[a] = s.findRoot(s.parent[a])
 	}
 	return s.parent[a]

--- a/pkg/util/disjointset/set.go
+++ b/pkg/util/disjointset/set.go
@@ -78,10 +78,8 @@ func (s *Set[T]) FindRoot(a T) int {
 	return s.findRootOriginalVal(a)
 }
 
+// FindVal finds the value of the set corresponding to the index.
 func (s *Set[T]) FindVal(idx int) (T, bool) {
-	if v, ok := s.idx2Val[s.findRootInternal(idx)]; ok {
-		return v, true
-	} else {
-		return v, false
-	}
+	v, ok := s.idx2Val[s.findRootInternal(idx)]
+	return v, ok
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53713

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
use the valid SQL and error SQL inside issue to produce result
and compare it with MySQL output, both them output like below:
```
mysql> source /Users/arenatlx/Downloads/error.txt
+------+------+------+------+
| c1   | c3   | c4   | c5   |
+------+------+------+------+
| NULL | NULL | 4    | NULL |
+------+------+------+------+
1 row in set (0.04 sec)
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue where the column evaluator could not detect column references in the input chunk. This bug caused the column evaluator to potentially lose the original input column data during projection, disrupting subsequent reference projection logic.
修复了 column evaluator 无法识别输入 chunk 中的列引用的问题。该问题会导致在投影过程中，column evaluator 可能丢失原始输入列的内容，从而破坏后续引用投影逻辑。


```
