### PR TITLE
parser: Fix keywords & keywords not checked in CI

### DIFF
--- a/pkg/parser/Makefile
+++ b/pkg/parser/Makefile
@@ -1,5 +1,3 @@
-.PHONY: all parser clean
-
 .PHONY: all
 all: fmt parser
 

--- a/pkg/parser/Makefile
+++ b/pkg/parser/Makefile
@@ -1,15 +1,20 @@
 .PHONY: all parser clean
 
-all: fmt parser generate
+.PHONY: all
+all: fmt parser
 
+.PHONY: test
 test: fmt parser
 	sh test.sh
 
-parser: parser.go hintparser.go
+.PHONY: parser
+parser: parser.go hintparser.go generate
 
+.PHONY: genkeyword
 genkeyword: generate_keyword/genkeyword.go
 	go build -C generate_keyword -o ../genkeyword
 
+.PHONY: generate
 generate: genkeyword parser.y
 	go generate
 
@@ -26,10 +31,12 @@ generate: genkeyword parser.y
 bin/goyacc: goyacc/main.go goyacc/format_yacc.go
 	GO111MODULE=on go build -o bin/goyacc goyacc/main.go goyacc/format_yacc.go
 
+.PHONY: fmt
 fmt: bin/goyacc parser_golden.y hintparser_golden.y
 	@echo "gofmt (simplify)"
 	@gofmt -s -l -w . 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 
+.PHONY: clean
 clean:
 	go clean -i ./...
 	rm -rf *.out

--- a/pkg/parser/Makefile
+++ b/pkg/parser/Makefile
@@ -8,7 +8,6 @@ test: fmt parser
 .PHONY: parser
 parser: parser.go hintparser.go generate
 
-.PHONY: genkeyword
 genkeyword: generate_keyword/genkeyword.go
 	go build -C generate_keyword -o ../genkeyword
 

--- a/pkg/parser/keywords.go
+++ b/pkg/parser/keywords.go
@@ -622,6 +622,7 @@ var Keywords = []KeywordsType{
 	{"VALIDATION", false, "unreserved"},
 	{"VALUE", false, "unreserved"},
 	{"VARIABLES", false, "unreserved"},
+	{"VECTOR", false, "unreserved"},
 	{"VIEW", false, "unreserved"},
 	{"VISIBLE", false, "unreserved"},
 	{"WAIT", false, "unreserved"},

--- a/pkg/parser/keywords_test.go
+++ b/pkg/parser/keywords_test.go
@@ -36,7 +36,7 @@ func TestKeywords(t *testing.T) {
 }
 
 func TestKeywordsLength(t *testing.T) {
-	require.Equal(t, 653, len(parser.Keywords))
+	require.Equal(t, 654, len(parser.Keywords))
 
 	reservedNr := 0
 	for _, kw := range parser.Keywords {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/48801

Problem Summary:

### What changed and how does it work?

In https://github.com/pingcap/tidb/pull/48807 a new Make action is introduced. However this action is not invoked in CI, nor listed in [TiDB Dev Guide](https://pingcap.github.io/tidb-dev-guide/understand-tidb/parser.html), causes mistakes like https://github.com/pingcap/tidb/pull/54246#issuecomment-2199710137.

This PR:
- Updates the incorrect Keywords list
- Calls `make generate` when `make parser` is called, prevent future mistakes happen again

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
