### PR TITLE
hint: avoid duplicate hints in QBHintHandler

### DIFF
--- a/pkg/planner/core/casetest/hint/BUILD.bazel
+++ b/pkg/planner/core/casetest/hint/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/hint/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/hint/testdata/integration_suite_out.json
@@ -1449,10 +1449,7 @@
           "      └─IndexRangeScan_148 19492.21 cop[tikv] table:t1, index:idx_a(a) range: decided by [eq(test.t1.a, test.t1.a)], keep order:false, stats:pseudo"
         ],
         "Warn": [
-          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid",
-          "[planner:1815]There are no matching table names for (t1) in optimizer hint /*+ INL_JOIN(t1, t1) */ or /*+ TIDB_INLJ(t1, t1) */. Maybe you can use the table alias name",
-          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid",
-          "[planner:1815]There are no matching table names for (t1, t1) in optimizer hint /*+ INL_JOIN(t1, t1, t1) */ or /*+ TIDB_INLJ(t1, t1, t1) */. Maybe you can use the table alias name"
+          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid"
         ]
       },
       {
@@ -1484,10 +1481,7 @@
           "                └─TableRowIDScan_69 9990.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "Warn": [
-          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid",
-          "[planner:1815]There are no matching table names for (t2) in optimizer hint /*+ MERGE_JOIN(t2, t2) */ or /*+ TIDB_SMJ(t2, t2) */. Maybe you can use the table alias name",
-          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid",
-          "[planner:1815]There are no matching table names for (t2, t2) in optimizer hint /*+ MERGE_JOIN(t2, t2, t2) */ or /*+ TIDB_SMJ(t2, t2, t2) */. Maybe you can use the table alias name"
+          "[planner:1815]We can only use one leading hint at most, when multiple leading hints are used, all leading hints will be invalid"
         ]
       },
       {

--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -836,8 +836,6 @@
           "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ],
         "Warn": [
-          "[planner:1815]There are no matching table names for (t1, t) in optimizer hint /*+ SHUFFLE_JOIN(t1, t, t1, t) */ or /*+ SHUFFLE_JOIN(t1, t, t1, t) */. Maybe you can use the table alias name",
-          "[planner:1815]There are no matching table names for (t1, t, t1, t) in optimizer hint /*+ SHUFFLE_JOIN(t1, t, t1, t, t1, t) */ or /*+ SHUFFLE_JOIN(t1, t, t1, t, t1, t) */. Maybe you can use the table alias name"
         ]
       },
       {

--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -835,8 +835,7 @@
           "                      └─Selection 9990.00 mpp[tiflash]  not(isnull(test.t.a))",
           "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ],
-        "Warn": [
-        ]
+        "Warn": null
       },
       {
         "SQL": "WITH CTE AS (SELECT /*+ MERGE(), broadcast_join(t1, t) */ t.a, t.b FROM t join t t1 where t.a = t1.a) SELECT * FROM CTE WHERE CTE.a <18 union select * from cte where cte.b > 1;",
@@ -866,10 +865,7 @@
           "                  └─Selection(Probe) 9990.00 mpp[tiflash]  not(isnull(test.t.a))",
           "                    └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ],
-        "Warn": [
-          "[planner:1815]There are no matching table names for (t1, t) in optimizer hint /*+ BROADCAST_JOIN(t1, t, t1, t) */ or /*+ TIDB_BCJ(t1, t, t1, t) */. Maybe you can use the table alias name",
-          "[planner:1815]There are no matching table names for (t1, t, t1, t) in optimizer hint /*+ BROADCAST_JOIN(t1, t, t1, t, t1, t) */ or /*+ TIDB_BCJ(t1, t, t1, t, t1, t) */. Maybe you can use the table alias name"
-        ]
+        "Warn": null
       },
       {
         "SQL": "select /*+ read_from_storage(tiflash[t1, t2]), broadcast_join(t1, t2), hash_join_build(t2) */ * from t t1 left join t t2 on t1.a=t2.a",

--- a/pkg/util/hint/hint_query_block.go
+++ b/pkg/util/hint/hint_query_block.go
@@ -16,6 +16,7 @@ package hint
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -295,7 +296,9 @@ func (p *QBHintHandler) GetCurrentStmtHints(hints []*ast.TableOptimizerHint, cur
 			}
 			continue
 		}
-		p.QBOffsetToHints[offset] = append(p.QBOffsetToHints[offset], hint)
+		if !slices.Contains(p.QBOffsetToHints[offset], hint) {
+			p.QBOffsetToHints[offset] = append(p.QBOffsetToHints[offset], hint)
+		}
 	}
 	return p.QBOffsetToHints[currentOffset]
 }

--- a/tests/integrationtest/r/index_merge.result
+++ b/tests/integrationtest/r/index_merge.result
@@ -852,7 +852,6 @@ show warnings;
 Level	Code	Message
 Warning	1815	use_index_merge(index_merge.t_alias) is inapplicable, check whether the table(index_merge.t_alias) exists
 Warning	1815	use_index_merge(index_merge.t_alias) is inapplicable, check whether the table(index_merge.t_alias) exists
-Warning	1815	use_index_merge(index_merge.t_alias) is inapplicable, check whether the table(index_merge.t_alias) exists
 with recursive cte1 as (select 1 c1, 1 c2, 1 c3 UNION ALL select /*+ use_index_merge(t_alias) */ c1 + 1, c2 + 1, c3 + 1 from cte1 t_alias where c1 < 10 or c2 < 10 and c3 < 10) select * from cte1 order by 1;
 c1	c2	c3
 1	1	1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53767

Problem Summary:

### What changed and how does it work?

QBHintHandler may produce duplicate hints. When it reaches the match stage, the first one will be marked as a hint, but the second one will be ignored, ultimately resulting in incorrect warning messages.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
