### PR TITLE
*: remove `ExtraPidCol` and replace it with `ExtraPhysTblIDCol`

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -683,7 +683,7 @@ func (b *executorBuilder) buildCleanupIndex(v *plannercore.CleanupIndex) exec.Ex
 	sessCtx := e.Ctx().GetSessionVars().StmtCtx
 	e.handleCols = buildHandleColsForExec(sessCtx, tblInfo, e.columns)
 	if e.index.Meta().Global {
-		e.columns = append(e.columns, model.NewExtraPartitionIDColInfo())
+		e.columns = append(e.columns, model.NewExtraPhysTblIDColInfo())
 	}
 	return e
 }
@@ -4935,7 +4935,7 @@ func NewRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model
 	}
 	defVal := func(i int, chk *chunk.Chunk) error {
 		if reqCols[i].ID < 0 {
-			// model.ExtraHandleID, ExtraPidColID, ExtraPhysTblID... etc
+			// model.ExtraHandleID, ExtraPhysTblID... etc
 			// Don't set the default value for that column.
 			chk.AppendNull(i)
 			return nil

--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -130,7 +130,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 
 			datumRow := make([]types.Datum, 0, len(fields))
 			for i, field := range fields {
-				if columns[i].ID == model.ExtraPidColID || columns[i].ID == model.ExtraPhysTblID {
+				if columns[i].ID == model.ExtraPhysTblID {
 					continue
 				}
 

--- a/pkg/expression/explain.go
+++ b/pkg/expression/explain.go
@@ -37,11 +37,11 @@ func (expr *ScalarFunction) explainInfo(ctx EvalContext, normalized bool) string
 	intest.Assert(normalized || ctx != nil)
 	var buffer bytes.Buffer
 	fmt.Fprintf(&buffer, "%s(", expr.FuncName.L)
-	// convert `in(_tidb_pid, -1)` to `in(_tidb_pid, dual)` whether normalized equals to true or false.
+	// convert `in(_tidb_tid, -1)` to `in(_tidb_tid, dual)` whether normalized equals to true or false.
 	if expr.FuncName.L == ast.In {
 		args := expr.GetArgs()
-		if len(args) == 2 && args[0].ExplainNormalizedInfo() == model.ExtraPartitionIdName.L && args[1].(*Constant).Value.GetInt64() == -1 {
-			buffer.WriteString(model.ExtraPartitionIdName.L + ", dual)")
+		if len(args) == 2 && strings.HasSuffix(args[0].ExplainNormalizedInfo(), model.ExtraPhysTblIdName.L) && args[1].(*Constant).Value.GetInt64() == -1 {
+			buffer.WriteString(args[0].ExplainNormalizedInfo() + ", dual)")
 			return buffer.String()
 		}
 	}

--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -383,13 +383,12 @@ func IsIndexPrefixCovered(tbInfo *TableInfo, index *IndexInfo, cols ...CIStr) bo
 // for use of execution phase.
 const ExtraHandleID = -1
 
-// ExtraPidColID is the column ID of column which store the partitionID decoded in global index values.
-const ExtraPidColID = -2
+// Deprecated: Use ExtraPhysTblID instead.
+// const ExtraPidColID = -2
 
 // ExtraPhysTblID is the column ID of column that should be filled in with the physical table id.
 // Primarily used for table partition dynamic prune mode, to return which partition (physical table id) the row came from.
-// Using a dedicated id for this, since in the future ExtraPidColID and ExtraPhysTblID may be used for the same request.
-// Must be after ExtraPidColID!
+// If used with a global index, the partition ID decoded from the key value will be filled in.
 const ExtraPhysTblID = -3
 
 // ExtraRowChecksumID is the column ID of column which holds the row checksum info.
@@ -435,8 +434,8 @@ const (
 // ExtraHandleName is the name of ExtraHandle Column.
 var ExtraHandleName = NewCIStr("_tidb_rowid")
 
-// ExtraPartitionIdName is the name of ExtraPartitionId Column.
-var ExtraPartitionIdName = NewCIStr("_tidb_pid") //nolint:revive
+// Deprecated: Use ExtraPhysTblIdName instead.
+// var ExtraPartitionIdName = NewCIStr("_tidb_pid") //nolint:revive
 
 // ExtraPhysTblIdName is the name of ExtraPhysTblID Column.
 var ExtraPhysTblIdName = NewCIStr("_tidb_tid") //nolint:revive
@@ -918,21 +917,6 @@ func NewExtraHandleColInfo() *ColumnInfo {
 	colInfo.SetFlen(flen)
 	colInfo.SetDecimal(decimal)
 
-	colInfo.SetCharset(charset.CharsetBin)
-	colInfo.SetCollate(charset.CollationBin)
-	return colInfo
-}
-
-// NewExtraPartitionIDColInfo mocks a column info for extra partition id column.
-func NewExtraPartitionIDColInfo() *ColumnInfo {
-	colInfo := &ColumnInfo{
-		ID:   ExtraPidColID,
-		Name: ExtraPartitionIdName,
-	}
-	colInfo.SetType(mysql.TypeLonglong)
-	flen, decimal := mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeLonglong)
-	colInfo.SetFlen(flen)
-	colInfo.SetDecimal(decimal)
 	colInfo.SetCharset(charset.CharsetBin)
 	colInfo.SetCollate(charset.CollationBin)
 	return colInfo

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1423,15 +1423,6 @@ func (ds *DataSource) FindBestTask(prop *property.PhysicalProperty, planCounter 
 				}
 			}
 			if canConvertPointGet {
-				// If the schema contains ExtraPidColID, do not convert to point get.
-				// Because the point get executor can not handle the extra partition ID column now.
-				// I.e. Global Index is used
-				for _, col := range ds.schema.Columns {
-					if col.ID == model.ExtraPidColID {
-						canConvertPointGet = false
-						break
-					}
-				}
 				if path != nil && path.Index != nil && path.Index.Global {
 					// Don't convert to point get during ddl
 					// TODO: Revisit truncate partition and global index
@@ -2144,6 +2135,15 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 		}
 	}
 
+	var extraPhysTblCol *expression.Column
+	// If `dataSouceSchema` contains `model.ExtraPhysTblID`, we should add it into `indexScan.schema`
+	for _, col := range is.dataSourceSchema.Columns {
+		if col.ID == model.ExtraPhysTblID {
+			extraPhysTblCol = col.Clone().(*expression.Column)
+			break
+		}
+	}
+
 	if isDoubleRead || is.Index.Global {
 		// If it's double read case, the first index must return handle. So we should add extra handle column
 		// if there isn't a handle column.
@@ -2157,23 +2157,19 @@ func (is *PhysicalIndexScan) initSchema(idxExprCols []*expression.Column, isDoub
 				})
 			}
 		}
-		// If it's global index, handle and PidColID columns has to be added, so that needed pids can be filtered.
-		if is.Index.Global {
+		// If it's global index, handle and PhysTblID columns has to be added, so that needed pids can be filtered.
+		if is.Index.Global && extraPhysTblCol == nil {
 			indexCols = append(indexCols, &expression.Column{
 				RetType:  types.NewFieldType(mysql.TypeLonglong),
-				ID:       model.ExtraPidColID,
+				ID:       model.ExtraPhysTblID,
 				UniqueID: is.SCtx().GetSessionVars().AllocPlanColumnID(),
-				OrigName: model.ExtraPartitionIdName.O,
+				OrigName: model.ExtraPhysTblIdName.O,
 			})
 		}
 	}
 
-	// If `dataSouceSchema` contains `model.ExtraPhysTblID`, we should add it into `indexScan.schema`
-	for _, col := range is.dataSourceSchema.Columns {
-		if col.ID == model.ExtraPhysTblID {
-			indexCols = append(indexCols, col.Clone().(*expression.Column))
-			break
-		}
+	if extraPhysTblCol != nil {
+		indexCols = append(indexCols, extraPhysTblCol)
 	}
 
 	is.SetSchema(expression.NewSchema(indexCols...))
@@ -2185,14 +2181,14 @@ func (is *PhysicalIndexScan) addSelectionConditionForGlobalIndex(p *DataSource, 
 	}
 	args := make([]expression.Expression, 0, len(p.partitionNames)+1)
 	for _, col := range is.schema.Columns {
-		if col.ID == model.ExtraPidColID {
+		if col.ID == model.ExtraPhysTblID {
 			args = append(args, col.Clone())
 			break
 		}
 	}
 
 	if len(args) != 1 {
-		return nil, errors.Errorf("Can't find column %s in schema %s", model.ExtraPartitionIdName.O, is.schema)
+		return nil, errors.Errorf("Can't find column %s in schema %s", model.ExtraPhysTblIdName.O, is.schema)
 	}
 
 	// For SQL like 'select x from t partition(p0, p1) use index(idx)',

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3892,7 +3892,7 @@ func unfoldWildStar(field *ast.SelectField, outputName types.NameSlice, column [
 		}
 		if (dbName.L == "" || dbName.L == name.DBName.L) &&
 			(tblName.L == "" || tblName.L == name.TblName.L) &&
-			col.ID != model.ExtraHandleID && col.ID != model.ExtraPidColID && col.ID != model.ExtraPhysTblID {
+			col.ID != model.ExtraHandleID && col.ID != model.ExtraPhysTblID {
 			colName := &ast.ColumnNameExpr{
 				Name: &ast.ColumnName{
 					Schema: name.DBName,

--- a/pkg/planner/core/plan_to_pb.go
+++ b/pkg/planner/core/plan_to_pb.go
@@ -465,8 +465,6 @@ func (p *PhysicalIndexScan) ToPB(_ *base.BuildPBContext, _ kv.StoreType) (*tipb.
 			columns = append(columns, model.NewExtraHandleColInfo())
 		} else if col.ID == model.ExtraPhysTblID {
 			columns = append(columns, model.NewExtraPhysTblIDColInfo())
-		} else if col.ID == model.ExtraPidColID {
-			columns = append(columns, model.NewExtraPartitionIDColInfo())
 		} else {
 			columns = append(columns, FindColumnInfoByID(tableColumns, col.ID))
 		}

--- a/pkg/planner/core/rule_column_pruning.go
+++ b/pkg/planner/core/rule_column_pruning.go
@@ -356,7 +356,7 @@ func (p *LogicalUnionScan) PruneColumns(parentUsedCols []*expression.Column, opt
 		parentUsedCols = append(parentUsedCols, p.handleCols.GetCol(i))
 	}
 	for _, col := range p.Schema().Columns {
-		if col.ID == model.ExtraPidColID || col.ID == model.ExtraPhysTblID {
+		if col.ID == model.ExtraPhysTblID {
 			parentUsedCols = append(parentUsedCols, col)
 		}
 	}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -471,15 +471,6 @@ func (*partitionProcessor) reconstructTableColNames(ds *DataSource) ([]*types.Fi
 			})
 			continue
 		}
-		if colExpr.ID == model.ExtraPidColID {
-			names = append(names, &types.FieldName{
-				DBName:      ds.DBName,
-				TblName:     ds.tableInfo.Name,
-				ColName:     model.ExtraPartitionIdName,
-				OrigColName: model.ExtraPartitionIdName,
-			})
-			continue
-		}
 		if colExpr.ID == model.ExtraPhysTblID {
 			names = append(names, &types.FieldName{
 				DBName:      ds.DBName,

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -925,7 +925,7 @@ func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
 	}
 	// Add ExtraPhysTblID if requested
 	// Assumes it is always last!
-	if e.columnInfos[len(e.columnInfos)-1].ColumnId == model.ExtraPhysTblID {
+	if e.columnInfos[len(e.columnInfos)-1].ColumnId == model.ExtraPhysTblID && min(len(e.fieldTps), len(values)) < len(e.columnInfos) {
 		var tblID int64
 		if pid := tablecodec.SplitIndexValue(value).PartitionID; len(pid) != 0 {
 			_, tblID, err = codec.DecodeInt(pid)

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -925,8 +925,8 @@ func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
 	}
 	// Add ExtraPhysTblID if requested
 	// Assumes it is always last!
-	// If we need pid, it already filled by above loop. Because `DecodeIndexKV` func will return pid in values.
-	// The following if statement is to ensure that tid can be filled in.
+	// If we need pid, it already filled by above loop. Because `DecodeIndexKV` func will return pid in `values`.
+	// The following if statement is to fill in the tid when we needed it.
 	if e.columnInfos[len(e.columnInfos)-1].ColumnId == model.ExtraPhysTblID && len(e.columnInfos) >= len(values) {
 		tblID := tablecodec.DecodeTableID(key)
 		chk.AppendInt64(len(e.columnInfos)-1, tblID)

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -925,16 +925,10 @@ func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
 	}
 	// Add ExtraPhysTblID if requested
 	// Assumes it is always last!
-	if e.columnInfos[len(e.columnInfos)-1].ColumnId == model.ExtraPhysTblID && min(len(e.fieldTps), len(values)) < len(e.columnInfos) {
-		var tblID int64
-		if pid := tablecodec.SplitIndexValue(value).PartitionID; len(pid) != 0 {
-			_, tblID, err = codec.DecodeInt(pid)
-			if err != nil {
-				return err
-			}
-		} else {
-			tblID = tablecodec.DecodeTableID(key)
-		}
+	// If we need pid, it already filled by above loop. Because `DecodeIndexKV` func will return pid in values.
+	// The following if statement is to ensure that tid can be filled in.
+	if e.columnInfos[len(e.columnInfos)-1].ColumnId == model.ExtraPhysTblID && len(e.columnInfos) >= len(values) {
+		tblID := tablecodec.DecodeTableID(key)
 		chk.AppendInt64(len(e.columnInfos)-1, tblID)
 	}
 	gotRow = true

--- a/pkg/store/mockstore/unistore/cophandler/mpp.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp.go
@@ -138,10 +138,6 @@ func (b *mppExecBuilder) buildIdxScan(pb *tipb.IndexScan) (*indexScanExec, error
 		*physTblIDColIdx = numIdxCols
 		lastCol = pb.Columns[numIdxCols-1]
 	}
-	if lastCol.GetColumnId() == model.ExtraPidColID {
-		numIdxCols--
-		lastCol = pb.Columns[numIdxCols-1]
-	}
 
 	hdlStatus := tablecodec.HandleDefault
 	if len(primaryColIds) == 0 {

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -314,8 +314,8 @@ func (e *indexScanExec) Process(key, value []byte) error {
 		}
 	}
 
-	// If we need pid, it already filled by above loop. Because `DecodeIndexKV` func will return pid in values.
-	// The following if statement is to ensure that tid can be filled in.
+	// If we need pid, it already filled by above loop. Because `DecodeIndexKV` func will return pid in `values`.
+	// The following if statement is to fill in the tid when we needed it.
 	if e.physTblIDColIdx != nil && *e.physTblIDColIdx >= len(values) {
 		tblID := tablecodec.DecodeTableID(key)
 		e.chk.AppendInt64(*e.physTblIDColIdx, tblID)

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -313,7 +313,8 @@ func (e *indexScanExec) Process(key, value []byte) error {
 			}
 		}
 	}
-	if e.physTblIDColIdx != nil {
+	// when index is a global index, pid is included in values and already filled in e.chk
+	if e.physTblIDColIdx != nil && *e.physTblIDColIdx >= len(values) {
 		tblID := tablecodec.DecodeTableID(key)
 		e.chk.AppendInt64(*e.physTblIDColIdx, tblID)
 	}

--- a/tests/integrationtest/r/globalindex/aggregate.result
+++ b/tests/integrationtest/r/globalindex/aggregate.result
@@ -19,7 +19,7 @@ id	estRows	task	access object	operator info
 HashAgg	1.00	root	NULL	funcs:count(Column#9)->Column#4, funcs:max(Column#10)->Column#5, funcs:min(Column#11)->Column#6
 └─IndexReader	1.00	root	partition:p0	index:HashAgg
   └─HashAgg	1.00	cop[tikv]	NULL	funcs:count(1)->Column#9, funcs:max(globalindex__aggregate.p.id)->Column#10, funcs:min(globalindex__aggregate.p.id)->Column#11
-    └─Selection	10000.00	cop[tikv]	NULL	in(_tidb_pid, pid0)
+    └─Selection	10000.00	cop[tikv]	NULL	in(_tidb_tid, tid0)
       └─IndexFullScan	10000.00	cop[tikv]	table:p, index:idx(id)	keep order:false, stats:pseudo
 select count(*), max(id), min(id) from p partition(p0) use index(idx);
 count(*)	max(id)	min(id)
@@ -41,7 +41,7 @@ explain format='brief' select avg(id), max(id), min(id) from p partition(p0) use
 id	estRows	task	access object	operator info
 HashAgg	8000.00	root	NULL	group by:globalindex__aggregate.p.c, funcs:avg(Column#9, Column#10)->Column#4, funcs:max(Column#11)->Column#5, funcs:min(Column#12)->Column#6
 └─IndexLookUp	8000.00	root	partition:p0	NULL
-  ├─Selection(Build)	10000.00	cop[tikv]	NULL	in(_tidb_pid, pid0)
+  ├─Selection(Build)	10000.00	cop[tikv]	NULL	in(_tidb_tid, tid0)
   │ └─IndexFullScan	10000.00	cop[tikv]	table:p, index:idx(id)	keep order:false, stats:pseudo
   └─HashAgg(Probe)	8000.00	cop[tikv]	NULL	group by:globalindex__aggregate.p.c, funcs:count(globalindex__aggregate.p.id)->Column#9, funcs:sum(globalindex__aggregate.p.id)->Column#10, funcs:max(globalindex__aggregate.p.id)->Column#11, funcs:min(globalindex__aggregate.p.id)->Column#12
     └─TableRowIDScan	10000.00	cop[tikv]	table:p	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/globalindex/expression_index.result
+++ b/tests/integrationtest/r/globalindex/expression_index.result
@@ -31,7 +31,7 @@ explain format='brief' select * from t partition(p0) use index(idx) where lower(
 id	estRows	task	access object	operator info
 Projection	3333.33	root	NULL	globalindex__expression_index.t.a, globalindex__expression_index.t.b
 └─IndexLookUp	3333.33	root	partition:p0	NULL
-  ├─Selection(Build)	3333.33	cop[tikv]	NULL	in(_tidb_pid, pid0)
+  ├─Selection(Build)	3333.33	cop[tikv]	NULL	in(_tidb_tid, tid0)
   │ └─IndexRangeScan	3333.33	cop[tikv]	table:t, index:idx(lower(`b`))	range:("c",+inf], keep order:false, stats:pseudo
   └─TableRowIDScan(Probe)	3333.33	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t partition(p0) use index(idx) where lower(b) > 'c';

--- a/tests/integrationtest/r/globalindex/index_join.result
+++ b/tests/integrationtest/r/globalindex/index_join.result
@@ -49,7 +49,7 @@ Projection	1.00	root	NULL	globalindex__index_join.p.id, globalindex__index_join.
   │ └─Selection	1.00	cop[tikv]	NULL	not(isnull(globalindex__index_join.t.id))
   │   └─TableFullScan	1.00	cop[tikv]	table:t	keep order:false
   └─IndexLookUp(Probe)	1.00	root	partition:p1	NULL
-    ├─Selection(Build)	1.00	cop[tikv]	NULL	in(_tidb_pid, pid1), not(isnull(globalindex__index_join.p.id))
+    ├─Selection(Build)	1.00	cop[tikv]	NULL	in(_tidb_tid, tid1), not(isnull(globalindex__index_join.p.id))
     │ └─IndexRangeScan	1.00	cop[tikv]	table:p, index:idx(id)	range: decided by [eq(globalindex__index_join.p.id, globalindex__index_join.t.id)], keep order:false
     └─TableRowIDScan(Probe)	1.00	cop[tikv]	table:p	keep order:false
 select * from p partition(p1) inner join t on p.id = t.id;
@@ -61,7 +61,7 @@ IndexJoin	1.00	root	NULL	inner join, inner:IndexReader, outer key:globalindex__i
 │ └─Selection	1.00	cop[tikv]	NULL	not(isnull(globalindex__index_join.t.id))
 │   └─TableFullScan	1.00	cop[tikv]	table:t	keep order:false
 └─IndexReader(Probe)	1.00	root	partition:p1	index:Selection
-  └─Selection	1.00	cop[tikv]	NULL	in(_tidb_pid, pid1), not(isnull(globalindex__index_join.p.id))
+  └─Selection	1.00	cop[tikv]	NULL	in(_tidb_tid, tid1), not(isnull(globalindex__index_join.p.id))
     └─IndexRangeScan	1.00	cop[tikv]	table:p, index:idx(id)	range: decided by [eq(globalindex__index_join.p.id, globalindex__index_join.t.id)], keep order:false
 select p.id from p partition(p1) inner join t on p.id = t.id;
 id
@@ -114,7 +114,7 @@ Projection	1.00	root	NULL	globalindex__index_join.p.id, globalindex__index_join.
   │ └─Selection	1.00	cop[tikv]	NULL	not(isnull(globalindex__index_join.t.id))
   │   └─TableFullScan	1.00	cop[tikv]	table:t	keep order:false
   └─IndexLookUp(Probe)	1.00	root	partition:p1	NULL
-    ├─Selection(Build)	1.00	cop[tikv]	NULL	in(_tidb_pid, pid1), not(isnull(globalindex__index_join.p.id))
+    ├─Selection(Build)	1.00	cop[tikv]	NULL	in(_tidb_tid, tid1), not(isnull(globalindex__index_join.p.id))
     │ └─IndexRangeScan	1.00	cop[tikv]	table:p, index:idx(id)	range: decided by [eq(globalindex__index_join.p.id, globalindex__index_join.t.id)], keep order:false
     └─TableRowIDScan(Probe)	1.00	cop[tikv]	table:p	keep order:false
 select * from p partition(p1) inner join t on p.id = t.id;
@@ -126,7 +126,7 @@ IndexJoin	1.00	root	NULL	inner join, inner:IndexReader, outer key:globalindex__i
 │ └─Selection	1.00	cop[tikv]	NULL	not(isnull(globalindex__index_join.t.id))
 │   └─TableFullScan	1.00	cop[tikv]	table:t	keep order:false
 └─IndexReader(Probe)	1.00	root	partition:p1	index:Selection
-  └─Selection	1.00	cop[tikv]	NULL	in(_tidb_pid, pid1), not(isnull(globalindex__index_join.p.id))
+  └─Selection	1.00	cop[tikv]	NULL	in(_tidb_tid, tid1), not(isnull(globalindex__index_join.p.id))
     └─IndexRangeScan	1.00	cop[tikv]	table:p, index:idx(id)	range: decided by [eq(globalindex__index_join.p.id, globalindex__index_join.t.id)], keep order:false
 select p.id from p partition(p1) inner join t on p.id = t.id;
 id

--- a/tests/integrationtest/r/globalindex/mem_index_lookup.result
+++ b/tests/integrationtest/r/globalindex/mem_index_lookup.result
@@ -27,7 +27,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_lookup.t.a, globalindex__mem_index_lookup.t.b
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_lookup.t.b, 2)
   └─IndexLookUp_11	3323.33	root	partition:p0	NULL
-    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0)
+    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_lookup.t._tidb_tid, tid0)
     │ └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
     └─TableRowIDScan_8(Probe)	3323.33	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t partition(p0) use index(idx1) where b <= 2;
@@ -38,7 +38,7 @@ id	estRows	task	access object	operator info
 Projection_5	3.32	root		globalindex__mem_index_lookup.t.a, globalindex__mem_index_lookup.t.b
 └─UnionScan_6	3.32	root		eq(globalindex__mem_index_lookup.t.a, 10), le(globalindex__mem_index_lookup.t.b, 2)
   └─IndexLookUp_12	3.32	root	partition:dual	
-    ├─Selection_10(Build)	3323.33	cop[tikv]		in(_tidb_pid, dual)
+    ├─Selection_10(Build)	3323.33	cop[tikv]		in(globalindex__mem_index_lookup.t._tidb_tid, dual)
     │ └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
     └─Selection_11(Probe)	3.32	cop[tikv]		eq(globalindex__mem_index_lookup.t.a, 10)
       └─TableRowIDScan_8	3323.33	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -49,7 +49,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_lookup.t.a, globalindex__mem_index_lookup.t.b
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_lookup.t.b, 2)
   └─IndexLookUp_11	3323.33	root	partition:p0,p1	NULL
-    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0, pid1)
+    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_lookup.t._tidb_tid, tid0, tid1)
     │ └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
     └─TableRowIDScan_8(Probe)	3323.33	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t partition(p0, p1) use index(idx1) where b <= 2;
@@ -86,7 +86,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_lookup.t.a, globalindex__mem_index_lookup.t.b, globalindex__mem_index_lookup.t.c
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_lookup.t.b, 2)
   └─IndexLookUp_11	3323.33	root	partition:p0	NULL
-    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0)
+    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_lookup.t._tidb_tid, tid0)
     │ └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
     └─TableRowIDScan_8(Probe)	3323.33	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t partition(p0) use index(idx1) where b <= 2;
@@ -97,7 +97,7 @@ id	estRows	task	access object	operator info
 Projection_5	0.33	root		globalindex__mem_index_lookup.t.a, globalindex__mem_index_lookup.t.b, globalindex__mem_index_lookup.t.c
 └─UnionScan_6	0.33	root		eq(globalindex__mem_index_lookup.t.a, 2010), le(globalindex__mem_index_lookup.t.b, 2)
   └─IndexLookUp_11	0.33	root	partition:dual	
-    ├─Selection_10(Build)	0.33	cop[tikv]		eq(globalindex__mem_index_lookup.t.a, 2010), in(_tidb_pid, dual)
+    ├─Selection_10(Build)	0.33	cop[tikv]		eq(globalindex__mem_index_lookup.t.a, 2010), in(globalindex__mem_index_lookup.t._tidb_tid, dual)
     │ └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
     └─TableRowIDScan_8(Probe)	0.33	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t partition(p1) use index(idx1) where b <= 2 and a = 2010;
@@ -107,7 +107,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_lookup.t.a, globalindex__mem_index_lookup.t.b, globalindex__mem_index_lookup.t.c
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_lookup.t.b, 2)
   └─IndexLookUp_11	3323.33	root	partition:p0,p1	NULL
-    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0, pid1)
+    ├─Selection_10(Build)	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_lookup.t._tidb_tid, tid0, tid1)
     │ └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
     └─TableRowIDScan_8(Probe)	3323.33	cop[tikv]	table:t	keep order:false, stats:pseudo
 select * from t partition(p0, p1) use index(idx1) where b <= 2;

--- a/tests/integrationtest/r/globalindex/mem_index_merge.result
+++ b/tests/integrationtest/r/globalindex/mem_index_merge.result
@@ -53,7 +53,7 @@ id	estRows	task	access object	operator info
 Projection_5	11.00	root	NULL	globalindex__mem_index_merge.tpk2.a, globalindex__mem_index_merge.tpk2.b, globalindex__mem_index_merge.tpk2.c, globalindex__mem_index_merge.tpk2.d
 └─UnionScan_6	11.00	root	NULL	or(eq(globalindex__mem_index_merge.tpk2.a, 1), eq(globalindex__mem_index_merge.tpk2.b, 4))
   └─IndexMerge_12	11.00	root	partition:p1	type: union
-    ├─Selection_9(Build)	1.00	cop[tikv]	NULL	in(_tidb_pid, pid1)
+    ├─Selection_9(Build)	1.00	cop[tikv]	NULL	in(globalindex__mem_index_merge.tpk2._tidb_tid, tid1)
     │ └─IndexRangeScan_7	1.00	cop[tikv]	table:tpk2, index:uidx_a(a)	range:[1,1], keep order:false, stats:pseudo
     ├─IndexRangeScan_10(Build)	10.00	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:false, stats:pseudo
     └─TableRowIDScan_11(Probe)	11.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
@@ -66,7 +66,7 @@ id	estRows	task	access object	operator info
 Projection_5	1111.11	root	NULL	globalindex__mem_index_merge.tpk2.a, globalindex__mem_index_merge.tpk2.b, globalindex__mem_index_merge.tpk2.c, globalindex__mem_index_merge.tpk2.d
 └─UnionScan_6	1111.11	root	NULL	gt(globalindex__mem_index_merge.tpk2.a, 1), gt(globalindex__mem_index_merge.tpk2.c, 1)
   └─IndexMerge_12	1111.11	root	partition:p1	type: intersection
-    ├─Selection_9(Build)	3333.33	cop[tikv]	NULL	in(_tidb_pid, pid1)
+    ├─Selection_9(Build)	3333.33	cop[tikv]	NULL	in(globalindex__mem_index_merge.tpk2._tidb_tid, tid1)
     │ └─IndexRangeScan_7	3333.33	cop[tikv]	table:tpk2, index:uidx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
     ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_c(c)	range:(1,+inf], keep order:false, stats:pseudo
     └─TableRowIDScan_11(Probe)	1111.11	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
@@ -133,7 +133,7 @@ id	estRows	task	access object	operator info
 Projection_5	11.00	root	NULL	globalindex__mem_index_merge.tpk2.a, globalindex__mem_index_merge.tpk2.b, globalindex__mem_index_merge.tpk2.c, globalindex__mem_index_merge.tpk2.d
 └─UnionScan_6	11.00	root	NULL	or(eq(globalindex__mem_index_merge.tpk2.a, 1), eq(globalindex__mem_index_merge.tpk2.b, 4))
   └─IndexMerge_12	11.00	root	partition:p1	type: union
-    ├─Selection_9(Build)	1.00	cop[tikv]	NULL	in(_tidb_pid, pid1)
+    ├─Selection_9(Build)	1.00	cop[tikv]	NULL	in(globalindex__mem_index_merge.tpk2._tidb_tid, tid1)
     │ └─IndexRangeScan_7	1.00	cop[tikv]	table:tpk2, index:uidx_a(a)	range:[1,1], keep order:false, stats:pseudo
     ├─IndexRangeScan_10(Build)	10.00	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:false, stats:pseudo
     └─TableRowIDScan_11(Probe)	11.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
@@ -146,7 +146,7 @@ id	estRows	task	access object	operator info
 Projection_5	1111.11	root	NULL	globalindex__mem_index_merge.tpk2.a, globalindex__mem_index_merge.tpk2.b, globalindex__mem_index_merge.tpk2.c, globalindex__mem_index_merge.tpk2.d
 └─UnionScan_6	1111.11	root	NULL	gt(globalindex__mem_index_merge.tpk2.a, 1), gt(globalindex__mem_index_merge.tpk2.c, 1)
   └─IndexMerge_12	1111.11	root	partition:p1	type: intersection
-    ├─Selection_9(Build)	1111.11	cop[tikv]	NULL	gt(globalindex__mem_index_merge.tpk2.c, 1), in(_tidb_pid, pid1)
+    ├─Selection_9(Build)	1111.11	cop[tikv]	NULL	gt(globalindex__mem_index_merge.tpk2.c, 1), in(globalindex__mem_index_merge.tpk2._tidb_tid, tid1)
     │ └─IndexRangeScan_7	3333.33	cop[tikv]	table:tpk2, index:uidx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
     ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_c(c)	range:(1,+inf], keep order:false, stats:pseudo
     └─TableRowIDScan_11(Probe)	1111.11	cop[tikv]	table:tpk2	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/globalindex/mem_index_reader.result
+++ b/tests/integrationtest/r/globalindex/mem_index_reader.result
@@ -26,7 +26,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_reader.t.b
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_reader.t.b, 2)
   └─IndexReader_10	3323.33	root	partition:p0	index:Selection_9
-    └─Selection_9	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0)
+    └─Selection_9	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_reader.t._tidb_tid, tid0)
       └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
 select b from t partition(p0) use index(idx1) where b <= 2;
 b
@@ -36,7 +36,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_reader.t.b
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_reader.t.b, 2)
   └─IndexReader_10	3323.33	root	partition:p0,p1	index:Selection_9
-    └─Selection_9	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0, pid1)
+    └─Selection_9	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_reader.t._tidb_tid, tid0, tid1)
       └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
 select b from t partition(p0, p1) use index(idx1) where b <= 2;
 b
