### PR TITLE
executor: populate correct user in set pwd for error msg

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -2445,7 +2445,8 @@ func (e *SimpleExec) executeSetPwd(ctx context.Context, s *ast.SetPwdStmt) error
 		checker := privilege.GetPrivilegeManager(e.Ctx())
 		activeRoles := e.Ctx().GetSessionVars().ActiveRoles
 		if checker != nil && !checker.RequestVerification(activeRoles, "", "", "", mysql.SuperPriv) {
-			return exeerrors.ErrDBaccessDenied.GenWithStackByArgs(u, h, "mysql")
+			currUser := e.Ctx().GetSessionVars().User
+			return exeerrors.ErrDBaccessDenied.GenWithStackByArgs(currUser.Username, currUser.Hostname, "mysql")
 		}
 	}
 	exists, err := userExistsInternal(ctx, sqlExecutor, u, h)

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -479,7 +479,7 @@ func TestSetPwd(t *testing.T) {
 	tk2 := testkit.NewTestKit(t, store)
 	require.NoError(t, tk2.Session().Auth(&auth.UserIdentity{Username: "u2", Hostname: "localhost"}, nil, nil, nil))
 	// Should have the correct error message saying u2 does not have enough privileges.
-	tk2.MustContainErrMsg("set password for 'u1'='randompassword'", "[executor:1044]Access denied for user 'u2'@'%' to database 'mysql'")
+	tk2.MustContainErrMsg("set password for 'u1'='randompassword'", "[executor:1044]Access denied for user 'u2'@'localhost' to database 'mysql'")
 }
 
 func TestFlushPrivilegesPanic(t *testing.T) {

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -479,7 +479,7 @@ func TestSetPwd(t *testing.T) {
 	tk2 := testkit.NewTestKit(t, store)
 	require.NoError(t, tk2.Session().Auth(&auth.UserIdentity{Username: "u2", Hostname: "localhost"}, nil, nil, nil))
 	// Should have the correct error message saying u2 does not have enough privileges.
-	tk2.MustContainErrMsg("set password for 'u1'='randompassword'", "[executor:1044]Access denied for user 'u2'@'localhost' to database 'mysql'")
+	tk2.MustContainErrMsg("set password for 'u1'='randompassword'", "[executor:1044]Access denied for user 'u2'")
 }
 
 func TestFlushPrivilegesPanic(t *testing.T) {

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -467,6 +467,19 @@ func TestSetPwd(t *testing.T) {
 	tk.MustExec(setPwdSQL)
 	result = tk.MustQuery(`SELECT authentication_string FROM mysql.User WHERE User="testpwd" and Host="localhost"`)
 	result.Check(testkit.Rows(auth.EncodePassword("pwd")))
+
+	// Test running SET PASSWORD FOR without sufficient privileges.
+	// Create user u1 with super privilege.
+	tk.MustExec("create user 'u1'")
+	tk.MustExec("grant super on *.* to u1")
+	// Create user u2 with create user privilege.
+	tk.MustExec("create user 'u2'")
+	tk.MustExec("grant create user on *.* to u2")
+
+	tk2 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk2.Session().Auth(&auth.UserIdentity{Username: "u2", Hostname: "localhost"}, nil, nil, nil))
+	// Should have the correct error message saying u2 does not have enough privileges.
+	tk2.MustContainErrMsg("set password for 'u1'='randompassword'", "[executor:1044]Access denied for user 'u2'@'%' to database 'mysql'")
 }
 
 func TestFlushPrivilegesPanic(t *testing.T) {

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -509,7 +509,7 @@ GRANT ALL ON *.* TO 'superuser';
 SET PASSWORD for 'nobodyuser' = 'newpassword';
 SET PASSWORD for 'nobodyuser' = '';
 SET PASSWORD for 'superuser' = 'newpassword';
-Error 1044 (42000): Access denied for user 'superuser'@'%' to database 'mysql'
+Error 1044 (42000): Access denied for user 'nobodyuser'@'127.0.0.1' to database 'mysql'
 CREATE ROLE tsg_r1;
 CREATE USER tsg_u1, tsg_u2;
 GRANT CONNECTION_ADMIN, ROLE_ADMIN, SYSTEM_VARIABLES_ADMIN, PROCESS ON *.* TO tsg_r1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
Fixes the wrong user and host info when `SET PASSWORD FOR` fails with insufficient privilege to be consistent with MySQL behavior.

Issue Number: close #54039

Problem Summary:

When populating the error message when the current user lacks sufficient privileges for executing `SET PASSWORD FOR` for another user, the current code used the wrong user/host info in the error message.

### What changed and how does it work?
Use the current session's user name/host in the error message.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue where incorrect user is populated in SET PASSWORD's error message when the current user doesn't have enough privileges
```
