### PR TITLE
Optimizer: Fix range extraction for CNF(conjunctive normal form) | tidb-test=pr/2341

### DIFF
--- a/pkg/bindinfo/global_handle_test.go
+++ b/pkg/bindinfo/global_handle_test.go
@@ -550,11 +550,10 @@ func TestSetVarFixControlWithBinding(t *testing.T) {
 	tk.MustExec(`create table t(id int, a varchar(100), b int, c int, index idx_ab(a, b))`)
 	tk.MustQuery(`explain select * from t where c = 10 and (a = 'xx' or (a = 'kk' and b = 1))`).Check(
 		testkit.Rows(
-			`IndexLookUp_12 0.01 root  `,
-			`├─Selection_10(Build) 0.02 cop[tikv]  or(eq(test.t.a, "xx"), and(eq(test.t.a, "kk"), eq(test.t.b, 1)))`,
-			`│ └─IndexRangeScan_8 20.00 cop[tikv] table:t, index:idx_ab(a, b) range:["kk","kk"], ["xx","xx"], keep order:false, stats:pseudo`,
-			`└─Selection_11(Probe) 0.01 cop[tikv]  eq(test.t.c, 10)`,
-			`  └─TableRowIDScan_9 0.02 cop[tikv] table:t keep order:false, stats:pseudo`))
+			`IndexLookUp_11 0.01 root  `,
+			`├─IndexRangeScan_8(Build) 10.10 cop[tikv] table:t, index:idx_ab(a, b) range:["kk" 1,"kk" 1], ["xx","xx"], keep order:false, stats:pseudo`,
+			`└─Selection_10(Probe) 0.01 cop[tikv]  eq(test.t.c, 10)`,
+			`  └─TableRowIDScan_9 10.10 cop[tikv] table:t keep order:false, stats:pseudo`))
 
 	tk.MustExec(`create global binding using select /*+ set_var(tidb_opt_fix_control='44389:ON') */ * from t where c = 10 and (a = 'xx' or (a = 'kk' and b = 1))`)
 	tk.MustQuery(`show warnings`).Check(testkit.Rows()) // no warning

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -17,7 +17,6 @@ package expression
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -994,9 +993,11 @@ func containOuterNot(expr Expression, not bool) bool {
 func Contains(exprs []Expression, e Expression) bool {
 	for _, expr := range exprs {
 		// Check string equivalence if one of the expressions is a clone.
-		str1 := fmt.Sprintf("", e)
-		str2 := fmt.Sprintf("", expr)
-		if e == expr || (str1 == str2) {
+		sameString := false
+		if e != nil && expr != nil {
+			sameString = (e.String() == expr.String())
+		}
+		if e == expr || sameString {
 			return true
 		}
 	}

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -17,6 +17,7 @@ package expression
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -992,7 +993,10 @@ func containOuterNot(expr Expression, not bool) bool {
 // Contains tests if `exprs` contains `e`.
 func Contains(exprs []Expression, e Expression) bool {
 	for _, expr := range exprs {
-		if e == expr {
+		// Check string equivalence if one of the expressions is a clone.
+		str1 := fmt.Sprintf("", e)
+		str2 := fmt.Sprintf("", expr)
+		if e == expr || (str1 == str2) {
 			return true
 		}
 	}

--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
+    shard_count = 3,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -85,13 +85,42 @@ func TestInvisibleIndex(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE t1 ( a INT, KEY( a ) INVISIBLE );")
 	tk.MustExec("INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);")
-	tk.MustQuery(`EXPLAIN SELECT a FROM t1;`).Check(
+	tk.MustQuery(`select a FROM t1;`).Check(
 		testkit.Rows(
 			`TableReader_5 10000.00 root  data:TableFullScan_4`,
 			`└─TableFullScan_4 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo`))
 	tk.MustExec("set session tidb_opt_use_invisible_indexes=on;")
-	tk.MustQuery(`EXPLAIN SELECT a FROM t1;`).Check(
+	tk.MustQuery(`select a FROM t1;`).Check(
 		testkit.Rows(
 			`IndexReader_7 10000.00 root  index:IndexFullScan_6`,
 			`└─IndexFullScan_6 10000.00 cop[tikv] table:t1, index:a(a) keep order:false, stats:pseudo`))
+}
+
+func TestRangeDerivation(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a1 int, b1 int, c1 int, primary key pkx (a1,b1));")
+	tk.MustExec("create table t1char (a1 char(5), b1 char(5), c1 int, primary key pkx (a1,b1));")
+	tk.MustExec("create table t(a int, b int, c int, primary key(a,b));")
+	tk.MustExec("create table tuk (a int, b int, c int, unique key (a, b, c));")
+	tk.MustExec("set @@session.tidb_regard_null_as_point=false;")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	indexRangeSuiteData := GetIndexRangeSuiteData()
+	indexRangeSuiteData.LoadTestCases(t, &input, &output)
+	indexRangeSuiteData.LoadTestCases(t, &input, &output)
+	for i, sql := range input {
+		plan := tk.MustQuery("explain format = 'brief' " + sql)
+		testdata.OnRecord(func() {
+			output[i].SQL = sql
+			output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
+		})
+		plan.Check(testkit.Rows(output[i].Plan...))
+	}
+
 }

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -85,12 +85,12 @@ func TestInvisibleIndex(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE t1 ( a INT, KEY( a ) INVISIBLE );")
 	tk.MustExec("INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);")
-	tk.MustQuery(`select a FROM t1;`).Check(
+	tk.MustQuery(`EXPLAIN SELECT a FROM t1;`).Check(
 		testkit.Rows(
 			`TableReader_5 10000.00 root  data:TableFullScan_4`,
 			`└─TableFullScan_4 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo`))
 	tk.MustExec("set session tidb_opt_use_invisible_indexes=on;")
-	tk.MustQuery(`select a FROM t1;`).Check(
+	tk.MustQuery(`EXPLAIN SELECT a FROM t1;`).Check(
 		testkit.Rows(
 			`IndexReader_7 10000.00 root  index:IndexFullScan_6`,
 			`└─IndexFullScan_6 10000.00 cop[tikv] table:t1, index:a(a) keep order:false, stats:pseudo`))
@@ -122,5 +122,4 @@ func TestRangeDerivation(t *testing.T) {
 		})
 		plan.Check(testkit.Rows(output[i].Plan...))
 	}
-
 }

--- a/pkg/planner/core/casetest/index/main_test.go
+++ b/pkg/planner/core/casetest/index/main_test.go
@@ -31,6 +31,7 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 	testDataMap.LoadTestSuiteData("testdata", "integration_suite")
+	testDataMap.LoadTestSuiteData("testdata", "index_range")
 
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
@@ -48,6 +49,10 @@ func TestMain(m *testing.M) {
 	}
 
 	goleak.VerifyTestMain(testmain.WrapTestingM(m, callback), opts...)
+}
+
+func GetIndexRangeSuiteData() testdata.TestData {
+	return testDataMap["index_range"]
 }
 
 func GetIntegrationSuiteData() testdata.TestData {

--- a/pkg/planner/core/casetest/index/testdata/index_range_in.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_in.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "TestRangeDerivation",
+    "cases": [
+	"select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  (a1>1) or (a1=1 and b1 >= 10) -- simple DNF on (a1,b1) ",
+	"select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  ((a1>1) or (a1=1 and b1 >= 10)) and (c1 > 10) -- -- same as previous example with another conjunct",
+	"select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  (a1>1) or (a1=1 and b1 > 10) -- simple DNF on (a1,b1) with open interval",
+	"select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  ((a1>1) or (a1=1 and b1 > 10)) and (c1 > 10) -- same as previous example with another conjunct",
+	"select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  ((a1<10) or (a1=10 and b1 < 20)) -- upper bound on (a1,b1)",
+	"select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where ((a1>1) or (a1=1 and b1 > 10)) and ((a1<10) or (a1=10 and b1 < 20)) -- upper and lower bound on (a1,b1)",
+	"select * from t where (a,b) in ((1,1),(2,2)) and c = 3 -- IN list",
+	"select * from tuk where a<=>null and b>0 and b<2;",
+	"select a,b,c  from tuk where a>3 and b=4 order by a,c;",
+	// Same test cases with char type
+	"select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  (a1>'1') or (a1='1' and b1 >= '10') -- simple DNF on (a1,b1) ",
+	"select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  ((a1>'1') or (a1='1' and b1 >= '10')) and (c1 > '10') -- -- same as previous example with another conjunct",
+	"select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  (a1>'1') or (a1='1' and b1 > '10') -- simple DNF on (a1,b1) with open interval",
+	"select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  ((a1>'1') or (a1='1' and b1 > '10')) and (c1 > '10') -- same as previous example with another conjunct",
+	"select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  ((a1<'10') or (a1='10' and b1 < '20')) -- upper bound on (a1,b1)",
+	"select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where ((a1>'1') or (a1='1' and b1 > '10')) and ((a1<'10') or (a1='10' and b1 < '20')) -- upper and lower bound on (a1,b1)"
+    ]
+  }
+]

--- a/pkg/planner/core/casetest/index/testdata/index_range_out.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_out.json
@@ -1,0 +1,144 @@
+[
+  {
+    "Name": "TestRangeDerivation",
+    "Cases": [
+      {
+        "SQL": "select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  (a1>1) or (a1=1 and b1 >= 10) -- simple DNF on (a1,b1) ",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─TableRangeScan 3366.67 cop[tikv] table:t1 range:[1 10,1 +inf], (1,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  ((a1>1) or (a1=1 and b1 >= 10)) and (c1 > 10) -- -- same as previous example with another conjunct",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─Selection 1118.52 cop[tikv]  gt(test.t1.c1, 10)",
+          "      └─TableRangeScan 3366.67 cop[tikv] table:t1 range:[1 10,1 +inf], (1,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  (a1>1) or (a1=1 and b1 > 10) -- simple DNF on (a1,b1) with open interval",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─TableRangeScan 3366.67 cop[tikv] table:t1 range:(1 10,1 +inf], (1,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  ((a1>1) or (a1=1 and b1 > 10)) and (c1 > 10) -- same as previous example with another conjunct",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─Selection 1118.52 cop[tikv]  gt(test.t1.c1, 10)",
+          "      └─TableRangeScan 3366.67 cop[tikv] table:t1 range:(1 10,1 +inf], (1,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where  ((a1<10) or (a1=10 and b1 < 20)) -- upper bound on (a1,b1)",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─TableRangeScan 3356.57 cop[tikv] table:t1 range:[-inf,10), [10 -inf,10 20), keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1,PKX) */ count(*) from t1 where ((a1>1) or (a1=1 and b1 > 10)) and ((a1<10) or (a1=10 and b1 < 20)) -- upper and lower bound on (a1,b1)",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─Selection 1122.61 cop[tikv]  or(gt(test.t1.a1, 1), and(eq(test.t1.a1, 1), gt(test.t1.b1, 10))), or(lt(test.t1.a1, 10), and(eq(test.t1.a1, 10), lt(test.t1.b1, 20)))",
+          "      └─TableRangeScan 1403.26 cop[tikv] table:t1 range:[1,1], (1,10), [10,10], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t where (a,b) in ((1,1),(2,2)) and c = 3 -- IN list",
+        "Plan": [
+          "Selection 0.00 root  eq(test.t.c, 3)",
+          "└─Batch_Point_Get 2.00 root table:t, clustered index:PRIMARY(a, b) keep order:false, desc:false"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a<=>null and b>0 and b<2;",
+        "Plan": [
+          "IndexReader 0.25 root  index:Selection",
+          "└─Selection 0.25 cop[tikv]  eq(test.tuk.b, 1)",
+          "  └─IndexRangeScan 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select a,b,c  from tuk where a>3 and b=4 order by a,c;",
+        "Plan": [
+          "IndexReader 3.33 root  index:Selection",
+          "└─Selection 3.33 cop[tikv]  eq(test.tuk.b, 4)",
+          "  └─IndexRangeScan 3333.33 cop[tikv] table:tuk, index:a(a, b, c) range:(3,+inf], keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  (a1>'1') or (a1='1' and b1 >= '10') -- simple DNF on (a1,b1) ",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─TableRangeScan 3366.67 cop[tikv] table:t1char range:[\"1\" \"10\",\"1\" +inf], (\"1\",+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  ((a1>'1') or (a1='1' and b1 >= '10')) and (c1 > '10') -- -- same as previous example with another conjunct",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─Selection 1118.52 cop[tikv]  gt(test.t1char.c1, 10)",
+          "      └─TableRangeScan 3366.67 cop[tikv] table:t1char range:[\"1\" \"10\",\"1\" +inf], (\"1\",+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  (a1>'1') or (a1='1' and b1 > '10') -- simple DNF on (a1,b1) with open interval",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─TableRangeScan 3366.67 cop[tikv] table:t1char range:(\"1\" \"10\",\"1\" +inf], (\"1\",+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  ((a1>'1') or (a1='1' and b1 > '10')) and (c1 > '10') -- same as previous example with another conjunct",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─Selection 1118.52 cop[tikv]  gt(test.t1char.c1, 10)",
+          "      └─TableRangeScan 3366.67 cop[tikv] table:t1char range:(\"1\" \"10\",\"1\" +inf], (\"1\",+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where  ((a1<'10') or (a1='10' and b1 < '20')) -- upper bound on (a1,b1)",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─TableRangeScan 3356.57 cop[tikv] table:t1char range:[-inf,\"10\"), [\"10\" -inf,\"10\" \"20\"), keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ USE_INDEX(t1char,PKX) */ count(*) from t1char where ((a1>'1') or (a1='1' and b1 > '10')) and ((a1<'10') or (a1='10' and b1 < '20')) -- upper and lower bound on (a1,b1)",
+        "Plan": [
+          "HashAgg 1.00 root  funcs:count(Column#5)->Column#4",
+          "└─TableReader 1.00 root  data:HashAgg",
+          "  └─HashAgg 1.00 cop[tikv]  funcs:count(1)->Column#5",
+          "    └─Selection 1122.61 cop[tikv]  or(gt(test.t1char.a1, \"1\"), and(eq(test.t1char.a1, \"1\"), gt(test.t1char.b1, \"10\"))), or(lt(test.t1char.a1, \"10\"), and(eq(test.t1char.a1, \"10\"), lt(test.t1char.b1, \"20\")))",
+          "      └─TableRangeScan 1403.26 cop[tikv] table:t1char range:[\"1\",\"1\"], (\"1\",\"10\"), [\"10\",\"10\"], keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  }
+]

--- a/pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -480,8 +480,8 @@
         "IndexPlan": [
           "HashJoin 0.03 root  CARTESIAN inner join",
           "├─IndexReader(Build) 0.01 root partition:p0 index:Selection",
-          "│ └─Selection 0.01 cop[tikv]  eq(test_partition_1.t1.id, 7), or(eq(test_partition_1.t1.a, 1), and(eq(test_partition_1.t1.a, 3), in(test_partition_1.t1.b, 3, 5)))",
-          "│   └─IndexRangeScan 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "│ └─Selection 0.01 cop[tikv]  eq(test_partition_1.t1.id, 7)",
+          "│   └─IndexRangeScan 10.20 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3 3,3 3], [3 5,3 5], keep order:false, stats:pseudo",
           "└─IndexReader(Probe) 3.00 root partition:p1 index:IndexRangeScan",
           "  └─IndexRangeScan 3.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 7 7,6 7 7], [7 7 7,7 7 7], [8 7 7,8 7 7], keep order:false, stats:pseudo"
         ]

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -463,6 +463,9 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		// TODO: we will optimize it later.
 		res.RemainedConds = AppendConditionsIfNotExist(res.RemainedConds, remainedConds)
 		res.Ranges = ranges
+		// Choosing between point ranges and bestCNF is needed since bestCNF does not cover the intersection
+		// of all conjuncts. Even when we add support for intersection, it could be turned off by a flag or it could be
+		// incomplete due to a long list of conjuncts.
 		if bestCNFItemRes != nil && res != nil && len(res.Ranges) != 0 {
 			bestCNFIsSubset := bestCNFItemRes.rangeResult.Ranges.Subset(d.sctx.TypeCtx, res.Ranges)
 			pointRangeIsSubset := res.Ranges.Subset(d.sctx.TypeCtx, bestCNFItemRes.rangeResult.Ranges)

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -463,11 +463,11 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		// TODO: we will optimize it later.
 		res.RemainedConds = AppendConditionsIfNotExist(res.RemainedConds, remainedConds)
 		res.Ranges = ranges
-		if bestCNFItemRes != nil {
+		if bestCNFItemRes != nil && res != nil && len(res.Ranges) != 0 {
 			bestCNFIsSubset := bestCNFItemRes.rangeResult.Ranges.Subset(d.sctx.TypeCtx, res.Ranges)
 			pointRangeIsSubset := res.Ranges.Subset(d.sctx.TypeCtx, bestCNFItemRes.rangeResult.Ranges)
 			// Pick bestCNFIsSubset if it is more selective than point ranges(res).
-			// Only optimization if it is a proper subset bestCNFIsSubset and !pointRangeIsSubset.
+			// Apply optimization if bestCNFItemRes is a proper subset of point ranges.
 			if bestCNFIsSubset && !pointRangeIsSubset {
 				// Update final result and just update: Ranges, AccessConds and RemainedConds
 				res.RemainedConds = removeConditions(res.RemainedConds, bestCNFItemRes.rangeResult.AccessConds)

--- a/tests/integrationtest/r/util/ranger.result
+++ b/tests/integrationtest/r/util/ranger.result
@@ -368,9 +368,9 @@ a	b	c
 2	2	3
 explain format='brief' select * from t use index(primary) where ((a = 1) or (a = 2 and b = 2)) and c = 3;
 id	estRows	task	access object	operator info
-IndexReader	0.75	root		index:Selection
-└─Selection	0.75	cop[tikv]		eq(util__ranger.t.c, 3), or(eq(util__ranger.t.a, 1), and(eq(util__ranger.t.a, 2), eq(util__ranger.t.b, 2)))
-  └─IndexRangeScan	2.00	cop[tikv]	table:t, index:PRIMARY(a, b, c)	range:[1,1], [2,2], keep order:false
+IndexReader	1.00	root		index:Selection
+└─Selection	1.00	cop[tikv]		eq(util__ranger.t.c, 3)
+  └─IndexRangeScan	2.00	cop[tikv]	table:t, index:PRIMARY(a, b, c)	range:[1,1], [2 2,2 2], keep order:false
 select * from t use index(primary) where ((a = 1) or (a = 2 and b = 2)) and c = 3;
 a	b	c
 2	2	3
@@ -415,10 +415,9 @@ a	b	c
 2	2	3
 explain format='brief' select * from t use index(primary) where ((a = 1) or (a = 2 and b = 2)) and c = 3;
 id	estRows	task	access object	operator info
-IndexLookUp	0.75	root		
-├─Selection(Build)	2.00	cop[tikv]		or(eq(util__ranger.t.a, 1), and(eq(util__ranger.t.a, 2), eq(util__ranger.t.b, 2)))
-│ └─IndexRangeScan	2.00	cop[tikv]	table:t, index:PRIMARY(a, b)	range:[1,1], [2,2], keep order:false
-└─Selection(Probe)	0.75	cop[tikv]		eq(util__ranger.t.c, 3)
+IndexLookUp	1.00	root		
+├─IndexRangeScan(Build)	2.00	cop[tikv]	table:t, index:PRIMARY(a, b)	range:[1,1], [2 2,2 2], keep order:false
+└─Selection(Probe)	1.00	cop[tikv]		eq(util__ranger.t.c, 3)
   └─TableRowIDScan	2.00	cop[tikv]	table:t	keep order:false
 select * from t use index(primary) where ((a = 1) or (a = 2 and b = 2)) and c = 3;
 a	b	c


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Ref #41598

### Problem Summary:
Index range extraction in the optimizer can handle disjunctions like 
((a = 1 and b = 2 and c > 3) or (a = 4 and b = 5 and c > 6)) and builds the proper index range like "(1 2 3,1 2 +inf], (4 5 6,4 5 +inf]" for this example. The problem is that when we add another conjunct like d > 3 then the optimizer takes another path which find only the point ranges "[1,1], [4,4]" in this example. Finding point ranges is OK for complex CNF where we only pick ranges from only one conjunct, But, in this case, the best conjunct is also better than point ranges. 

### What changed and how does it work?
 We added code that picks the best conjunct ranges if it is more selective than the point ranges. For example, "(1 2 3,1 2 +inf], (4 5 6,4 5 +inf]" is more selective than "[1,1], [4,4]" . We implemented that by checking if the best CNF ranges is a subset of the point ranges. 

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```