@@ -70,7 +70,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_reader.t.b
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_reader.t.b, 2)
   └─IndexReader_10	3323.33	root	partition:p0	index:Selection_9
-    └─Selection_9	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0)
+    └─Selection_9	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_reader.t._tidb_tid, tid0)
       └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
 select b from t partition(p0) use index(idx1) where b <= 2;
 b
@@ -80,7 +80,7 @@ id	estRows	task	access object	operator info
 Projection_5	3323.33	root	NULL	globalindex__mem_index_reader.t.b
 └─UnionScan_6	3323.33	root	NULL	le(globalindex__mem_index_reader.t.b, 2)
   └─IndexReader_10	3323.33	root	partition:p0,p1	index:Selection_9
-    └─Selection_9	3323.33	cop[tikv]	NULL	in(_tidb_pid, pid0, pid1)
+    └─Selection_9	3323.33	cop[tikv]	NULL	in(globalindex__mem_index_reader.t._tidb_tid, tid0, tid1)
       └─IndexRangeScan_7	3323.33	cop[tikv]	table:t, index:idx1(b)	range:[-inf,2], keep order:false, stats:pseudo
 select b from t partition(p0, p1) use index(idx1) where b <= 2;
 b

--- a/tests/integrationtest/r/globalindex/misc.result
+++ b/tests/integrationtest/r/globalindex/misc.result
@@ -123,7 +123,7 @@ bbc
 explain format = 'brief' select a from t partition (p1) order by a;
 id	estRows	task	access object	operator info
 IndexReader	3.00	root	partition:p1	index:Selection
