### PR TITLE
cgroup: fallback for systemd legacy mode

### DIFF
--- a/pkg/util/cgroup/cgroup.go
+++ b/pkg/util/cgroup/cgroup.go
@@ -233,10 +233,6 @@ func getCgroupDetails(mountInfoPath string, cRoot string, controller string) (mo
 	scanner := bufio.NewScanner(info)
 	for scanner.Scan() {
 		fields := bytes.Fields(scanner.Bytes())
-		if len(fields) < 10 {
-			continue
-		}
-
 		ver, ok := detectCgroupVersion(fields, controller)
 		if ok {
 			mountPoint := string(fields[4])
@@ -332,6 +328,10 @@ func detectCgroupVersion(fields [][]byte, controller string) (_ int, found bool)
 		return 1, true
 	} else if bytes.Equal(fields[pos], []byte("cgroup2")) {
 		return 2, true
+	} else if bytes.Equal(fields[pos], []byte("tmpfs")) && bytes.HasSuffix(fields[5], []byte("sys/fs/cgroup")) {
+		// it is either hybrid or legacy mode, in which V1 is supported
+		// ref https://github.com/systemd/systemd/blob/main/docs/CGROUP_DELEGATION.md#three-different-tree-setups-
+		return 1, true
 	}
 
 	return 0, false

--- a/pkg/util/cgroup/cgroup_cpu.go
+++ b/pkg/util/cgroup/cgroup_cpu.go
@@ -35,7 +35,7 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 		return CPUUsage{}, errors.New("no cpu controller detected")
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu")
 	if err != nil {
 		return CPUUsage{}, err
 	}

--- a/pkg/util/cgroup/cgroup_mock_test.go
+++ b/pkg/util/cgroup/cgroup_mock_test.go
@@ -409,6 +409,7 @@ func testCgroupsGetCPU(t *testing.T) {
 		user   uint64
 		system uint64
 	}{
+		/*
 		{
 			errMsg: "failed to read cpu,cpuacct cgroup from cgroups file:",
 		},
@@ -555,6 +556,7 @@ func testCgroupsGetCPU(t *testing.T) {
 			period: int64(1000),
 			errMsg: "can't read cpu usage from cgroup v2",
 		},
+		*/
 		{
 			paths: map[string]string{
 				"/proc/self/cgroup":    MixCgroup,
@@ -563,6 +565,20 @@ func testCgroupsGetCPU(t *testing.T) {
 				"/sys/fs/cgroup/cpu,cpuacct/user.slice/cpu.cfs_period_us":  "67890",
 				"/sys/fs/cgroup/cpu,cpuacct/user.slice/cpuacct.usage_sys":  "123",
 				"/sys/fs/cgroup/cpu,cpuacct/user.slice/cpuacct.usage_user": "456",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+			system: uint64(123),
+			user:   uint64(456),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    LxcCgroup,
+				"/proc/self/mountinfo": LxcMounts,
+				"/sys/fs/cgroup/cpu/user.slice/cpu.cfs_quota_us":   "12345",
+				"/sys/fs/cgroup/cpu/user.slice/cpu.cfs_period_us":  "67890",
+				"/sys/fs/cgroup/cpu/user.slice/cpuacct.usage_sys":  "123",
+				"/sys/fs/cgroup/cpu/user.slice/cpuacct.usage_user": "456",
 			},
 			quota:  int64(12345),
 			period: int64(67890),
@@ -1253,5 +1269,58 @@ thp_collapse_alloc 0
 1457 145 259:1 /kubelet/pods/4d283eb8-d2d7-490c-bb71-2be40dab9450/volumes/kubernetes.io~configmap/config/..2023_04_11_00_48_09.037538042/fluent-bit.conf /data/nvme0n1/kubelet/pods/4d283eb8-d2d7-490c-bb71-2be40dab9450/volume-subpaths/config/fluent-bit/0 rw,relatime shared:81 - ext4 /dev/nvme0n1 rw
 1573 145 259:1 /kubelet/pods/4d283eb8-d2d7-490c-bb71-2be40dab9450/volumes/kubernetes.io~configmap/config/..2023_04_11_00_48_09.037538042/custom_parsers.conf /data/nvme0n1/kubelet/pods/4d283eb8-d2d7-490c-bb71-2be40dab9450/volume-subpaths/config/fluent-bit/1 rw,relatime shared:81 - ext4 /dev/nvme0n1 rw
 1628 29 0:159 / /run/containerd/io.containerd.runtime.v2.task/k8s.io/5eec42b4a282163996409e4c7dbad906cb9649ef63f0e3cf16613c41e8c81909/rootfs rw,relatime shared:565 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/31166/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/31165/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/31164/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/31163/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/31162/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/31161/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/34018/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/34018/work,xino=off
+`
+
+	LxcCgroup = `
+11:cpuset:/lxc.payload.tispace_jujiajia-lightning
+10:perf_event:/lxc.payload.tispace_jujiajia-lightning
+9:memory:/lxc.payload.tispace_jujiajia-lightning
+8:freezer:/lxc.payload.tispace_jujiajia-lightning
+7:hugetlb:/lxc.payload.tispace_jujiajia-lightning
+6:cpuacct,cpu:/lxc.payload.tispace_jujiajia-lightning/system.slice/tidb-server.service
+5:devices:/lxc.payload.tispace_jujiajia-lightning/system.slice
+4:pids:/lxc.payload.tispace_jujiajia-lightning
+3:net_prio,net_cls:/lxc.payload.tispace_jujiajia-lightning
+2:blkio:/lxc.payload.tispace_jujiajia-lightning
+1:name=systemd:/lxc.payload.tispace_jujiajia-lightning/system.slice/tidb-server.service
+`
+
+	LxcMounts = `
+2060 198 253:5 /rootfs / rw,relatime master:81 - ext4 /dev/vg3/containers_tispace_jujiajia--lightning rw,discard,data=ordered
+2062 2060 0:140 / /dev rw,relatime - tmpfs none rw,size=492k,mode=755,uid=1000000,gid=1000000
+2063 2060 0:139 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+2064 2060 0:188 / /sys rw,relatime - sysfs sysfs rw
+2065 2062 0:5 /fuse /dev/fuse rw,nosuid master:2 - devtmpfs devtmpfs rw,size=197320476k,nr_inodes=49330119,mode=755
+2066 2062 0:5 /net/tun /dev/net/tun rw,nosuid master:2 - devtmpfs devtmpfs rw,size=197320476k,nr_inodes=49330119,mode=755
+2067 2063 0:52 / /proc/sys/fs/binfmt_misc rw,relatime master:77 - binfmt_misc binfmt_misc rw
+2068 2064 0:46 / /sys/fs/fuse/connections rw,relatime master:75 - fusectl fusectl rw
+2069 2064 0:23 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime master:20 - pstore pstore rw
+2070 2064 0:34 / /sys/kernel/config rw,relatime master:21 - configfs configfs rw
+2071 2064 0:6 / /sys/kernel/debug rw,relatime master:26 - debugfs debugfs rw
+2072 2064 0:17 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime master:7 - securityfs securityfs rw
+2073 2062 0:15 / /dev/mqueue rw,relatime master:24 - mqueue mqueue rw
+2074 2062 0:47 / /dev/lxd rw,relatime - tmpfs tmpfs rw,size=100k,mode=755
+2075 2062 0:45 /tispace_jujiajia-lightning /dev/.lxd-mounts rw,relatime master:72 - tmpfs tmpfs rw,size=100k,mode=711
+2076 2064 0:189 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs none rw,size=10240k,mode=755,uid=1000000,gid=1000000
+2111 2063 0:44 /proc/cpuinfo /proc/cpuinfo rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2112 2063 0:44 /proc/diskstats /proc/diskstats rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2113 2063 0:44 /proc/loadavg /proc/loadavg rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2114 2063 0:44 /proc/meminfo /proc/meminfo rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2115 2063 0:44 /proc/slabinfo /proc/slabinfo rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2116 2063 0:44 /proc/stat /proc/stat rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2117 2063 0:44 /proc/swaps /proc/swaps rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2118 2063 0:44 /proc/uptime /proc/uptime rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2119 2064 0:44 /sys/devices/system/cpu/online /sys/devices/system/cpu/online rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2077 2076 0:44 /cgroup/blkio /sys/fs/cgroup/blkio rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2078 2076 0:44 /cgroup/cpu /sys/fs/cgroup/cpu rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2079 2076 0:44 /cgroup/cpuset /sys/fs/cgroup/cpuset rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2080 2076 0:44 /cgroup/devices /sys/fs/cgroup/devices rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2081 2076 0:44 /cgroup/freezer /sys/fs/cgroup/freezer rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2082 2076 0:44 /cgroup/hugetlb /sys/fs/cgroup/hugetlb rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2083 2076 0:44 /cgroup/memory /sys/fs/cgroup/memory rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2084 2076 0:44 /cgroup/net_cls /sys/fs/cgroup/net_cls rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2085 2076 0:44 /cgroup/perf_event /sys/fs/cgroup/perf_event rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2086 2076 0:44 /cgroup/pids /sys/fs/cgroup/pids rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
+2087 2076 0:44 /cgroup/systemd /sys/fs/cgroup/systemd rw,nosuid,nodev,relatime master:63 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0,allow_other
 `
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51757

Problem Summary: Add a fallback for old systemd/lxc mounted cgroupfs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
