### PR TITLE
executor: reuse memory in the deleteSingleTableByChunk

### DIFF
--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -128,7 +128,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 				}
 				rowCount = 0
 			}
-			
+
 			for i, field := range fields {
 				if columns[i].ID == model.ExtraPidColID || columns[i].ID == model.ExtraPhysTblID {
 					continue

--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -128,7 +128,6 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 				}
 				rowCount = 0
 			}
-
 			for i, field := range fields {
 				if columns[i].ID == model.ExtraPidColID || columns[i].ID == model.ExtraPhysTblID {
 					continue
@@ -143,7 +142,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 				return err
 			}
 			rowCount++
-			clear(datumRow)
+			datumRow = datumRow[:0]
 		}
 		chk = chunk.Renew(chk, e.MaxChunkSize())
 		if txn, _ := e.Ctx().Txn(false); txn != nil {

--- a/pkg/executor/delete.go
+++ b/pkg/executor/delete.go
@@ -98,6 +98,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 	batchDelete := e.Ctx().GetSessionVars().BatchDelete && !e.Ctx().GetSessionVars().InTxn() &&
 		variable.EnableBatchDML.Load() && batchDMLSize > 0
 	fields := exec.RetTypes(e.Children(0))
+	datumRow := make([]types.Datum, 0, len(fields))
 	chk := exec.TryNewCacheChunk(e.Children(0))
 	columns := e.Children(0).Schema().Columns
 	if len(columns) != len(fields) {
@@ -127,8 +128,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 				}
 				rowCount = 0
 			}
-
-			datumRow := make([]types.Datum, 0, len(fields))
+			
 			for i, field := range fields {
 				if columns[i].ID == model.ExtraPidColID || columns[i].ID == model.ExtraPhysTblID {
 					continue
@@ -143,6 +143,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 				return err
 			}
 			rowCount++
+			clear(datumRow)
 		}
 		chk = chunk.Renew(chk, e.MaxChunkSize())
 		if txn, _ := e.Ctx().Txn(false); txn != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54080

Problem Summary:

### What changed and how does it work?


(*DeleteExec).deleteSingleTableByChunk spend too much time on making slices

https://flamegraph.com/share/e51414c2-2d3a-11ef-aba3-6a3d1814cbe4

<img width="1890" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/21e2545c-0c6e-4010-8e7a-00dd8acd8917">


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

https://flamegraph.com/share/c1ef40c6-2d78-11ef-aba3-6a3d1814cbe4

<img width="1428" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/dc302448-6ec4-4377-92bc-4b798e0a4dfa">

I find many ```runtime.memmove``` in the ```executor.(*DeleteExec).deleteOneRow```
. so I think that deleteOneRow has copied the ```slices```. so it cannot affect the result.


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
