### PR TITLE
expression: fix the type of casting YEAR as json

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -815,7 +815,7 @@ func (b *builtinCastIntAsJSONSig) evalJSON(ctx EvalContext, row chunk.Row) (res 
 	}
 	if mysql.HasIsBooleanFlag(b.args[0].GetType(ctx).GetFlag()) {
 		res = types.CreateBinaryJSON(val != 0)
-	} else if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
+	} else if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) || b.args[0].GetType(ctx).GetType() == mysql.TypeYear {
 		res = types.CreateBinaryJSON(uint64(val))
 	} else {
 		res = types.CreateBinaryJSON(val)

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -1148,7 +1148,7 @@ func (b *builtinCastIntAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 				result.AppendJSON(types.CreateBinaryJSON(nums[i] != 0))
 			}
 		}
-	} else if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
+	} else if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) || b.args[0].GetType(ctx).GetType() == mysql.TypeYear {
 		for i := 0; i < n; i++ {
 			if buf.IsNull(i) {
 				result.AppendNull()

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -762,3 +762,6 @@ SELECT JSON_SCHEMA_VALID(CONCAT('{"foo": ',repeat('[', 1000),repeat(']', 1000),'
 Error 3157 (22032): The JSON document exceeds the maximum depth.
 SELECT JSON_SCHEMA_VALID('{"properties": {"a": {"exclusiveMinimum": true}}}', '{}');
 Error 3853 (22032): Invalid JSON type in argument 1 to function json_schema_valid; an error unmarshaling properties from json: error unmarshaling exclusiveMinimum from json: json: cannot unmarshal bool into Go value of type jsonschema.ExclusiveMinimum is required.
+select json_type(cast(cast('2024' as year) as json));
+json_type(cast(cast('2024' as year) as json))
+UNSIGNED INTEGER

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -480,3 +480,7 @@ SELECT JSON_SCHEMA_VALID(CONCAT('{"foo": ',repeat('[', 1000),repeat(']', 1000),'
 # - https://bugs.mysql.com/bug.php?id=106454
 -- error 3853
 SELECT JSON_SCHEMA_VALID('{"properties": {"a": {"exclusiveMinimum": true}}}', '{}');
+
+# TestIssue54494
+# https://github.com/pingcap/tidb/issues/54494
+select json_type(cast(cast('2024' as year) as json));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #54027, close #54494

Problem Summary:

When casting YEAR as JSON, the YEAR argument is not regarded as an unsigned value.

### What changed and how does it work?

Regard the `YEAR` argument as an unsigned value, and give `unsigned integer` json type.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the `json_type` of a json value converted from `YEAR` is not correct.
```
