### PR TITLE
executor: introduce ExecStmtRuntime and copy the implementation

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -59,6 +59,7 @@ go_library(
         "reload_expr_pushdown_blacklist.go",
         "replace.go",
         "revoke.go",
+        "runtime.go",
         "sample.go",
         "select_into.go",
         "set.go",

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -15,11 +15,9 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
-	"runtime/trace"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,7 +26,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
@@ -37,7 +34,6 @@ import (
 	executor_metrics "github.com/pingcap/tidb/pkg/executor/metrics"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
-	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -48,9 +44,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
-	"github.com/pingcap/tidb/pkg/plugin"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/sessionstates"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
@@ -61,15 +55,11 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
-	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/hint"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/redact"
 	"github.com/pingcap/tidb/pkg/util/replayer"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
-	"github.com/pingcap/tidb/pkg/util/stmtsummary"
-	stmtsummaryv2 "github.com/pingcap/tidb/pkg/util/stmtsummary/v2"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 	"github.com/pingcap/tidb/pkg/util/topsql"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -79,7 +69,6 @@ import (
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // processinfoSetter is the interface use to set current running process info.
@@ -92,7 +81,7 @@ type processinfoSetter interface {
 type recordSet struct {
 	fields     []*ast.ResultField
 	executor   exec.Executor
-	stmt       *ExecStmt
+	stmt       *ExecStmtRuntime
 	lastErrs   []error
 	txnStartTS uint64
 	once       sync.Once
@@ -218,40 +207,13 @@ func (a *recordSet) OnFetchReturned() {
 
 // ExecStmt implements the sqlexec.Statement interface, it builds a planner.Plan to an sqlexec.Statement.
 type ExecStmt struct {
-	// GoCtx stores parent go context.Context for a stmt.
-	GoCtx context.Context
-	// InfoSchema stores a reference to the schema information.
-	InfoSchema infoschema.InfoSchema
-	// Plan stores a reference to the final physical plan.
-	Plan base.Plan
-	// Text represents the origin query text.
-	Text string
-
-	StmtNode ast.StmtNode
-
-	Ctx sessionctx.Context
+	ExecStmtRuntime
 
 	// LowerPriority represents whether to lower the execution priority of a query.
 	LowerPriority     bool
-	isPreparedStmt    bool
 	isSelectForUpdate bool
-	retryCount        uint
-	retryStartTime    time.Time
 
-	// Phase durations are splited into two parts: 1. trying to lock keys (but
-	// failed); 2. the final iteration of the retry loop. Here we use
-	// [2]time.Duration to record such info for each phase. The first duration
-	// is increased only within the current iteration. When we meet a
-	// pessimistic lock error and decide to retry, we add the first duration to
-	// the second and reset the first to 0 by calling `resetPhaseDurations`.
-	phaseBuildDurations [2]time.Duration
-	phaseOpenDurations  [2]time.Duration
-	phaseNextDurations  [2]time.Duration
-	phaseLockDurations  [2]time.Duration
-
-	// OutputNames will be set if using cached plan
-	OutputNames []*types.FieldName
-	PsStmt      *plannercore.PlanCacheStmt
+	PsStmt *plannercore.PlanCacheStmt
 }
 
 // GetStmtNode returns the stmtNode inside Statement
@@ -336,7 +298,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 
 	return &recordSet{
 		executor:   executor,
-		stmt:       a,
+		stmt:       &a.ExecStmtRuntime,
 		txnStartTS: startTs,
 	}, nil
 }
@@ -571,7 +533,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 
 	return &recordSet{
 		executor:   e,
-		stmt:       a,
+		stmt:       &a.ExecStmtRuntime,
 		txnStartTS: txnStartTS,
 	}, nil
 }
@@ -830,7 +792,7 @@ type chunkRowRecordSet struct {
 	idx      int
 	fields   []*ast.ResultField
 	e        exec.Executor
-	execStmt *ExecStmt
+	execStmt *ExecStmtRuntime
 }
 
 func (c *chunkRowRecordSet) Fields() []*ast.ResultField {
@@ -921,7 +883,7 @@ func (a *ExecStmt) runPessimisticSelectForUpdate(ctx context.Context, e exec.Exe
 			break
 		}
 		if req.NumRows() == 0 {
-			return &chunkRowRecordSet{rows: rows, e: e, execStmt: a}, nil
+			return &chunkRowRecordSet{rows: rows, e: e, execStmt: &a.ExecStmtRuntime}, nil
 		}
 		iter := chunk.NewIterator4Chunk(req)
 		for r := iter.Begin(); r != iter.End(); r = iter.Next() {
@@ -1206,13 +1168,6 @@ func (a *ExecStmt) openExecutor(ctx context.Context, e exec.Executor) (err error
 	return err
 }
 
-func (a *ExecStmt) next(ctx context.Context, e exec.Executor, req *chunk.Chunk) error {
-	start := time.Now()
-	err := exec.Next(ctx, e, req)
-	a.phaseNextDurations[0] += time.Since(start)
-	return err
-}
-
 func (a *ExecStmt) resetPhaseDurations() {
 	a.phaseBuildDurations[1] += a.phaseBuildDurations[0]
 	a.phaseBuildDurations[0] = 0
@@ -1226,26 +1181,6 @@ func (a *ExecStmt) resetPhaseDurations() {
 
 // QueryReplacer replaces new line and tab for grep result including query string.
 var QueryReplacer = strings.NewReplacer("\r", " ", "\n", " ", "\t", " ")
-
-func (a *ExecStmt) logAudit() {
-	sessVars := a.Ctx.GetSessionVars()
-	if sessVars.InRestrictedSQL {
-		return
-	}
-
-	err := plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
-		audit := plugin.DeclareAuditManifest(p.Manifest)
-		if audit.OnGeneralEvent != nil {
-			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
-			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
-			audit.OnGeneralEvent(ctx, sessVars, plugin.Completed, cmd)
-		}
-		return nil
-	})
-	if err != nil {
-		log.Error("log audit log failure", zap.Error(err))
-	}
-}
 
 // FormatSQL is used to format the original SQL, e.g. truncating long SQL, appending prepared arguments.
 func FormatSQL(sql string) stringutil.StringerFunc {
@@ -1279,200 +1214,6 @@ func getPhaseDurationObserver(phase string, internal bool) prometheus.Observer {
 	return executor_metrics.ExecUnknown
 }
 
-func (a *ExecStmt) observePhaseDurations(internal bool, commitDetails *util.CommitDetails) {
-	for _, it := range []struct {
-		duration time.Duration
-		phase    string
-	}{
-		{a.phaseBuildDurations[0], executor_metrics.PhaseBuildFinal},
-		{a.phaseBuildDurations[1], executor_metrics.PhaseBuildLocking},
-		{a.phaseOpenDurations[0], executor_metrics.PhaseOpenFinal},
-		{a.phaseOpenDurations[1], executor_metrics.PhaseOpenLocking},
-		{a.phaseNextDurations[0], executor_metrics.PhaseNextFinal},
-		{a.phaseNextDurations[1], executor_metrics.PhaseNextLocking},
-		{a.phaseLockDurations[0], executor_metrics.PhaseLockFinal},
-		{a.phaseLockDurations[1], executor_metrics.PhaseLockLocking},
-	} {
-		if it.duration > 0 {
-			getPhaseDurationObserver(it.phase, internal).Observe(it.duration.Seconds())
-		}
-	}
-	if commitDetails != nil {
-		for _, it := range []struct {
-			duration time.Duration
-			phase    string
-		}{
-			{commitDetails.PrewriteTime, executor_metrics.PhaseCommitPrewrite},
-			{commitDetails.CommitTime, executor_metrics.PhaseCommitCommit},
-			{commitDetails.GetCommitTsTime, executor_metrics.PhaseCommitWaitCommitTS},
-			{commitDetails.GetLatestTsTime, executor_metrics.PhaseCommitWaitLatestTS},
-			{commitDetails.LocalLatchTime, executor_metrics.PhaseCommitWaitLatch},
-			{commitDetails.WaitPrewriteBinlogTime, executor_metrics.PhaseCommitWaitBinlog},
-		} {
-			if it.duration > 0 {
-				getPhaseDurationObserver(it.phase, internal).Observe(it.duration.Seconds())
-			}
-		}
-	}
-	if stmtDetailsRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey); stmtDetailsRaw != nil {
-		d := stmtDetailsRaw.(*execdetails.StmtExecDetails).WriteSQLRespDuration
-		if d > 0 {
-			getPhaseDurationObserver(executor_metrics.PhaseWriteResponse, internal).Observe(d.Seconds())
-		}
-	}
-}
-
-// FinishExecuteStmt is used to record some information after `ExecStmt` execution finished:
-// 1. record slow log if needed.
-// 2. record summary statement.
-// 3. record execute duration metric.
-// 4. update the `PrevStmt` in session variable.
-// 5. reset `DurationParse` in session variable.
-func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults bool) {
-	a.checkPlanReplayerCapture(txnTS)
-
-	sessVars := a.Ctx.GetSessionVars()
-	execDetail := sessVars.StmtCtx.GetExecDetails()
-	// Attach commit/lockKeys runtime stats to executor runtime stats.
-	if (execDetail.CommitDetail != nil || execDetail.LockKeysDetail != nil) && sessVars.StmtCtx.RuntimeStatsColl != nil {
-		statsWithCommit := &execdetails.RuntimeStatsWithCommit{
-			Commit:   execDetail.CommitDetail,
-			LockKeys: execDetail.LockKeysDetail,
-		}
-		sessVars.StmtCtx.RuntimeStatsColl.RegisterStats(a.Plan.ID(), statsWithCommit)
-	}
-	// Record related SLI metrics.
-	if execDetail.CommitDetail != nil && execDetail.CommitDetail.WriteSize > 0 {
-		a.Ctx.GetTxnWriteThroughputSLI().AddTxnWriteSize(execDetail.CommitDetail.WriteSize, execDetail.CommitDetail.WriteKeys)
-	}
-	if execDetail.ScanDetail != nil && sessVars.StmtCtx.AffectedRows() > 0 {
-		processedKeys := atomic.LoadInt64(&execDetail.ScanDetail.ProcessedKeys)
-		if processedKeys > 0 {
-			// Only record the read keys in write statement which affect row more than 0.
-			a.Ctx.GetTxnWriteThroughputSLI().AddReadKeys(processedKeys)
-		}
-	}
-	succ := err == nil
-	if a.Plan != nil {
-		// If this statement has a Plan, the StmtCtx.plan should have been set when it comes here,
-		// but we set it again in case we missed some code paths.
-		sessVars.StmtCtx.SetPlan(a.Plan)
-	}
-	// `LowSlowQuery` and `SummaryStmt` must be called before recording `PrevStmt`.
-	a.LogSlowQuery(txnTS, succ, hasMoreResults)
-	a.SummaryStmt(succ)
-	a.observeStmtFinishedForTopSQL()
-	if sessVars.StmtCtx.IsTiFlash.Load() {
-		if succ {
-			executor_metrics.TotalTiFlashQuerySuccCounter.Inc()
-		} else {
-			metrics.TiFlashQueryTotalCounter.WithLabelValues(metrics.ExecuteErrorToLabel(err), metrics.LblError).Inc()
-		}
-	}
-	sessVars.PrevStmt = FormatSQL(a.GetTextToLog(false))
-	a.recordLastQueryInfo(err)
-	a.observePhaseDurations(sessVars.InRestrictedSQL, execDetail.CommitDetail)
-	executeDuration := time.Since(sessVars.StartTime) - sessVars.DurationCompile
-	if sessVars.InRestrictedSQL {
-		executor_metrics.SessionExecuteRunDurationInternal.Observe(executeDuration.Seconds())
-	} else {
-		executor_metrics.SessionExecuteRunDurationGeneral.Observe(executeDuration.Seconds())
-	}
-	// Reset DurationParse due to the next statement may not need to be parsed (not a text protocol query).
-	sessVars.DurationParse = 0
-	// Clean the stale read flag when statement execution finish
-	sessVars.StmtCtx.IsStaleness = false
-	// Clean the MPP query info
-	sessVars.StmtCtx.MPPQueryInfo.QueryID.Store(0)
-	sessVars.StmtCtx.MPPQueryInfo.QueryTS.Store(0)
-	sessVars.StmtCtx.MPPQueryInfo.AllocatedMPPTaskID.Store(0)
-	sessVars.StmtCtx.MPPQueryInfo.AllocatedMPPGatherID.Store(0)
-
-	if sessVars.StmtCtx.ReadFromTableCache {
-		metrics.ReadFromTableCacheCounter.Inc()
-	}
-
-	// Update fair locking related counters by stmt
-	if execDetail.LockKeysDetail != nil {
-		if execDetail.LockKeysDetail.AggressiveLockNewCount > 0 || execDetail.LockKeysDetail.AggressiveLockDerivedCount > 0 {
-			executor_metrics.FairLockingStmtUsedCount.Inc()
-			// If this statement is finished when some of the keys are locked with conflict in the last retry, or
-			// some of the keys are derived from the previous retry, we consider the optimization of fair locking
-			// takes effect on this statement.
-			if execDetail.LockKeysDetail.LockedWithConflictCount > 0 || execDetail.LockKeysDetail.AggressiveLockDerivedCount > 0 {
-				executor_metrics.FairLockingStmtEffectiveCount.Inc()
-			}
-		}
-	}
-	// If the transaction is committed, update fair locking related counters by txn
-	if execDetail.CommitDetail != nil {
-		if sessVars.TxnCtx.FairLockingUsed {
-			executor_metrics.FairLockingTxnUsedCount.Inc()
-		}
-		if sessVars.TxnCtx.FairLockingEffective {
-			executor_metrics.FairLockingTxnEffectiveCount.Inc()
-		}
-	}
-
-	a.Ctx.ReportUsageStats()
-}
-
-func (a *ExecStmt) recordLastQueryInfo(err error) {
-	sessVars := a.Ctx.GetSessionVars()
-	// Record diagnostic information for DML statements
-	recordLastQuery := false
-	switch typ := a.StmtNode.(type) {
-	case *ast.ShowStmt:
-		recordLastQuery = typ.Tp != ast.ShowSessionStates
-	case *ast.ExecuteStmt, ast.DMLNode:
-		recordLastQuery = true
-	}
-	if recordLastQuery {
-		var lastRUConsumption float64
-		if ruDetailRaw := a.GoCtx.Value(util.RUDetailsCtxKey); ruDetailRaw != nil {
-			ruDetail := ruDetailRaw.(*util.RUDetails)
-			lastRUConsumption = ruDetail.RRU() + ruDetail.WRU()
-		}
-		failpoint.Inject("mockRUConsumption", func(_ failpoint.Value) {
-			lastRUConsumption = float64(len(sessVars.StmtCtx.OriginalSQL))
-		})
-		// Keep the previous queryInfo for `show session_states` because the statement needs to encode it.
-		sessVars.LastQueryInfo = sessionstates.QueryInfo{
-			TxnScope:      sessVars.CheckAndGetTxnScope(),
-			StartTS:       sessVars.TxnCtx.StartTS,
-			ForUpdateTS:   sessVars.TxnCtx.GetForUpdateTS(),
-			RUConsumption: lastRUConsumption,
-		}
-		if err != nil {
-			sessVars.LastQueryInfo.ErrMsg = err.Error()
-		}
-	}
-}
-
-func (a *ExecStmt) checkPlanReplayerCapture(txnTS uint64) {
-	if kv.GetInternalSourceType(a.GoCtx) == kv.InternalTxnStats {
-		return
-	}
-	se := a.Ctx
-	if !se.GetSessionVars().InRestrictedSQL && se.GetSessionVars().IsPlanReplayerCaptureEnabled() {
-		stmtNode := a.GetStmtNode()
-		if se.GetSessionVars().EnablePlanReplayedContinuesCapture {
-			if checkPlanReplayerContinuesCaptureValidStmt(stmtNode) {
-				checkPlanReplayerContinuesCapture(se, stmtNode, txnTS)
-			}
-		} else {
-			checkPlanReplayerCaptureTask(se, stmtNode, txnTS)
-		}
-	}
-}
-
-// CloseRecordSet will finish the execution of current statement and do some record work
-func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) {
-	a.FinishExecuteStmt(txnStartTS, lastErr, false)
-	a.logAudit()
-	a.Ctx.GetSessionVars().StmtCtx.DetachMemDiskTracker()
-}
-
 // Clean CTE storage shared by different CTEFullScan executor within a SQL stmt.
 // Will return err in two situations:
 // 1. Got err when remove disk spill file.
@@ -1503,186 +1244,6 @@ func resetCTEStorageMap(se sessionctx.Context) error {
 	}
 	se.GetSessionVars().StmtCtx.CTEStorageMap = nil
 	return nil
-}
-
-// LogSlowQuery is used to print the slow query in the log files.
-func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
-	sessVars := a.Ctx.GetSessionVars()
-	stmtCtx := sessVars.StmtCtx
-	level := log.GetLevel()
-	cfg := config.GetGlobalConfig()
-	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
-	threshold := time.Duration(atomic.LoadUint64(&cfg.Instance.SlowThreshold)) * time.Millisecond
-	enable := cfg.Instance.EnableSlowLog.Load()
-	// if the level is Debug, or trace is enabled, print slow logs anyway
-	force := level <= zapcore.DebugLevel || trace.IsEnabled()
-	if (!enable || costTime < threshold) && !force {
-		return
-	}
-	sql := FormatSQL(a.GetTextToLog(true))
-	_, digest := stmtCtx.SQLDigest()
-
-	var indexNames string
-	if len(stmtCtx.IndexNames) > 0 {
-		// remove duplicate index.
-		idxMap := make(map[string]struct{})
-		buf := bytes.NewBuffer(make([]byte, 0, 4))
-		buf.WriteByte('[')
-		for _, idx := range stmtCtx.IndexNames {
-			_, ok := idxMap[idx]
-			if ok {
-				continue
-			}
-			idxMap[idx] = struct{}{}
-			if buf.Len() > 1 {
-				buf.WriteByte(',')
-			}
-			buf.WriteString(idx)
-		}
-		buf.WriteByte(']')
-		indexNames = buf.String()
-	}
-	var stmtDetail execdetails.StmtExecDetails
-	stmtDetailRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey)
-	if stmtDetailRaw != nil {
-		stmtDetail = *(stmtDetailRaw.(*execdetails.StmtExecDetails))
-	}
-	var tikvExecDetail util.ExecDetails
-	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
-	if tikvExecDetailRaw != nil {
-		tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
-	}
-	ruDetails := util.NewRUDetails()
-	if ruDetailsVal := a.GoCtx.Value(util.RUDetailsCtxKey); ruDetailsVal != nil {
-		ruDetails = ruDetailsVal.(*util.RUDetails)
-	}
-
-	execDetail := stmtCtx.GetExecDetails()
-	copTaskInfo := stmtCtx.CopTasksDetails()
-	memMax := sessVars.MemTracker.MaxConsumed()
-	diskMax := sessVars.DiskTracker.MaxConsumed()
-	_, planDigest := GetPlanDigest(stmtCtx)
-
-	binaryPlan := ""
-	if variable.GenerateBinaryPlan.Load() {
-		binaryPlan = getBinaryPlan(a.Ctx)
-		if len(binaryPlan) > 0 {
-			binaryPlan = variable.SlowLogBinaryPlanPrefix + binaryPlan + variable.SlowLogPlanSuffix
-		}
-	}
-
-	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
-
-	var (
-		keyspaceName string
-		keyspaceID   uint32
-	)
-	keyspaceName = keyspace.GetKeyspaceNameBySettings()
-	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
-		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
-	}
-	if txnTS == 0 {
-		// TODO: txnTS maybe ambiguous, consider logging stale-read-ts with a new field in the slow log.
-		txnTS = sessVars.TxnCtx.StaleReadTs
-	}
-
-	slowItems := &variable.SlowQueryLogItems{
-		TxnTS:             txnTS,
-		KeyspaceName:      keyspaceName,
-		KeyspaceID:        keyspaceID,
-		SQL:               sql.String(),
-		Digest:            digest.String(),
-		TimeTotal:         costTime,
-		TimeParse:         sessVars.DurationParse,
-		TimeCompile:       sessVars.DurationCompile,
-		TimeOptimize:      sessVars.DurationOptimization,
-		TimeWaitTS:        sessVars.DurationWaitTS,
-		IndexNames:        indexNames,
-		CopTasks:          copTaskInfo,
-		ExecDetail:        execDetail,
-		MemMax:            memMax,
-		DiskMax:           diskMax,
-		Succ:              succ,
-		Plan:              getPlanTree(stmtCtx),
-		PlanDigest:        planDigest.String(),
-		BinaryPlan:        binaryPlan,
-		Prepared:          a.isPreparedStmt,
-		HasMoreResults:    hasMoreResults,
-		PlanFromCache:     sessVars.FoundInPlanCache,
-		PlanFromBinding:   sessVars.FoundInBinding,
-		RewriteInfo:       sessVars.RewritePhaseInfo,
-		KVTotal:           time.Duration(atomic.LoadInt64(&tikvExecDetail.WaitKVRespDuration)),
-		PDTotal:           time.Duration(atomic.LoadInt64(&tikvExecDetail.WaitPDRespDuration)),
-		BackoffTotal:      time.Duration(atomic.LoadInt64(&tikvExecDetail.BackoffDuration)),
-		WriteSQLRespTotal: stmtDetail.WriteSQLRespDuration,
-		ResultRows:        resultRows,
-		ExecRetryCount:    a.retryCount,
-		IsExplicitTxn:     sessVars.TxnCtx.IsExplicit,
-		IsWriteCacheTable: stmtCtx.WaitLockLeaseTime > 0,
-		UsedStats:         stmtCtx.GetUsedStatsInfo(false),
-		IsSyncStatsFailed: stmtCtx.IsSyncStatsFailed,
-		Warnings:          collectWarningsForSlowLog(stmtCtx),
-		ResourceGroupName: sessVars.StmtCtx.ResourceGroupName,
-		RRU:               ruDetails.RRU(),
-		WRU:               ruDetails.WRU(),
-		WaitRUDuration:    ruDetails.RUWaitDuration(),
-	}
-	failpoint.Inject("assertSyncStatsFailed", func(val failpoint.Value) {
-		if val.(bool) {
-			if !slowItems.IsSyncStatsFailed {
-				panic("isSyncStatsFailed should be true")
-			}
-		}
-	})
-	if a.retryCount > 0 {
-		slowItems.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)
-	}
-	if _, ok := a.StmtNode.(*ast.CommitStmt); ok && sessVars.PrevStmt != nil {
-		slowItems.PrevStmt = sessVars.PrevStmt.String()
-	}
-	slowLog := sessVars.SlowLogFormat(slowItems)
-	if trace.IsEnabled() {
-		trace.Log(a.GoCtx, "details", slowLog)
-	}
-	logutil.SlowQueryLogger.Warn(slowLog)
-	if costTime >= threshold {
-		if sessVars.InRestrictedSQL {
-			executor_metrics.TotalQueryProcHistogramInternal.Observe(costTime.Seconds())
-			executor_metrics.TotalCopProcHistogramInternal.Observe(execDetail.TimeDetail.ProcessTime.Seconds())
-			executor_metrics.TotalCopWaitHistogramInternal.Observe(execDetail.TimeDetail.WaitTime.Seconds())
-		} else {
-			executor_metrics.TotalQueryProcHistogramGeneral.Observe(costTime.Seconds())
-			executor_metrics.TotalCopProcHistogramGeneral.Observe(execDetail.TimeDetail.ProcessTime.Seconds())
-			executor_metrics.TotalCopWaitHistogramGeneral.Observe(execDetail.TimeDetail.WaitTime.Seconds())
-			if execDetail.ScanDetail != nil && execDetail.ScanDetail.ProcessedKeys != 0 {
-				executor_metrics.CopMVCCRatioHistogramGeneral.Observe(float64(execDetail.ScanDetail.TotalKeys) / float64(execDetail.ScanDetail.ProcessedKeys))
-			}
-		}
-		var userString string
-		if sessVars.User != nil {
-			userString = sessVars.User.String()
-		}
-		var tableIDs string
-		if len(stmtCtx.TableIDs) > 0 {
-			tableIDs = strings.ReplaceAll(fmt.Sprintf("%v", stmtCtx.TableIDs), " ", ",")
-		}
-		domain.GetDomain(a.Ctx).LogSlowQuery(&domain.SlowQueryInfo{
-			SQL:        sql.String(),
-			Digest:     digest.String(),
-			Start:      sessVars.StartTime,
-			Duration:   costTime,
-			Detail:     stmtCtx.GetExecDetails(),
-			Succ:       succ,
-			ConnID:     sessVars.ConnectionID,
-			SessAlias:  sessVars.SessionAlias,
-			TxnTS:      txnTS,
-			User:       userString,
-			DB:         sessVars.CurrentDB,
-			TableIDs:   tableIDs,
-			IndexNames: indexNames,
-			Internal:   sessVars.InRestrictedSQL,
-		})
-	}
 }
 
 func extractMsgFromSQLWarn(sqlWarn *contextutil.SQLWarn) string {
@@ -1820,163 +1381,6 @@ func getEncodedPlan(stmtCtx *stmtctx.StatementContext, genHint bool) (encodedPla
 	return
 }
 
-// SummaryStmt collects statements for information_schema.statements_summary
-func (a *ExecStmt) SummaryStmt(succ bool) {
-	sessVars := a.Ctx.GetSessionVars()
-	var userString string
-	if sessVars.User != nil {
-		userString = sessVars.User.Username
-	}
-
-	// Internal SQLs must also be recorded to keep the consistency of `PrevStmt` and `PrevStmtDigest`.
-	if !stmtsummaryv2.Enabled() || ((sessVars.InRestrictedSQL || len(userString) == 0) && !stmtsummaryv2.EnabledInternal()) {
-		sessVars.SetPrevStmtDigest("")
-		return
-	}
-	// Ignore `PREPARE` statements, but record `EXECUTE` statements.
-	if _, ok := a.StmtNode.(*ast.PrepareStmt); ok {
-		return
-	}
-	stmtCtx := sessVars.StmtCtx
-	// Make sure StmtType is filled even if succ is false.
-	if stmtCtx.StmtType == "" {
-		stmtCtx.StmtType = ast.GetStmtLabel(a.StmtNode)
-	}
-	normalizedSQL, digest := stmtCtx.SQLDigest()
-	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
-	charset, collation := sessVars.GetCharsetInfo()
-
-	var prevSQL, prevSQLDigest string
-	if _, ok := a.StmtNode.(*ast.CommitStmt); ok {
-		// If prevSQLDigest is not recorded, it means this `commit` is the first SQL once stmt summary is enabled,
-		// so it's OK just to ignore it.
-		if prevSQLDigest = sessVars.GetPrevStmtDigest(); len(prevSQLDigest) == 0 {
-			return
-		}
-		prevSQL = sessVars.PrevStmt.String()
-	}
-	sessVars.SetPrevStmtDigest(digest.String())
-
-	// No need to encode every time, so encode lazily.
-	planGenerator := func() (p string, h string, e any) {
-		defer func() {
-			e = recover()
-			if e != nil {
-				logutil.BgLogger().Warn("fail to generate plan info",
-					zap.Stack("backtrace"),
-					zap.Any("error", e))
-			}
-		}()
-		p, h = getEncodedPlan(stmtCtx, !sessVars.InRestrictedSQL)
-		return
-	}
-	var binPlanGen func() string
-	if variable.GenerateBinaryPlan.Load() {
-		binPlanGen = func() string {
-			binPlan := getBinaryPlan(a.Ctx)
-			return binPlan
-		}
-	}
-	// Generating plan digest is slow, only generate it once if it's 'Point_Get'.
-	// If it's a point get, different SQLs leads to different plans, so SQL digest
-	// is enough to distinguish different plans in this case.
-	var planDigest string
-	var planDigestGen func() string
-	if a.Plan.TP() == plancodec.TypePointGet {
-		planDigestGen = func() string {
-			_, planDigest := GetPlanDigest(stmtCtx)
-			return planDigest.String()
-		}
-	} else {
-		_, tmp := GetPlanDigest(stmtCtx)
-		planDigest = tmp.String()
-	}
-
-	execDetail := stmtCtx.GetExecDetails()
-	copTaskInfo := stmtCtx.CopTasksDetails()
-	memMax := sessVars.MemTracker.MaxConsumed()
-	diskMax := sessVars.DiskTracker.MaxConsumed()
-	sql := a.GetTextToLog(false)
-	var stmtDetail execdetails.StmtExecDetails
-	stmtDetailRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey)
-	if stmtDetailRaw != nil {
-		stmtDetail = *(stmtDetailRaw.(*execdetails.StmtExecDetails))
-	}
-	var tikvExecDetail util.ExecDetails
-	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
-	if tikvExecDetailRaw != nil {
-		tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
-	}
-	var ruDetail *util.RUDetails
-	if ruDetailRaw := a.GoCtx.Value(util.RUDetailsCtxKey); ruDetailRaw != nil {
-		ruDetail = ruDetailRaw.(*util.RUDetails)
-	}
-
-	if stmtCtx.WaitLockLeaseTime > 0 {
-		if execDetail.BackoffSleep == nil {
-			execDetail.BackoffSleep = make(map[string]time.Duration)
-		}
-		execDetail.BackoffSleep["waitLockLeaseForCacheTable"] = stmtCtx.WaitLockLeaseTime
-		execDetail.BackoffTime += stmtCtx.WaitLockLeaseTime
-		execDetail.TimeDetail.WaitTime += stmtCtx.WaitLockLeaseTime
-	}
-
-	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
-
-	var (
-		keyspaceName string
-		keyspaceID   uint32
-	)
-	keyspaceName = keyspace.GetKeyspaceNameBySettings()
-	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
-		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
-	}
-
-	stmtExecInfo := &stmtsummary.StmtExecInfo{
-		SchemaName:          strings.ToLower(sessVars.CurrentDB),
-		OriginalSQL:         sql,
-		Charset:             charset,
-		Collation:           collation,
-		NormalizedSQL:       normalizedSQL,
-		Digest:              digest.String(),
-		PrevSQL:             prevSQL,
-		PrevSQLDigest:       prevSQLDigest,
-		PlanGenerator:       planGenerator,
-		BinaryPlanGenerator: binPlanGen,
-		PlanDigest:          planDigest,
-		PlanDigestGen:       planDigestGen,
-		User:                userString,
-		TotalLatency:        costTime,
-		ParseLatency:        sessVars.DurationParse,
-		CompileLatency:      sessVars.DurationCompile,
-		StmtCtx:             stmtCtx,
-		CopTasks:            copTaskInfo,
-		ExecDetail:          &execDetail,
-		MemMax:              memMax,
-		DiskMax:             diskMax,
-		StartTime:           sessVars.StartTime,
-		IsInternal:          sessVars.InRestrictedSQL,
-		Succeed:             succ,
-		PlanInCache:         sessVars.FoundInPlanCache,
-		PlanInBinding:       sessVars.FoundInBinding,
-		ExecRetryCount:      a.retryCount,
-		StmtExecDetails:     stmtDetail,
-		ResultRows:          resultRows,
-		TiKVExecDetails:     tikvExecDetail,
-		Prepared:            a.isPreparedStmt,
-		KeyspaceName:        keyspaceName,
-		KeyspaceID:          keyspaceID,
-		RUDetail:            ruDetail,
-		ResourceGroupName:   sessVars.StmtCtx.ResourceGroupName,
-
-		PlanCacheUnqualified: sessVars.StmtCtx.PlanCacheUnqualified(),
-	}
-	if a.retryCount > 0 {
-		stmtExecInfo.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)
-	}
-	stmtsummaryv2.Add(stmtExecInfo)
-}
-
 // GetTextToLog return the query text to log.
 func (a *ExecStmt) GetTextToLog(keepHint bool) string {
 	var sql string
@@ -2038,30 +1442,6 @@ func (a *ExecStmt) observeStmtBeginForTopSQL(ctx context.Context) context.Contex
 	}
 	topsql.RegisterPlan(normalizedPlan, planDigest)
 	return topsql.AttachSQLAndPlanInfo(ctx, sqlDigest, planDigest)
