### PR TITLE
br: fix backup to aliyum OSS not support ak/sk as env

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -299,7 +299,7 @@ func createOssRAMCred() (*credentials.Credentials, error) {
 	return credentials.NewChainCredentials([]credentials.Provider{
 		&credentials.EnvProvider{},
 		&credentials.SharedCredentialsProvider{},
-		&credentials.StaticProvider{Value: credentials.Value{ncred.AccessKeyId, ncred.AccessKeySecret, ncred.AccessKeyStsToken, ""}},
+		&credentials.StaticProvider{Value: credentials.Value{AccessKeyID: ncred.AccessKeyId, SecretAccessKey: ncred.AccessKeySecret, SessionToken: ncred.AccessKeyStsToken, ProviderName: ""}},
 	}), nil
 }
 

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -291,7 +291,7 @@ func createOssRAMCred() (*credentials.Credentials, error) {
 	if err != nil {
 		return nil, nil
 	}
-    var aliCred, ok = cred.(*alicred.StsTokenCredential)
+	var aliCred, ok = cred.(*alicred.StsTokenCredential)
 	if !ok {
 		return nil, errors.Errorf("invalid credential type %T", cred)
 	}

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -280,7 +280,6 @@ func autoNewCred(qs *backuppb.S3) (cred *credentials.Credentials, err error) {
 	}
 	// if it Contains 'aliyuncs', fetch the sts token.
 	if strings.Contains(endpoint, domainAliyun) {
-		// if we didn't get the credential, use ali provider.
 		return createOssRAMCred()
 	}
 	// other case ,return no error and run default(aws) follow.
@@ -290,15 +289,14 @@ func autoNewCred(qs *backuppb.S3) (cred *credentials.Credentials, err error) {
 func createOssRAMCred() (*credentials.Credentials, error) {
 	cred, err := aliproviders.NewInstanceMetadataProvider().Retrieve()
 	if err != nil {
-		log.Info("failed to retrieve alibaba ram provider", zap.Error(err))
 		return nil, nil
 	}
-	ncred := cred.(*alicred.StsTokenCredential)
-	aliCred := credentials.NewStaticCredentials(ncred.AccessKeyId, ncred.AccessKeySecret, ncred.AccessKeyStsToken)
-	if _, err := aliCred.Get(); err != nil {
+	aliCred := cred.(*alicred.StsTokenCredential)
+	newCred := credentials.NewStaticCredentials(aliCred.AccessKeyId, aliCred.AccessKeySecret, aliCred.AccessKeyStsToken)
+	if _, err := newCred.Get(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return aliCred, nil
+	return newCred, nil
 }
 
 // NewS3Storage initialize a new s3 storage for metadata.

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -281,10 +281,10 @@ func autoNewCred(qs *backuppb.S3) (cred *credentials.Credentials, err error) {
 	// if it Contains 'aliyuncs', fetch the sts token.
 	if strings.Contains(endpoint, domainAliyun) {
 		// if we didn't get the credential, use ali provider.
-		if _,err := cred.Get(); err != nil {
+		if _, err := cred.Get(); err != nil {
 			return createOssRAMCred()
 		}
-		return cred,nil
+		return cred, nil
 	}
 	// other case ,return no error and run default(aws) follow.
 	return nil, nil
@@ -300,7 +300,7 @@ func createOssRAMCred() (*credentials.Credentials, error) {
 		&credentials.EnvProvider{},
 		&credentials.SharedCredentialsProvider{},
 		&credentials.StaticProvider{Value: credentials.Value{ncred.AccessKeyId, ncred.AccessKeySecret, ncred.AccessKeyStsToken, ""}},
-	}),nil
+	}), nil
 }
 
 // NewS3Storage initialize a new s3 storage for metadata.

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -327,7 +327,6 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *ExternalStora
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	log.Info("s3 storage config", zap.String("endpoint", qs.Endpoint), zap.Bool("cred is nil", cred == nil))
 	if cred != nil {
 		awsConfig.WithCredentials(cred)
 	}

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -289,13 +289,18 @@ func autoNewCred(qs *backuppb.S3) (cred *credentials.Credentials, err error) {
 func createOssRAMCred() (*credentials.Credentials, error) {
 	cred, err := aliproviders.NewInstanceMetadataProvider().Retrieve()
 	if err != nil {
+		log.Warn("failed to get aliyun ram credential", zap.Error(err))
 		return nil, nil
 	}
 	var aliCred, ok = cred.(*alicred.StsTokenCredential)
 	if !ok {
 		return nil, errors.Errorf("invalid credential type %T", cred)
 	}
-	newCred := credentials.NewStaticCredentials(aliCred.AccessKeyId, aliCred.AccessKeySecret, aliCred.AccessKeyStsToken)
+	newCred := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{},
+		&credentials.StaticProvider{Value: credentials.Value{AccessKeyID: aliCred.AccessKeyId, SecretAccessKey: aliCred.AccessKeySecret, SessionToken: aliCred.AccessKeyStsToken, ProviderName: ""}},
+	})
 	if _, err := newCred.Get(); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -291,7 +291,10 @@ func createOssRAMCred() (*credentials.Credentials, error) {
 	if err != nil {
 		return nil, nil
 	}
-	aliCred := cred.(*alicred.StsTokenCredential)
+    var aliCred, ok = cred.(*alicred.StsTokenCredential)
+	if !ok {
+		return nil, errors.Errorf("invalid credential type %T", cred)
+	}
 	newCred := credentials.NewStaticCredentials(aliCred.AccessKeyId, aliCred.AccessKeySecret, aliCred.AccessKeyStsToken)
 	if _, err := newCred.Get(); err != nil {
 		return nil, errors.Trace(err)

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -281,10 +281,7 @@ func autoNewCred(qs *backuppb.S3) (cred *credentials.Credentials, err error) {
 	// if it Contains 'aliyuncs', fetch the sts token.
 	if strings.Contains(endpoint, domainAliyun) {
 		// if we didn't get the credential, use ali provider.
-		if _, err := cred.Get(); err != nil {
-			return createOssRAMCred()
-		}
-		return cred, nil
+		return createOssRAMCred()
 	}
 	// other case ,return no error and run default(aws) follow.
 	return nil, nil
@@ -293,14 +290,15 @@ func autoNewCred(qs *backuppb.S3) (cred *credentials.Credentials, err error) {
 func createOssRAMCred() (*credentials.Credentials, error) {
 	cred, err := aliproviders.NewInstanceMetadataProvider().Retrieve()
 	if err != nil {
-		return nil, errors.Annotate(err, "Alibaba RAM Provider Retrieve")
+		log.Info("failed to retrieve alibaba ram provider", zap.Error(err))
+		return nil, nil
 	}
 	ncred := cred.(*alicred.StsTokenCredential)
-	return credentials.NewChainCredentials([]credentials.Provider{
-		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{},
-		&credentials.StaticProvider{Value: credentials.Value{AccessKeyID: ncred.AccessKeyId, SecretAccessKey: ncred.AccessKeySecret, SessionToken: ncred.AccessKeyStsToken, ProviderName: ""}},
-	}), nil
+	aliCred := credentials.NewStaticCredentials(ncred.AccessKeyId, ncred.AccessKeySecret, ncred.AccessKeyStsToken)
+	if _, err := aliCred.Get(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return aliCred, nil
 }
 
 // NewS3Storage initialize a new s3 storage for metadata.
@@ -331,6 +329,7 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *ExternalStora
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	log.Info("s3 storage config", zap.String("endpoint", qs.Endpoint), zap.Bool("cred is nil", cred == nil))
 	if cred != nil {
 		awsConfig.WithCredentials(cred)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/45551

Problem Summary:

### What changed and how does it work?

Fix the problem that BR only accept credentials from ISM service.
Now, if the BR can't get the ISM credentials, it will try to retrieve credentials from other sources.
And even if it got, it will still try to apply env provider and then shared provider first.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Protocol:
1. Set access-key and secret-access-key as my local machine environmental variable.
2. Try `br backup full` from a public address (my local machine) without ISM access-key.
3. Check if the full backup task finished and if the Aliyun OSS server received the backup files.

Result:
1. On my local machine:
```
./bin/br backup full     --pd "localhost:45129"     --storage "s3://test-cred/backup-data-2?endpoint=https://oss-cn-beijing.aliyuncs.com&provider=alibaba" --check-requirements=false
Detail BR log in /tmp/br.log.2024-06-27T15.12.35+0800 
Full Backup <------------------------------------------------------------------> 100.00%
Checksum <---------------------------------------------------------------------> 100.00%
[2024/06/27 15:13:10.064 +08:00] [INFO] [collector.go:77] ["Full Backup success summary"
] [total-ranges=13] [ranges-succeed=13] [ranges-failed=0] [backup-checksum=75.981913ms] [backup-fast-checksum=59.160314ms] [backup-total-ranges=119] [backup-total-regions=119] [total-take=34.226278783s] [BackupTS=450749369217187841] [total-kv=1402] [total-kv-size=409kB] [average-speed=11.95kB/s] [backup-data-size(after-compressed)=92.64kB] [Size=92636]                                                                                      
```

2. On the Aliyun OSS machine
<img width="810" alt="截屏2024-06-27 15 19 08" src="https://github.com/pingcap/tidb/assets/79858083/53ad43f1-53a2-47bc-bb7f-27d554feb89a">

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the problem that BR only accept credentials from ISM service.
Now, if the BR can't get the ISM credentials, it will behave as same as other endpoints and try to retrieve credentials from other sources. 
And even if it got, it will still try to apply env provider and then shared provider first.
```
