### PR TITLE
executor: optimize executor runtime stats by avoid unnecessary clone

### DIFF
--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -119,9 +119,9 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	s1.procKeys.Add(100)
 	s1.procKeys.Add(200)
 
-	s2 := *s1
-	stmtStats.RegisterStats(1, s1)
-	stmtStats.RegisterStats(1, &s2)
+	s2 := s1.Clone()
+	stmtStats.RegisterStats(1, s1.Clone())
+	stmtStats.RegisterStats(1, s2)
 	stats := stmtStats.GetRootStats(1)
 	expect := "time:1s, open:0s, close:0s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, backoff{RegionMiss: 2ms}"
 	require.Equal(t, expect, stats.String())
@@ -134,7 +134,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	}
 	s1.reqStat.RecordRPCErrorStats("server_is_busy")
 	s1.reqStat.RecordRPCErrorStats("server_is_busy")
-	stmtStats.RegisterStats(2, s1)
+	stmtStats.RegisterStats(2, s1.Clone())
 	stats = stmtStats.GetRootStats(2)
 	expect = "cop_task: {num: 2, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 1s, tot_wait: 1s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:1, total_time:1s}, rpc_errors:{server_is_busy:2}}, backoff{RegionMiss: 1ms}"
 	require.Equal(t, expect, stats.String())

