### PR TITLE
executor: try to optimize index merge reader query may send too many cop task

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -745,20 +745,20 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 
 // calculateBatchSize calculates a suitable initial batch size.
 func (e *IndexLookUpExecutor) calculateBatchSize(initBatchSize, maxBatchSize int) int {
+	if e.indexPaging {
+		// If indexPaging is true means this query has limit, so use initBatchSize to avoid scan some unnecessary data.
+		return min(initBatchSize, maxBatchSize)
+	}
 	var estRows int
 	if len(e.idxPlans) > 0 {
 		estRows = int(e.idxPlans[0].StatsCount())
 	}
-	return CalculateBatchSize(e.indexPaging, estRows, initBatchSize, maxBatchSize)
+	return CalculateBatchSize(estRows, initBatchSize, maxBatchSize)
 }
 
 // CalculateBatchSize calculates a suitable initial batch size. It exports for testing.
-func CalculateBatchSize(indexPaging bool, estRows, initBatchSize, maxBatchSize int) int {
+func CalculateBatchSize(estRows, initBatchSize, maxBatchSize int) int {
 	batchSize := min(initBatchSize, maxBatchSize)
-	if indexPaging {
-		// If indexPaging is true means this query has limit, so use initBatchSize to avoid scan some unnecessary data.
-		return batchSize
-	}
 	if estRows >= maxBatchSize {
 		return maxBatchSize
 	}

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -398,7 +398,8 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx().GetDistSQLCtx(), &builder.Request, e.partialNetDataSizes[workID])).
 					SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
 
-				worker.batchSize = min(e.MaxChunkSize(), worker.maxBatchSize)
+				estRows := int(is.StatsCount())
+				worker.batchSize = CalculateBatchSize(estRows, e.MaxChunkSize(), worker.maxBatchSize)
 				if builder.Request.Paging.Enable && builder.Request.Paging.MinPagingSize < uint64(worker.batchSize) {
 					// when paging enabled and Paging.MinPagingSize less than initBatchSize, change Paging.MinPagingSize to
 					// initial batchSize to avoid redundant paging RPC, see more detail in https://github.com/pingcap/tidb/issues/54066

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -398,8 +398,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx().GetDistSQLCtx(), &builder.Request, e.partialNetDataSizes[workID])).
 					SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
 
