### PR TITLE
planner: merge FullSchema and FullNames of subplans when rewriting "in (subquery)" to inner join

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1244,6 +1244,11 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		copy(join.OutputNames(), planCtx.plan.OutputNames())
 		copy(join.OutputNames()[planCtx.plan.Schema().Len():], agg.OutputNames())
 		join.AttachOnConds(expression.SplitCNFItems(checkCondition))
+		// set FullSchema and FullNames for this join
+		if left, ok := planCtx.plan.(*logicalop.LogicalJoin); ok && left.FullSchema != nil {
+			join.FullSchema = left.FullSchema
+			join.FullNames = left.FullNames
+		}
 		// Set join hint for this join.
 		if planCtx.builder.TableHints() != nil {
 			join.SetPreferredJoinTypeAndOrder(planCtx.builder.TableHints())

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -718,3 +718,8 @@ Projection_11	6.00	root		1->Column#18
   └─Projection_17(Probe)	10000.00	root		cast(test.t61a85298.col_71, double BINARY)->Column#19
     └─TableReader_19	10000.00	root		data:TableFullScan_18
       └─TableFullScan_18	10000.00	cop[tikv]	table:t61a85298	keep order:false, stats:pseudo
+drop table if exists t0, t1;
+CREATE TABLE t0(c0 int);
+CREATE TABLE t1(c0 int);
+SELECT t0.c0, t1.c0 FROM t0 NATURAL JOIN t1 WHERE '1' AND (t0.c0 IN (SELECT c0 FROM t0));
+c0	c0

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -492,3 +492,9 @@ FROM (
 ) AS derived_table
 WHERE 16739493649928310215 MEMBER OF (derived_table.col_60767)
    OR NOT (JSON_CONTAINS(derived_table.col_60767, '6019730272580550835'));
+
+# TestIssue53766
+drop table if exists t0, t1;
+CREATE TABLE t0(c0 int);
+CREATE TABLE t1(c0 int);
+SELECT t0.c0, t1.c0 FROM t0 NATURAL JOIN t1 WHERE '1' AND (t0.c0 IN (SELECT c0 FROM t0));


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53766 

Problem Summary:

### What changed and how does it work?
Merge FullSchema and FullNames of subplans when rewring "in (subquery)" to inner join, which will be used to rewrite fields when using natural join.
https://github.com/pingcap/tidb/blob/438169989e2d6ab5f778238d02eb50c8eb408a76/pkg/planner/core/expression_rewriter.go#L2469-L2485
The merging code I referenced was from the code in buildJoin as follows:

https://github.com/pingcap/tidb/blob/438169989e2d6ab5f778238d02eb50c8eb408a76/pkg/planner/core/logical_plan_builder.go#L985-L1026
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
