### PR TITLE
expression: correct the erroneous scalar function equivalence check

### DIFF
--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -365,6 +365,9 @@ func (sf *ScalarFunction) Equal(ctx EvalContext, e Expression) bool {
 	if sf.FuncName.L != fun.FuncName.L {
 		return false
 	}
+	if sf.RetType != fun.RetType {
+		return false
+	}
 	return sf.Function.equal(ctx, fun.Function)
 }
 

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -365,7 +365,7 @@ func (sf *ScalarFunction) Equal(ctx EvalContext, e Expression) bool {
 	if sf.FuncName.L != fun.FuncName.L {
 		return false
 	}
-	if sf.RetType != fun.RetType {
+	if !sf.RetType.Equal(fun.RetType) {
 		return false
 	}
 	return sf.Function.equal(ctx, fun.Function)

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -259,7 +259,7 @@ func TestSubstituteCorCol2Constant(t *testing.T) {
 	ret, err = SubstituteCorCol2Constant(ctx, plus3)
 	require.NoError(t, err)
 	ans3 := newFunctionWithMockCtx(ast.Plus, ans1, col1)
-	require.True(t, ret.Equal(ctx, ans3))
+	require.False(t, ret.Equal(ctx, ans3))
 }
 
 func TestPushDownNot(t *testing.T) {

--- a/pkg/parser/types/field_type.go
+++ b/pkg/parser/types/field_type.go
@@ -289,7 +289,7 @@ func (ft *FieldType) Equal(other *FieldType) bool {
 	// because flen for them is useless.
 	// The decimal field can be ignored if the type is int or string.
 	tpEqual := (ft.GetType() == other.GetType()) || (ft.GetType() == mysql.TypeVarchar && other.GetType() == mysql.TypeVarString) || (ft.GetType() == mysql.TypeVarString && other.GetType() == mysql.TypeVarchar)
-	flenEqual := ft.flen == other.flen || (ft.EvalType() == ETReal && ft.decimal == UnspecifiedLength)
+	flenEqual := ft.flen == other.flen || (ft.EvalType() == ETReal && ft.decimal == UnspecifiedLength) || ft.EvalType() == ETJson
 	ignoreDecimal := ft.EvalType() == ETInt || ft.EvalType() == ETString
 	partialEqual := tpEqual &&
 		(ignoreDecimal || ft.decimal == other.decimal) &&

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -58,3 +58,31 @@ func TestIssue43461(t *testing.T) {
 
 	require.NotEqual(t, is.Columns, ts.Columns)
 }
+
+func Test53726(t *testing.T) {
+	// test for RemoveUnnecessaryFirstRow
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t7(c int); ")
+	tk.MustExec("insert into t7 values (575932053), (-258025139);")
+	tk.MustQuery("select distinct cast(c as decimal), cast(c as signed) from t7").
+		Sort().Check(testkit.Rows("-258025139 -258025139", "575932053 575932053"))
+	tk.MustQuery("explain select distinct cast(c as decimal), cast(c as signed) from t7").
+		Check(testkit.Rows(
+			"HashAgg_8 8000.00 root  group by:Column#7, Column#8, funcs:firstrow(Column#7)->Column#3, funcs:firstrow(Column#8)->Column#4",
+			"└─TableReader_9 8000.00 root  data:HashAgg_4",
+			"  └─HashAgg_4 8000.00 cop[tikv]  group by:cast(test.t7.c, bigint(22) BINARY), cast(test.t7.c, decimal(10,0) BINARY), ",
+			"    └─TableFullScan_7 10000.00 cop[tikv] table:t7 keep order:false, stats:pseudo"))
+
+	tk.MustExec("analyze table t7")
+	tk.MustQuery("select distinct cast(c as decimal), cast(c as signed) from t7").
+		Sort().
+		Check(testkit.Rows("-258025139 -258025139", "575932053 575932053"))
+	tk.MustQuery("explain select distinct cast(c as decimal), cast(c as signed) from t7").
+		Check(testkit.Rows(
+			"HashAgg_6 2.00 root  group by:Column#13, Column#14, funcs:firstrow(Column#11)->Column#3, funcs:firstrow(Column#12)->Column#4",
+			"└─Projection_12 2.00 root  cast(test.t7.c, decimal(10,0) BINARY)->Column#11, cast(test.t7.c, bigint(22) BINARY)->Column#12, cast(test.t7.c, decimal(10,0) BINARY)->Column#13, cast(test.t7.c, bigint(22) BINARY)->Column#14",
+			"  └─TableReader_11 2.00 root  data:TableFullScan_10",
+			"    └─TableFullScan_10 2.00 cop[tikv] table:t7 keep order:false"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53726

Problem Summary:

### What changed and how does it work?

when planer call ```RemoveUnnecessaryFirstRow```. it will check the expression between ```Agg``` and ```GroupBy```. but it doesn't check the return type. so it get wrong unnecessary ```FirstRow```.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
