### PR TITLE
ddl: record the used indexID for global-sort reorg

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -62,6 +62,11 @@ type BackfillSubTaskMeta struct {
 	TS             uint64   `json:"ts,omitempty"`
 	// Each group of MetaGroups represents a different index kvs meta.
 	MetaGroups []*external.SortedKVMeta `json:"meta_groups,omitempty"`
+	// EleIDs stands for the index/column IDs to backfill with distributed framework.
+	// After the subtask is finished, EleIDs should have the same length as
+	// MetaGroups, and they are in the same order.
+	EleIDs []int64 `json:"ele_ids,omitempty"`
+
 	// Only used for adding one single index.
 	// Keep this for compatibility with v7.5.
 	external.SortedKVMeta `json:",inline"`

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -197,7 +197,7 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 				tk.MustExec("admin check table " + tn + ";")
 				tk.MustExec("alter table " + tn + " drop index idx_1, drop index idx_2;")
 			}
-			
+
 			tk.MustContainErrMsg(
 				"alter table t_dup add index idx(a), add unique index idx2(b);",
 				"Duplicate entry '2' for key 't_dup.idx2'",

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -197,14 +197,10 @@ func TestGlobalSortMultiSchemaChange(t *testing.T) {
 				tk.MustExec("admin check table " + tn + ";")
 				tk.MustExec("alter table " + tn + " drop index idx_1, drop index idx_2;")
 			}
-			expected := "Duplicate entry '2' for key 't_dup.idx2'"
-			if tc.name == "ingest_dist_gs_backfill" {
-				expected = "Duplicate entry"
-			}
-
+			
 			tk.MustContainErrMsg(
 				"alter table t_dup add index idx(a), add unique index idx2(b);",
-				expected,
+				"Duplicate entry '2' for key 't_dup.idx2'",
 			)
 		})
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53677

Problem Summary:

### What changed and how does it work?

This is a follow-up of PR https://github.com/pingcap/tidb/pull/53632 to resolve a TODO. Before this PR, we don't know which index does a ingest subtask belong, so we can't generate the index name of "duplicate entry" error.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
