### PR TITLE
executor: fix the potential regression of #53855

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
@@ -747,9 +748,20 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 
 // calculateBatchSize calculates a suitable initial batch size.
 func (e *IndexLookUpExecutor) calculateBatchSize(initBatchSize, maxBatchSize int) int {
+	// If initBatchSize is less than MaxChunkSize, there should be limit upon the reader.
+	// So we use the slow start strategy to avoid unnecessary rpc.
+	if initBatchSize < e.ctx.GetSessionVars().MaxChunkSize {
+		return initBatchSize
+	}
 	var estRows int
 	if len(e.idxPlans) > 0 {
 		estRows = int(e.idxPlans[0].StatsCount())
+	}
+	// https://github.com/pingcap/tidb/pull/53855
+	// There're some problems that the initBatchSize(which is the requiredRows from the upper executor) is not well maintained. Sometimes we'll need to tune it by hand.
+	// We leave this hack here to avoid the performance regression.
+	if e.ctx.GetSessionVars().MinPagingSize < variable.DefMinPagingSize || e.ctx.GetSessionVars().MaxPagingSize < variable.DefMaxPagingSize {
+		return initBatchSize
 	}
 	return CalculateBatchSize(e.indexPaging, estRows, initBatchSize, maxBatchSize)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50344, #53855 

Problem Summary:

If the `initBatchSize`(`RequiredRows` from the upper executor) is set to a smaller value. Don't replace it.

And add some hack for #50344, to make sure that at least we have some ways to improve its performance.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
