### PR TITLE
backup: add version checker for store based backup

### DIFF
--- a/br/pkg/version/version.go
+++ b/br/pkg/version/version.go
@@ -233,6 +233,15 @@ func CheckVersionForBR(s *metapb.Store, tikvVersion *semver.Version) error {
 			s.Address, tikvVersion)
 	}
 
+	// 8.2 br(store based backup) does not support tikv <= 8.1
+	// due to the performance issue https://github.com/tikv/tikv/issues/17168
+	// TODO: we can remove this check if the performance issue is fixed and cherry-pick
+	if (BRVersion.Major > 8 || (BRVersion.Major == 8 && BRVersion.Minor >= 2)) &&
+		(tikvVersion.Major < 8 || (tikvVersion.Major == 8 && tikvVersion.Minor < 2)) {
+		return errors.Annotatef(berrors.ErrVersionMismatch, "TiKV node %s version %s and BR %s version mismatch, please use the same version of BR",
+			s.Address, tikvVersion, build.ReleaseVersion)
+	}
+
 	// don't warn if we are the master build, which always have the version v4.0.0-beta.2-*
 	if build.GitBranch != "master" && tikvVersion.Compare(*BRVersion) > 0 {
 		log.Warn(fmt.Sprintf("BR version is outdated, please consider use version %s of BR", tikvVersion))

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -329,6 +329,24 @@ func TestCheckClusterVersion(t *testing.T) {
 	}
 
 	{
+		build.ReleaseVersion = "v8.2.0"
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: "v8.1.0"}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBR)
+		require.Error(t, err)
+	}
+
+	{
+		build.ReleaseVersion = "v8.1.0"
+		mock.getAllStores = func() []*metapb.Store {
+			return []*metapb.Store{{Version: "v8.2.0"}}
+		}
+		err := CheckClusterVersion(context.Background(), &mock, CheckVersionForBR)
+		require.NoError(t, err)
+	}
+
+	{
 		mock.getAllStores = func() []*metapb.Store {
 			return []*metapb.Store{{Version: "v6.4.0"}}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52534

Problem Summary:
Due to https://github.com/tikv/tikv/issues/17168, the current tikv does not support backup with subranges very well. 
So we need a version checker in case of use store based backup running on old version of tikv.(There is no correctness issue, but the performance may not work as expected.)

### What changed and how does it work?
Add a version check
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
