### PR TITLE
executor: Refine partition number in hash join v2

### DIFF
--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -699,9 +699,10 @@ func prepare4HashJoinV2(testCase *hashJoinTestCase, innerExec, outerExec exec.Ex
 		buildKeyTypes = append(buildKeyTypes, innerTypes[i])
 	}
 	hashJoinCtx := &join.HashJoinCtxV2{
-		OtherCondition:  nil,
-		PartitionNumber: min(testCase.concurrency, 16),
+		OtherCondition: nil,
 	}
+	hashJoinCtx.Concurrency = uint(testCase.concurrency)
+	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.SessCtx = testCase.ctx
 	hashJoinCtx.JoinType = testCase.joinType
 	hashJoinCtx.Concurrency = uint(testCase.concurrency)

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1515,38 +1515,6 @@ func extractUsedColumnsInJoinOtherCondition(expr expression.CNFExprs, leftColumn
 	return leftColumnIndex, rightColumnIndex
 }
 
-// partitionNumber is always power of 2
-func genHashJoinPartitionNumber(partitionHint int) int {
-	prevRet := 16
-	currentRet := 8
-	for currentRet != 0 {
-		if currentRet < partitionHint {
-			return prevRet
-		}
-		prevRet = currentRet
-		currentRet = currentRet >> 1
-	}
-	return 1
-}
-
-func getPartitionMaskOffset(partitionNumber int) int {
-	getRightMostSetPos := func(num uint64) int {
-		ret := 0
-		for num&1 != 1 {
-			num = num >> 1
-			ret++
-		}
-		if num != 1 {
-			// partitionNumber is always pow of 2
-			panic("should not reach here")
-		}
-		return ret
-	}
-	rightMostPos := getRightMostSetPos(uint64(partitionNumber))
-	// top rightMostPos bits in hash value will be used to partition data
-	return 64 - rightMostPos
-}
-
 func (b *executorBuilder) buildHashJoinV2(v *plannercore.PhysicalHashJoin) exec.Executor {
 	leftExec := b.build(v.Children()[0])
 	if b.err != nil {
@@ -1558,21 +1526,19 @@ func (b *executorBuilder) buildHashJoinV2(v *plannercore.PhysicalHashJoin) exec.
 		return nil
 	}
 
-	partitionNumber := genHashJoinPartitionNumber(int(v.Concurrency))
 	e := &join.HashJoinV2Exec{
 		BaseExecutor:          exec.NewBaseExecutor(b.ctx, v.Schema(), v.ID(), leftExec, rightExec),
 		ProbeSideTupleFetcher: &join.ProbeSideTupleFetcherV2{},
 		ProbeWorkers:          make([]*join.ProbeWorkerV2, v.Concurrency),
 		BuildWorkers:          make([]*join.BuildWorkerV2, v.Concurrency),
 		HashJoinCtxV2: &join.HashJoinCtxV2{
-			OtherCondition:      v.OtherConditions,
-			PartitionNumber:     partitionNumber,
-			PartitionMaskOffset: getPartitionMaskOffset(partitionNumber),
+			OtherCondition: v.OtherConditions,
 		},
 	}
 	e.HashJoinCtxV2.SessCtx = b.ctx
 	e.HashJoinCtxV2.JoinType = v.JoinType
 	e.HashJoinCtxV2.Concurrency = v.Concurrency
+	e.HashJoinCtxV2.SetupPartitionInfo()
 	e.ChunkAllocPool = e.AllocPool
 	e.HashJoinCtxV2.RightAsBuildSide = true
 	if v.InnerChildIdx == 1 && v.UseOuterToBuild {

--- a/pkg/executor/join/BUILD.bazel
+++ b/pkg/executor/join/BUILD.bazel
@@ -79,7 +79,7 @@ go_test(
     ],
     embed = [":join"],
     flaky = True,
-    shard_count = 46,
+    shard_count = 47,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/join/base_join_probe.go
+++ b/pkg/executor/join/base_join_probe.go
@@ -172,7 +172,7 @@ func (j *baseJoinProbe) SetChunkForProbe(chk *chunk.Chunk) (err error) {
 	} else {
 		j.matchedRowsHeaders = make([]uintptr, logicalRows)
 	}
-	for i := 0; i < int(j.ctx.PartitionNumber); i++ {
+	for i := 0; i < int(j.ctx.partitionNumber); i++ {
 		j.hashValues[i] = j.hashValues[i][:0]
 	}
 	if j.ctx.ProbeFilter != nil {
@@ -227,11 +227,11 @@ func (j *baseJoinProbe) SetChunkForProbe(chk *chunk.Chunk) (err error) {
 		// See https://golang.org/pkg/hash/#Hash
 		_, _ = hash.Write(j.serializedKeys[logicalRowIndex])
 		hashValue := hash.Sum64()
-		partIndex := hashValue >> j.ctx.PartitionMaskOffset
+		partIndex := hashValue >> j.ctx.partitionMaskOffset
 		j.hashValues[partIndex] = append(j.hashValues[partIndex], posAndHashValue{hashValue: hashValue, pos: logicalRowIndex})
 	}
 	j.currentProbeRow = 0
-	for i := 0; i < int(j.ctx.PartitionNumber); i++ {
+	for i := 0; i < int(j.ctx.partitionNumber); i++ {
 		for index := range j.hashValues[i] {
 			j.matchedRowsHeaders[j.hashValues[i][index].pos] = j.ctx.hashTableContext.hashTable.tables[i].lookup(j.hashValues[i][index].hashValue)
 		}
@@ -508,8 +508,8 @@ func NewJoinProbe(ctx *HashJoinCtxV2, workID uint, joinType core.JoinType, keyIn
 	for i := 0; i < chunk.InitialCapacity; i++ {
 		base.selRows = append(base.selRows, i)
 	}
-	base.hashValues = make([][]posAndHashValue, ctx.PartitionNumber)
-	for i := 0; i < int(ctx.PartitionNumber); i++ {
+	base.hashValues = make([][]posAndHashValue, ctx.partitionNumber)
+	for i := 0; i < int(ctx.partitionNumber); i++ {
 		base.hashValues[i] = make([]posAndHashValue, 0, chunk.InitialCapacity)
 	}
 	base.serializedKeys = make([][]byte, 0, chunk.InitialCapacity)

--- a/pkg/executor/join/base_join_probe.go
+++ b/pkg/executor/join/base_join_probe.go
@@ -227,7 +227,7 @@ func (j *baseJoinProbe) SetChunkForProbe(chk *chunk.Chunk) (err error) {
 		// See https://golang.org/pkg/hash/#Hash
 		_, _ = hash.Write(j.serializedKeys[logicalRowIndex])
 		hashValue := hash.Sum64()
-		partIndex := hashValue % uint64(j.ctx.PartitionNumber)
+		partIndex := hashValue >> j.ctx.PartitionMaskOffset
 		j.hashValues[partIndex] = append(j.hashValues[partIndex], posAndHashValue{hashValue: hashValue, pos: logicalRowIndex})
 	}
 	j.currentProbeRow = 0

--- a/pkg/executor/join/base_join_probe.go
+++ b/pkg/executor/join/base_join_probe.go
@@ -172,7 +172,7 @@ func (j *baseJoinProbe) SetChunkForProbe(chk *chunk.Chunk) (err error) {
 	} else {
 		j.matchedRowsHeaders = make([]uintptr, logicalRows)
 	}
-	for i := 0; i < j.ctx.PartitionNumber; i++ {
+	for i := 0; i < int(j.ctx.PartitionNumber); i++ {
 		j.hashValues[i] = j.hashValues[i][:0]
 	}
 	if j.ctx.ProbeFilter != nil {
@@ -231,7 +231,7 @@ func (j *baseJoinProbe) SetChunkForProbe(chk *chunk.Chunk) (err error) {
 		j.hashValues[partIndex] = append(j.hashValues[partIndex], posAndHashValue{hashValue: hashValue, pos: logicalRowIndex})
 	}
 	j.currentProbeRow = 0
-	for i := 0; i < j.ctx.PartitionNumber; i++ {
+	for i := 0; i < int(j.ctx.PartitionNumber); i++ {
 		for index := range j.hashValues[i] {
 			j.matchedRowsHeaders[j.hashValues[i][index].pos] = j.ctx.hashTableContext.hashTable.tables[i].lookup(j.hashValues[i][index].hashValue)
 		}
@@ -509,7 +509,7 @@ func NewJoinProbe(ctx *HashJoinCtxV2, workID uint, joinType core.JoinType, keyIn
 		base.selRows = append(base.selRows, i)
 	}
 	base.hashValues = make([][]posAndHashValue, ctx.PartitionNumber)
-	for i := 0; i < ctx.PartitionNumber; i++ {
+	for i := 0; i < int(ctx.PartitionNumber); i++ {
 		base.hashValues[i] = make([]posAndHashValue, 0, chunk.InitialCapacity)
 	}
 	base.serializedKeys = make([][]byte, 0, chunk.InitialCapacity)

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -125,10 +125,11 @@ func (htc *hashTableContext) mergeRowTablesToHashTable(tableMeta *TableMeta, par
 // HashJoinCtxV2 is the hash join ctx used in hash join v2
 type HashJoinCtxV2 struct {
 	hashJoinCtxBase
-	PartitionNumber int
-	ProbeKeyTypes   []*types.FieldType
-	BuildKeyTypes   []*types.FieldType
-	stats           *hashJoinRuntimeStatsV2
+	PartitionNumber     int
+	PartitionMaskOffset int
+	ProbeKeyTypes       []*types.FieldType
+	BuildKeyTypes       []*types.FieldType
+	stats               *hashJoinRuntimeStatsV2
 
 	RightAsBuildSide               bool
 	BuildFilter                    expression.CNFExprs

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -669,6 +669,7 @@ func (e *HashJoinV2Exec) createTasks(buildTaskCh chan<- *buildTask, totalSegment
 	for {
 		hasNewTask := false
 		for partIdx := range subTables {
+			// create table by round-robin all the partitions so the build thread is likely to build different partition at the same time
 			if partitionStartIndex[partIdx] < partitionSegmentLength[partIdx] {
 				startIndex := partitionStartIndex[partIdx]
 				endIndex := min(startIndex+segStep, partitionSegmentLength[partIdx])

--- a/pkg/executor/join/hash_table_v2.go
+++ b/pkg/executor/join/hash_table_v2.go
@@ -55,7 +55,7 @@ func newSubTable(table *rowTable) *subTable {
 	if table.validKeyCount() == 0 {
 		ret.isHashTableEmpty = true
 	}
-	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(1024))
+	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(32))
 	ret.hashTable = make([]uintptr, hashTableLength)
 	ret.posMask = hashTableLength - 1
 	return ret

--- a/pkg/executor/join/hash_table_v2_test.go
+++ b/pkg/executor/join/hash_table_v2_test.go
@@ -72,16 +72,15 @@ func createRowTable(rows int) (*rowTable, error) {
 		}
 	}
 
-	partitionNumber := 1
 	chk := testutil.GenRandomChunks(buildTypes, rows)
 	hashJoinCtx := &HashJoinCtxV2{
-		PartitionNumber: partitionNumber,
-		hashTableMeta:   meta,
+		hashTableMeta: meta,
 	}
 	hashJoinCtx.Concurrency = 1
+	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.initHashTableContext()
 	hashJoinCtx.SessCtx = mock.NewContext()
-	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, partitionNumber, hasNullableKey, false, false)
+	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.PartitionNumber, hasNullableKey, false, false)
 	err := builder.processOneChunk(chk, hashJoinCtx.SessCtx.GetSessionVars().StmtCtx.TypeCtx(), hashJoinCtx, 0)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/join/hash_table_v2_test.go
+++ b/pkg/executor/join/hash_table_v2_test.go
@@ -80,7 +80,7 @@ func createRowTable(rows int) (*rowTable, error) {
 	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.initHashTableContext()
 	hashJoinCtx.SessCtx = mock.NewContext()
-	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.PartitionNumber, hasNullableKey, false, false)
+	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.partitionNumber, hasNullableKey, false, false)
 	err := builder.processOneChunk(chk, hashJoinCtx.SessCtx.GetSessionVars().StmtCtx.TypeCtx(), hashJoinCtx, 0)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/join/hash_table_v2_test.go
+++ b/pkg/executor/join/hash_table_v2_test.go
@@ -246,7 +246,7 @@ func checkRowIter(t *testing.T, table *hashTableV2, scanConcurrency int) {
 }
 
 func TestRowIter(t *testing.T) {
-	partitionNumbers := []int{1, 5, 10}
+	partitionNumbers := []int{1, 4, 8}
 	// normal case
 	for _, partitionNumber := range partitionNumbers {
 		// create row tables

--- a/pkg/executor/join/hash_table_v2_test.go
+++ b/pkg/executor/join/hash_table_v2_test.go
@@ -90,22 +90,22 @@ func createRowTable(rows int) (*rowTable, error) {
 }
 
 func TestHashTableSize(t *testing.T) {
-	rowTable := createMockRowTable(10, 5, true)
+	rowTable := createMockRowTable(2, 5, true)
 	subTable := newSubTable(rowTable)
-	// min hash table size is 1024
-	require.Equal(t, 1024, len(subTable.hashTable))
-	rowTable = createMockRowTable(1024, 1, true)
+	// min hash table size is 32
+	require.Equal(t, 32, len(subTable.hashTable))
+	rowTable = createMockRowTable(32, 1, true)
 	subTable = newSubTable(rowTable)
-	require.Equal(t, 2048, len(subTable.hashTable))
-	rowTable = createMockRowTable(1025, 1, true)
+	require.Equal(t, 64, len(subTable.hashTable))
+	rowTable = createMockRowTable(33, 1, true)
 	subTable = newSubTable(rowTable)
-	require.Equal(t, 2048, len(subTable.hashTable))
-	rowTable = createMockRowTable(2048, 1, true)
+	require.Equal(t, 64, len(subTable.hashTable))
+	rowTable = createMockRowTable(64, 1, true)
 	subTable = newSubTable(rowTable)
-	require.Equal(t, 4096, len(subTable.hashTable))
-	rowTable = createMockRowTable(2049, 1, true)
+	require.Equal(t, 128, len(subTable.hashTable))
+	rowTable = createMockRowTable(65, 1, true)
 	subTable = newSubTable(rowTable)
-	require.Equal(t, 4096, len(subTable.hashTable))
+	require.Equal(t, 128, len(subTable.hashTable))
 }
 
 func TestBuild(t *testing.T) {

--- a/pkg/executor/join/inner_join_probe_test.go
+++ b/pkg/executor/join/inner_join_probe_test.go
@@ -289,7 +289,7 @@ func testJoinProbe(t *testing.T, withSel bool, leftKeyIndex []int, rightKeyIndex
 			break
 		}
 	}
-	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.PartitionNumber, hasNullableKey, buildFilter != nil, joinProbe.NeedScanRowTable())
+	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.partitionNumber, hasNullableKey, buildFilter != nil, joinProbe.NeedScanRowTable())
 	chunkNumber := 3
 	buildChunks := make([]*chunk.Chunk, 0, chunkNumber)
 	probeChunks := make([]*chunk.Chunk, 0, chunkNumber)
@@ -342,7 +342,7 @@ func testJoinProbe(t *testing.T, withSel bool, leftKeyIndex []int, rightKeyIndex
 	}
 	builder.appendRemainingRowLocations(0, hashJoinCtx.hashTableContext)
 	checkRowLocationAlignment(t, hashJoinCtx.hashTableContext.rowTables[0])
-	hashJoinCtx.hashTableContext.mergeRowTablesToHashTable(hashJoinCtx.hashTableMeta, hashJoinCtx.PartitionNumber)
+	hashJoinCtx.hashTableContext.mergeRowTablesToHashTable(hashJoinCtx.hashTableMeta, hashJoinCtx.partitionNumber)
 	// build hash table
 	for i := 0; i < partitionNumber; i++ {
 		hashJoinCtx.hashTableContext.hashTable.buildHashTableForTest(i, 0, len(hashJoinCtx.hashTableContext.hashTable.tables[i].rowData.segments))

--- a/pkg/executor/join/inner_join_probe_test.go
+++ b/pkg/executor/join/inner_join_probe_test.go
@@ -262,7 +262,6 @@ func testJoinProbe(t *testing.T, withSel bool, leftKeyIndex []int, rightKeyIndex
 		BuildFilter:           buildFilter,
 		ProbeFilter:           probeFilter,
 		OtherCondition:        otherCondition,
-		PartitionNumber:       partitionNumber,
 		BuildKeyTypes:         buildKeyTypes,
 		ProbeKeyTypes:         probeKeyTypes,
 		RightAsBuildSide:      rightAsBuildSide,
@@ -274,6 +273,7 @@ func testJoinProbe(t *testing.T, withSel bool, leftKeyIndex []int, rightKeyIndex
 	hashJoinCtx.SessCtx = mock.NewContext()
 	hashJoinCtx.JoinType = joinType
 	hashJoinCtx.Concurrency = uint(partitionNumber)
+	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.initHashTableContext()
 	joinProbe := NewJoinProbe(hashJoinCtx, 0, joinType, probeKeyIndex, joinedTypes, probeKeyTypes, rightAsBuildSide)
 	buildSchema := &expression.Schema{}
@@ -289,7 +289,7 @@ func testJoinProbe(t *testing.T, withSel bool, leftKeyIndex []int, rightKeyIndex
 			break
 		}
 	}
-	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, partitionNumber, hasNullableKey, buildFilter != nil, joinProbe.NeedScanRowTable())
+	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.PartitionNumber, hasNullableKey, buildFilter != nil, joinProbe.NeedScanRowTable())
 	chunkNumber := 3
 	buildChunks := make([]*chunk.Chunk, 0, chunkNumber)
 	probeChunks := make([]*chunk.Chunk, 0, chunkNumber)

--- a/pkg/executor/join/inner_join_probe_test.go
+++ b/pkg/executor/join/inner_join_probe_test.go
@@ -274,6 +274,8 @@ func testJoinProbe(t *testing.T, withSel bool, leftKeyIndex []int, rightKeyIndex
 	hashJoinCtx.JoinType = joinType
 	hashJoinCtx.Concurrency = uint(partitionNumber)
 	hashJoinCtx.SetupPartitionInfo()
+	// update the partition number
+	partitionNumber = int(hashJoinCtx.partitionNumber)
 	hashJoinCtx.initHashTableContext()
 	joinProbe := NewJoinProbe(hashJoinCtx, 0, joinType, probeKeyIndex, joinedTypes, probeKeyTypes, rightAsBuildSide)
 	buildSchema := &expression.Schema{}

--- a/pkg/executor/join/inner_join_probe_test.go
+++ b/pkg/executor/join/inner_join_probe_test.go
@@ -436,7 +436,7 @@ func TestInnerJoinProbeBasic(t *testing.T) {
 	rTypes1 := []*types.FieldType{uintTp, stringTp, intTp, stringTp, tinyTp}
 
 	rightAsBuildSide := []bool{true, false}
-	partitionNumber := 3
+	partitionNumber := 4
 
 	testCases := []testCase{
 		// normal case
@@ -513,14 +513,15 @@ func TestInnerJoinProbeAllJoinKeys(t *testing.T) {
 	lUsed := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
 	rUsed := lUsed
 	rightAsBuildSide := []bool{true, false}
+	partitionNumber := 4
 
 	// single key
 	for i := 0; i < len(lTypes); i++ {
 		for _, rightAsBuild := range rightAsBuildSide {
 			lKeyTypes := []*types.FieldType{lTypes[i]}
 			rKeyTypes := []*types.FieldType{rTypes[i]}
-			testJoinProbe(t, false, []int{i}, []int{i}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
-			testJoinProbe(t, false, []int{i}, []int{i}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
+			testJoinProbe(t, false, []int{i}, []int{i}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
+			testJoinProbe(t, false, []int{i}, []int{i}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
 		}
 	}
 	// composed key
@@ -528,29 +529,29 @@ func TestInnerJoinProbeAllJoinKeys(t *testing.T) {
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, uintTp}
 		rKeyTypes := []*types.FieldType{intTp, uintTp}
-		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
-		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
 	}
 	// variable size, inlined
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, binaryStringTp}
 		rKeyTypes := []*types.FieldType{intTp, binaryStringTp}
-		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
-		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
 	}
 	// fixed size, not inlined
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, datetimeTp}
 		rKeyTypes := []*types.FieldType{intTp, datetimeTp}
-		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
-		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
 	}
 	// variable size, not inlined
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, decimalTp}
 		rKeyTypes := []*types.FieldType{intTp, decimalTp}
-		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
-		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
+		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), nullableLTypes, nullableRTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, plannercore.InnerJoin, 100)
 	}
 }
 
@@ -575,11 +576,12 @@ func TestInnerJoinProbeOtherCondition(t *testing.T) {
 	otherCondition := make(expression.CNFExprs, 0)
 	otherCondition = append(otherCondition, sf)
 	rightAsBuildSide := []bool{true, false}
+	partitionNumber := 4
 
 	for _, rightAsBuild := range rightAsBuildSide {
-		testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, otherCondition, 3, plannercore.InnerJoin, 200)
-		testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{}, []int{}, []int{1}, []int{3}, nil, nil, otherCondition, 3, plannercore.InnerJoin, 200)
-		testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, otherCondition, 3, plannercore.InnerJoin, 200)
+		testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, otherCondition, partitionNumber, plannercore.InnerJoin, 200)
+		testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{}, []int{}, []int{1}, []int{3}, nil, nil, otherCondition, partitionNumber, plannercore.InnerJoin, 200)
+		testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, otherCondition, partitionNumber, plannercore.InnerJoin, 200)
 	}
 }
 
@@ -606,14 +608,15 @@ func TestInnerJoinProbeWithSel(t *testing.T) {
 	otherCondition := make(expression.CNFExprs, 0)
 	otherCondition = append(otherCondition, sf)
 	otherConditions := []expression.CNFExprs{otherCondition, nil}
+	partitionNumber := 4
 
 	rightAsBuildSide := []bool{true, false}
 
 	for _, rightAsBuild := range rightAsBuildSide {
 		for _, oc := range otherConditions {
-			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, oc, 3, plannercore.InnerJoin, 500)
-			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{}, []int{}, []int{1}, []int{3}, nil, nil, oc, 3, plannercore.InnerJoin, 500)
-			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, oc, 3, plannercore.InnerJoin, 500)
+			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, oc, partitionNumber, plannercore.InnerJoin, 500)
+			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightAsBuild, []int{}, []int{}, []int{1}, []int{3}, nil, nil, oc, partitionNumber, plannercore.InnerJoin, 500)
+			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, nil, nil, oc, partitionNumber, plannercore.InnerJoin, 500)
 		}
 	}
 }

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -497,7 +497,7 @@ type rowTableBuilder struct {
 	rowNumberInCurrentRowTableSeg []int64
 }
 
