### PR TITLE
ddl: support referring objects in runningJobs

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -215,6 +215,7 @@ type DDL interface {
 		ctx sessionctx.Context,
 		schema model.CIStr,
 		info *model.TableInfo,
+		involvingRef []model.InvolvingSchemaInfo,
 		cs ...CreateTableWithInfoConfigurier) error
 
 	// BatchCreateTableWithInfo is like CreateTableWithInfo, but can handle multiple tables.

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -2853,7 +2853,7 @@ func (d *ddl) createTableWithInfoJob(
 		args = append(args, ctx.GetSessionVars().ForeignKeyChecks)
 	}
 
-	var involvingSchemas []model.InvolvingSchemaInfo
+	involvingSchemas := make([]model.InvolvingSchemaInfo, 0, len(involvingRef)+len(tbInfo.ForeignKeys)+1)
 	if len(involvingRef) > 0 {
 		involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
 			Database: schema.Name.L,
@@ -3249,13 +3249,13 @@ func (d *ddl) FlashbackCluster(ctx sessionctx.Context, flashbackTS uint64) error
 		Args: []any{
 			flashbackTS,
 			map[string]any{},
-			true,         /* tidb_gc_enable */
-			variable.On,  /* tidb_enable_auto_analyze */
-			variable.Off, /* tidb_super_read_only */
-			0,            /* totalRegions */
-			0,            /* startTS */
-			0,            /* commitTS */
-			variable.On,  /* tidb_ttl_job_enable */
+			true,           /* tidb_gc_enable */
+			variable.On,    /* tidb_enable_auto_analyze */
+			variable.Off,   /* tidb_super_read_only */
+			0,              /* totalRegions */
+			0,              /* startTS */
+			0,              /* commitTS */
+			variable.On,    /* tidb_ttl_job_enable */
 			[]kv.KeyRange{} /* flashback key_ranges */},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		// FLASHBACK CLUSTER affects all schemas and tables.

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -310,9 +310,11 @@ func (d *ddl) ModifySchemaDefaultPlacement(ctx sessionctx.Context, stmt *ast.Alt
 		InvolvingSchemaInfo: []model.InvolvingSchemaInfo{{
 			Database: dbInfo.Name.L,
 			Table:    model.InvolvingAll,
-			Shared:   &model.InvolvingSharedSchemaInfo{Policy: placementPolicyRef.Name.L},
 		}},
 		SQLMode: ctx.GetSessionVars().SQLMode,
+	}
+	if placementPolicyRef != nil {
+		job.InvolvingSchemaInfo[0].Shared = &model.InvolvingSharedSchemaInfo{Policy: placementPolicyRef.Name.L}
 	}
 	err = d.DoDDLJob(ctx, job)
 	err = d.callHookOnChanged(job, err)

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -3249,13 +3249,13 @@ func (d *ddl) FlashbackCluster(ctx sessionctx.Context, flashbackTS uint64) error
 		Args: []any{
 			flashbackTS,
 			map[string]any{},
-			true,           /* tidb_gc_enable */
-			variable.On,    /* tidb_enable_auto_analyze */
-			variable.Off,   /* tidb_super_read_only */
-			0,              /* totalRegions */
-			0,              /* startTS */
-			0,              /* commitTS */
-			variable.On,    /* tidb_ttl_job_enable */
+			true,         /* tidb_gc_enable */
+			variable.On,  /* tidb_enable_auto_analyze */
+			variable.Off, /* tidb_super_read_only */
+			0,            /* totalRegions */
+			0,            /* startTS */
+			0,            /* commitTS */
+			variable.On,  /* tidb_ttl_job_enable */
 			[]kv.KeyRange{} /* flashback key_ranges */},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		// FLASHBACK CLUSTER affects all schemas and tables.

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -2865,10 +2865,6 @@ func (d *ddl) createTableWithInfoJob(
 
 	involvingSchemas := make([]model.InvolvingSchemaInfo, 0, len(involvingRef)+len(tbInfo.ForeignKeys)+1)
 	if len(involvingRef) > 0 {
-		involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
-			Database: schema.Name.L,
-			Table:    tbInfo.Name.L,
-		})
 		involvingSchemas = append(involvingSchemas, involvingRef...)
 	}
 	for _, fk := range tbInfo.ForeignKeys {
@@ -2882,6 +2878,12 @@ func (d *ddl) createTableWithInfoJob(
 		involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
 			Policy: ref.Name.L,
 			Mode:   model.SharedInvolving,
+		})
+	}
+	if len(involvingSchemas) > 0 {
+		involvingSchemas = append(involvingSchemas, model.InvolvingSchemaInfo{
+			Database: schema.Name.L,
+			Table:    tbInfo.Name.L,
 		})
 	}
 
@@ -3349,8 +3351,7 @@ func (d *ddl) CreateView(ctx sessionctx.Context, s *ast.CreateViewStmt) (err err
 		onExist = OnExistReplace
 	}
 
-	var involvingRef []model.InvolvingSchemaInfo
-	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, involvingRef, onExist)
+	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, nil, onExist)
 }
 
 // BuildViewInfo builds a ViewInfo structure from an ast.CreateViewStmt.

