### PR TITLE
ddl/ingest: add synchronization to `UnregisterEngines`

### DIFF
--- a/pkg/ddl/ingest/backend.go
+++ b/pkg/ddl/ingest/backend.go
@@ -17,6 +17,7 @@ package ingest
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -107,6 +108,10 @@ type litBackendCtx struct {
 	updateInterval  time.Duration
 	checkpointMgr   *CheckpointManager
 	etcdClient      *clientv3.Client
+
+	// unregisterMu prevents concurrent calls of `UnregisterEngines`.
+	// For details, see https://github.com/pingcap/tidb/issues/53843.
+	unregisterMu sync.Mutex
 }
 
 func (bc *litBackendCtx) handleErrorAfterCollectRemoteDuplicateRows(err error, indexID int64, tbl table.Table, hasDupe bool) error {

--- a/pkg/ddl/ingest/engine_mgr.go
+++ b/pkg/ddl/ingest/engine_mgr.go
@@ -101,6 +101,12 @@ func (bc *litBackendCtx) Register(indexIDs []int64, tableName string) ([]Engine,
 
 // UnregisterEngines implements BackendCtx.
 func (bc *litBackendCtx) UnregisterEngines() {
+	bc.unregisterMu.Lock()
+	defer bc.unregisterMu.Unlock()
+
+	if len(bc.engines) == 0 {
+		return
+	}
 	numIdx := int64(len(bc.engines))
 	for _, ei := range bc.engines {
 		ei.Clean()

--- a/tests/realtikvtest/addindextest3/functional_test.go
+++ b/tests/realtikvtest/addindextest3/functional_test.go
@@ -17,13 +17,16 @@ package addindextest
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/tests/realtikvtest"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/util"
 )
 
@@ -73,4 +76,24 @@ func TestDDLTestEstimateTableRowSize(t *testing.T) {
 		size = ddl.EstimateTableRowSizeForTest(ctx, store, exec, partition)
 		require.Equal(t, 19, size)
 	}
+}
+
+func TestBackendCtxConcurrentUnregister(t *testing.T) {
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	discovery := store.(tikv.Storage).GetRegionCache().PDClient().GetServiceDiscovery()
+	bCtx, err := ingest.LitBackCtxMgr.Register(context.Background(), 1, false, nil, discovery, "test")
+	require.NoError(t, err)
+	_, err = bCtx.Register([]int64{1, 2, 3, 4, 5, 6, 7}, "t")
+	require.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			bCtx.UnregisterEngines()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	ingest.LitBackCtxMgr.Unregister(1)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53843

Problem Summary:

See https://github.com/pingcap/tidb/issues/53843#issuecomment-2151345657.

> There are concurrent close operations:
>
> ```
> [2024/06/05 07:06:07.811 +00:00] [INFO] [backend.go:344] ["engine close start"] [category=ddl-ingest] [engineTag=:8] [engineUUID=faa79115-fb21-579d-a6d9-5c344586b1de]
> [2024/06/05 07:06:09.824 +00:00] [INFO] [backend.go:344] ["engine close start"] [category=ddl-ingest] [engineTag=:8] [engineUUID=faa79115-fb21-579d-a6d9-5c344586b1de]
> ...
> [2024/06/05 07:06:10.237 +00:00] [INFO] [backend.go:346] ["engine close completed"] [category=ddl-ingest] [engineTag=:8] [engineUUID=faa79115-fb21-579d-a6d9-5c344586b1de] [takeTime=2.425636049s] []
> ```
>
> One of them is from `pipeline.Close()` and the other is from `unregister()` caused by cancelling.

![image](https://github.com/pingcap/tidb/assets/24713065/0eb3901f-f0cf-436e-80be-a3d31c64ea6b)

The cancellation operation of User conflicts with the close operation of Dist Framework, resulting in a data race.

### What changed and how does it work?

Add synchronization to `UnregisterEngines`.

Maybe later we can refactor the structure to

![image](https://github.com/pingcap/tidb/assets/24713065/6083e7fa-8ae5-44ea-897a-9c6ea7c22d48)

by removing global `BackendCtxMgr`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