-func createRowTableBuilder(buildKeyIndex []int, buildKeyTypes []*types.FieldType, partitionNumber int, hasNullableKey bool, hasFilter bool, keepFilteredRows bool) *rowTableBuilder {
+func createRowTableBuilder(buildKeyIndex []int, buildKeyTypes []*types.FieldType, partitionNumber uint, hasNullableKey bool, hasFilter bool, keepFilteredRows bool) *rowTableBuilder {
 	builder := &rowTableBuilder{
 		buildKeyIndex:                 buildKeyIndex,
 		buildKeyTypes:                 buildKeyTypes,
@@ -528,7 +528,7 @@ func (b *rowTableBuilder) initBuffer() {
 	}
 }
 
-func (b *rowTableBuilder) initHashValueAndPartIndexForOneChunk(partitionMaskOffset, partitionNumber int) {
+func (b *rowTableBuilder) initHashValueAndPartIndexForOneChunk(partitionMaskOffset int, partitionNumber uint) {
 	h := fnv.New64()
 	fakePartIndex := uint64(0)
 	for logicalRowIndex, physicalRowIndex := range b.usedRows {

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -572,7 +572,7 @@ func (b *rowTableBuilder) processOneChunk(chk *chunk.Chunk, typeCtx types.Contex
 		return err
 	}
 
-	b.initHashValueAndPartIndexForOneChunk(hashJoinCtx.PartitionMaskOffset, hashJoinCtx.PartitionNumber)
+	b.initHashValueAndPartIndexForOneChunk(hashJoinCtx.partitionMaskOffset, hashJoinCtx.partitionNumber)
 
 	// 2. build rowtable
 	return b.appendToRowTable(chk, hashJoinCtx, workerID)

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -548,7 +548,7 @@ func (b *rowTableBuilder) initHashValueAndPartIndexForOneChunk(partitionMaskOffs
 
 func (b *rowTableBuilder) processOneChunk(chk *chunk.Chunk, typeCtx types.Context, hashJoinCtx *HashJoinCtxV2, workerID int) error {
 	b.ResetBuffer(chk)
-	b.firstSegRowSizeHint = max(uint(1), uint(float64(len(b.usedRows))/float64(hashJoinCtx.PartitionNumber)*float64(1.2)))
+	b.firstSegRowSizeHint = max(uint(1), uint(float64(len(b.usedRows))/float64(hashJoinCtx.partitionNumber)*float64(1.2)))
 	var err error
 	if b.hasFilter {
 		b.filterVector, err = expression.VectorizedFilter(hashJoinCtx.SessCtx.GetExprCtx().GetEvalCtx(), hashJoinCtx.SessCtx.GetSessionVars().EnableVectorizedExpression, hashJoinCtx.BuildFilter, chunk.NewIterator4Chunk(chk), b.filterVector)

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -509,20 +509,39 @@ func createRowTableBuilder(buildKeyIndex []int, buildKeyTypes []*types.FieldType
 	return builder
 }
 
-func (b *rowTableBuilder) initHashValueAndPartIndexForOneChunk(partitionNumber uint64) {
+func (b *rowTableBuilder) initBuffer() {
+	b.serializedKeyVectorBuffer = make([][]byte, chunk.InitialCapacity)
+	b.partIdxVector = make([]int, 0, chunk.InitialCapacity)
+	b.hashValue = make([]uint64, 0, chunk.InitialCapacity)
+	if b.hasFilter {
+		b.filterVector = make([]bool, 0, chunk.InitialCapacity)
+	}
+	if b.hasNullableKey {
+		b.nullKeyVector = make([]bool, 0, chunk.InitialCapacity)
+		for i := 0; i < chunk.InitialCapacity; i++ {
+			b.nullKeyVector = append(b.nullKeyVector, false)
+		}
+	}
+	b.selRows = make([]int, 0, chunk.InitialCapacity)
+	for i := 0; i < chunk.InitialCapacity; i++ {
+		b.selRows = append(b.selRows, i)
+	}
+}
+
+func (b *rowTableBuilder) initHashValueAndPartIndexForOneChunk(partitionMaskOffset, partitionNumber int) {
 	h := fnv.New64()
 	fakePartIndex := uint64(0)
 	for logicalRowIndex, physicalRowIndex := range b.usedRows {
 		if (b.filterVector != nil && !b.filterVector[physicalRowIndex]) || (b.nullKeyVector != nil && b.nullKeyVector[physicalRowIndex]) {
 			b.hashValue[logicalRowIndex] = fakePartIndex
 			b.partIdxVector[logicalRowIndex] = int(fakePartIndex)
-			fakePartIndex = (fakePartIndex + 1) % partitionNumber
+			fakePartIndex = (fakePartIndex + 1) % uint64(partitionNumber)
 			continue
 		}
 		h.Write(b.serializedKeyVectorBuffer[logicalRowIndex])
 		hash := h.Sum64()
 		b.hashValue[logicalRowIndex] = hash
-		b.partIdxVector[logicalRowIndex] = int(hash % partitionNumber)
+		b.partIdxVector[logicalRowIndex] = int(hash >> partitionMaskOffset)
 		h.Reset()
 	}
 }
@@ -553,7 +572,7 @@ func (b *rowTableBuilder) processOneChunk(chk *chunk.Chunk, typeCtx types.Contex
 		return err
 	}
 
-	b.initHashValueAndPartIndexForOneChunk(uint64(hashJoinCtx.PartitionNumber))
+	b.initHashValueAndPartIndexForOneChunk(hashJoinCtx.PartitionMaskOffset, hashJoinCtx.PartitionNumber)
 
 	// 2. build rowtable
 	return b.appendToRowTable(chk, hashJoinCtx, workerID)

--- a/pkg/executor/join/left_outer_join_probe_test.go
+++ b/pkg/executor/join/left_outer_join_probe_test.go
@@ -123,7 +123,7 @@ func TestLeftOuterJoinProbeBasic(t *testing.T) {
 	rTypes1 := []*types.FieldType{uintTp, stringTp, intTp, stringTp, tinyTp}
 
 	rightAsBuildSide := []bool{true, false}
-	partitionNumber := 3
+	partitionNumber := 4
 	simpleFilter := createSimpleFilter(t)
 	hasFilter := []bool{false, true}
 
@@ -206,6 +206,7 @@ func TestLeftOuterJoinProbeAllJoinKeys(t *testing.T) {
 	lUsed := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17}
 	rUsed := lUsed
 	joinType := plannercore.LeftOuterJoin
+	partitionNumber := 4
 
 	rightAsBuildSide := []bool{true, false}
 
@@ -214,8 +215,8 @@ func TestLeftOuterJoinProbeAllJoinKeys(t *testing.T) {
 		lKeyTypes := []*types.FieldType{lTypes[i]}
 		rKeyTypes := []*types.FieldType{rTypes[i]}
 		for _, rightAsBuild := range rightAsBuildSide {
-			testJoinProbe(t, false, []int{i}, []int{i}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
-			testJoinProbe(t, false, []int{i}, []int{i}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
+			testJoinProbe(t, false, []int{i}, []int{i}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
+			testJoinProbe(t, false, []int{i}, []int{i}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
 		}
 	}
 	// composed key
@@ -223,29 +224,29 @@ func TestLeftOuterJoinProbeAllJoinKeys(t *testing.T) {
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, uintTp}
 		rKeyTypes := []*types.FieldType{intTp, uintTp}
-		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
-		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
+		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
+		testJoinProbe(t, false, []int{1, 2}, []int{1, 2}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
 	}
 	// variable size, inlined
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, binaryStringTp}
 		rKeyTypes := []*types.FieldType{intTp, binaryStringTp}
-		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
-		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
+		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
+		testJoinProbe(t, false, []int{1, 17}, []int{1, 17}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
 	}
 	// fixed size, not inlined
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, datetimeTp}
 		rKeyTypes := []*types.FieldType{intTp, datetimeTp}
-		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
-		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
+		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
+		testJoinProbe(t, false, []int{1, 13}, []int{1, 13}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
 	}
 	// variable size, not inlined
 	for _, rightAsBuild := range rightAsBuildSide {
 		lKeyTypes := []*types.FieldType{intTp, decimalTp}
 		rKeyTypes := []*types.FieldType{intTp, decimalTp}
-		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
-		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, 3, joinType, 100)
+		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, lKeyTypes, rKeyTypes, lTypes, rTypes, rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
+		testJoinProbe(t, false, []int{1, 14}, []int{1, 14}, toNullableTypes(lKeyTypes), toNullableTypes(rKeyTypes), toNullableTypes(lTypes), toNullableTypes(rTypes), rightAsBuild, lUsed, rUsed, nil, nil, nil, nil, nil, partitionNumber, joinType, 100)
 	}
 }
 
@@ -273,6 +274,7 @@ func TestLeftOuterJoinProbeOtherCondition(t *testing.T) {
 	simpleFilter := createSimpleFilter(t)
 	hasFilter := []bool{false, true}
 	rightAsBuildSide := []bool{false, true}
+	partitionNumber := 4
 
 	for _, rightBuild := range rightAsBuildSide {
 		for _, testFilter := range hasFilter {
@@ -280,9 +282,9 @@ func TestLeftOuterJoinProbeOtherCondition(t *testing.T) {
 			if !testFilter {
 				leftFilter = nil
 			}
-			testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, 3, joinType, 200)
-			testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{}, []int{}, []int{1}, []int{3}, leftFilter, nil, otherCondition, 3, joinType, 200)
-			testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, 3, joinType, 200)
+			testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, partitionNumber, joinType, 200)
+			testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{}, []int{}, []int{1}, []int{3}, leftFilter, nil, otherCondition, partitionNumber, joinType, 200)
+			testJoinProbe(t, false, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, partitionNumber, joinType, 200)
 		}
 	}
 }
@@ -313,6 +315,7 @@ func TestLeftOuterJoinProbeWithSel(t *testing.T) {
 	rightAsBuildSide := []bool{false, true}
 	simpleFilter := createSimpleFilter(t)
 	hasFilter := []bool{false, true}
+	partitionNumber := 4
 
 	for _, rightBuild := range rightAsBuildSide {
 		for _, useFilter := range hasFilter {
@@ -320,9 +323,9 @@ func TestLeftOuterJoinProbeWithSel(t *testing.T) {
 			if !useFilter {
 				leftFilter = nil
 			}
-			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, 3, joinType, 500)
-			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{}, []int{}, []int{1}, []int{3}, leftFilter, nil, otherCondition, 3, joinType, 500)
-			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, 3, joinType, 500)
+			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, partitionNumber, joinType, 500)
+			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{intTp}, []*types.FieldType{intTp}, lTypes, rTypes, rightBuild, []int{}, []int{}, []int{1}, []int{3}, leftFilter, nil, otherCondition, partitionNumber, joinType, 500)
+			testJoinProbe(t, true, []int{0}, []int{0}, []*types.FieldType{nullableIntTp}, []*types.FieldType{nullableIntTp}, toNullableTypes(lTypes), toNullableTypes(rTypes), rightBuild, []int{1, 2, 4}, []int{0}, []int{1}, []int{3}, leftFilter, nil, otherCondition, partitionNumber, joinType, 500)
 		}
 	}
 }

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -116,7 +116,7 @@ func checkKeys(t *testing.T, withSelCol bool, buildFilter expression.CNFExprs, b
 	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.initHashTableContext()
 	hashJoinCtx.SessCtx = mock.NewContext()
-	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.PartitionNumber, hasNullableKey, buildFilter != nil, keepFilteredRows)
+	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.partitionNumber, hasNullableKey, buildFilter != nil, keepFilteredRows)
 	err := builder.processOneChunk(chk, hashJoinCtx.SessCtx.GetSessionVars().StmtCtx.TypeCtx(), hashJoinCtx, 0)
 	require.NoError(t, err, "processOneChunk returns error")
 	builder.appendRemainingRowLocations(0, hashJoinCtx.hashTableContext)
@@ -598,13 +598,13 @@ func TestBalanceOfFilteredRows(t *testing.T) {
 	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.initHashTableContext()
 	hashJoinCtx.SessCtx = mock.NewContext()
-	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.PartitionNumber, hasNullableKey, true, true)
+	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, hashJoinCtx.partitionNumber, hasNullableKey, true, true)
 	err := builder.processOneChunk(chk, hashJoinCtx.SessCtx.GetSessionVars().StmtCtx.TypeCtx(), hashJoinCtx, 0)
 	require.NoError(t, err)
 	builder.appendRemainingRowLocations(0, hashJoinCtx.hashTableContext)
 	rowTables := hashJoinCtx.hashTableContext.rowTables[0]
