### PR TITLE
executor: reuse memory for parallelSortSpillHelper

### DIFF
--- a/pkg/executor/sortexec/parallel_sort_spill_helper.go
+++ b/pkg/executor/sortexec/parallel_sort_spill_helper.go
@@ -52,7 +52,7 @@ func newParallelSortSpillHelper(sortExec *SortExec, fieldTypes []*types.FieldTyp
 		errOutputChan: errOutputChan,
 		finishCh:      finishCh,
 		fieldTypes:    fieldTypes,
-		tmpSpillChunk: chunk.NewChunkWithCapacity(fieldTypes, spillChunkSize),
+		tmpSpillChunk: chunk.NewChunkFromPoolWithCapacity(fieldTypes, spillChunkSize),
 	}
 }
 
@@ -60,6 +60,7 @@ func (p *parallelSortSpillHelper) close() {
 	for _, inDisk := range p.sortedRowsInDisk {
 		inDisk.Close()
 	}
+	p.tmpSpillChunk.Destroy(spillChunkSize, p.fieldTypes)
 }
 
 func (p *parallelSortSpillHelper) isNotSpilledNoLock() bool {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53861

Problem Summary:

### What changed and how does it work?



we get a profiler while we benchmark sync load. it takes too much time on the newParallelSortSpillHelper. it is unnecessary.

https://flamegraph.com/share/4dca9137-2419-11ef-ab1b-b6898751f631

<img width="1422" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/ea6abe07-46e8-43d0-852d-d063751fbc55">


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

after optimization

t takes less time on the newParallelSortSpillHelper

https://flamegraph.com/share/822c3df8-247d-11ef-ab1b-b6898751f631

<img width="991" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/b659e427-c0fd-4db1-848b-7a078e9af4e6">


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
