### PR TITLE
planner: change the rewrite rule of row expression

### DIFF
--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/planner/core/casetest/index/testdata/integration_suite_in.json
+++ b/pkg/planner/core/casetest/index/testdata/integration_suite_in.json
@@ -19,5 +19,18 @@
       "select b from t3 where a = 1 and b is not null",
       "select b from t3 where a = 1 and b is null"
     ]
+  },
+  {
+    "name": "TestRowFunctionMatchTheIndexRangeScan",
+    "cases": [
+      "select k1 from t1 where (k1,k2) > (1,2)",
+      "select k1 from t1 where (k1,k2) >= (1,2)",
+      "select k1 from t1 where (k1,k2) < (1,2)",
+      "select k1 from t1 where (k1, k2) <= (1,2)",
+      "select k1 from t1 where (k1,k2) = (1,2)",
+      "select k1 from t1 where (k1, k2) != (1,2); -- could not match range scan",
+      "select k1 from t1 where (k1) <=> (1); -- could not match range scan",
+      "select k1 from t1 where (k1, k2) in ((1,2), (3,4))"
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/index/testdata/integration_suite_in.json
+++ b/pkg/planner/core/casetest/index/testdata/integration_suite_in.json
@@ -30,7 +30,10 @@
       "select k1 from t1 where (k1,k2) = (1,2)",
       "select k1 from t1 where (k1, k2) != (1,2); -- could not match range scan",
       "select k1 from t1 where (k1) <=> (1); -- could not match range scan",
-      "select k1 from t1 where (k1, k2) in ((1,2), (3,4))"
+      "select k1 from t1 where (k1, k2) in ((1,2), (3,4))",
+      "select k1 from t1 where (k1, k2) > (1,2) and (k1, k2) < (4,5)",
+      "select k1 from t1 where (k1, k2) >= (1,2) and (k1, k2) <= (4,5)",
+      "select k1 from t1 where (k2, k3) > (1,2); -- could not match range scan "
     ]
   }
 ]

--- a/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
@@ -200,5 +200,82 @@
         "Result": null
       }
     ]
