### PR TITLE
config: Change tidb_opt_projection_push_down default value to true | tidb-test=pr/2359

### DIFF
--- a/bazel-tidb_dev
+++ b/bazel-tidb_dev
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_yibinhu/4f08269a2abe07f00945d9adaa286392/execroot/_main

--- a/bazel-tidb_dev
+++ b/bazel-tidb_dev
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_yibinhu/4f08269a2abe07f00945d9adaa286392/execroot/_main

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1006,7 +1006,7 @@ var defaultConf = Config{
 		TxnEntrySizeLimit:                 DefTxnEntrySizeLimit,
 		TxnTotalSizeLimit:                 DefTxnTotalSizeLimit,
 		DistinctAggPushDown:               false,
-		ProjectionPushDown:                false,
+		ProjectionPushDown:                true,
 		CommitterConcurrency:              defTiKVCfg.CommitterConcurrency,
 		MaxTxnTTL:                         defTiKVCfg.MaxTxnTTL, // 1hour
 		GOGC:                              100,

--- a/pkg/executor/distsql_test.go
+++ b/pkg/executor/distsql_test.go
@@ -361,6 +361,7 @@ func TestAdaptiveClosestRead(t *testing.T) {
 	// the avg row size is more accurate in check_rpc mode when unistre is used.
 	// See: https://github.com/pingcap/tidb/issues/31744#issuecomment-1016309883
 	tk.MustExec("set @@tidb_enable_chunk_rpc = '1'")
+	tk.MustExec("set @@tidb_opt_projection_push_down = '0'")
 
 	readCounter := func(counter prometheus.Counter) float64 {
 		var metric dto.Metric

--- a/pkg/executor/explainfor_test.go
+++ b/pkg/executor/explainfor_test.go
@@ -352,6 +352,7 @@ func TestIssue28259(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec(`set tidb_enable_prepared_plan_cache=1`)
+	tk.MustExec(`set tidb_opt_projection_push_down=0`)
 
 	// test for indexRange
 	tk.MustExec("use test")

--- a/pkg/executor/testdata/prepare_suite_out.json
+++ b/pkg/executor/testdata/prepare_suite_out.json
@@ -82,9 +82,9 @@
               }
             ],
             "Plan": [
-              "Projection_4 10.00 root  test.t1.a",
-              "└─IndexReader_6 10.00 root  index:IndexRangeScan_5",
-              "  └─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:b(b, a) range:[3,3], keep order:false, stats:pseudo"
+              "IndexReader_9 10.00 root  index:Projection_5",
+              "└─Projection_5 10.00 cop[tikv]  test.t1.a",
+              "  └─IndexRangeScan_8 10.00 cop[tikv] table:t1, index:b(b, a) range:[3,3], keep order:false, stats:pseudo"
             ],
             "LastPlanUseCache": "0",
             "Result": [
@@ -100,9 +100,9 @@
               }
             ],
             "Plan": [
-              "Projection_4 10.00 root  test.t1.a",
-              "└─IndexReader_6 10.00 root  index:IndexRangeScan_5",
-              "  └─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:b(b, a) range:[2,2], keep order:false, stats:pseudo"
+              "IndexReader_9 10.00 root  index:Projection_5",
+              "└─Projection_5 10.00 cop[tikv]  test.t1.a",
+              "  └─IndexRangeScan_8 10.00 cop[tikv] table:t1, index:b(b, a) range:[2,2], keep order:false, stats:pseudo"
             ],
             "LastPlanUseCache": "1",
             "Result": [
@@ -118,9 +118,9 @@
               }
             ],
             "Plan": [
-              "Projection_4 10.00 root  test.t1.a",
-              "└─IndexReader_6 10.00 root  index:IndexRangeScan_5",
-              "  └─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:b(b, a) range:[-200,-200], keep order:false, stats:pseudo"
+              "IndexReader_9 10.00 root  index:Projection_5",
+              "└─Projection_5 10.00 cop[tikv]  test.t1.a",
+              "  └─IndexRangeScan_8 10.00 cop[tikv] table:t1, index:b(b, a) range:[-200,-200], keep order:false, stats:pseudo"
             ],
             "LastPlanUseCache": "1",
             "Result": null
