### PR TITLE
planner: skip index scan plan for tablesample

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1521,6 +1521,10 @@ func (ds *DataSource) FindBestTask(prop *property.PhysicalProperty, planCounter 
 		if ds.preferStoreType&h.PreferTiFlash != 0 {
 			continue
 		}
+		// TableSample do not support index scan.
+		if ds.SampleInfo != nil {
+			continue
+		}
 		idxTask, err := ds.convertToIndexScan(prop, candidate, opt)
 		if err != nil {
 			return nil, 0, err

--- a/tests/integrationtest/r/executor/sample.result
+++ b/tests/integrationtest/r/executor/sample.result
@@ -194,7 +194,7 @@ a
 2100
 4500
 select a from t use index (idx_0) tablesample regions() order by a;
-Error 8128 (HY000): Invalid TABLESAMPLE: plan not supported
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
 DROP TABLE IF EXISTS a;
 CREATE TABLE a (pk bigint unsigned primary key clustered, v text);
 INSERT INTO a WITH RECURSIVE b(pk) AS (SELECT 1 UNION ALL SELECT pk+1 FROM b WHERE pk < 1000) SELECT pk, 'a' FROM b;
@@ -224,3 +224,7 @@ a	b
 1	1
 2	2
 set @@tidb_partition_prune_mode=default;
+drop table if exists t;
+create table t (a decimal(62,2) not null, key idx (a), primary key (a) clustered);
+select a from t tablesample regions() order by a;
+a

--- a/tests/integrationtest/t/executor/sample.test
+++ b/tests/integrationtest/t/executor/sample.test
@@ -119,7 +119,7 @@ split table t between (0) and (10000) regions 5;
 insert into t values (1000, 1, '1'), (1001, 1, '1'), (2100, 2, '2'), (4500, 3, '3');
 create index idx_0 on t (b);
 select a from t tablesample regions() order by a;
--- error 8128
+-- error 1815
 select a from t use index (idx_0) tablesample regions() order by a;
 
 # TestTableSampleUnsignedIntHandle
@@ -143,3 +143,8 @@ select * from t tablesample regions() order by a;
 set @@tidb_partition_prune_mode='dynamic';
 select * from t tablesample regions() order by a;
 set @@tidb_partition_prune_mode=default;
+
+# TestTableSampleNoIndexScan
+drop table if exists t;
+create table t (a decimal(62,2) not null, key idx (a), primary key (a) clustered);
+select a from t tablesample regions() order by a;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54015

Problem Summary:

`TABLESAMPLE REGIONS()` should be only valid in table scan.

### What changed and how does it work?

Skip index scan plan for `TABLESAMPLE`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
