### PR TITLE
sessionctx: add tidb_analyze_column_options global variable

### DIFF
--- a/docs/design/2024-05-23-predicate-columns.md
+++ b/docs/design/2024-05-23-predicate-columns.md
@@ -26,7 +26,7 @@
     - [Performance Tests](#performance-tests)
   - [Impacts \& Risks](#impacts--risks)
     - [If new predicate columns appear, they cannot be analyzed in time](#if-new-predicate-columns-appear-they-cannot-be-analyzed-in-time)
-    - [Use PREDICATE COLUMNS when your workload's query pattern is relatively stable](#use-predicate-columns-when-your-workloads-query-pattern-is--relatively-stable)
+    - [Use PREDICATE COLUMNS when your workload's query pattern is relatively stable](#use-predicate-columns-when-your-workloads-query-pattern-is-relatively-stable)
   - [Investigation \& Alternatives](#investigation--alternatives)
     - [CRDB](#crdb)
       - [Summary](#summary)
@@ -214,14 +214,14 @@ In the experimental implementation, we introduce a new global variable `tidb_ena
 
 But because we decided to track all columns by default, so it becomes unnecessary to use this variable. We will mark it deprecated and remove it in the future.
 
-In this feature, we introduce a new global variable `tidb_analyze_default_column_choice` to control whether to use predicate columns or all columns in the analyze process.
+In this feature, we introduce a new global variable `tidb_analyze_column_options` to control whether to use predicate columns or all columns in the analyze process.
 
 Users can set this variable to `ALL` or `PREDICATE` to analyze all columns or only predicate columns. The default value will be `PREDICATE` after this feature is fully implemented.
 
 ```sql
-SET GLOBAL tidb_analyze_default_column_choice = 'PREDICATE';
+SET GLOBAL tidb_analyze_column_options = 'PREDICATE';
 
-SET GLOBAL tidb_analyze_default_column_choice = 'ALL';
+SET GLOBAL tidb_analyze_column_options = 'ALL';
 ```
 
 | Value     | Description                                                    |

--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -681,6 +681,14 @@ func TestSetVar(t *testing.T) {
 	require.Error(t, tk.ExecToErr("set tidb_enable_column_tracking = 0"))
 	require.Error(t, tk.ExecToErr("set global tidb_enable_column_tracking = -1"))
 
+	// test for tidb_analyze_default_column_choice
+	tk.MustQuery("select @@tidb_analyze_default_column_choice").Check(testkit.Rows("ALL"))
+	tk.MustExec("set global tidb_analyze_default_column_choice = 'PREDICATE'")
+	tk.MustQuery("select @@tidb_analyze_default_column_choice").Check(testkit.Rows("PREDICATE"))
+	tk.MustExec("set global tidb_analyze_default_column_choice = 'all'")
+	tk.MustQuery("select @@tidb_analyze_default_column_choice").Check(testkit.Rows("ALL"))
+	require.Error(t, tk.ExecToErr("set global tidb_analyze_default_column_choice = 'UNKNOWN'"))
+
 	// test for tidb_ignore_prepared_cache_close_stmt
 	tk.MustQuery("select @@global.tidb_ignore_prepared_cache_close_stmt").Check(testkit.Rows("0")) // default value is 0
 	tk.MustExec("set global tidb_ignore_prepared_cache_close_stmt=1")

--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -681,13 +681,13 @@ func TestSetVar(t *testing.T) {
 	require.Error(t, tk.ExecToErr("set tidb_enable_column_tracking = 0"))
 	require.Error(t, tk.ExecToErr("set global tidb_enable_column_tracking = -1"))
 
-	// test for tidb_analyze_default_column_choice
-	tk.MustQuery("select @@tidb_analyze_default_column_choice").Check(testkit.Rows("ALL"))
-	tk.MustExec("set global tidb_analyze_default_column_choice = 'PREDICATE'")
-	tk.MustQuery("select @@tidb_analyze_default_column_choice").Check(testkit.Rows("PREDICATE"))
-	tk.MustExec("set global tidb_analyze_default_column_choice = 'all'")
-	tk.MustQuery("select @@tidb_analyze_default_column_choice").Check(testkit.Rows("ALL"))
-	require.Error(t, tk.ExecToErr("set global tidb_analyze_default_column_choice = 'UNKNOWN'"))
+	// test for tidb_analyze_column_options
+	tk.MustQuery("select @@tidb_analyze_column_options").Check(testkit.Rows("ALL"))
+	tk.MustExec("set global tidb_analyze_column_options = 'PREDICATE'")
+	tk.MustQuery("select @@tidb_analyze_column_options").Check(testkit.Rows("PREDICATE"))
+	tk.MustExec("set global tidb_analyze_column_options = 'all'")
+	tk.MustQuery("select @@tidb_analyze_column_options").Check(testkit.Rows("ALL"))
+	require.Error(t, tk.ExecToErr("set global tidb_analyze_column_options = 'UNKNOWN'"))
 
 	// test for tidb_ignore_prepared_cache_close_stmt
 	tk.MustQuery("select @@global.tidb_ignore_prepared_cache_close_stmt").Check(testkit.Rows("0")) // default value is 0

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1014,14 +1014,14 @@ var defaultSysVars = []*SysVar{
 	},
 	{
 		Scope: ScopeGlobal,
-		Name:  TiDBAnalyzeDefaultColumnChoice,
-		Value: DefTiDBAnalyzeDefaultColumnChoice,
+		Name:  TiDBAnalyzeColumnOptions,
+		Value: DefTiDBAnalyzeColumnOptions,
 		Type:  TypeStr,
 		GetGlobal: func(ctx context.Context, s *SessionVars) (string, error) {
-			return AnalyzeDefaultColumnChoice.Load(), nil
+			return AnalyzeColumnOptions.Load(), nil
 		},
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
-			AnalyzeDefaultColumnChoice.Store(strings.ToUpper(val))
+			AnalyzeColumnOptions.Store(strings.ToUpper(val))
 			return nil
 		},
 		Validation: func(s *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
@@ -1029,7 +1029,7 @@ var defaultSysVars = []*SysVar{
 			if choice != model.AllColumns.String() && choice != model.PredicateColumns.String() {
 				return "", errors.Errorf(
 					"invalid value for %s, it should be either '%s' or '%s'",
-					TiDBAnalyzeDefaultColumnChoice,
+					TiDBAnalyzeColumnOptions,
 					model.AllColumns.String(),
 					model.PredicateColumns.String(),
 				)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/util/fixcontrol"
 	"github.com/pingcap/tidb/pkg/privilege/privileges/ldap"
@@ -1010,7 +1011,33 @@ var defaultSysVars = []*SysVar{
 			RunAutoAnalyze.Store(TiDBOptOn(val))
 			return nil
 		},
-	}, {
+	},
+	{
+		Scope: ScopeGlobal,
+		Name:  TiDBAnalyzeDefaultColumnChoice,
+		Value: DefTiDBAnalyzeDefaultColumnChoice,
+		Type:  TypeStr,
+		GetGlobal: func(ctx context.Context, s *SessionVars) (string, error) {
+			return AnalyzeDefaultColumnChoice.Load(), nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			AnalyzeDefaultColumnChoice.Store(strings.ToUpper(val))
+			return nil
+		},
+		Validation: func(s *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+			choice := strings.ToUpper(normalizedValue)
+			if choice != model.AllColumns.String() && choice != model.PredicateColumns.String() {
+				return "", errors.Errorf(
+					"invalid value for %s, it should be either '%s' or '%s'",
+					TiDBAnalyzeDefaultColumnChoice,
+					model.AllColumns.String(),
+					model.PredicateColumns.String(),
+				)
+			}
+			return normalizedValue, nil
+		},
+	},
+	{
 		Scope: ScopeGlobal, Name: TiDBEnableAutoAnalyzePriorityQueue, Value: BoolToOnOff(DefTiDBEnableAutoAnalyzePriorityQueue), Type: TypeBool,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 			return BoolToOnOff(EnableAutoAnalyzePriorityQueue.Load()), nil

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -977,11 +977,11 @@ const (
 	// TiDBEnableColumnTracking enables collecting predicate columns.
 	// DEPRECATED: This variable is deprecated, please do not use this variable.
 	TiDBEnableColumnTracking = "tidb_enable_column_tracking"
-	// TiDBAnalyzeDefaultColumnChoice specifies the default column selection strategy for both manual and automatic analyze operations.
+	// TiDBAnalyzeColumnOptions specifies the default column selection strategy for both manual and automatic analyze operations.
 	// It accepts two values:
 	// `PREDICATE`: Analyze only the columns that are used in the predicates of the query.
 	// `ALL`: Analyze all columns in the table.
-	TiDBAnalyzeDefaultColumnChoice = "tidb_analyze_default_column_choice"
+	TiDBAnalyzeColumnOptions = "tidb_analyze_column_options"
 	// TiDBDisableColumnTrackingTime records the last time TiDBEnableColumnTracking is set off.
 	// It is used to invalidate the collected predicate columns after turning off TiDBEnableColumnTracking, which avoids physical deletion.
 	// It doesn't have cache in memory, and we directly get/set the variable value from/to mysql.tidb.
@@ -1377,7 +1377,7 @@ const (
 	DefTiDBMemQuotaAnalyze                         = -1
 	DefTiDBEnableAutoAnalyze                       = true
 	DefTiDBEnableAutoAnalyzePriorityQueue          = true
-	DefTiDBAnalyzeDefaultColumnChoice              = "ALL"
+	DefTiDBAnalyzeColumnOptions                    = "ALL"
 	DefTiDBMemOOMAction                            = "CANCEL"
 	DefTiDBMaxAutoAnalyzeTime                      = 12 * 60 * 60
 	DefTiDBEnablePrepPlanCache                     = true
@@ -1507,26 +1507,26 @@ var (
 	ProcessGeneralLog              = atomic.NewBool(false)
 	RunAutoAnalyze                 = atomic.NewBool(DefTiDBEnableAutoAnalyze)
 	EnableAutoAnalyzePriorityQueue = atomic.NewBool(DefTiDBEnableAutoAnalyzePriorityQueue)
-	// AnalyzeDefaultColumnChoice is a global variable that indicates the default column choice for ANALYZE.
+	// AnalyzeColumnOptions is a global variable that indicates the default column choice for ANALYZE.
 	// The value of this variable is a string that can be one of the following values:
 	// "PREDICATE", "ALL".
 	// The behavior of the analyze operation depends on the value of `tidb_persist_analyze_options`:
 	// 1. If `tidb_persist_analyze_options` is enabled and the column choice from the analyze options record is set to `default`,
-	//    the value of `tidb_analyze_default_column_choice` determines the behavior of the analyze operation.
-	// 2. If `tidb_persist_analyze_options` is disabled, `tidb_analyze_default_column_choice` is used directly to decide
+	//    the value of `tidb_analyze_column_options` determines the behavior of the analyze operation.
+	// 2. If `tidb_persist_analyze_options` is disabled, `tidb_analyze_column_options` is used directly to decide
 	//    whether to analyze all columns or just the predicate columns.
-	AnalyzeDefaultColumnChoice       = atomic.NewString(DefTiDBAnalyzeDefaultColumnChoice)
-	GlobalLogMaxDays                 = atomic.NewInt32(int32(config.GetGlobalConfig().Log.File.MaxDays))
-	QueryLogMaxLen                   = atomic.NewInt32(DefTiDBQueryLogMaxLen)
-	EnablePProfSQLCPU                = atomic.NewBool(false)
-	EnableBatchDML                   = atomic.NewBool(false)
-	EnableTmpStorageOnOOM            = atomic.NewBool(DefTiDBEnableTmpStorageOnOOM)
-	ddlReorgWorkerCounter      int32 = DefTiDBDDLReorgWorkerCount
-	ddlReorgBatchSize          int32 = DefTiDBDDLReorgBatchSize
-	ddlFlashbackConcurrency    int32 = DefTiDBDDLFlashbackConcurrency
-	ddlErrorCountLimit         int64 = DefTiDBDDLErrorCountLimit
-	ddlReorgRowFormat          int64 = DefTiDBRowFormatV2
-	maxDeltaSchemaCount        int64 = DefTiDBMaxDeltaSchemaCount
+	AnalyzeColumnOptions          = atomic.NewString(DefTiDBAnalyzeColumnOptions)
+	GlobalLogMaxDays              = atomic.NewInt32(int32(config.GetGlobalConfig().Log.File.MaxDays))
+	QueryLogMaxLen                = atomic.NewInt32(DefTiDBQueryLogMaxLen)
+	EnablePProfSQLCPU             = atomic.NewBool(false)
+	EnableBatchDML                = atomic.NewBool(false)
+	EnableTmpStorageOnOOM         = atomic.NewBool(DefTiDBEnableTmpStorageOnOOM)
+	ddlReorgWorkerCounter   int32 = DefTiDBDDLReorgWorkerCount
+	ddlReorgBatchSize       int32 = DefTiDBDDLReorgBatchSize
+	ddlFlashbackConcurrency int32 = DefTiDBDDLFlashbackConcurrency
+	ddlErrorCountLimit      int64 = DefTiDBDDLErrorCountLimit
+	ddlReorgRowFormat       int64 = DefTiDBRowFormatV2
+	maxDeltaSchemaCount     int64 = DefTiDBMaxDeltaSchemaCount
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
 	DDLSlowOprThreshold                  = config.GetGlobalConfig().Instance.DDLSlowOprThreshold
 	ForcePriority                        = int32(DefTiDBForcePriority)

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -977,6 +977,11 @@ const (
 	// TiDBEnableColumnTracking enables collecting predicate columns.
 	// DEPRECATED: This variable is deprecated, please do not use this variable.
 	TiDBEnableColumnTracking = "tidb_enable_column_tracking"
+	// TiDBAnalyzeDefaultColumnChoice specifies the default column selection strategy for both manual and automatic analyze operations.
+	// It accepts two values:
+	// `PREDICATE`: Analyze only the columns that are used in the predicates of the query.
+	// `ALL`: Analyze all columns in the table.
+	TiDBAnalyzeDefaultColumnChoice = "tidb_analyze_default_column_choice"
 	// TiDBDisableColumnTrackingTime records the last time TiDBEnableColumnTracking is set off.
 	// It is used to invalidate the collected predicate columns after turning off TiDBEnableColumnTracking, which avoids physical deletion.
 	// It doesn't have cache in memory, and we directly get/set the variable value from/to mysql.tidb.
@@ -1372,6 +1377,7 @@ const (
 	DefTiDBMemQuotaAnalyze                         = -1
 	DefTiDBEnableAutoAnalyze                       = true
 	DefTiDBEnableAutoAnalyzePriorityQueue          = true
+	DefTiDBAnalyzeDefaultColumnChoice              = "ALL"
 	DefTiDBMemOOMAction                            = "CANCEL"
 	DefTiDBMaxAutoAnalyzeTime                      = 12 * 60 * 60
 	DefTiDBEnablePrepPlanCache                     = true
@@ -1498,20 +1504,29 @@ const (
 
 // Process global variables.
 var (
-	ProcessGeneralLog                    = atomic.NewBool(false)
-	RunAutoAnalyze                       = atomic.NewBool(DefTiDBEnableAutoAnalyze)
-	EnableAutoAnalyzePriorityQueue       = atomic.NewBool(DefTiDBEnableAutoAnalyzePriorityQueue)
-	GlobalLogMaxDays                     = atomic.NewInt32(int32(config.GetGlobalConfig().Log.File.MaxDays))
-	QueryLogMaxLen                       = atomic.NewInt32(DefTiDBQueryLogMaxLen)
-	EnablePProfSQLCPU                    = atomic.NewBool(false)
-	EnableBatchDML                       = atomic.NewBool(false)
-	EnableTmpStorageOnOOM                = atomic.NewBool(DefTiDBEnableTmpStorageOnOOM)
-	ddlReorgWorkerCounter          int32 = DefTiDBDDLReorgWorkerCount
-	ddlReorgBatchSize              int32 = DefTiDBDDLReorgBatchSize
-	ddlFlashbackConcurrency        int32 = DefTiDBDDLFlashbackConcurrency
-	ddlErrorCountLimit             int64 = DefTiDBDDLErrorCountLimit
-	ddlReorgRowFormat              int64 = DefTiDBRowFormatV2
-	maxDeltaSchemaCount            int64 = DefTiDBMaxDeltaSchemaCount
+	ProcessGeneralLog              = atomic.NewBool(false)
+	RunAutoAnalyze                 = atomic.NewBool(DefTiDBEnableAutoAnalyze)
+	EnableAutoAnalyzePriorityQueue = atomic.NewBool(DefTiDBEnableAutoAnalyzePriorityQueue)
+	// AnalyzeDefaultColumnChoice is a global variable that indicates the default column choice for ANALYZE.
+	// The value of this variable is a string that can be one of the following values:
+	// "PREDICATE", "ALL".
+	// The behavior of the analyze operation depends on the value of `tidb_persist_analyze_options`:
+	// 1. If `tidb_persist_analyze_options` is enabled and the column choice from the analyze options record is set to `default`,
+	//    the value of `tidb_analyze_default_column_choice` determines the behavior of the analyze operation.
+	// 2. If `tidb_persist_analyze_options` is disabled, `tidb_analyze_default_column_choice` is used directly to decide
+	//    whether to analyze all columns or just the predicate columns.
+	AnalyzeDefaultColumnChoice       = atomic.NewString(DefTiDBAnalyzeDefaultColumnChoice)
+	GlobalLogMaxDays                 = atomic.NewInt32(int32(config.GetGlobalConfig().Log.File.MaxDays))
+	QueryLogMaxLen                   = atomic.NewInt32(DefTiDBQueryLogMaxLen)
+	EnablePProfSQLCPU                = atomic.NewBool(false)
+	EnableBatchDML                   = atomic.NewBool(false)
+	EnableTmpStorageOnOOM            = atomic.NewBool(DefTiDBEnableTmpStorageOnOOM)
+	ddlReorgWorkerCounter      int32 = DefTiDBDDLReorgWorkerCount
+	ddlReorgBatchSize          int32 = DefTiDBDDLReorgBatchSize
+	ddlFlashbackConcurrency    int32 = DefTiDBDDLFlashbackConcurrency
+	ddlErrorCountLimit         int64 = DefTiDBDDLErrorCountLimit
+	ddlReorgRowFormat          int64 = DefTiDBRowFormatV2
+	maxDeltaSchemaCount        int64 = DefTiDBMaxDeltaSchemaCount
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
 	DDLSlowOprThreshold                  = config.GetGlobalConfig().Instance.DDLSlowOprThreshold
 	ForcePriority                        = int32(DefTiDBForcePriority)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/53567

Problem Summary:
We need to introduce a new global variable to control which columns we need to analyze during the auto-analyze and manual analyze.

Users can set this variable to ALL or PREDICATE to analyze all columns or only predicate columns. The default value will be PREDICATE after this feature is fully implemented.


### What changed and how does it work?

- Added a new global variable called `tidb_analyze_column_options`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/54200#issuecomment-2188438122)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