@@ -134,9 +134,9 @@
               }
             ],
             "Plan": [
-              "Projection_4 10.00 root  test.t1.a",
-              "└─IndexReader_6 10.00 root  index:IndexRangeScan_5",
-              "  └─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:b(b, a) range:[0,0], keep order:false, stats:pseudo"
+              "IndexReader_9 10.00 root  index:Projection_5",
+              "└─Projection_5 10.00 cop[tikv]  test.t1.a",
+              "  └─IndexRangeScan_8 10.00 cop[tikv] table:t1, index:b(b, a) range:[0,0], keep order:false, stats:pseudo"
             ],
             "LastPlanUseCache": "0",
             "Result": null

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -938,6 +938,7 @@ func TestQuickBinding(t *testing.T) {
 	tk := s.newTestKitWithRoot(t)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
 
+	tk.MustExec("set tidb_opt_projection_push_down = 0")
 	tk.MustExec("use test")
 	tk.MustExec(`create table t1 (pk int, a int, b int, c int, primary key(pk), key k_a(a), key k_bc(b, c))`)
 	tk.MustExec(`create table t2 (a int, b int, c int, key k_a(a), key k_bc(b, c))`) // no primary key

--- a/pkg/planner/cardinality/testdata/cardinality_suite_out.json
+++ b/pkg/planner/cardinality/testdata/cardinality_suite_out.json
@@ -4177,8 +4177,8 @@
       {
         "Query": "explain format = 'brief' select a, b from t where a = 1 and b = 1 and c = 1",
         "Result": [
-          "Projection 16.00 root  test.t.a, test.t.b",
-          "└─IndexReader 16.00 root  index:IndexRangeScan",
+          "IndexReader 16.00 root  index:Projection",
+          "└─Projection 16.00 cop[tikv]  test.t.a, test.t.b",
           "  └─IndexRangeScan 16.00 cop[tikv] table:t, index:iabc(a, b, c) range:[1 1 1,1 1 1], keep order:false"
         ]
       },

--- a/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
@@ -136,7 +136,7 @@
       },
       {
         "SQL": "select f from t where a > 1",
-        "Best": "TableReader(Table(t))->Projection"
+        "Best": "TableReader(Table(t)->Projection)"
       },
       {
         "SQL": "select f from t where a > 1 limit 10",

--- a/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
+++ b/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
@@ -177,11 +177,11 @@
       {
         "SQL": "explain select  /*+ READ_FROM_STORAGE(TIFLASH[s]) */ a from s where a = 10 and b is null; -- index path huristic rule will prune tiflash path",
         "Plan": [
-          "TableReader_15 0.10 root  MppVersion: 2, data:ExchangeSender_14",
-          "└─ExchangeSender_14 0.10 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection_13 0.10 mpp[tiflash]  test.s.a",
-          "    └─Selection_10 0.10 mpp[tiflash]  isnull(test.s.b)",
-          "      └─TableFullScan_9 10.00 mpp[tiflash] table:s pushed down filter:eq(test.s.a, 10), keep order:false, stats:pseudo"
+          "TableReader_17 0.10 root  MppVersion: 2, data:ExchangeSender_16",
+          "└─ExchangeSender_16 0.10 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection_14 0.10 mpp[tiflash]  test.s.a",
+          "    └─Selection_11 0.10 mpp[tiflash]  isnull(test.s.b)",
+          "      └─TableFullScan_10 10.00 mpp[tiflash] table:s pushed down filter:eq(test.s.a, 10), keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -361,8 +361,8 @@
         "SQL": "EXPLAIN format = 'brief' SELECT count(a) from t where c=1; -- 11. type not supported",
         "Plan": [
           "StreamAgg 1.00 root  funcs:count(test.t.a)->Column#6",
-          "└─Projection 10.00 root  test.t.a",
-          "  └─TableReader 10.00 root  data:Selection",
+          "└─TableReader 10.00 root  data:Projection",
+          "  └─Projection 10.00 cop[tikv]  test.t.a",
           "    └─Selection 10.00 cop[tikv]  eq(test.t.c, 1)",
           "      └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
@@ -377,8 +377,8 @@
         "SQL": "EXPLAIN format = 'brief' SELECT count(a) from t where d=1; -- 11.1. type not supported",
         "Plan": [
           "StreamAgg 1.00 root  funcs:count(test.t.a)->Column#6",
-          "└─Projection 10.00 root  test.t.a",
-          "  └─TableReader 10.00 root  data:Selection",
+          "└─TableReader 10.00 root  data:Projection",
+          "  └─Projection 10.00 cop[tikv]  test.t.a",
           "    └─Selection 10.00 cop[tikv]  eq(test.t.d, 1)",
           "      └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ],

--- a/pkg/planner/core/casetest/flatplan/testdata/flat_plan_suite_out.json
+++ b/pkg/planner/core/casetest/flatplan/testdata/flat_plan_suite_out.json
@@ -120,8 +120,8 @@
           {
             "Depth": 1,
             "Label": 0,
-            "IsRoot": true,
-            "StoreType": 2,
+            "IsRoot": false,
+            "StoreType": 0,
             "ReqType": 0,
             "IsPhysicalPlan": true,
             "TextTreeIndent": "│ ",
@@ -156,8 +156,8 @@
           {
             "Depth": 1,
             "Label": 0,
-            "IsRoot": true,
-            "StoreType": 2,
+            "IsRoot": false,
+            "StoreType": 0,
             "ReqType": 0,
             "IsPhysicalPlan": true,
             "TextTreeIndent": "│ ",

--- a/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
@@ -207,8 +207,8 @@
       {
         "SQL": "select k1 from t1 where (k1,k2) > (1,2)",
         "Plan": [
-          "Projection 3366.67 root  test.t1.k1",
-          "└─IndexReader 3366.67 root  index:IndexRangeScan",
+          "IndexReader 3366.67 root  index:Projection",
+          "└─Projection 3366.67 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 3366.67 cop[tikv] table:t1, index:pk1(k1, k2) range:(1 2,1 +inf], (1,+inf], keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -216,8 +216,8 @@
       {
         "SQL": "select k1 from t1 where (k1,k2) >= (1,2)",
         "Plan": [
-          "Projection 3366.67 root  test.t1.k1",
-          "└─IndexReader 3366.67 root  index:IndexRangeScan",
+          "IndexReader 3366.67 root  index:Projection",
+          "└─Projection 3366.67 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 3366.67 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 +inf], (1,+inf], keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -225,8 +225,8 @@
       {
         "SQL": "select k1 from t1 where (k1,k2) < (1,2)",
         "Plan": [
-          "Projection 3356.57 root  test.t1.k1",
-          "└─IndexReader 3356.57 root  index:IndexRangeScan",
+          "IndexReader 3356.57 root  index:Projection",
+          "└─Projection 3356.57 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 3356.57 cop[tikv] table:t1, index:pk1(k1, k2) range:[-inf,1), [1 -inf,1 2), keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -234,8 +234,8 @@
       {
         "SQL": "select k1 from t1 where (k1, k2) <= (1,2)",
         "Plan": [
-          "Projection 3356.57 root  test.t1.k1",
-          "└─IndexReader 3356.57 root  index:IndexRangeScan",
+          "IndexReader 3356.57 root  index:Projection",
+          "└─Projection 3356.57 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 3356.57 cop[tikv] table:t1, index:pk1(k1, k2) range:[-inf,1), [1 -inf,1 2], keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -243,8 +243,8 @@
       {
         "SQL": "select k1 from t1 where (k1,k2) = (1,2)",
         "Plan": [
-          "Projection 0.10 root  test.t1.k1",
-          "└─IndexReader 0.10 root  index:IndexRangeScan",
+          "IndexReader 0.10 root  index:Projection",
+          "└─Projection 0.10 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 0.10 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 2], keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -252,8 +252,8 @@
       {
         "SQL": "select k1 from t1 where (k1, k2) != (1,2); -- could not match range scan",
         "Plan": [
-          "Projection 8882.21 root  test.t1.k1",
-          "└─IndexReader 8882.21 root  index:Selection",
+          "IndexReader 8882.21 root  index:Projection",
+          "└─Projection 8882.21 cop[tikv]  test.t1.k1",
           "  └─Selection 8882.21 cop[tikv]  or(ne(test.t1.k1, 1), ne(test.t1.k2, 2))",
           "    └─IndexFullScan 10000.00 cop[tikv] table:t1, index:pk1(k1, k2) keep order:false, stats:pseudo"
         ],
@@ -270,8 +270,8 @@
       {
         "SQL": "select k1 from t1 where (k1, k2) in ((1,2), (3,4))",
         "Plan": [
-          "Projection 0.20 root  test.t1.k1",
-          "└─IndexReader 0.20 root  index:IndexRangeScan",
+          "IndexReader 0.20 root  index:Projection",
+          "└─Projection 0.20 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 0.20 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 2], [3 4,3 4], keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -279,8 +279,8 @@
       {
         "SQL": "select k1 from t1 where (k1, k2) > (1,2) and (k1, k2) < (4,5)",
         "Plan": [
-          "Projection 316.57 root  test.t1.k1",
-          "└─IndexReader 316.57 root  index:IndexRangeScan",
+          "IndexReader 316.57 root  index:Projection",
+          "└─Projection 316.57 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 316.57 cop[tikv] table:t1, index:pk1(k1, k2) range:(1 2,1 +inf], (1,4), [4 -inf,4 5), keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -288,8 +288,8 @@
       {
         "SQL": "select k1 from t1 where (k1, k2) >= (1,2) and (k1, k2) <= (4,5)",
         "Plan": [
-          "Projection 316.57 root  test.t1.k1",
-          "└─IndexReader 316.57 root  index:IndexRangeScan",
+          "IndexReader 316.57 root  index:Projection",
+          "└─Projection 316.57 cop[tikv]  test.t1.k1",
           "  └─IndexRangeScan 316.57 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 +inf], (1,4), [4 -inf,4 5], keep order:false, stats:pseudo"
         ],
         "Result": null
@@ -297,8 +297,8 @@
       {
         "SQL": "select k1 from t1 where (k2, k3) > (1,2); -- could not match range scan ",
         "Plan": [
-          "Projection 3335.56 root  test.t1.k1",
-          "└─TableReader 3335.56 root  data:Selection",
+          "TableReader 3335.56 root  data:Projection",
+          "└─Projection 3335.56 cop[tikv]  test.t1.k1",
           "  └─Selection 3335.56 cop[tikv]  or(gt(test.t1.k2, 1), and(eq(test.t1.k2, 1), gt(test.t1.k3, 2)))",
           "    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],

--- a/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
@@ -182,8 +182,8 @@
       {
         "SQL": "select b from t3 where a = 1 and b is not null",
         "Plan": [
-          "Projection 10.00 root  test.t3.b",
-          "└─TableReader 10.00 root  data:TableRangeScan",
+          "TableReader 10.00 root  data:Projection",
+          "└─Projection 10.00 cop[tikv]  test.t3.b",
           "  └─TableRangeScan 10.00 cop[tikv] table:t3 range:[1,1], keep order:false, stats:pseudo"
         ],
         "Result": [

--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -2057,11 +2057,11 @@
       },
       {
         "SQL": "select a from t where c >= 4",
-        "Best": "IndexReader(Index(t.c_d_e)[[4,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[4,+inf]]->Projection)"
       },
       {
         "SQL": "select a from t where c <= 4",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,4]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[-inf,4]]->Projection)"
       },
       {
         "SQL": "select a from t where c = 4 and d = 5 and e = 6",
@@ -2069,43 +2069,43 @@
       },
       {
         "SQL": "select a from t where d = 4 and c = 5",
-        "Best": "IndexReader(Index(t.c_d_e)[[5 4,5 4]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[5 4,5 4]]->Projection)"
       },
       {
         "SQL": "select a from t where c = 4 and e < 5",
-        "Best": "IndexReader(Index(t.c_d_e)[[4,4]]->Sel([lt(test.t.e, 5)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[4,4]]->Sel([lt(test.t.e, 5)])->Projection)"
       },
       {
         "SQL": "select a from t where c = 4 and d <= 5 and d > 3",
-        "Best": "IndexReader(Index(t.c_d_e)[(4 3,4 5]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[(4 3,4 5]]->Projection)"
       },
       {
         "SQL": "select a from t where d <= 5 and d > 3",
-        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Sel([le(test.t.d, 5) gt(test.t.d, 3)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Sel([le(test.t.d, 5) gt(test.t.d, 3)])->Projection)"
       },
       {
         "SQL": "select a from t where c between 1 and 2",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,2]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,2]]->Projection)"
       },
       {
         "SQL": "select a from t where c not between 1 and 2",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1) (2,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1) (2,+inf]]->Projection)"
       },
       {
         "SQL": "select a from t where c <= 5 and c >= 3 and d = 1",
-        "Best": "IndexReader(Index(t.c_d_e)[[3,5]]->Sel([eq(test.t.d, 1)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[3,5]]->Sel([eq(test.t.d, 1)])->Projection)"
       },
       {
         "SQL": "select a from t where c = 1 or c = 2 or c = 3",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,3]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,3]]->Projection)"
       },
       {
         "SQL": "select b from t where c = 1 or c = 2 or c = 3 or c = 4 or c = 5",
-        "Best": "TableReader(Table(t)->Sel([or(or(eq(test.t.c, 1), eq(test.t.c, 2)), or(eq(test.t.c, 3), or(eq(test.t.c, 4), eq(test.t.c, 5))))]))->Projection"
+        "Best": "TableReader(Table(t)->Sel([or(or(eq(test.t.c, 1), eq(test.t.c, 2)), or(eq(test.t.c, 3), or(eq(test.t.c, 4), eq(test.t.c, 5))))])->Projection)"
       },
       {
         "SQL": "select a from t where c = 5",
-        "Best": "IndexReader(Index(t.c_d_e)[[5,5]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[5,5]]->Projection)"
       },
       {
         "SQL": "select a from t where c = 5 and b = 1",
@@ -2117,19 +2117,19 @@
       },
       {
         "SQL": "select a from t where c in (1)",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,1]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,1]]->Projection)"
       },
       {
         "SQL": "select a from t where c in ('1')",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,1]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,1]]->Projection)"
       },
       {
         "SQL": "select a from t where c = 1.0",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,1]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,1]]->Projection)"
       },
       {
         "SQL": "select a from t where c in (1) and d > 3",
-        "Best": "IndexReader(Index(t.c_d_e)[(1 3,1 +inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[(1 3,1 +inf]]->Projection)"
       },
       {
         "SQL": "select a from t where c in (1, 2, 3) and (d > 3 and d < 4 or d > 5 and d < 6)",
@@ -2137,11 +2137,11 @@
       },
       {
         "SQL": "select a from t where c in (1, 2, 3) and (d > 2 and d < 4 or d > 5 and d < 7)",
-        "Best": "IndexReader(Index(t.c_d_e)[[1 3,1 3] [1 6,1 6] [2 3,2 3] [2 6,2 6] [3 3,3 3] [3 6,3 6]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1 3,1 3] [1 6,1 6] [2 3,2 3] [2 6,2 6] [3 3,3 3] [3 6,3 6]]->Projection)"
       },
       {
         "SQL": "select a from t where c in (1, 2, 3)",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,1] [2,2] [3,3]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,1] [2,2] [3,3]]->Projection)"
       },
       {
         "SQL": "select a from t where c in (1, 2, 3) and d in (1,2) and e = 1",
@@ -2149,75 +2149,75 @@
       },
       {
         "SQL": "select a from t where d in (1, 2, 3)",
-        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Sel([in(test.t.d, 1, 2, 3)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Sel([in(test.t.d, 1, 2, 3)])->Projection)"
       },
       {
         "SQL": "select a from t where c not in (1)",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1) (1,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1) (1,+inf]]->Projection)"
       },
       {
         "SQL": "select a from t use index(c_d_e) where c != 1",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1) (1,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1) (1,+inf]]->Projection)"
       },
       {
         "SQL": "select a from t where c_str like ''",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"\",\"\"]]->Sel([like(test.t.c_str, , 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"\",\"\"]]->Sel([like(test.t.c_str, , 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abc\"]]->Sel([like(test.t.c_str, abc, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abc\"]]->Sel([like(test.t.c_str, abc, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str not like 'abc'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[NULL,+inf]]->Sel([not(like(test.t.c_str, abc, 92))]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[NULL,+inf]]->Sel([not(like(test.t.c_str, abc, 92))])->Projection)"
       },
       {
         "SQL": "select a from t where not (c_str like 'abc' or c_str like 'abd')",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[NULL,+inf]]->Sel([and(not(like(test.t.c_str, abc, 92)), not(like(test.t.c_str, abd, 92)))]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[NULL,+inf]]->Sel([and(not(like(test.t.c_str, abc, 92)), not(like(test.t.c_str, abd, 92)))])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like '_abc'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[NULL,+inf]]->Sel([like(test.t.c_str, _abc, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[NULL,+inf]]->Sel([like(test.t.c_str, _abc, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc%'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abd\")]->Sel([like(test.t.c_str, abc%, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abd\")]->Sel([like(test.t.c_str, abc%, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc_'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abd\")]->Sel([like(test.t.c_str, abc_, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abd\")]->Sel([like(test.t.c_str, abc_, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc%af'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abd\")]->Sel([like(test.t.c_str, abc%af, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc\",\"abd\")]->Sel([like(test.t.c_str, abc%af, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc\\_' escape ''",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc_\"]]->Sel([like(test.t.c_str, abc\\_, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc_\"]]->Sel([like(test.t.c_str, abc\\_, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc\\_'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc_\"]]->Sel([like(test.t.c_str, abc\\_, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc_\"]]->Sel([like(test.t.c_str, abc\\_, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc\\\\_'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc_\"]]->Sel([like(test.t.c_str, abc\\_, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc_\"]]->Sel([like(test.t.c_str, abc\\_, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc\\_%'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc`\")]->Sel([like(test.t.c_str, abc\\_%, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc`\")]->Sel([like(test.t.c_str, abc\\_%, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc=_%' escape '='",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc`\")]->Sel([like(test.t.c_str, abc=_%, 61)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc`\")]->Sel([like(test.t.c_str, abc=_%, 61)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 'abc\\__'",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc`\")]->Sel([like(test.t.c_str, abc\\__, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"abc_\",\"abc`\")]->Sel([like(test.t.c_str, abc\\__, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c_str like 123",
-        "Best": "IndexReader(Index(t.c_d_e_str)[[\"123\",\"123\"]]->Sel([like(test.t.c_str, 123, 92)]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e_str)[[\"123\",\"123\"]]->Sel([like(test.t.c_str, 123, 92)])->Projection)"
       },
       {
         "SQL": "select a from t where c = 1.9 and d > 3",
@@ -2225,19 +2225,19 @@
       },
       {
         "SQL": "select a from t where c < 1.1",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,2)])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[-inf,2)]->Projection)"
       },
       {
         "SQL": "select a from t where c <= 1.9",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[-inf,1]]->Projection)"
       },
       {
         "SQL": "select a from t where c >= 1.1",
-        "Best": "IndexReader(Index(t.c_d_e)[[2,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[2,+inf]]->Projection)"
       },
       {
         "SQL": "select a from t where c > 1.9",
-        "Best": "IndexReader(Index(t.c_d_e)[(1,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[(1,+inf]]->Projection)"
       },
       {
         "SQL": "select a from t where c = 123456789098765432101234",
@@ -2245,7 +2245,7 @@
       },
       {
         "SQL": "select a from t where c = 'hanfei'",
-        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Sel([eq(cast(test.t.c, double BINARY), cast(hanfei, double BINARY))]))->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Sel([eq(cast(test.t.c, double BINARY), cast(hanfei, double BINARY))])->Projection)"
       }
     ]
   },

