### PR TITLE
test: use a mysql driver supporting cursor fetch to test the cursor fetch function

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7645,6 +7645,19 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_yangkeao_go_mysql_driver",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/YangKeao/go-mysql-driver",
+        sha256 = "66ba9bed8b68899ea4adc729fbaf160bd634fe1afa51621a3dc5b153b538eb57",
+        strip_prefix = "github.com/YangKeao/go-mysql-driver@v0.0.0-20240627104025-dd5589458cfa",
+        urls = [
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/YangKeao/go-mysql-driver/com_github_yangkeao_go_mysql_driver-v0.0.0-20240627104025-dd5589458cfa.zip",
+            "http://ats.apps.svc/gomod/github.com/YangKeao/go-mysql-driver/com_github_yangkeao_go_mysql_driver-v0.0.0-20240627104025-dd5589458cfa.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/YangKeao/go-mysql-driver/com_github_yangkeao_go_mysql_driver-v0.0.0-20240627104025-dd5589458cfa.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/YangKeao/go-mysql-driver/com_github_yangkeao_go_mysql_driver-v0.0.0-20240627104025-dd5589458cfa.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_yeya24_promlinter",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/yeya24/promlinter",
@@ -9683,6 +9696,19 @@ def go_deps():
             "http://ats.apps.svc/gomod/go.etcd.io/gofail/io_etcd_go_gofail-v0.1.0.zip",
             "https://cache.hawkingrei.com/gomod/go.etcd.io/gofail/io_etcd_go_gofail-v0.1.0.zip",
             "https://storage.googleapis.com/pingcapmirror/gomod/go.etcd.io/gofail/io_etcd_go_gofail-v0.1.0.zip",
+        ],
+    )
+    go_repository(
+        name = "io_filippo_edwards25519",
+        build_file_proto_mode = "disable_global",
+        importpath = "filippo.io/edwards25519",
+        sha256 = "9ac43a686d06fdebd719f7af3866c87eb069302272dfb131007adf471c308b65",
+        strip_prefix = "filippo.io/edwards25519@v1.1.0",
+        urls = [
+            "http://bazel-cache.pingcap.net:8080/gomod/filippo.io/edwards25519/io_filippo_edwards25519-v1.1.0.zip",
+            "http://ats.apps.svc/gomod/filippo.io/edwards25519/io_filippo_edwards25519-v1.1.0.zip",
+            "https://cache.hawkingrei.com/gomod/filippo.io/edwards25519/io_filippo_edwards25519-v1.1.0.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/filippo.io/edwards25519/io_filippo_edwards25519-v1.1.0.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/Shopify/sarama v1.29.0
+	github.com/YangKeao/go-mysql-driver v0.0.0-20240627104025-dd5589458cfa
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1581
 	github.com/apache/skywalking-eyes v0.4.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
@@ -147,6 +148,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.38.0 h1:Az68ZRGlnNTpIBbLjSMIV2BDcwwXYlRlQzis0llkpJg=
 cloud.google.com/go/storage v1.38.0/go.mod h1:tlUADB0mAb9BgYls9lq+8MGkfzOXuLrnHXlpHmvFJoY=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0 h1:1nGuui+4POelzDwI7RG56yfQJHCnKvwfMoU7VsEp+Zg=
@@ -85,6 +87,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
+github.com/YangKeao/go-mysql-driver v0.0.0-20240627104025-dd5589458cfa h1:mx7rQczQb38AWgiFJsuwvygvOnktsz/mknqUJNByB1Q=
+github.com/YangKeao/go-mysql-driver v0.0.0-20240627104025-dd5589458cfa/go.mod h1:qn/VrHolklFxsKZNciiayiHO5qi+2v1TN5jEKDkPC2g=
 github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117 h1:+OqGGFc2YHFd82aSHmjlILVt1t4JWJjrNIfV8cVEPow=
 github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117/go.mod h1:bMGIq3AGbytbaMwf8wdv5Phdxz0FWHTIYMSzyrYgnQs=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=

--- a/pkg/server/internal/testserverclient/BUILD.bazel
+++ b/pkg/server/internal/testserverclient/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//require",
+        "@com_github_yangkeao_go_mysql_driver//:go-mysql-driver",
         "@org_golang_x_text//encoding/simplifiedchinese",
         "@org_uber_go_zap//:zap",
     ],

--- a/pkg/server/internal/testserverclient/server_client.go
+++ b/pkg/server/internal/testserverclient/server_client.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	mysqlcursor "github.com/YangKeao/go-mysql-driver"
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -117,6 +118,18 @@ func (cli *TestServerClient) GetDSN(overriders ...configOverrider) string {
 			overrider(config)
 		}
 	}
