### PR TITLE
lightning: skip non-unique index for duplicate detection

### DIFF
--- a/pkg/lightning/backend/local/duplicate.go
+++ b/pkg/lightning/backend/local/duplicate.go
@@ -720,7 +720,7 @@ func (m *DupeDetector) buildDupTasks() ([]dupTask, error) {
 		putToTaskFunc(ranges, nil)
 	})
 	for _, indexInfo := range m.tbl.Meta().Indices {
-		if indexInfo.State != model.StatePublic {
+		if indexInfo.State != model.StatePublic || !indexInfo.Unique {
 			continue
 		}
 		keyRanges, err = tableIndexKeyRanges(m.tbl.Meta(), indexInfo)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53669 

Problem Summary:
ightning should not run duplicate detection on non-unique index.

### What changed and how does it work?
skip non-unique index for duplicate detection.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
