### PR TITLE
planner: use ordered index with is null predicate | tidb-test=pr/2368

### DIFF
--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -182,6 +182,16 @@ func getPotentialEqOrInColOffset(sctx *rangerctx.RangerContext, expr expression.
 				return i
 			}
 		}
+	case ast.IsNull:
+		c, ok := f.GetArgs()[0].(*expression.Column)
+		if !ok {
+			return -1
+		}
+		for i, col := range cols {
+			if col.EqualColumn(c) {
+				return i
+			}
+		}
 	}
 	return -1
 }
@@ -635,27 +645,34 @@ func allEqOrIn(expr expression.Expression) bool {
 			}
 		}
 		return true
-	case ast.EQ, ast.NullEQ, ast.In:
+	case ast.EQ, ast.NullEQ, ast.In, ast.IsNull:
 		return true
 	}
 	return false
 }
 
 func extractValueInfo(expr expression.Expression) *valueInfo {
-	if f, ok := expr.(*expression.ScalarFunction); ok && (f.FuncName.L == ast.EQ || f.FuncName.L == ast.NullEQ) {
-		getValueInfo := func(c *expression.Constant) *valueInfo {
-			mutable := c.ParamMarker != nil || c.DeferredExpr != nil
-			var value *types.Datum
-			if !mutable {
-				value = &c.Value
+	if f, ok := expr.(*expression.ScalarFunction); ok {
+		if f.FuncName.L == ast.IsNull {
+			val := &types.Datum{}
+			val.SetNull()
+			return &valueInfo{value: val, mutable: false}
+		}
+		if f.FuncName.L == ast.EQ || f.FuncName.L == ast.NullEQ {
+			getValueInfo := func(c *expression.Constant) *valueInfo {
+				mutable := c.ParamMarker != nil || c.DeferredExpr != nil
+				var value *types.Datum
+				if !mutable {
+					value = &c.Value
+				}
+				return &valueInfo{value, mutable}
 			}
-			return &valueInfo{value, mutable}
-		}
-		if c, ok := f.GetArgs()[0].(*expression.Constant); ok {
-			return getValueInfo(c)
-		}
-		if c, ok := f.GetArgs()[1].(*expression.Constant); ok {
-			return getValueInfo(c)
+			if c, ok := f.GetArgs()[0].(*expression.Constant); ok {
+				return getValueInfo(c)
+			}
+			if c, ok := f.GetArgs()[1].(*expression.Constant); ok {
+				return getValueInfo(c)
+			}
 		}
 	}
 	return nil
@@ -714,8 +731,12 @@ func ExtractEqAndInCondition(sctx *rangerctx.RangerContext, conditions []express
 		if ma == nil {
 			if accesses[i] != nil {
 				if allEqOrIn(accesses[i]) {
-					newConditions = append(newConditions, accesses[i])
 					columnValues[i] = extractValueInfo(accesses[i])
+					if columnValues[i] != nil && columnValues[i].value != nil && columnValues[i].value.IsNull() {
+						accesses[i] = nil
+					} else {
+						newConditions = append(newConditions, accesses[i])
+					}
 				} else {
 					accesses[i] = nil
 				}

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -600,6 +600,13 @@ explain format = 'brief' select * from t3 where a >= 'a' and a <= 'a' and b = 'b
 id	estRows	task	access object	operator info
 IndexReader	0.33	root		index:IndexRangeScan
 └─IndexRangeScan	0.33	cop[tikv]	table:t3, index:a(a, b, c)	range:("a" "b" "c","a" "b" +inf], keep order:false, stats:pseudo
+explain format = 'brief' select * from t1 where a is null or a in (1, 2, 3);
+id	estRows	task	access object	operator info
+IndexReader	260.00	root		index:IndexRangeScan
+└─IndexRangeScan	260.00	cop[tikv]	table:t1, index:a(a, b, c)	range:[NULL,NULL], [1,3], keep order:false, stats:pseudo
+explain format = 'brief' select * from t1 where a is null and a = 1;
+id	estRows	task	access object	operator info
+TableDual	0.00	root		rows:0
 drop table if exists t1;
 CREATE TABLE t1 (
 key1 int(11) NOT NULL,

--- a/tests/integrationtest/r/util/ranger.result
+++ b/tests/integrationtest/r/util/ranger.result
@@ -482,9 +482,8 @@ a	b	c
 1	2	2
 explain format='brief' select * from t where a = 1 and (b is null or b = 2) and c > 1;
 id	estRows	task	access object	operator info
-IndexReader	0.07	root		index:Selection
-└─Selection	0.07	cop[tikv]		gt(util__ranger.t.c, 1)
-  └─IndexRangeScan	0.20	cop[tikv]	table:t, index:a(a, b, c)	range:[1 NULL,1 NULL], [1 2,1 2], keep order:false, stats:pseudo
+IndexReader	0.67	root		index:IndexRangeScan
+└─IndexRangeScan	0.67	cop[tikv]	table:t, index:a(a, b, c)	range:(1 NULL 1,1 NULL +inf], (1 2 1,1 2 +inf], keep order:false, stats:pseudo
 select * from t where a = 1 and (b is null or b = 2) and c > 1;
 a	b	c
 1	2	2

--- a/tests/integrationtest/t/planner/core/casetest/integration.test
+++ b/tests/integrationtest/t/planner/core/casetest/integration.test
@@ -173,6 +173,8 @@ explain format = 'brief' select * from t0 where a > 1 and a < 3 order by b limit
 explain format = 'brief' select * from t1 where a >= 2 and a <= 2 and b = 2 and c > 2;
 explain format = 'brief' select * from t2 where a >= 2.5 and a <= 2.5 order by b limit 2;
 explain format = 'brief' select * from t3 where a >= 'a' and a <= 'a' and b = 'b' and c > 'c';
+explain format = 'brief' select * from t1 where a is null or a in (1, 2, 3);
+explain format = 'brief' select * from t1 where a is null and a = 1;
 
 # TestIssue22105
 drop table if exists t1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54188 

Problem Summary: Properly classify columns with null predicates (e.g. `WHERE a IS NULL`) as constant so index selection can take advantage of that to satisfy a sort in https://github.com/pingcap/tidb/blob/432bb79f9732cb89a0be220ca93415df37a4849e/pkg/planner/core/find_best_task.go#L791.

### What changed and how does it work?
Added checks for is null predicate during planning and fill corresponding data structures marking that column as a constant.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