-}
-
-func (a *ExecStmt) observeStmtFinishedForTopSQL() {
-	vars := a.Ctx.GetSessionVars()
-	if vars == nil {
-		return
-	}
-	if stats := a.Ctx.GetStmtStats(); stats != nil && topsqlstate.TopSQLEnabled() {
-		sqlDigest, planDigest := a.getSQLPlanDigest()
-		execDuration := time.Since(vars.StartTime) + vars.DurationParse
-		stats.OnExecutionFinished(sqlDigest, planDigest, execDuration)
-	}
-}
-
-func (a *ExecStmt) getSQLPlanDigest() ([]byte, []byte) {
-	var sqlDigest, planDigest []byte
-	vars := a.Ctx.GetSessionVars()
-	if _, d := vars.StmtCtx.SQLDigest(); d != nil {
-		sqlDigest = d.Bytes()
-	}
-	if _, d := vars.StmtCtx.GetPlanDigest(); d != nil {
-		planDigest = d.Bytes()
-	}
-	return sqlDigest, planDigest
 }
 
 // only allow select/delete/update/insert/execute stmt captured by continues capture

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -209,6 +209,17 @@ func (a *recordSet) OnFetchReturned() {
 type ExecStmt struct {
 	ExecStmtRuntime
 
+	// GoCtx stores parent go context.Context for a stmt.
+	GoCtx context.Context
+	// InfoSchema stores a reference to the schema information.
+	InfoSchema infoschema.InfoSchema
+	// Plan stores a reference to the final physical plan.
+	Plan base.Plan
+	// Text represents the origin query text.
+	Text string
+
+	Ctx sessionctx.Context
+
 	// LowerPriority represents whether to lower the execution priority of a query.
 	LowerPriority     bool
 	isSelectForUpdate bool

--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -116,14 +116,16 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 	}
 	stmtCtx.SetPlan(finalPlan)
 	stmt := &ExecStmt{
-		GoCtx:         ctx,
-		InfoSchema:    is,
-		Plan:          finalPlan,
+		ExecStmtRuntime: ExecStmtRuntime{
+			GoCtx:       ctx,
+			InfoSchema:  is,
+			Plan:        finalPlan,
+			Text:        stmtNode.Text(),
+			StmtNode:    stmtNode,
+			Ctx:         c.Ctx,
+			OutputNames: names,
+		},
 		LowerPriority: lowerPriority,
-		Text:          stmtNode.Text(),
-		StmtNode:      stmtNode,
-		Ctx:           c.Ctx,
-		OutputNames:   names,
 	}
 	// Use cached plan if possible.
 	if preparedObj != nil && plannercore.IsSafeToReusePointGetExecutor(c.Ctx, is, preparedObj) {

--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -125,6 +125,11 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 			Ctx:         c.Ctx,
 			OutputNames: names,
 		},
+		GoCtx:         ctx,
+		InfoSchema:    is,
+		Plan:          finalPlan,
+		Text:          stmtNode.Text(),
+		Ctx:           c.Ctx,
 		LowerPriority: lowerPriority,
 	}
 	// Use cached plan if possible.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2062,9 +2062,10 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	vars.FoundInPlanCache = false
 	vars.PrevFoundInBinding = vars.FoundInBinding
 	vars.FoundInBinding = false
