### PR TITLE
statistics: do not load unnecessary index statistics

### DIFF
--- a/pkg/statistics/handle/handle_hist.go
+++ b/pkg/statistics/handle/handle_hist.go
@@ -368,9 +368,9 @@ func (*Handle) readStatsForOneItem(sctx sessionctx.Context, item model.TableItem
 		return nil, errors.Trace(err)
 	}
 	if len(rows) == 0 {
-		logutil.BgLogger().Error("fail to get stats version for this histogram", zap.Int64("table_id", item.TableID),
+		logutil.BgLogger().Error("fail to get stats version for this histogram, normally this wouldn't happen, please check if this column or index has a histogram record in `mysql.stats_histogram`", zap.Int64("table_id", item.TableID),
 			zap.Int64("hist_id", item.ID), zap.Bool("is_index", item.IsIndex))
-		return nil, errors.Trace(fmt.Errorf("fail to get stats version for this histogram, table_id:%v, hist_id:%v, is_index:%v", item.TableID, item.ID, item.IsIndex))
+		return nil, errors.Trace(fmt.Errorf("fail to get stats version for this histogram, normally this wouldn't happen, please check if this column or index has a histogram record in `mysql.stats_histogram`, table_id:%v, hist_id:%v, is_index:%v", item.TableID, item.ID, item.IsIndex))
 	}
 	statsVer := rows[0].GetInt64(0)
 	if item.IsIndex {

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -581,7 +581,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache util.StatsCac
 	if !ok || !index.IsLoadNeeded() {
 		if !index.IsLoadNeeded() {
 			logutil.BgLogger().Warn(
-				"Although the index stats is not required to load, an attempt is still made to load it. Please verify if this index has any histogram records in the `mysql.stats_histograms` table.",
+				"Although the index stats is not required to load, an attempt is still made to load it.",
 				zap.Int64("table_id", idx.TableID), zap.Int64("hist_id", idx.ID),
 			)
 		}

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -577,6 +577,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache util.StatsCac
 	}
 	index, ok := tbl.Indices[idx.ID]
 	// Double check if the index is really needed to load.
+	// If we don't do this it might cause a memory leak.
 	// See: https://github.com/pingcap/tidb/issues/54022
 	if !ok || !index.IsLoadNeeded() {
 		if !index.IsLoadNeeded() {

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -540,8 +540,8 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsCache util.StatsCa
 		return errors.Trace(err)
 	}
 	if len(rows) == 0 {
-		logutil.BgLogger().Error("fail to get stats version for this histogram", zap.Int64("table_id", col.TableID), zap.Int64("hist_id", col.ID))
-		return errors.Trace(fmt.Errorf("fail to get stats version for this histogram, table_id:%v, hist_id:%v", col.TableID, col.ID))
+		logutil.BgLogger().Error("fail to get stats version for this histogram, normally this wouldn't happen, please check if this column or index has a histogram record in `mysql.stats_histogram`", zap.Int64("table_id", col.TableID), zap.Int64("column_id", col.ID))
+		return errors.Trace(fmt.Errorf("fail to get stats version for this histogram, normally this wouldn't happen, please check if this column or index has a histogram record in `mysql.stats_histogram`, table_id:%v, column_id:%v", col.TableID, col.ID))
 	}
 	statsVer := rows[0].GetInt64(0)
 	colHist := &statistics.Column{
@@ -608,8 +608,8 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache util.StatsCac
 		return errors.Trace(err)
 	}
 	if len(rows) == 0 {
-		logutil.BgLogger().Error("fail to get stats version for this histogram", zap.Int64("table_id", idx.TableID), zap.Int64("hist_id", idx.ID))
-		return errors.Trace(fmt.Errorf("fail to get stats version for this histogram, table_id:%v, hist_id:%v", idx.TableID, idx.ID))
+		logutil.BgLogger().Error("fail to get stats version for this histogram, normally this wouldn't happen, please check if this column or index has a histogram record in `mysql.stats_histogram`", zap.Int64("table_id", idx.TableID), zap.Int64("index_id", idx.ID))
+		return errors.Trace(fmt.Errorf("fail to get stats version for this histogram, normally this wouldn't happen, please check if this column or index has a histogram record in `mysql.stats_histogram`, table_id:%v, index_id:%v", idx.TableID, idx.ID))
 	}
 	idxHist := &statistics.Index{Histogram: *hg, CMSketch: cms, TopN: topN, FMSketch: fms,
 		Info: index.Info, StatsVer: rows[0].GetInt64(0),

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -582,7 +582,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, statsCache util.StatsCac
 	if !ok || !index.IsLoadNeeded() {
 		if !index.IsLoadNeeded() {
 			logutil.BgLogger().Warn(
-				"Although the index stats is not required to load, an attempt is still made to load it.",
+				"Although the index stats is not required to load, an attempt is still made to load it, skip it",
 				zap.Int64("table_id", idx.TableID), zap.Int64("hist_id", idx.ID),
 			)
 		}

--- a/tests/realtikvtest/statisticstest/BUILD.bazel
+++ b/tests/realtikvtest/statisticstest/BUILD.bazel
@@ -10,6 +10,8 @@ go_test(
     flaky = True,
     race = "on",
     deps = [
+        "//pkg/parser/model",
+        "//pkg/statistics",
         "//pkg/testkit",
         "//tests/realtikvtest",
         "@com_github_stretchr_testify//require",

--- a/tests/realtikvtest/statisticstest/statistics_test.go
+++ b/tests/realtikvtest/statisticstest/statistics_test.go
@@ -241,7 +241,8 @@ func TestNoNeedIndexStatsLoading(t *testing.T) {
 	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test;")
-	tk.MustExec("create table t(a int, b int, index ia(a));")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table if not exists t(a int, b int, index ia(a));")
 	tk.MustExec("drop stats t;")
 	tk.MustExec("insert into t value(1,1), (2,2);")
 	require.Eventually(t, func() bool {

--- a/tests/realtikvtest/statisticstest/statistics_test.go
+++ b/tests/realtikvtest/statisticstest/statistics_test.go
@@ -248,7 +248,7 @@ func TestNoNeedIndexStatsLoading(t *testing.T) {
 	require.Eventually(t, func() bool {
 		rows := tk.MustQuery("show stats_meta").Rows()
 		return len(rows) > 0
-	}, 2*time.Minute, 30*time.Millisecond)
+	}, 2*time.Minute, 5*time.Millisecond)
 	tk.MustExec("set tidb_opt_objective='determinate';")
 	tk.MustQuery("select * from t where a = 1 and b = 1;").Check(testkit.Rows("1 1"))
 	table, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54022

Problem Summary:

See more at the issue. 

A quick summary:
If you have `tidb_opt_objective='determine'` enabled, it will trigger some async stats load for some tables. If there tables histogram isn't in the system, it would cause some problems when we try to load it.

### What changed and how does it work?

Check that the index statistics are really needed before loading them.

If we don't check it here, it will cause some problems if the index statistics don't exist.

**Note:** We still don't know why the histogram record for the index is missing. There are some possible issues:

1. When users create this table, they may not have created this index yet, so we don't create the record for it automatically. (But if this is the case, I don't why do we have the index in the stats cache information)
2. It may have been accidentally dropped, but I can't find any scenario where we would only drop one index for a table.

What happened in the test case:
1. We create a table and the `statsHandle.Update(do.InfoSchema())` will load this table into the stats cache. You can test it by breakpoint here:
![image](https://github.com/pingcap/tidb/assets/29879298/bffe734e-4420-487c-af98-5926a77c7d1c)
3. We drop the stats of the stats, it will clean up all system table records for this table.
4. We insert some data and wait for the modfiy_count and the count is not null in the `mysql.stats_meta`.
5. Try to select some data from this table by ID, it would trigger an async load. Then we get that bug.
https://github.com/hi-rustin/tidb/blob/648fc6386aa9aabb365baf0912f1e18c4ab74d95/pkg/planner/core/logical_plan_builder.go#L4824
6. So in the test case we check if the index is still in the needed item array after we fix it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/54060#issuecomment-2174949286)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a memory leak when loading index statistics.
修复加载 index 统计信息可能会造成内存泄漏的问题
```
