### PR TITLE
planner: rename column `LAST_PLAN_CACHE_UNQUALIFIED_REASON` to `PLAN_CACHE_UNQUALIFIED_LAST_REASON` in statement_summary

### DIFF
--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -1389,7 +1389,7 @@ var tableStatementsSummaryCols = []columnInfo{
 	{name: stmtsummary.AvgQueuedRcTimeStr, tp: mysql.TypeLonglong, size: 22, flag: mysql.NotNullFlag | mysql.UnsignedFlag, comment: "Max time of waiting for available request-units"},
 	{name: stmtsummary.ResourceGroupName, tp: mysql.TypeVarchar, size: 64, comment: "Bind resource group name"},
 	{name: stmtsummary.PlanCacheUnqualifiedStr, tp: mysql.TypeLonglong, size: 20, flag: mysql.NotNullFlag, comment: "The number of times that these statements are not supported by the plan cache"},
-	{name: stmtsummary.LastPlanCacheUnqualifiedStr, tp: mysql.TypeBlob, size: types.UnspecifiedLength, comment: "The last reason why the statement is not supported by the plan cache"},
+	{name: stmtsummary.PlanCacheUnqualifiedLastReasonStr, tp: mysql.TypeBlob, size: types.UnspecifiedLength, comment: "The last reason why the statement is not supported by the plan cache"},
 }
 
 var tableStorageStatsCols = []columnInfo{

--- a/pkg/util/stmtsummary/reader.go
+++ b/pkg/util/stmtsummary/reader.go
@@ -305,7 +305,7 @@ const (
 	PlanInCacheStr                    = "PLAN_IN_CACHE"
 	PlanCacheHitsStr                  = "PLAN_CACHE_HITS"
 	PlanCacheUnqualifiedStr           = "PLAN_CACHE_UNQUALIFIED"
-	LastPlanCacheUnqualifiedStr       = "LAST_PLAN_CACHE_UNQUALIFIED_REASON"
+	PlanCacheUnqualifiedLastReasonStr = "PLAN_CACHE_UNQUALIFIED_LAST_REASON"
 	PlanInBindingStr                  = "PLAN_IN_BINDING"
 	QuerySampleTextStr                = "QUERY_SAMPLE_TEXT"
 	PrevSampleTextStr                 = "PREV_SAMPLE_TEXT"
@@ -665,7 +665,7 @@ var columnValueFactoryMap = map[string]columnValueFactory{
 	PlanCacheUnqualifiedStr: func(_ *stmtSummaryReader, ssElement *stmtSummaryByDigestElement, _ *stmtSummaryByDigest) any {
 		return ssElement.planCacheUnqualifiedCount
 	},
-	LastPlanCacheUnqualifiedStr: func(_ *stmtSummaryReader, ssElement *stmtSummaryByDigestElement, _ *stmtSummaryByDigest) any {
+	PlanCacheUnqualifiedLastReasonStr: func(_ *stmtSummaryReader, ssElement *stmtSummaryByDigestElement, _ *stmtSummaryByDigest) any {
 		return ssElement.lastPlanCacheUnqualified
 	},
 }

--- a/pkg/util/stmtsummary/v2/column.go
+++ b/pkg/util/stmtsummary/v2/column.go
@@ -120,7 +120,7 @@ const (
 	PlanInCacheStr                    = "PLAN_IN_CACHE"
 	PlanCacheHitsStr                  = "PLAN_CACHE_HITS"
 	PlanCacheUnqualifiedStr           = "PLAN_CACHE_UNQUALIFIED"
-	LastPlanCacheUnqualifiedStr       = "LAST_PLAN_CACHE_UNQUALIFIED_REASON"
+	PlanCacheUnqualifiedLastReasonStr = "PLAN_CACHE_UNQUALIFIED_LAST_REASON"
 	PlanInBindingStr                  = "PLAN_IN_BINDING"
 	QuerySampleTextStr                = "QUERY_SAMPLE_TEXT"
 	PrevSampleTextStr                 = "PREV_SAMPLE_TEXT"
@@ -487,8 +487,8 @@ var columnFactoryMap = map[string]columnFactory{
 	PlanCacheUnqualifiedStr: func(_ columnInfo, record *StmtRecord) any {
 		return record.PlanCacheUnqualifiedCount
 	},
-	LastPlanCacheUnqualifiedStr: func(_ columnInfo, record *StmtRecord) any {
-		return record.LastPlanCacheUnqualified
+	PlanCacheUnqualifiedLastReasonStr: func(_ columnInfo, record *StmtRecord) any {
+		return record.PlanCacheUnqualifiedLastReason
 	},
 }
 

--- a/pkg/util/stmtsummary/v2/record.go
+++ b/pkg/util/stmtsummary/v2/record.go
@@ -151,8 +151,8 @@ type StmtRecord struct {
 	ResourceGroupName string `json:"resource_group_name"`
 	stmtsummary.StmtRUSummary
 
-	PlanCacheUnqualifiedCount int64  `json:"plan_cache_unqualified_count"`
-	LastPlanCacheUnqualified  string `json:"last_plan_cache_unqualified"` // the reason why this query is unqualified for the plan cache
+	PlanCacheUnqualifiedCount      int64  `json:"plan_cache_unqualified_count"`
+	PlanCacheUnqualifiedLastReason string `json:"plan_cache_unqualified_last_reason"` // the reason why this query is unqualified for the plan cache
 }
 
 // NewStmtRecord creates a new StmtRecord from StmtExecInfo.
@@ -373,7 +373,7 @@ func (r *StmtRecord) Add(info *stmtsummary.StmtExecInfo) {
 	}
 	if info.PlanCacheUnqualified != "" {
 		r.PlanCacheUnqualifiedCount++
-		r.LastPlanCacheUnqualified = info.PlanCacheUnqualified
+		r.PlanCacheUnqualifiedLastReason = info.PlanCacheUnqualified
 	}
 	// SPM
 	if info.PlanInBinding {
@@ -550,8 +550,8 @@ func (r *StmtRecord) Merge(other *StmtRecord) {
 	// Plan cache
 	r.PlanCacheHits += other.PlanCacheHits
 	r.PlanCacheUnqualifiedCount += other.PlanCacheUnqualifiedCount
-	if other.LastPlanCacheUnqualified != "" {
-		r.LastPlanCacheUnqualified = other.LastPlanCacheUnqualified
+	if other.PlanCacheUnqualifiedLastReason != "" {
+		r.PlanCacheUnqualifiedLastReason = other.PlanCacheUnqualifiedLastReason
 	}
 	// Other
 	r.SumAffectedRows += other.SumAffectedRows


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50618

Problem Summary: planner: rename column `LAST_PLAN_CACHE_UNQUALIFIED_REASON` to `PLAN_CACHE_UNQUALIFIED_LAST_REASON` in statement_summary

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
