### PR TITLE
lighting: lightning configuration tidb.tls = false should not affect cluster certificate (PD's connection) 

### DIFF
--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -176,14 +176,12 @@ func (d *DBStore) adjust(
 
 	if d.Security == nil {
 		d.Security = &Security{
-			CAPath:                   s.CAPath,
-			CertPath:                 s.CertPath,
-			KeyPath:                  s.KeyPath,
-			CABytes:                  s.CABytes,
-			CertBytes:                s.CertBytes,
-			KeyBytes:                 s.KeyBytes,
-			RedactInfoLog:            s.RedactInfoLog,
-			AllowFallbackToPlaintext: s.AllowFallbackToPlaintext,
+			CAPath:    s.CAPath,
+			CertPath:  s.CertPath,
+			KeyPath:   s.KeyPath,
+			CABytes:   s.CABytes,
+			CertBytes: s.CertBytes,
+			KeyBytes:  s.KeyBytes,
 		}
 	}
 

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -175,7 +175,16 @@ func (d *DBStore) adjust(
 	}
 
 	if d.Security == nil {
-		d.Security = s
+		d.Security = &Security{
+			CAPath:                   s.CAPath,
+			CertPath:                 s.CertPath,
+			KeyPath:                  s.KeyPath,
+			CABytes:                  s.CABytes,
+			CertBytes:                s.CertBytes,
+			KeyBytes:                 s.KeyBytes,
+			RedactInfoLog:            s.RedactInfoLog,
+			AllowFallbackToPlaintext: s.AllowFallbackToPlaintext,
+		}
 	}
 
 	switch d.TLS {
@@ -200,12 +209,6 @@ func (d *DBStore) adjust(
 	case "":
 	case "false":
 		d.Security.TLSConfig = nil
-		d.Security.CAPath = ""
-		d.Security.CertPath = ""
-		d.Security.KeyPath = ""
-		d.Security.CABytes = nil
-		d.Security.CertBytes = nil
-		d.Security.KeyBytes = nil
 	default:
 		return common.ErrInvalidConfig.GenWithStack("unsupported `tidb.tls` config %s", d.TLS)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54172

Problem Summary:
Based on the issue, my suggestion to fix the problem is to treat the `d.Security` and `d.TLS` settings separately in the `DBStore.adjust` function. Specifically, the `d.Security` setting should not be modified by the `d.TLS` value, so that even if the `d.TLS` setting is `false`, the cluster certificate (`s.CAPath`, `s.CertPath`, `s.KeyPath`, etc.) is Security to be set to `d.Security`. This ensures that the TLS setting for the TiDB connection does not affect the cluster certificate setting.

Translated with DeepL.com (free version)

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