-	vars.DurationWaitTS = 0
 	vars.CurrInsertBatchExtraCols = nil
 	vars.CurrInsertValues = chunk.Row{}
+
+	sc.StartTime = time.Now()
 
 	return
 }

--- a/pkg/executor/runtime.go
+++ b/pkg/executor/runtime.go
@@ -1,0 +1,697 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime/trace"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	executor_metrics "github.com/pingcap/tidb/pkg/executor/metrics"
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/keyspace"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/plugin"
+	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/sessionstates"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/execdetails"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/plancodec"
+	"github.com/pingcap/tidb/pkg/util/redact"
+	"github.com/pingcap/tidb/pkg/util/stmtsummary"
+	stmtsummaryv2 "github.com/pingcap/tidb/pkg/util/stmtsummary/v2"
+	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
+	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// ExecStmtRuntime controls the execute and close of a statement.
+type ExecStmtRuntime struct {
+	// GoCtx stores parent go context.Context for a stmt.
+	GoCtx context.Context
+	// InfoSchema stores a reference to the schema information.
+	InfoSchema infoschema.InfoSchema
+	// Plan stores a reference to the final physical plan.
+	Plan base.Plan
+	// Text represents the origin query text.
+	Text string
+
+	StmtNode ast.StmtNode
+
+	Ctx sessionctx.Context
+
+	isPreparedStmt bool
+	retryCount     uint
+	retryStartTime time.Time
+
+	// Phase durations are splited into two parts: 1. trying to lock keys (but
+	// failed); 2. the final iteration of the retry loop. Here we use
+	// [2]time.Duration to record such info for each phase. The first duration
+	// is increased only within the current iteration. When we meet a
+	// pessimistic lock error and decide to retry, we add the first duration to
+	// the second and reset the first to 0 by calling `resetPhaseDurations`.
+	phaseBuildDurations [2]time.Duration
+	phaseOpenDurations  [2]time.Duration
+	phaseNextDurations  [2]time.Duration
+	phaseLockDurations  [2]time.Duration
+
+	// OutputNames will be set if using cached plan
+	OutputNames []*types.FieldName
+}
+
+// GetStmtNode returns the stmtNode inside Statement
+func (a *ExecStmtRuntime) GetStmtNode() ast.StmtNode {
+	return a.StmtNode
+}
+
+func (a *ExecStmtRuntime) next(ctx context.Context, e exec.Executor, req *chunk.Chunk) error {
+	start := time.Now()
+	err := exec.Next(ctx, e, req)
+	a.phaseNextDurations[0] += time.Since(start)
+	return err
+}
+
+func (a *ExecStmtRuntime) logAudit() {
+	sessVars := a.Ctx.GetSessionVars()
+	if sessVars.InRestrictedSQL {
+		return
+	}
+
+	err := plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
+		audit := plugin.DeclareAuditManifest(p.Manifest)
+		if audit.OnGeneralEvent != nil {
+			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
+			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
+			audit.OnGeneralEvent(ctx, sessVars, plugin.Completed, cmd)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Error("log audit log failure", zap.Error(err))
+	}
+}
+
+func (a *ExecStmtRuntime) observePhaseDurations(internal bool, commitDetails *util.CommitDetails) {
+	for _, it := range []struct {
+		duration time.Duration
+		phase    string
+	}{
+		{a.phaseBuildDurations[0], executor_metrics.PhaseBuildFinal},
+		{a.phaseBuildDurations[1], executor_metrics.PhaseBuildLocking},
+		{a.phaseOpenDurations[0], executor_metrics.PhaseOpenFinal},
+		{a.phaseOpenDurations[1], executor_metrics.PhaseOpenLocking},
+		{a.phaseNextDurations[0], executor_metrics.PhaseNextFinal},
+		{a.phaseNextDurations[1], executor_metrics.PhaseNextLocking},
+		{a.phaseLockDurations[0], executor_metrics.PhaseLockFinal},
+		{a.phaseLockDurations[1], executor_metrics.PhaseLockLocking},
+	} {
+		if it.duration > 0 {
+			getPhaseDurationObserver(it.phase, internal).Observe(it.duration.Seconds())
+		}
+	}
+	if commitDetails != nil {
+		for _, it := range []struct {
+			duration time.Duration
+			phase    string
+		}{
+			{commitDetails.PrewriteTime, executor_metrics.PhaseCommitPrewrite},
+			{commitDetails.CommitTime, executor_metrics.PhaseCommitCommit},
+			{commitDetails.GetCommitTsTime, executor_metrics.PhaseCommitWaitCommitTS},
+			{commitDetails.GetLatestTsTime, executor_metrics.PhaseCommitWaitLatestTS},
+			{commitDetails.LocalLatchTime, executor_metrics.PhaseCommitWaitLatch},
+			{commitDetails.WaitPrewriteBinlogTime, executor_metrics.PhaseCommitWaitBinlog},
+		} {
+			if it.duration > 0 {
+				getPhaseDurationObserver(it.phase, internal).Observe(it.duration.Seconds())
+			}
+		}
+	}
+	if stmtDetailsRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey); stmtDetailsRaw != nil {
+		d := stmtDetailsRaw.(*execdetails.StmtExecDetails).WriteSQLRespDuration
+		if d > 0 {
+			getPhaseDurationObserver(executor_metrics.PhaseWriteResponse, internal).Observe(d.Seconds())
+		}
+	}
+}
+
+// FinishExecuteStmt is used to record some information after `ExecStmtRuntime` execution finished:
+// 1. record slow log if needed.
+// 2. record summary statement.
+// 3. record execute duration metric.
+// 4. update the `PrevStmt` in session variable.
+// 5. reset `DurationParse` in session variable.
+func (a *ExecStmtRuntime) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults bool) {
+	a.checkPlanReplayerCapture(txnTS)
+
+	sessVars := a.Ctx.GetSessionVars()
+	execDetail := sessVars.StmtCtx.GetExecDetails()
+	// Attach commit/lockKeys runtime stats to executor runtime stats.
+	if (execDetail.CommitDetail != nil || execDetail.LockKeysDetail != nil) && sessVars.StmtCtx.RuntimeStatsColl != nil {
+		statsWithCommit := &execdetails.RuntimeStatsWithCommit{
+			Commit:   execDetail.CommitDetail,
+			LockKeys: execDetail.LockKeysDetail,
+		}
+		sessVars.StmtCtx.RuntimeStatsColl.RegisterStats(a.Plan.ID(), statsWithCommit)
+	}
+	// Record related SLI metrics.
+	if execDetail.CommitDetail != nil && execDetail.CommitDetail.WriteSize > 0 {
+		a.Ctx.GetTxnWriteThroughputSLI().AddTxnWriteSize(execDetail.CommitDetail.WriteSize, execDetail.CommitDetail.WriteKeys)
+	}
+	if execDetail.ScanDetail != nil && sessVars.StmtCtx.AffectedRows() > 0 {
+		processedKeys := atomic.LoadInt64(&execDetail.ScanDetail.ProcessedKeys)
+		if processedKeys > 0 {
+			// Only record the read keys in write statement which affect row more than 0.
+			a.Ctx.GetTxnWriteThroughputSLI().AddReadKeys(processedKeys)
+		}
+	}
+	succ := err == nil
+	if a.Plan != nil {
+		// If this statement has a Plan, the StmtCtx.plan should have been set when it comes here,
+		// but we set it again in case we missed some code paths.
+		sessVars.StmtCtx.SetPlan(a.Plan)
+	}
+	// `LowSlowQuery` and `SummaryStmt` must be called before recording `PrevStmt`.
+	a.LogSlowQuery(txnTS, succ, hasMoreResults)
+	a.SummaryStmt(succ)
+	a.observeStmtFinishedForTopSQL()
+	if sessVars.StmtCtx.IsTiFlash.Load() {
+		if succ {
+			executor_metrics.TotalTiFlashQuerySuccCounter.Inc()
+		} else {
+			metrics.TiFlashQueryTotalCounter.WithLabelValues(metrics.ExecuteErrorToLabel(err), metrics.LblError).Inc()
+		}
+	}
+	sessVars.PrevStmt = FormatSQL(a.GetTextToLog(false))
+	a.recordLastQueryInfo(err)
+	a.observePhaseDurations(sessVars.InRestrictedSQL, execDetail.CommitDetail)
+	executeDuration := time.Since(sessVars.StartTime) - sessVars.DurationCompile
+	if sessVars.InRestrictedSQL {
+		executor_metrics.SessionExecuteRunDurationInternal.Observe(executeDuration.Seconds())
+	} else {
+		executor_metrics.SessionExecuteRunDurationGeneral.Observe(executeDuration.Seconds())
+	}
+	// Reset DurationParse due to the next statement may not need to be parsed (not a text protocol query).
+	sessVars.DurationParse = 0
+	// Clean the stale read flag when statement execution finish
+	sessVars.StmtCtx.IsStaleness = false
+	// Clean the MPP query info
+	sessVars.StmtCtx.MPPQueryInfo.QueryID.Store(0)
+	sessVars.StmtCtx.MPPQueryInfo.QueryTS.Store(0)
+	sessVars.StmtCtx.MPPQueryInfo.AllocatedMPPTaskID.Store(0)
+	sessVars.StmtCtx.MPPQueryInfo.AllocatedMPPGatherID.Store(0)
+
+	if sessVars.StmtCtx.ReadFromTableCache {
+		metrics.ReadFromTableCacheCounter.Inc()
+	}
+
+	// Update fair locking related counters by stmt
+	if execDetail.LockKeysDetail != nil {
+		if execDetail.LockKeysDetail.AggressiveLockNewCount > 0 || execDetail.LockKeysDetail.AggressiveLockDerivedCount > 0 {
+			executor_metrics.FairLockingStmtUsedCount.Inc()
+			// If this statement is finished when some of the keys are locked with conflict in the last retry, or
+			// some of the keys are derived from the previous retry, we consider the optimization of fair locking
+			// takes effect on this statement.
+			if execDetail.LockKeysDetail.LockedWithConflictCount > 0 || execDetail.LockKeysDetail.AggressiveLockDerivedCount > 0 {
+				executor_metrics.FairLockingStmtEffectiveCount.Inc()
+			}
+		}
+	}
+	// If the transaction is committed, update fair locking related counters by txn
+	if execDetail.CommitDetail != nil {
+		if sessVars.TxnCtx.FairLockingUsed {
+			executor_metrics.FairLockingTxnUsedCount.Inc()
+		}
+		if sessVars.TxnCtx.FairLockingEffective {
+			executor_metrics.FairLockingTxnEffectiveCount.Inc()
+		}
+	}
+
+	a.Ctx.ReportUsageStats()
+}
+
+func (a *ExecStmtRuntime) recordLastQueryInfo(err error) {
+	sessVars := a.Ctx.GetSessionVars()
+	// Record diagnostic information for DML statements
+	recordLastQuery := false
+	switch typ := a.StmtNode.(type) {
+	case *ast.ShowStmt:
+		recordLastQuery = typ.Tp != ast.ShowSessionStates
+	case *ast.ExecuteStmt, ast.DMLNode:
+		recordLastQuery = true
+	}
+	if recordLastQuery {
+		var lastRUConsumption float64
+		if ruDetailRaw := a.GoCtx.Value(util.RUDetailsCtxKey); ruDetailRaw != nil {
+			ruDetail := ruDetailRaw.(*util.RUDetails)
+			lastRUConsumption = ruDetail.RRU() + ruDetail.WRU()
+		}
+		failpoint.Inject("mockRUConsumption", func(_ failpoint.Value) {
+			lastRUConsumption = float64(len(sessVars.StmtCtx.OriginalSQL))
+		})
+		// Keep the previous queryInfo for `show session_states` because the statement needs to encode it.
+		sessVars.LastQueryInfo = sessionstates.QueryInfo{
+			TxnScope:      sessVars.CheckAndGetTxnScope(),
+			StartTS:       sessVars.TxnCtx.StartTS,
+			ForUpdateTS:   sessVars.TxnCtx.GetForUpdateTS(),
+			RUConsumption: lastRUConsumption,
+		}
+		if err != nil {
+			sessVars.LastQueryInfo.ErrMsg = err.Error()
+		}
+	}
+}
+
+func (a *ExecStmtRuntime) checkPlanReplayerCapture(txnTS uint64) {
+	if kv.GetInternalSourceType(a.GoCtx) == kv.InternalTxnStats {
+		return
+	}
+	se := a.Ctx
+	if !se.GetSessionVars().InRestrictedSQL && se.GetSessionVars().IsPlanReplayerCaptureEnabled() {
+		stmtNode := a.GetStmtNode()
+		if se.GetSessionVars().EnablePlanReplayedContinuesCapture {
+			if checkPlanReplayerContinuesCaptureValidStmt(stmtNode) {
+				checkPlanReplayerContinuesCapture(se, stmtNode, txnTS)
+			}
+		} else {
+			checkPlanReplayerCaptureTask(se, stmtNode, txnTS)
+		}
+	}
+}
+
+// CloseRecordSet will finish the execution of current statement and do some record work
+func (a *ExecStmtRuntime) CloseRecordSet(txnStartTS uint64, lastErr error) {
+	a.FinishExecuteStmt(txnStartTS, lastErr, false)
+	a.logAudit()
+	a.Ctx.GetSessionVars().StmtCtx.DetachMemDiskTracker()
+}
+
+// LogSlowQuery is used to print the slow query in the log files.
+func (a *ExecStmtRuntime) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
+	sessVars := a.Ctx.GetSessionVars()
+	stmtCtx := sessVars.StmtCtx
+	level := log.GetLevel()
+	cfg := config.GetGlobalConfig()
+	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
+	threshold := time.Duration(atomic.LoadUint64(&cfg.Instance.SlowThreshold)) * time.Millisecond
+	enable := cfg.Instance.EnableSlowLog.Load()
+	// if the level is Debug, or trace is enabled, print slow logs anyway
+	force := level <= zapcore.DebugLevel || trace.IsEnabled()
+	if (!enable || costTime < threshold) && !force {
+		return
+	}
+	sql := FormatSQL(a.GetTextToLog(true))
+	_, digest := stmtCtx.SQLDigest()
+
+	var indexNames string
+	if len(stmtCtx.IndexNames) > 0 {
+		// remove duplicate index.
+		idxMap := make(map[string]struct{})
+		buf := bytes.NewBuffer(make([]byte, 0, 4))
+		buf.WriteByte('[')
+		for _, idx := range stmtCtx.IndexNames {
+			_, ok := idxMap[idx]
+			if ok {
+				continue
+			}
+			idxMap[idx] = struct{}{}
+			if buf.Len() > 1 {
+				buf.WriteByte(',')
+			}
+			buf.WriteString(idx)
+		}
+		buf.WriteByte(']')
+		indexNames = buf.String()
+	}
+	var stmtDetail execdetails.StmtExecDetails
+	stmtDetailRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey)
+	if stmtDetailRaw != nil {
+		stmtDetail = *(stmtDetailRaw.(*execdetails.StmtExecDetails))
+	}
+	var tikvExecDetail util.ExecDetails
+	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
+	if tikvExecDetailRaw != nil {
+		tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
+	}
+	ruDetails := util.NewRUDetails()
+	if ruDetailsVal := a.GoCtx.Value(util.RUDetailsCtxKey); ruDetailsVal != nil {
+		ruDetails = ruDetailsVal.(*util.RUDetails)
+	}
+
+	execDetail := stmtCtx.GetExecDetails()
+	copTaskInfo := stmtCtx.CopTasksDetails()
+	memMax := sessVars.MemTracker.MaxConsumed()
+	diskMax := sessVars.DiskTracker.MaxConsumed()
+	_, planDigest := GetPlanDigest(stmtCtx)
+
+	binaryPlan := ""
+	if variable.GenerateBinaryPlan.Load() {
+		binaryPlan = getBinaryPlan(a.Ctx)
+		if len(binaryPlan) > 0 {
+			binaryPlan = variable.SlowLogBinaryPlanPrefix + binaryPlan + variable.SlowLogPlanSuffix
+		}
+	}
+
+	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
+
+	var (
+		keyspaceName string
+		keyspaceID   uint32
+	)
+	keyspaceName = keyspace.GetKeyspaceNameBySettings()
+	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
+		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
+	}
+	if txnTS == 0 {
+		// TODO: txnTS maybe ambiguous, consider logging stale-read-ts with a new field in the slow log.
+		txnTS = sessVars.TxnCtx.StaleReadTs
+	}
+
+	slowItems := &variable.SlowQueryLogItems{
+		TxnTS:             txnTS,
+		KeyspaceName:      keyspaceName,
+		KeyspaceID:        keyspaceID,
+		SQL:               sql.String(),
+		Digest:            digest.String(),
+		TimeTotal:         costTime,
+		TimeParse:         sessVars.DurationParse,
+		TimeCompile:       sessVars.DurationCompile,
+		TimeOptimize:      sessVars.DurationOptimization,
+		TimeWaitTS:        sessVars.DurationWaitTS,
+		IndexNames:        indexNames,
+		CopTasks:          copTaskInfo,
+		ExecDetail:        execDetail,
+		MemMax:            memMax,
+		DiskMax:           diskMax,
+		Succ:              succ,
+		Plan:              getPlanTree(stmtCtx),
+		PlanDigest:        planDigest.String(),
+		BinaryPlan:        binaryPlan,
+		Prepared:          a.isPreparedStmt,
+		HasMoreResults:    hasMoreResults,
+		PlanFromCache:     sessVars.FoundInPlanCache,
+		PlanFromBinding:   sessVars.FoundInBinding,
+		RewriteInfo:       sessVars.RewritePhaseInfo,
+		KVTotal:           time.Duration(atomic.LoadInt64(&tikvExecDetail.WaitKVRespDuration)),
+		PDTotal:           time.Duration(atomic.LoadInt64(&tikvExecDetail.WaitPDRespDuration)),
+		BackoffTotal:      time.Duration(atomic.LoadInt64(&tikvExecDetail.BackoffDuration)),
+		WriteSQLRespTotal: stmtDetail.WriteSQLRespDuration,
+		ResultRows:        resultRows,
+		ExecRetryCount:    a.retryCount,
+		IsExplicitTxn:     sessVars.TxnCtx.IsExplicit,
+		IsWriteCacheTable: stmtCtx.WaitLockLeaseTime > 0,
+		UsedStats:         stmtCtx.GetUsedStatsInfo(false),
+		IsSyncStatsFailed: stmtCtx.IsSyncStatsFailed,
+		Warnings:          collectWarningsForSlowLog(stmtCtx),
+		ResourceGroupName: sessVars.StmtCtx.ResourceGroupName,
+		RRU:               ruDetails.RRU(),
+		WRU:               ruDetails.WRU(),
+		WaitRUDuration:    ruDetails.RUWaitDuration(),
+	}
+	failpoint.Inject("assertSyncStatsFailed", func(val failpoint.Value) {
+		if val.(bool) {
+			if !slowItems.IsSyncStatsFailed {
+				panic("isSyncStatsFailed should be true")
+			}
+		}
+	})
+	if a.retryCount > 0 {
+		slowItems.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)
+	}
+	if _, ok := a.StmtNode.(*ast.CommitStmt); ok && sessVars.PrevStmt != nil {
+		slowItems.PrevStmt = sessVars.PrevStmt.String()
+	}
+	slowLog := sessVars.SlowLogFormat(slowItems)
+	if trace.IsEnabled() {
+		trace.Log(a.GoCtx, "details", slowLog)
+	}
+	logutil.SlowQueryLogger.Warn(slowLog)
+	if costTime >= threshold {
+		if sessVars.InRestrictedSQL {
+			executor_metrics.TotalQueryProcHistogramInternal.Observe(costTime.Seconds())
+			executor_metrics.TotalCopProcHistogramInternal.Observe(execDetail.TimeDetail.ProcessTime.Seconds())
+			executor_metrics.TotalCopWaitHistogramInternal.Observe(execDetail.TimeDetail.WaitTime.Seconds())
+		} else {
+			executor_metrics.TotalQueryProcHistogramGeneral.Observe(costTime.Seconds())
+			executor_metrics.TotalCopProcHistogramGeneral.Observe(execDetail.TimeDetail.ProcessTime.Seconds())
+			executor_metrics.TotalCopWaitHistogramGeneral.Observe(execDetail.TimeDetail.WaitTime.Seconds())
+			if execDetail.ScanDetail != nil && execDetail.ScanDetail.ProcessedKeys != 0 {
+				executor_metrics.CopMVCCRatioHistogramGeneral.Observe(float64(execDetail.ScanDetail.TotalKeys) / float64(execDetail.ScanDetail.ProcessedKeys))
+			}
+		}
+		var userString string
+		if sessVars.User != nil {
+			userString = sessVars.User.String()
+		}
+		var tableIDs string
+		if len(stmtCtx.TableIDs) > 0 {
+			tableIDs = strings.ReplaceAll(fmt.Sprintf("%v", stmtCtx.TableIDs), " ", ",")
+		}
+		domain.GetDomain(a.Ctx).LogSlowQuery(&domain.SlowQueryInfo{
+			SQL:        sql.String(),
+			Digest:     digest.String(),
+			Start:      sessVars.StartTime,
+			Duration:   costTime,
+			Detail:     stmtCtx.GetExecDetails(),
+			Succ:       succ,
+			ConnID:     sessVars.ConnectionID,
+			SessAlias:  sessVars.SessionAlias,
+			TxnTS:      txnTS,
+			User:       userString,
+			DB:         sessVars.CurrentDB,
+			TableIDs:   tableIDs,
+			IndexNames: indexNames,
+			Internal:   sessVars.InRestrictedSQL,
+		})
+	}
+}
+
+// SummaryStmt collects statements for information_schema.statements_summary
+func (a *ExecStmtRuntime) SummaryStmt(succ bool) {
+	sessVars := a.Ctx.GetSessionVars()
+	var userString string
+	if sessVars.User != nil {
+		userString = sessVars.User.Username
+	}
+
+	// Internal SQLs must also be recorded to keep the consistency of `PrevStmt` and `PrevStmtDigest`.
+	if !stmtsummaryv2.Enabled() || ((sessVars.InRestrictedSQL || len(userString) == 0) && !stmtsummaryv2.EnabledInternal()) {
+		sessVars.SetPrevStmtDigest("")
+		return
+	}
+	// Ignore `PREPARE` statements, but record `EXECUTE` statements.
+	if _, ok := a.StmtNode.(*ast.PrepareStmt); ok {
+		return
+	}
+	stmtCtx := sessVars.StmtCtx
+	// Make sure StmtType is filled even if succ is false.
+	if stmtCtx.StmtType == "" {
+		stmtCtx.StmtType = ast.GetStmtLabel(a.StmtNode)
+	}
+	normalizedSQL, digest := stmtCtx.SQLDigest()
+	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
+	charset, collation := sessVars.GetCharsetInfo()
+
+	var prevSQL, prevSQLDigest string
+	if _, ok := a.StmtNode.(*ast.CommitStmt); ok {
+		// If prevSQLDigest is not recorded, it means this `commit` is the first SQL once stmt summary is enabled,
+		// so it's OK just to ignore it.
+		if prevSQLDigest = sessVars.GetPrevStmtDigest(); len(prevSQLDigest) == 0 {
+			return
+		}
+		prevSQL = sessVars.PrevStmt.String()
+	}
+	sessVars.SetPrevStmtDigest(digest.String())
+
+	// No need to encode every time, so encode lazily.
+	planGenerator := func() (p string, h string, e any) {
+		defer func() {
+			e = recover()
+			if e != nil {
+				logutil.BgLogger().Warn("fail to generate plan info",
+					zap.Stack("backtrace"),
+					zap.Any("error", e))
+			}
+		}()
+		p, h = getEncodedPlan(stmtCtx, !sessVars.InRestrictedSQL)
+		return
+	}
+	var binPlanGen func() string
+	if variable.GenerateBinaryPlan.Load() {
+		binPlanGen = func() string {
+			binPlan := getBinaryPlan(a.Ctx)
+			return binPlan
+		}
+	}
+	// Generating plan digest is slow, only generate it once if it's 'Point_Get'.
+	// If it's a point get, different SQLs leads to different plans, so SQL digest
+	// is enough to distinguish different plans in this case.
+	var planDigest string
+	var planDigestGen func() string
+	if a.Plan.TP() == plancodec.TypePointGet {
+		planDigestGen = func() string {
+			_, planDigest := GetPlanDigest(stmtCtx)
+			return planDigest.String()
+		}
+	} else {
+		_, tmp := GetPlanDigest(stmtCtx)
+		planDigest = tmp.String()
+	}
+
+	execDetail := stmtCtx.GetExecDetails()
+	copTaskInfo := stmtCtx.CopTasksDetails()
+	memMax := sessVars.MemTracker.MaxConsumed()
+	diskMax := sessVars.DiskTracker.MaxConsumed()
+	sql := a.GetTextToLog(false)
+	var stmtDetail execdetails.StmtExecDetails
+	stmtDetailRaw := a.GoCtx.Value(execdetails.StmtExecDetailKey)
+	if stmtDetailRaw != nil {
+		stmtDetail = *(stmtDetailRaw.(*execdetails.StmtExecDetails))
+	}
+	var tikvExecDetail util.ExecDetails
+	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
+	if tikvExecDetailRaw != nil {
+		tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
+	}
+	var ruDetail *util.RUDetails
+	if ruDetailRaw := a.GoCtx.Value(util.RUDetailsCtxKey); ruDetailRaw != nil {
+		ruDetail = ruDetailRaw.(*util.RUDetails)
+	}
+
+	if stmtCtx.WaitLockLeaseTime > 0 {
+		if execDetail.BackoffSleep == nil {
+			execDetail.BackoffSleep = make(map[string]time.Duration)
+		}
+		execDetail.BackoffSleep["waitLockLeaseForCacheTable"] = stmtCtx.WaitLockLeaseTime
+		execDetail.BackoffTime += stmtCtx.WaitLockLeaseTime
+		execDetail.TimeDetail.WaitTime += stmtCtx.WaitLockLeaseTime
+	}
+
+	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
+
+	var (
+		keyspaceName string
+		keyspaceID   uint32
+	)
+	keyspaceName = keyspace.GetKeyspaceNameBySettings()
+	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
+		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
+	}
+
+	stmtExecInfo := &stmtsummary.StmtExecInfo{
+		SchemaName:          strings.ToLower(sessVars.CurrentDB),
+		OriginalSQL:         sql,
+		Charset:             charset,
+		Collation:           collation,
+		NormalizedSQL:       normalizedSQL,
+		Digest:              digest.String(),
+		PrevSQL:             prevSQL,
+		PrevSQLDigest:       prevSQLDigest,
+		PlanGenerator:       planGenerator,
+		BinaryPlanGenerator: binPlanGen,
+		PlanDigest:          planDigest,
+		PlanDigestGen:       planDigestGen,
+		User:                userString,
+		TotalLatency:        costTime,
+		ParseLatency:        sessVars.DurationParse,
+		CompileLatency:      sessVars.DurationCompile,
+		StmtCtx:             stmtCtx,
+		CopTasks:            copTaskInfo,
+		ExecDetail:          &execDetail,
+		MemMax:              memMax,
+		DiskMax:             diskMax,
+		StartTime:           sessVars.StartTime,
+		IsInternal:          sessVars.InRestrictedSQL,
+		Succeed:             succ,
+		PlanInCache:         sessVars.FoundInPlanCache,
+		PlanInBinding:       sessVars.FoundInBinding,
+		ExecRetryCount:      a.retryCount,
+		StmtExecDetails:     stmtDetail,
+		ResultRows:          resultRows,
+		TiKVExecDetails:     tikvExecDetail,
+		Prepared:            a.isPreparedStmt,
+		KeyspaceName:        keyspaceName,
+		KeyspaceID:          keyspaceID,
+		RUDetail:            ruDetail,
+		ResourceGroupName:   sessVars.StmtCtx.ResourceGroupName,
+
+		PlanCacheUnqualified: sessVars.StmtCtx.PlanCacheUnqualified(),
+	}
+	if a.retryCount > 0 {
+		stmtExecInfo.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)
+	}
+	stmtsummaryv2.Add(stmtExecInfo)
+}
+
+// GetTextToLog return the query text to log.
+func (a *ExecStmtRuntime) GetTextToLog(keepHint bool) string {
+	var sql string
+	sessVars := a.Ctx.GetSessionVars()
+	rmode := sessVars.EnableRedactLog
+	if rmode == errors.RedactLogEnable {
+		if keepHint {
+			sql = parser.NormalizeKeepHint(sessVars.StmtCtx.OriginalSQL)
+		} else {
+			sql, _ = sessVars.StmtCtx.SQLDigest()
+		}
+	} else if sensitiveStmt, ok := a.StmtNode.(ast.SensitiveStmtNode); ok {
+		sql = sensitiveStmt.SecureText()
+	} else {
+		sql = redact.String(rmode, sessVars.StmtCtx.OriginalSQL+sessVars.PlanCacheParams.String())
+	}
+	return sql
+}
+
+func (a *ExecStmtRuntime) observeStmtFinishedForTopSQL() {
+	vars := a.Ctx.GetSessionVars()
+	if vars == nil {
+		return
+	}
+	if stats := a.Ctx.GetStmtStats(); stats != nil && topsqlstate.TopSQLEnabled() {
+		sqlDigest, planDigest := a.getSQLPlanDigest()
+		execDuration := time.Since(vars.StartTime) + vars.DurationParse
+		stats.OnExecutionFinished(sqlDigest, planDigest, execDuration)
+	}
+}
+
+func (a *ExecStmtRuntime) getSQLPlanDigest() ([]byte, []byte) {
+	var sqlDigest, planDigest []byte
+	vars := a.Ctx.GetSessionVars()
+	if _, d := vars.StmtCtx.SQLDigest(); d != nil {
+		sqlDigest = d.Bytes()
+	}
+	if _, d := vars.StmtCtx.GetPlanDigest(); d != nil {
+		planDigest = d.Bytes()
+	}
+	return sqlDigest, planDigest
+}

