### PR TITLE
executor: fix tidb crash when calling Close and Finish 

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2065,6 +2065,7 @@ func (cc *clientConn) handleStmt(
 		}
 		cc.ctx.GetSessionVars().SQLKiller.InWriteResultSet.Store(true)
 		defer cc.ctx.GetSessionVars().SQLKiller.InWriteResultSet.Store(false)
+		defer cc.ctx.GetSessionVars().SQLKiller.Reset()
 		if retryable, err := cc.writeResultSet(ctx, rs, false, status, 0); err != nil {
 			return retryable, err
 		}

--- a/pkg/server/internal/resultset/resultset.go
+++ b/pkg/server/internal/resultset/resultset.go
@@ -16,6 +16,7 @@ package resultset
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -54,6 +55,10 @@ type tidbResultSet struct {
 	preparedStmt *core.PlanCacheStmt
 	columns      []*column.Info
 	closed       int32
+	// finishLock is a mutex used to synchronize access to the `Next` and `Finish` functions of the adapter.
+	// It ensures that only one goroutine can access the `Next` and `Finish` functions at a time, preventing race conditions.
+	// When we terminate the current SQL externally (e.g., kill query), an additional goroutine would be used to call the `Finish` function.
+	finishLock sync.Mutex
 }
 
 func (trs *tidbResultSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
@@ -61,17 +66,24 @@ func (trs *tidbResultSet) NewChunk(alloc chunk.Allocator) *chunk.Chunk {
 }
 
 func (trs *tidbResultSet) Next(ctx context.Context, req *chunk.Chunk) error {
+	trs.finishLock.Lock()
+	defer trs.finishLock.Unlock()
 	return trs.recordSet.Next(ctx, req)
 }
 
 func (trs *tidbResultSet) Finish() error {
-	if x, ok := trs.recordSet.(interface{ Finish() error }); ok {
-		return x.Finish()
+	if trs.finishLock.TryLock() {
+		defer trs.finishLock.Unlock()
+		if x, ok := trs.recordSet.(interface{ Finish() error }); ok {
+			return x.Finish()
+		}
 	}
 	return nil
 }
 
 func (trs *tidbResultSet) Close() {
+	trs.finishLock.Lock()
+	defer trs.finishLock.Unlock()
 	if !atomic.CompareAndSwapInt32(&trs.closed, 0, 1) {
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -947,11 +947,6 @@ func killQuery(conn *clientConn, maxExecutionTime bool) {
 			logutil.BgLogger().Warn("error setting read deadline for kill.", zap.Error(err))
 		}
 	}
-	defer func() {
-		if err := recover(); err != nil {
-			logutil.BgLogger().Error("killQuery panic", zap.Any("err", err))
-		}
-	}()
 	sessVars.SQLKiller.FinishResultSet()
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -947,6 +947,11 @@ func killQuery(conn *clientConn, maxExecutionTime bool) {
 			logutil.BgLogger().Warn("error setting read deadline for kill.", zap.Error(err))
 		}
 	}
+	defer func() {
+		if err := recover(); err != nil {
+			logutil.BgLogger().Error("killQuery panic", zap.Any("err", err))
+		}
+	}()
 	sessVars.SQLKiller.FinishResultSet()
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54335

Problem Summary:

### What changed and how does it work?

1. Move the `finishLock` to `tidbResultSet` to protect Close() and Finish().
2. Clear `SQLKiller.Finish()` when `writeResultSet` finished.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
