### PR TITLE
executor: remove redundant memory pre-allocations in parallel sort executor

### DIFF
--- a/pkg/executor/sortexec/parallel_sort_worker.go
+++ b/pkg/executor/sortexec/parallel_sort_worker.go
@@ -62,7 +62,6 @@ func newParallelSortWorker(
 	sortedRowsIter *chunk.Iterator4Slice,
 	maxChunkSize int,
 	spillHelper *parallelSortSpillHelper) *parallelSortWorker {
-	maxSortedRowsLimit := maxChunkSize * 30
 	return &parallelSortWorker{
 		workerIDForTest:        workerIDForTest,
 		lessRowFunc:            lessRowFunc,
@@ -73,9 +72,9 @@ func newParallelSortWorker(
 		timesOfRowCompare:      0,
 		memTracker:             memTracker,
 		sortedRowsIter:         sortedRowsIter,
-		maxSortedRowsLimit:     maxSortedRowsLimit,
+		maxSortedRowsLimit:     maxChunkSize * 30,
 		spillHelper:            spillHelper,
-		batchRows:              make([]chunk.Row, 0, maxSortedRowsLimit),
+		batchRows:              make([]chunk.Row, 0),
 	}
 }
 
@@ -129,7 +128,7 @@ func (p *parallelSortWorker) multiWayMergeLocalSortedRows() ([]chunk.Row, error)
 func (p *parallelSortWorker) sortBatchRows() {
 	slices.SortFunc(p.batchRows, p.keyColumnsLess)
 	p.localSortedRows = append(p.localSortedRows, chunk.NewIterator4Slice(p.batchRows))
-	p.batchRows = make([]chunk.Row, 0, p.maxSortedRowsLimit)
+	p.batchRows = make([]chunk.Row, 0)
 }
 
 func (p *parallelSortWorker) sortLocalRows() ([]chunk.Row, error) {

--- a/pkg/executor/sortexec/sort.go
+++ b/pkg/executor/sortexec/sort.go
@@ -382,7 +382,7 @@ func (e *SortExec) generateResultFromMemory() (bool, error) {
 	}
 
 	maxChunkSize := e.MaxChunkSize()
-	resBuf := make([]rowWithError, 0)
+	resBuf := make([]rowWithError, 0, 3)
 	idx := int64(0)
 	var row chunk.Row
 	for {

--- a/pkg/executor/sortexec/sort.go
+++ b/pkg/executor/sortexec/sort.go
@@ -382,7 +382,7 @@ func (e *SortExec) generateResultFromMemory() (bool, error) {
 	}
 
 	maxChunkSize := e.MaxChunkSize()
-	resBuf := make([]rowWithError, 0, maxChunkSize)
+	resBuf := make([]rowWithError, 0)
 	idx := int64(0)
 	var row chunk.Row
 	for {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54070

Problem Summary:

### What changed and how does it work?

From clinic we can see that tidb memory usage is larger than normal and most of memory are allocated in sort executor. So we suspect that it's too many allocations which caused the performance regression.
![mem-cmp](https://github.com/pingcap/tidb/assets/15918072/0c70b60a-ceeb-4747-a43e-873da6ba6594)
![memory](https://github.com/pingcap/tidb/assets/15918072/1293cbf9-1691-460f-b086-23ef11e3686e)

To verify our suspicion we check the cpu usage and find that most cpu are consumed by memory allocation in sort executor. Moreover, GC STW Duration is very high. So I think we can ensure that it's too memory allocation who causes the performance regression in benchbot.
![cpu](https://github.com/pingcap/tidb/assets/15918072/40ddbebd-b003-4ff1-9da6-4172241d97cf)
![stw](https://github.com/pingcap/tidb/assets/15918072/306d3569-c7a9-4d8a-b51e-13d6a9356bdf)

In order to eliminate the memory re-allocation when slice expands, we set a large capacity when creating slices. However, It's a waste to reserving so many memory and wasted memory will be very large because tp sqls usually process few rows while sort executos will be created for many times(showed in the following picture). So I think we can remove the pre-allocation in sort executor to fix this regression. I think this fix will not have a strong impact on sort performance because main bottleneck in parallel sort is io, not memory allocation.
![sort](https://github.com/pingcap/tidb/assets/15918072/fcd26ce7-c1b5-40ff-aee5-a601b30dd888)

With this pr, performance regression is fixed.
![20240618-152416](https://github.com/pingcap/tidb/assets/15918072/a65850d2-3252-426c-9621-f95c2ea00455)

fixed:
BenchmarkUnionScanTableReadDescRead:
1863      618281 ns/op    148918 B/op     2677 allocs/op
BenchmarkUnionScanIndexReadDescRead:
1922      620293 ns/op    153910 B/op     2750 allocs/op
BenchmarkUnionScanIndexLookUpDescRead:
1744      673479 ns/op    248234 B/op     2820 allocs/op

master:
BenchmarkUnionScanTableReadDescRead:
1826      599392 ns/op    215502 B/op     2674 allocs/op
BenchmarkUnionScanIndexReadDescRead:
1964      593482 ns/op    219032 B/op     2740 allocs/op
BenchmarkUnionScanIndexLookUpDescRead:
1791      659653 ns/op    320267 B/op     2815 allocs/op

dataset: tpch10
sql1: explain analyze select L_COMMENT, L_EXTENDEDPRICE from lineitem where L_SUPPKEY > 95000 order by L_COMMENT desc, L_EXTENDEDPRICE asc;

sql2: explain analyze select * from lineitem where L_SUPPKEY > 95000 order by L_COMMENT desc, L_EXTENDEDPRICE asc;

  | Sql1 | Sql2
-- | -- | --
Master | 7.30s | 15.36s
Fixed | 6.94s | 16.36s

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Remove redundant memory pre-allocations in parallel sort executor
```
