### PR TITLE
backup: use history iterator to scan ddl jobs

### DIFF
--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
     embed = [":backup"],
     flaky = True,
     race = "on",
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//br/pkg/conn",
         "//br/pkg/gluetidb/mock",

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -1064,8 +1064,8 @@ func WriteBackupDDLJobs(metaWriter *metautil.MetaWriter, g glue.Glue, store kv.S
 			// no more jobs
 			break
 		}
-		count += len(cacheJobs)
 		jobs, finished := appendJobsFn(cacheJobs)
+		count += len(jobs)
 		allJobs = append(allJobs, jobs...)
 		if finished {
 			// no more jobs between [LastTS, ts]

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -1006,6 +1006,10 @@ func WriteBackupDDLJobs(metaWriter *metautil.MetaWriter, g glue.Glue, store kv.S
 			if skipUnsupportedDDLJob(job) {
 				continue
 			}
+			if job.BinlogInfo != nil && job.BinlogInfo.SchemaVersion <= lastSchemaVersion {
+				// early exits to stop unnecessary scan
+				return true, nil
+			}
 
 			if (job.State == model.JobStateDone || job.State == model.JobStateSynced) &&
 				(job.BinlogInfo != nil && job.BinlogInfo.SchemaVersion > lastSchemaVersion && job.BinlogInfo.SchemaVersion <= backupSchemaVersion) {
@@ -1026,8 +1030,6 @@ func WriteBackupDDLJobs(metaWriter *metautil.MetaWriter, g glue.Glue, store kv.S
 					return true, errors.Trace(err)
 				}
 			}
-			// early exits to stop unnecessary scan
-			return true, nil
 		}
 		return true, nil
 	}

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -1044,6 +1044,9 @@ func WriteBackupDDLJobs(metaWriter *metautil.MetaWriter, g glue.Glue, store kv.S
 		return errors.Trace(err)
 	}
 
+	// filter out the jobs
+	allJobs, _ = appendJobsFn(allJobs)
+
 	historyJobsIter, err := ddl.GetLastHistoryDDLJobsIterator(newestMeta)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -188,6 +188,65 @@ func TestGetTS(t *testing.T) {
 	require.Equal(t, backupts, ts)
 }
 
+func TestGetHistoryDDLJobs(t *testing.T) {
+	s := createBackupSuite(t)
+
+	tk := testkit.NewTestKit(t, s.cluster.Storage)
+	lastTS1, err := s.cluster.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+	require.NoErrorf(t, err, "Error get last ts: %s", err)
+	tk.MustExec("CREATE DATABASE IF NOT EXISTS test_db;")
+	tk.MustExec("CREATE TABLE IF NOT EXISTS test_db.test_table (c1 INT);")
+	lastTS2, err := s.cluster.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+	require.NoErrorf(t, err, "Error get last ts: %s", err)
+	tk.MustExec("RENAME TABLE test_db.test_table to test_db.test_table1;")
+	tk.MustExec("DROP TABLE test_db.test_table1;")
+	tk.MustExec("DROP DATABASE test_db;")
+	tk.MustExec("CREATE DATABASE test_db;")
+	tk.MustExec("USE test_db;")
+	tk.MustExec("CREATE TABLE test_table1 (c2 CHAR(255));")
+	tk.MustExec("RENAME TABLE test_table1 to test_table;")
+	tk.MustExec("RENAME TABLE test_table to test_table2;")
+	tk.MustExec("RENAME TABLE test_table2 to test_table;")
+	lastTS3, err := s.cluster.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+	require.NoErrorf(t, err, "Error get last ts: %s", err)
+	tk.MustExec("TRUNCATE TABLE test_table;")
+	ts, err := s.cluster.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+	require.NoErrorf(t, err, "Error get last ts: %s", err)
+
+	checkFn := func(lastTS uint64, ts uint64, jobsCount int) {
+		cipher := backuppb.CipherInfo{CipherType: encryptionpb.EncryptionMethod_PLAINTEXT}
+		metaWriter := metautil.NewMetaWriter(s.storage, metautil.MetaFileSize, false, "", &cipher)
+		ctx := context.Background()
+		metaWriter.StartWriteMetasAsync(ctx, metautil.AppendDDL)
+		s.mockGlue.SetSession(tk.Session())
+		err = backup.WriteBackupDDLJobs(metaWriter, s.mockGlue, s.cluster.Storage, lastTS, ts, false)
+		require.NoErrorf(t, err, "Error get ddl jobs: %s", err)
+		err = metaWriter.FinishWriteMetas(ctx, metautil.AppendDDL)
+		require.NoError(t, err, "Flush failed", err)
+		err = metaWriter.FlushBackupMeta(ctx)
+		require.NoError(t, err, "Finally flush backup meta failed", err)
+
+		metaBytes, err := s.storage.ReadFile(ctx, metautil.MetaFile)
+		require.NoError(t, err)
+		mockMeta := &backuppb.BackupMeta{}
+		err = proto.Unmarshal(metaBytes, mockMeta)
+		require.NoError(t, err)
+		// check the schema version
+		metaReader := metautil.NewMetaReader(mockMeta, s.storage, &cipher)
+		allDDLJobsBytes, err := metaReader.ReadDDLs(ctx)
+		require.NoError(t, err)
+		var allDDLJobs []*model.Job
+		err = json.Unmarshal(allDDLJobsBytes, &allDDLJobs)
+		require.NoError(t, err)
+		require.Len(t, allDDLJobs, jobsCount)
+	}
+
+	checkFn(lastTS1, ts, 11)
+	checkFn(lastTS2, ts, 9)
+	checkFn(lastTS1, lastTS2, 2)
+	checkFn(lastTS3, ts, 1)
+}
+
 func TestSkipUnsupportedDDLJob(t *testing.T) {
 	s := createBackupSuite(t)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54139

Problem Summary:
sometimes cluster might have too many ddl jobs. backup should skip unnecessary scan of ddl jobs during the backup incremental ddls.
### What changed and how does it work?
Use `GetLastHistoryDDLJobsIterator` instead of `GetAllDDLJobs`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