--- a/pkg/ddl/ddl_running_jobs.go
+++ b/pkg/ddl/ddl_running_jobs.go
@@ -139,14 +139,35 @@ func (j *runningJobs) checkRunnable(jobID int64, involves []model.InvolvingSchem
 		}
 
 		for _, checkingObj := range toCheck {
-			if info.Database != model.InvolvingNone &&
-				hasSchemaConflict(info.Database, info.Table, checkingObj.schemas) {
-				return false
+			if info.Database != model.InvolvingNone {
+				if hasSchemaConflict(info.Database, info.Table, checkingObj.schemas) {
+					return false
+				}
+				// model.InvolvingSchemaInfo is like an enumerate type
+				intest.Assert(
+					info.Policy == "" && info.ResourceGroup == "",
+					"InvolvingSchemaInfo should be like an enumerate type: %#v",
+					info,
+				)
+				continue
 			}
 
-			if _, ok := checkingObj.placementPolicies[info.Policy]; ok {
-				return false
+			if info.Policy != "" {
+				if _, ok := checkingObj.placementPolicies[info.Policy]; ok {
+					return false
+				}
+				intest.Assert(
+					info.ResourceGroup == "",
+					"InvolvingSchemaInfo should be like an enumerate type: %#v",
+					info,
+				)
+				continue
 			}
+			intest.Assert(
+				info.ResourceGroup != "",
+				"InvolvingSchemaInfo should be like an enumerate type: %#v",
+				info,
+			)
 			if _, ok := checkingObj.resourceGroups[info.ResourceGroup]; ok {
 				return false
 			}

--- a/pkg/ddl/ddl_running_jobs.go
+++ b/pkg/ddl/ddl_running_jobs.go
@@ -37,27 +37,183 @@ type runningJobs struct {
 
 	ids          map[int64]struct{}
 	idsStrGetter func() string
+
 	// database -> table -> struct{}
 	//
 	// if the job is only related to a database, the table-level entry key is
 	// model.InvolvingAll. When remove a job, runningJobs will make sure no
 	// zero-length map exists in table-level.
-	schemas map[string]map[string]struct{}
-}
+	schemas           map[string]map[string]struct{}
+	placementPolicies map[string]struct{}
+	resourceGroups    map[string]struct{}
 
-// TODO(lance6716): support jobs involving objects that are exclusive (ALTER
-// PLACEMENT POLICY vs ALTER PLACEMENT POLICY) and shared (ALTER TABLE PLACEMENT
-// POLICY vs ALTER TABLE PLACEMENT POLICY)
-func newRunningJobs() *runningJobs {
-	return &runningJobs{
-		ids:          make(map[int64]struct{}),
-		idsStrGetter: func() string { return "" },
-		schemas:      make(map[string]map[string]struct{}),
+	shared struct {
+		schemas           map[string]map[string]struct{}
+		placementPolicies map[string]struct{}
+		resourceGroups    map[string]struct{}
+	}
+
+	// to implement the fair lock semantics, we need to save the pending exclusive
+	// object requests to block future shared object requests.
+	pending struct {
+		schemas           map[string]map[string]struct{}
+		placementPolicies map[string]struct{}
+		resourceGroups    map[string]struct{}
 	}
 }
 
-// add should only add the argument that passed the last checkRunnable.
-func (j *runningJobs) add(jobID int64, involves []model.InvolvingSchemaInfo) {
+func newRunningJobs() *runningJobs {
+	ret := &runningJobs{
+		ids:               make(map[int64]struct{}),
+		idsStrGetter:      func() string { return "" },
+		schemas:           make(map[string]map[string]struct{}),
+		placementPolicies: make(map[string]struct{}),
+		resourceGroups:    make(map[string]struct{}),
+	}
+	ret.shared.schemas = make(map[string]map[string]struct{})
+	ret.shared.placementPolicies = make(map[string]struct{})
+	ret.shared.resourceGroups = make(map[string]struct{})
+	ret.pending.schemas = make(map[string]map[string]struct{})
+	ret.pending.placementPolicies = make(map[string]struct{})
+	ret.pending.resourceGroups = make(map[string]struct{})
+
+	return ret
+}
+
+// checkRunnable checks whether the job can be run. If the caller found a
+// runnable job and decides to add it, it must addRunning before next
+// checkRunnable invocation. Otherwise, it should addPending before next
+// checkRunnable invocation.
+func (j *runningJobs) checkRunnable(jobID int64, involves []model.InvolvingSchemaInfo) bool {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+
+	if _, ok := j.ids[jobID]; ok {
+		// should not happen
+		if intest.InTest {
+			panic(fmt.Sprintf("job %d is already running", jobID))
+		}
+		return false
+	}
+	// Currently flashback cluster is the only DDL that involves ALL schemas.
+	if _, ok := j.schemas[model.InvolvingAll]; ok {
+		return false
+	}
+
+	for _, info := range involves {
+		if intest.InTest {
+			if info.Database == model.InvolvingNone && info.Table != model.InvolvingNone {
+				panic(fmt.Sprintf(
+					"job %d is invalid. While database is empty, involved table name is not empty: %s",
+					jobID, info.Table,
+				))
+			}
+			if info.Database != model.InvolvingNone && info.Table == model.InvolvingNone {
+				panic(fmt.Sprintf(
+					"job %d is invalid. While table is empty, involved database name is not empty: %s",
+					jobID, info.Database,
+				))
+			}
+		}
+
+		// 1. check exclusive objects of involves. Exclusive objects conflicts with
+		// running exclusive and shared objects.
+
+		// 1.1 check for Database == model.InvolvingAll, where the only case is FLASHBACK
+		// CLUSTER
+		if info.Database == model.InvolvingAll {
+			if len(j.schemas) != 0 || len(j.shared.schemas) != 0 ||
+				len(j.placementPolicies) != 0 || len(j.shared.placementPolicies) != 0 ||
+				len(j.resourceGroups) != 0 || len(j.shared.resourceGroups) != 0 {
+				return false
+			}
+			continue
+		}
+
+		// 1.2 check schema exclusive objects
+		if hasSchemaConflict(info.Database, info.Table, j.schemas) {
+			return false
+		}
+		if hasSchemaConflict(info.Database, info.Table, j.shared.schemas) {
+			return false
+		}
+
+		// 1.3 check placement policy exclusive objects
+		if _, ok := j.placementPolicies[info.Policy]; ok {
+			return false
+		}
+		if _, ok := j.shared.placementPolicies[info.Policy]; ok {
+			return false
+		}
+
+		// 1.4 check resource group exclusive objects
+		if _, ok := j.resourceGroups[info.ResourceGroup]; ok {
+			return false
+		}
+		if _, ok := j.shared.resourceGroups[info.ResourceGroup]; ok {
+			return false
+		}
+
+		// 2. check shared objects of involves. Shared objects conflicts with running
+		// exclusive objects and pending exclusive objects.
+
+		shared := info.Shared
+		if shared == nil {
+			continue
+		}
+
+		// 2.1 check schema shared objects
+		if hasSchemaConflict(shared.Database, shared.Table, j.schemas) {
+			return false
+		}
+		if hasSchemaConflict(shared.Database, shared.Table, j.pending.schemas) {
+			return false
+		}
+
+		// 2.2 check placement policy exclusive objects
+		if _, ok := j.placementPolicies[shared.Policy]; ok {
+			return false
+		}
+		if _, ok := j.pending.placementPolicies[shared.Policy]; ok {
+			return false
+		}
+
+		// 2.3 check resource group exclusive objects
+		if _, ok := j.resourceGroups[shared.ResourceGroup]; ok {
+			return false
+		}
+		if _, ok := j.pending.resourceGroups[shared.ResourceGroup]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasSchemaConflict(
+	requestDatabase, requestTable string,
+	schemas map[string]map[string]struct{},
+) bool {
+	tbls, ok := schemas[requestDatabase]
+	if !ok {
+		return false
+	}
+	if requestTable == model.InvolvingAll {
+		// we rely on no zero-length map exists in table-level. So if the table-level
+		// entry exists, it must conflict with InvolvingAll.
+		return true
+	}
+	if _, ok2 := tbls[model.InvolvingAll]; ok2 {
+		return true
+	}
+	if _, ok2 := tbls[requestTable]; ok2 {
+		return true
+	}
+	return false
+}
+
+// addRunning should only add the argument that passed the last checkRunnable.
+// The added jobs can be removed by removeRunning.
+func (j *runningJobs) addRunning(jobID int64, involves []model.InvolvingSchemaInfo) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
@@ -65,29 +221,40 @@ func (j *runningJobs) add(jobID int64, involves []model.InvolvingSchemaInfo) {
 	j.updateIDsStrGetter()
 
 	for _, info := range involves {
-		// DDL jobs related to placement policies and resource groups
-		if info.Database == model.InvolvingNone {
-			// should not happen
-			if intest.InTest {
-				if info.Table != model.InvolvingNone {
-					panic(fmt.Sprintf(
-						"job %d is invalid, involved table name is not empty: %s",
-						jobID, info.Table,
-					))
-				}
+		if info.Database != model.InvolvingNone {
+			if _, ok := j.schemas[info.Database]; !ok {
+				j.schemas[info.Database] = make(map[string]struct{})
 			}
-			continue
+			j.schemas[info.Database][info.Table] = struct{}{}
+		}
+		if info.Policy != model.InvolvingNone {
+			j.placementPolicies[info.Policy] = struct{}{}
+		}
+		if info.ResourceGroup != model.InvolvingNone {
+			j.resourceGroups[info.ResourceGroup] = struct{}{}
 		}
 
-		if _, ok := j.schemas[info.Database]; !ok {
-			j.schemas[info.Database] = make(map[string]struct{})
+		shared := info.Shared
+		if shared == nil {
+			continue
 		}
-		j.schemas[info.Database][info.Table] = struct{}{}
+		if shared.Database != model.InvolvingNone {
+			if _, ok := j.shared.schemas[shared.Database]; !ok {
+				j.shared.schemas[shared.Database] = make(map[string]struct{})
+			}
+			j.shared.schemas[shared.Database][shared.Table] = struct{}{}
+		}
+		if shared.Policy != model.InvolvingNone {
+			j.shared.placementPolicies[shared.Policy] = struct{}{}
+		}
+		if shared.ResourceGroup != model.InvolvingNone {
+			j.shared.resourceGroups[shared.ResourceGroup] = struct{}{}
+		}
 	}
 }
 
-// remove can be concurrently called with add and checkRunnable.
-func (j *runningJobs) remove(jobID int64, involves []model.InvolvingSchemaInfo) {
+// removeRunning can be concurrently called with add and checkRunnable.
+func (j *runningJobs) removeRunning(jobID int64, involves []model.InvolvingSchemaInfo) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
@@ -106,7 +273,58 @@ func (j *runningJobs) remove(jobID int64, involves []model.InvolvingSchemaInfo) 
 		if len(j.schemas[info.Database]) == 0 {
 			delete(j.schemas, info.Database)
 		}
+		delete(j.placementPolicies, info.Policy)
+		delete(j.resourceGroups, info.ResourceGroup)
+
+		shared := info.Shared
+		if shared == nil {
+			continue
+		}
+		if db, ok := j.shared.schemas[shared.Database]; ok {
+			delete(db, shared.Table)
+		}
+		if len(j.shared.schemas[shared.Database]) == 0 {
+			delete(j.shared.schemas, shared.Database)
+		}
+		delete(j.shared.placementPolicies, shared.Policy)
+		delete(j.shared.resourceGroups, shared.ResourceGroup)
 	}
+}
+
+// addPending is used to record the exclusive objects of jobs that can not run,
+// to block following jobs which has intersected shared objects with the pending
+// jobs. So we can have a "fair lock" semantics.
+//
+// The pending jobs can be removed by resetAllPending.
+func (j *runningJobs) addPending(involves []model.InvolvingSchemaInfo) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	for _, info := range involves {
+		if info.Database != model.InvolvingNone {
+			if _, ok := j.pending.schemas[info.Database]; !ok {
+				j.pending.schemas[info.Database] = make(map[string]struct{})
+			}
+			j.pending.schemas[info.Database][info.Table] = struct{}{}
+		}
+		if info.Policy != model.InvolvingNone {
+			j.pending.placementPolicies[info.Policy] = struct{}{}
+		}
+		if info.ResourceGroup != model.InvolvingNone {
+			j.pending.resourceGroups[info.ResourceGroup] = struct{}{}
+		}
+	}
+}
+
+// resetAllPending should be called when caller finishes the round of getting a
+// runnable DDL job.
+func (j *runningJobs) resetAllPending() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	j.pending.schemas = make(map[string]map[string]struct{})
+	j.pending.placementPolicies = make(map[string]struct{})
+	j.pending.resourceGroups = make(map[string]struct{})
 }
 
 func (j *runningJobs) updateIDsStrGetter() {
@@ -135,48 +353,4 @@ func (j *runningJobs) allIDs() string {
 	j.mu.RLock()
 	defer j.mu.RUnlock()
 	return j.idsStrGetter()
-}
-
-// checkRunnable checks whether the job can be run. If the caller found a
-// runnable job and decides to add it, it must add before next checkRunnable
-// invocation.
-func (j *runningJobs) checkRunnable(jobID int64, involves []model.InvolvingSchemaInfo) bool {
-	j.mu.RLock()
-	defer j.mu.RUnlock()
-
-	if _, ok := j.ids[jobID]; ok {
-		// should not happen
-		if intest.InTest {
-			panic(fmt.Sprintf("job %d is already running", jobID))
-		}
-		return false
-	}
-	// Currently flashback cluster is the only DDL that involves ALL schemas.
-	if _, ok := j.schemas[model.InvolvingAll]; ok {
-		return false
-	}
-
-	for _, info := range involves {
-		if info.Database == model.InvolvingAll {
-			if len(j.schemas) != 0 {
-				return false
-			}
-			continue
-		}
-
-		tbls, ok := j.schemas[info.Database]
-		if !ok {
-			continue
-		}
-		if info.Table == model.InvolvingAll {
-			return false
-		}
-		if _, ok2 := tbls[model.InvolvingAll]; ok2 {
-			return false
-		}
-		if _, ok2 := tbls[info.Table]; ok2 {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/ddl/ddl_running_jobs_test.go
+++ b/pkg/ddl/ddl_running_jobs_test.go
@@ -42,8 +42,10 @@ func mkJob(id int64, schemaTableNames ...string) (int64, []model.InvolvingSchema
 
 func checkInvariants(t *testing.T, j *runningJobs) {
 	// check table-level entry should not have zero length
-	for _, tables := range j.schemas {
-		require.Greater(t, len(tables), 0)
+	for _, checkingObj := range []*objects{j.exclusive, j.shared, j.pending} {
+		for _, tables := range checkingObj.schemas {
+			require.Greater(t, len(tables), 0)
+		}
 	}
 }
 
@@ -209,7 +211,7 @@ func TestExclusiveShared(t *testing.T) {
 
 	failedInvolves := []model.InvolvingSchemaInfo{
 		{Database: "db2", Table: model.InvolvingAll},
-		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db1", Table: "t1"}},
+		{Database: "db1", Table: "t1", Mode: model.SharedInvolving},
 	}
 	runnable = j.checkRunnable(0, failedInvolves)
 	require.False(t, runnable)
@@ -217,7 +219,7 @@ func TestExclusiveShared(t *testing.T) {
 	jobID2 := int64(2)
 	involves2 := []model.InvolvingSchemaInfo{
 		{Database: "db3", Table: model.InvolvingAll},
-		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db2", Table: "t2"}},
+		{Database: "db2", Table: "t2", Mode: model.SharedInvolving},
 	}
 	runnable = j.checkRunnable(jobID2, involves2)
 	require.True(t, runnable)
@@ -226,7 +228,7 @@ func TestExclusiveShared(t *testing.T) {
 	jobID3 := int64(3)
 	involves3 := []model.InvolvingSchemaInfo{
 		{Database: "db4", Table: model.InvolvingAll},
-		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db2", Table: "t2"}},
+		{Database: "db2", Table: "t2", Mode: model.SharedInvolving},
 	}
 	runnable = j.checkRunnable(jobID3, involves3)
 	require.True(t, runnable)
@@ -245,7 +247,7 @@ func TestExclusiveShared(t *testing.T) {
 	jobID4 := int64(4)
 	involves4 := []model.InvolvingSchemaInfo{
 		{Database: "db100", Table: model.InvolvingAll},
-		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db2", Table: "t2"}},
+		{Database: "db2", Table: "t2", Mode: model.SharedInvolving},
 	}
 	runnable = j.checkRunnable(jobID4, involves4)
 	require.False(t, runnable)

--- a/pkg/ddl/ddl_running_jobs_test.go
+++ b/pkg/ddl/ddl_running_jobs_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func mkJob(id int64, schemaTableNames ...string) (int64, []model.InvolvingSchemaInfo) {
-	schemaInfos := make([]model.InvolvingSchemaInfo, len(schemaTableNames))
+	schemaInfos := make([]model.InvolvingSchemaInfo, 0, len(schemaTableNames))
 	for _, schemaTableName := range schemaTableNames {
 		ss := strings.Split(schemaTableName, ".")
 		schemaInfos = append(schemaInfos, model.InvolvingSchemaInfo{
@@ -168,7 +168,9 @@ func TestSchemaPolicyAndResourceGroup(t *testing.T) {
 
 	jobID2 := int64(2)
 	involves2 := []model.InvolvingSchemaInfo{
-		{Database: "db2", Table: model.InvolvingAll, Policy: "p0", ResourceGroup: "g0"},
+		{Database: "db2", Table: model.InvolvingAll},
+		{Policy: "p0"},
+		{ResourceGroup: "g0"},
 	}
 	runnable = j.checkRunnable(jobID2, involves2)
 	require.True(t, runnable)

--- a/pkg/ddl/ddl_running_jobs_test.go
+++ b/pkg/ddl/ddl_running_jobs_test.go
@@ -47,26 +47,25 @@ func checkInvariants(t *testing.T, j *runningJobs) {
 	}
 }
 
-func TestRunningJobs(t *testing.T) {
-	orderedAllIDs := func(ids string) string {
-		if ids == "" {
-			return ""
-		}
-
-		ss := strings.Split(ids, ",")
-		ssid := make([]int, len(ss))
-		for i := range ss {
-			id, err := strconv.Atoi(ss[i])
-			require.NoError(t, err)
-			ssid[i] = id
-		}
-		sort.Ints(ssid)
-		for i := range ssid {
-			ss[i] = strconv.Itoa(ssid[i])
-		}
-		return strings.Join(ss, ",")
+func orderedAllIDs(ids string) string {
+	if ids == "" {
+		return ""
 	}
 
+	ss := strings.Split(ids, ",")
+	ssid := make([]int, len(ss))
+	for i := range ss {
+		id, _ := strconv.Atoi(ss[i])
+		ssid[i] = id
+	}
+	sort.Ints(ssid)
+	for i := range ssid {
+		ss[i] = strconv.Itoa(ssid[i])
+	}
+	return strings.Join(ss, ",")
+}
+
+func TestRunningJobs(t *testing.T) {
 	j := newRunningJobs()
 	require.Equal(t, "", j.allIDs())
 	checkInvariants(t, j)
@@ -77,11 +76,11 @@ func TestRunningJobs(t *testing.T) {
 	jobID1, involves1 := mkJob(1, "db1.t1", "db1.t2")
 	runnable = j.checkRunnable(jobID1, involves1)
 	require.True(t, runnable)
-	j.add(jobID1, involves1)
+	j.addRunning(jobID1, involves1)
 	jobID2, involves2 := mkJob(2, "db2.t3")
 	runnable = j.checkRunnable(jobID2, involves2)
 	require.True(t, runnable)
-	j.add(jobID2, involves2)
+	j.addRunning(jobID2, involves2)
 	require.Equal(t, "1,2", orderedAllIDs(j.allIDs()))
 	checkInvariants(t, j)
 
@@ -97,10 +96,10 @@ func TestRunningJobs(t *testing.T) {
 	jobID3, involves3 := mkJob(3, "db1.*")
 	runnable = j.checkRunnable(jobID3, involves3)
 	require.False(t, runnable)
-	j.remove(jobID1, involves1)
+	j.removeRunning(jobID1, involves1)
 	runnable = j.checkRunnable(jobID3, involves3)
 	require.True(t, runnable)
-	j.add(jobID3, involves3)
+	j.addRunning(jobID3, involves3)
 	require.Equal(t, "2,3", orderedAllIDs(j.allIDs()))
 	checkInvariants(t, j)
 
@@ -110,7 +109,7 @@ func TestRunningJobs(t *testing.T) {
 	jobID4, involves4 := mkJob(4, "db4.t100")
 	runnable = j.checkRunnable(jobID4, involves4)
 	require.True(t, runnable)
-	j.add(jobID4, involves4)
+	j.addRunning(jobID4, involves4)
 	require.Equal(t, "2,3,4", orderedAllIDs(j.allIDs()))
 	checkInvariants(t, j)
 
@@ -118,18 +117,146 @@ func TestRunningJobs(t *testing.T) {
 	runnable = j.checkRunnable(jobID5, involves5)
 	require.False(t, runnable)
 
-	j.remove(jobID2, involves2)
-	j.remove(jobID3, involves3)
-	j.remove(jobID4, involves4)
+	j.removeRunning(jobID2, involves2)
+	j.removeRunning(jobID3, involves3)
+	j.removeRunning(jobID4, involves4)
 	require.Equal(t, "", orderedAllIDs(j.allIDs()))
 	checkInvariants(t, j)
 
 	runnable = j.checkRunnable(jobID5, involves5)
 	require.True(t, runnable)
-	j.add(jobID5, involves5)
+	j.addRunning(jobID5, involves5)
 	require.Equal(t, "5", orderedAllIDs(j.allIDs()))
 	checkInvariants(t, j)
 
 	runnable = j.checkRunnable(mkJob(0, "db1.t1"))
 	require.False(t, runnable)
+}
+
+func TestSchemaPolicyAndResourceGroup(t *testing.T) {
+	j := newRunningJobs()
+
+	jobID1, involves1 := mkJob(1, "db1.t1", "db1.t2")
+	runnable := j.checkRunnable(jobID1, involves1)
+	require.True(t, runnable)
+	j.addRunning(jobID1, involves1)
+
+	failedInvolves := []model.InvolvingSchemaInfo{
+		{Policy: "p0"},
+		{Database: "db1", Table: model.InvolvingAll},
+	}
+	runnable = j.checkRunnable(0, failedInvolves)
+	require.False(t, runnable)
+
+	failedInvolves = []model.InvolvingSchemaInfo{
+		{Database: model.InvolvingAll, Table: model.InvolvingAll},
+		{ResourceGroup: "g0"},
+	}
+	runnable = j.checkRunnable(0, failedInvolves)
+	require.False(t, runnable)
+
+	jobID2 := int64(2)
+	involves2 := []model.InvolvingSchemaInfo{
+		{Database: "db2", Table: model.InvolvingAll, Policy: "p0", ResourceGroup: "g0"},
+	}
+	runnable = j.checkRunnable(jobID2, involves2)
+	require.True(t, runnable)
+	j.addRunning(jobID2, involves2)
+
+	jobID3 := int64(3)
+	involves3 := []model.InvolvingSchemaInfo{
+		{Policy: "p1"},
+		{ResourceGroup: "g1"},
+	}
+	runnable = j.checkRunnable(jobID3, involves3)
+	require.True(t, runnable)
+	j.addRunning(jobID3, involves3)
+	require.Equal(t, "1,2,3", orderedAllIDs(j.allIDs()))
+
+	failedInvolves = []model.InvolvingSchemaInfo{
+		{ResourceGroup: "g0"},
+	}
+	runnable = j.checkRunnable(0, failedInvolves)
+	require.False(t, runnable)
+
+	j.removeRunning(jobID2, involves2)
+	require.Equal(t, "1,3", orderedAllIDs(j.allIDs()))
+
+	jobID4 := int64(4)
+	involves4 := []model.InvolvingSchemaInfo{
+		{Policy: "p0"},
+		{Database: "db3", Table: "t3"},
+	}
+	runnable = j.checkRunnable(jobID4, involves4)
+	require.True(t, runnable)
+	j.addRunning(jobID4, involves4)
+	require.Equal(t, "1,3,4", orderedAllIDs(j.allIDs()))
+
+	failedInvolves = []model.InvolvingSchemaInfo{
+		{Database: "db3", Table: "t3"},
+	}
+	runnable = j.checkRunnable(0, failedInvolves)
+	require.False(t, runnable)
+}
+
+func TestExclusiveShared(t *testing.T) {
+	j := newRunningJobs()
+
+	jobID1, involves1 := mkJob(1, "db1.t1", "db1.t2")
+	runnable := j.checkRunnable(jobID1, involves1)
+	require.True(t, runnable)
+	j.addRunning(jobID1, involves1)
+
+	failedInvolves := []model.InvolvingSchemaInfo{
+		{Database: "db2", Table: model.InvolvingAll},
+		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db1", Table: "t1"}},
+	}
+	runnable = j.checkRunnable(0, failedInvolves)
+	require.False(t, runnable)
+
+	jobID2 := int64(2)
+	involves2 := []model.InvolvingSchemaInfo{
+		{Database: "db3", Table: model.InvolvingAll},
+		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db2", Table: "t2"}},
+	}
+	runnable = j.checkRunnable(jobID2, involves2)
+	require.True(t, runnable)
+	j.addRunning(jobID2, involves2)
+
+	jobID3 := int64(3)
+	involves3 := []model.InvolvingSchemaInfo{
+		{Database: "db4", Table: model.InvolvingAll},
+		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db2", Table: "t2"}},
+	}
+	runnable = j.checkRunnable(jobID3, involves3)
+	require.True(t, runnable)
+	j.addRunning(jobID3, involves3)
+	require.Equal(t, "1,2,3", orderedAllIDs(j.allIDs()))
+
+	pendingInvolves := []model.InvolvingSchemaInfo{
+		{Database: "db2", Table: "t2"},
+	}
+	runnable = j.checkRunnable(0, pendingInvolves)
+	require.False(t, runnable)
+	j.addPending(pendingInvolves)
+	require.Equal(t, "1,2,3", orderedAllIDs(j.allIDs()))
+
+	// because there's a pending job on db2.t2, next job on db2.t2 should be blocked
+	jobID4 := int64(4)
+	involves4 := []model.InvolvingSchemaInfo{
+		{Database: "db100", Table: model.InvolvingAll},
+		{Shared: &model.InvolvingSharedSchemaInfo{Database: "db2", Table: "t2"}},
+	}
+	runnable = j.checkRunnable(jobID4, involves4)
+	require.False(t, runnable)
+	require.Equal(t, "1,2,3", orderedAllIDs(j.allIDs()))
+
+	// mimic all running job is finished and here's the next round to get jobs
+	j.resetAllPending()
+	j.removeRunning(jobID1, involves1)
+	j.removeRunning(jobID2, involves2)
+	j.removeRunning(jobID3, involves3)
+
+	runnable = j.checkRunnable(0, pendingInvolves)
+	require.True(t, runnable)
 }

--- a/pkg/ddl/foreign_key_test.go
+++ b/pkg/ddl/foreign_key_test.go
@@ -213,9 +213,6 @@ func TestForeignKey(t *testing.T) {
 }
 
 func TestTruncateOrDropTableWithForeignKeyReferred2(t *testing.T) {
-	// TODO(lance6716): enable this test case after introduce exclusive and shared objects on runningJobs.
-	t.Skip("this test implicitly depends on DDL job dependency on FK and " +
-		"TestTruncateOrDropTableWithForeignKeyReferred. Will enable it soon.")
 	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, testLease)
 	d := dom.DDL()
 	tk := testkit.NewTestKit(t, store)
@@ -312,9 +309,6 @@ func TestDropIndexNeededInForeignKey2(t *testing.T) {
 }
 
 func TestDropDatabaseWithForeignKeyReferred2(t *testing.T) {
-	// TODO(lance6716): enable this test case after introduce exclusive and shared objects on runningJobs.
-	t.Skip("this test implicitly depends on DDL job dependency on FK and " +
-		"TestDropDatabaseWithForeignKeyReferred. Will enable it soon.")
 	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, testLease)
 	d := dom.DDL()
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -184,6 +184,7 @@ func (s *jobScheduler) close() {
 	}
 }
 
+// getJob reads tidb_ddl_job and returns the first runnable DDL job.
 func (s *jobScheduler) getJob(se *sess.Session, tp jobType) (*model.Job, error) {
 	defer s.runningJobs.resetAllPending()
 

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -518,12 +518,12 @@ func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.
 	failpoint.InjectCall("beforeDelivery2Worker", job)
 	injectFailPointForGetJob(job)
 	jobID, involvedSchemaInfos := job.ID, job.GetInvolvingSchemaInfo()
-	s.runningJobs.add(jobID, involvedSchemaInfos)
+	s.runningJobs.addRunning(jobID, involvedSchemaInfos)
 	metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Inc()
 	s.wg.RunWithLog(func() {
 		defer func() {
 			failpoint.InjectCall("afterDelivery2Worker", job)
-			s.runningJobs.remove(jobID, involvedSchemaInfos)
+			s.runningJobs.removeRunning(jobID, involvedSchemaInfos)
 			asyncNotify(s.ddlJobNotifyCh)
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()
 			if wk.ctx.Err() != nil && ingest.LitBackCtxMgr != nil {

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -185,6 +185,8 @@ func (s *jobScheduler) close() {
 }
 
 func (s *jobScheduler) getJob(se *sess.Session, tp jobType) (*model.Job, error) {
+	defer s.runningJobs.resetAllPending()
+
 	not := "not"
 	label := "get_job_general"
 	if tp == jobTypeReorg {
@@ -240,7 +242,6 @@ func (s *jobScheduler) getJob(se *sess.Session, tp jobType) (*model.Job, error) 
 			s.runningJobs.addPending(involving)
 			return nil, errors.Trace(err)
 		}
-		s.runningJobs.resetAllPending()
 		return &job, nil
 	}
 	return nil, nil

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -15,7 +15,10 @@
 package ddl
 
 import (
+	"fmt"
+
 	"github.com/pingcap/errors"
+	ddllogutil "github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -23,6 +26,8 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/intest"
+	"go.uber.org/zap"
 )
 
 func (d *ddl) MultiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info *model.MultiSchemaInfo) error {
@@ -35,18 +40,78 @@ func (d *ddl) MultiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info *mode
 		return errors.Trace(err)
 	}
 
+	logFn := ddllogutil.DDLLogger().Warn
+	if intest.InTest {
+		logFn = ddllogutil.DDLLogger().Fatal
+	}
+
+	var involvingSchemaInfo []model.InvolvingSchemaInfo
+	for _, j := range subJobs {
+		switch j.Type {
+		case model.ActionAlterTablePlacement:
+			ref, ok := j.Args[0].(*model.PolicyRefInfo)
+			if !ok {
+				logFn("unexpected type of policy reference info",
+					zap.Any("args[0]", j.Args[0]),
+					zap.String("type", fmt.Sprintf("%T", j.Args[0])))
+				continue
+			}
+			if ref == nil {
+				continue
+			}
+			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
+				Shared: &model.InvolvingSharedSchemaInfo{Policy: ref.Name.L},
+			})
+		case model.ActionAddForeignKey:
+			ref, ok := j.Args[0].(*model.FKInfo)
+			if !ok {
+				logFn("unexpected type of foreign key info",
+					zap.Any("args[0]", j.Args[0]),
+					zap.String("type", fmt.Sprintf("%T", j.Args[0])))
+				continue
+			}
+			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
+				Shared: &model.InvolvingSharedSchemaInfo{
+					Database: ref.RefSchema.L,
+					Table:    ref.RefTable.L,
+				},
+			})
+		case model.ActionAlterTablePartitionPlacement:
+			if len(j.Args) < 2 {
+				logFn("unexpected number of arguments for partition placement",
+					zap.Int("len(args)", len(j.Args)),
+					zap.Any("args", j.Args))
+				continue
+			}
+			ref, ok := j.Args[1].(*model.PolicyRefInfo)
+			if !ok {
+				logFn("unexpected type of policy reference info",
+					zap.Any("args[0]", j.Args[0]),
+					zap.String("type", fmt.Sprintf("%T", j.Args[0])))
+				continue
+			}
+			if ref == nil {
+				continue
+			}
+			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
+				Shared: &model.InvolvingSharedSchemaInfo{Policy: ref.Name.L},
+			})
+		}
+	}
+
 	job := &model.Job{
-		SchemaID:        schema.ID,
-		TableID:         t.Meta().ID,
-		SchemaName:      schema.Name.L,
-		TableName:       t.Meta().Name.L,
-		Type:            model.ActionMultiSchemaChange,
-		BinlogInfo:      &model.HistoryInfo{},
-		Args:            nil,
-		MultiSchemaInfo: info,
-		ReorgMeta:       nil,
-		CDCWriteSource:  ctx.GetSessionVars().CDCWriteSource,
-		SQLMode:         ctx.GetSessionVars().SQLMode,
+		SchemaID:            schema.ID,
+		TableID:             t.Meta().ID,
+		SchemaName:          schema.Name.L,
+		TableName:           t.Meta().Name.L,
+		Type:                model.ActionMultiSchemaChange,
+		BinlogInfo:          &model.HistoryInfo{},
+		Args:                nil,
+		MultiSchemaInfo:     info,
+		ReorgMeta:           nil,
+		CDCWriteSource:      ctx.GetSessionVars().CDCWriteSource,
+		InvolvingSchemaInfo: involvingSchemaInfo,
+		SQLMode:             ctx.GetSessionVars().SQLMode,
 	}
 	if containsDistTaskSubJob(subJobs) {
 		job.ReorgMeta, err = newReorgMetaFromVariables(job, ctx)

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -60,7 +60,8 @@ func (d *ddl) MultiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info *mode
 				continue
 			}
 			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
-				Shared: &model.InvolvingSharedSchemaInfo{Policy: ref.Name.L},
+				Policy: ref.Name.L,
+				Mode:   model.SharedInvolving,
 			})
 		case model.ActionAddForeignKey:
 			ref, ok := j.Args[0].(*model.FKInfo)
@@ -71,10 +72,9 @@ func (d *ddl) MultiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info *mode
 				continue
 			}
 			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
-				Shared: &model.InvolvingSharedSchemaInfo{
-					Database: ref.RefSchema.L,
-					Table:    ref.RefTable.L,
-				},
+				Database: ref.RefSchema.L,
+				Table:    ref.RefTable.L,
+				Mode:     model.SharedInvolving,
 			})
 		case model.ActionAlterTablePartitionPlacement:
 			if len(j.Args) < 2 {
@@ -94,7 +94,8 @@ func (d *ddl) MultiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info *mode
 				continue
 			}
 			involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
-				Shared: &model.InvolvingSharedSchemaInfo{Policy: ref.Name.L},
+				Policy: ref.Name.L,
+				Mode:   model.SharedInvolving,
 			})
 		}
 	}

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -100,6 +100,13 @@ func (d *ddl) MultiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info *mode
 		}
 	}
 
+	if len(involvingSchemaInfo) > 0 {
+		involvingSchemaInfo = append(involvingSchemaInfo, model.InvolvingSchemaInfo{
+			Database: schema.Name.L,
+			Table:    t.Meta().Name.L,
+		})
+	}
+
 	job := &model.Job{
 		SchemaID:            schema.ID,
 		TableID:             t.Meta().ID,

--- a/pkg/ddl/placement_policy_test.go
+++ b/pkg/ddl/placement_policy_test.go
@@ -770,7 +770,7 @@ func TestCreateTableWithInfoPlacement(t *testing.T) {
 	tk.MustExec("drop placement policy p1")
 	tk.MustExec("create placement policy p1 followers=2")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	require.Nil(t, dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl, ddl.OnExistError))
+	require.Nil(t, dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl, nil, ddl.OnExistError))
 	tk.MustQuery("show create table t1").Check(testkit.Rows("t1 CREATE TABLE `t1` (\n" +
 		"  `a` int(11) DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
@@ -791,7 +791,7 @@ func TestCreateTableWithInfoPlacement(t *testing.T) {
 	tbl2.Name = model.NewCIStr("t3")
 	tbl2.PlacementPolicyRef.Name = model.NewCIStr("pxx")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl2, ddl.OnExistError)
+	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl2, nil, ddl.OnExistError)
 	require.Equal(t, "[schema:8239]Unknown placement policy 'pxx'", err.Error())
 }
 

--- a/pkg/ddl/placement_sql_test.go
+++ b/pkg/ddl/placement_sql_test.go
@@ -534,7 +534,7 @@ func TestPlacementMode(t *testing.T) {
 	require.NotNil(t, tbl.PlacementPolicyRef)
 	tbl.Name = model.NewCIStr("t2")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, ddl.OnExistError)
+	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, nil, ddl.OnExistError)
 	require.NoError(t, err)
 	tk.MustQuery("show create table t2").Check(testkit.Rows("t2 CREATE TABLE `t2` (\n" +
 		"  `id` int(11) DEFAULT NULL\n" +
@@ -548,7 +548,7 @@ func TestPlacementMode(t *testing.T) {
 	tbl.Name = model.NewCIStr("t2")
 	tbl.PlacementPolicyRef.Name = model.NewCIStr("pxx")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, ddl.OnExistError)
+	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, nil, ddl.OnExistError)
 	require.NoError(t, err)
 	tk.MustQuery("show create table t2").Check(testkit.Rows("t2 CREATE TABLE `t2` (\n" +
 		"  `id` int(11) DEFAULT NULL\n" +

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -463,7 +463,7 @@ func (d *Checker) CreateSchemaWithInfo(ctx sessionctx.Context, info *model.DBInf
 }
 
 // CreateTableWithInfo implements the DDL interface.
-func (*Checker) CreateTableWithInfo(_ sessionctx.Context, _ model.CIStr, _ *model.TableInfo, _ ...ddl.CreateTableWithInfoConfigurier) error {
+func (*Checker) CreateTableWithInfo(_ sessionctx.Context, _ model.CIStr, _ *model.TableInfo, _ []model.InvolvingSchemaInfo, _ ...ddl.CreateTableWithInfoConfigurier) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -230,7 +230,7 @@ func (d SchemaTracker) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStm
 		onExist = ddl.OnExistIgnore
 	}
 
-	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, onExist)
+	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, nil, onExist)
 }
 
 // CreateTableWithInfo implements the DDL interface.
@@ -238,6 +238,7 @@ func (d SchemaTracker) CreateTableWithInfo(
 	_ sessionctx.Context,
 	dbName model.CIStr,
 	info *model.TableInfo,
+	_ []model.InvolvingSchemaInfo,
 	cs ...ddl.CreateTableWithInfoConfigurier,
 ) error {
 	c := ddl.GetCreateTableWithInfoConfig(cs)
@@ -264,7 +265,7 @@ func (d SchemaTracker) CreateTableWithInfo(
 
 // CreateView implements the DDL interface.
 func (d SchemaTracker) CreateView(ctx sessionctx.Context, s *ast.CreateViewStmt) error {
-	viewInfo, err := ddl.BuildViewInfo(ctx, s)
+	viewInfo, err := ddl.BuildViewInfo(s)
 	if err != nil {
 		return err
 	}
@@ -290,7 +291,7 @@ func (d SchemaTracker) CreateView(ctx sessionctx.Context, s *ast.CreateViewStmt)
 		onExist = ddl.OnExistReplace
 	}
 
-	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, onExist)
+	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, nil, onExist)
 }
 
 // DropTable implements the DDL interface.
@@ -1189,7 +1190,7 @@ func (SchemaTracker) AlterResourceGroup(_ sessionctx.Context, _ *ast.AlterResour
 // BatchCreateTableWithInfo implements the DDL interface, it will call CreateTableWithInfo for each table.
 func (d SchemaTracker) BatchCreateTableWithInfo(ctx sessionctx.Context, schema model.CIStr, info []*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
 	for _, tableInfo := range info {
-		if err := d.CreateTableWithInfo(ctx, schema, tableInfo, cs...); err != nil {
+		if err := d.CreateTableWithInfo(ctx, schema, tableInfo, nil, cs...); err != nil {
 			return err
 		}
 	}

--- a/pkg/ddl/systable/manager_test.go
+++ b/pkg/ddl/systable/manager_test.go
@@ -49,7 +49,7 @@ func TestManager(t *testing.T) {
 		_, err := mgr.GetJobByID(ctx, 9999)
 		require.ErrorIs(t, err, systable.ErrNotFound)
 		tk.MustExec(`insert into mysql.tidb_ddl_job(job_id, reorg, schema_ids, table_ids, job_meta, type, processing)
-					values(9999, 0, '1', '1', '{"id":9999,"schema_name":"db","table_name":"tbl"}', 1, 0)`)
+					values(9999, 0, '1', '1', '{"id":9999}', 1, 0)`)
 		job, err := mgr.GetJobByID(ctx, 9999)
 		require.NoError(t, err)
 		require.EqualValues(t, 9999, job.ID)

--- a/pkg/ddl/systable/manager_test.go
+++ b/pkg/ddl/systable/manager_test.go
@@ -49,7 +49,7 @@ func TestManager(t *testing.T) {
 		_, err := mgr.GetJobByID(ctx, 9999)
 		require.ErrorIs(t, err, systable.ErrNotFound)
 		tk.MustExec(`insert into mysql.tidb_ddl_job(job_id, reorg, schema_ids, table_ids, job_meta, type, processing)
-					values(9999, 0, '1', '1', '{"id":9999}', 1, 0)`)
+					values(9999, 0, '1', '1', '{"id":9999,"schema_name":"db","table_name":"tbl"}', 1, 0)`)
 		job, err := mgr.GetJobByID(ctx, 9999)
 		require.NoError(t, err)
 		require.EqualValues(t, 9999, job.ID)

--- a/pkg/executor/brie_utils.go
+++ b/pkg/executor/brie_utils.go
@@ -109,7 +109,7 @@ func BRIECreateTable(
 
 	table = table.Clone()
 
-	return d.CreateTableWithInfo(sctx, dbName, table, append(cs, ddl.OnExistIgnore)...)
+	return d.CreateTableWithInfo(sctx, dbName, table, nil, append(cs, ddl.OnExistIgnore)...)
 }
 
 // BRIECreateTables creates the tables with OnExistIgnore option in batch

--- a/pkg/parser/model/ddl.go
+++ b/pkg/parser/model/ddl.go
@@ -586,35 +586,36 @@ type Job struct {
 }
 
 // InvolvingSchemaInfo returns the schema info involved in the job. The value
-// should be stored in lower case. The top level fields are exclusively used for
-// the job, and the shared objects are saved in Shared field.
-//
-// Exclusive and shared objects are considered like the exclusive lock and shared
-// lock when calculate DDL job dependencies. And we also implement the fair lock
-// semantic which means if job B (exclusive request object 0) is waiting for the
-// running job A (shared request object 0), and job C (shared request object 0)
-// arrives, job C should also be blocked until job B is finished although job A &
-// C has no dependency.
+// should be stored in lower case. No need to use this type as one-of
+// Database/Table, Policy, ResourceGroup.
 type InvolvingSchemaInfo struct {
-	Database      string                     `json:"database"`
-	Table         string                     `json:"table"`
-	Policy        string                     `json:"policy,omitempty"`
-	ResourceGroup string                     `json:"resource_group,omitempty"`
-	Shared        *InvolvingSharedSchemaInfo `json:"shared,omitempty"`
+	Database      string                  `json:"database,omitempty"`
+	Table         string                  `json:"table,omitempty"`
+	Policy        string                  `json:"policy,omitempty"`
+	ResourceGroup string                  `json:"resource_group,omitempty"`
+	Mode          InvolvingSchemaInfoMode `json:"mode,omitempty"`
 }
 
-// InvolvingSharedSchemaInfo is used by InvolvingSchemaInfo.
-type InvolvingSharedSchemaInfo struct {
-	Database      string `json:"database,omitempty"`
-	Table         string `json:"table,omitempty"`
-	Policy        string `json:"policy,omitempty"`
-	ResourceGroup string `json:"resource_group,omitempty"`
-}
+type InvolvingSchemaInfoMode int
+
+// ExclusiveInvolving and SharedInvolving are considered like the exclusive lock
+// and shared lock when calculate DDL job dependencies. And we also implement the
+// fair lock semantic which means if we have job A/B/C arrive in order, and job B
+// (exclusive request object 0) is waiting for the running job A (shared request
+// object 0), and job C (shared request object 0) arrives, job C should also be
+// blocked until job B is finished although job A & C has no dependency.
+const (
+	// ExclusiveInvolving is the default value to keep compatibility with old
+	// versions.
+	ExclusiveInvolving InvolvingSchemaInfoMode = iota
+	SharedInvolving
+)
 
 const (
-	// InvolvingAll means all schemas/tables are affected. If it's used in
-	// InvolvingSchemaInfo.Database, it also means all placement policies and
-	// resource groups are affected. Currently the only usage is FLASHBACK CLUSTER.
+	// InvolvingAll means all schemas/tables are affected. It's used in
+	// InvolvingSchemaInfo.Database/Tables fields. When both the Database and Tables
+	// are InvolvingAll it also means all placement policies and resource groups are
+	// affected. Currently the only case is FLASHBACK CLUSTER.
 	InvolvingAll = "*"
 	// InvolvingNone means no schema/table is affected.
 	InvolvingNone = ""

--- a/pkg/parser/model/ddl.go
+++ b/pkg/parser/model/ddl.go
@@ -1057,7 +1057,7 @@ func (job *Job) GetInvolvingSchemaInfo() []InvolvingSchemaInfo {
 	}
 	table := job.TableName
 	// for schema related DDL, such as 'drop schema xxx'
-	if table == "" {
+	if len(job.SchemaName) > 0 && table == "" {
 		table = InvolvingAll
 	}
 	return []InvolvingSchemaInfo{

--- a/pkg/parser/model/ddl.go
+++ b/pkg/parser/model/ddl.go
@@ -596,6 +596,7 @@ type InvolvingSchemaInfo struct {
 	Mode          InvolvingSchemaInfoMode `json:"mode,omitempty"`
 }
 
+// InvolvingSchemaInfoMode is used by InvolvingSchemaInfo.Mode.
 type InvolvingSchemaInfoMode int
 
 // ExclusiveInvolving and SharedInvolving are considered like the exclusive lock

--- a/pkg/parser/model/ddl.go
+++ b/pkg/parser/model/ddl.go
@@ -586,8 +586,9 @@ type Job struct {
 }
 
 // InvolvingSchemaInfo returns the schema info involved in the job. The value
-// should be stored in lower case. No need to use this type as one-of
-// Database/Table, Policy, ResourceGroup.
+// should be stored in lower case. Only one type of the three member types
+// (Database&Table, Policy, ResourceGroup) should only be set in a
+// InvolvingSchemaInfo.
 type InvolvingSchemaInfo struct {
 	Database      string                  `json:"database,omitempty"`
 	Table         string                  `json:"table,omitempty"`


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52795, ref https://github.com/pingcap/tidb/issues/53246

Problem Summary:

### What changed and how does it work?

a DDL job will modify and refer to multiple objects (database, table, placement policy, resource group). Treat it like the job will lock these objects, in exclusive or shared lock mode. If the job finished all locking, then it can run now. In other words, the job has no dependency on other running jobs. This PR implements this lock-like behaviour.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
