### PR TITLE
backup: use tombstone instead of offline during CheckStoreLiveness

### DIFF
--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -511,6 +511,8 @@ func TestMainBackupLoop(t *testing.T) {
 		GetBackupClientCallBack: mockGetBackupClientCallBack,
 	}
 
+	// an offline store still can be backed up.
+	s.mockCluster.StopStore(1)
 	connectedStore = make(map[uint64]int)
 	require.NoError(t, s.backupClient.RunLoop(backgroundCtx, mainLoop))
 

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -583,7 +583,7 @@ func TestMainBackupLoop(t *testing.T) {
 	}
 	remainStoreID := uint64(1)
 	dropStoreID := uint64(2)
-	s.mockCluster.StopStore(dropStoreID)
+	s.mockCluster.MarkTombstone(dropStoreID)
 	dropBackupResponses := mockBackupResponses[dropStoreID]
 	lock.Lock()
 	mockBackupResponses[dropStoreID] = nil
@@ -642,7 +642,7 @@ func TestMainBackupLoop(t *testing.T) {
 	}
 	remainStoreID = uint64(1)
 	dropStoreID = uint64(2)
-	s.mockCluster.StopStore(dropStoreID)
+	s.mockCluster.MarkTombstone(dropStoreID)
 
 	mainLoop = &backup.MainBackupLoop{
 		BackupSender: &mockBackupBackupSender{

--- a/br/pkg/utils/misc.go
+++ b/br/pkg/utils/misc.go
@@ -131,7 +131,10 @@ func GRPCConn(ctx context.Context, storeAddr string, tlsConf *tls.Config, opts .
 // Some versions of PD may not set the store state in the gRPC response.
 // We need to check it manually.
 func CheckStoreLiveness(s *metapb.Store) error {
-	if s.State != metapb.StoreState_Up {
+	// note: offline store is also considered as alive.
+	// because the real meaning of offline is "Going Offline".
+	// https://docs.pingcap.com/tidb/v7.5/tidb-scheduling#information-collection
+	if s.State != metapb.StoreState_Up && s.State != metapb.StoreState_Offline {
 		return errors.Annotatef(berrors.ErrKVStorage, "the store state isn't up, it is %s", s.State)
 	}
 	// If the field isn't present (the default value), skip this check.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/52534

Problem Summary:
A store is `offline` in PD doesn't mean the store cannot serve. some region leader still in that store. so we cannot simple skip `offline` store during backup.

### What changed and how does it work?
still backup up/offline store. only skip tombstone store.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
