### PR TITLE
datum: check len(s) before calculating and checking runeCount

### DIFF
--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -1095,7 +1095,7 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, ctx Context, padZero boo
 		// overflowed part is all whitespaces
 		var overflowed string
 		var characterLen int
-		var needRecalculateLen bool
+		var needCalculateLen bool
 
 		// For  mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob(defined in tidb)
 		// and tinytext, text, mediumtext, longtext(not explicitly defined in tidb, corresponding to blob(s) in tidb) flen is the store length limit regardless of charset.
@@ -1148,7 +1148,7 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, ctx Context, padZero boo
 						overflowed = s[truncateLen:]
 						s = truncateStr(s, truncateLen)
 					} else {
-						needRecalculateLen = true
+						needCalculateLen = true
 					}
 				}
 			}
@@ -1159,16 +1159,16 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, ctx Context, padZero boo
 		}
 
 		if len(overflowed) != 0 {
-			trimed := strings.TrimRight(overflowed, " \t\n\r")
-			if len(trimed) == 0 && !IsBinaryStr(tp) && IsTypeChar(tp.GetType()) {
+			trimmed := strings.TrimRight(overflowed, " \t\n\r")
+			if len(trimmed) == 0 && !IsBinaryStr(tp) && IsTypeChar(tp.GetType()) {
 				if tp.GetType() == mysql.TypeVarchar {
-					if needRecalculateLen {
+					if needCalculateLen {
 						characterLen = utf8.RuneCountInString(s)
 					}
 					ctx.AppendWarning(ErrTruncated.FastGen("Data truncated, field len %d, data len %d", flen, characterLen))
 				}
 			} else {
-				if needRecalculateLen {
+				if needCalculateLen {
 					characterLen = utf8.RuneCountInString(s)
 				}
 				err = ErrDataTooLong.FastGen("Data Too Long, field len %d, data len %d", flen, characterLen)

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -1095,6 +1095,7 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, ctx Context, padZero boo
 		// overflowed part is all whitespaces
 		var overflowed string
 		var characterLen int
+		var needRecalculateLen bool
 
 		// For  mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob(defined in tidb)
 		// and tinytext, text, mediumtext, longtext(not explicitly defined in tidb, corresponding to blob(s) in tidb) flen is the store length limit regardless of charset.
@@ -1126,25 +1127,29 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, ctx Context, padZero boo
 					s = truncateStr(s, truncateLen)
 				}
 			default:
-				characterLen = utf8.RuneCountInString(s)
-				if characterLen > flen {
-					// 1. If len(s) is 0 and flen is 0, truncateLen will be 0, don't truncate s.
-					//    CREATE TABLE t (a char(0));
-					//    INSERT INTO t VALUES (``);
-					// 2. If len(s) is 10 and flen is 0, truncateLen will be 0 too, but we still need to truncate s.
-					//    SELECT 1, CAST(1234 AS CHAR(0));
-					// So truncateLen is not a suitable variable to determine to do truncate or not.
-					var runeCount int
-					var truncateLen int
-					for i := range s {
-						if runeCount == flen {
-							truncateLen = i
-							break
+				if len(s) > flen {
+					characterLen = utf8.RuneCountInString(s)
+					if characterLen > flen {
+						// 1. If len(s) is 0 and flen is 0, truncateLen will be 0, don't truncate s.
+						//    CREATE TABLE t (a char(0));
+						//    INSERT INTO t VALUES (``);
+						// 2. If len(s) is 10 and flen is 0, truncateLen will be 0 too, but we still need to truncate s.
+						//    SELECT 1, CAST(1234 AS CHAR(0));
+						// So truncateLen is not a suitable variable to determine to do truncate or not.
+						var runeCount int
+						var truncateLen int
+						for i := range s {
+							if runeCount == flen {
+								truncateLen = i
+								break
+							}
+							runeCount++
 						}
-						runeCount++
+						overflowed = s[truncateLen:]
+						s = truncateStr(s, truncateLen)
+					} else {
+						needRecalculateLen = true
 					}
-					overflowed = s[truncateLen:]
-					s = truncateStr(s, truncateLen)
 				}
 			}
 		} else if len(s) > flen {
@@ -1157,9 +1162,15 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, ctx Context, padZero boo
 			trimed := strings.TrimRight(overflowed, " \t\n\r")
 			if len(trimed) == 0 && !IsBinaryStr(tp) && IsTypeChar(tp.GetType()) {
 				if tp.GetType() == mysql.TypeVarchar {
+					if needRecalculateLen {
+						characterLen = utf8.RuneCountInString(s)
+					}
 					ctx.AppendWarning(ErrTruncated.FastGen("Data truncated, field len %d, data len %d", flen, characterLen))
 				}
 			} else {
+				if needRecalculateLen {
+					characterLen = utf8.RuneCountInString(s)
+				}
 				err = ErrDataTooLong.FastGen("Data Too Long, field len %d, data len %d", flen, characterLen)
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53942

Problem Summary:

`RuneCountInString` can be unexpectedly time-consuming for certain workloads. Since the number of runes must be smaller than or equal to the length of the string, we can fast check the length first. Only calculate the number of runes when necessary.

Before:
```
go test -run=^$ -bench=BenchmarkInsertIntoSelect -benchmem -benchtime=100x
     100	 136332696 ns/op	106229159 B/op	  507278 allocs/op
```

This PR:
```
go test -run=^$ -bench=BenchmarkInsertIntoSelect -benchmem -benchtime=100x
     100	 123812334 ns/op	106041608 B/op	  506652 allocs/op
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test: already covered by existing cases and benchmarks
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
