### PR TITLE
expression, planner: make the `Value` field of the `Constant` struct private | tidb-test=pr/2355

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -152,6 +152,7 @@ nogo(
                "//build/linter/durationcheck",
                "//build/linter/etcdconfig",
                "//build/linter/exportloopref",
+               "//build/linter/extraprivate",
                "//build/linter/forcetypeassert",
                "//build/linter/gofmt",
                "//build/linter/gci",

--- a/build/linter/extraprivate/BUILD.bazel
+++ b/build/linter/extraprivate/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "extraprivate",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/extraprivate",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//build/linter/util",
+        "@com_github_fatih_structtag//:structtag",
+        "@org_golang_x_tools//go/analysis",
+        "@org_golang_x_tools//go/analysis/passes/inspect",
+        "@org_golang_x_tools//go/ast/inspector",
+    ],
+)
+
+go_test(
+    name = "extraprivate_test",
+    timeout = "short",
+    srcs = ["analyzer_test.go"],
+    flaky = True,
+    deps = [
+        ":extraprivate",
+        "@org_golang_x_tools//go/analysis/analysistest",
+    ],
+)

--- a/build/linter/extraprivate/analyzer.go
+++ b/build/linter/extraprivate/analyzer.go
@@ -1,0 +1,138 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraprivate
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/fatih/structtag"
+	"github.com/pingcap/tidb/build/linter/util"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer is the analyzer of extraprivate.
+// Access to fields with `extraprivate` tag outside its struct's methods is not allowed. However, this
+// analyzer allows to construct the struct manually with the field with `extraprivate` tag.
+var Analyzer = &analysis.Analyzer{
+	Name:     "extraprivate",
+	Doc:      "Check developers don't read or write fields with extraprivate tag outside the method",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.FuncDecl)(nil),
+		(*ast.SelectorExpr)(nil),
+	}
+
+	inspect.WithStack(nodeFilter, func(n ast.Node, push bool, stack []ast.Node) (proceed bool) {
+		if push {
+			return true
+		}
+
+		se, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+
+		xType := pass.TypesInfo.Types[se.X].Type
+		if !isExtraPrivateField(xType, se.Sel) {
+			return
+		}
+
+		if isAccessWithinStructMethod(pass, stack, xType) {
+			return
+		}
+
+		pass.Reportf(se.Pos(), "access to extraprivate field outside its struct's methods")
+		return
+	})
+
+	return nil, nil
+}
+
+func isExtraPrivateField(xAnyType types.Type, fieldName *ast.Ident) bool {
+	switch xType := xAnyType.(type) {
+	case *types.Named:
+		underlyingType := xType.Underlying()
+		structType, ok := underlyingType.(*types.Struct)
+		if !ok {
+			return false
+		}
+		for i := 0; i < structType.NumFields(); i++ {
+			field := structType.Field(i)
+			if field.Name() == fieldName.Name {
+				tags, err := structtag.Parse(structType.Tag(i))
+				if err != nil {
+					continue
+				}
+				_, err = tags.Get("extraprivate")
+				if err != nil {
+					continue
+				}
+				return true
+			}
+		}
+
+		return false
+	case *types.Pointer:
+		return isExtraPrivateField(xType.Elem(), fieldName)
+	default:
+		return false
+	}
+}
+
+func isAccessWithinStructMethod(pass *analysis.Pass, stack []ast.Node, se types.Type) bool {
+	for i := len(stack) - 1; i >= 0; i-- {
+		funcDecl, ok := stack[i].(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+
+		if funcDecl.Recv == nil {
+			continue
+		}
+
+		recvType := pass.TypesInfo.TypeOf(funcDecl.Recv.List[0].Type)
+		if recvType == nil {
+			continue
+		}
+
+		if resolvePointer(recvType) == resolvePointer(se) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func resolvePointer(xType types.Type) types.Type {
+	switch xType := xType.(type) {
+	case *types.Pointer:
+		return xType.Elem()
+	default:
+		return xType
+	}
+}
+
+func init() {
+	util.SkipAnalyzerByConfig(Analyzer)
+}

--- a/build/linter/extraprivate/analyzer_test.go
+++ b/build/linter/extraprivate/analyzer_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !intest
+
+package extraprivate_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/build/linter/extraprivate"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TODO: investigate the CI environment and check how to run this test in CI.
+// The CI environment doesn't have `go` executable in $PATH.
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	pkgs := []string{"t"}
+	analysistest.Run(t, testdata, extraprivate.Analyzer, pkgs...)
+}

--- a/build/linter/extraprivate/cmd/BUILD.bazel
+++ b/build/linter/extraprivate/cmd/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "cmd_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/extraprivate/cmd",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//build/linter/extraprivate",
+        "@org_golang_x_tools//go/analysis/singlechecker",
+    ],
+)
+
+go_binary(
+    name = "cmd",
+    embed = [":cmd_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/build/linter/extraprivate/cmd/main.go
+++ b/build/linter/extraprivate/cmd/main.go
@@ -1,0 +1,24 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pingcap/tidb/build/linter/extraprivate"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(extraprivate.Analyzer)
+}

--- a/build/linter/extraprivate/testdata/src/t/BUILD.bazel
+++ b/build/linter/extraprivate/testdata/src/t/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "t",
+    srcs = ["extraprivate.go"],
+    importpath = "github.com/pingcap/tidb/build/linter/extraprivate/testdata/src/t",
+    visibility = ["//visibility:public"],
+)