-└─Selection	3.00	cop[tikv]	NULL	in(_tidb_pid, pid1)
+└─Selection	3.00	cop[tikv]	NULL	in(_tidb_tid, tid1)
   └─IndexFullScan	3.00	cop[tikv]	table:t, index:a(a)	keep order:true
 drop table if exists t;
 create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) STORED) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
@@ -176,5 +176,5 @@ bbc
 explain format = 'brief' select a from t partition (p1) order by a;
 id	estRows	task	access object	operator info
 IndexReader	3.00	root	partition:p1	index:Selection
-└─Selection	3.00	cop[tikv]	NULL	in(_tidb_pid, pid1)
+└─Selection	3.00	cop[tikv]	NULL	in(_tidb_tid, tid1)
   └─IndexFullScan	3.00	cop[tikv]	table:t, index:a(a)	keep order:true

--- a/tests/integrationtest/r/globalindex/misc.result
+++ b/tests/integrationtest/r/globalindex/misc.result
@@ -73,8 +73,7 @@ select * from test_t1 where a = 1;
 a	b	c
 1	1	1
 drop table if exists t;
-create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) VIRTUAL) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
-alter table t add unique index (a);
+create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) VIRTUAL, unique index (a)) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
 insert into t (a) values  ('aaa'),('abc'),('acd');
 analyze table t;
 select a from t partition (p0) order by a;
