### PR TITLE
test: fix data race in RefreshSession

### DIFF
--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -117,9 +117,9 @@ func NewTestKitWithSession(t testing.TB, store kv.Storage, se sessiontypes.Sessi
 func (tk *TestKit) RefreshSession() {
 	tk.session = NewSession(tk.t, tk.store)
 	if intest.InTest {
-		testkitRandSeed := uint64(time.Now().UnixNano())
-		tk.t.Logf("RefreshSession rand seed: %d", testkitRandSeed)
-		rng := rand.New(rand.NewSource(int64(testkitRandSeed)))
+		seed := uint64(time.Now().UnixNano())
+		tk.t.Logf("RefreshSession rand seed: %d", seed)
+		rng := rand.New(rand.NewSource(int64(seed)))
 		if rng.Intn(10) >= 3 { // 70% chance to run infoschema v2
 			tk.MustExec("set @@global.tidb_schema_cache_size = 1024 * 1024 * 1024")
 		}

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -113,23 +113,14 @@ func NewTestKitWithSession(t testing.TB, store kv.Storage, se sessiontypes.Sessi
 	}
 }
 
-var (
-	testkitRNG      *rand.Rand
-	testkitRandSeed uint64
-)
-
-func init() {
-	testkitRandSeed = uint64(time.Now().UnixNano())
-	testkitRNG = rand.New(rand.NewSource(int64(testkitRandSeed)))
-}
-
 // RefreshSession set a new session for the testkit
 func (tk *TestKit) RefreshSession() {
 	tk.session = NewSession(tk.t, tk.store)
-
 	if intest.InTest {
+		testkitRandSeed := uint64(time.Now().UnixNano())
 		tk.t.Logf("RefreshSession rand seed: %d", testkitRandSeed)
-		if testkitRNG.Intn(10) >= 3 { // 70% chance to run infoschema v2
+		rng := rand.New(rand.NewSource(int64(testkitRandSeed)))
+		if rng.Intn(10) >= 3 { // 70% chance to run infoschema v2
 			tk.MustExec("set @@global.tidb_schema_cache_size = 1024 * 1024 * 1024")
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54376

Problem Summary:

`rand.Rand` is not thread-safe.

### What changed and how does it work?

Initialize the random number generator inside `RefreshSession()` is enough for reproducing.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
