### PR TITLE
br: pre-check TiKV disk space before restore task

### DIFF
--- a/br/pkg/errors/errors.go
+++ b/br/pkg/errors/errors.go
@@ -97,7 +97,6 @@ var (
 	ErrKVClusterIDMismatch = errors.Normalize("tikv cluster ID mismatch", errors.RFCCodeText("BR:KV:ErrKVClusterIDMismatch"))
 	ErrKVNotLeader         = errors.Normalize("not leader", errors.RFCCodeText("BR:KV:ErrKVNotLeader"))
 	ErrKVNotTiKV           = errors.Normalize("storage is not tikv", errors.RFCCodeText("BR:KV:ErrNotTiKVStorage"))
-	ErrKVDiskNotEnough     = errors.Normalize("tikv disk is not enough", errors.RFCCodeText("BR:KV:ErrKVDiskNotEnough"))
 
 	// ErrKVEpochNotMatch is the error raised when ingestion failed with "epoch
 	// not match". This error is retryable.

--- a/br/pkg/errors/errors.go
+++ b/br/pkg/errors/errors.go
@@ -97,6 +97,7 @@ var (
 	ErrKVClusterIDMismatch = errors.Normalize("tikv cluster ID mismatch", errors.RFCCodeText("BR:KV:ErrKVClusterIDMismatch"))
 	ErrKVNotLeader         = errors.Normalize("not leader", errors.RFCCodeText("BR:KV:ErrKVNotLeader"))
 	ErrKVNotTiKV           = errors.Normalize("storage is not tikv", errors.RFCCodeText("BR:KV:ErrNotTiKVStorage"))
+	ErrKVDiskNotEnough     = errors.Normalize("tikv disk is not enough", errors.RFCCodeText("BR:KV:ErrKVDiskNotEnough"))
 
 	// ErrKVEpochNotMatch is the error raised when ingestion failed with "epoch
 	// not match". This error is retryable.

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/cdcutil",
         "//pkg/util/collate",
+        "//pkg/util/engine",
         "//pkg/util/mathutil",
         "//pkg/util/table-filter",
         "@com_github_docker_go_units//:go-units",

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -109,7 +109,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 31,
+    shard_count = 32,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -109,7 +109,7 @@ go_test(
     ],
     embed = [":task"],
     flaky = True,
-    shard_count = 29,
+    shard_count = 31,
     deps = [
         "//br/pkg/backup",
         "//br/pkg/config",
@@ -145,6 +145,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//http",
         "@org_golang_google_grpc//keepalive",
     ],
 )

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//http",
         "@com_google_cloud_go_storage//:storage",
         "@io_etcd_go_etcd_client_pkg_v3//transport",
         "@io_etcd_go_etcd_client_v3//:client",

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1267,7 +1267,7 @@ func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File, 
 			tiflashCnt += 1
 			continue
 		}
-		tikvCnt += 2
+		tikvCnt += 1
 	}
 
 	// We won't need to restore more than 1800 PB data at one time, right?

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -820,6 +820,10 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		return errors.Annotate(berrors.ErrRestoreInvalidBackup, "contain tables but no databases")
 	}
 
+	//TODO: (Ris) use the files and tikv space info
+	// get tikv space
+	
+
 	archiveSize := reader.ArchiveSize(ctx, files)
 	g.Record(summary.RestoreDataSize, archiveSize)
 	//restore from tidb will fetch a general Size issue https://github.com/pingcap/tidb/issues/27247

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1238,10 +1238,10 @@ func CheckStoreSpace(necessary uint64, store *http.StoreInfo) error {
 	// Be careful editing the message, it is used in DiskCheckBackoffer
 	available, err := units.RAMInBytes(store.Status.Available)
 	if err != nil {
-		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s",store.Store.ID, store.Status.Available)
+		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s", store.Store.ID, store.Status.Available)
 	}
 	if available <= 0 {
-		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s",store.Store.ID, store.Status.Available)
+		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s", store.Store.ID, store.Status.Available)
 	}
 	if uint64(available) < necessary {
 		return errors.Annotatef(berrors.ErrKVDiskNotEnough, "store %d has no enough space, available %s, necessary %s",
@@ -1290,10 +1290,10 @@ func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File, 
 				if err := CheckStoreSpace(tiflashUsage, &store); err != nil {
 					return errors.Trace(err)
 				}
-			} else {
-				if err := CheckStoreSpace(tikvUsage, &store); err != nil {
-					return errors.Trace(err)
-				}
+				continue
+			}
+			if err := CheckStoreSpace(tikvUsage, &store); err != nil {
+				return errors.Trace(err)
 			}
 		}
 		return nil

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1183,7 +1183,7 @@ func getMaxReplica(ctx context.Context, mgr *conn.Mgr) (cnt uint64, err error) {
 		return err
 	}, utils.NewPDReqBackoffer())
 	if err != nil {
-		return 0, errors.New(err.Error())
+		return 0, errors.Trace(err)
 	}
 
 	key := "max-replicas"

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1186,7 +1186,7 @@ func getMaxReplica(ctx context.Context, mgr *conn.Mgr) (int, error) {
 	return int(val.(float64)), nil
 }
 