@@ -126,8 +125,7 @@ IndexReader	3.00	root	partition:p1	index:Selection
 └─Selection	3.00	cop[tikv]	NULL	in(_tidb_tid, tid1)
   └─IndexFullScan	3.00	cop[tikv]	table:t, index:a(a)	keep order:true
 drop table if exists t;
-create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) STORED) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
-alter table t add unique index (a);
+create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) STORED, unique index (a)) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
 insert into t (a) values  ('aaa'),('abc'),('acd');
 analyze table t;
 select a from t partition (p0) order by a;

--- a/tests/integrationtest/t/globalindex/aggregate.test
+++ b/tests/integrationtest/t/globalindex/aggregate.test
@@ -10,7 +10,7 @@ insert into p values (1,3), (2,3), (3,4), (4,4), (5,6), (7,9), (8,9);
 explain format='brief' select count(*), max(id), min(id) from p use index(idx);
 select count(*), max(id), min(id) from p use index(idx);
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /in\(_tidb_tid, [0-9]+\)/in(_tidb_tid, tid0)/
 explain format='brief' select count(*), max(id), min(id) from p partition(p0) use index(idx);
 select count(*), max(id), min(id) from p partition(p0) use index(idx);
 
@@ -18,7 +18,7 @@ explain format='brief' select avg(id), max(id), min(id) from p use index(idx) gr
 --sorted_result
 select avg(id), max(id), min(id) from p use index(idx) group by c;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /in\(_tidb_tid, [0-9]+\)/in(_tidb_tid, tid0)/
 explain format='brief' select avg(id), max(id), min(id) from p partition(p0) use index(idx) group by c;
 select avg(id), max(id), min(id) from p partition(p0) use index(idx) group by c;
 

