### PR TITLE
planner: The length function could not be substitute when collation of mapped column is utfxxx_bin

### DIFF
--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -204,11 +204,9 @@ func (s *propConstSolver) propagateConstantEQ() {
 		}
 		cols := make([]*Column, 0, len(mapper))
 		cons := make([]Expression, 0, len(mapper))
-		collations := make([]string, 0, len(mapper))
 		for id, con := range mapper {
 			cols = append(cols, s.columns[id])
 			cons = append(cons, con)
-			collations = append(collations, s.columns[id].GetStaticType().GetCollate())
 		}
 		for i, cond := range s.conditions {
 			if !visited[i] {

--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -16,7 +16,6 @@ package expression
 
 import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
-	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/types"
@@ -213,14 +212,6 @@ func (s *propConstSolver) propagateConstantEQ() {
 		}
 		for i, cond := range s.conditions {
 			if !visited[i] {
-				if currentFun, ok := cond.(*ScalarFunction); ok &&
-					currentFun.FuncName.L == ast.Length &&
-					(collations[i] == charset.CollationUTF8MB4 || collations[i] == charset.CollationUTF8) {
-					// If the collation of the column is PAD SPACE,
-					// we can't propagate the constant to the length function.
-					// Fixed issue #53730
-					continue
-				}
 				s.conditions[i] = ColumnSubstitute(s.ctx, cond, NewSchema(cols...), cons)
 			}
 		}

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -114,6 +114,9 @@ type BuildContext interface {
 	// in most cases except for the method `isNullRejected` in planner.
 	// See the comments for `isNullRejected` in planner for more details.
 	IsInNullRejectCheck() bool
+	// IsConstantPropagateCheck returns the flag to indicate whether the expression is in constant propagate check.
+	// It should be true only when we are doing constant propagation in rule_predicate_push_down.
+	IsConstantPropagateCheck() bool
 	// ConnectionID indicates the connection ID of the current session.
 	// If the context is not in a session, it should return 0.
 	ConnectionID() uint64
@@ -142,6 +145,21 @@ func WithNullRejectCheck(ctx ExprContext) *NullRejectCheckExprContext {
 
 // IsInNullRejectCheck always returns true for `NullRejectCheckExprContext`
 func (ctx *NullRejectCheckExprContext) IsInNullRejectCheck() bool {
+	return true
+}
+
+// ConstantPropagateCheckContext is a wrapper to return true for `IsConstantPropagateCheck`.
+type ConstantPropagateCheckContext struct {
+	ExprContext
+}
+
+// WithConstantPropagateCheck returns a new `ConstantPropagateCheckContext` with the given `ExprContext`.
+func WithConstantPropagateCheck(ctx ExprContext) *ConstantPropagateCheckContext {
+	return &ConstantPropagateCheckContext{ExprContext: ctx}
+}
+
+// IsConstantPropagateCheck always returns true for `ConstantPropagateCheckContext`
+func (ctx *ConstantPropagateCheckContext) IsConstantPropagateCheck() bool {
 	return true
 }
 

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -114,6 +114,11 @@ func (ctx *SessionExprContext) IsInNullRejectCheck() bool {
 	return false
 }
 
+// IsConstantPropagateCheck returns whether the ctx is in constant propagate check.
+func (ctx *SessionExprContext) IsConstantPropagateCheck() bool {
+	return false
+}
+
 // GetWindowingUseHighPrecision determines whether to compute window operations without loss of precision.
 // see https://dev.mysql.com/doc/refman/8.0/en/window-function-optimization.html for more details.
 func (ctx *SessionExprContext) GetWindowingUseHighPrecision() bool {

--- a/pkg/expression/contextstatic/exprctx.go
+++ b/pkg/expression/contextstatic/exprctx.go
@@ -268,6 +268,11 @@ func (ctx *StaticExprContext) IsInNullRejectCheck() bool {
 	return false
 }
 
+// IsConstantPropagateCheck implements the `ExprContext.IsConstantPropagateCheck` and should always return false.
+func (ctx *StaticExprContext) IsConstantPropagateCheck() bool {
+	return false
+}
+
 // ConnectionID implements the `ExprContext.ConnectionID`.
 func (ctx *StaticExprContext) ConnectionID() uint64 {
 	return ctx.connectionID

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -472,6 +472,7 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 		// we can't propagate the constant to the length function.
 		// For example, schema = ['name'], newExprs = ['a'], v = length(name).
 		// We can't substitute name with 'a' in length(name) because the collation of name is PAD SPACE.
+		// TODO: We will fix it here temporarily, and redesign the logic if we encounter more similar functions or situations later.
 		// Fixed issue #53730
 		if ctx.IsConstantPropagateCheck() && v.FuncName.L == ast.Length {
 			arg0, isColumn := v.GetArgs()[0].(*Column)

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression/contextopt"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/opcode"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -466,6 +467,27 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 				return true, false, e
 			}
 			return false, false, v
+		}
+		// If the collation of the column is PAD SPACE,
+		// we can't propagate the constant to the length function.
+		// For example, schema = ['name'], newExprs = ['a'], v = length(name).
+		// We can't substitute name with 'a' in length(name) because the collation of name is PAD SPACE.
+		// Fixed issue #53730
+		if v.FuncName.L == ast.Length {
+			arg0, isColumn := v.GetArgs()[0].(*Column)
+			if isColumn {
+				id := schema.ColumnIndex(arg0)
+				if id != -1 {
+					_, isConstant := newExprs[id].(*Constant)
+					if isConstant {
+						mappedNewColumnCollate := schema.Columns[id].GetStaticType().GetCollate()
+						if mappedNewColumnCollate == charset.CollationUTF8MB4 ||
+							mappedNewColumnCollate == charset.CollationUTF8 {
+							return false, false, v
+						}
+					}
+				}
+			}
 		}
 		// cowExprRef is a copy-on-write util, args array allocation happens only
 		// when expr in args is changed

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -473,7 +473,7 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 		// For example, schema = ['name'], newExprs = ['a'], v = length(name).
 		// We can't substitute name with 'a' in length(name) because the collation of name is PAD SPACE.
 		// Fixed issue #53730
-		if v.FuncName.L == ast.Length {
+		if ctx.IsConstantPropagateCheck() && v.FuncName.L == ast.Length {
 			arg0, isColumn := v.GetArgs()[0].(*Column)
 			if isColumn {
 				id := schema.ColumnIndex(arg0)

--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -9,10 +9,11 @@ go_test(
         "rule_inject_extra_projection_test.go",
         "rule_join_reorder_test.go",
         "rule_outer2inner_test.go",
+        "rule_predicate_pushdown_test.go",
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/domain",
         "//pkg/expression",

--- a/pkg/planner/core/casetest/rule/main_test.go
+++ b/pkg/planner/core/casetest/rule/main_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 	testDataMap.LoadTestSuiteData("testdata", "outer2inner")
 	testDataMap.LoadTestSuiteData("testdata", "derive_topn_from_window")
 	testDataMap.LoadTestSuiteData("testdata", "join_reorder_suite")
+	testDataMap.LoadTestSuiteData("testdata", "predicate_pushdown_suite")
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
 		goleak.IgnoreTopFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
@@ -60,4 +61,8 @@ func GetDerivedTopNSuiteData() testdata.TestData {
 
 func GetJoinReorderSuiteData() testdata.TestData {
 	return testDataMap["join_reorder_suite"]
+}
+
+func GetPredicatePushdownSuiteData() testdata.TestData {
+	return testDataMap["predicate_pushdown_suite"]
 }

--- a/pkg/planner/core/casetest/rule/rule_predicate_pushdown_test.go
+++ b/pkg/planner/core/casetest/rule/rule_predicate_pushdown_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+func runPredicatePushdownTestData(t *testing.T, tk *testkit.TestKit, name string) {
+	var input []string
+	var output []struct {
+		SQL     string
+		Plan    []string
+		Warning []string
+	}
+	predicatePushdownSuiteData := GetPredicatePushdownSuiteData()
+	predicatePushdownSuiteData.LoadTestCasesByName(name, t, &input, &output)
+	require.Equal(t, len(input), len(output))
+	for i := range input {
+		if strings.Contains(input[i], "set") {
+			tk.MustExec(input[i])
+			continue
+		}
+		testdata.OnRecord(func() {
+			output[i].SQL = input[i]
+			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery("explain format = 'brief' " + input[i]).Rows())
+			output[i].Warning = testdata.ConvertRowsToStrings(tk.MustQuery("show warnings").Rows())
+		})
+		tk.MustQuery("explain format = 'brief' " + input[i]).Check(testkit.Rows(output[i].Plan...))
+		tk.MustQuery("show warnings").Check(testkit.Rows(output[i].Warning...))
+	}
+}
+
+func TestConstantPropagateWithCollation(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	// create table
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key, name varchar(20));")
+
+	runPredicatePushdownTestData(t, tk, "TestConstantPropagateWithCollation")
+}

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_in.json
@@ -5,7 +5,8 @@
       "set names utf8",
       "select * from t where name='a' and length(name)=1; -- without constant propagated",
       "set names utf8mb4",
-      "select * from t where name='a' and length(name)=1; -- without constant propagated"
+      "select * from t where name='a' and length(name)=1; -- without constant propagated",
+      "select * from (select 'test' as b from t) n where length(b) > 2; -- can be substituted"
     ]
   }
 ]

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_in.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "TestConstantPropagateWithCollation",
+    "cases": [
+      "set names utf8",
+      "select * from t where name='a' and length(name)=1; -- without constant propagated",
+      "set names utf8mb4",
+      "select * from t where name='a' and length(name)=1; -- without constant propagated"
+    ]
+  }
+]

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
@@ -29,6 +29,15 @@
           "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
         "Warning": null
+      },
+      {
+        "SQL": "select * from (select 'test' as b from t) n where length(b) > 2; -- can be substituted",
+        "Plan": [
+          "Projection 10000.00 root  test->Column#3",
+          "└─TableReader 10000.00 root  data:TableFullScan",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
       }
     ]
   }

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
@@ -24,8 +24,8 @@
       {
         "SQL": "select * from t where name='a' and length(name)=1; -- without constant propagated",
         "Plan": [
-          "TableReader 10.00 root  data:Selection",
-          "└─Selection 10.00 cop[tikv]  eq(test.t.name, \"a\")",
+          "TableReader 8.00 root  data:Selection",
+          "└─Selection 8.00 cop[tikv]  eq(length(test.t.name), 1), eq(test.t.name, \"a\")",
           "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
         "Warning": null

--- a/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/predicate_pushdown_suite_out.json
@@ -1,0 +1,35 @@
+[
+  {
+    "Name": "TestConstantPropagateWithCollation",
+    "Cases": [
+      {
+        "SQL": "",
+        "Plan": null,
+        "Warning": null
+      },
+      {
+        "SQL": "select * from t where name='a' and length(name)=1; -- without constant propagated",
+        "Plan": [
+          "TableReader 8.00 root  data:Selection",
+          "└─Selection 8.00 cop[tikv]  eq(length(test.t.name), 1), eq(test.t.name, \"a\")",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      },
+      {
+        "SQL": "",
+        "Plan": null,
+        "Warning": null
+      },
+      {
+        "SQL": "select * from t where name='a' and length(name)=1; -- without constant propagated",
+        "Plan": [
+          "TableReader 10.00 root  data:Selection",
+          "└─Selection 10.00 cop[tikv]  eq(test.t.name, \"a\")",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warning": null
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

The constant propagated should consider the collation of mapped column.
For example, 
```
set collation = utf8_bin || set collation= utf8mb4_bin
where name='a' and length(name) = 1
```
The name = 'a' doesn't mean the all of column name data is 'a'. The 'a    ' also can match the name='a' condition.
The reason is that 'utf8_bin' and 'utf8mb4_bin' are 'PAD SPACE' collation which means that it will ignore the trailing spaces.
**This kind of constant couldn't be propagated to 'Length' function. **

So I changed the columnSubstitute function to special due with 'length' function case.

Issue Number: close #53730

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the error unexpected eliminated 'length()' conditions when collation is utf8_bin or utf8mb4_bin
```
