### PR TITLE
*: add test for issue #54254 and it has been fixed by pr #54183

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3094,6 +3094,11 @@ func TestIssue53634(t *testing.T) {
 	ts.RunTestIssue53634(t, ts.Domain)
 }
 
+func TestIssue54254(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuiteWithDDLLease(t, "20s")
+	ts.RunTestIssue54254(t, ts.Domain)
+}
+
 func TestAuthSocket(t *testing.T) {
 	defer server2.ClearOSUserForAuthSocket()
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54254 #48457

Problem Summary: add test for issue #54254 and it has been fixed by pr #54183

### What changed and how does it work?

PR #54183 also fix the issue #54254, and I've verified and add a test `TestIssue54254`  for it.

Without the fix in PR #54183, the test `TestIssue54254` will failed and has the same panic stack, such as following:

```log
[2024/06/28 14:06:22.604 +08:00] [ERROR] [conn.go:1024] ["connection running loop panic"] [conn=2097158] [session_alias=] [lastSQL="UPDATE stock SET c = ? WHERE a= ? AND b = 'a' [arguments: (101, 1)]"] [err="runtime error: index out of range [4] with length 4"] [stack="github.com/pingcap/tidb/pkg/server.(*clientConn).Run.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/conn.go:1027
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:914
github.com/pingcap/tidb/pkg/executor.(*Compiler).Compile.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/executor/compiler.go:57
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:914
runtime.goPanicIndex
	/usr/local/go/src/runtime/panic.go:114
github.com/pingcap/tidb/pkg/planner/core.GetUpdateColumnsInfo
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/logical_plan_builder.go:5855
github.com/pingcap/tidb/pkg/planner/core.(*Update).buildTbl2UpdateColumns
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/foreign_key.go:336
github.com/pingcap/tidb/pkg/planner/core.(*Update).buildOnUpdateFKTriggers
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/foreign_key.go:224
github.com/pingcap/tidb/pkg/planner/core.buildPointUpdatePlan
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/point_get_plan.go:1970
github.com/pingcap/tidb/pkg/planner/core.tryUpdatePointPlan
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/point_get_plan.go:1910
github.com/pingcap/tidb/pkg/planner/core.TryFastPlan
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/point_get_plan.go:923
github.com/pingcap/tidb/pkg/planner.Optimize
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/optimize.go:224
github.com/pingcap/tidb/pkg/planner/core.generateNewPlan
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/plan_cache.go:316
github.com/pingcap/tidb/pkg/planner/core.GetPlanFromPlanCache
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/core/plan_cache.go:265
github.com/pingcap/tidb/pkg/planner.OptimizeExecStmt
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/optimize.go:541
github.com/pingcap/tidb/pkg/planner.Optimize
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/planner/optimize.go:163
github.com/pingcap/tidb/pkg/executor.(*Compiler).Compile
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/executor/compiler.go:99
github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/session/session.go:2098
github.com/pingcap/tidb/pkg/server.(*TiDBContext).ExecuteStmt
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/driver_tidb.go:294
github.com/pingcap/tidb/pkg/server.(*clientConn).executePreparedStmtAndWriteResult
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/conn_stmt.go:306
github.com/pingcap/tidb/pkg/server.(*clientConn).executePlanCacheStmt
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/conn_stmt.go:234
github.com/pingcap/tidb/pkg/server.(*clientConn).handleStmtExecute
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/conn_stmt.go:225
github.com/pingcap/tidb/pkg/server.(*clientConn).dispatch
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/conn.go:1386
github.com/pingcap/tidb/pkg/server.(*clientConn).Run
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/conn.go:1125
github.com/pingcap/tidb/pkg/server.(*Server).onConn
	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/server.go:739"] 
...
...
...
--- FAIL: TestIssue54254 (0.54s)
    server_client.go:2966: 
        	Error Trace:	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/internal/testserverclient/server_client.go:2966
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/ddl/util/callback/callback.go:124
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/ddl/job_table.go:634
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/ddl/job_table.go:538
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/util/wait_group_wrapper.go:171
        	            				/usr/local/go/src/runtime/asm_arm64.s:1197
        	Error:      	Received unexpected error:
        	            	Error 1105 (HY000): runtime error: index out of range [4] with length 4
        	Test:       	TestIssue54254
    server_client.go:865: 
        	Error Trace:	/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/internal/testserverclient/server_client.go:865
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/internal/testserverclient/server_client.go:2991
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/internal/testserverclient/server_client.go:2890
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/internal/testserverclient/server_client.go:134
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/internal/testserverclient/server_client.go:2862
        	            				/Users/cs/code/goread/src/github.com/pingcap/tidb/pkg/server/tests/commontest/tidb_test.go:3099
        	Error:      	Not equal: 
        	            	expected: "1 a 101 x <nil>\n2 b 102 z <nil>"
        	            	actual  : "1 a 11 x <nil>\n2 b 22 y <nil>"
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