--- a/tests/integrationtest/t/globalindex/expression_index.test
+++ b/tests/integrationtest/t/globalindex/expression_index.test
@@ -19,7 +19,7 @@ select * from t use index(idx) where lower(b) = 'c';
 explain format='brief' select * from t use index(idx) where lower(b) > 'c' order by lower(b);
 select * from t use index(idx) where lower(b) > 'c' order by lower(b);
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /in\(_tidb_tid, [0-9]+\)/in(_tidb_tid, tid0)/
 explain format='brief' select * from t partition(p0) use index(idx) where lower(b) > 'c';
 select * from t partition(p0) use index(idx) where lower(b) > 'c';
 

--- a/tests/integrationtest/t/globalindex/index_join.test
+++ b/tests/integrationtest/t/globalindex/index_join.test
@@ -21,11 +21,11 @@ explain format='brief' select * from p inner join t on p.id = t.id;
 select p.id from p inner join t on p.id = t.id;
 
 --echo # TestGlobalIndexJoinSpecifiedPartition
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain format='brief' select * from p partition(p1) inner join t on p.id = t.id;
 select * from p partition(p1) inner join t on p.id = t.id;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain format='brief' select p.id from p partition(p1) inner join t on p.id = t.id;
 select p.id from p partition(p1) inner join t on p.id = t.id;
 
