### PR TITLE
ddl: handle cluster state retrieval failure

### DIFF
--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -352,9 +352,8 @@ func (d *ddl) startLocalWorkerLoop() {
 }
 
 func (s *jobScheduler) startDispatchLoopWithRetry() {
-	const maxRetry = 10
 	const retryInterval = 3 * time.Second
-	for i := 0; i < maxRetry; i++ {
+	for {
 		err := s.startDispatchLoop()
 		if err == nil {
 			return
@@ -364,7 +363,6 @@ func (s *jobScheduler) startDispatchLoopWithRetry() {
 			return
 		}
 		logutil.DDLLogger().Warn("startDispatchLoop failed, retrying",
-			zap.Int("retryCnt", i),
 			zap.Error(err))
 
 		select {

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -354,7 +354,8 @@ func (d *ddl) startLocalWorkerLoop() {
 func (s *jobScheduler) startDispatchLoop() {
 	sessCtx, err := s.sessPool.Get()
 	if err != nil {
-		logutil.DDLLogger().Fatal("dispatch loop get session failed, it should not happen, please try restart TiDB", zap.Error(err))
+		logutil.DDLLogger().Warn("dispatch loop get session failed, quit", zap.Error(err))
+		return
 	}
 	defer s.sessPool.Put(sessCtx)
 	se := sess.NewSession(sessCtx)
@@ -363,7 +364,8 @@ func (s *jobScheduler) startDispatchLoop() {
 		notifyDDLJobByEtcdCh = s.etcdCli.Watch(s.schCtx, addingDDLJobNotifyKey)
 	}
 	if err := s.checkAndUpdateClusterState(true); err != nil {
-		logutil.DDLLogger().Fatal("dispatch loop get cluster state failed, it should not happen, please try restart TiDB", zap.Error(err))
+		logutil.DDLLogger().Warn("dispatch loop get cluster state failed, quit", zap.Error(err))
+		return
 	}
 	ticker := time.NewTicker(dispatchLoopWaitingDuration)
 	defer ticker.Stop()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53808

Problem Summary:

When TiDB is just elected as the DDL owner and `startDispatchLoop` is not started, there maybe a "context canceled" error when  owner retired for some reasons(like PD connection issue):

```
[2024/06/03 12:42:37.820 +08:00] [INFO] [manager.go:232] ["retire owner"] ["owner info"="[ddl] /tidb/ddl/fg/owner ownerManager 4e189321-5fd4-48fa-ad33-a8a92ed10cef"]
[2024/06/03 12:42:37.820 +08:00] [INFO] [syncer.go:485] ["schema version sync loop interrupted, retrying..."] [category=ddl]
[2024/06/03 12:42:37.820 +08:00] [WARN] [job_table.go:424] ["get global state failed"] [category=ddl] [error="context canceled"]
[2024/06/03 12:42:37.820 +08:00] [FATAL] [job_table.go:366] ["dispatch loop get cluster state failed, it should not happen, please try restart TiDB"] [category=ddl] [error="context canceled"] [stack="github.com/pingcap/tidb/pkg/ddl.(*jobScheduler).startDispatchLoop\n\t/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/pkg/ddl/job_table.go:366\ngithub.com/pingcap/tidb/pkg/util.(*WaitGroupWrapper).RunWithLog.func1\n\t/home/jenkins/agent/workspace/build-common/go/src/github.com/pingcap/tidb/pkg/util/wait_group_wrapper.go:171"]
```

### What changed and how does it work?

Since `startDispatchLoop` is not only called at TiDB cluster initialization, we should not os.Exit(1).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