--- a/pkg/executor/batch_point_get.go
+++ b/pkg/executor/batch_point_get.go
@@ -177,14 +177,15 @@ func (e *BatchPointGetExec) Close() error {
 	if e.RuntimeStats() != nil && e.snapshot != nil {
 		e.snapshot.SetOption(kv.CollectRuntimeStats, nil)
 	}
-	if e.indexUsageReporter != nil {
+	if e.indexUsageReporter != nil && e.stats != nil {
 		kvReqTotal := e.stats.GetCmdRPCCount(tikvrpc.CmdBatchGet)
 		// We cannot distinguish how many rows are coming from each partition. Here, we calculate all index usages
 		// percentage according to the row counts for the whole table.
+		rows := e.RuntimeStats().GetActRows()
 		if e.idxInfo != nil {
-			e.indexUsageReporter.ReportPointGetIndexUsage(e.tblInfo.ID, e.tblInfo.ID, e.idxInfo.ID, e.ID(), kvReqTotal)
+			e.indexUsageReporter.ReportPointGetIndexUsage(e.tblInfo.ID, e.tblInfo.ID, e.idxInfo.ID, kvReqTotal, rows)
 		} else {
-			e.indexUsageReporter.ReportPointGetIndexUsageForHandle(e.tblInfo, e.tblInfo.ID, e.ID(), kvReqTotal)
+			e.indexUsageReporter.ReportPointGetIndexUsageForHandle(e.tblInfo, e.tblInfo.ID, kvReqTotal, rows)
 		}
 	}
 	e.inited = 0

--- a/pkg/executor/internal/exec/indexusage.go
+++ b/pkg/executor/internal/exec/indexusage.go
@@ -89,30 +89,24 @@ func (e *IndexUsageReporter) ReportCopIndexUsage(tableID int64, physicalTableID 
 
 // ReportPointGetIndexUsageForHandle wraps around `ReportPointGetIndexUsage` to get the `indexID` automatically
 // from the `table.Table` if the table has a clustered index or integer primary key.
-func (e *IndexUsageReporter) ReportPointGetIndexUsageForHandle(tblInfo *model.TableInfo, physicalTableID int64, planID int, kvRequestTotal int64) {
+func (e *IndexUsageReporter) ReportPointGetIndexUsageForHandle(tblInfo *model.TableInfo, physicalTableID int64, kvRequestTotal, rows int64) {
 	idxID, ok := getClusterIndexID(tblInfo)
 	if !ok {
 		return
 	}
 
-	e.ReportPointGetIndexUsage(tblInfo.ID, physicalTableID, idxID, planID, kvRequestTotal)
+	e.ReportPointGetIndexUsage(tblInfo.ID, physicalTableID, idxID, kvRequestTotal, rows)
 }
 
 // ReportPointGetIndexUsage reports the index usage of a point get or batch point get
-func (e *IndexUsageReporter) ReportPointGetIndexUsage(tableID int64, physicalTableID int64, indexID int64, planID int, kvRequestTotal int64) {
+func (e *IndexUsageReporter) ReportPointGetIndexUsage(tableID int64, physicalTableID int64, indexID int64, kvRequestTotal, rows int64) {
 	tableRowCount, ok := e.getTableRowCount(physicalTableID)
 	if !ok {
 		// skip if the table is empty or the stats is not valid
 		return
 	}
 
-	basic := e.runtimeStatsColl.GetBasicRuntimeStats(planID, false)
-	if basic == nil {
-		return
-	}
-	accessRows := basic.GetActRows()
-
-	sample := indexusage.NewSample(0, uint64(kvRequestTotal), uint64(accessRows), uint64(tableRowCount))
+	sample := indexusage.NewSample(0, uint64(kvRequestTotal), uint64(rows), uint64(tableRowCount))
 	e.reporter.Update(tableID, indexID, sample)
 }
 

--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -52,9 +52,7 @@ func TestIndexUsageReporter(t *testing.T) {
 	runtimeStatsColl := sc.RuntimeStatsColl
 
 	// For PointGet and BatchPointGet
-	planID := 3
-	runtimeStatsColl.GetBasicRuntimeStats(planID, true).Record(time.Second, 2024)
-	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)
+	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, 1, 2024)
 
 	require.Eventually(t, func() bool {
 		tk.Session().ReportUsageStats()
@@ -63,7 +61,7 @@ func TestIndexUsageReporter(t *testing.T) {
 	}, time.Second*5, time.Millisecond)
 
 	// For Index Scan
-	planID = 4
+	planID := 4
 	rows := uint64(2024)
 	zero := uint64(0)
 	executorID := "test-executor"
@@ -87,9 +85,7 @@ func TestIndexUsageReporter(t *testing.T) {
 		Version:       statistics.PseudoVersion,
 		RealtimeCount: 100,
 	})
-	planID = 4
-	runtimeStatsColl.GetBasicRuntimeStats(planID, true).Record(time.Second, 2024)
-	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)
+	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, 1, 2024)
 
 	require.Eventually(t, func() bool {
 		tk.Session().ReportUsageStats()

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -269,7 +269,7 @@ func (e *PointGetExecutor) Close() error {
 	if e.RuntimeStats() != nil && e.snapshot != nil {
 		e.snapshot.SetOption(kv.CollectRuntimeStats, nil)
 	}
-	if e.indexUsageReporter != nil && e.stats != nil {
+	if e.indexUsageReporter != nil {
 		tableID := e.tblInfo.ID
 		physicalTableID := GetPhysID(e.tblInfo, e.partitionDefIdx)
 		kvReqTotal := e.stats.SnapshotRuntimeStats.GetCmdRPCCount(tikvrpc.CmdGet)

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -204,7 +204,7 @@ func (e *PointGetExecutor) Recreated(p *plannercore.PointGetPlan) {
 	// It's necessary to at least reset the `runtimeStats` of the `BaseExecutor`.
 	// As the `StmtCtx` may have changed, a new index usage reporter should also be created.
 	e.BaseExecutor = exec.NewBaseExecutor(e.Ctx(), p.Schema(), p.ID())
-	e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
+	//e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
 }
 
 // Init set fields needed for PointGetExecutor reuse, this does NOT change baseExecutor field
@@ -269,14 +269,15 @@ func (e *PointGetExecutor) Close() error {
 	if e.RuntimeStats() != nil && e.snapshot != nil {
 		e.snapshot.SetOption(kv.CollectRuntimeStats, nil)
 	}
-	if e.indexUsageReporter != nil {
+	if e.indexUsageReporter != nil && e.stats != nil {
 		tableID := e.tblInfo.ID
 		physicalTableID := GetPhysID(e.tblInfo, e.partitionDefIdx)
 		kvReqTotal := e.stats.SnapshotRuntimeStats.GetCmdRPCCount(tikvrpc.CmdGet)
+		rows := e.RuntimeStats().GetActRows()
 		if e.idxInfo != nil {
-			e.indexUsageReporter.ReportPointGetIndexUsage(tableID, physicalTableID, e.idxInfo.ID, e.ID(), kvReqTotal)
+			e.indexUsageReporter.ReportPointGetIndexUsage(tableID, physicalTableID, e.idxInfo.ID, kvReqTotal, rows)
 		} else {
-			e.indexUsageReporter.ReportPointGetIndexUsageForHandle(e.tblInfo, physicalTableID, e.ID(), kvReqTotal)
+			e.indexUsageReporter.ReportPointGetIndexUsageForHandle(e.tblInfo, physicalTableID, kvReqTotal, rows)
 		}
 	}
 	e.done = false

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -204,7 +204,7 @@ func (e *PointGetExecutor) Recreated(p *plannercore.PointGetPlan) {
 	// It's necessary to at least reset the `runtimeStats` of the `BaseExecutor`.
 	// As the `StmtCtx` may have changed, a new index usage reporter should also be created.
 	e.BaseExecutor = exec.NewBaseExecutor(e.Ctx(), p.Schema(), p.ID())
-	//e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
+	e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
 }
 
 // Init set fields needed for PointGetExecutor reuse, this does NOT change baseExecutor field

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1493,7 +1493,7 @@ func (e *RuntimeStatsColl) RegisterStats(planID int, info RuntimeStats) {
 		}
 	}
 	if !found {
-		stats.groupRss = append(stats.groupRss, info.Clone())
+		stats.groupRss = append(stats.groupRss, info)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #56649

Problem Summary: Optimize executor runtime stats by avoid unnecessary clone.

### What changed and how does it work?

- Optimize executor runtime stats by avoid unnecessary clone.

<img width="3006" alt="image" src="https://github.com/user-attachments/assets/2391dd33-cc38-4bd2-afbf-159ccac3af69">

- Tiny optimize index usage reporter for point_get.

version | workload | thread | QPS | QPS Increase
-- | -- | -- | -- | --
master | oltp_point_select | 10 | 17156 |  
This PR | oltp_point_select | 10 | 17365 | 1.2 %
master | oltp_point_select | 100 | 85664 |  
This PR | oltp_point_select | 100 | 86774 | 1.2%

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
