### PR TITLE
statistics: updating stats cache can trigger evict

### DIFF
--- a/pkg/statistics/handle/cache/internal/lfu/BUILD.bazel
+++ b/pkg/statistics/handle/cache/internal/lfu/BUILD.bazel
@@ -30,7 +30,7 @@ go_test(
     embed = [":lfu"],
     flaky = True,
     race = "on",
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/statistics",
         "//pkg/statistics/handle/cache/internal/testutil",

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -207,6 +207,7 @@ func (s *LFU) onExit(val any) {
 	if s.closed.Load() {
 		return
 	}
+	s.triggerEvict()
 	// Subtract the memory usage of the table from the total memory usage.
 	s.addCost(-val.(*statistics.Table).MemoryUsage().TotalTrackingMemUsage())
 }

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -295,3 +295,15 @@ func TestMemoryControl(t *testing.T) {
 	lfu.wait()
 	require.Equal(t, int64(10)*(2*mockCMSMemoryUsage+mockCMSMemoryUsage), lfu.Cost())
 }
+
+func TestMemoryControlWithUpdate(t *testing.T) {
+	capacity := int64(100)
+	lfu, err := NewLFU(capacity)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		t1 := testutil.NewMockStatisticsTable(i, 1, true, false, false)
+		lfu.Put(1, t1)
+	}
+	time.Sleep(1 * time.Second)
+	require.Equal(t, int64(0), lfu.Cost())
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53742

Problem Summary:

### What changed and how does it work?

ristretto will evict the data when inserting data. If LFU meets high-update scenes, it cannot evict. so we need to write some entry value to trigger the value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