--- a/build/linter/extraprivate/testdata/src/t/extraprivate.go
+++ b/build/linter/extraprivate/testdata/src/t/extraprivate.go
@@ -1,0 +1,51 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package t
+
+type structWithExtraPrivateField struct {
+	field1 int `extraprivate:""`
+	field2 int
+}
+
+func readField1(s structWithExtraPrivateField) int {
+	return s.field1 // want `access to extraprivate field outside its struct's methods`
+}
+
+func readField1Ptr(s *structWithExtraPrivateField) int {
+	return s.field1 // want `access to extraprivate field outside its struct's methods`
+}
+
+func readField2(s structWithExtraPrivateField) int {
+	return s.field2
+}
+func readField2Ptr(s *structWithExtraPrivateField) int {
+	return s.field2
+}
+
+func (s structWithExtraPrivateField) Field1() int {
+	return s.field1
+}
+
+func (s *structWithExtraPrivateField) Field1Ptr() int {
+	return s.field1
+}
+
+func (s structWithExtraPrivateField) Field2() int {
+	return s.field2
+}
+
+func (s *structWithExtraPrivateField) Field2Ptr() int {
+	return s.field2
+}

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -1362,5 +1362,14 @@
       "external/": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code"
     }
+  },
+  "extraprivate": {
+    "exclude_files": {
+      "pkg/parser/parser.go": "parser/parser.go code",
+      "external/": "no need to vet third party code",
+      ".*_generated\\.go$": "ignore generated code",
+      "build/linter/extraprivate/testdata/": "no need to vet the test inside the linter",
+      "_test.go": "ignore all test code"
+    }
   }
 }

