### PR TITLE
planner: include both indexes and columns in job info

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -124,7 +124,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		return e.handleResultsError(ctx, concurrency, needGlobalStats, globalStatsMap, resultsCh, len(tasks))
 	})
 	for _, task := range tasks {
-		prepareV2AnalyzeJobInfo(task.colExec, false)
+		prepareV2AnalyzeJobInfo(task.colExec)
 		AddNewAnalyzeJob(e.Ctx(), task.job)
 	}
 	failpoint.Inject("mockKillPendingAnalyzeJob", func() {

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -422,9 +422,9 @@ func prepareIndexes(e *AnalyzeColumnsExec, b *strings.Builder) {
 	}
 	if len(indexes) < len(e.tableInfo.Indices) {
 		if len(indexes) > 1 {
-			b.WriteString(" columns ")
+			b.WriteString(" indexes ")
 		} else {
-			b.WriteString(" column ")
+			b.WriteString(" index ")
 		}
 		for i, index := range indexes {
 			if i > 0 {

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -392,7 +392,11 @@ func prepareColumns(e *AnalyzeColumnsExec, b *strings.Builder) {
 		cols = cols[:len(cols)-1]
 	}
 	if len(cols) < len(e.tableInfo.Columns) {
-		b.WriteString(" columns ")
+		if len(cols) > 1 {
+			b.WriteString(" columns ")
+		} else {
+			b.WriteString(" column ")
+		}
 		for i, col := range cols {
 			if i > 0 {
 				b.WriteString(", ")

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -391,6 +391,10 @@ func prepareColumns(e *AnalyzeColumnsExec, b *strings.Builder) {
 	if len(cols) > 0 && cols[len(cols)-1].ID == model.ExtraHandleID {
 		cols = cols[:len(cols)-1]
 	}
+	// If there are no columns, skip the process.
+	if len(cols) == 0 {
+		return
+	}
 	if len(cols) < len(e.tableInfo.Columns) {
 		if len(cols) > 1 {
 			b.WriteString(" columns ")

--- a/pkg/executor/show_stats_test.go
+++ b/pkg/executor/show_stats_test.go
@@ -407,7 +407,7 @@ func TestShowAnalyzeStatus(t *testing.T) {
 	require.Equal(t, "test", rows[0][0])
 	require.Equal(t, "t", rows[0][1])
 	require.Equal(t, "", rows[0][2])
-	require.Equal(t, "analyze table all columns with 256 buckets, 100 topn, 1 samplerate", rows[0][3])
+	require.Equal(t, "analyze table all indexes, all columns with 256 buckets, 100 topn, 1 samplerate", rows[0][3])
 	require.Equal(t, "2", rows[0][4])
 	checkTime := func(val any) {
 		str, ok := val.(string)

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2914,7 +2914,7 @@ func TestAnalyzeMVIndex(t *testing.T) {
 	// 2. analyze and check analyze jobs
 	tk.MustExec("analyze table t with 1 samplerate, 3 topn")
 	tk.MustQuery("select id, table_schema, table_name, partition_name, job_info, processed_rows, state from mysql.analyze_jobs order by id").
-		Check(testkit.Rows("1 test t  analyze table columns a with 256 buckets, 3 topn, 1 samplerate 27 finished",
+		Check(testkit.Rows("1 test t  analyze table index ia, column a with 256 buckets, 3 topn, 1 samplerate 27 finished",
 			"2 test t  analyze index ij_signed 190 finished",
 			"3 test t  analyze index ij_unsigned 135 finished",
 			"4 test t  analyze index ij_double 154 finished",

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2775,7 +2775,7 @@ func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
 	tk.MustQuery("select job_info from mysql.analyze_jobs where table_schema = 'test' and table_name = 't'").Sort().Check(
 		testkit.Rows(
 			"analyze index idx_c",
-			"analyze table column idx_b, columns a, b with 256 buckets, 100 topn, 1 samplerate",
+			"analyze table index idx_b, columns a, b with 256 buckets, 100 topn, 1 samplerate",
 		))
 
 	is := dom.InfoSchema()

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2156,19 +2156,19 @@ func TestShowAanalyzeStatusJobInfo(t *testing.T) {
 		require.Equal(t, expected, rows[0][3])
 		tk.MustExec("delete from mysql.analyze_jobs")
 	}
-	checkJobInfo("analyze table columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
+	checkJobInfo("analyze table all indexes, columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
 	tk.MustExec("set global tidb_persist_analyze_options = 1")
 	tk.MustExec("select * from t where c > 1")
 	h := dom.StatsHandle()
 	require.NoError(t, h.DumpColStatsUsageToKV())
 	tk.MustExec("analyze table t predicate columns with 2 topn, 2 buckets")
-	checkJobInfo("analyze table columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
+	checkJobInfo("analyze table all indexes, columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
 	tk.MustExec("analyze table t")
-	checkJobInfo("analyze table columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
+	checkJobInfo("analyze table all indexes, columns b, c, d with 2 buckets, 2 topn, 1 samplerate")
 	tk.MustExec("analyze table t columns a with 1 topn, 3 buckets")
-	checkJobInfo("analyze table columns a, b, d with 3 buckets, 1 topn, 1 samplerate")
+	checkJobInfo("analyze table all indexes, columns a, b, d with 3 buckets, 1 topn, 1 samplerate")
 	tk.MustExec("analyze table t")
-	checkJobInfo("analyze table columns a, b, d with 3 buckets, 1 topn, 1 samplerate")
+	checkJobInfo("analyze table all indexes, columns a, b, d with 3 buckets, 1 topn, 1 samplerate")
 }
 
 func TestAnalyzePartitionTableWithDynamicMode(t *testing.T) {
@@ -2775,7 +2775,7 @@ func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
 	tk.MustQuery("select job_info from mysql.analyze_jobs where table_schema = 'test' and table_name = 't'").Sort().Check(
 		testkit.Rows(
 			"analyze index idx_c",
-			"analyze table columns a, b with 256 buckets, 100 topn, 1 samplerate",
+			"analyze table column idx_b, columns a, b with 256 buckets, 100 topn, 1 samplerate",
 		))
 
 	is := dom.InfoSchema()

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -342,7 +342,7 @@ func TestAutoAnalyzeSkipColumnTypes(t *testing.T) {
 		exec.AutoAnalyzeMinCnt = originalVal
 	}()
 	require.True(t, h.HandleAutoAnalyze())
-	tk.MustQuery("select job_info from mysql.analyze_jobs where job_info like '%auto analyze table%'").Check(testkit.Rows("auto analyze table columns a, b, d with 256 buckets, 100 topn, 1 samplerate"))
+	tk.MustQuery("select job_info from mysql.analyze_jobs where job_info like '%auto analyze table%'").Check(testkit.Rows("auto analyze table all indexes, columns a, b, d with 256 buckets, 100 topn, 1 samplerate"))
 }
 
 func TestAutoAnalyzeOnEmptyTable(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -125,7 +125,7 @@ func TestAutoAnalyzeWithPredicateColumns(t *testing.T) {
 
 	// Check analyze jobs.
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t auto analyze table columns a with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t auto analyze table column a with 256 buckets, 100 topn, 1 samplerate"),
 	)
 }
 

--- a/pkg/statistics/handle/usage/predicate_column_test.go
+++ b/pkg/statistics/handle/usage/predicate_column_test.go
@@ -267,7 +267,7 @@ func TestAnalyzeWithNoPredicateColumnsAndNoIndexes(t *testing.T) {
 	tk.MustExec("analyze table t")
 	// FIXME: We should correct the job info or skip this kind of job.
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t analyze table column  with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t analyze table with 256 buckets, 100 topn, 1 samplerate"),
 	)
 }
 

--- a/pkg/statistics/handle/usage/predicate_column_test.go
+++ b/pkg/statistics/handle/usage/predicate_column_test.go
@@ -242,7 +242,6 @@ func TestAnalyzeNoPredicateColumnsWithIndexes(t *testing.T) {
 			"Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is \"use min(1, 110000/10000) as the sample-rate=1\"",
 		),
 	)
-	// TODO: we should also include indexes in the job info.
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
 		testkit.Rows("t analyze table all indexes, columns a, b with 256 buckets, 100 topn, 1 samplerate"),
 	)

--- a/pkg/statistics/handle/usage/predicate_column_test.go
+++ b/pkg/statistics/handle/usage/predicate_column_test.go
@@ -244,7 +244,7 @@ func TestAnalyzeNoPredicateColumnsWithIndexes(t *testing.T) {
 	)
 	// TODO: we should also include indexes in the job info.
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t analyze table columns a, b with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t analyze table all indexes, columns a, b with 256 buckets, 100 topn, 1 samplerate"),
 	)
 }
 
@@ -290,6 +290,6 @@ func TestAnalyzeNoPredicateColumnsWithPrimaryKey(t *testing.T) {
 	// Analyze table.
 	tk.MustExec("analyze table t")
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t analyze table columns a, b with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t analyze table all indexes, columns a, b with 256 buckets, 100 topn, 1 samplerate"),
 	)
 }

--- a/pkg/statistics/handle/usage/predicate_column_test.go
+++ b/pkg/statistics/handle/usage/predicate_column_test.go
@@ -74,7 +74,7 @@ func TestAnalyzeTableWithPredicateColumns(t *testing.T) {
 	// Analyze table and check analyze jobs.
 	tk.MustExec("analyze table t")
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t analyze table columns a with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t analyze table column a with 256 buckets, 100 topn, 1 samplerate"),
 	)
 
 	// More columns.
@@ -175,7 +175,7 @@ func TestAnalyzeTableWithTiDBPersistAnalyzeOptionsDisabled(t *testing.T) {
 	// Analyze again, it should use the predicate columns.
 	tk.MustExec("analyze table t")
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t analyze table columns a with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t analyze table column a with 256 buckets, 100 topn, 1 samplerate"),
 	)
 }
 
@@ -267,7 +267,7 @@ func TestAnalyzeWithNoPredicateColumnsAndNoIndexes(t *testing.T) {
 	tk.MustExec("analyze table t")
 	// FIXME: We should correct the job info or skip this kind of job.
 	tk.MustQuery("select table_name, job_info from mysql.analyze_jobs order by id desc limit 1").Check(
-		testkit.Rows("t analyze table columns  with 256 buckets, 100 topn, 1 samplerate"),
+		testkit.Rows("t analyze table column  with 256 buckets, 100 topn, 1 samplerate"),
 	)
 }
 

--- a/tests/integrationtest/r/executor/analyze.result
+++ b/tests/integrationtest/r/executor/analyze.result
@@ -824,12 +824,12 @@ delete from mysql.analyze_jobs;
 analyze table t;
 select job_info from mysql.analyze_jobs where job_info like '%analyze table%';
 job_info
-analyze table columns a, b, d with 256 buckets, 100 topn, 1 samplerate
+analyze table all indexes, columns a, b, d with 256 buckets, 100 topn, 1 samplerate
 delete from mysql.analyze_jobs;
 analyze table t columns a, e;
 select job_info from mysql.analyze_jobs where job_info like '%analyze table%';
 job_info
-analyze table columns a, d with 256 buckets, 100 topn, 1 samplerate
+analyze table all indexes, columns a, d with 256 buckets, 100 topn, 1 samplerate
 set @@session.tidb_analyze_skip_column_types = default;
 DROP TABLE IF EXISTS Issue34228;
 CREATE TABLE Issue34228 (id bigint NOT NULL, dt datetime NOT NULL) PARTITION BY RANGE COLUMNS(dt) (PARTITION p202201 VALUES LESS THAN ("2022-02-01"), PARTITION p202202 VALUES LESS THAN ("2022-03-01"));


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/53567

Problem Summary:

We display `job_info` in the `mysql.analyze_jobs` table. But we didn't include the indexes information in this column. We need to make it clearer after introducing the predicate columns feature because, by default, we only analyze the index if there are no predicate columns. 

### What changed and how does it work?

- Removed the unused parameter and added more comments
- Distinguished between singular and plural.
- Included the indexes info.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
在 analyze_job 中显示分析了的 indexes 信息
Display information about analyzed indexes in analyze_job
```