-				estRows := int(is.StatsCount())
-				worker.batchSize = CalculateBatchSize(estRows, e.MaxChunkSize(), worker.maxBatchSize)
+				worker.batchSize = CalculateBatchSize(int(is.StatsCount()), e.MaxChunkSize(), worker.maxBatchSize)
 				if builder.Request.Paging.Enable && builder.Request.Paging.MinPagingSize < uint64(worker.batchSize) {
 					// when paging enabled and Paging.MinPagingSize less than initBatchSize, change Paging.MinPagingSize to
 					// initial batchSize to avoid redundant paging RPC, see more detail in https://github.com/pingcap/tidb/issues/54066


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54160

Problem Summary: as title said, see more info in issue #54160

### What changed and how does it work?

Increate index merge read executor initial batch size.

This PR can reduce the CPU consumption and improve QPS of index-merge read queries with more than 1024 rows.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

1. prepare data:

```sql
drop table if exists t;
create table t (id int key auto_increment, b int, c int, index idx1 (b), index idx2(c));
insert into t () values (), (), (), (), (), (), (), ();
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t;
insert into t (b) select b from t limit 34464;
update t set b = rand() * 1000000 ;
update t set c = rand() * 1000000 ;
split table t between (0) and (100000) regions 100;
set @@tidb_store_batch_size=0;
analyze table t;
```

**Before:**

```sql
> explain analyze select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * from t where b < 100000 or c < 100000;
+---------------------------+----------+---------+-----------+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------+---------+------+
| id                        | estRows  | actRows | task      | access object          | execution info                                                                                                                                                                                                                                                                                                                                                  | operator info                         | memory  | disk |
+---------------------------+----------+---------+-----------+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------+---------+------+
| IndexMerge_8              | 18971.33 | 19007   | root      |                        | time:20.2ms, loops:20, RU:394.749815, index_task:{fetch_handle:13.749666ms, merge:2.837791ms}, table_task:{num:8, concurrency:5, fetch_row:52.230336ms, wait_time:36.838583ms}                                                                                                                                                                                  | type: union                           | 1.06 MB | N/A  |
| ├─IndexRangeScan_5(Build) | 9967.06  | 9956    | cop[tikv] | table:t, index:idx1(b) | time:7.08ms, loops:12, cop_task: {num: 1, max: 6.91ms, proc_keys: 0, tot_proc: 6ms, copr_cache_hit_ratio: 0.00, build_task_duration: 47µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:6.89ms}}, tikv_task:{time:6.82ms, loops:0}, time_detail: {total_process_time: 6ms}                                                                 | range:[-inf,100000), keep order:false | N/A     | N/A  |
| ├─IndexRangeScan_6(Build) | 10001.08 | 10004   | cop[tikv] | table:t, index:idx2(c) | time:5.96ms, loops:12, cop_task: {num: 1, max: 5.77ms, proc_keys: 0, tot_proc: 5ms, copr_cache_hit_ratio: 0.00, build_task_duration: 45.2µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:5.74ms}}, tikv_task:{time:5.6ms, loops:0}, time_detail: {total_process_time: 5ms}                                                                | range:[-inf,100000), keep order:false | N/A     | N/A  |
| └─TableRowIDScan_7(Probe) | 18971.33 | 19007   | cop[tikv] | table:t                | time:41.9ms, loops:28, cop_task: {num: 800, max: 2.62ms, min: 39.5µs, avg: 121.6µs, p95: 290µs, copr_cache_hit_ratio: 0.00, build_task_duration: 1.43ms, max_distsql_concurrency: 15, max_extra_concurrency: 39}, rpc_info:{Cop:{num_rpc:800, total_time:91.7ms}}, tikv_task:{proc max:815µs, min:30µs, avg: 84.6µs, p80:96µs, p95:150.9µs, iters:0, tasks:800} | keep order:false                      | N/A     | N/A  |
+---------------------------+----------+---------+-----------+------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------+---------+------+
```

Pay attention to the execution information of `TableRowIDScan_7` executor, it sends 800 cop RPC.

```sql
TableRowIDScan_7(Probe) | ... | time:41.9ms, loops:28, cop_task: {num: 800, ...}, {Cop:{num_rpc:800, total_time:91.7ms}},
```

**This PR:**

```sql
> explain analyze select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * from t where b < 100000 or c < 100000;
+---------------------------+----------+---------+-----------+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------+---------+------+
| id                        | estRows  | actRows | task      | access object          | execution info                                                                                                                                                                                                                                                                                                                               | operator info                                                                                                                | memory  | disk |
+---------------------------+----------+---------+-----------+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------+---------+------+
| IndexMerge_8              | 55422.12 | 18857   | root      |                        | time:18.2ms, loops:20, RU:109.096169, index_task:{fetch_handle:12.821582ms, merge:2.633875ms}, table_task:{num:2, concurrency:5, fetch_row:17.965333ms, wait_time:17.317459ms}                                                                                                                                                               | type: union                                                                                                                  | 1.16 MB | N/A  |
| ├─IndexRangeScan_5(Build) | 33233.33 | 9855    | cop[tikv] | table:t, index:idx1(b) | time:5.98ms, loops:12, cop_task: {num: 1, max: 5.8ms, proc_keys: 0, tot_proc: 5ms, copr_cache_hit_ratio: 0.00, build_task_duration: 60µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:5.76ms}}, tikv_task:{time:5.69ms, loops:0}, time_detail: {total_process_time: 5ms}                                               | range:[-inf,100000), keep order:false, stats:partial[idx1:allEvicted, idx2:allEvicted, id:allEvicted...(more: 2 allEvicted)] | N/A     | N/A  |
| ├─IndexRangeScan_6(Build) | 33233.33 | 10037   | cop[tikv] | table:t, index:idx2(c) | time:6ms, loops:12, cop_task: {num: 1, max: 5.86ms, proc_keys: 0, tot_proc: 5ms, copr_cache_hit_ratio: 0.00, build_task_duration: 20.3µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:5.83ms}}, tikv_task:{time:5.73ms, loops:0}, time_detail: {total_process_time: 5ms}                                               | range:[-inf,100000), keep order:false, stats:partial[idx1:allEvicted, idx2:allEvicted, id:allEvicted...(more: 2 allEvicted)] | N/A     | N/A  |
| └─TableRowIDScan_7(Probe) | 55422.12 | 18857   | cop[tikv] | table:t                | time:10.1ms, loops:21, cop_task: {num: 200, max: 893.8µs, min: 116.5µs, avg: 211µs, p95: 475.5µs, copr_cache_hit_ratio: 0.00, build_task_duration: 621µs, max_distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:200, total_time:40.3ms}}, tikv_task:{proc max:793.8µs, min:104.7µs, avg: 188µs, p80:196.1µs, p95:372.2µs, iters:0, tasks:200} | keep order:false, stats:partial[idx1:allEvicted, idx2:allEvicted, id:allEvicted...(more: 2 allEvicted)]                      | N/A     | N/A  |
+---------------------------+----------+---------+-----------+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------+---------+------+
```

`TableRowIDScan_7` executor only sends 200 cop RPC now.

```sql
TableRowIDScan_7(Probe) | ... | time:10.1ms, loops:21,, cop_task: {num: 200, ...}, {Cop:{num_rpc:200, total_time:40.3ms}},
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