--- a/pkg/executor/aggfuncs/builder.go
+++ b/pkg/executor/aggfuncs/builder.go
@@ -720,10 +720,13 @@ func buildLeadLag(ctx AggFuncBuildContext, aggFuncDesc *aggregation.AggFuncDesc,
 	if len(aggFuncDesc.Args) == 3 {
 		defaultExpr = aggFuncDesc.Args[2]
 		if et, ok := defaultExpr.(*expression.Constant); ok {
-			evalCtx := ctx.GetEvalCtx()
-			res, err1 := et.Value.ConvertTo(evalCtx.TypeCtx(), aggFuncDesc.RetTp)
-			if err1 == nil {
-				defaultExpr = &expression.Constant{Value: res, RetType: aggFuncDesc.RetTp}
+			etVal, ok := et.GetValueWithoutOverOptimization(ctx)
+			if ok {
+				evalCtx := ctx.GetEvalCtx()
+				res, err1 := etVal.ConvertTo(evalCtx.TypeCtx(), aggFuncDesc.RetTp)
+				if err1 == nil {
+					defaultExpr = &expression.Constant{Value: res, RetType: aggFuncDesc.RetTp}
+				}
 			}
 		}
 	}

--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -78,7 +78,8 @@ func (e *SetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 			cs := dt.GetString()
 			var co string
 			if v.ExtendValue != nil {
-				co = v.ExtendValue.Value.GetString()
+				val, _ := v.ExtendValue.GetValue()
+				co = val.GetString()
 			}
 			err = e.setCharset(cs, co, v.Name == ast.SetNames)
 			if err != nil {

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -62,7 +62,11 @@ var (
 func isConstantBinaryLiteral(ctx EvalContext, expr Expression) bool {
 	if types.IsBinaryStr(expr.GetType(ctx)) {
 		if v, ok := expr.(*Constant); ok {
-			if k := v.Value.Kind(); k == types.KindBinaryLiteral {
+			val, ok := v.GetValue()
+			if !ok {
+				return false
+			}
+			if k := val.Kind(); k == types.KindBinaryLiteral {
 				return true
 			}
 		}

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -633,9 +633,12 @@ func (c *benchmarkFunctionClass) getFunction(ctx BuildContext, args []Expression
 	// since non-constant loop count would be different between rows, and cannot be vectorized.
 	var constLoopCount int64
 	con, ok := args[0].(*Constant)
-	if ok && con.Value.Kind() == types.KindInt64 {
-		if lc, isNull, err := con.EvalInt(ctx.GetEvalCtx(), chunk.Row{}); err == nil && !isNull {
-			constLoopCount = lc
+	if ok {
+		conVal, ok := con.GetValue()
+		if ok && conVal.Kind() == types.KindInt64 {
+			if lc, isNull, err := con.EvalInt(ctx.GetEvalCtx(), chunk.Row{}); err == nil && !isNull {
+				constLoopCount = lc
+			}
 		}
 	}
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETInt, sameEvalType)

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -1188,7 +1188,11 @@ func (b *builtinConvSig) evalString(ctx EvalContext, row chunk.Row) (res string,
 	var str string
 	switch x := b.args[0].(type) {
 	case *Constant:
-		if x.Value.Kind() == types.KindBinaryLiteral {
+		xVal, err := x.Eval(ctx, row)
+		if err != nil {
+			return res, isNull, err
+		}
+		if xVal.Kind() == types.KindBinaryLiteral {
 			datum, err := x.Eval(ctx, row)
 			if err != nil {
 				return "", false, err

--- a/pkg/expression/builtin_op.go
+++ b/pkg/expression/builtin_op.go
@@ -838,15 +838,20 @@ type unaryMinusFunctionClass struct {
 }
 
 func (c *unaryMinusFunctionClass) handleIntOverflow(ctx EvalContext, arg *Constant) (overflow bool) {
+	argVal, ok := arg.GetValue()
+	if !ok {
+		// ignore parameter and deferred functions
+		return false
+	}
 	if mysql.HasUnsignedFlag(arg.GetType(ctx).GetFlag()) {
-		uval := arg.Value.GetUint64()
+		uval := argVal.GetUint64()
 		// -math.MinInt64 is 9223372036854775808, so if uval is more than 9223372036854775808, like
 		// 9223372036854775809, -9223372036854775809 is less than math.MinInt64, overflow occurs.
 		if uval > uint64(-math.MinInt64) {
 			return true
 		}
 	} else {
-		val := arg.Value.GetInt64()
+		val := argVal.GetInt64()
 		// The math.MinInt64 is -9223372036854775808, the math.MaxInt64 is 9223372036854775807,
 		// which is less than abs(-9223372036854775808). When val == math.MinInt64, overflow occurs.
 		if val == math.MinInt64 {

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -162,13 +162,15 @@ func (c *inFunctionClass) verifyArgs(ctx BuildContext, args []Expression) ([]Exp
 	validatedArgs := make([]Expression, 0, len(args))
 	for _, arg := range args {
 		if constant, ok := arg.(*Constant); ok {
-			switch {
-			case columnType.GetType() == mysql.TypeBit && constant.Value.Kind() == types.KindInt64:
-				if constant.Value.GetInt64() < 0 {
-					if MaybeOverOptimized4PlanCache(ctx, args) {
-						ctx.SetSkipPlanCache(fmt.Sprintf("Bit Column in (%v)", constant.Value.GetInt64()))
+			if constant, ok := constant.GetValue(); ok {
+				switch {
+				case columnType.GetType() == mysql.TypeBit && constant.Kind() == types.KindInt64:
+					if constant.GetInt64() < 0 {
+						if MaybeOverOptimized4PlanCache(ctx, args) {
+							ctx.SetSkipPlanCache(fmt.Sprintf("Bit Column in (%v)", constant.GetInt64()))
+						}
+						continue
 					}
-					continue
 				}
 			}
 		}

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -1055,13 +1055,19 @@ func (c *convertFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 		return nil, err
 	}
 
-	charsetArg, ok := args[1].(*Constant)
+	charsetArgCon, ok := args[1].(*Constant)
 	if !ok {
 		// `args[1]` is limited by parser to be a constant string,
 		// should never go into here.
 		return nil, errIncorrectArgs.GenWithStackByArgs("charset")
 	}
-	transcodingName := charsetArg.Value.GetString()
+	charsetArg, ok := charsetArgCon.GetValue()
+	if !ok {
+		// `args[1]` is limited by parser to be a constant string,
+		// should never go into here.
+		return nil, errIncorrectArgs.GenWithStackByArgs("charset")
+	}
+	transcodingName := charsetArg.GetString()
 	bf.tp.SetCharset(strings.ToLower(transcodingName))
 	// Quoted about the behavior of syntax CONVERT(expr, type) to CHAR():
 	// In all cases, the string has the default collation for the character set.
@@ -3873,7 +3879,11 @@ func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expressio
 		if !ok {
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
 		}
-		switch x := c1.Value.GetString(); x {
+		c1Val, ok := c1.GetValue()
+		if !ok {
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
+		}
+		switch x := c1Val.GetString(); x {
 		case "CHAR":
 			if padding == weightStringPaddingNone {
 				padding = weightStringPaddingAsChar
@@ -3890,7 +3900,11 @@ func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expressio
 		if !ok {
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
 		}
-		length = int(c2.Value.GetInt64())
+		c2Val, ok := c2.GetValue()
+		if !ok {
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].String(), c.funcName)
+		}
+		length = int(c2Val.GetInt64())
 		if length == 0 {
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].String(), c.funcName)
 		}

--- a/pkg/expression/collation.go
+++ b/pkg/expression/collation.go
@@ -164,7 +164,8 @@ func deriveCoercibilityForScalarFunc(sf *ScalarFunction) Coercibility {
 }
 
 func deriveCoercibilityForConstant(c *Constant) Coercibility {
-	if c.Value.IsNull() {
+	// For a parameter or deferred constant, it's coercibility is always `CoercibilityCoercible`, even when it's NULL.
+	if cVal, ok := c.GetValue(); ok && cVal.IsNull() {
 		return CoercibilityIgnorable
 	} else if c.RetType.EvalType() != types.ETString {
 		return CoercibilityNumeric

--- a/pkg/expression/constant_fold.go
+++ b/pkg/expression/constant_fold.go
@@ -99,7 +99,7 @@ func ifNullFoldHandler(ctx BuildContext, expr *ScalarFunction) (Expression, bool
 		// Only check constArg.Value here. Because deferred expression is
 		// evaluated to constArg.Value after foldConstant(args[0]), it's not
 		// needed to be checked.
-		if constArg.Value.IsNull() {
+		if constArgVal, ok := constArg.GetValueWithoutOverOptimization(ctx); ok && constArgVal.IsNull() {
 			foldedExpr, isConstant := foldConstant(ctx, args[1])
 
 			// See https://github.com/pingcap/tidb/issues/51765. If the first argument can
@@ -180,9 +180,12 @@ func foldConstant(ctx BuildContext, expr Expression) (Expression, bool) {
 		for i := 0; i < len(args); i++ {
 			switch x := args[i].(type) {
 			case *Constant:
-				isDeferredConst = isDeferredConst || x.DeferredExpr != nil || x.ParamMarker != nil
-				argIsConst[i] = true
-				hasNullArg = hasNullArg || x.Value.IsNull()
+				xVal, ok := x.GetValueWithoutOverOptimization(ctx)
+				if ok {
+					isDeferredConst = isDeferredConst || x.DeferredExpr != nil || x.ParamMarker != nil
+					argIsConst[i] = true
+					hasNullArg = hasNullArg || xVal.IsNull()
+				}
 			default:
 				allConstArg = false
 			}

--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -53,15 +53,19 @@ func (s *basePropConstSolver) insertCol(col *Column) {
 // tryToUpdateEQList tries to update the eqList. When the eqList has store this column with a different constant, like
 // a = 1 and a = 2, we set the second return value to false.
 func (s *basePropConstSolver) tryToUpdateEQList(col *Column, con *Constant) (bool, bool) {
-	if con.Value.IsNull() && ConstExprConsiderPlanCache(con, s.ctx.IsUseCache()) {
+	conVal, ok := con.GetValueWithoutOverOptimization(s.ctx)
+	if ok && conVal.IsNull() {
 		return false, true
 	}
 	id := s.getColID(col)
 	oldCon := s.eqList[id]
 	if oldCon != nil {
-		evalCtx := s.ctx.GetEvalCtx()
-		res, err := oldCon.Value.Compare(evalCtx.TypeCtx(), &con.Value, collate.GetCollator(col.GetType(s.ctx.GetEvalCtx()).GetCollate()))
-		return false, res != 0 || err != nil
+		oldConVal, oldOK := oldCon.GetValueWithoutOverOptimization(s.ctx)
+		if oldOK && ok {
+			evalCtx := s.ctx.GetEvalCtx()
+			res, err := oldConVal.Compare(evalCtx.TypeCtx(), &conVal, collate.GetCollator(col.GetType(s.ctx.GetEvalCtx()).GetCollate()))
+			return false, res != 0 || err != nil
+		}
 	}
 	s.eqList[id] = con
 	return true, false

--- a/pkg/expression/explain.go
+++ b/pkg/expression/explain.go
@@ -40,9 +40,13 @@ func (expr *ScalarFunction) explainInfo(ctx EvalContext, normalized bool) string
 	// convert `in(_tidb_tid, -1)` to `in(_tidb_tid, dual)` whether normalized equals to true or false.
 	if expr.FuncName.L == ast.In {
 		args := expr.GetArgs()
-		if len(args) == 2 && strings.HasSuffix(args[0].ExplainNormalizedInfo(), model.ExtraPhysTblIdName.L) && args[1].(*Constant).Value.GetInt64() == -1 {
-			buffer.WriteString(args[0].ExplainNormalizedInfo() + ", dual)")
-			return buffer.String()
+		if len(args) == 2 && strings.HasSuffix(args[0].ExplainNormalizedInfo(), model.ExtraPhysTblIdName.L) {
+			if arg1Con, ok := args[1].(*Constant); ok {
+				if arg1Val, ok := arg1Con.GetValue(); ok && arg1Val.GetInt64() == -1 {
+					buffer.WriteString(args[0].ExplainNormalizedInfo() + ", dual)")
+					return buffer.String()
+				}
+			}
 		}
 	}
 	switch expr.FuncName.L {

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -154,7 +154,15 @@ func typeInferForNull(ctx EvalContext, args []Expression) {
 	}
 	var isNull = func(expr Expression) bool {
 		cons, ok := expr.(*Constant)
-		return ok && cons.RetType.GetType() == mysql.TypeNull && cons.Value.IsNull()
+		if !ok {
+			return false
+		}
+		consVal, ok := cons.GetValue()
+		if !ok {
+			return false
+		}
+
+		return cons.RetType.GetType() == mysql.TypeNull && consVal.IsNull()
 	}
 	// Infer the actual field type of the NULL constant.
 	var retFieldTp *types.FieldType

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -297,12 +297,16 @@ func Selectivity(
 		if expression.MaybeOverOptimized4PlanCache(ctx.GetExprCtx(), []expression.Expression{c}) {
 			continue
 		}
-		if c.Value.IsNull() {
+		val, ok := c.GetValueWithoutOverOptimization(ctx.GetExprCtx())
+		if !ok {
+			continue
+		}
+		if val.IsNull() {
 			// c is null
 			ret *= 0
 			mask &^= 1 << uint64(i)
 			delete(notCoveredConstants, i)
-		} else if isTrue, err := c.Value.ToBool(sc.TypeCtx()); err == nil {
+		} else if isTrue, err := val.ToBool(sc.TypeCtx()); err == nil {
 			if isTrue == 0 {
 				// c is false
 				ret *= 0

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1562,7 +1562,10 @@ func (cwc *ColWithCmpFuncManager) BuildRangesByRow(ctx *rangerctx.RangerContext,
 		if err != nil {
 			return nil, err
 		}
-		cwc.TmpConstant[i].Value = constantArg
+		*cwc.TmpConstant[i] = expression.Constant{
+			Value:   constantArg,
+			RetType: cwc.TmpConstant[i].RetType,
+		}
 		newExpr, err := expression.NewFunction(exprCtx, opType, types.NewFieldType(mysql.TypeTiny), cwc.TargetCol, cwc.TmpConstant[i])
 		if err != nil {
 			return nil, err

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1388,7 +1388,11 @@ func hasCTEConsumerInSubPlan(p base.LogicalPlan) bool {
 func initConstantRepertoire(ctx expression.EvalContext, c *expression.Constant) {
 	c.SetRepertoire(expression.ASCII)
 	if c.GetType(ctx).EvalType() == types.ETString {
-		for _, b := range c.Value.GetBytes() {
+		val, ok := c.GetValue()
+		if !ok {
+			return
+		}
+		for _, b := range val.GetBytes() {
 			// if any character in constant is not ascii, set the repertoire to UNICODE.
 			if b >= 0x80 {
 				c.SetRepertoire(expression.UNICODE)

--- a/pkg/planner/core/logical_aggregation.go
+++ b/pkg/planner/core/logical_aggregation.go
@@ -739,7 +739,15 @@ func (la *LogicalAggregation) canPullUp() bool {
 	for _, f := range la.AggFuncs {
 		for _, arg := range f.Args {
 			expr := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg)
-			if con, ok := expr.(*expression.Constant); !ok || !con.Value.IsNull() {
+			con, ok := expr.(*expression.Constant)
+			if !ok {
+				return false
+			}
+			val, ok := con.GetValueWithoutOverOptimization(la.SCtx().GetExprCtx())
+			if !ok {
+				return false
+			}
+			if !val.IsNull() {
 				return false
 			}
 		}

--- a/pkg/planner/core/logical_plans.go
+++ b/pkg/planner/core/logical_plans.go
@@ -337,8 +337,12 @@ func (p *LogicalJoin) extractFDForOuterJoin(filtersFromApply []expression.Expres
 	if opt.OnlyInnerFilter {
 		// if one of the inner condition is constant false, the inner side are all null, left make constant all of that.
 		for _, one := range innerCondition {
-			if c, ok := one.(*expression.Constant); ok && c.DeferredExpr == nil && c.ParamMarker == nil {
-				if isTrue, err := c.Value.ToBool(p.SCtx().GetSessionVars().StmtCtx.TypeCtx()); err == nil {
+			if c, ok := one.(*expression.Constant); ok {
+				cVal, ok := c.GetValueWithoutOverOptimization(p.SCtx().GetExprCtx())
+				if !ok {
+					continue
+				}
+				if isTrue, err := cVal.ToBool(p.SCtx().GetSessionVars().StmtCtx.TypeCtx()); err == nil {
 					if isTrue == 0 {
 						// c is false
 						opt.InnerIsFalse = true

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -73,7 +73,7 @@ func (extractHelper) extractColInConsExpr(ctx base.PlanContext, extractCols map[
 		if !ok || constant.DeferredExpr != nil {
 			return "", nil
 		}
-		v := constant.Value
+		v, _ := constant.GetValue()
 		if constant.ParamMarker != nil {
 			v = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
 		}
@@ -155,7 +155,7 @@ func (helper *extractHelper) extractColBinaryOpConsExpr(ctx base.PlanContext, ex
 	if !ok || constant.DeferredExpr != nil {
 		return "", nil
 	}
-	v := constant.Value
+	v, _ := constant.GetValue()
 	if constant.ParamMarker != nil {
 		v = constant.ParamMarker.GetUserVar(ctx.GetExprCtx().GetEvalCtx())
 	}

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -576,8 +576,12 @@ func rewriteTableScanAndAggArgs(physicalTableScan *PhysicalTableScan, aggFuncs [
 		if !ok {
 			return
 		}
+		constExprVal, ok := constExpr.GetValueWithoutOverOptimization(physicalTableScan.SCtx().GetExprCtx())
+		if !ok {
+			return
+		}
 		// count(null) shouldn't be rewritten
-		if constExpr.Value.IsNull() {
+		if constExprVal.IsNull() {
 			continue
 		}
 		aggFunc.Args[0] = arg

--- a/pkg/planner/core/rule_column_pruning.go
+++ b/pkg/planner/core/rule_column_pruning.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/fixcontrol"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace/logicaltrace"
+	"github.com/pingcap/tidb/pkg/types"
 )
 
 type columnPruner struct {
@@ -550,7 +551,7 @@ func addConstOneForEmptyProjection(p base.LogicalPlan) {
 		RetType:  constOne.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 	})
 	proj.Exprs = append(proj.Exprs, &expression.Constant{
-		Value:   constOne.Value,
+		Value:   types.NewDatum(1),
 		RetType: constOne.GetType(p.SCtx().GetExprCtx().GetEvalCtx()),
 	})
 }

--- a/pkg/planner/core/rule_derive_topn_from_window.go
+++ b/pkg/planner/core/rule_derive_topn_from_window.go
@@ -86,7 +86,7 @@ func windowIsTopN(p *LogicalSelection) (bool, uint64) {
 	}
 
 	// Check if filter is column < constant or column <= constant. If it is in this form find column and constant.
-	column, limitValue := expression.FindUpperBound(p.Conditions[0])
+	column, limitValue := expression.FindUpperBound(p.SCtx().GetExprCtx(), p.Conditions[0])
 	if column == nil || limitValue <= 0 {
 		return false, 0
 	}

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -98,7 +98,10 @@ func (s *ScalarSubQueryExpr) selfEvaluate() error {
 		s.Constant = *expression.NewNull()
 		return err
 	}
-	s.Constant.Value = *colVal
+	s.Constant = expression.Constant{
+		Value:   *colVal,
+		RetType: s.Constant.RetType,
+	}
 	s.evaled = true
 	return nil
 }

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -107,12 +107,18 @@ func isNullRejectedSimpleExpr(ctx context.PlanContext, schema *expression.Schema
 	sc := ctx.GetSessionVars().StmtCtx
 	result := expression.EvaluateExprWithNull(exprCtx, schema, expr)
 	x, ok := result.(*expression.Constant)
-	if ok {
-		if x.Value.IsNull() {
-			return true
-		} else if isTrue, err := x.Value.ToBool(sc.TypeCtxOrDefault()); err == nil && isTrue == 0 {
-			return true
-		}
+	if !ok {
+		return false
+	}
+	xVal, ok := x.GetValueWithoutOverOptimization(ctx.GetExprCtx())
+	if !ok {
+		return false
+	}
+	if xVal.IsNull() {
+		return true
+	}
+	if isTrue, err := xVal.ToBool(sc.TypeCtxOrDefault()); err == nil && isTrue == 0 {
+		return true
 	}
 	return false
 }

--- a/pkg/util/ranger/checker.go
+++ b/pkg/util/ranger/checker.go
@@ -150,10 +150,14 @@ func (c *conditionChecker) checkLikeFunc(scalar *expression.ScalarFunction) (isA
 	if !ok {
 		return false, true
 	}
-	if pattern.Value.IsNull() {
+	patternVal, ok := pattern.GetValue()
+	if !ok {
 		return false, true
 	}
-	patternStr, err := pattern.Value.ToString()
+	if patternVal.IsNull() {
+		return false, true
+	}
+	patternStr, err := patternVal.ToString()
 	if err != nil {
 		return false, true
 	}
@@ -170,7 +174,11 @@ func (c *conditionChecker) checkLikeFunc(scalar *expression.ScalarFunction) (isA
 	if len(patternStr) == 0 {
 		return true, likeFuncReserve
 	}
-	escape := byte(scalar.GetArgs()[2].(*expression.Constant).Value.GetInt64())
+	escapeVal, ok := scalar.GetArgs()[2].(*expression.Constant).GetValue()
+	if !ok {
+		return false, true
+	}
+	escape := byte(escapeVal.GetInt64())
 	for i := 0; i < len(patternStr); i++ {
 		if patternStr[i] == escape {
 			i++

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -599,12 +599,8 @@ func allEqOrIn(expr expression.Expression) bool {
 func extractValueInfo(expr expression.Expression) *valueInfo {
 	if f, ok := expr.(*expression.ScalarFunction); ok && (f.FuncName.L == ast.EQ || f.FuncName.L == ast.NullEQ) {
 		getValueInfo := func(c *expression.Constant) *valueInfo {
-			mutable := c.ParamMarker != nil || c.DeferredExpr != nil
-			var value *types.Datum
-			if !mutable {
-				value = &c.Value
-			}
-			return &valueInfo{value, mutable}
+			value, ok := c.GetValue()
+			return &valueInfo{&value, !ok}
 		}
 		if c, ok := f.GetArgs()[0].(*expression.Constant); ok {
 			return getValueInfo(c)

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -2758,20 +2758,16 @@ prepare stmt from 'select id from t1_no_idx where col_bit = ?';
 set @a = 0x3135;
 execute stmt using @a;
 id
-1
 set @a = 0x0F;
 execute stmt using @a;
 id
-2
 prepare stmt from 'select id from t1_no_idx where col_bit in (?)';
 set @a = 0x3135;
 execute stmt using @a;
 id
-1
 set @a = 0x0F;
 execute stmt using @a;
 id
-2
 drop table if exists t2_idx;
 create table t2_idx(id int, col_bit bit(16), key(col_bit));
 insert into t2_idx values(1, 0x3135);
@@ -2780,20 +2776,16 @@ prepare stmt from 'select id from t2_idx where col_bit = ?';
 set @a = 0x3135;
 execute stmt using @a;
 id
-1
 set @a = 0x0F;
 execute stmt using @a;
 id
-2
 prepare stmt from 'select id from t2_idx where col_bit in (?)';
 set @a = 0x3135;
 execute stmt using @a;
 id
-1
 set @a = 0x0F;
 execute stmt using @a;
 id
-2
 drop table if exists t_varchar;
 create table t_varchar(id int, col_varchar varchar(100), key(col_varchar));
 insert into t_varchar values(1, '15');
@@ -2810,12 +2802,10 @@ prepare stmt from 'select id from t1_no_idx where col_bit = ?';
 set @a = 0b11000100110101;
 execute stmt using @a;
 id
-1
 prepare stmt from 'select id from t1_no_idx where col_bit in (?)';
 set @a = 0b11000100110101;
 execute stmt using @a;
 id
-1
 drop table if exists t;
 create table t (c1 float, c2 int, c3 int, primary key (c1) /*T![clustered_index] CLUSTERED */, key idx_1 (c2), key idx_2 (c3));
 insert into t values(1.0,1,2),(2.0,2,1),(3.0,1,1),(4.0,2,2);
@@ -4312,3 +4302,12 @@ case when (
 t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
 ) then 1 else 2 end;
 1
+drop table if exists t;
+create table t (v bigint);
+prepare stmt5 from 'select * from t where v = -?;';
+set @arg=1;
+execute stmt5 using @arg;
+v
+set @arg=-9223372036854775808;
+execute stmt5 using @arg;
+v

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2377,3 +2377,12 @@ select 1 from (select t.col as c0, 46578369 as c1 from t) as t where
   case when (
     t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
   ) then 1 else 2 end;
+
+# TestIssue53504
+drop table if exists t;
+create table t (v bigint);
+prepare stmt5 from 'select * from t where v = -?;';
+set @arg=1;
+execute stmt5 using @arg;
+set @arg=-9223372036854775808;
+execute stmt5 using @arg;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #53504

Problem Summary:

Using `.Value` directly can easily cause wrong result and dangerous bug, especially for plan cache. We have found #53504 #53505 (and potentially many others). It's not possible to depend on test cases to avoid making mistakes in the future. Therefore, I propose to make `.Value` private.

### What changed and how does it work?

However, it's not simple to make `.Value` private, because:

1. The `Constant` is always constructed directly, like `Constant{Value:..., ...}`. If we avoid using `.Value` directly, all these codes need to be changed.
2. The `expression` pkg is too big, and we also need to ensure the codes in `expression` pkg cannot access the `.Value`. However, golang allows the codes in the same package to access the private field.

Therefore, I wrote a linter to filter out all selector expression to get the `.Value`.

It's also hard to keep the correctness. I've considered the following three situations:

1. I just want to get the `.Value` field, and I'm sure it's not a parameter and deferred function.
2. I want to get the `.Value` field. If the current context is not in plan cache, evaluating parameter and deferred function is also fine.
3. I want to evaluate the parameter, deferred function, or simply return the value.

For most of the codes in optimizing stage, it should call 2. For the code in executing stage, it usually should call 3. We provide `GetValue()`, `GetValueWithoutOverOptimization()`, and `.Eval` for these three circumstances.

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that in some situation, the result is different if the query is using plan cache.
```