+	return config.FormatDSN()
+}
+
+// GetDSN generates a DSN string for MySQL connection.
+func (cli *TestServerClient) GetDSNWithCursor(fetchSize uint32) string {
+	config := mysqlcursor.NewConfig()
+	config.User = "root"
+	config.Net = "tcp"
+	config.Addr = fmt.Sprintf("127.0.0.1:%d", cli.Port)
+	config.DBName = "test"
+	config.Params = make(map[string]string)
+	config.FetchSize = fetchSize
 	return config.FormatDSN()
 }
 

--- a/pkg/server/tests/cursor/BUILD.bazel
+++ b/pkg/server/tests/cursor/BUILD.bazel
@@ -8,12 +8,13 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/metrics",
         "//pkg/parser/mysql",
         "//pkg/server",
+        "//pkg/server/tests/servertestkit",
         "//pkg/session",
         "//pkg/store/mockstore/unistore",
         "//pkg/testkit",
@@ -22,6 +23,7 @@ go_test(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",
+        "@com_github_yangkeao_go_mysql_driver//:go-mysql-driver",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/server/tests/cursor/cursor_test.go
+++ b/pkg/server/tests/cursor/cursor_test.go
@@ -16,15 +16,19 @@ package cursor
 
 import (
 	"context"
+	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math/rand"
 	"testing"
 
+	mysqlcursor "github.com/YangKeao/go-mysql-driver"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	server2 "github.com/pingcap/tidb/pkg/server"
+	"github.com/pingcap/tidb/pkg/server/tests/servertestkit"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
@@ -156,4 +160,69 @@ func TestCursorFetchExecuteCheck(t *testing.T) {
 		appendUint32([]byte{tmysql.ComStmtExecute}, uint32(stmt.ID())),
 		tmysql.CursorTypeReadOnly|tmysql.CursorTypeScrollable, 0x1, 0x0, 0x0, 0x0,
 	)))
+}
+
+func TestConcurrentExecuteAndFetch(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	mysqldriver := &mysqlcursor.MySQLDriver{}
+	rawConn, err := mysqldriver.Open(ts.GetDSNWithCursor(10))
+	require.NoError(t, err)
+	conn := rawConn.(mysqlcursor.Connection)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(), "drop table if exists t1", nil)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(context.Background(), "create table t1(id int primary key, v int)", nil)
+	require.NoError(t, err)
+	rowCount := 1000
+	for i := 0; i < rowCount; i++ {
+		_, err = conn.ExecContext(context.Background(), fmt.Sprintf("insert into t1 values(%d, %d)", i, i), nil)
+		require.NoError(t, err)
+	}
+
+	// Normal execute. Simple table reader.
+	execTimes := 0
+outerLoop:
+	for execTimes < 50 {
+		execTimes++
+		rawStmt, err := conn.Prepare("select * from t1 order by id")
+		require.NoError(t, err)
+		stmt := rawStmt.(mysqlcursor.Statement)
+
+		// This query will return 10000 rows and use cursor fetch.
+		rows, err := stmt.QueryContext(context.Background(), nil)
+		require.NoError(t, err)
+
+		dest := make([]driver.Value, 2)
+		fetchRowCount := int64(0)
+
+		for {
+			// Now, we'll have two cases: 0. fetch 1. execute another statement
+			switch rand.Int() % 2 {
+			case 0:
+				// it'll send `FETCH` commands for every 10 rows.
+				err := rows.Next(dest)
+				if err != nil {
+					switch err {
+					case io.EOF:
+						require.Equal(t, int64(rowCount), fetchRowCount)
+						rows.Close()
+						break outerLoop
+					default:
+						require.NoError(t, err)
+					}
+				}
+				require.Equal(t, fetchRowCount, dest[0])
+				require.Equal(t, fetchRowCount, dest[1])
+				fetchRowCount++
+			case 1:
+				rows, err := conn.QueryContext(context.Background(), "select * from t1 order by id limit 1", nil)
+				require.NoError(t, err)
+				err = rows.Next(dest)
+				require.NoError(t, err)
+				require.NoError(t, rows.Close())
+			}
+		}
+	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #54286

Problem Summary:

I've extended the go mysql driver to support `fetchSize` argument (See the [commit](https://github.com/YangKeao/go-mysql-driver/commit/dd5589458cfa93737bab4038c769c3435053aa12)). Though it's not suitable to use it directly with `sql` standard library, we can use the function exposed by it directly to test TiDB now.

### What changed and how does it work?

1. Fork a go mysql driver and support cursor fetch.
2. Add a test for cursor fetch function in TiDB with it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