--- a/pkg/executor/runtime.go
+++ b/pkg/executor/runtime.go
@@ -112,7 +112,7 @@ func (a *ExecStmtRuntime) logAudit() {
 		audit := plugin.DeclareAuditManifest(p.Manifest)
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
-			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
+			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StmtCtx.StartTime)
 			audit.OnGeneralEvent(ctx, sessVars, plugin.Completed, cmd)
 		}
 		return nil
@@ -215,14 +215,12 @@ func (a *ExecStmtRuntime) FinishExecuteStmt(txnTS uint64, err error, hasMoreResu
 	sessVars.PrevStmt = FormatSQL(a.GetTextToLog(false))
 	a.recordLastQueryInfo(err)
 	a.observePhaseDurations(sessVars.InRestrictedSQL, execDetail.CommitDetail)
-	executeDuration := time.Since(sessVars.StartTime) - sessVars.DurationCompile
+	executeDuration := time.Since(sessVars.StmtCtx.StartTime) - sessVars.StmtCtx.DurationCompile
 	if sessVars.InRestrictedSQL {
 		executor_metrics.SessionExecuteRunDurationInternal.Observe(executeDuration.Seconds())
 	} else {
 		executor_metrics.SessionExecuteRunDurationGeneral.Observe(executeDuration.Seconds())
 	}
-	// Reset DurationParse due to the next statement may not need to be parsed (not a text protocol query).
-	sessVars.DurationParse = 0
 
 	if sessVars.StmtCtx.ReadFromTableCache {
 		metrics.ReadFromTableCacheCounter.Inc()
@@ -315,7 +313,7 @@ func (a *ExecStmtRuntime) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults b
 	stmtCtx := sessVars.StmtCtx
 	level := log.GetLevel()
 	cfg := config.GetGlobalConfig()
-	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
+	costTime := time.Since(sessVars.StmtCtx.StartTime) + sessVars.StmtCtx.DurationParse
 	threshold := time.Duration(atomic.LoadUint64(&cfg.Instance.SlowThreshold)) * time.Millisecond
 	enable := cfg.Instance.EnableSlowLog.Load()
 	// if the level is Debug, or trace is enabled, print slow logs anyway
@@ -397,10 +395,10 @@ func (a *ExecStmtRuntime) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults b
 		SQL:               sql.String(),
 		Digest:            digest.String(),
 		TimeTotal:         costTime,
-		TimeParse:         sessVars.DurationParse,
-		TimeCompile:       sessVars.DurationCompile,
-		TimeOptimize:      sessVars.DurationOptimization,
-		TimeWaitTS:        sessVars.DurationWaitTS,
+		TimeParse:         sessVars.StmtCtx.DurationParse,
+		TimeCompile:       sessVars.StmtCtx.DurationCompile,
+		TimeOptimize:      sessVars.StmtCtx.DurationOptimization,
+		TimeWaitTS:        sessVars.StmtCtx.DurationWaitTS,
 		IndexNames:        indexNames,
 		CopTasks:          copTaskInfo,
 		ExecDetail:        execDetail,
@@ -439,7 +437,7 @@ func (a *ExecStmtRuntime) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults b
 		}
 	})
 	if a.retryCount > 0 {
-		slowItems.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)
+		slowItems.ExecRetryTime = costTime - sessVars.StmtCtx.DurationParse - sessVars.StmtCtx.DurationCompile - time.Since(a.retryStartTime)
 	}
 	if _, ok := a.StmtNode.(*ast.CommitStmt); ok && sessVars.PrevStmt != nil {
 		slowItems.PrevStmt = sessVars.PrevStmt.String()
@@ -473,7 +471,7 @@ func (a *ExecStmtRuntime) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults b
 		domain.GetDomain(a.Ctx).LogSlowQuery(&domain.SlowQueryInfo{
 			SQL:        sql.String(),
 			Digest:     digest.String(),
-			Start:      sessVars.StartTime,
+			Start:      sessVars.StmtCtx.StartTime,
 			Duration:   costTime,
 			Detail:     stmtCtx.GetExecDetails(),
 			Succ:       succ,
@@ -512,7 +510,7 @@ func (a *ExecStmtRuntime) SummaryStmt(succ bool) {
 		stmtCtx.StmtType = ast.GetStmtLabel(a.StmtNode)
 	}
 	normalizedSQL, digest := stmtCtx.SQLDigest()
-	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
+	costTime := time.Since(sessVars.StmtCtx.StartTime) + sessVars.StmtCtx.DurationParse
 	charset, collation := sessVars.GetCharsetInfo()
 
 	var prevSQL, prevSQLDigest string
@@ -616,14 +614,14 @@ func (a *ExecStmtRuntime) SummaryStmt(succ bool) {
 		PlanDigestGen:       planDigestGen,
 		User:                userString,
 		TotalLatency:        costTime,
-		ParseLatency:        sessVars.DurationParse,
-		CompileLatency:      sessVars.DurationCompile,
+		ParseLatency:        sessVars.StmtCtx.DurationParse,
+		CompileLatency:      sessVars.StmtCtx.DurationCompile,
 		StmtCtx:             stmtCtx,
 		CopTasks:            copTaskInfo,
 		ExecDetail:          &execDetail,
 		MemMax:              memMax,
 		DiskMax:             diskMax,
-		StartTime:           sessVars.StartTime,
+		StartTime:           sessVars.StmtCtx.StartTime,
 		IsInternal:          sessVars.InRestrictedSQL,
 		Succeed:             succ,
 		PlanInCache:         sessVars.FoundInPlanCache,
@@ -641,7 +639,7 @@ func (a *ExecStmtRuntime) SummaryStmt(succ bool) {
 		PlanCacheUnqualified: sessVars.StmtCtx.PlanCacheUnqualified(),
 	}
 	if a.retryCount > 0 {
-		stmtExecInfo.ExecRetryTime = costTime - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)
+		stmtExecInfo.ExecRetryTime = costTime - sessVars.StmtCtx.DurationParse - sessVars.StmtCtx.DurationCompile - time.Since(a.retryStartTime)
 	}
 	stmtsummaryv2.Add(stmtExecInfo)
 }
@@ -672,7 +670,7 @@ func (a *ExecStmtRuntime) observeStmtFinishedForTopSQL() {
 	}
 	if stats := a.Ctx.GetStmtStats(); stats != nil && topsqlstate.TopSQLEnabled() {
 		sqlDigest, planDigest := a.getSQLPlanDigest()
-		execDuration := time.Since(vars.StartTime) + vars.DurationParse
+		execDuration := time.Since(vars.StmtCtx.StartTime) + vars.StmtCtx.DurationParse
 		stats.OnExecutionFinished(sqlDigest, planDigest, execDuration)
 	}
 }

--- a/pkg/executor/runtime.go
+++ b/pkg/executor/runtime.go
@@ -223,13 +223,6 @@ func (a *ExecStmtRuntime) FinishExecuteStmt(txnTS uint64, err error, hasMoreResu
 	}
 	// Reset DurationParse due to the next statement may not need to be parsed (not a text protocol query).
 	sessVars.DurationParse = 0
-	// Clean the stale read flag when statement execution finish
-	sessVars.StmtCtx.IsStaleness = false
-	// Clean the MPP query info
-	sessVars.StmtCtx.MPPQueryInfo.QueryID.Store(0)
-	sessVars.StmtCtx.MPPQueryInfo.QueryTS.Store(0)
-	sessVars.StmtCtx.MPPQueryInfo.AllocatedMPPTaskID.Store(0)
-	sessVars.StmtCtx.MPPQueryInfo.AllocatedMPPGatherID.Store(0)
 
 	if sessVars.StmtCtx.ReadFromTableCache {
 		metrics.ReadFromTableCacheCounter.Inc()

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -503,7 +503,7 @@ func optimize(ctx context.Context, sctx pctx.PlanContext, node ast.Node, is info
 	finalPlan, cost, err := core.DoOptimize(ctx, sctx, builder.GetOptFlag(), logic)
 	// TODO: capture plan replayer here if it matches sql and plan digest
 
-	sessVars.DurationOptimization = time.Since(beginOpt)
+	sessVars.StmtCtx.DurationOptimization = time.Since(beginOpt)
 	return finalPlan, names, cost, err
 }
 

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1683,7 +1683,7 @@ func (cc *clientConn) audit(eventType plugin.GeneralEvent) {
 		audit := plugin.DeclareAuditManifest(p.Manifest)
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&cc.ctx.GetSessionVars().CommandValue))]
-			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, cc.ctx.GetSessionVars().StartTime)
+			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, cc.ctx.GetSessionVars().StmtCtx.StartTime)
 			audit.OnGeneralEvent(ctx, cc.ctx.GetSessionVars(), eventType, cmd)
 		}
 		return nil