-	for i := 0; i < int(hashJoinCtx.PartitionNumber); i++ {
-		require.Equal(t, int(3000/hashJoinCtx.PartitionNumber), int(rowTables[i].rowCount()))
+	for i := 0; i < int(hashJoinCtx.partitionNumber); i++ {
+		require.Equal(t, int(3000/hashJoinCtx.partitionNumber), int(rowTables[i].rowCount()))
 	}
 }
 
@@ -638,11 +638,10 @@ func TestSetupPartitionInfo(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-
 		hashJoinCtx := &HashJoinCtxV2{}
 		hashJoinCtx.Concurrency = test.concurrency
 		hashJoinCtx.SetupPartitionInfo()
-		require.Equal(t, test.partitionNumber, hashJoinCtx.PartitionNumber)
-		require.Equal(t, test.partitionMaskOffset, hashJoinCtx.PartitionMaskOffset)
+		require.Equal(t, test.partitionNumber, hashJoinCtx.partitionNumber)
+		require.Equal(t, test.partitionMaskOffset, hashJoinCtx.partitionMaskOffset)
 	}
 }

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -588,7 +588,7 @@ func TestBalanceOfFilteredRows(t *testing.T) {
 		}
 	}
 
-	partitionNumber := 4
+	partitionNumber := uint(4)
 	buildFilter := createImpossibleFilter(t)
 	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, partitionNumber, hasNullableKey, true, true)
 	chk := testutil.GenRandomChunks(buildTypes, 3000)