+  },
+  {
+    "Name": "TestRowFunctionMatchTheIndexRangeScan",
+    "Cases": [
+      {
+        "SQL": "select k1 from t1 where (k1,k2) > (1,2)",
+        "Plan": [
+          "Projection 3366.67 root  test.t1.k1",
+          "└─IndexReader 3366.67 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 3366.67 cop[tikv] table:t1, index:pk1(k1, k2) range:(1 2,1 +inf], (1,+inf], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1,k2) >= (1,2)",
+        "Plan": [
+          "Projection 3366.67 root  test.t1.k1",
+          "└─IndexReader 3366.67 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 3366.67 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 +inf], (1,+inf], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1,k2) < (1,2)",
+        "Plan": [
+          "Projection 3356.57 root  test.t1.k1",
+          "└─IndexReader 3356.57 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 3356.57 cop[tikv] table:t1, index:pk1(k1, k2) range:[-inf,1), [1 -inf,1 2), keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1, k2) <= (1,2)",
+        "Plan": [
+          "Projection 3356.57 root  test.t1.k1",
+          "└─IndexReader 3356.57 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 3356.57 cop[tikv] table:t1, index:pk1(k1, k2) range:[-inf,1), [1 -inf,1 2], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1,k2) = (1,2)",
+        "Plan": [
+          "Projection 0.10 root  test.t1.k1",
+          "└─IndexReader 0.10 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 0.10 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 2], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1, k2) != (1,2); -- could not match range scan",
+        "Plan": [
+          "Projection 8882.21 root  test.t1.k1",
+          "└─IndexReader 8882.21 root  index:Selection",
+          "  └─Selection 8882.21 cop[tikv]  or(ne(test.t1.k1, 1), ne(test.t1.k2, 2))",
+          "    └─IndexFullScan 10000.00 cop[tikv] table:t1, index:pk1(k1, k2) keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1) <=> (1); -- could not match range scan",
+        "Plan": [
+          "IndexReader 10.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 10.00 cop[tikv] table:t1, index:pk1(k1, k2) range:[1,1], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1, k2) in ((1,2), (3,4))",
+        "Plan": [
+          "Projection 0.20 root  test.t1.k1",
+          "└─IndexReader 0.20 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 0.20 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 2], [3 4,3 4], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/index/testdata/integration_suite_out.json
@@ -275,6 +275,36 @@
           "  └─IndexRangeScan 0.20 cop[tikv] table:t1, index:pk1(k1, k2) range:[1 2,1 2], [3 4,3 4], keep order:false, stats:pseudo"
         ],
         "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1, k2) > (1,2) and (k1, k2) < (4,5)",
+        "Plan": [
+          "Projection 1122.61 root  test.t1.k1",
+          "└─IndexReader 1122.61 root  index:Selection",
+          "  └─Selection 1122.61 cop[tikv]  or(gt(test.t1.k1, 1), and(eq(test.t1.k1, 1), gt(test.t1.k2, 2))), or(lt(test.t1.k1, 4), and(eq(test.t1.k1, 4), lt(test.t1.k2, 5)))",
+          "    └─IndexRangeScan 1403.26 cop[tikv] table:t1, index:pk1(k1, k2) range:[1,1], (1,4), [4,4], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k1, k2) >= (1,2) and (k1, k2) <= (4,5)",
+        "Plan": [
+          "Projection 1122.61 root  test.t1.k1",
+          "└─IndexReader 1122.61 root  index:Selection",
+          "  └─Selection 1122.61 cop[tikv]  or(gt(test.t1.k1, 1), and(eq(test.t1.k1, 1), ge(test.t1.k2, 2))), or(lt(test.t1.k1, 4), and(eq(test.t1.k1, 4), le(test.t1.k2, 5)))",
+          "    └─IndexRangeScan 1403.26 cop[tikv] table:t1, index:pk1(k1, k2) range:[1,1], (1,4), [4,4], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select k1 from t1 where (k2, k3) > (1,2); -- could not match range scan ",
+        "Plan": [
+          "Projection 3335.56 root  test.t1.k1",
+          "└─TableReader 3335.56 root  data:Selection",
+          "  └─Selection 3335.56 cop[tikv]  or(gt(test.t1.k2, 1), and(eq(test.t1.k2, 1), gt(test.t1.k3, 2)))",
+          "    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Result": null
       }
     ]
   }

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -385,9 +385,10 @@ func (er *expressionRewriter) ctxStackAppend(col expression.Expression, name *ty
 // constructBinaryOpFunction converts binary operator functions
 /*
 	The algorithm is as follows:
-	1. If the length of the two sides of the expression is not equal, return an error.
-	2. If the operator is EQ, NE, or NullEQ, converts (a0,a1,a2) op (b0,b1,b2) to (a0 op b0) and (a1 op b1) and (a2 op b2)
-	3. If the operator is not EQ, NE, or NullEQ,
+	1. If the length of the two sides of the expression is 1, return l op r directly.
+    2. If the length of the two sides of the expression is not equal, return an error.
+	3. If the operator is EQ, NE, or NullEQ, converts (a0,a1,a2) op (b0,b1,b2) to (a0 op b0) and (a1 op b1) and (a2 op b2)
+	4. If the operator is not EQ, NE, or NullEQ,
             converts (a0,a1,a2) op (b0,b1,b2) to (a0 > b0) or (a0 = b0 and a1 > b1) or (a0 = b0 and a1 = b1 and a2 op b2)
 	   Especially, op is GE or LE, the prefix element will be converted to > or <.
             converts (a0,a1,a2) >= (b0,b1,b2) to (a0 > b0) or (a0 = b0 and a1 > b1) or (a0 = b0 and a1 = b1 and a2 >= b2)

--- a/pkg/planner/core/partition_pruning_test.go
+++ b/pkg/planner/core/partition_pruning_test.go
@@ -553,14 +553,13 @@ func TestPartitionRangeColumnsForExpr(t *testing.T) {
 		{"a is null", partitionRangeOR{{0, 1}}},
 		{"12 > a", partitionRangeOR{{0, 12}}},
 		{"4 <= a", partitionRangeOR{{1, 14}}},
-		// The expression is converted to 'if ...', see constructBinaryOpFunction, so not possible to break down to ranges
-		{"(a,b) < (4,4)", partitionRangeOR{{0, 14}}},
+		{"(a,b) < (4,4)", partitionRangeOR{{0, 4}}},
 		{"(a,b) = (4,4)", partitionRangeOR{{4, 5}}},
 		{"a < 4 OR (a = 4 AND b < 4)", partitionRangeOR{{0, 4}}},
-		// The expression is converted to 'if ...', see constructBinaryOpFunction, so not possible to break down to ranges
-		{"(a,b,c) < (4,4,4)", partitionRangeOR{{0, 14}}},
+		{"(a,b,c) < (4,4,4)", partitionRangeOR{{0, 5}}},
 		{"a < 4 OR (a = 4 AND b < 4) OR (a = 4 AND b = 4 AND c < 4)", partitionRangeOR{{0, 5}}},
-		{"(a,b,c) >= (4,7,4)", partitionRangeOR{{0, len(partDefs)}}},
+		{"(a,b,c) >= (4,7,4)", partitionRangeOR{{5, len(partDefs)}}},
+		{"a > 4 or (a= 4 and b > 7) or (a = 4 and b = 7 and c >= 4)", partitionRangeOR{{5, len(partDefs)}}},
 		{"(a,b,c) = (4,7,4)", partitionRangeOR{{5, 6}}},
 		{"a < 2 and a > 10", partitionRangeOR{}},
 		{"a < 1 and a > 1", partitionRangeOR{}},


### PR DESCRIPTION
### What problem does this PR solve?

(x,y,z) op (a,b,c)
rewritten
(x op a) or (x = a and y op b) or (x = a and y = b and z op c)

The new rewriting method allows buildrange to handle range construction problems more conveniently.


<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #41598

Problem Summary:

### What changed and how does it work?

The old expression rewrite is rewritten row expression to if(x!=a, x> a, if(xxxx)). The range builder could not easy build and merge this kind of expr range.

The new expression rewritten to (x op a) or (x = a and y op b) or (x = a and y = b and z op c) . It will be rewritten as a DNF which is more conveniently for Range builder.

### Check List
Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The row expression will be rewritten into DNF. This form is more conducive to more precise range builder of the index, thereby reducing key reading.
```