--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -51,6 +51,7 @@ func TestPlanStatsLoad(t *testing.T) {
 	tk.MustExec("set @@session.tidb_analyze_version=2")
 	tk.MustExec("set @@session.tidb_partition_prune_mode = 'static'")
 	tk.MustExec("set @@session.tidb_stats_load_sync_wait = 60000")
+	tk.MustExec("set tidb_opt_projection_push_down = 0")
 	tk.MustExec("create table t(a int, b int, c int, d int, primary key(a), key idx(b))")
 	tk.MustExec("insert into t values (1,1,1,1),(2,2,2,2),(3,3,3,3)")
 	tk.MustExec("create table pt(a int, b int, c int) partition by range(a) (partition p0 values less than (10), partition p1 values less than (20), partition p2 values less than maxvalue)")

--- a/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
+++ b/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
@@ -443,8 +443,8 @@
         "Plan": [
           " TableReader         root         ",
           " └─ExchangeSender    cop[tiflash] ",
-          "   └─Selection       cop[tiflash] gt(test.t1.a, ?), or(lt(test.t1.a, ?), lt(test.t1.b, ?))",
-          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.b, ?), keep order:false"
+          "   └─Selection       cop[tiflash] gt(test.t1.b, ?), or(lt(test.t1.a, ?), lt(test.t1.b, ?))",
+          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.a, ?), keep order:false"
         ]
       },
       {
@@ -461,8 +461,8 @@
         "Plan": [
           " TableReader         root         ",
           " └─ExchangeSender    cop[tiflash] ",
-          "   └─Selection       cop[tiflash] gt(test.t1.a, ?), gt(test.t1.c, ?), or(gt(test.t1.a, ?), lt(test.t1.b, ?))",
-          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.b, ?), keep order:false"
+          "   └─Selection       cop[tiflash] gt(test.t1.b, ?), gt(test.t1.c, ?), or(gt(test.t1.a, ?), lt(test.t1.b, ?))",
+          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.a, ?), keep order:false"
         ]
       },
       {

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -827,8 +827,8 @@ func TestGlobalStats(t *testing.T) {
 	tk.MustExec("analyze table t;")
 	// test the indexScan
 	tk.MustQuery("explain format = 'brief' select b from t where a > 5 and b > 10;").Check(testkit.Rows(
-		"Projection 2.67 root  test.t.b",
-		"└─IndexReader 2.67 root partition:all index:Selection",
+		"IndexReader 2.67 root partition:all index:Projection",
+		"└─Projection 2.67 cop[tikv]  test.t.b",
 		"  └─Selection 2.67 cop[tikv]  gt(test.t.b, 10)",
 		"    └─IndexRangeScan 4.00 cop[tikv] table:t, index:idx_ab(a, b) range:(5,+inf], keep order:false"))
 	// test the indexLookUp

--- a/tests/integrationtest/r/clustered_index.result
+++ b/tests/integrationtest/r/clustered_index.result
@@ -52,15 +52,15 @@ StreamAgg_17	1.00	root		funcs:count(Column#9)->Column#7
     └─IndexRangeScan_16	41.00	cop[tikv]	table:tbl_0, index:idx_3(col_0)	range:[-inf,41), keep order:false
 explain select col_14 from with_cluster_index.tbl_2 where col_11 <> '2013-11-01' ;
 id	estRows	task	access object	operator info
-Projection_4	4509.00	root		with_cluster_index.tbl_2.col_14
-└─IndexReader_6	4509.00	root		index:IndexRangeScan_5
-  └─IndexRangeScan_5	4509.00	cop[tikv]	table:tbl_2, index:idx_9(col_11)	range:[-inf,2013-11-01 00:00:00), (2013-11-01 00:00:00,+inf], keep order:false
+IndexReader_9	4509.00	root		index:Projection_5
+└─Projection_5	4509.00	cop[tikv]		with_cluster_index.tbl_2.col_14
+  └─IndexRangeScan_8	4509.00	cop[tikv]	table:tbl_2, index:idx_9(col_11)	range:[-inf,2013-11-01 00:00:00), (2013-11-01 00:00:00,+inf], keep order:false
 explain select col_14 from wout_cluster_index.tbl_2 where col_11 <> '2013-11-01' ;
 id	estRows	task	access object	operator info
-Projection_4	4509.00	root		wout_cluster_index.tbl_2.col_14
-└─TableReader_7	4509.00	root		data:Selection_6
-  └─Selection_6	4509.00	cop[tikv]		ne(wout_cluster_index.tbl_2.col_11, 2013-11-01 00:00:00.000000)
-    └─TableFullScan_5	4673.00	cop[tikv]	table:tbl_2	keep order:false
+TableReader_14	4509.00	root		data:Projection_5
+└─Projection_5	4509.00	cop[tikv]		wout_cluster_index.tbl_2.col_14
+  └─Selection_13	4509.00	cop[tikv]		ne(wout_cluster_index.tbl_2.col_11, 2013-11-01 00:00:00.000000)
+    └─TableFullScan_12	4673.00	cop[tikv]	table:tbl_2	keep order:false
 explain select sum( col_4 ) from with_cluster_index.tbl_0 where col_3 != '1993-12-02' ;
 id	estRows	task	access object	operator info
 StreamAgg_17	1.00	root		funcs:sum(Column#8)->Column#6

--- a/tests/integrationtest/r/cte.result
+++ b/tests/integrationtest/r/cte.result
@@ -620,37 +620,37 @@ c1	c2
 // Same as above, but test recursive cte.
 explain select * from t1 where c1 > all(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 1) select c1 from cte1);
 id	estRows	task	access object	operator info
-Projection_26	10000.00	root		cte.t1.c1, cte.t1.c2
-└─Apply_28	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(cte.t1.c1, Column#14), if(ne(Column#15, 0), NULL, 1)), or(eq(Column#16, 0), if(isnull(cte.t1.c1), NULL, 0)))
-  ├─TableReader_30(Build)	10000.00	root		data:TableFullScan_29
-  │ └─TableFullScan_29	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-  └─HashAgg_31(Probe)	10000.00	root		funcs:max(Column#19)->Column#14, funcs:sum(Column#20)->Column#15, funcs:count(1)->Column#16
-    └─Projection_35	200000.00	root		cte.t2.c1->Column#19, cast(isnull(cte.t2.c1), decimal(20,0) BINARY)->Column#20
-      └─CTEFullScan_33	200000.00	root	CTE:cte1	data:CTE_0
+Projection_30	10000.00	root		cte.t1.c1, cte.t1.c2
+└─Apply_32	10000.00	root		CARTESIAN inner join, other cond:or(and(gt(cte.t1.c1, Column#14), if(ne(Column#15, 0), NULL, 1)), or(eq(Column#16, 0), if(isnull(cte.t1.c1), NULL, 0)))
+  ├─TableReader_34(Build)	10000.00	root		data:TableFullScan_33
+  │ └─TableFullScan_33	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─HashAgg_35(Probe)	10000.00	root		funcs:max(Column#19)->Column#14, funcs:sum(Column#20)->Column#15, funcs:count(1)->Column#16
+    └─Projection_39	200000.00	root		cte.t2.c1->Column#19, cast(isnull(cte.t2.c1), decimal(20,0) BINARY)->Column#20
+      └─CTEFullScan_37	200000.00	root	CTE:cte1	data:CTE_0
 CTE_0	20.00	root		Recursive CTE, limit(offset:0, count:1)
-├─Projection_19(Seed Part)	10.00	root		cte.t2.c1
-│ └─TableReader_22	10.00	root		data:Selection_21
-│   └─Selection_21	10.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
-│     └─TableFullScan_20	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─Projection_23(Recursive Part)	10.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1
-  └─CTETable_24	10.00	root		Scan on CTE_0
+├─TableReader_26(Seed Part)	10.00	root		data:Projection_20
+│ └─Projection_20	10.00	cop[tikv]		cte.t2.c1
+│   └─Selection_25	10.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
+│     └─TableFullScan_24	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+└─Projection_27(Recursive Part)	10.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1
+  └─CTETable_28	10.00	root		Scan on CTE_0
 select * from t1 where c1 > all(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 1) select c1 from cte1);
 c1	c2
 2	1
 2	3
 explain select * from t1 where exists(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 10) select c1 from cte1);
 id	estRows	task	access object	operator info
-Apply_25	10000.00	root		CARTESIAN semi join
-├─TableReader_27(Build)	10000.00	root		data:TableFullScan_26
-│ └─TableFullScan_26	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─CTEFullScan_28(Probe)	200000.00	root	CTE:cte1	data:CTE_0
+Apply_29	10000.00	root		CARTESIAN semi join
+├─TableReader_31(Build)	10000.00	root		data:TableFullScan_30
+│ └─TableFullScan_30	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─CTEFullScan_32(Probe)	200000.00	root	CTE:cte1	data:CTE_0
 CTE_0	20.00	root		Recursive CTE, limit(offset:0, count:10)
-├─Projection_17(Seed Part)	10.00	root		cte.t2.c1
-│ └─TableReader_20	10.00	root		data:Selection_19
-│   └─Selection_19	10.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
-│     └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
-└─Projection_21(Recursive Part)	10.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1
-  └─CTETable_22	10.00	root		Scan on CTE_0
+├─TableReader_24(Seed Part)	10.00	root		data:Projection_18
+│ └─Projection_18	10.00	cop[tikv]		cte.t2.c1
+│   └─Selection_23	10.00	cop[tikv]		eq(cte.t2.c2, cte.t1.c2)
+│     └─TableFullScan_22	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+└─Projection_25(Recursive Part)	10.00	root		cast(plus(cte.t2.c1, 1), int(11))->cte.t2.c1
+  └─CTETable_26	10.00	root		Scan on CTE_0
 select * from t1 where exists(with recursive cte1 as (select c1 from t2 where t2.c2 = t1.c2 union all select c1+1 as c1 from cte1 limit 10) select c1 from cte1);
 c1	c2
 2	1

--- a/tests/integrationtest/r/executor/chunk_reuse.result
+++ b/tests/integrationtest/r/executor/chunk_reuse.result
@@ -223,16 +223,14 @@ explain format='brief' select id1 from t3 where id2 > '3' or id8 < 10 union (sel
 id	estRows	task	access object	operator info
 HashAgg	8878.22	root		group by:Column#17, funcs:firstrow(Column#17)->Column#17
 └─Union	11097.78	root		
-  ├─Projection	5548.89	root		executor__chunk_reuse.t3.id1->Column#17
-  │ └─IndexMerge	5548.89	root		type: union
-  │   ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t3, index:id2(id2)	range:("3",+inf], keep order:false, stats:pseudo
-  │   ├─IndexRangeScan(Build)	3323.33	cop[tikv]	table:t3, index:id8(id8)	range:[-inf,10), keep order:false, stats:pseudo
-  │   └─TableRowIDScan(Probe)	5548.89	cop[tikv]	table:t3	keep order:false, stats:pseudo
-  └─Projection	5548.89	root		executor__chunk_reuse.t3.id1->Column#17
-    └─IndexMerge	5548.89	root		type: union
-      ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t3, index:id2(id2)	range:("4",+inf], keep order:false, stats:pseudo
-      ├─IndexRangeScan(Build)	3323.33	cop[tikv]	table:t3, index:id8(id8)	range:[-inf,7), keep order:false, stats:pseudo
-      └─TableRowIDScan(Probe)	5548.89	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  ├─TableReader	5548.89	root		data:Projection
+  │ └─Projection	5548.89	cop[tikv]		executor__chunk_reuse.t3.id1->Column#17
+  │   └─Selection	5548.89	cop[tikv]		or(gt(executor__chunk_reuse.t3.id2, "3"), lt(executor__chunk_reuse.t3.id8, 10))
+  │     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  └─TableReader	5548.89	root		data:Projection
+    └─Projection	5548.89	cop[tikv]		executor__chunk_reuse.t3.id1->Column#17
+      └─Selection	5548.89	cop[tikv]		or(gt(executor__chunk_reuse.t3.id2, "4"), lt(executor__chunk_reuse.t3.id8, 7))
+        └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
 select id1 from t3 where id2 > '3' or id8 < 10 union (select id1 from t3 where id2 > '4' or id8 < 7);
 id1
 1

--- a/tests/integrationtest/r/executor/explain.result
+++ b/tests/integrationtest/r/executor/explain.result
@@ -347,22 +347,22 @@ Update_17	N/A	root		N/A
 └─Projection_28	8.00	root		executor__explain.t1.id1, executor__explain.t1.id2, executor__explain.t1.id3, executor__explain.t1.id4, executor__explain.t1.id5, executor__explain.t1.id6, executor__explain.t1.id7, executor__explain.t1._tidb_rowid
   └─Selection_29	8.00	root		eq(minus(executor__explain.t1.id6, ifnull(executor__explain.t1.id7, 0)), ifnull(Column#22, 0))
     └─HashJoin_32	10.00	root		left outer join, equal:[eq(executor__explain.t1.id2, executor__explain.t2.id2)]
-      ├─HashAgg_69(Build)	12.50	root		group by:executor__explain.t2.id2, funcs:count(1)->Column#22, funcs:firstrow(executor__explain.t2.id2)->executor__explain.t2.id2
-      │ └─IndexJoin_76	15.62	root		inner join, inner:IndexReader_75, outer key:executor__explain.t2.id10, inner key:executor__explain.t3.id20, equal cond:eq(executor__explain.t2.id10, executor__explain.t3.id20)
-      │   ├─IndexHashJoin_93(Build)	12.50	root		inner join, inner:IndexLookUp_90, outer key:executor__explain.t1.id2, inner key:executor__explain.t2.id2, equal cond:eq(executor__explain.t1.id2, executor__explain.t2.id2)
-      │   │ ├─Projection_103(Build)	10.00	root		executor__explain.t1.id2
-      │   │ │ └─IndexLookUp_109	10.00	root		
-      │   │ │   ├─IndexRangeScan_107(Build)	10.00	cop[tikv]	table:rn, index:ix_id1(id1)	range:["03","03"], keep order:false, stats:pseudo
-      │   │ │   └─TableRowIDScan_108(Probe)	10.00	cop[tikv]	table:rn	keep order:false, stats:pseudo
-      │   │ └─IndexLookUp_90(Probe)	12.50	root		
-      │   │   ├─IndexRangeScan_88(Build)	12.50	cop[tikv]	table:b, index:IX_id2(id2)	range: decided by [eq(executor__explain.t2.id2, executor__explain.t1.id2)], keep order:false, stats:pseudo
-      │   │   └─TableRowIDScan_89(Probe)	12.50	cop[tikv]	table:b	keep order:false, stats:pseudo
-      │   └─IndexReader_75(Probe)	12.50	root		index:Selection_74
-      │     └─Selection_74	12.50	cop[tikv]		not(isnull(executor__explain.t3.id20))
-      │       └─IndexRangeScan_73	12.50	cop[tikv]	table:c, index:IX_id20(id20)	range: decided by [eq(executor__explain.t3.id20, executor__explain.t2.id10)], keep order:false, stats:pseudo
-      └─IndexLookUp_68(Probe)	10.00	root		
-        ├─IndexRangeScan_66(Build)	10.00	cop[tikv]	table:a, index:ix_id1(id1)	range:["03","03"], keep order:false, stats:pseudo
-        └─TableRowIDScan_67(Probe)	10.00	cop[tikv]	table:a	keep order:false, stats:pseudo
+      ├─HashAgg_70(Build)	12.50	root		group by:executor__explain.t2.id2, funcs:count(1)->Column#22, funcs:firstrow(executor__explain.t2.id2)->executor__explain.t2.id2
+      │ └─IndexJoin_77	15.62	root		inner join, inner:IndexReader_76, outer key:executor__explain.t2.id10, inner key:executor__explain.t3.id20, equal cond:eq(executor__explain.t2.id10, executor__explain.t3.id20)
+      │   ├─IndexHashJoin_94(Build)	12.50	root		inner join, inner:IndexLookUp_91, outer key:executor__explain.t1.id2, inner key:executor__explain.t2.id2, equal cond:eq(executor__explain.t1.id2, executor__explain.t2.id2)
+      │   │ ├─Projection_104(Build)	10.00	root		executor__explain.t1.id2
+      │   │ │ └─IndexLookUp_111	10.00	root		
+      │   │ │   ├─IndexRangeScan_109(Build)	10.00	cop[tikv]	table:rn, index:ix_id1(id1)	range:["03","03"], keep order:false, stats:pseudo
+      │   │ │   └─TableRowIDScan_110(Probe)	10.00	cop[tikv]	table:rn	keep order:false, stats:pseudo
+      │   │ └─IndexLookUp_91(Probe)	12.50	root		
+      │   │   ├─IndexRangeScan_89(Build)	12.50	cop[tikv]	table:b, index:IX_id2(id2)	range: decided by [eq(executor__explain.t2.id2, executor__explain.t1.id2)], keep order:false, stats:pseudo
+      │   │   └─TableRowIDScan_90(Probe)	12.50	cop[tikv]	table:b	keep order:false, stats:pseudo
+      │   └─IndexReader_76(Probe)	12.50	root		index:Selection_75
+      │     └─Selection_75	12.50	cop[tikv]		not(isnull(executor__explain.t3.id20))
+      │       └─IndexRangeScan_74	12.50	cop[tikv]	table:c, index:IX_id20(id20)	range: decided by [eq(executor__explain.t3.id20, executor__explain.t2.id10)], keep order:false, stats:pseudo
+      └─IndexLookUp_69(Probe)	10.00	root		
+        ├─IndexRangeScan_67(Build)	10.00	cop[tikv]	table:a, index:ix_id1(id1)	range:["03","03"], keep order:false, stats:pseudo
+        └─TableRowIDScan_68(Probe)	10.00	cop[tikv]	table:a	keep order:false, stats:pseudo
 drop table if exists t;
 create table t (a int, b int, index (a));
 insert into t values (1, 1);

--- a/tests/integrationtest/r/explain_cte.result
+++ b/tests/integrationtest/r/explain_cte.result
@@ -467,13 +467,13 @@ id	estRows	task	access object	operator info
 Update_17	N/A	root		N/A
 └─HashJoin_22	15.61	root		inner join, equal:[eq(explain_cte.t1.a, explain_cte.t2.c)]
   ├─HashJoin_30(Build)	12.49	root		inner join, equal:[eq(explain_cte.t3.e, explain_cte.t2.d)]
-  │ ├─Projection_32(Build)	9.99	root		explain_cte.t3.e
-  │ │ └─TableReader_35	9.99	root		data:Selection_34
-  │ │   └─Selection_34	9.99	cop[tikv]		eq(explain_cte.t3.f, 1234), not(isnull(explain_cte.t3.e))
-  │ │     └─TableFullScan_33	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-  │ └─TableReader_38(Probe)	9980.01	root		data:Selection_37
-  │   └─Selection_37	9980.01	cop[tikv]		not(isnull(explain_cte.t2.c)), not(isnull(explain_cte.t2.d))
-  │     └─TableFullScan_36	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+  │ ├─TableReader_39(Build)	9.99	root		data:Projection_33
+  │ │ └─Projection_33	9.99	cop[tikv]		explain_cte.t3.e
+  │ │   └─Selection_38	9.99	cop[tikv]		eq(explain_cte.t3.f, 1234), not(isnull(explain_cte.t3.e))
+  │ │     └─TableFullScan_37	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  │ └─TableReader_42(Probe)	9980.01	root		data:Selection_41
+  │   └─Selection_41	9980.01	cop[tikv]		not(isnull(explain_cte.t2.c)), not(isnull(explain_cte.t2.d))
+  │     └─TableFullScan_40	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
   └─TableReader_26(Probe)	9990.00	root		data:Selection_25
     └─Selection_25	9990.00	cop[tikv]		not(isnull(explain_cte.t1.a))
       └─TableFullScan_24	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/explain_easy.result
+++ b/tests/integrationtest/r/explain_easy.result
@@ -648,8 +648,8 @@ id	estRows	task	access object	operator info
 Point_Get	1.00	root	table:t	handle:0
 explain format = 'brief' select * from t where _tidb_rowid > 0;
 id	estRows	task	access object	operator info
-Projection	8000.00	root		explain_easy.t.a
-└─TableReader	10000.00	root		data:TableRangeScan
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		explain_easy.t.a
   └─TableRangeScan	10000.00	cop[tikv]	table:t	range:(0,+inf], keep order:false, stats:pseudo
 explain format = 'brief' select a, _tidb_rowid from t where a > 0;
 id	estRows	task	access object	operator info
@@ -658,8 +658,8 @@ TableReader	3333.33	root		data:Selection
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format = 'brief' select * from t where _tidb_rowid > 0 and a > 0;
 id	estRows	task	access object	operator info
-Projection	2666.67	root		explain_easy.t.a
-└─TableReader	2666.67	root		data:Selection
+TableReader	2666.67	root		data:Projection
+└─Projection	2666.67	cop[tikv]		explain_easy.t.a
   └─Selection	2666.67	cop[tikv]		gt(explain_easy.t.a, 0)
     └─TableRangeScan	3333.33	cop[tikv]	table:t	range:(0,+inf], keep order:false, stats:pseudo
 drop table if exists t;

--- a/tests/integrationtest/r/explain_generate_column_substitute.result
+++ b/tests/integrationtest/r/explain_generate_column_substitute.result
@@ -624,16 +624,16 @@ id
 1
 desc format = 'brief' SELECT id FROM person ignore index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	8000.00	root		explain_generate_column_substitute.person.id
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		explain_generate_column_substitute.person.id
   └─Selection	8000.00	cop[tikv]		eq(json_unquote(cast(json_extract(explain_generate_column_substitute.person.address_info, "$.city"), var_string(16777216))), "Beijing")
     └─TableFullScan	10000.00	cop[tikv]	table:person	keep order:false, stats:pseudo
 SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id
 desc format = 'brief' SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	10.00	root		explain_generate_column_substitute.person.id
-└─IndexReader	10.00	root		index:IndexRangeScan
+IndexReader	10.00	root		index:Projection
+└─Projection	10.00	cop[tikv]		explain_generate_column_substitute.person.id
   └─IndexRangeScan	10.00	cop[tikv]	table:person, index:city(city)	range:["Beijing","Beijing"], keep order:false, stats:pseudo
 drop table person;
 create table t(a char(5), b char(6) as (concat(a, a)), index bx(b));
@@ -664,8 +664,8 @@ id
 1
 desc format = 'brief' SELECT id FROM person ignore index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	8000.00	root		explain_generate_column_substitute.person.id
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		explain_generate_column_substitute.person.id
   └─Selection	8000.00	cop[tikv]		eq(json_unquote(cast(json_extract(explain_generate_column_substitute.person.address_info, "$.city"), var_string(16777216))), "Beijing")
     └─TableFullScan	10000.00	cop[tikv]	table:person	keep order:false, stats:pseudo
 SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
@@ -673,8 +673,8 @@ id
 1
 desc format = 'brief' SELECT id FROM person force index(`city`) WHERE address_info->>"$.city" = 'Beijing';
 id	estRows	task	access object	operator info
-Projection	10.00	root		explain_generate_column_substitute.person.id
-└─IndexReader	10.00	root		index:IndexRangeScan
+IndexReader	10.00	root		index:Projection
+└─Projection	10.00	cop[tikv]		explain_generate_column_substitute.person.id
   └─IndexRangeScan	10.00	cop[tikv]	table:person, index:city(city)	range:["Beijing","Beijing"], keep order:false, stats:pseudo
 drop table person;
 create table t(a char(5), b char(10) as (concat(a, a)), index bx(b));

--- a/tests/integrationtest/r/explain_shard_index.result
+++ b/tests/integrationtest/r/explain_shard_index.result
@@ -35,14 +35,14 @@ Projection	8000.00	root		explain_shard_index.test3.id, explain_shard_index.test3
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where ((a=100 and b = 100) or a = 200) and b = 300;
 id	estRows	task	access object	operator info
-Projection	0.01	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
-└─TableReader	0.01	root		data:Selection
+TableReader	0.01	root		data:Projection
+└─Projection	0.01	cop[tikv]		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
   └─Selection	0.01	cop[tikv]		eq(explain_shard_index.test3.b, 300), or(0, eq(explain_shard_index.test3.a, 200))
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where a = b;
 id	estRows	task	access object	operator info
-Projection	8000.00	root		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		explain_shard_index.test3.id, explain_shard_index.test3.a, explain_shard_index.test3.b
   └─Selection	8000.00	cop[tikv]		eq(explain_shard_index.test3.a, explain_shard_index.test3.b)
     └─TableFullScan	10000.00	cop[tikv]	table:test3	keep order:false, stats:pseudo
 explain format=brief select * from test3 where a = b and b = 100;

--- a/tests/integrationtest/r/expression/explain.result
+++ b/tests/integrationtest/r/expression/explain.result
@@ -331,26 +331,26 @@ drop table if exists reg;
 create table reg(a varchar(20) null,b varchar(20) null,rep varchar(20) null) charset=utf8mb4 collate=utf8mb4_general_ci;
 explain format = 'brief' select a from reg where regexp_like(a, b);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		expression__explain.reg.a
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		expression__explain.reg.a
   └─Selection	8000.00	cop[tikv]		regexp_like(expression__explain.reg.a, expression__explain.reg.b)
     └─TableFullScan	10000.00	cop[tikv]	table:reg	keep order:false, stats:pseudo
 explain format = 'brief' select a from reg where regexp_instr(a, b);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		expression__explain.reg.a
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		expression__explain.reg.a
   └─Selection	8000.00	cop[tikv]		regexp_instr(expression__explain.reg.a, expression__explain.reg.b)
     └─TableFullScan	10000.00	cop[tikv]	table:reg	keep order:false, stats:pseudo
 explain format = 'brief' select a from reg where regexp_substr(a, b);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		expression__explain.reg.a
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		expression__explain.reg.a
   └─Selection	8000.00	cop[tikv]		regexp_substr(expression__explain.reg.a, expression__explain.reg.b)
     └─TableFullScan	10000.00	cop[tikv]	table:reg	keep order:false, stats:pseudo
 explain format = 'brief' select a from reg where regexp_replace(a, b, rep);
 id	estRows	task	access object	operator info
-Projection	8000.00	root		expression__explain.reg.a
-└─TableReader	8000.00	root		data:Selection
+TableReader	8000.00	root		data:Projection
+└─Projection	8000.00	cop[tikv]		expression__explain.reg.a
   └─Selection	8000.00	cop[tikv]		regexp_replace(expression__explain.reg.a, expression__explain.reg.b, expression__explain.reg.rep)
     └─TableFullScan	10000.00	cop[tikv]	table:reg	keep order:false, stats:pseudo
 drop table if exists regbin;

--- a/tests/integrationtest/r/index_merge.result
+++ b/tests/integrationtest/r/index_merge.result
@@ -814,18 +814,18 @@ c1	c2	c3	c4	c5
 5	5	5	5	5
 explain with recursive cte1 as (select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 10 or c2 < 10 and c3 < 10 UNION ALL select c1 + 100 from cte1 where c1 < 10) select * from cte1 order by 1;
 id	estRows	task	access object	operator info
-Sort_23	7309.33	root		index_merge.t1.c1
-└─CTEFullScan_26	7309.33	root	CTE:cte1	data:CTE_0
+Sort_24	7309.33	root		index_merge.t1.c1
+└─CTEFullScan_27	7309.33	root	CTE:cte1	data:CTE_0
 CTE_0	7309.33	root		Recursive CTE
 ├─Projection_14(Seed Part)	4060.74	root		index_merge.t1.c1
-│ └─IndexMerge_19	2250.55	root		type: union
-│   ├─IndexRangeScan_15(Build)	3323.33	cop[tikv]	table:t1, index:c1(c1)	range:[-inf,10), keep order:false, stats:pseudo
-│   ├─IndexRangeScan_16(Build)	3323.33	cop[tikv]	table:t1, index:c2(c2)	range:[-inf,10), keep order:false, stats:pseudo
-│   └─Selection_18(Probe)	2250.55	cop[tikv]		or(lt(index_merge.t1.c1, 10), and(lt(index_merge.t1.c2, 10), lt(index_merge.t1.c3, 10)))
-│     └─TableRowIDScan_17	5542.21	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─Projection_20(Recursive Part)	3248.59	root		cast(plus(index_merge.t1.c1, 100), int(11))->index_merge.t1.c1
-  └─Selection_21	3248.59	root		lt(index_merge.t1.c1, 10)
-    └─CTETable_22	4060.74	root		Scan on CTE_0
+│ └─IndexMerge_20	2250.55	root		type: union
+│   ├─IndexRangeScan_16(Build)	3323.33	cop[tikv]	table:t1, index:c1(c1)	range:[-inf,10), keep order:false, stats:pseudo
+│   ├─IndexRangeScan_17(Build)	3323.33	cop[tikv]	table:t1, index:c2(c2)	range:[-inf,10), keep order:false, stats:pseudo
+│   └─Selection_19(Probe)	2250.55	cop[tikv]		or(lt(index_merge.t1.c1, 10), and(lt(index_merge.t1.c2, 10), lt(index_merge.t1.c3, 10)))
+│     └─TableRowIDScan_18	5542.21	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection_21(Recursive Part)	3248.59	root		cast(plus(index_merge.t1.c1, 100), int(11))->index_merge.t1.c1
+  └─Selection_22	3248.59	root		lt(index_merge.t1.c1, 10)
+    └─CTETable_23	4060.74	root		Scan on CTE_0
 with recursive cte1 as (select /*+ use_index_merge(t1) */ c1 from t1 where c1 < 10 or c2 < 10 and c3 < 10 UNION ALL select c1 + 100 from cte1 where c1 < 10) select * from cte1 order by 1;
 c1
 1

--- a/tests/integrationtest/r/planner/core/casetest/index/index.result
+++ b/tests/integrationtest/r/planner/core/casetest/index/index.result
@@ -662,7 +662,7 @@ explain format = 'verbose' insert into t3 select a, b, c from t1 where f = 2;
 id	estRows	estCost	task	access object	operator info
 Insert_1	N/A	N/A	root		N/A
 └─Projection_6	1.00	253.74	root		planner__core__casetest__index__index.t1.a, planner__core__casetest__index__index.t1.b, planner__core__casetest__index__index.t1.c
-  └─Point_Get_7	1.00	253.44	root	table:t1, index:f(f)	
+  └─Point_Get_8	1.00	253.44	root	table:t1, index:f(f)	
 show warnings;
 Level	Code	Message
 Note	1105	unique index f of t1 is selected since the path only has point ranges with double scan

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -1424,22 +1424,22 @@ explain select /*+ TIDB_INLJ(t2_part@sel_2) */ * from t1 where t1.b<10 and not e
 id	estRows	task	access object	operator info
 HashJoin_19	2658.67	root		anti semi join, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
 ├─PartitionUnion_23(Build)	13293.33	root		
-│ ├─Projection_24	3323.33	root		planner__core__casetest__integration.t2_part.a
-│ │ └─TableReader_27	3323.33	root		data:Selection_26
-│ │   └─Selection_26	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-│ │     └─TableFullScan_25	10000.00	cop[tikv]	table:t2_part, partition:p0	keep order:false, stats:pseudo
-│ ├─Projection_28	3323.33	root		planner__core__casetest__integration.t2_part.a
-│ │ └─TableReader_31	3323.33	root		data:Selection_30
+│ ├─TableReader_31	3323.33	root		data:Projection_25
+│ │ └─Projection_25	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
 │ │   └─Selection_30	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-│ │     └─TableFullScan_29	10000.00	cop[tikv]	table:t2_part, partition:p1	keep order:false, stats:pseudo
-│ ├─Projection_32	3323.33	root		planner__core__casetest__integration.t2_part.a
-│ │ └─TableReader_35	3323.33	root		data:Selection_34
-│ │   └─Selection_34	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-│ │     └─TableFullScan_33	10000.00	cop[tikv]	table:t2_part, partition:p2	keep order:false, stats:pseudo
-│ └─Projection_36	3323.33	root		planner__core__casetest__integration.t2_part.a
-│   └─TableReader_39	3323.33	root		data:Selection_38
-│     └─Selection_38	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-│       └─TableFullScan_37	10000.00	cop[tikv]	table:t2_part, partition:p3	keep order:false, stats:pseudo
+│ │     └─TableFullScan_29	10000.00	cop[tikv]	table:t2_part, partition:p0	keep order:false, stats:pseudo
+│ ├─TableReader_39	3323.33	root		data:Projection_33
+│ │ └─Projection_33	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection_38	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ │     └─TableFullScan_37	10000.00	cop[tikv]	table:t2_part, partition:p1	keep order:false, stats:pseudo
+│ ├─TableReader_47	3323.33	root		data:Projection_41
+│ │ └─Projection_41	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection_46	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ │     └─TableFullScan_45	10000.00	cop[tikv]	table:t2_part, partition:p2	keep order:false, stats:pseudo
+│ └─TableReader_55	3323.33	root		data:Projection_49
+│   └─Projection_49	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│     └─Selection_54	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│       └─TableFullScan_53	10000.00	cop[tikv]	table:t2_part, partition:p3	keep order:false, stats:pseudo
 └─TableReader_22(Probe)	3323.33	root		data:Selection_21
   └─Selection_21	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
     └─TableFullScan_20	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/indexmerge_path.result
+++ b/tests/integrationtest/r/planner/core/indexmerge_path.result
@@ -956,11 +956,11 @@ INSERT INTO `t` VALUES('[12474495489656359869, 14407883655486982855, 42211846364
 EXPLAIN SELECT /*+ use_index_merge(t)*/ MIN(col_37)  FROM t WHERE col_38 BETWEEN '1984-12-13' AND '1975-01-28' OR JSON_CONTAINS(col_37, '138480458355390957') GROUP BY col_38 HAVING col_38 != '1988-03-22';
 id	estRows	task	access object	operator info
 Projection_8	6.66	root		planner__core__indexmerge_path.t.col_37->Column#7
-└─IndexMerge_13	6.66	root		type: union
-  ├─TableFullScan_9(Build)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-  ├─IndexRangeScan_10(Build)	10.00	cop[tikv]	table:t, index:idx_17(cast(`col_37` as unsigned array), col_38)	range:[138480458355390957,138480458355390957], keep order:false, stats:pseudo
-  └─Selection_12(Probe)	6.66	cop[tikv]		ne(planner__core__indexmerge_path.t.col_38, 1988-03-22 00:00:00.000000)
-    └─TableRowIDScan_11	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexMerge_14	6.66	root		type: union
+  ├─TableFullScan_10(Build)	0.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:idx_17(cast(`col_37` as unsigned array), col_38)	range:[138480458355390957,138480458355390957], keep order:false, stats:pseudo
+  └─Selection_13(Probe)	6.66	cop[tikv]		ne(planner__core__indexmerge_path.t.col_38, 1988-03-22 00:00:00.000000)
+    └─TableRowIDScan_12	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 SELECT /*+ use_index_merge(t)*/ MIN(col_37)  FROM t WHERE col_38 BETWEEN '1984-12-13' AND '1975-01-28' OR JSON_CONTAINS(col_37, '138480458355390957') GROUP BY col_38 HAVING col_38 != '1988-03-22';
 MIN(col_37)
 drop table if exists t1;

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -681,10 +681,10 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or c > 10000 ord
 id	estRows	task	access object	operator info
 Sort_5	5548.89	root		planner__core__integration.t.a, planner__core__integration.t.b
 └─Projection_7	5548.89	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_11	5548.89	root		type: union
-    ├─TableRangeScan_8(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	5548.89	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	5548.89	root		type: union
+    ├─TableRangeScan_9(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	5548.89	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or c > 10000 order by a, b;
 a	b
 1	1
@@ -692,11 +692,11 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or a > 88 or c >
 id	estRows	task	access object	operator info
 Sort_5	7771.11	root		planner__core__integration.t.a, planner__core__integration.t.b
 └─Projection_7	7771.11	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_12	7771.11	root		type: union
-    ├─TableRangeScan_8(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:(88,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	7771.11	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	7771.11	root		type: union
+    ├─TableRangeScan_9(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:(88,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	7771.11	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or a > 88 or c > 10000 order by a, b;
 a	b
 1	1
@@ -705,14 +705,14 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or (a >= 10 and 
 id	estRows	task	access object	operator info
 Sort_5	8015.79	root		planner__core__integration.t.a, planner__core__integration.t.b
 └─Projection_7	8015.79	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_15	7119.80	root		type: union
-    ├─TableRangeScan_8(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─TableRangeScan_9	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─Selection_14(Probe)	7119.80	cop[tikv]		or(or(lt(planner__core__integration.t.a, 2), and(ge(planner__core__integration.t.a, 10), ge(planner__core__integration.t.b, 10))), or(gt(planner__core__integration.t.c, 100), lt(planner__core__integration.t.c, 1)))
-      └─TableRowIDScan_13	8882.21	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_16	7119.80	root		type: union
+    ├─TableRangeScan_9(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─TableRangeScan_10	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─Selection_15(Probe)	7119.80	cop[tikv]		or(or(lt(planner__core__integration.t.a, 2), and(ge(planner__core__integration.t.a, 10), ge(planner__core__integration.t.b, 10))), or(gt(planner__core__integration.t.c, 100), lt(planner__core__integration.t.c, 1)))
+      └─TableRowIDScan_14	8882.21	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or (a >= 10 and b >= 10) or c > 100 or c < 1 order by a, b;
 a	b
 1	1
@@ -722,16 +722,16 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or (a >= 10 and 
 id	estRows	task	access object	operator info
 Sort_5	8235.60	root		planner__core__integration.t.a, planner__core__integration.t.b
 └─Projection_7	8235.60	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_17	7315.03	root		type: union
-    ├─TableRangeScan_8(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─TableRangeScan_9	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
-    ├─Selection_12(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
-    │ └─TableRangeScan_11	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_13(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_14(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─Selection_16(Probe)	7315.03	cop[tikv]		or(or(lt(planner__core__integration.t.a, 2), and(ge(planner__core__integration.t.a, 10), ge(planner__core__integration.t.b, 10))), or(and(ge(planner__core__integration.t.a, 20), lt(planner__core__integration.t.b, 10)), or(gt(planner__core__integration.t.c, 100), lt(planner__core__integration.t.c, 1))))
-      └─TableRowIDScan_15	8882.21	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_18	7315.03	root		type: union
+    ├─TableRangeScan_9(Build)	3323.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─TableRangeScan_10	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
+    ├─Selection_13(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
+    │ └─TableRangeScan_12	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_14(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_15(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─Selection_17(Probe)	7315.03	cop[tikv]		or(or(lt(planner__core__integration.t.a, 2), and(ge(planner__core__integration.t.a, 10), ge(planner__core__integration.t.b, 10))), or(and(ge(planner__core__integration.t.a, 20), lt(planner__core__integration.t.b, 10)), or(gt(planner__core__integration.t.c, 100), lt(planner__core__integration.t.c, 1))))
+      └─TableRowIDScan_16	8882.21	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or (a >= 10 and b >= 10) or (a >= 20 and b < 10) or c > 100 or c < 1 order by a, b;
 a	b
 1	1
@@ -924,10 +924,10 @@ explain select /*+ use_index_merge(t) */ a from t where c < 10 or a < 2 order by
 id	estRows	task	access object	operator info
 Sort_5	5542.21	root		planner__core__integration.t.a
 └─Projection_7	5542.21	root		planner__core__integration.t.a
-  └─IndexMerge_11	5542.21	root		type: union
-    ├─IndexRangeScan_8(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:a(a, b)	range:[-inf,2), keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	5542.21	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	5542.21	root		type: union
+    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3323.33	cop[tikv]	table:t, index:a(a, b)	range:[-inf,2), keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	5542.21	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a from t where c < 10 or a < 2 order by a;
 a
 1
@@ -935,10 +935,10 @@ explain select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or c > 1
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a
-  └─IndexMerge_11	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or c > 10000 order by a;
 a
 1
@@ -946,11 +946,11 @@ explain select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or _tidb
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a
-  └─IndexMerge_12	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or _tidb_rowid < 10 or c > 11 order by a;
 a
 1
@@ -960,13 +960,13 @@ explain select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or (a >=
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a
-  └─IndexMerge_14	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or c > 100 or c < 1 order by a;
 a
 1
@@ -976,15 +976,15 @@ explain select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or (a >=
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a
-  └─IndexMerge_16	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─Selection_12(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_11	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_13(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_14(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_15(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_17	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─Selection_13(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_12	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_14(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_15(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_16(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or (a >= 20 and b < 10) or c > 100 or c < 1 order by a;
 a
 1
@@ -1134,10 +1134,10 @@ explain select /*+ use_index_merge(t) */ a,b from t where c < 10 or a < 2 order 
 id	estRows	task	access object	operator info
 Sort_5	5542.21	root		planner__core__integration.t.a
 └─Projection_7	5542.21	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_11	5542.21	root		type: union
-    ├─IndexRangeScan_8(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:a(a, b)	range:[-inf,2), keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	5542.21	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	5542.21	root		type: union
+    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3323.33	cop[tikv]	table:t, index:a(a, b)	range:[-inf,2), keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	5542.21	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where c < 10 or a < 2 order by a;
 a	b
 1	1
@@ -1145,10 +1145,10 @@ explain select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or c >
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_11	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or c > 10000 order by a;
 a	b
 1	1
@@ -1156,11 +1156,11 @@ explain select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or _ti
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_12	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or _tidb_rowid < 10 or c > 11 order by a;
 a	b
 1	1
@@ -1170,13 +1170,13 @@ explain select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or (a 
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_14	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or c > 100 or c < 1 order by a;
 a	b
 1	1
@@ -1186,15 +1186,15 @@ explain select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or (a 
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_16	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─Selection_12(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_11	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_13(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_14(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_15(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_17	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─Selection_13(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_12	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_14(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_15(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_16(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or (a >= 20 and b < 10) or c > 100 or c < 1 order by a;
 a	b
 1	1
@@ -1285,10 +1285,10 @@ explain select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or c >
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.c, planner__core__integration.t.a
-  └─IndexMerge_11	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or c > 10000 order by a;
 c	a
 1	1
@@ -1296,11 +1296,11 @@ explain select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or _ti
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.c, planner__core__integration.t.a
-  └─IndexMerge_12	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or _tidb_rowid < 10 or c > 11 order by a;
 c	a
 1	1
@@ -1310,13 +1310,13 @@ explain select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or (a 
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.c, planner__core__integration.t.a
-  └─IndexMerge_14	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or c > 100 or c < 1 order by a;
 c	a
 1	1
@@ -1326,15 +1326,15 @@ explain select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or (a 
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.c, planner__core__integration.t.a
-  └─IndexMerge_16	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─Selection_12(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_11	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_13(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_14(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_15(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_17	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─Selection_13(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_12	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_14(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_15(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_16(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ c,a from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or (a >= 20 and b < 10) or c > 100 or c < 1 order by a;
 c	a
 1	1
@@ -1355,10 +1355,10 @@ explain select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or c
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.b, planner__core__integration.t.a, planner__core__integration.t.c
-  └─IndexMerge_11	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or c > 10000 order by a;
 b	a	c
 1	1	1
@@ -1366,11 +1366,11 @@ explain select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or _
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.b, planner__core__integration.t.a, planner__core__integration.t.c
-  └─IndexMerge_12	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(11,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or _tidb_rowid < 10 or c > 11 order by a;
 b	a	c
 1	1	1
@@ -1380,13 +1380,13 @@ explain select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or (
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.b, planner__core__integration.t.a, planner__core__integration.t.c
-  └─IndexMerge_14	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or c > 100 or c < 1 order by a;
 b	a	c
 1	1	1
@@ -1396,15 +1396,15 @@ explain select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or (
 id	estRows	task	access object	operator info
 Sort_5	8000.00	root		planner__core__integration.t.a
 └─Projection_7	8000.00	root		planner__core__integration.t.b, planner__core__integration.t.a, planner__core__integration.t.c
-  └─IndexMerge_16	8000.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─Selection_10(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_9	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─Selection_12(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
-    │ └─IndexRangeScan_11	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_13(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_14(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_15(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_17	8000.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─Selection_11(Build)	1111.11	cop[tikv]		ge(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_10	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─Selection_13(Build)	1107.78	cop[tikv]		lt(planner__core__integration.t.b, 10)
+    │ └─IndexRangeScan_12	3333.33	cop[tikv]	table:t, index:a(a, b)	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_14(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_15(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_16(Probe)	8000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,a,c from t where _tidb_rowid < 2 or (a >= 10 and b >= 10) or (a >= 20 and b < 10) or c > 100 or c < 1 order by a;
 b	a	c
 1	1	1
@@ -1486,11 +1486,11 @@ explain select /*+ use_index_merge(t) */ b from t where b < 10 or c < 11 or c > 
 id	estRows	task	access object	operator info
 Sort_5	7767.77	root		planner__core__integration.t.b
 └─Projection_7	7767.77	root		planner__core__integration.t.b
-  └─IndexMerge_12	7767.77	root		type: union
-    ├─IndexRangeScan_8(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,11), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(50,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	7767.77	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	7767.77	root		type: union
+    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,11), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(50,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	7767.77	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b from t where b < 10 or c < 11 or c > 50 order by b;
 b
 1
@@ -1500,10 +1500,10 @@ explain select /*+ use_index_merge(t) */ b from t where a < 2 or c > 10000 order
 id	estRows	task	access object	operator info
 Sort_5	3334.67	root		planner__core__integration.t.b
 └─Projection_7	3334.67	root		planner__core__integration.t.b
-  └─IndexMerge_11	3334.67	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	3334.67	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	3334.67	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	3334.67	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b from t where a < 2 or c > 10000 order by b;
 b
 1
@@ -1511,11 +1511,11 @@ explain select /*+ use_index_merge(t) */ b from t where a < 2 or a < 10 or b > 1
 id	estRows	task	access object	operator info
 Sort_5	3340.00	root		planner__core__integration.t.b
 └─Projection_7	3340.00	root		planner__core__integration.t.b
-  └─IndexMerge_12	3340.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:(11,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	3340.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	3340.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:(11,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	3340.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b from t where a < 2 or a < 10 or b > 11 order by b;
 b
 1
@@ -1524,12 +1524,12 @@ explain select /*+ use_index_merge(t) */ b from t where a < 2 or b >= 10 or c > 
 id	estRows	task	access object	operator info
 Sort_5	7771.56	root		planner__core__integration.t.b
 └─Projection_7	7771.56	root		planner__core__integration.t.b
-  └─IndexMerge_13	7771.56	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	7771.56	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_14	7771.56	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_13(Probe)	7771.56	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b from t where a < 2 or b >= 10 or c > 100 or c < 1 order by b;
 b
 1
@@ -1539,13 +1539,13 @@ explain select /*+ use_index_merge(t) */ b from t where a < 2 or a >= 10 or a >=
 id	estRows	task	access object	operator info
 Sort_5	7033.48	root		planner__core__integration.t.b
 └─Projection_7	7033.48	root		planner__core__integration.t.b
-  └─IndexMerge_14	7033.48	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
-    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	7033.48	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	7033.48	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
+    ├─TableRangeScan_11(Build)	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	7033.48	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b from t where a < 2 or a >= 10 or a >= 20 or c > 100 or b < 1 order by b;
 b
 1
@@ -1624,11 +1624,11 @@ explain select /*+ use_index_merge(t) */ a,b from t where b < 10 or c < 11 or c 
 id	estRows	task	access object	operator info
 Sort_5	7767.77	root		planner__core__integration.t.b
 └─Projection_7	7767.77	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_12	7767.77	root		type: union
-    ├─IndexRangeScan_8(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,11), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(50,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	7767.77	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	7767.77	root		type: union
+    ├─IndexRangeScan_9(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,11), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(50,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	7767.77	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where b < 10 or c < 11 or c > 50 order by b;
 a	b
 1	1
@@ -1638,10 +1638,10 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or c > 10000 ord
 id	estRows	task	access object	operator info
 Sort_5	3334.67	root		planner__core__integration.t.b
 └─Projection_7	3334.67	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_11	3334.67	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	3334.67	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	3334.67	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	3334.67	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or c > 10000 order by b;
 a	b
 1	1
@@ -1661,12 +1661,12 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or b >= 10 or c 
 id	estRows	task	access object	operator info
 Sort_5	7771.56	root		planner__core__integration.t.b
 └─Projection_7	7771.56	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_13	7771.56	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	7771.56	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_14	7771.56	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_13(Probe)	7771.56	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or b >= 10 or c > 100 or c < 1 order by b;
 a	b
 1	1
@@ -1676,13 +1676,13 @@ explain select /*+ use_index_merge(t) */ a,b from t where a < 2 or a >= 10 or a 
 id	estRows	task	access object	operator info
 Sort_5	7033.48	root		planner__core__integration.t.b
 └─Projection_7	7033.48	root		planner__core__integration.t.a, planner__core__integration.t.b
-  └─IndexMerge_14	7033.48	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
-    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	7033.48	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	7033.48	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
+    ├─TableRangeScan_11(Build)	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	7033.48	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ a,b from t where a < 2 or a >= 10 or a >= 20 or c > 100 or b < 1 order by b;
 a	b
 1	1
@@ -1705,10 +1705,10 @@ explain select /*+ use_index_merge(t) */ b,c from t where a < 2 or c > 10000 ord
 id	estRows	task	access object	operator info
 Sort_5	3334.67	root		planner__core__integration.t.b
 └─Projection_7	3334.67	root		planner__core__integration.t.b, planner__core__integration.t.c
-  └─IndexMerge_11	3334.67	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_10(Probe)	3334.67	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_12	3334.67	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(10000,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	3334.67	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,c from t where a < 2 or c > 10000 order by b;
 b	c
 1	1
@@ -1716,11 +1716,11 @@ explain select /*+ use_index_merge(t) */ b,c from t where a < 2 or a < 10 or b >
 id	estRows	task	access object	operator info
 Sort_5	3340.00	root		planner__core__integration.t.b
 └─Projection_7	3340.00	root		planner__core__integration.t.b, planner__core__integration.t.c
-  └─IndexMerge_12	3340.00	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:(11,+inf], keep order:false, stats:pseudo
-    └─TableRowIDScan_11(Probe)	3340.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_13	3340.00	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[-inf,10), keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:(11,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	3340.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,c from t where a < 2 or a < 10 or b > 11 order by b;
 b	c
 1	1
@@ -1729,12 +1729,12 @@ explain select /*+ use_index_merge(t) */ b,c from t where a < 2 or b >= 10 or c 
 id	estRows	task	access object	operator info
 Sort_5	7771.56	root		planner__core__integration.t.b
 └─Projection_7	7771.56	root		planner__core__integration.t.b, planner__core__integration.t.c
-  └─IndexMerge_13	7771.56	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:[10,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	7771.56	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_14	7771.56	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:t, index:b(b)	range:[10,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:idx_c(c)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_13(Probe)	7771.56	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,c from t where a < 2 or b >= 10 or c > 100 or c < 1 order by b;
 b	c
 1	1
@@ -1744,13 +1744,13 @@ explain select /*+ use_index_merge(t) */ b,c from t where a < 2 or a >= 10 or a 
 id	estRows	task	access object	operator info
 Sort_5	7033.48	root		planner__core__integration.t.b
 └─Projection_7	7033.48	root		planner__core__integration.t.b, planner__core__integration.t.c
-  └─IndexMerge_14	7033.48	root		type: union
-    ├─TableRangeScan_8(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
-    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
-    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_11(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
-    ├─IndexRangeScan_12(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,1), keep order:false, stats:pseudo
-    └─TableRowIDScan_13(Probe)	7033.48	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexMerge_15	7033.48	root		type: union
+    ├─TableRangeScan_9(Build)	3333.33	cop[tikv]	table:t	range:[-inf,2), keep order:false, stats:pseudo
+    ├─TableRangeScan_10(Build)	3333.33	cop[tikv]	table:t	range:[10,+inf], keep order:false, stats:pseudo
+    ├─TableRangeScan_11(Build)	3333.33	cop[tikv]	table:t	range:[20,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_12(Build)	3333.33	cop[tikv]	table:t, index:idx_c(c)	range:(100,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_13(Build)	3323.33	cop[tikv]	table:t, index:b(b)	range:[-inf,1), keep order:false, stats:pseudo
+    └─TableRowIDScan_14(Probe)	7033.48	cop[tikv]	table:t	keep order:false, stats:pseudo
 select /*+ use_index_merge(t) */ b,c from t where a < 2 or a >= 10 or a >= 20 or c > 100 or b < 1 order by b;
 b	c
 1	1

--- a/tests/integrationtest/r/planner/core/plan.result
+++ b/tests/integrationtest/r/planner/core/plan.result
@@ -136,113 +136,113 @@ drop table if exists t1;
 CREATE TABLE `t1` (  `a` varchar(10) DEFAULT NULL,  `b` varchar(10) DEFAULT NULL,  KEY `expression_index` ((concat(`a`, `b`))),  KEY `expression_index_2` ((concat(`a`, `b`))),  KEY `idx` ((concat(`a`, `b`)),`a`),  KEY `idx1` (`a`,(concat(`a`, `b`))),  KEY `idx2` (`a`,(concat(`a`, `b`)),`b`));
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 explain format='brief' select * from t1  where concat(a, b) like "aadwa" and a = "a";
 id	estRows	task	access object	operator info
-Projection	0.10	root		planner__core__plan.t1.a, planner__core__plan.t1.b
-└─IndexReader	0.10	root		index:Selection
+IndexReader	0.10	root		index:Projection
+└─Projection	0.10	cop[tikv]		planner__core__plan.t1.a, planner__core__plan.t1.b
   └─Selection	0.10	cop[tikv]		like(concat(planner__core__plan.t1.a, planner__core__plan.t1.b), "aadwa", 92)
     └─IndexRangeScan	0.10	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["a" "aadwa","a" "aadwa"], keep order:false, stats:pseudo
 explain format='brief' select b from t1 where concat(a, b) >= "aa" and a = "b";
 id	estRows	task	access object	operator info
-Projection	33.33	root		planner__core__plan.t1.b
-└─IndexReader	33.33	root		index:IndexRangeScan
+IndexReader	33.33	root		index:Projection
+└─Projection	33.33	cop[tikv]		planner__core__plan.t1.b
   └─IndexRangeScan	33.33	cop[tikv]	table:t1, index:idx2(a, concat(`a`, `b`), b)	range:["b" "aa","b" +inf], keep order:false, stats:pseudo
 insert into t1 values("a", "adwa");
 select * from t1  where concat(a, b) like "aadwa" and a = "a";

--- a/tests/integrationtest/r/sessionctx/setvar.result
+++ b/tests/integrationtest/r/sessionctx/setvar.result
@@ -1142,21 +1142,21 @@ select /*+ set_var(tidb_opt_projection_push_down=0) */ @@tidb_opt_projection_pus
 0
 select @@tidb_opt_projection_push_down;
 @@tidb_opt_projection_push_down
-0
+1
 set @@tidb_opt_projection_push_down=default;
 select @@tidb_opt_projection_push_down;
 @@tidb_opt_projection_push_down
-0
+1
 select /*+ set_var(tidb_opt_projection_push_down=1) */ @@tidb_opt_projection_push_down;
 @@tidb_opt_projection_push_down
 1
 select @@tidb_opt_projection_push_down;
 @@tidb_opt_projection_push_down
-0
+1
 set @@tidb_opt_projection_push_down=default;
 select @@tidb_opt_projection_push_down;
 @@tidb_opt_projection_push_down
-0
+1
 select /*+ set_var(tidb_enable_vectorized_expression=0) */ @@tidb_enable_vectorized_expression;
 @@tidb_enable_vectorized_expression
 0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51876 

Problem Summary:

Described in #51876 

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

benchbot test performance, no significant performance differences:
![2irsq7zFnl](https://github.com/pingcap/tidb/assets/12403562/9207abcd-a368-4e33-8e18-d3084870ad65)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Change the default value of tidb_opt_projection_push_down to true so that TIDB can choose to push down projections to TIKV to reduce network bandwith usage. 
```
