### PR TITLE
executor: avoid use fmt.Sprintf

### DIFF
--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -16,7 +16,7 @@ package exec
 
 import (
 	"context"
-	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/ngaut/pools"
@@ -403,7 +403,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) (err error) {
 		return err
 	}
 
-	r, ctx := tracing.StartRegionEx(ctx, fmt.Sprintf("%T.Next", e))
+	r, ctx := tracing.StartRegionEx(ctx, reflect.TypeOf(e).String()+".Next")
 	defer r.End()
 
 	e.RegisterSQLAndPlanInExecForTopSQL()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54001

Problem Summary:  avoid use fmt.Sprintf.

### What changed and how does it work?

Sysbench oltp_point_select:

|         | thread | QPS |
|---------|--------|-----|
| Before  | 200    | 72211  |
| This PR | 200    | 72616 |

QPS improve 0.56%.

Before: 

<img width="711" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/fa9ca5b5-2025-42e0-ac7d-9ed61465413d">

This PR:

<img width="765" alt="image" src="https://github.com/pingcap/tidb/assets/26020263/186ad91f-c670-4458-9f26-ca5617c84ce5">


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
