### PR TITLE
lightning: reduce the "unable to get keyspace name" log level to DEBUG

### DIFF
--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -407,6 +407,12 @@ func NewImportControllerWithPauser(
 		}
 		p.TaskType = taskType
 
+		// TODO: we should not need to check config here.
+		// Instead, we should perform the following during switch mode:
+		//  1. for each tikv, try to switch mode without any ranges.
+		//  2. if it returns normally, it means the store is using a raft-v1 engine.
+		//  3. if it returns the `partitioned-raft-kv only support switch mode with range set` error,
+		//     it means the store is a raft-v2 engine and we will include the ranges from now on.
 		isRaftKV2, err := common.IsRaftKV2(ctx, db)
 		if err != nil {
 			log.FromContext(ctx).Warn("check isRaftKV2 failed", zap.Error(err))

--- a/lightning/pkg/server/lightning.go
+++ b/lightning/pkg/server/lightning.go
@@ -567,7 +567,7 @@ func (l *Lightning) run(taskCtx context.Context, taskCfg *config.Config, o *opti
 		if keyspaceName == "" {
 			keyspaceName, err = getKeyspaceName(db)
 			if err != nil {
-				o.logger.Warn("unable to get keyspace name, lightning will use empty keyspace name", zap.Error(err))
+				o.logger.Debug("unable to get keyspace name, lightning will use empty keyspace name", zap.Error(err))
 			}
 		}
 		o.logger.Info("acquired keyspace name", zap.String("keyspaceName", keyspaceName))

--- a/lightning/pkg/server/lightning.go
+++ b/lightning/pkg/server/lightning.go
@@ -566,8 +566,18 @@ func (l *Lightning) run(taskCtx context.Context, taskCfg *config.Config, o *opti
 		keyspaceName = taskCfg.TikvImporter.KeyspaceName
 		if keyspaceName == "" {
 			keyspaceName, err = getKeyspaceName(db)
+			if err != nil && common.IsAccessDeniedNeedConfigPrivilegeError(err) {
+				// if the cluster is not multitenant we don't really need to know about the keyspace.
+				// since the doc does not say we require CONFIG privilege,
+				// spelling out the Access Denied error just confuses the users.
+				// hide such allowed errors unless log level is DEBUG.
+				o.logger.Info("keyspace is unspecified and target user has no config privilege, assuming dedicated cluster")
+				if o.logger.Level() > zapcore.DebugLevel {
+					err = nil
+				}
+			}
 			if err != nil {
-				o.logger.Debug("unable to get keyspace name, lightning will use empty keyspace name", zap.Error(err))
+				o.logger.Warn("unable to get keyspace name, lightning will use empty keyspace name", zap.Error(err))
 			}
 		}
 		o.logger.Info("acquired keyspace name", zap.String("keyspaceName", keyspaceName))

--- a/pkg/lightning/common/util.go
+++ b/pkg/lightning/common/util.go
@@ -696,3 +696,9 @@ func IsRaftKV2(ctx context.Context, db *sql.DB) (bool, error) {
 	}
 	return false, rows.Err()
 }
+
+// IsAccessDeniedNeedConfigPrivilegeError checks if err is generated from a query to TiDB which failed due to missing CONFIG privilege.
+func IsAccessDeniedNeedConfigPrivilegeError(err error) bool {
+	e, ok := err.(*mysql.MySQLError)
+	return ok && e.Number == errno.ErrSpecificAccessDenied && strings.Contains(e.Message, "CONFIG")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #54232

Problem Summary: When the keyspace-name is empty (default), and the user connecting to downstream TiDB is not a superuser, there will be a confusing "access denied" warning requesting CONFIG privilege. This confuses users to think that this privilege is actually required.

### What changed and how does it work?

Just reduce the log level to DEBUG.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
