### PR TITLE
expression: truncate time part for current_date columns

### DIFF
--- a/pkg/expression/helper.go
+++ b/pkg/expression/helper.go
@@ -92,14 +92,22 @@ func GetTimeValue(ctx BuildContext, v any, tp byte, fsp int, explicitTz *time.Lo
 	switch x := v.(type) {
 	case string:
 		lowerX := strings.ToLower(x)
-		if lowerX == ast.CurrentTimestamp || lowerX == ast.CurrentDate {
+		switch lowerX {
+		case ast.CurrentTimestamp:
 			if value, err = getTimeCurrentTimeStamp(ctx.GetEvalCtx(), tp, fsp); err != nil {
 				return d, err
 			}
-		} else if lowerX == types.ZeroDatetimeStr {
+		case ast.CurrentDate:
+			if value, err = getTimeCurrentTimeStamp(ctx.GetEvalCtx(), tp, fsp); err != nil {
+				return d, err
+			}
+			yy, mm, dd := value.Year(), value.Month(), value.Day()
+			truncated := types.FromDate(yy, mm, dd, 0, 0, 0, 0)
+			value.SetCoreTime(truncated)
+		case types.ZeroDatetimeStr:
 			value, err = types.ParseTimeFromNum(tc, 0, tp, fsp)
 			terror.Log(err)
-		} else {
+		default:
 			value, err = types.ParseTime(tc, x, tp, fsp)
 			if err != nil {
 				return d, err

--- a/tests/integrationtest/r/executor/write.result
+++ b/tests/integrationtest/r/executor/write.result
@@ -2149,6 +2149,6 @@ drop table t1, t2;
 drop table if exists t;
 create table t (a date default current_date);
 insert into t values();
-select count(1) from t where a = date(now());
+select count(1) from t where a = date(a);
 count(1)
 1

--- a/tests/integrationtest/r/executor/write.result
+++ b/tests/integrationtest/r/executor/write.result
@@ -2146,3 +2146,9 @@ Error 1364 (HY000): Field 'pk' doesn't have a default value
 replace t2 set c=default(a);
 Error 3105 (HY000): The value specified for generated column 'c' in table 't2' is not allowed.
 drop table t1, t2;
+drop table if exists t;
+create table t (a date default current_date);
+insert into t values();
+select count(1) from t where a = date(now());
+count(1)
+1

--- a/tests/integrationtest/t/executor/write.test
+++ b/tests/integrationtest/t/executor/write.test
@@ -1354,4 +1354,4 @@ drop table t1, t2;
 drop table if exists t;
 create table t (a date default current_date);
 insert into t values();
-select count(1) from t where a = date(now());
+select count(1) from t where a = date(a);

--- a/tests/integrationtest/t/executor/write.test
+++ b/tests/integrationtest/t/executor/write.test
@@ -1350,3 +1350,8 @@ replace t2 set a=default(a), c=default(c);
 replace t2 set c=default(a);
 drop table t1, t2;
 
+# TestIssue53746
+drop table if exists t;
+create table t (a date default current_date);
+insert into t values();
+select count(1) from t where a = date(now());


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/53746

Problem Summary:

When TiDB uses `current_date` as default value, "hour:minuate:second" is not truncated correctly. As a result, the queries with equal condition cannot match.

### What changed and how does it work?

Truncate time part for `current_date`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
