### PR TITLE
*: bump client-go to fix #46602

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3603,8 +3603,8 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:5EFWY0ESuWKyCZBwFkZxD3/UO/p/M1dHw8lqDaiwTAo=",
-        version = "v2.0.4-0.20240510070224-92eaf4613ea5",
+        sum = "h1:ZVeek5EpxLzG/soloyJxmYa/jJ8KsrOAP+ZGn7+JPyw=",
+        version = "v2.0.4-0.20240611032030-02a6a912e7a8",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tdakkota/asciicheck v0.1.1
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.4-0.20240510070224-92eaf4613ea5
+	github.com/tikv/client-go/v2 v2.0.4-0.20240611032030-02a6a912e7a8
 	github.com/tikv/pd/client v0.0.0-20230904040343-947701a32c05
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144
 	github.com/twmb/murmur3 v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -948,8 +948,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tikv/client-go/v2 v2.0.4-0.20240510070224-92eaf4613ea5 h1:5EFWY0ESuWKyCZBwFkZxD3/UO/p/M1dHw8lqDaiwTAo=
-github.com/tikv/client-go/v2 v2.0.4-0.20240510070224-92eaf4613ea5/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
+github.com/tikv/client-go/v2 v2.0.4-0.20240611032030-02a6a912e7a8 h1:ZVeek5EpxLzG/soloyJxmYa/jJ8KsrOAP+ZGn7+JPyw=
+github.com/tikv/client-go/v2 v2.0.4-0.20240611032030-02a6a912e7a8/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
 github.com/tikv/pd/client v0.0.0-20230904040343-947701a32c05 h1:e4hLUKfgfPeJPZwOfU+/I/03G0sn6IZqVcbX/5o+hvM=
 github.com/tikv/pd/client v0.0.0-20230904040343-947701a32c05/go.mod h1:MLIl+d2WbOF4A3U88WKtyXrQQW417wZDDvBcq2IW9bQ=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDHS9/4U9yQo1UcPQM0kOMJHn29EoH/Ro=

--- a/store/copr/batch_coprocessor_test.go
+++ b/store/copr/batch_coprocessor_test.go
@@ -168,9 +168,9 @@ func TestGetUsedStores(t *testing.T) {
 	cache := NewRegionCache(tikv.NewRegionCache(pdCli))
 	defer cache.Close()
 
-	cache.SetRegionCacheStore(1, tikvrpc.TiFlash, 0, nil)
-	cache.SetRegionCacheStore(2, tikvrpc.TiFlash, 0, nil)
-	cache.SetRegionCacheStore(3, tikvrpc.TiFlash, 0, nil)
+	cache.SetRegionCacheStore(1, tikvrpc.TiFlash, 1, nil)
+	cache.SetRegionCacheStore(2, tikvrpc.TiFlash, 1, nil)
+	cache.SetRegionCacheStore(3, tikvrpc.TiFlash, 1, nil)
 
 	allUsedTiFlashStoresMap := make(map[uint64]struct{})
 	allUsedTiFlashStoresMap[2] = struct{}{}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46602

Problem Summary: `GetTiFlashStores` exported by client-go would return unresolved stores, which causes mpp probe keep checking tomebstone stores.

### What changed and how does it work?

Bump client-go so that `GetTiFlashStores` only returns resolved stores.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that tidb keeps sending probe requests to tomebstone tiflash stores.
```
