### PR TITLE
executor: fix issue of index lookup query scan index  may sent redundancy RPC when enable paging

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -686,6 +686,12 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 			SetMemTracker(tracker).
 			SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
 
+		if builder.Request.Paging.Enable && builder.Request.Paging.MinPagingSize < uint64(initBatchSize) {
+			builder.Request.Paging.MinPagingSize = uint64(initBatchSize)
+			if builder.Request.Paging.MaxPagingSize < uint64(initBatchSize) {
+				builder.Request.Paging.MaxPagingSize = uint64(initBatchSize)
+			}
+		}
 		results := make([]distsql.SelectResult, 0, len(kvRanges))
 		for _, kvRange := range kvRanges {
 			// check if executor is closed

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -687,6 +687,8 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 			SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
 
 		if builder.Request.Paging.Enable && builder.Request.Paging.MinPagingSize < uint64(initBatchSize) {
+			// when paging enabled and Paging.MinPagingSize less than initBatchSize, change Paging.MinPagingSize to
+			// initBatchSize to avoid redundant paging RPC, see more detail in https://github.com/pingcap/tidb/issues/53827
 			builder.Request.Paging.MinPagingSize = uint64(initBatchSize)
 			if builder.Request.Paging.MaxPagingSize < uint64(initBatchSize) {
 				builder.Request.Paging.MaxPagingSize = uint64(initBatchSize)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53827

Problem Summary: As title said, see more detail in issue #53827.

### What changed and how does it work?

Set index lookup scan index cop request `min_page_size` to `initBatchSize`.

### Benchmark

- prepare

```sql
 drop table if exists t;
create table t (id int key auto_increment, b int, c int, index idx (b));
insert into t () values (), (), (), (), (), (), (), ();
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
update t set b = id, c = id;
```
- bench index lookup query with 1 thread by [loadgen](https://github.com/crazycs520/loadgen)

```sh
loadgen bench --sql="select * from t use index(idx);" --thread=1 --host 0.0.0.0 --port 4000
```

#### Before This PR:

```sql
> select EXEC_COUNT,AVG_LATENCY, SUM_COP_TASK_NUM/EXEC_COUNT as AVG_COP_TASK_NUM, AVG_MEM, QUERY_SAMPLE_TEXT  from `STATEMENTS_SUMMARY` where digest = 'e5796985ccafe2f71126ed6c0ac939ffa015a8c0744a24b7aee6d587103fd2f7'\G
***************************[ 1. row ]***************************
EXEC_COUNT        | 6362
AVG_LATENCY       | 3206889    -- 3.2ms
AVG_COP_TASK_NUM  | 4.0000     -- 3 cop RPC for scan index, 1 cop RPC for table reader
AVG_MEM           | 70349
QUERY_SAMPLE_TEXT | select * from t use index(idx);
```

#### This PR

```sql
***************************[ 1. row ]***************************
EXEC_COUNT        | 6111
AVG_LATENCY       | 2578004    -- 2.57ms
AVG_COP_TASK_NUM  | 2.0000     -- 1 cop RPC for scan index, 1 cop RPC for table reader
AVG_MEM           | 70350
QUERY_SAMPLE_TEXT | select * from t use index(idx);
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