--- a/pkg/server/conn_stmt.go
+++ b/pkg/server/conn_stmt.go
@@ -425,7 +425,7 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 }
 
 func (cc *clientConn) handleStmtFetch(ctx context.Context, data []byte) (err error) {
-	cc.ctx.GetSessionVars().StartTime = time.Now()
+	cc.ctx.GetSessionVars().StmtCtx.StartTime = time.Now()
 	cc.ctx.GetSessionVars().ClearAlloc(nil, false)
 	cc.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 	defer cc.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, false)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1577,7 +1577,7 @@ func (s *session) Parse(ctx context.Context, sql string) ([]ast.StmtNode, error)
 	}
 
 	durParse := time.Since(parseStartTime)
-	s.GetSessionVars().DurationParse = durParse
+	s.GetSessionVars().StmtCtx.DurationParse = durParse
 	isInternal := s.isInternal()
 	if isInternal {
 		session_metrics.SessionExecuteParseDurationInternal.Observe(durParse.Seconds())
@@ -2010,7 +2010,6 @@ func (s *session) ExecuteStmt(ctx context.Context, stmtNode ast.StmtNode) (sqlex
 	}
 
 	sessVars := s.sessionVars
-	sessVars.StartTime = time.Now()
 
 	// Some executions are done in compile stage, so we reset them before compile.
 	if err := executor.ResetContextOfStmt(s, stmtNode); err != nil {
@@ -2120,8 +2119,8 @@ func (s *session) ExecuteStmt(ctx context.Context, stmtNode ast.StmtNode) (sqlex
 		return nil, err
 	}
 
-	durCompile := time.Since(s.sessionVars.StartTime)
-	s.GetSessionVars().DurationCompile = durCompile
+	durCompile := time.Since(s.sessionVars.StmtCtx.StartTime)
+	s.GetSessionVars().StmtCtx.DurationCompile = durCompile
 	if s.isInternal() {
 		session_metrics.SessionExecuteCompileDurationInternal.Observe(durCompile.Seconds())
 	} else {

--- a/pkg/session/txn.go
+++ b/pkg/session/txn.go
@@ -598,7 +598,7 @@ func (txn *LazyTxn) Wait(ctx context.Context, sctx sessionctx.Context) (kv.Trans
 	}
 	if txn.pending() {
 		defer func(begin time.Time) {
-			sctx.GetSessionVars().DurationWaitTS = time.Since(begin)
+			sctx.GetSessionVars().StmtCtx.DurationWaitTS = time.Since(begin)
 		}(time.Now())
 
 		// Transaction is lazy initialized.

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -402,6 +402,17 @@ type StatementContext struct {
 
 	// MDLRelatedTableIDs is used to store the table IDs that are related to the current MDL lock.
 	MDLRelatedTableIDs map[int64]struct{}
+
+	// StartTime is the start time of the last query.
+	StartTime time.Time
+	// DurationParse is the duration of parsing SQL string to AST of the last query.
+	DurationParse time.Duration
+	// DurationCompile is the duration of compiling AST to execution plan of the last query.
+	DurationCompile time.Duration
+	// DurationOptimization is the duration of optimizing a query.
+	DurationOptimization time.Duration
+	// DurationWaitTS is the duration of waiting for a snapshot TS
+	DurationWaitTS time.Duration
 }
 
 // DefaultStmtErrLevels is the default error levels for statement

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1117,23 +1117,8 @@ type SessionVars struct {
 	// NoopFuncsMode allows OFF/ON/WARN values as 0/1/2.
 	NoopFuncsMode int
 
-	// StartTime is the start time of the last query.
-	StartTime time.Time
-
-	// DurationParse is the duration of parsing SQL string to AST of the last query.
-	DurationParse time.Duration
-
-	// DurationCompile is the duration of compiling AST to execution plan of the last query.
-	DurationCompile time.Duration
-
 	// RewritePhaseInfo records all information about the rewriting phase.
 	RewritePhaseInfo
-
-	// DurationOptimization is the duration of optimizing a query.
-	DurationOptimization time.Duration
-
-	// DurationWaitTS is the duration of waiting for a snapshot TS
-	DurationWaitTS time.Duration
 
 	// PrevStmt is used to store the previous executed statement in the current session.
 	PrevStmt fmt.Stringer

--- a/pkg/sessiontxn/isolation/readcommitted.go
+++ b/pkg/sessiontxn/isolation/readcommitted.go
@@ -190,7 +190,7 @@ func (p *PessimisticRCTxnContextProvider) getStmtTS() (ts uint64, err error) {
 	if ts, err = p.stmtTSFuture.Wait(); err != nil {
 		return 0, err
 	}
-	p.sctx.GetSessionVars().DurationWaitTS += time.Since(start)
+	p.sctx.GetSessionVars().StmtCtx.DurationWaitTS += time.Since(start)
 
 	txn.SetOption(kv.SnapshotTS, ts)
 	p.stmtTS = ts

--- a/pkg/sessiontxn/isolation/repeatable_read.go
+++ b/pkg/sessiontxn/isolation/repeatable_read.go
@@ -91,7 +91,7 @@ func (p *PessimisticRRTxnContextProvider) getForUpdateTs() (ts uint64, err error
 	if ts, err = futureTS.Wait(); err != nil {
 		return 0, err
 	}
-	p.sctx.GetSessionVars().DurationWaitTS += time.Since(start)
+	p.sctx.GetSessionVars().StmtCtx.DurationWaitTS += time.Since(start)
 
 	txnCtx.SetForUpdateTS(ts)
 	txn.SetOption(kv.SnapshotTS, ts)

--- a/pkg/sessiontxn/isolation/repeatable_read_test.go
+++ b/pkg/sessiontxn/isolation/repeatable_read_test.go
@@ -690,11 +690,11 @@ func TestRRWaitTSTimeInSlowLog(t *testing.T) {
 	tk.MustExec("insert into t values (1, 1)")
 
 	tk.MustExec("begin pessimistic")
-	waitTS1 := se.GetSessionVars().DurationWaitTS
+	waitTS1 := se.GetSessionVars().StmtCtx.DurationWaitTS
 	tk.MustExec("update t set v = v + 10 where id = 1")
-	waitTS2 := se.GetSessionVars().DurationWaitTS
+	waitTS2 := se.GetSessionVars().StmtCtx.DurationWaitTS
 	tk.MustExec("delete from t")
-	waitTS3 := se.GetSessionVars().DurationWaitTS
+	waitTS3 := se.GetSessionVars().StmtCtx.DurationWaitTS
 	tk.MustExec("commit")
 	require.NotEqual(t, waitTS1, waitTS2)
 	require.NotEqual(t, waitTS1, waitTS3)

--- a/pkg/sessiontxn/txn_rc_tso_optimize_test.go
+++ b/pkg/sessiontxn/txn_rc_tso_optimize_test.go
@@ -809,11 +809,11 @@ func TestRcWaitTSInSlowLog(t *testing.T) {
 	sctx.SetValue(sessiontxn.TsoRequestCount, 0)
 
 	tk.MustExec("begin pessimistic")
-	waitTs1 := sctx.GetSessionVars().DurationWaitTS
+	waitTs1 := sctx.GetSessionVars().StmtCtx.DurationWaitTS
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 = 1")
-	waitTs2 := sctx.GetSessionVars().DurationWaitTS
+	waitTs2 := sctx.GetSessionVars().StmtCtx.DurationWaitTS
 	tk.MustExec("update t1 set id3 = id3 + 10 where id1 > 3 and id1 < 6")
-	waitTs3 := sctx.GetSessionVars().DurationWaitTS
+	waitTs3 := sctx.GetSessionVars().StmtCtx.DurationWaitTS
 	tk.MustExec("commit")
 	require.NotEqual(t, waitTs1, waitTs2)
 	require.NotEqual(t, waitTs1, waitTs2)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53938

Problem Summary:

The original `*ExecStmt` controls everything, and the logic inside is too complicated. Now we extracted a smaller part of it, and make the smaller part cleaner.

### What changed and how does it work?

1. The first commit copies a `ExecStmtRuntime` from the `ExecStmt`, and also copy some implementations related to execute and close. Also it removes the original implementation on `ExecStmt`.
2. The second commit tries to do some abstraction and make it possible to use `ExecStmtRuntime` without modifying the `StmtCtx`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > Refactor. It should be covered by existing tests.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
