### PR TITLE
unistore: use location cache to reduce the syscall

### DIFF
--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -49,6 +50,32 @@ import (
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tipb/go-tipb"
 )
+
+var globalLocationMap *locationMap = newLocationMap()
+
+type locationMap struct {
+	lmap map[string]*time.Location
+	mu   sync.RWMutex
+}
+
+func newLocationMap() *locationMap {
+	return &locationMap{
+		lmap: make(map[string]*time.Location),
+	}
+}
+
+func (l *locationMap) getLocation(name string) (*time.Location, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	result, ok := l.lmap[name]
+	return result, ok
+}
+
+func (l *locationMap) setLocation(name string, value *time.Location) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lmap[name] = value
+}
 
 // MPPCtx is the mpp execution context
 type MPPCtx struct {
@@ -309,9 +336,13 @@ func buildDAG(reader *dbreader.DBReader, lockStore *lockstore.MemStore, req *cop
 	case "System":
 		tz = time.Local
 	default:
-		tz, err = time.LoadLocation(dagReq.TimeZoneName)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
+		tz, ok := globalLocationMap.getLocation(dagReq.TimeZoneName)
+		if !ok {
+			tz, err = time.LoadLocation(dagReq.TimeZoneName)
+			if err != nil {
+				return nil, nil, errors.Trace(err)
+			}
+			globalLocationMap.setLocation(dagReq.TimeZoneName, tz)
 		}
 	}
 	sctx := flagsAndTzToSessionContext(dagReq.Flags, tz)

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -336,7 +336,8 @@ func buildDAG(reader *dbreader.DBReader, lockStore *lockstore.MemStore, req *cop
 	case "System":
 		tz = time.Local
 	default:
-		tz, ok := globalLocationMap.getLocation(dagReq.TimeZoneName)
+		var ok bool
+		tz, ok = globalLocationMap.getLocation(dagReq.TimeZoneName)
 		if !ok {
 			tz, err = time.LoadLocation(dagReq.TimeZoneName)
 			if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54097

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

we cannot see any syscall in the cophandler.buildDAG 

<img width="1378" alt="image" src="https://github.com/pingcap/tidb/assets/3427324/2e1d9758-c760-4309-8900-98371d6dde30">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