@@ -49,11 +49,11 @@ explain format='brief' select * from p inner join t on p.id = t.id;
 select p.id from p inner join t on p.id = t.id;
 
 --echo # TestGlobalIndexJoinForClusteredSpecifiedPartition
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain format='brief' select * from p partition(p1) inner join t on p.id = t.id;
 select * from p partition(p1) inner join t on p.id = t.id;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain format='brief' select p.id from p partition(p1) inner join t on p.id = t.id;
 select p.id from p partition(p1) inner join t on p.id = t.id;
 

--- a/tests/integrationtest/t/globalindex/mem_index_lookup.test
+++ b/tests/integrationtest/t/globalindex/mem_index_lookup.test
@@ -18,7 +18,7 @@ explain select * from t use index(idx1) where b > 2;
 --sorted_result
 select * from t use index(idx1) where b > 2;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid0)/
 explain select * from t partition(p0) use index(idx1) where b <= 2;
 --sorted_result
 select * from t partition(p0) use index(idx1) where b <= 2;
@@ -27,7 +27,7 @@ explain select * from t partition(p1) use index(idx1) where b <= 2 and a = 10;
 --sorted_result
 select * from t partition(p1) use index(idx1) where b <= 2 and a = 10;
 
---replace_regex /in\(_tidb_pid, [0-9]+, [0-9]+\)/in(_tidb_pid, pid0, pid1)/
+--replace_regex /_tidb_tid, [0-9]+, [0-9]+\)/_tidb_tid, tid0, tid1)/
 explain select * from t partition(p0, p1) use index(idx1) where b <= 2;
 --sorted_result
 select * from t partition(p0, p1) use index(idx1) where b <= 2;
