### PR TITLE
planner, executor: fix index lookup join's inner index order should should be correctly mapped to join keys

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3367,7 +3367,7 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndex
 			CompareFuncs:            v.CompareFuncs,
 			ColLens:                 v.IdxColLens,
 			Desc:                    v.Desc,
-			KeyOff2KeyOffOrderByIdx: v.KeyOff2KeyOffOrderByIdx,
+			OrderByIdxOffset2KeyOff: v.OrderByIdxOffset2KeyOff,
 		},
 		WorkerWg:      new(sync.WaitGroup),
 		IsOuterJoin:   v.JoinType.IsOuterJoin(),

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1542,8 +1542,8 @@ func (p *PhysicalIndexJoin) MemoryUsage() (sum int64) {
 type PhysicalIndexMergeJoin struct {
 	PhysicalIndexJoin
 
-	// KeyOff2KeyOffOrderByIdx maps the offsets in join keys to the offsets in join keys order by index.
-	KeyOff2KeyOffOrderByIdx []int
+	// OrderByIdxOffset2KeyOff maps the offsets in join keys to the offsets in join keys order by index.
+	OrderByIdxOffset2KeyOff []int
 	// CompareFuncs store the compare functions for outer join keys and inner join key.
 	CompareFuncs []expression.CompareFunc
 	// OuterCompareFuncs store the compare functions for outer join keys and outer join
@@ -1561,7 +1561,7 @@ func (p *PhysicalIndexMergeJoin) MemoryUsage() (sum int64) {
 		return
 	}
 
-	sum = p.PhysicalIndexJoin.MemoryUsage() + size.SizeOfSlice*3 + int64(cap(p.KeyOff2KeyOffOrderByIdx))*size.SizeOfInt +
+	sum = p.PhysicalIndexJoin.MemoryUsage() + size.SizeOfSlice*3 + int64(cap(p.OrderByIdxOffset2KeyOff))*size.SizeOfInt +
 		int64(cap(p.CompareFuncs)+cap(p.OuterCompareFuncs))*size.SizeOfFunc + size.SizeOfBool*2
 	return
 }


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54064

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner, executor: fix index lookup join's inner index order should should be correctly mapped to join keys
```