@@ -604,7 +604,7 @@ func TestBalanceOfFilteredRows(t *testing.T) {
 	require.NoError(t, err)
 	builder.appendRemainingRowLocations(0, hashJoinCtx.hashTableContext)
 	rowTables := hashJoinCtx.hashTableContext.rowTables[0]
-	for i := 0; i < partitionNumber; i++ {
+	for i := 0; i < int(partitionNumber); i++ {
 		require.Equal(t, 3000/partitionNumber, int(rowTables[i].rowCount()))
 	}
 }

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -607,3 +607,42 @@ func TestBalanceOfFilteredRows(t *testing.T) {
 		require.Equal(t, int(3000/hashJoinCtx.PartitionNumber), int(rowTables[i].rowCount()))
 	}
 }
+
+func TestSetupPartitionInfo(t *testing.T) {
+	type testCase struct {
+		concurrency         uint
+		partitionNumber     uint
+		partitionMaskOffset int
+	}
+
+	testCases := []testCase{
+		{1, 1, 64},
+		{2, 2, 63},
+		{3, 4, 62},
+		{4, 4, 62},
+		{5, 8, 61},
+		{6, 8, 61},
+		{7, 8, 61},
+		{8, 8, 61},
+		{9, 16, 60},
+		{10, 16, 60},
+		{11, 16, 60},
+		{12, 16, 60},
+		{13, 16, 60},
+		{14, 16, 60},
+		{15, 16, 60},
+		{16, 16, 60},
+		{17, 16, 60},
+		{18, 16, 60},
+		{100, 16, 60},
+	}
+
+	for _, test := range testCases {
+
+		hashJoinCtx := &HashJoinCtxV2{}
+		hashJoinCtx.Concurrency = test.concurrency
+		hashJoinCtx.SetupPartitionInfo()
+		require.Equal(t, test.partitionNumber, hashJoinCtx.PartitionNumber)
+		require.Equal(t, test.partitionMaskOffset, hashJoinCtx.PartitionMaskOffset)
+	}
+}

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -588,7 +588,7 @@ func TestBalanceOfFilteredRows(t *testing.T) {
 		}
 	}
 
