### PR TITLE
executor: Do not save long-lived unsafe.Pointer in hash join v2

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1672,7 +1672,7 @@ func (b *executorBuilder) buildHashJoinV2(v *plannercore.PhysicalHashJoin) exec.
 }
 
 func (b *executorBuilder) buildHashJoin(v *plannercore.PhysicalHashJoin) exec.Executor {
-	if join.EnableHashJoinV2.Load() && v.CanUseHashJoinV2() {
+	if join.IsHashJoinV2Enabled() && v.CanUseHashJoinV2() {
 		return b.buildHashJoinV2(v)
 	}
 	leftExec := b.build(v.Children()[0])

--- a/pkg/executor/join/BUILD.bazel
+++ b/pkg/executor/join/BUILD.bazel
@@ -78,7 +78,7 @@ go_test(
     ],
     embed = [":join"],
     flaky = True,
-    shard_count = 40,
+    shard_count = 41,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -46,8 +46,9 @@ var (
 
 // IsHashJoinV2Enabled return true if hash join v2 is enabled
 func IsHashJoinV2Enabled() bool {
-	// sizeOfUintptr should always equal to sizeOfUnsafePointer, add this check here in case in the future
-	// go runtime change this
+	// sizeOfUintptr should always equal to sizeOfUnsafePointer, because according to golang's doc,
+	// a Pointer can be converted to an uintptr. Add this check here in case in the future go runtime
+	// change this
 	return enableHashJoinV2.Load() && sizeOfUintptr >= sizeOfUnsafePointer
 }
 

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -40,9 +40,16 @@ import (
 
 var (
 	_ exec.Executor = &HashJoinV2Exec{}
-	// EnableHashJoinV2 is a variable used only in test
-	EnableHashJoinV2 = atomic.Bool{}
+	// enableHashJoinV2 is a variable used only in test
+	enableHashJoinV2 = atomic.Bool{}
 )
+
+// IsHashJoinV2Enabled return true if hash join v2 is enabled
+func IsHashJoinV2Enabled() bool {
+	// sizeOfUintptr should always equal to sizeOfUnsafePointer, add this check here in case in the future
+	// go runtime change this
+	return enableHashJoinV2.Load() && sizeOfUintptr >= sizeOfUnsafePointer
+}
 
 type hashTableContext struct {
 	// rowTables is used during split partition stage, each buildWorker has

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -83,9 +83,7 @@ func (htc *hashTableContext) getCurrentRowSegment(workerID, partitionID int, tab
 
 func (htc *hashTableContext) finalizeCurrentSeg(workerID, partitionID int, builder *rowTableBuilder) {
 	seg := htc.getCurrentRowSegment(workerID, partitionID, nil, false)
-	for _, pos := range builder.startPosInRawData[partitionID] {
-		seg.rowStartOffset = append(seg.rowStartOffset, pos)
-	}
+	seg.rowStartOffset = append(seg.rowStartOffset, builder.startPosInRawData[partitionID]...)
 	builder.crrntSizeOfRowTable[partitionID] = 0
 	builder.startPosInRawData[partitionID] = builder.startPosInRawData[partitionID][:0]
 	failpoint.Inject("finalizeCurrentSegPanic", nil)

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -17,14 +17,6 @@ package join
 import (
 	"bytes"
 	"context"
-	"math"
-	"runtime/trace"
-	"strconv"
-	"sync"
-	"sync/atomic"
-	"time"
-	"unsafe"
-
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -37,6 +29,12 @@ import (
 	"github.com/pingcap/tidb/pkg/util/disk"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/memory"
+	"math"
+	"runtime/trace"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
 var (
@@ -78,7 +76,7 @@ func (htc *hashTableContext) getCurrentRowSegment(workerID, partitionID int, tab
 func (htc *hashTableContext) finalizeCurrentSeg(workerID, partitionID int, builder *rowTableBuilder) {
 	seg := htc.getCurrentRowSegment(workerID, partitionID, nil, false)
 	for _, pos := range builder.startPosInRawData[partitionID] {
-		seg.rowLocations = append(seg.rowLocations, unsafe.Pointer(&seg.rawData[pos]))
+		seg.rowStartOffset = append(seg.rowStartOffset, pos)
 	}
 	builder.crrntSizeOfRowTable[partitionID] = 0
 	builder.startPosInRawData[partitionID] = builder.startPosInRawData[partitionID][:0]

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -17,6 +17,13 @@ package join
 import (
 	"bytes"
 	"context"
+	"math"
+	"runtime/trace"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -29,12 +36,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/disk"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/memory"
-	"math"
-	"runtime/trace"
-	"strconv"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 var (

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -51,6 +51,11 @@ func IsHashJoinV2Enabled() bool {
 	return enableHashJoinV2.Load() && sizeOfUintptr >= sizeOfUnsafePointer
 }
 
+// SetEnableHashJoinV2 enable/disable hash join v2
+func SetEnableHashJoinV2(enable bool) {
+	enableHashJoinV2.Store(enable)
+}
+
 type hashTableContext struct {
 	// rowTables is used during split partition stage, each buildWorker has
 	// its own rowTable

--- a/pkg/executor/join/hash_table_v2.go
+++ b/pkg/executor/join/hash_table_v2.go
@@ -21,13 +21,13 @@ import (
 
 type subTable struct {
 	rowData          *rowTable
-	hashTable        []unsafe.Pointer
+	hashTable        []uintptr
 	posMask          uint64
 	isRowTableEmpty  bool
 	isHashTableEmpty bool
 }
 
-func (st *subTable) lookup(hashValue uint64) unsafe.Pointer {
+func (st *subTable) lookup(hashValue uint64) uintptr {
 	return st.hashTable[hashValue&st.posMask]
 }
 
@@ -56,21 +56,21 @@ func newSubTable(table *rowTable) *subTable {
 		ret.isHashTableEmpty = true
 	}
 	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(1024))
-	ret.hashTable = make([]unsafe.Pointer, hashTableLength)
+	ret.hashTable = make([]uintptr, hashTableLength)
 	ret.posMask = hashTableLength - 1
 	return ret
 }
 
 func (st *subTable) updateHashValue(pos uint64, rowAddress unsafe.Pointer) {
-	prev := st.hashTable[pos]
-	st.hashTable[pos] = rowAddress
+	prev := *(*unsafe.Pointer)(unsafe.Pointer(&st.hashTable[pos]))
+	*(*unsafe.Pointer)(unsafe.Pointer(&st.hashTable[pos])) = rowAddress
 	setNextRowAddress(rowAddress, prev)
 }
 
 func (st *subTable) atomicUpdateHashValue(pos uint64, rowAddress unsafe.Pointer) {
 	for {
-		prev := atomic.LoadPointer(&st.hashTable[pos])
-		if atomic.CompareAndSwapPointer(&st.hashTable[pos], prev, rowAddress) {
+		prev := atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&st.hashTable[pos])))
+		if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&st.hashTable[pos])), prev, rowAddress) {
 			setNextRowAddress(rowAddress, prev)
 			break
 		}
@@ -81,7 +81,7 @@ func (st *subTable) build(startSegmentIndex int, endSegmentIndex int) {
 	if startSegmentIndex == 0 && endSegmentIndex == len(st.rowData.segments) {
 		for i := startSegmentIndex; i < endSegmentIndex; i++ {
 			for _, index := range st.rowData.segments[i].validJoinKeyPos {
-				rowAddress := st.rowData.segments[i].rowLocations[index]
+				rowAddress := st.rowData.segments[i].getRowPointer(index)
 				hashValue := st.rowData.segments[i].hashValues[index]
 				pos := hashValue & st.posMask
 				st.updateHashValue(pos, rowAddress)
@@ -90,7 +90,7 @@ func (st *subTable) build(startSegmentIndex int, endSegmentIndex int) {
 	} else {
 		for i := startSegmentIndex; i < endSegmentIndex; i++ {
 			for _, index := range st.rowData.segments[i].validJoinKeyPos {
-				rowAddress := st.rowData.segments[i].rowLocations[index]
+				rowAddress := st.rowData.segments[i].getRowPointer(index)
 				hashValue := st.rowData.segments[i].hashValues[index]
 				pos := hashValue & st.posMask
 				st.atomicUpdateHashValue(pos, rowAddress)
@@ -117,7 +117,7 @@ type rowIter struct {
 }
 
 func (ri *rowIter) getValue() unsafe.Pointer {
-	return ri.table.tables[ri.currentPos.subTableIndex].rowData.segments[ri.currentPos.rowSegmentIndex].rowLocations[ri.currentPos.rowIndex]
+	return ri.table.tables[ri.currentPos.subTableIndex].rowData.segments[ri.currentPos.rowSegmentIndex].getRowPointer(int(ri.currentPos.rowIndex))
 }
 
 func (ri *rowIter) next() {

--- a/pkg/executor/join/inner_join_probe.go
+++ b/pkg/executor/join/inner_join_probe.go
@@ -16,6 +16,7 @@ package join
 
 import (
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -45,11 +46,11 @@ func (j *innerJoinProbe) Probe(joinResult *hashjoinWorkerResult, sqlKiller *sqlk
 	defer joinedChk.SetInCompleteChunk(isInCompleteChunk)
 
 	for remainCap > 0 && j.currentProbeRow < j.chunkRows {
-		if j.matchedRowsHeaders[j.currentProbeRow] != nil {
-			candidateRow := j.matchedRowsHeaders[j.currentProbeRow]
+		if j.matchedRowsHeaders[j.currentProbeRow] != 0 {
+			candidateRow := *(*unsafe.Pointer)(unsafe.Pointer(&j.matchedRowsHeaders[j.currentProbeRow]))
 			if isKeyMatched(meta.keyMode, j.serializedKeys[j.currentProbeRow], candidateRow, meta) {
 				// key matched, convert row to column for build side
-				j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: j.currentProbeRow, buildRowStart: candidateRow}, joinedChk, 0, hasOtherCondition)
+				j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(j.currentProbeRow, candidateRow), joinedChk, 0, hasOtherCondition)
 				j.matchedRowsForCurrentProbeRow++
 				remainCap--
 			} else {

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -29,10 +29,12 @@ import (
 	"github.com/pingcap/tidb/pkg/util/serialization"
 )
 
-const sizeOfNextPtr = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+const sizeOfNextPtr = int(unsafe.Sizeof(uintptr(0)))
 const sizeOfLengthField = int(unsafe.Sizeof(uint64(1)))
 const usedFlagMaskBigEndian = uint32(1) << 31
 const usedFlagMaskLittleEndian = uint32(1) << 7
+const sizeOfUnsafePointer = int(unsafe.Sizeof(unsafe.Pointer(nil)))
+const sizeOfUintptr = int(unsafe.Sizeof(uintptr(0)))
 
 var fakeAddrPlaceHolder = []byte{0, 0, 0, 0, 0, 0, 0, 0}
 

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -205,7 +205,7 @@ type rowTable struct {
 }
 
 // used for test
-func (rt *rowTable) getRowStart(rowIndex int) unsafe.Pointer {
+func (rt *rowTable) getRowPointer(rowIndex int) unsafe.Pointer {
 	for segIndex := 0; segIndex < len(rt.segments); segIndex++ {
 		if rowIndex < len(rt.segments[segIndex].rowStartOffset) {
 			return rt.segments[segIndex].getRowPointer(rowIndex)

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -61,19 +61,23 @@ type rowTableSegment struct {
 	   * join key is not inlined + have other conditions: columns used in other condition, rest columns that will be used as join output
 	   * join key is not inlined + no other conditions: columns that will be used as join output
 	*/
-	rawData         []byte           // the chunk of memory to save the row data
-	hashValues      []uint64         // the hash value of each rows
-	rowLocations    []unsafe.Pointer // the start address of each row
-	validJoinKeyPos []int            // the pos of rows that need to be inserted into hash table, used in hash table build
+	rawData         []byte   // the chunk of memory to save the row data
+	hashValues      []uint64 // the hash value of each rows
+	rowStartOffset  []uint64 // the start address of each row
+	validJoinKeyPos []int    // the pos of rows that need to be inserted into hash table, used in hash table build
 	finalized       bool
 }
 
 func (rts *rowTableSegment) totalUsedBytes() int64 {
 	ret := int64(cap(rts.rawData))
 	ret += int64(cap(rts.hashValues) * int(serialization.Uint64Len))
-	ret += int64(cap(rts.rowLocations) * sizeOfNextPtr)
+	ret += int64(cap(rts.rowStartOffset) * int(serialization.Uint64Len))
 	ret += int64(cap(rts.validJoinKeyPos) * int(serialization.IntLen))
 	return ret
+}
+
+func (rts *rowTableSegment) getRowPointer(index int) unsafe.Pointer {
+	return unsafe.Pointer(&rts.rawData[rts.rowStartOffset[index]])
 }
 
 const maxRowTableSegmentSize = 1024
@@ -83,13 +87,13 @@ func newRowTableSegment() *rowTableSegment {
 		// TODO: @XuHuaiyu if joinKeyIsInlined, the cap of rawData can be calculated
 		rawData:         make([]byte, 0),
 		hashValues:      make([]uint64, 0, maxRowTableSegmentSize),
-		rowLocations:    make([]unsafe.Pointer, 0, maxRowTableSegmentSize),
+		rowStartOffset:  make([]uint64, 0, maxRowTableSegmentSize),
 		validJoinKeyPos: make([]int, 0, maxRowTableSegmentSize),
 	}
 }
 
 func (rts *rowTableSegment) rowCount() int64 {
-	return int64(len(rts.rowLocations))
+	return int64(len(rts.rowStartOffset))
 }
 
 func (rts *rowTableSegment) validKeyCount() uint64 {
@@ -106,8 +110,8 @@ func setNextRowAddress(rowStart unsafe.Pointer, nextRowAddress unsafe.Pointer) {
 	*(*unsafe.Pointer)(rowStart) = nextRowAddress
 }
 
-func getNextRowAddress(rowStart unsafe.Pointer) unsafe.Pointer {
-	return *(*unsafe.Pointer)(rowStart)
+func getNextRowAddress(rowStart unsafe.Pointer) uintptr {
+	return uintptr(*(*unsafe.Pointer)(rowStart))
 }
 
 // TableMeta is the join table meta used in hash join v2
@@ -172,7 +176,7 @@ func (meta *TableMeta) getKeyBytes(rowStart unsafe.Pointer) []byte {
 func (meta *TableMeta) advanceToRowData(matchedRowInfo *matchedRowInfo) {
 	if meta.rowDataOffset == -1 {
 		// variable length, non-inlined key
-		matchedRowInfo.buildRowOffset = sizeOfNextPtr + meta.nullMapLength + sizeOfLengthField + int(meta.getSerializedKeyLength(matchedRowInfo.buildRowStart))
+		matchedRowInfo.buildRowOffset = sizeOfNextPtr + meta.nullMapLength + sizeOfLengthField + int(meta.getSerializedKeyLength(*(*unsafe.Pointer)(unsafe.Pointer(&matchedRowInfo.buildRowStart))))
 	} else {
 		matchedRowInfo.buildRowOffset = meta.rowDataOffset
 	}
@@ -203,10 +207,10 @@ type rowTable struct {
 // used for test
 func (rt *rowTable) getRowStart(rowIndex int) unsafe.Pointer {
 	for segIndex := 0; segIndex < len(rt.segments); segIndex++ {
-		if rowIndex < len(rt.segments[segIndex].rowLocations) {
-			return rt.segments[segIndex].rowLocations[rowIndex]
+		if rowIndex < len(rt.segments[segIndex].rowStartOffset) {
+			return rt.segments[segIndex].getRowPointer(rowIndex)
 		}
-		rowIndex -= len(rt.segments[segIndex].rowLocations)
+		rowIndex -= len(rt.segments[segIndex].rowStartOffset)
 	}
 	return nil
 }
@@ -218,7 +222,7 @@ func (rt *rowTable) getValidJoinKeyPos(rowIndex int) int {
 			return startOffset + rt.segments[segIndex].validJoinKeyPos[rowIndex]
 		}
 		rowIndex -= len(rt.segments[segIndex].validJoinKeyPos)
-		startOffset += len(rt.segments[segIndex].rowLocations)
+		startOffset += len(rt.segments[segIndex].rowStartOffset)
 	}
 	return -1
 }

--- a/pkg/executor/join/join_row_table_test.go
+++ b/pkg/executor/join/join_row_table_test.go
@@ -29,6 +29,10 @@ func TestFixedOffsetInRowLayout(t *testing.T) {
 	require.Equal(t, 8, sizeOfLengthField)
 }
 
+func TestUintptrCanHoldPointer(t *testing.T) {
+	require.Equal(t, true, sizeOfUintptr >= sizeOfUnsafePointer)
+}
+
 func TestJoinTableMetaKeyMode(t *testing.T) {
 	tinyTp := types.NewFieldType(mysql.TypeTiny)
 	intTp := types.NewFieldType(mysql.TypeLonglong)

--- a/pkg/executor/join/left_outer_join_probe.go
+++ b/pkg/executor/join/left_outer_join_probe.go
@@ -16,6 +16,7 @@ package join
 
 import (
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -92,7 +93,7 @@ func (j *leftOuterJoinProbe) ScanRowTable(joinResult *hashjoinWorkerResult, sqlK
 		currentRow := j.rowIter.getValue()
 		if !meta.isCurrentRowUsed(currentRow) {
 			// append build side of this row
-			j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{buildRowStart: currentRow}, joinResult.chk, 0, false)
+			j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, currentRow), joinResult.chk, 0, false)
 			insertedRows++
 		}
 		j.rowIter.next()
@@ -211,12 +212,12 @@ func (j *leftOuterJoinProbe) probeForRightBuild(chk, joinedChk *chunk.Chunk, rem
 	hasOtherCondition := j.ctx.hasOtherCondition()
 
 	for remainCap > 0 && j.currentProbeRow < j.chunkRows {
-		if j.matchedRowsHeaders[j.currentProbeRow] != nil {
+		if j.matchedRowsHeaders[j.currentProbeRow] != 0 {
 			// hash value match
-			candidateRow := j.matchedRowsHeaders[j.currentProbeRow]
+			candidateRow := *(*unsafe.Pointer)(unsafe.Pointer(&j.matchedRowsHeaders[j.currentProbeRow]))
 			if isKeyMatched(meta.keyMode, j.serializedKeys[j.currentProbeRow], candidateRow, meta) {
 				// join key match
-				j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: j.currentProbeRow, buildRowStart: candidateRow}, joinedChk, 0, hasOtherCondition)
+				j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(j.currentProbeRow, candidateRow), joinedChk, 0, hasOtherCondition)
 				if !hasOtherCondition {
 					// has no other condition, key match mean join match
 					j.isNotMatchedRows[j.currentProbeRow] = false
@@ -268,12 +269,12 @@ func (j *leftOuterJoinProbe) probeForLeftBuild(chk, joinedChk *chunk.Chunk, rema
 	hasOtherCondition := j.ctx.hasOtherCondition()
 
 	for remainCap > 0 && j.currentProbeRow < j.chunkRows {
-		if j.matchedRowsHeaders[j.currentProbeRow] != nil {
+		if j.matchedRowsHeaders[j.currentProbeRow] != 0 {
 			// hash value match
-			candidateRow := j.matchedRowsHeaders[j.currentProbeRow]
+			candidateRow := *(*unsafe.Pointer)(unsafe.Pointer(&j.matchedRowsHeaders[j.currentProbeRow]))
 			if isKeyMatched(meta.keyMode, j.serializedKeys[j.currentProbeRow], candidateRow, meta) {
 				// join key match
-				j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: j.currentProbeRow, buildRowStart: candidateRow}, joinedChk, 0, hasOtherCondition)
+				j.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(j.currentProbeRow, candidateRow), joinedChk, 0, hasOtherCondition)
 				if !hasOtherCondition {
 					// has no other condition, key match means join match
 					meta.setUsedFlag(candidateRow)
@@ -305,7 +306,7 @@ func (j *leftOuterJoinProbe) probeForLeftBuild(chk, joinedChk *chunk.Chunk, rema
 		err = j.buildResultAfterOtherCondition(chk, joinedChk)
 		for index, result := range j.selected {
 			if result {
-				meta.setUsedFlag(j.rowIndexInfos[index].buildRowStart)
+				meta.setUsedFlag(*(*unsafe.Pointer)(unsafe.Pointer(&j.rowIndexInfos[index].buildRowStart)))
 			}
 		}
 	}

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -134,8 +134,8 @@ func checkKeys(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs, b
 			}
 			validKeyPos := rowTables[0].getValidJoinKeyPos(validJoinKeyRowIndex)
 			require.Equal(t, logicalIndex, validKeyPos, "valid key pos not match, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
-			rowStart := rowTables[0].getRowStart(validKeyPos)
-			require.NotEqual(t, uintptr(0), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
+			rowStart := rowTables[0].getRowPointer(validKeyPos)
+			require.NotEqual(t, unsafe.Pointer(nil), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			require.Equal(t, builder.serializedKeyVectorBuffer[logicalIndex], meta.getKeyBytes(rowStart), "key not match, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			validJoinKeyRowIndex++
 		}
@@ -149,12 +149,12 @@ func checkKeys(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs, b
 				// filtered row, skip
 				continue
 			}
-			rowStart := rowTables[0].getRowStart(rowIndex)
-			require.NotEqual(t, uintptr(0), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
+			rowStart := rowTables[0].getRowPointer(rowIndex)
+			require.NotEqual(t, unsafe.Pointer(nil), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			require.Equal(t, builder.serializedKeyVectorBuffer[logicalIndex], meta.getKeyBytes(rowStart), "key not match, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			rowIndex++
 		}
-		rowStart := rowTables[0].getRowStart(rowIndex)
+		rowStart := rowTables[0].getRowPointer(rowIndex)
 		require.Equal(t, unsafe.Pointer(nil), rowStart, "row start must be nil at the end of the test")
 	}
 }
@@ -342,8 +342,8 @@ func checkColumns(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs
 	if keepFilteredRows {
 		require.Equal(t, uint64(len(builder.usedRows)), rowTables[0].rowCount())
 		for logicalIndex, physicalIndex := range builder.usedRows {
-			rowStart := rowTables[0].getRowStart(logicalIndex)
-			require.NotEqual(t, uintptr(0), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
+			rowStart := rowTables[0].getRowPointer(logicalIndex)
+			require.NotEqual(t, unsafe.Pointer(nil), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			if hasOtherConditionColumns {
 				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, rowStart), tmpChunk, 0, hasOtherConditionColumns)
 			} else {
@@ -380,8 +380,8 @@ func checkColumns(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs
 				// filtered row, skip
 				continue
 			}
-			rowStart := rowTables[0].getRowStart(rowIndex)
-			require.NotEqual(t, uintptr(0), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
+			rowStart := rowTables[0].getRowPointer(rowIndex)
+			require.NotEqual(t, unsafe.Pointer(nil), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			if hasOtherConditionColumns {
 				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, rowStart), tmpChunk, 0, hasOtherConditionColumns)
 			} else {
@@ -396,7 +396,7 @@ func checkColumns(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs
 				mockJoinProber.batchConstructBuildRows(resultChunk, 0, hasOtherConditionColumns)
 			}
 		}
-		rowStart := rowTables[0].getRowStart(rowIndex)
+		rowStart := rowTables[0].getRowPointer(rowIndex)
 		require.Equal(t, unsafe.Pointer(nil), rowStart, "row start must be nil at the end of the test")
 		if hasOtherConditionColumns {
 			checkColumnResult(t, builder, keepFilteredRows, tmpChunk, chk, hashJoinCtx, hasOtherConditionColumns)

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -74,7 +74,8 @@ func checkRowLocationAlignment(t *testing.T, rowTables []*rowTable) {
 			continue
 		}
 		for _, seg := range rt.segments {
-			for _, rowLocation := range seg.rowLocations {
+			for index := range seg.rowStartOffset {
+				rowLocation := seg.getRowPointer(index)
 				require.Equal(t, uint64(0), uint64(uintptr(rowLocation))%8, "row location must be 8 byte aligned")
 			}
 		}
@@ -344,9 +345,9 @@ func checkColumns(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs
 			rowStart := rowTables[0].getRowStart(logicalIndex)
 			require.NotEqual(t, uintptr(0), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			if hasOtherConditionColumns {
-				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: 0, buildRowStart: rowStart}, tmpChunk, 0, hasOtherConditionColumns)
+				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, rowStart), tmpChunk, 0, hasOtherConditionColumns)
 			} else {
-				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: 0, buildRowStart: rowStart}, resultChunk, 0, hasOtherConditionColumns)
+				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, rowStart), resultChunk, 0, hasOtherConditionColumns)
 			}
 		}
 		if len(mockJoinProber.cachedBuildRows) > 0 {
@@ -382,9 +383,9 @@ func checkColumns(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs
 			rowStart := rowTables[0].getRowStart(rowIndex)
 			require.NotEqual(t, uintptr(0), rowStart, "row start must not be nil, logical index = "+strconv.Itoa(logicalIndex)+", physical index = "+strconv.Itoa(physicalIndex))
 			if hasOtherConditionColumns {
-				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: 0, buildRowStart: rowStart}, tmpChunk, 0, hasOtherConditionColumns)
+				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, rowStart), tmpChunk, 0, hasOtherConditionColumns)
 			} else {
-				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(&matchedRowInfo{probeRowIndex: 0, buildRowStart: rowStart}, resultChunk, 0, hasOtherConditionColumns)
+				mockJoinProber.appendBuildRowToCachedBuildRowsAndConstructBuildRowsIfNeeded(createMatchRowInfo(0, rowStart), resultChunk, 0, hasOtherConditionColumns)
 			}
 			rowIndex++
 		}

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -183,7 +183,7 @@ func TestIssue30289(t *testing.T) {
 	}()
 	useHashJoinV2 := []bool{true, false}
 	for _, hashJoinV2 := range useHashJoinV2 {
-		join.EnableHashJoinV2.Store(hashJoinV2)
+		join.SetEnableHashJoinV2(hashJoinV2)
 		err := tk.QueryToErr("select /*+ hash_join(t1) */ * from t t1 join t t2 on t1.a=t2.a")
 		require.EqualError(t, err, "issue30289 build return error")
 	}
@@ -202,7 +202,7 @@ func TestIssue51998(t *testing.T) {
 	}()
 	useHashJoinV2 := []bool{true, false}
 	for _, hashJoinV2 := range useHashJoinV2 {
-		join.EnableHashJoinV2.Store(hashJoinV2)
+		join.SetEnableHashJoinV2(hashJoinV2)
 		err := tk.QueryToErr("select /*+ hash_join(t1) */ * from t t1 join t t2 on t1.a=t2.a")
 		require.EqualError(t, err, "issue51998 build return error")
 	}
@@ -619,7 +619,7 @@ func TestIssue42662(t *testing.T) {
 	tk.MustExec("set global tidb_mem_oom_action = 'cancel'")
 	useHashJoinV2 := []bool{true, false}
 	for _, hashJoinV2 := range useHashJoinV2 {
-		join.EnableHashJoinV2.Store(hashJoinV2)
+		join.SetEnableHashJoinV2(hashJoinV2)
 		require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/join/issue42662_1", `return(true)`))
 		// tk.Session() should be marked as MemoryTop1Tracker but not killed.
 		tk.MustQuery("select /*+ hash_join(t1)*/ * from t1 join t2 on t1.a = t2.a and t1.b = t2.b")

--- a/pkg/executor/test/jointest/hashjoin/hash_join_test.go
+++ b/pkg/executor/test/jointest/hashjoin/hash_join_test.go
@@ -489,9 +489,9 @@ func TestFinalizeCurrentSegPanic(t *testing.T) {
 	tk.MustExec("create table t2 (a int, b int, c int)")
 	tk.MustExec("insert into t1 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
 	tk.MustExec("insert into t2 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	fpName := "github.com/pingcap/tidb/pkg/executor/join/finalizeCurrentSegPanic"
 	require.NoError(t, failpoint.Enable(fpName, "panic(\"finalizeCurrentSegPanic\")"))
@@ -512,9 +512,9 @@ func TestSplitPartitionPanic(t *testing.T) {
 	tk.MustExec("create table t2 (a int, b int, c int)")
 	tk.MustExec("insert into t1 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
 	tk.MustExec("insert into t2 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	fpName := "github.com/pingcap/tidb/pkg/executor/join/splitPartitionPanic"
 	require.NoError(t, failpoint.Enable(fpName, "panic(\"splitPartitionPanic\")"))
@@ -535,9 +535,9 @@ func TestProcessOneProbeChunkPanic(t *testing.T) {
 	tk.MustExec("create table t2 (a int, b int, c int)")
 	tk.MustExec("insert into t1 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
 	tk.MustExec("insert into t2 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	fpName := "github.com/pingcap/tidb/pkg/executor/join/processOneProbeChunkPanic"
 	require.NoError(t, failpoint.Enable(fpName, "panic(\"processOneProbeChunkPanic\")"))
@@ -558,9 +558,9 @@ func TestCreateTasksPanic(t *testing.T) {
 	tk.MustExec("create table t2 (a int, b int, c int)")
 	tk.MustExec("insert into t1 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
 	tk.MustExec("insert into t2 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	fpName := "github.com/pingcap/tidb/pkg/executor/join/createTasksPanic"
 	require.NoError(t, failpoint.Enable(fpName, "panic(\"createTasksPanic\")"))
@@ -581,9 +581,9 @@ func TestBuildHashTablePanic(t *testing.T) {
 	tk.MustExec("create table t2 (a int, b int, c int)")
 	tk.MustExec("insert into t1 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
 	tk.MustExec("insert into t2 values (1, 1, 1), (1, 2, 2), (2, 1, 3), (2, 2, 4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	fpName := "github.com/pingcap/tidb/pkg/executor/join/buildHashTablePanic"
 	require.NoError(t, failpoint.Enable(fpName, "panic(\"buildHashTablePanic\")"))
@@ -604,9 +604,9 @@ func TestKillDuringProbe(t *testing.T) {
 	tk.MustExec("create table t1(c1 int, c2 int)")
 	tk.MustExec("insert into t values(1,1),(2,2)")
 	tk.MustExec("insert into t1 values(2,3),(4,4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/join/killedDuringProbe", "return(true)"))
 	defer func() {
@@ -637,9 +637,9 @@ func TestKillDuringBuild(t *testing.T) {
 	tk.MustExec("create table t1(c1 int, c2 int)")
 	tk.MustExec("insert into t values(1,1),(2,2)")
 	tk.MustExec("insert into t1 values(2,3),(4,4)")
-	join.EnableHashJoinV2.Store(true)
+	join.SetEnableHashJoinV2(true)
 	defer func() {
-		join.EnableHashJoinV2.Store(false)
+		join.SetEnableHashJoinV2(false)
 	}()
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/join/killedDuringBuild", "return(true)"))
 	defer func() {

--- a/pkg/executor/test/seqtest/seq_executor_test.go
+++ b/pkg/executor/test/seqtest/seq_executor_test.go
@@ -1304,7 +1304,7 @@ func TestOOMPanicInHashJoinWhenFetchBuildRows(t *testing.T) {
 	}()
 	useHashJoinV2 := []bool{true, false}
 	for _, hashJoinV2 := range useHashJoinV2 {
-		join.EnableHashJoinV2.Store(hashJoinV2)
+		join.SetEnableHashJoinV2(hashJoinV2)
 		err := tk.QueryToErr("select * from t as t2  join t as t1 where t1.c1=t2.c1")
 		require.EqualError(t, err, "failpoint panic: ERROR 1105 (HY000): Out Of Memory Quota![conn=1]")
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127

Problem Summary:
In #53208, it creates a lots of long-lived `unsafe.Pointer` during hash join's build, a simple performance test shows lots of `unsafe.Pointer` will significantly increases gc time:
gc with a lots of unsafe.Pointer
```
[gc_test]# cat pointer_gc.go 
package main

import "runtime"
import "time"
import "fmt"
import "unsafe"

func main() {
        a := make([]byte, 1e9*8)
        b := make([]unsafe.Pointer, 1e9)
        for i := 0; i < 1e9; i++ {
                b[i] = unsafe.Pointer(&a[i*8])
        }
        for i := 0; i < 1e9; i++ {
                *(*int64)(b[i]) = int64(i)
        }
        for i := 0; i < 10; i++ {
                start := time.Now()
                runtime.GC()
                fmt.Printf("GC took %s\n", time.Since(start))
        }

        for i := 0; i < 1e9; i++ {
                if *(*int64)(b[i]) != int64(i) {
                        panic("test failed")
                }
        }

        runtime.KeepAlive(a)
        runtime.KeepAlive(b)
}
[gc_test]# ./pointer_gc 
GC took 442.535362ms
GC took 421.290733ms
GC took 442.405494ms
GC took 449.971723ms
GC took 426.559535ms
GC took 444.889418ms
GC took 468.164119ms
GC took 461.121191ms
GC took 458.241395ms
GC took 479.782243ms

```
gc with a lots of uintptr
```
[gc_test]# cat uintptr_gc.go 
package main

import "runtime"
import "time"
import "fmt"
import "unsafe"

func main() {
        a := make([]byte, 1e9*8)
        b := make([]uintptr, 1e9)
        for i := 0; i < 1e9; i++ {
                *(*unsafe.Pointer)((unsafe.Pointer)(&b[i])) = unsafe.Pointer(&a[i*8])
        }
        for i := 0; i < 1e9; i++ {
                *(*int64)((unsafe.Pointer)(&b[i])) = int64(i)
        }

        for i := 0; i < 10; i++ {
                start := time.Now()
                runtime.GC()
                fmt.Printf("GC took %s\n", time.Since(start))
        }

        for i := 0; i < 1e9; i++ {
                if *(*int64)((unsafe.Pointer)(&b[i])) != int64(i) {
                        panic("test failed")
                }
        }

        runtime.KeepAlive(a)
        runtime.KeepAlive(b)
}
[gc_test]# ./uintptr_gc 
GC took 1.818511ms
GC took 836.665µs
GC took 830.171µs
GC took 913.262µs
GC took 925.983µs
GC took 849.608µs
GC took 950.502µs
GC took 862.005µs
GC took 892.863µs
GC took 848.197µs

```
So this pr remove all the long-lived `unsafe.Pointer` during hash join v2. For the variable that used to be `unsafe.Pointer`, this pr use `uintptr` instead. 

But go runtime actually forbit to convert `uintptr` to `unsafe.Pointer` directly:
```
https://pkg.go.dev/unsafe
Note that both conversions must appear in the same expression, with only the intervening arithmetic between them:

// INVALID: uintptr cannot be stored in variable
// before conversion back to Pointer.
u := uintptr(p)
p = unsafe.Pointer(u + offset)
``` 
this pr use the follow hack to read/write `unsafe.Pointer` from/to `uintptr`
```
*(*unsafe.Pointer)(unsafe.Pointer(&uintptr)) = unsafePointer
unsafePointer := *(*unsafe.Pointer)(unsafe.Pointer(&uintptr))
```
### What changed and how does it work? 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
