### PR TITLE
executor: fix query panic on INFORMATION_SCHEMA.CLUSTER_SLOW_QUERY with some slow query files

### DIFF
--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -1147,13 +1147,8 @@ func readLastLines(ctx context.Context, file *os.File, endCursor int64) ([]strin
 		lines = append(chars, lines...) // nozero
 
 		// find first '\n' or '\r'
-		for i := 0; i < len(chars); i++ {
-			// reach the line end
-			// the first newline may be in the line end at the first round
-			if i >= len(lines)-1 {
-				break
-			}
-			if (chars[i] == 10 || chars[i] == 13) && chars[i+1] != 10 && chars[i+1] != 13 {
+		for i := 0; i < len(chars)-1; i++ {
+			if (chars[i] == '\n' || chars[i] == '\r') && chars[i+1] != '\n' && chars[i+1] != '\r' {
 				firstNonNewlinePos = i + 1
 				break
 			}

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -768,3 +768,27 @@ func removeFiles(fileNames []string) {
 		os.Remove(fileName)
 	}
 }
+
+func TestIssue54324(t *testing.T) {
+	f, err := os.CreateTemp("", "test-tidb-slow-query-issue54324")
+	require.NoError(t, err)
+	defer os.Remove(f.Name()) // clean up
+
+	w := bufio.NewWriter(f)
+	for i := 0; i < 8191; i++ {
+		w.WriteByte('x')
+	}
+	w.WriteByte('\n')
+	for i := 0; i < 4096; i++ {
+		w.WriteByte('a')
+	}
+	require.NoError(t, w.Flush())
+
+	stat, err := f.Stat()
+	require.NoError(t, err)
+	endCursor := stat.Size()
+	lines, readBytes, err := readLastLines(context.Background(), f, endCursor)
+	require.NoError(t, err)
+	require.Len(t, lines, 2)
+	require.Equal(t, readBytes, 8192+4096)
+}


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54324

Problem Summary:

### What changed and how does it work?

The old code does not handle all the cases well.
`if i >= len(lines)-1` should be a typo, it should be something like `if i >= len(chars)-1`
And the simplified logic is just the same as this PR.


### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
