### PR TITLE
ddl: handle create writer error for index ingest operator

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -595,6 +595,7 @@ func NewIndexIngestOperator(
 				writer, err := engines[i].CreateWriter(writerID)
 				if err != nil {
 					logutil.Logger(ctx).Error("create index ingest worker failed", zap.Error(err))
+					ctx.onError(err)
 					return nil
 				}
 				writers = append(writers, writer)

--- a/pkg/ddl/ingest/env.go
+++ b/pkg/ddl/ingest/env.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/lightning/log"
@@ -68,6 +69,10 @@ func InitGlobalLightningEnv(filterProcessingJobIDs FilterProcessingJobIDsFunc) {
 	} else {
 		memTotal = memTotal / 2
 	}
+	failpoint.Inject("setMemTotalInMB", func(val failpoint.Value) {
+		i := val.(int)
+		memTotal = uint64(i) * size.MB
+	})
 	LitBackCtxMgr = NewLitBackendCtxMgr(sortPath, memTotal, filterProcessingJobIDs)
 	litRLimit = util.GenRLimit("ddl-ingest")
 	LitInitialized = true

--- a/pkg/ddl/ingest/env.go
+++ b/pkg/ddl/ingest/env.go
@@ -70,6 +70,7 @@ func InitGlobalLightningEnv(filterProcessingJobIDs FilterProcessingJobIDsFunc) {
 		memTotal = memTotal / 2
 	}
 	failpoint.Inject("setMemTotalInMB", func(val failpoint.Value) {
+		//nolint: forcetypeassert
 		i := val.(int)
 		memTotal = uint64(i) * size.MB
 	})

--- a/tests/realtikvtest/addindextest3/BUILD.bazel
+++ b/tests/realtikvtest/addindextest3/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//pkg/table",
         "//pkg/table/tables",
         "//pkg/testkit",
+        "//pkg/testkit/testfailpoint",
         "//pkg/util/chunk",
         "//tests/realtikvtest",
         "@com_github_ngaut_pools//:pools",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53791

Problem Summary:

We should always handle `createWorker` error, because if some index workers cannot start, there may be a data inconsistency issue.

### What changed and how does it work?

Handle create writer error for index ingest operator.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
