### PR TITLE
ddl: set proper default flen of decimal(0) columns

### DIFF
--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1429,21 +1429,22 @@ func checkColumn(colDef *ast.ColumnDef) error {
 			}
 		}
 	case mysql.TypeNewDecimal:
-		if tp.GetDecimal() > mysql.MaxDecimalScale {
-			return types.ErrTooBigScale.GenWithStackByArgs(tp.GetDecimal(), colDef.Name.Name.O, mysql.MaxDecimalScale)
+		tpFlen := tp.GetFlen()
+		tpDecimal := tp.GetDecimal()
+		if tpDecimal > mysql.MaxDecimalScale {
+			return types.ErrTooBigScale.GenWithStackByArgs(tpDecimal, colDef.Name.Name.O, mysql.MaxDecimalScale)
 		}
-
-		if tp.GetFlen() > mysql.MaxDecimalWidth {
-			return types.ErrTooBigPrecision.GenWithStackByArgs(tp.GetFlen(), colDef.Name.Name.O, mysql.MaxDecimalWidth)
+		if tpFlen > mysql.MaxDecimalWidth {
+			return types.ErrTooBigPrecision.GenWithStackByArgs(tpFlen, colDef.Name.Name.O, mysql.MaxDecimalWidth)
 		}
-
-		if tp.GetFlen() < tp.GetDecimal() {
+		if tpFlen < tpDecimal {
 			return types.ErrMBiggerThanD.GenWithStackByArgs(colDef.Name.Name.O)
 		}
 		// If decimal and flen all equals 0, just set flen to default value.
-		if tp.GetDecimal() == 0 && tp.GetFlen() == 0 {
+		if tpFlen == 0 && (tpDecimal == 0 || tpDecimal == types.UnspecifiedLength) {
 			defaultFlen, _ := mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeNewDecimal)
 			tp.SetFlen(defaultFlen)
+			tp.SetDecimal(0)
 		}
 	case mysql.TypeBit:
 		if tp.GetFlen() <= 0 {

--- a/tests/integrationtest/r/ddl/column.result
+++ b/tests/integrationtest/r/ddl/column.result
@@ -76,3 +76,11 @@ alter table t1 add column(c datetime default '11abc');
 Error 1067 (42000): Invalid default value for 'c'
 alter table t1 add column d date default '2024-10';
 Error 1067 (42000): Invalid default value for 'd'
+drop table if exists t;
+create table t(a decimal(0,0), b decimal(0));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` decimal(10,0) DEFAULT NULL,
+  `b` decimal(10,0) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin

--- a/tests/integrationtest/t/ddl/column.test
+++ b/tests/integrationtest/t/ddl/column.test
@@ -39,3 +39,8 @@ alter table t1 add column(c tinyint default '11abc');
 alter table t1 add column(c datetime default '11abc');
 --error 1067
 alter table t1 add column d date default '2024-10';
+
+# TestIssue53779
+drop table if exists t;
+create table t(a decimal(0,0), b decimal(0));
+show create table t;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53779

Problem Summary:

See #53779.

### What changed and how does it work?

Handle `Decimal(0)` properly in preprocessing.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