-	partitionNumber := 5
+	partitionNumber := 4
 	buildFilter := createImpossibleFilter(t)
 	builder := createRowTableBuilder(buildKeyIndex, buildKeyTypes, partitionNumber, hasNullableKey, true, true)
 	chk := testutil.GenRandomChunks(buildTypes, 3000)

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -186,10 +186,10 @@ func TestLargeColumn(t *testing.T) {
 	}
 
 	hashJoinCtx := &HashJoinCtxV2{
-		PartitionNumber: 1,
-		hashTableMeta:   meta,
+		hashTableMeta: meta,
 	}
 	hashJoinCtx.Concurrency = 1
+	hashJoinCtx.SetupPartitionInfo()
 	hashJoinCtx.initHashTableContext()
 	hashJoinCtx.SessCtx = mock.NewContext()
 	err := builder.processOneChunk(chk, hashJoinCtx.SessCtx.GetSessionVars().StmtCtx.TypeCtx(), hashJoinCtx, 0)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127

Problem Summary:
Current, we dispatch row to each partition by the LSB bits in hash value
https://github.com/pingcap/tidb/blob/31c1de0b4f30d708de8228aa72c1a0dbff547504/pkg/executor/join/join_row_table.go#L540
And in each partition, we build hash table also based on the LSB bits in hash value
https://github.com/pingcap/tidb/blob/31c1de0b4f30d708de8228aa72c1a0dbff547504/pkg/executor/join/hash_table_v2.go#L86
This may increase the hash table conflicts especially if partition number is power of 2
### What changed and how does it work?
1. make the partition number to be a number that is pow of 2
2. dispatch row to each partition by the n MSB bits in hash value 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
