### PR TITLE
ddl: only unregister backendCtx after deliver job worker for local mode

### DIFF
--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -537,7 +537,9 @@ func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.
 			s.runningJobs.removeRunning(jobID, involvedSchemaInfos)
 			asyncNotify(s.ddlJobNotifyCh)
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()
-			if wk.ctx.Err() != nil && ingest.LitBackCtxMgr != nil {
+			if wk.ctx.Err() != nil && ingest.LitBackCtxMgr != nil &&
+				// dist task executor manager will handle backend ctx unregistering correctly.
+				job.ReorgMeta != nil && !job.ReorgMeta.IsDistReorg {
 				// if ctx cancelled, i.e. owner changed, we need to Unregister the backend
 				// as litBackendCtx is holding this very 'ctx', and it cannot reuse now.
 				// TODO make LitBackCtxMgr a local value of the job scheduler, it makes


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53910

Problem Summary:

The `unregister()` after `delivery2Worker()` may conflict with the executor of the DXF. 

When DXF executor starts to import:

https://github.com/pingcap/tidb/blob/fd2b5e97a10a7b16fc1836bd8b76b43dfdb33024/pkg/lightning/backend/local/local.go#L1296

And tidb receives `SigKill`, ddl workers exit first, calling `unregister()`, which removes all engines from `engineManager`.

As a result, import executor actually does nothing, but mistakenly thinks it is successful. And the state is saved to subtask table.

### What changed and how does it work?

When we use DXF, backend ctx should be owned by DXF. Other goroutines should not modify backend ctx.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