-func calNecessary(files []*backuppb.File, maxReplica int, storeCnt int) (uint64) {
+func calNecessary(files []*backuppb.File, maxReplica int, storeCnt int) uint64 {
 	var totalSize uint64
 	for _, file := range files {
 		size := file.GetTotalBytes()
@@ -1197,8 +1197,8 @@ func calNecessary(files []*backuppb.File, maxReplica int, storeCnt int) (uint64)
 
 func checkTiKVSpace(necessary uint64, store *http.StoreInfo) error {
 	available, err := units.RAMInBytes(store.Status.Available)
-	if err != nil {	
-			return errors.Errorf("store %d has invalid available space %s", store.Store.ID, store.Status.Available)
+	if err != nil {
+		return errors.Errorf("store %d has invalid available space %s", store.Store.ID, store.Status.Available)
 	}
 	if uint64(available) < necessary {
 		return errors.Errorf("store %d has no enough space, available %s, necessary %s",
@@ -1208,11 +1208,11 @@ func checkTiKVSpace(necessary uint64, store *http.StoreInfo) error {
 }
 
 func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File) error {
-	maxReplica,err := getMaxReplica(ctx, mgr)
+	maxReplica, err := getMaxReplica(ctx, mgr)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	stores,err := conn.GetAllTiKVStoresWithRetry(ctx, mgr.GetPDClient(), connutil.SkipTiFlash)
+	stores, err := conn.GetAllTiKVStoresWithRetry(ctx, mgr.GetPDClient(), connutil.SkipTiFlash)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1220,8 +1220,8 @@ func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File) 
 	necessary := calNecessary(files, maxReplica, storeCnt)
 
 	pdCli := mgr.GetPDHTTPClient()
-	for _,store := range stores {
-		info,err := pdCli.GetStore(ctx, store.GetId())
+	for _, store := range stores {
+		info, err := pdCli.GetStore(ctx, store.GetId())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1244,7 +1244,7 @@ func CheckStoreSpace(necessary uint64, store *http.StoreInfo) error {
 		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s", store.Store.ID, store.Status.Available)
 	}
 	if uint64(available) < necessary {
-		return errors.Annotatef(berrors.ErrKVDiskNotEnough, "store %d has no enough space, available %s, necessary %s",
+		return errors.Errorf("store %d has no space left on device, available %s, necessary %s",
 			store.Store.ID, units.BytesSize(float64(available)), units.BytesSize(float64(necessary)))
 	}
 	return nil

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1263,16 +1263,20 @@ func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File, 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	tikvUsage := EstimateTikvUsage(files, maxReplica, len(kvStores)) * 11 / 10
-	tiflashUsage := EstimateTiflashUsage(tables, len(tiflashStores)) * 11 / 10
 
+	tikvUsage := EstimateTikvUsage(files, maxReplica, len(kvStores))
+	tiflashUsage := EstimateTiflashUsage(tables, len(tiflashStores))
+
+	extraPreserve := func(base uint64, ratio uint64) uint64 {
+		return base * ratio / 100
+	}
 	for _, tikv := range kvStores {
-		if err := CheckStoreSpace(tikvUsage, tikv); err != nil {
+		if err := CheckStoreSpace(extraPreserve(tikvUsage,110), tikv); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	for _, tiflash := range tiflashStores {
-		if err := CheckStoreSpace(tiflashUsage, tiflash); err != nil {
+		if err := CheckStoreSpace(extraPreserve(tiflashUsage,110), tiflash); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -433,11 +433,11 @@ func TestCalNecessary(t *testing.T) {
 	for _, f := range files {
 		total += f.GetSize_()
 	}
-	ret := task.CalNecessary(files, replica, storeCnt)
+	ret := task.EstimateTikvUsage(files, replica, storeCnt)
 	require.Equal(t, ret, total*replica/uint64(storeCnt))
 }
 
 func TestCheckTikvSpace(t *testing.T) {
 	store := pdhttp.StoreInfo{Store: pdhttp.MetaStore{ID: 1}, Status: pdhttp.StoreStatus{Available: "500GB"}}
-	require.NoError(t, task.CheckTiKVSpace(400*1024*1024*1024, &store))
+	require.NoError(t, task.CheckStoreSpace(400*1024*1024*1024, &store))
 }

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -32,6 +32,8 @@ import (
 	pdhttp "github.com/tikv/pd/client/http"
 )
 
+const pb uint64 = 1024 * 1024 * 1024 * 1024 * 1024
+
 func TestPreCheckTableTiFlashReplicas(t *testing.T) {
 	mockStores := []*metapb.Store{
 		{
@@ -420,7 +422,6 @@ func TestFilterDDLJobByRules(t *testing.T) {
 }
 
 func TestTikvUsage(t *testing.T) {
-	pb := uint64(1024 * 1024 * 1024 * 1024 * 1024)
 	files := []*backuppb.File{
 		{Name: "F1", Size_: 1 * pb},
 		{Name: "F2", Size_: 2 * pb},
@@ -439,7 +440,6 @@ func TestTikvUsage(t *testing.T) {
 }
 
 func TestTiflashUsage(t *testing.T) {
-	pb := uint64(1024 * 1024 * 1024 * 1024 * 1024)
 	tables := []*metautil.Table{
 		{TiFlashReplicas: 0, Files: []*backuppb.File{{Size_: 1 * pb}}},
 		{TiFlashReplicas: 1, Files: []*backuppb.File{{Size_: 2 * pb}}},
@@ -452,6 +452,6 @@ func TestTiflashUsage(t *testing.T) {
 }
 
 func TestCheckTikvSpace(t *testing.T) {
-	store := pdhttp.StoreInfo{Store: pdhttp.MetaStore{ID: 1}, Status: pdhttp.StoreStatus{Available: "500GB"}}
-	require.NoError(t, task.CheckStoreSpace(400*1024*1024*1024, &store))
+	store := pdhttp.StoreInfo{Store: pdhttp.MetaStore{ID: 1}, Status: pdhttp.StoreStatus{Available: "500PB"}}
+	require.NoError(t, task.CheckStoreSpace(400*pb, &store))
 }

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -38,10 +38,6 @@ const (
 	resetTSWaitInterval    = 50 * time.Millisecond
 	resetTSMaxWaitInterval = 2 * time.Second
 
-	checkDiskRetryTime       = 5
-	checkDiskWaitInterval    = 50 * time.Millisecond
-	checkDiskMaxWaitInterval = 1 * time.Second
-
 	resetTSRetryTimeExt       = 600
 	resetTSWaitIntervalExt    = 500 * time.Millisecond
 	resetTSMaxWaitIntervalExt = 300 * time.Second
@@ -293,9 +289,9 @@ type DiskCheckBackoffer struct {
 
 func NewDiskCheckBackoffer() Backoffer {
 	return &DiskCheckBackoffer{
-		attempt:      checkDiskRetryTime,
-		delayTime:    checkDiskWaitInterval,
-		maxDelayTime: checkDiskMaxWaitInterval,
+		attempt:      resetTSRetryTime,
+		delayTime:    resetTSWaitInterval,
+		maxDelayTime: resetTSMaxWaitInterval,
 	}
 }
 
@@ -314,7 +310,7 @@ func (bo *DiskCheckBackoffer) NextBackoff(err error) time.Duration {
 			bo.attempt = 0
 		} else {
 			bo.delayTime = 2 * bo.delayTime
-			bo.attempt--
+			bo.attempt = 5
 		}
 	}
 

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -302,15 +302,15 @@ func NewDiskCheckBackoffer() Backoffer {
 func (bo *DiskCheckBackoffer) NextBackoff(err error) time.Duration {
 	e := errors.Cause(err)
 	switch e { // nolint:errorlint
-	case berrors.ErrPDInvalidResponse:
-		bo.delayTime = 2 * bo.delayTime
-		bo.attempt--
 	case berrors.ErrKVDiskNotEnough:
 		bo.delayTime = 0
 		bo.attempt = 0
+	case berrors.ErrPDInvalidResponse:
+		bo.delayTime = 2 * bo.delayTime
+		bo.attempt--
 	default:
 		bo.delayTime = 2 * bo.delayTime
-		bo.attempt = 3
+		bo.attempt--
 	}
 
 	if bo.delayTime > bo.maxDelayTime {

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -302,6 +302,9 @@ func NewDiskCheckBackoffer() Backoffer {
 func (bo *DiskCheckBackoffer) NextBackoff(err error) time.Duration {
 	e := errors.Cause(err)
 	switch e { // nolint:errorlint
+	case nil, context.Canceled, context.DeadlineExceeded:
+		bo.delayTime = 0
+		bo.attempt = 0
 	case berrors.ErrKVDiskNotEnough:
 		bo.delayTime = 0
 		bo.attempt = 0

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -310,7 +310,10 @@ func (bo *DiskCheckBackoffer) NextBackoff(err error) time.Duration {
 			bo.attempt = 0
 		} else {
 			bo.delayTime = 2 * bo.delayTime
-			bo.attempt = 5
+			if bo.attempt > 5 {
+				bo.attempt = 5
+			}
+			bo.attempt--
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54316
Problem Summary:

### What changed and how does it work?

Add a pre-check before the restore work, now the br will estimate the disk usage and check if each TiKV has enough disk space. User could disable this function by setting  `--check-requirements=false`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add a pre-check before the restore work, now the br will estimate the disk usage and check if each TiKV has enough disk space. User could disable this function by setting  `--check-requirements=false`
```
