### PR TITLE
ddl: fix flaky test TestCancel & fix panic when we failed to get job in delivery2Worker

### DIFF
--- a/pkg/ddl/cancel_test.go
+++ b/pkg/ddl/cancel_test.go
@@ -248,8 +248,6 @@ func TestCancel(t *testing.T) {
 	cancelResult := atomicutil.NewBool(false)
 	cancelWhenReorgNotStart := atomicutil.NewBool(false)
 
-	// there might be a time gap between tk.MustExec return and the calling of OnJobUpdated,
-	// and it causes we call the hook with an unexpected prepare job.
 	hookFunc := func(job *model.Job) {
 		if testutil.TestMatchCancelState(t, job, allTestCase[i.Load()].cancelState, allTestCase[i.Load()].sql) && !canceled.Load() {
 			if !cancelWhenReorgNotStart.Load() && job.SchemaState == model.StateWriteReorganization && job.MayNeedReorg() && job.RowCount == 0 {
@@ -277,6 +275,7 @@ func TestCancel(t *testing.T) {
 	}
 
 	for j, tc := range allTestCase {
+		t.Logf("running test case %d: %s", j, tc.sql)
 		i.Store(int64(j))
 		msg := fmt.Sprintf("sql: %s, state: %s", tc.sql, tc.cancelState)
 		if tc.onJobBefore {

--- a/pkg/ddl/cancel_test.go
+++ b/pkg/ddl/cancel_test.go
@@ -209,7 +209,7 @@ func TestCancel(t *testing.T) {
 	var enterCnt, exitCnt atomic.Int32
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeDelivery2Worker", func(job *model.Job) { enterCnt.Add(1) })
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterDelivery2Worker", func(job *model.Job) { exitCnt.Add(1) })
-	waitDDLWorkerExisted := func() {
+	waitDDLWorkerExited := func() {
 		require.Eventually(t, func() bool {
 			return enterCnt.Load() == exitCnt.Load()
 		}, 10*time.Second, 10*time.Millisecond)
@@ -284,7 +284,7 @@ func TestCancel(t *testing.T) {
 		dom.DDL().SetHook(h.Clone())
 	}
 
-	waitDDLWorkerExisted()
+	waitDDLWorkerExited()
 	for j, tc := range allTestCase {
 		t.Logf("running test case %d: %s", j, tc.sql)
 		i.Store(int64(j))
@@ -294,7 +294,7 @@ func TestCancel(t *testing.T) {
 			for _, prepareSQL := range tc.prepareSQL {
 				tk.MustExec(prepareSQL)
 			}
-			waitDDLWorkerExisted()
+			waitDDLWorkerExited()
 			canceled.Store(false)
 			cancelWhenReorgNotStart.Store(true)
 			registerHook(hook, true)
@@ -303,7 +303,7 @@ func TestCancel(t *testing.T) {
 			} else {
 				tk.MustExec(tc.sql)
 			}
-			waitDDLWorkerExisted()
+			waitDDLWorkerExited()
 			if canceled.Load() {
 				require.Equal(t, tc.expectCancelled, cancelResult.Load(), msg)
 			}
@@ -313,7 +313,7 @@ func TestCancel(t *testing.T) {
 			for _, prepareSQL := range tc.prepareSQL {
 				tk.MustExec(prepareSQL)
 			}
-			waitDDLWorkerExisted()
+			waitDDLWorkerExited()
 			canceled.Store(false)
 			cancelWhenReorgNotStart.Store(false)
 			registerHook(hook, false)
@@ -322,7 +322,7 @@ func TestCancel(t *testing.T) {
 			} else {
 				tk.MustExec(tc.sql)
 			}
-			waitDDLWorkerExisted()
+			waitDDLWorkerExited()
 			if canceled.Load() {
 				require.Equal(t, tc.expectCancelled, cancelResult.Load(), msg)
 			}

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -529,6 +529,7 @@ func (d *ddl) delivery2LocalWorker(pool *workerPool, task *limitJobTask) {
 
 // delivery2Worker owns the worker, need to put it back to the pool in this function.
 func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.Job) {
+	failpoint.InjectCall("beforeDelivery2Worker", job)
 	injectFailPointForGetJob(job)
 	jobID, involvedSchemaInfos := job.ID, job.GetInvolvingSchemaInfo()
 	s.runningJobs.add(jobID, involvedSchemaInfos)

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -561,7 +561,7 @@ func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.
 			// job is already moved to history.
 			failpoint.InjectCall("beforeRefreshJob", job)
 			for {
-				job, err = s.sysTblMgr.GetJobByID(s.schCtx, job.ID)
+				job, err = s.sysTblMgr.GetJobByID(s.schCtx, jobID)
 				failpoint.InjectCall("mockGetJobByIDFail", &err)
 				if err == nil {
 					break
@@ -569,10 +569,10 @@ func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.
 
 				if err == systable.ErrNotFound {
 					logutil.DDLLogger().Info("job not found, might already finished",
-						zap.Int64("job_id", job.ID), zap.Stringer("state", job.State))
+						zap.Int64("job_id", jobID))
 					return
 				}
-				logutil.DDLLogger().Error("get job failed", zap.Error(err))
+				logutil.DDLLogger().Error("get job failed", zap.Int64("job_id", jobID), zap.Error(err))
 				select {
 				case <-s.schCtx.Done():
 					return

--- a/pkg/ddl/tests/adminpause/BUILD.bazel
+++ b/pkg/ddl/tests/adminpause/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/errno",
         "//pkg/parser/model",
         "//pkg/testkit",
+        "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testsetup",
         "//pkg/util/sqlexec",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/ddl/tests/adminpause/pause_cancel_test.go
+++ b/pkg/ddl/tests/adminpause/pause_cancel_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -90,7 +91,7 @@ func pauseAndCancelStmt(t *testing.T, stmtKit *testkit.TestKit, adminCommandKit 
 	var isCancelled = &atomic.Bool{}
 	var cancelResultChn = make(chan []sqlexec.RecordSet, 1)
 	var cancelErrChn = make(chan error, 1)
-	var cancelFunc = func(jobType string) {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRefreshJob", func(*model.Job) {
 		Logger.Debug("pauseAndCancelStmt: OnGetJobBeforeExported, ",
 			zap.String("Expected Schema State", stmtCase.schemaState.String()))
 
@@ -107,7 +108,7 @@ func pauseAndCancelStmt(t *testing.T, stmtKit *testkit.TestKit, adminCommandKit 
 
 			isCancelled.CompareAndSwap(false, true) // In case that it runs into this scope again and again
 		}
-	}
+	})
 	var verifyCancelResult = func(t *testing.T, adminCommandKit *testkit.TestKit) {
 		require.True(t, isCancelled.Load())
 
@@ -130,7 +131,6 @@ func pauseAndCancelStmt(t *testing.T, stmtKit *testkit.TestKit, adminCommandKit 
 	originalHook := dom.DDL().GetHook()
 
 	hook.OnJobRunBeforeExported = pauseFunc
-	hook.OnGetJobBeforeExported = cancelFunc
 	dom.DDL().SetHook(hook.Clone())
 
 	isPaused.Store(false)
@@ -152,6 +152,7 @@ func pauseAndCancelStmt(t *testing.T, stmtKit *testkit.TestKit, adminCommandKit 
 
 	// Release the hook, so that we could run the `rollbackStmts` successfully.
 	dom.DDL().SetHook(originalHook)
+	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/beforeRefreshJob")
 
 	for _, rollbackStmt := range stmtCase.rollbackStmts {
 		// no care about the result here, since the `statement` could have been cancelled OR finished successfully.

--- a/pkg/ddl/testutil/testutil.go
+++ b/pkg/ddl/testutil/testutil.go
@@ -107,14 +107,14 @@ func TestMatchCancelState(t *testing.T, job *model.Job, cancelState any, sql str
 	switch v := cancelState.(type) {
 	case model.SchemaState:
 		if job.Type == model.ActionMultiSchemaChange {
-			msg := fmt.Sprintf("unexpected multi-schema change(sql: %s, cancel state: %s)", sql, v)
+			msg := fmt.Sprintf("unexpected multi-schema change(sql: %s, cancel state: %s, job: %s)", sql, v, job.String())
 			require.Failf(t, msg, "use []model.SchemaState as cancel states instead")
 			return false
 		}
 		return job.SchemaState == v
 	case SubStates: // For multi-schema change sub-jobs.
 		if job.MultiSchemaInfo == nil {
-			msg := fmt.Sprintf("not multi-schema change(sql: %s, cancel state: %v)", sql, v)
+			msg := fmt.Sprintf("not multi-schema change(sql: %s, cancel state: %v, job: %s)", sql, v, job.String())
 			require.Failf(t, msg, "use model.SchemaState as the cancel state instead")
 			return false
 		}

--- a/pkg/ddl/testutil/testutil.go
+++ b/pkg/ddl/testutil/testutil.go
@@ -104,6 +104,9 @@ type SubStates = []model.SchemaState
 
 // TestMatchCancelState is used to test whether the cancel state matches.
 func TestMatchCancelState(t *testing.T, job *model.Job, cancelState any, sql string) bool {
+	if job.Query != sql {
+		return false
+	}
 	switch v := cancelState.(type) {
 	case model.SchemaState:
 		if job.Type == model.ActionMultiSchemaChange {

--- a/pkg/ddl/testutil/testutil.go
+++ b/pkg/ddl/testutil/testutil.go
@@ -104,9 +104,6 @@ type SubStates = []model.SchemaState
 
 // TestMatchCancelState is used to test whether the cancel state matches.
 func TestMatchCancelState(t *testing.T, job *model.Job, cancelState any, sql string) bool {
-	if job.Query != sql {
-		return false
-	}
 	switch v := cancelState.(type) {
 	case model.SchemaState:
 		if job.Type == model.ActionMultiSchemaChange {

--- a/pkg/testkit/testfailpoint/failpoint.go
+++ b/pkg/testkit/testfailpoint/failpoint.go
@@ -36,3 +36,8 @@ func EnableCall(t testing.TB, name string, fn any) {
 		require.NoError(t, failpoint.Disable(name))
 	})
 }
+
+// Disable disables fail-point.
+func Disable(t testing.TB, name string) {
+	require.NoError(t, failpoint.Disable(name))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36582

ref #53246 

Problem Summary:

### What changed and how does it work?
- see https://github.com/pingcap/tidb/issues/36582#issuecomment-2148790415 for the cause of flaky
- when we failed to get job in delivery2Worker, job variable is nil, it cannot be accecssed, it's introduced in this pr https://github.com/pingcap/tidb/pull/53747
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
