### PR TITLE
br: fix backoffer can't handle multierrs

### DIFF
--- a/br/pkg/restore/import_retry_test.go
+++ b/br/pkg/restore/import_retry_test.go
@@ -592,21 +592,21 @@ func TestFilterFilesByRegion(t *testing.T) {
 	}
 }
 
-func TestRetryRecognizeErrCode (t *testing.T) {
-	waitTime := 1*time.Millisecond
-	maxWaitTime := 16*time.Millisecond
+func TestRetryRecognizeErrCode(t *testing.T) {
+	waitTime := 1 * time.Millisecond
+	maxWaitTime := 16 * time.Millisecond
 	ctx := context.Background()
 	inner := 0
 	outer := 0
 	utils.WithRetry(ctx, func() error {
 		e := utils.WithRetry(ctx, func() error {
-			inner ++
+			inner++
 			e := status.Error(codes.Unavailable, "the connection to TiKV has been cut by a neko, meow :3")
 			if e != nil {
 				return errors.Trace(e)
 			}
 			return nil
-			}, utils.NewBackoffer(10, waitTime, maxWaitTime, utils.NewErrorContext("download sst", 3)))
+		}, utils.NewBackoffer(10, waitTime, maxWaitTime, utils.NewErrorContext("download sst", 3)))
 		outer++
 		return errors.Trace(e)
 	}, utils.NewBackoffer(10, waitTime, maxWaitTime, utils.NewErrorContext("import sst", 3)))

--- a/br/pkg/restore/import_retry_test.go
+++ b/br/pkg/restore/import_retry_test.go
@@ -593,20 +593,24 @@ func TestFilterFilesByRegion(t *testing.T) {
 }
 
 func TestRetryRecognizeErrCode (t *testing.T) {
-	waitTime := 10*time.Millisecond
-	maxWaitTime := 10*time.Millisecond
+	waitTime := 1*time.Millisecond
+	maxWaitTime := 16*time.Millisecond
 	ctx := context.Background()
-	cnt := 0
+	inner := 0
+	outer := 0
 	utils.WithRetry(ctx, func() error {
 		e := utils.WithRetry(ctx, func() error {
-			cnt ++
-				e := status.Error(codes.Unavailable, "the connection to TiKV has been cut by a neko, meow :3")
-				if e != nil {
-					return errors.Trace(e)
-				}
-				return nil
-			}, utils.NewBackoffer(8, waitTime, maxWaitTime, utils.NewErrorContext("download sst", 3)))
+			inner ++
+			e := status.Error(codes.Unavailable, "the connection to TiKV has been cut by a neko, meow :3")
+			if e != nil {
+				return errors.Trace(e)
+			}
+			return nil
+			}, utils.NewBackoffer(10, waitTime, maxWaitTime, utils.NewErrorContext("download sst", 3)))
+		outer++
 		return errors.Trace(e)
-	}, utils.NewBackoffer(16, waitTime, maxWaitTime, utils.NewErrorContext("import sst", 3)))
-	require.Equal(t, 64, cnt)
+	}, utils.NewBackoffer(10, waitTime, maxWaitTime, utils.NewErrorContext("import sst", 3)))
+	// require.Error(t, ctx.Err())
+	require.Equal(t, 10, outer)
+	require.Equal(t, 100, inner)
 }

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -152,12 +153,14 @@ func NewDownloadSSTBackoffer() Backoffer {
 
 func (bo *importerBackoffer) NextBackoff(err error) time.Duration {
 	// we don't care storeID here.
-	res := bo.errContext.HandleErrorMsg(err.Error(), 0)
+	errs := multierr.Errors(err)
+	lastErr := errs[len(errs)-1]
+	res := bo.errContext.HandleErrorMsg(lastErr.Error(), 0)
 	if res.Strategy == RetryStrategy {
 		bo.delayTime = 2 * bo.delayTime
 		bo.attempt--
 	} else {
-		e := errors.Cause(err)
+		e := errors.Cause(lastErr)
 		switch e { // nolint:errorlint
 		case berrors.ErrKVEpochNotMatch, berrors.ErrKVDownloadFailed, berrors.ErrKVIngestFailed, berrors.ErrPDLeaderNotFound:
 			bo.delayTime = 2 * bo.delayTime


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54053

Problem Summary:

Backoffer can't recognize multierrs, therefore it would stop retry for recursive retry calling

### What changed and how does it work?

Enable backoffer to recognize the multierr, and it will only check the last err returned

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