@@ -53,7 +53,7 @@ explain select * from t use index(idx1) where b > 2;
 --sorted_result
 select * from t use index(idx1) where b > 2;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid0)/
 explain select * from t partition(p0) use index(idx1) where b <= 2;
 --sorted_result
 select * from t partition(p0) use index(idx1) where b <= 2;
@@ -62,7 +62,7 @@ explain select * from t partition(p1) use index(idx1) where b <= 2 and a = 2010;
 --sorted_result
 select * from t partition(p1) use index(idx1) where b <= 2 and a = 2010;
 
---replace_regex /in\(_tidb_pid, [0-9]+, [0-9]+\)/in(_tidb_pid, pid0, pid1)/
+--replace_regex /_tidb_tid, [0-9]+, [0-9]+\)/_tidb_tid, tid0, tid1)/
 explain select * from t partition(p0, p1) use index(idx1) where b <= 2;
 --sorted_result
 select * from t partition(p0, p1) use index(idx1) where b <= 2;

--- a/tests/integrationtest/t/globalindex/mem_index_merge.test
+++ b/tests/integrationtest/t/globalindex/mem_index_merge.test
@@ -31,13 +31,13 @@ select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 where a > 1 and c
 select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 where a > 0 and c > 0;
 
 --echo ## for indexMerge union with specified PARTITION
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain select /*+ use_index_merge(tpk2, uidx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
 --sorted_result
 select /*+ use_index_merge(tpk2, uidx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
 
 --echo ## for indexMerge intersection with specified PARTITION
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
 --sorted_result
 select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
@@ -80,13 +80,13 @@ select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 where a > 1 and c
 select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 where a > 0 and c > 0;
 
 --echo ## for indexMerge union with specified PARTITION
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain select /*+ use_index_merge(tpk2, uidx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
 --sorted_result
 select /*+ use_index_merge(tpk2, uidx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
 
 --echo ## for indexMerge intersection with specified PARTITION
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
 explain select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
 --sorted_result
 select /*+ use_index_merge(tpk2, uidx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;

--- a/tests/integrationtest/t/globalindex/mem_index_reader.test
+++ b/tests/integrationtest/t/globalindex/mem_index_reader.test
@@ -18,12 +18,12 @@ explain select b from t use index(idx1) where b > 2;
 --sorted_result
 select b from t use index(idx1) where b > 2;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid0)/
 explain select b from t partition(p0) use index(idx1) where b <= 2;
 --sorted_result
 select b from t partition(p0) use index(idx1) where b <= 2;
 
---replace_regex /in\(_tidb_pid, [0-9]+, [0-9]+\)/in(_tidb_pid, pid0, pid1)/
+--replace_regex /_tidb_tid, [0-9]+, [0-9]+\)/_tidb_tid, tid0, tid1)/
 explain select b from t partition(p0, p1) use index(idx1) where b <= 2;
 --sorted_result
 select b from t partition(p0, p1) use index(idx1) where b <= 2;
@@ -48,12 +48,12 @@ explain select b from t use index(idx1) where b > 2;
 --sorted_result
 select b from t use index(idx1) where b > 2;
 
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid0)/
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid0)/
 explain select b from t partition(p0) use index(idx1) where b <= 2;
 --sorted_result
 select b from t partition(p0) use index(idx1) where b <= 2;
 
---replace_regex /in\(_tidb_pid, [0-9]+, [0-9]+\)/in(_tidb_pid, pid0, pid1)/
+--replace_regex /_tidb_tid, [0-9]+, [0-9]+\)/_tidb_tid, tid0, tid1)/
 explain select b from t partition(p0, p1) use index(idx1) where b <= 2;
 --sorted_result
 select b from t partition(p0, p1) use index(idx1) where b <= 2;

--- a/tests/integrationtest/t/globalindex/misc.test
+++ b/tests/integrationtest/t/globalindex/misc.test
@@ -81,8 +81,7 @@ select * from test_t1 where a = 1;
 ## Test generated column with global index
 drop table if exists t;
 ## Test for virtual generated column with global index
-create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) VIRTUAL) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
-alter table t add unique index (a);
+create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) VIRTUAL, unique index (a)) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
 insert into t (a) values  ('aaa'),('abc'),('acd');
 analyze table t;
 select a from t partition (p0) order by a;
@@ -105,8 +104,7 @@ explain format = 'brief' select a from t partition (p1) order by a;
 
 drop table if exists t;
 ## Test for stored generated column with global index
-create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) STORED) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
-alter table t add unique index (a);
+create table t (a varchar(10), b varchar(1) GENERATED ALWAYS AS (substr(a,1,1)) STORED, unique index (a)) partition by list columns(b) (partition p0 values in ('a','c'), partition p1 values in ('b','d'));
 insert into t (a) values  ('aaa'),('abc'),('acd');
 analyze table t;
 select a from t partition (p0) order by a;

--- a/tests/integrationtest/t/globalindex/misc.test
+++ b/tests/integrationtest/t/globalindex/misc.test
@@ -100,7 +100,7 @@ select a from t order by a;
 select * from t where a = 'bbc';
 select a from t partition (p0) order by a;
 select a from t partition (p1) order by a;
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /in\(_tidb_tid, [0-9]+\)/in(_tidb_tid, tid1)/
 explain format = 'brief' select a from t partition (p1) order by a;
 
 drop table if exists t;
@@ -124,6 +124,6 @@ select a from t order by a;
 select * from t where a = 'bbc';
 select a from t partition (p0) order by a;
 select a from t partition (p1) order by a;
---replace_regex /in\(_tidb_pid, [0-9]+\)/in(_tidb_pid, pid1)/
+--replace_regex /in\(_tidb_tid, [0-9]+\)/in(_tidb_tid, tid1)/
 explain format = 'brief' select a from t partition (p1) order by a;
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53929 

Problem Summary:

The problem is we added `ExtraPhysTblID` to DataSource's schema for get the partition id. But it returns table id instead of partition id when using `indexReader` executor working with global index, because we decode index key to get it. After deep into the code, I found it's hard to fix it elegantly. In logical plan builder phase, we can't determined it will select a global index path or not which means we can't add`ExtraPidColID` column into `DataSource` in this phase.

Then I think maybe we could combine two columns, let it gets return values from different place(Seems `ExtraPhysTblID` is useless for global index, always return table ID for every records). When it is a global index, we could decode pid by index value, otherwise we could decode table id by index/row key. Also it could reduce potential errors, no need to select to use `ExtraPhysTblID` or `ExtraPidColID` when we write the code.

Related PR in TiKV side https://github.com/tikv/tikv/pull/17141


### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
