### PR TITLE
expression: remove unused MarshalJSON function in Expression

### DIFF
--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -402,11 +402,6 @@ func (col *Column) String() string {
 	return builder.String()
 }
 
-// MarshalJSON implements json.Marshaler interface.
-func (col *Column) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%q", col)), nil
-}
-
 // GetType implements Expression interface.
 func (col *Column) GetType(_ EvalContext) *types.FieldType {
 	return col.GetStaticType()

--- a/pkg/expression/column_test.go
+++ b/pkg/expression/column_test.go
@@ -36,10 +36,6 @@ func TestColumn(t *testing.T) {
 	require.False(t, col.IsCorrelated())
 	require.True(t, col.EqualColumn(col.Decorrelate(nil)))
 
-	marshal, err := col.MarshalJSON()
-	require.NoError(t, err)
-	require.EqualValues(t, []byte{0x22, 0x43, 0x6f, 0x6c, 0x75, 0x6d, 0x6e, 0x23, 0x31, 0x22}, marshal)
-
 	intDatum := types.NewIntDatum(1)
 	corCol := &CorrelatedColumn{Column: *col, Data: &intDatum}
 	invalidCorCol := &CorrelatedColumn{Column: Column{}}

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -156,11 +156,6 @@ func (c *Constant) String() string {
 	return fmt.Sprintf("%v", c.Value.GetValue())
 }
 
-// MarshalJSON implements json.Marshaler interface.
-func (c *Constant) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%q", c)), nil
-}
-
 // Clone implements Expression interface.
 func (c *Constant) Clone() Expression {
 	con := *c

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -15,7 +15,6 @@
 package expression
 
 import (
-	goJSON "encoding/json"
 	"fmt"
 
 	"github.com/pingcap/errors"
@@ -166,7 +165,6 @@ const (
 // Expression represents all scalar expression in SQL.
 type Expression interface {
 	fmt.Stringer
-	goJSON.Marshaler
 	VecExpr
 	CollationInfo
 

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -109,9 +109,6 @@ func TestConstant(t *testing.T) {
 	require.True(t, NewZero().Decorrelate(nil).Equal(ctx, NewZero()))
 	require.Equal(t, []byte{0x0, 0x8, 0x0}, NewZero().HashCode())
 	require.False(t, NewZero().Equal(ctx, NewOne()))
-	res, err := NewZero().MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, []byte{0x22, 0x30, 0x22}, res)
 }
 
 func TestIsBinaryLiteral(t *testing.T) {

--- a/pkg/expression/scalar_function_test.go
+++ b/pkg/expression/scalar_function_test.go
@@ -98,9 +98,6 @@ func TestScalarFunction(t *testing.T) {
 	}
 
 	sf := newFunctionWithMockCtx(ast.LT, a, NewOne())
-	res, err := sf.MarshalJSON()
-	require.NoError(t, err)
-	require.EqualValues(t, []byte{0x22, 0x6c, 0x74, 0x28, 0x43, 0x6f, 0x6c, 0x75, 0x6d, 0x6e, 0x23, 0x31, 0x2c, 0x20, 0x31, 0x29, 0x22}, res)
 	require.False(t, sf.IsCorrelated())
 	require.Equal(t, ConstNone, sf.ConstLevel())
 	require.True(t, sf.Decorrelate(nil).Equal(ctx, sf))

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -256,21 +256,6 @@ func (s *ScalarSubQueryExpr) String() string {
 	return builder.String()
 }
 
-// MarshalJSON implements the goJSON.Marshaler interface.
-func (s *ScalarSubQueryExpr) MarshalJSON() ([]byte, error) {
-	if s.evalErr != nil {
-		return nil, s.evalErr
-	}
-	if s.evaled {
-		return s.Constant.MarshalJSON()
-	}
-	err := s.selfEvaluate()
-	if err != nil {
-		return nil, err
-	}
-	return s.Constant.MarshalJSON()
-}
-
 // VecEvalInt evaluates this expression in a vectorized manner.
 func (*ScalarSubQueryExpr) VecEvalInt(_ expression.EvalContext, _ *chunk.Chunk, _ *chunk.Column) error {
 	return errors.Errorf("ScalarSubQueryExpr doesn't implement the vec eval yet")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/53840

Problem Summary:

The `MarshalJSON` function of `Expression` interface is not used in TiDB. This PR tried to remove it.

### What changed and how does it work?

1. Remove the `MarshalJSON` method for `Expression` and its implementations.

I've checked through some static analyze + manually analyze in https://github.com/pingcap/tidb/pull/53841. The `MarshalJSON` method is not used in tidb. Blaming the code shows that it's originally introduced in https://github.com/pingcap/tidb/pull/1632, and it's not used anymore.

(The linter in #53841 cannot be used, because it'll report every use-case of `json.Marshal` on an interface which didn't implement `json.Marshal`. It's not possible to actually statically analyze this case.)

We cannot give a proper implementation for `MarshalJSON` without context (as the `Constant` can describe a parameter, which requires a context to give meaningful value). It'd be better to remove this implementation to avoid misuse in the future.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > The existing tests should cover this modification (or it'll be a big problem :face_exhaling: ).
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
