### PR TITLE
backup: fix the missing first store state during backup

### DIFF
--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
     embed = [":backup"],
     flaky = True,
     race = "on",
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//br/pkg/conn",
         "//br/pkg/gluetidb/mock",
@@ -83,6 +83,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/util/table-filter",
         "@com_github_golang_protobuf//proto",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
         "@com_github_stretchr_testify//require",

--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
+        "@com_github_pingcap_kvproto//pkg/kvrpcpb",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//testutils",

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -1107,9 +1107,8 @@ func (bc *Client) BackupRanges(
 		GetBackupClientCallBack: func(ctx context.Context, storeID uint64, reset bool) (backuppb.BackupClient, error) {
 			if reset {
 				return bc.mgr.ResetBackupClient(ctx, storeID)
-			} else {
-				return bc.mgr.GetBackupClient(ctx, storeID)
 			}
+			return bc.mgr.GetBackupClient(ctx, storeID)
 		},
 	}
 

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -90,7 +90,7 @@ func (s *MainBackupSender) SendAsync(
 ) {
 	go func() {
 		defer func() {
-			logutil.CL(ctx).Info("exit store backup goroutine", zap.Uint64("store", storeID))
+			logutil.CL(ctx).Info("store backup goroutine exits", zap.Uint64("store", storeID))
 			close(respCh)
 		}()
 		err := startBackup(ctx, storeID, request, cli, respCh)
@@ -125,7 +125,7 @@ func (l *MainBackupLoop) CollectStoreBackupsAsync(
 ) {
 	go func() {
 		defer func() {
-			logutil.CL(ctx).Info("exit collect backups goroutine", zap.Uint64("round", round))
+			logutil.CL(ctx).Info("collect backups goroutine exits", zap.Uint64("round", round))
 			close(globalCh)
 		}()
 		cases := make([]reflect.SelectCase, 0)
@@ -260,6 +260,8 @@ mainLoop:
 				}
 				if storeBackupInfo.One != 0 {
 					storeID := storeBackupInfo.One
+					logutil.CL(mainCtx).Info("receive notifaction and retry backup on this store",
+						zap.Uint64("storeID", storeID), zap.Uint64("round", round))
 					store, err := bc.mgr.GetPDClient().GetStore(mainCtx, storeID)
 					if err != nil {
 						// cannot get store, maybe store has scaled-in.

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -312,11 +312,13 @@ mainLoop:
 			case respAndStore, ok := <-globalBackupResultCh:
 				if !ok {
 					// resolve all txn lock before next round starts
-					bo := utils.AdaptTiKVBackoffer(handleCtx, MaxResolveLocksbackupOffSleepMs, berrors.ErrUnknown)
-					_, err = bc.mgr.GetLockResolver().ResolveLocks(bo.Inner(), 0, allTxnLocks)
-					if err != nil {
-						logutil.CL(handleCtx).Warn("failed to resolve locks, ignore and wait for next round to resolve",
-							zap.Uint64("round", round), zap.Error(err))
+					if len(allTxnLocks) > 0 {
+						bo := utils.AdaptTiKVBackoffer(handleCtx, MaxResolveLocksbackupOffSleepMs, berrors.ErrUnknown)
+						_, err = bc.mgr.GetLockResolver().ResolveLocks(bo.Inner(), 0, allTxnLocks)
+						if err != nil {
+							logutil.CL(handleCtx).Warn("failed to resolve locks, ignore and wait for next round to resolve",
+								zap.Uint64("round", round), zap.Error(err))
+						}
 					}
 					// this round backup finished. break and check incomplete ranges in mainLoop.
 					break handleLoop

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -313,7 +313,7 @@ mainLoop:
 				if !ok {
 					// resolve all txn lock before next round starts
 					bo := utils.AdaptTiKVBackoffer(handleCtx, MaxResolveLocksbackupOffSleepMs, berrors.ErrUnknown)
-					_, _, _, err = bc.mgr.GetLockResolver().ResolveLocksForRead(bo.Inner(), 0, allTxnLocks, true)
+					_, err = bc.mgr.GetLockResolver().ResolveLocks(bo.Inner(), 0, allTxnLocks)
 					if err != nil {
 						logutil.CL(handleCtx).Warn("failed to resolve locks, ignore and wait for next round to resolve",
 							zap.Uint64("round", round), zap.Error(err))

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -56,7 +56,7 @@ var connectedStore map[uint64]int
 
 var _ backup.BackupSender = (*mockBackupBackupSender)(nil)
 
-func mockGetBackupClientCallBack(ctx context.Context, storeID uint64) (backuppb.BackupClient, error) {
+func mockGetBackupClientCallBack(ctx context.Context, storeID uint64, reset bool) (backuppb.BackupClient, error) {
 	lock.Lock()
 	defer lock.Unlock()
 	connectedStore[storeID] += 1

--- a/br/pkg/backup/store.go
+++ b/br/pkg/backup/store.go
@@ -225,26 +225,34 @@ func ObserveStoreChangesAsync(ctx context.Context, stateNotifier chan BackupRetr
 		}
 
 		watcher := storewatch.New(pdCli, cb)
+		// make a first step, and make the state correct for next 30s check
+		err := watcher.Step(ctx)
+		if err != nil {
+			logutil.CL(ctx).Warn("failed to watch store changes at beginning, ignore it", zap.Error(err))
+		}
 		tick := time.NewTicker(30 * time.Second)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-tick.C:
-				logutil.CL(ctx).Info("check store changes by tick")
+				// reset the state
+				sendAll = false
+				clear(newJoinStoresMap)
+				logutil.CL(ctx).Info("check store changes every tick")
 				err := watcher.Step(ctx)
 				if err != nil {
 					logutil.CL(ctx).Warn("failed to watch store changes, ignore it", zap.Error(err))
 				}
 				if sendAll {
+					logutil.CL(ctx).Info("detect some store(s) restarted or disconnected, notify with all stores")
 					notifyFn(ctx, BackupRetryPolicy{All: true})
 				} else if len(newJoinStoresMap) > 0 {
 					for storeID := range newJoinStoresMap {
+						logutil.CL(ctx).Info("detect a new registered store, notify with this store", zap.Uint64("storeID", storeID))
 						notifyFn(ctx, BackupRetryPolicy{One: storeID})
 					}
 				}
-				sendAll = false
-				clear(newJoinStoresMap)
 			}
 		}
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/52534
close https://github.com/pingcap/tidb/issues/53926

Problem Summary:
The previous implementation of `storewatch` has the wrong beginning state. we must take the first step before the tick starts. Then the `WithOnNewStoreRegistered` will have the correct `lastStore` states to make computing results correct.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
