### PR TITLE
privilege: fix `auth_socket` bug, should only allow os user name to login

### DIFF
--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -584,6 +584,13 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 			logutil.BgLogger().Warn("verify through LDAP Simple failed", zap.String("username", user.Username), zap.Error(err))
 			return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
+	} else if record.AuthPlugin == mysql.AuthSocket {
+		if string(authentication) != authUser && string(authentication) != pwd {
+			logutil.BgLogger().Error("Failed socket auth", zap.String("authUser", authUser),
+				zap.String("socket_user", string(authentication)),
+				zap.String("authentication_string", pwd))
+			return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
+		}
 	} else if len(pwd) > 0 && len(authentication) > 0 {
 		switch record.AuthPlugin {
 		// NOTE: If the checking of the clear-text password fails, please set `info.FailedDueToWrongPassword = true`.
@@ -609,22 +616,13 @@ func (p *UserPrivileges) ConnectionVerification(user *auth.UserIdentity, authUse
 				info.FailedDueToWrongPassword = true
 				return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 			}
-		case mysql.AuthSocket:
-			if string(authentication) != authUser && string(authentication) != pwd {
-				logutil.BgLogger().Error("Failed socket auth", zap.String("authUser", authUser),
-					zap.String("socket_user", string(authentication)),
-					zap.String("authentication_string", pwd))
-				return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
-			}
 		default:
 			logutil.BgLogger().Error("unknown authentication plugin", zap.String("authUser", authUser), zap.String("plugin", record.AuthPlugin))
 			return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 		}
 	} else if len(pwd) > 0 || len(authentication) > 0 {
-		if record.AuthPlugin != mysql.AuthSocket {
-			info.FailedDueToWrongPassword = true
-			return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
-		}
+		info.FailedDueToWrongPassword = true
+		return info, ErrAccessDenied.FastGenByArgs(user.Username, user.Hostname, hasPassword)
 	}
 
 	// Login a locked account is not allowed.

--- a/pkg/server/mock_conn.go
+++ b/pkg/server/mock_conn.go
@@ -140,3 +140,13 @@ func CreateMockConn(t *testing.T, server *Server) MockConn {
 		t:          t,
 	}
 }
+
+// MockOSUserForAuthSocket mocks the OS user for AUTH_SOCKET plugin
+func MockOSUserForAuthSocket(uname string) {
+	mockOSUserForAuthSocketTest.Store(&uname)
+}
+
+// ClearOSUserForAuthSocket clears the mocked OS user for AUTH_SOCKET plugin
+func ClearOSUserForAuthSocket() {
+	mockOSUserForAuthSocketTest.Store(nil)
+}

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -3086,4 +3087,73 @@ func TestConnectionCount(t *testing.T) {
 func TestTypeAndCharsetOfSendLongData(t *testing.T) {
 	ts := servertestkit.CreateTidbTestSuite(t)
 	ts.RunTestTypeAndCharsetOfSendLongData(t)
+}
+
+func TestAuthSocket(t *testing.T) {
+	defer server2.ClearOSUserForAuthSocket()
+
+	cfg := util2.NewTestConfig()
+	cfg.Socket = filepath.Join(t.TempDir(), "authsock.sock")
+	cfg.Port = 0
+	cfg.Status.StatusPort = 0
+	ts := servertestkit.CreateTidbTestSuiteWithCfg(t, cfg)
+	ts.WaitUntilServerCanConnect()
+
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		dbt.MustExec("CREATE USER 'u1'@'%' IDENTIFIED WITH auth_socket;")
+		dbt.MustExec("CREATE USER 'u2'@'%' IDENTIFIED WITH auth_socket AS 'sockuser'")
+		dbt.MustExec("CREATE USER 'sockuser'@'%' IDENTIFIED WITH auth_socket;")
+	})
+
+	// network login should be denied
+	for _, uname := range []string{"u1", "u2", "u3"} {
+		server2.MockOSUserForAuthSocket(uname)
+		db, err := sql.Open("mysql", ts.GetDSN(func(config *mysql.Config) {
+			config.User = uname
+		}))
+		require.NoError(t, err)
+		_, err = db.Conn(context.TODO())
+		require.EqualError(t,
+			err,
+			fmt.Sprintf("Error 1045 (28000): Access denied for user '%s'@'127.0.0.1' (using password: NO)", uname),
+		)
+		require.NoError(t, db.Close())
+	}
+
+	socketAuthConf := func(user string) func(*mysql.Config) {
+		return func(config *mysql.Config) {
+			config.User = user
+			config.Net = "unix"
+			config.Addr = cfg.Socket
+			config.DBName = ""
+		}
+	}
+
+	server2.MockOSUserForAuthSocket("sockuser")
+
+	// mysql username that is different with the OS user should be rejected.
+	db, err := sql.Open("mysql", ts.GetDSN(socketAuthConf("u1")))
+	require.NoError(t, err)
+	_, err = db.Conn(context.TODO())
+	require.EqualError(t, err, "Error 1045 (28000): Access denied for user 'u1'@'localhost' (using password: YES)")
+	require.NoError(t, db.Close())
+
+	// mysql username that is the same with the OS user should be accepted.
+	ts.RunTests(t, socketAuthConf("sockuser"), func(dbt *testkit.DBTestKit) {
+		rows := dbt.MustQuery("select current_user();")
+		ts.CheckRows(t, rows, "sockuser@%")
+	})
+
+	// When a user is created with `IDENTIFIED WITH auth_socket AS ...`.
+	// It should be accepted when username or as string is the same with OS user.
+	ts.RunTests(t, socketAuthConf("u2"), func(dbt *testkit.DBTestKit) {
+		rows := dbt.MustQuery("select current_user();")
+		ts.CheckRows(t, rows, "u2@%")
+	})
+
+	server2.MockOSUserForAuthSocket("u2")
+	ts.RunTests(t, socketAuthConf("u2"), func(dbt *testkit.DBTestKit) {
+		rows := dbt.MustQuery("select current_user();")
+		ts.CheckRows(t, rows, "u2@%")
+	})
 }

--- a/pkg/server/tests/servertestkit/testkit.go
+++ b/pkg/server/tests/servertestkit/testkit.go
@@ -70,6 +70,7 @@ func CreateTidbTestSuiteWithCfg(t *testing.T, cfg *config.Config) *TidbTestSuite
 	require.NoError(t, err)
 	ts.Tidbdrv = srv.NewTiDBDriver(ts.Store)
 
+	srv.RunInGoTestChan = make(chan struct{})
 	server, err := srv.NewServer(cfg, ts.Tidbdrv)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54031

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)


1. my os user is `wangchao`

```
$ whoami
wangchao
```

2. create users:

```mysql
> CREATE USER 'u1'@'localhost' IDENTIFIED WITH auth_socket;
Query OK, 0 rows affected
Time: 0.017s
> CREATE USER 'u2'@'localhost' IDENTIFIED WITH auth_socket AS "wangchao";
Query OK, 0 rows affected
Time: 0.012s
> CREATE USER 'wangchao'@'localhost' IDENTIFIED WITH auth_socket;
Query OK, 0 rows affected
Time: 0.025s
TiDB root@127.0.0.1:test> select host,user,authentication_string,plugin from mysql.user;
+-----------+----------+-----------------------+-----------------------+
| host      | user     | authentication_string | plugin                |
+-----------+----------+-----------------------+-----------------------+
| %         | root     |                       | mysql_native_password |
| localhost | u1       |                       | auth_socket           |
| localhost | u2       | wangchao              | auth_socket           |
| localhost | wangchao |                       | auth_socket           |
+-----------+----------+-----------------------+-----------------------+
4 rows in set
Time: 0.011s
```

3. Try log in:

`u1` is rejected because it is not same with os user:
```
$ mysql --comments -uu1 -S/tmp/tidb-4001.sock
ERROR 1045 (28000): Access denied for user 'u1'@'localhost' (using password: YES)
```

`u2` is allowed because its authenticate string is same with os user:
```
$ mysql --comments -uu2 -S/tmp/tidb-4001.sock
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2097182
Server version: 8.0.11-TiDB-None TiDB Server (Apache License 2.0) Community Edition, MySQL 8.0 compatible
...
```

`wangchao` is allowed because its the os user name:
```
> mysql --comments -uwangchao -S/tmp/tidb-4001.sock
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2097184
Server version: 8.0.11-TiDB-None TiDB Server (Apache License 2.0) Community Edition, MySQL 8.0 compatible
...
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix `auth_socket` bug, should only allow os user name to login
```
