### PR TITLE
table: Use `MutateBuffers` to manage buffers

### DIFF
--- a/pkg/table/context/BUILD.bazel
+++ b/pkg/table/context/BUILD.bazel
@@ -1,18 +1,44 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "context",
-    srcs = ["table.go"],
+    srcs = [
+        "buffers.go",
+        "table.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/table/context",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/errctx",
         "//pkg/expression/context",
         "//pkg/infoschema/context",
         "//pkg/kv",
         "//pkg/parser/model",
         "//pkg/sessionctx/variable",
+        "//pkg/tablecodec",
         "//pkg/types",
+        "//pkg/util/rowcodec",
         "//pkg/util/tableutil",
         "@com_github_pingcap_tipb//go-binlog",
+    ],
+)
+
+go_test(
+    name = "context_test",
+    timeout = "short",
+    srcs = ["buffers_test.go"],
+    embed = [":context"],
+    flaky = True,
+    shard_count = 5,
+    deps = [
+        "//pkg/errctx",
+        "//pkg/kv",
+        "//pkg/parser/mysql",
+        "//pkg/sessionctx/variable",
+        "//pkg/tablecodec",
+        "//pkg/types",
+        "//pkg/util/rowcodec",
+        "@com_github_stretchr_testify//mock",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/table/context/BUILD.bazel
+++ b/pkg/table/context/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     srcs = ["buffers_test.go"],
     embed = [":context"],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/errctx",
         "//pkg/kv",

--- a/pkg/table/context/buffers.go
+++ b/pkg/table/context/buffers.go
@@ -1,0 +1,185 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"time"
+
+	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/rowcodec"
+)
+
+type encodeRowBuffer struct {
+	// colIDs is the column ids for a row to be encoded.
+	colIDs []int64
+	// row is the column data for a row to be encoded.
+	row []types.Datum
+	// encoded is the buffer for the encoding result.
+	encoded []byte
+	// tempValues is the buffer used temporary when encoding a row with old format.
+	tempValues []types.Datum
+}
+
+// Reset resets the inner buffers to a capacity.
+func (b *encodeRowBuffer) reset(capacity int) {
+	b.colIDs = ensureCapacityAndReset(b.colIDs, 0, capacity)
+	b.row = ensureCapacityAndReset(b.row, 0, capacity)
+}
+
+// AddColVal adds a column value to the buffer.
+func (b *encodeRowBuffer) AddColVal(colID int64, val types.Datum) {
+	b.colIDs = append(b.colIDs, colID)
+	b.row = append(b.row, val)
+}
+
+// WriteMemBufferEncoded writes the encoded row to the memBuffer.
+func (b *encodeRowBuffer) WriteMemBufferEncoded(
+	cfg RowEncodingConfig, loc *time.Location, ec errctx.Context,
+	memBuffer kv.MemBuffer, key kv.Key, flags ...kv.FlagsOp,
+) error {
+	var checksum rowcodec.Checksum
+	if cfg.IsRowLevelChecksumEnabled {
+		checksum = rowcodec.RawChecksum{Key: key}
+	}
+
+	b.tempValues = ensureCapacityAndReset(b.tempValues, len(b.row)*2)
+	encoded, err := tablecodec.EncodeRow(
+		loc, b.row, b.colIDs, b.encoded[:0], b.tempValues, checksum, cfg.RowEncoder,
+	)
+	if err = ec.HandleError(err); err != nil {
+		return err
+	}
+	b.encoded = encoded
+
+	if len(flags) == 0 {
+		return memBuffer.Set(key, b.encoded)
+	}
+	return memBuffer.SetWithFlags(key, b.encoded, flags...)
+}
+
+// AddRecordBuffer is the buffer for AddRecord operation.
+type AddRecordBuffer struct {
+	encodeRowBuffer
+}
+
+// GetColDataBuffer returns the buffer for column data.
+// TODO: make sure the inner buffer is not used outside directly.
+func (b *AddRecordBuffer) GetColDataBuffer() ([]int64, []types.Datum) {
+	return b.colIDs, b.row
+}
+
+// Reset resets the inner buffers to a capacity.
+func (b *AddRecordBuffer) Reset(capacity int) {
+	b.encodeRowBuffer.reset(capacity)
+}
+
+// UpdateRecordBuffer is the buffer for UpdateRecord operation.
+type UpdateRecordBuffer struct {
+	encodeRowBuffer
+	rowToCheck []types.Datum
+}
+
+// GetRowToCheck gets the row data for constraint check.
+// TODO: make sure the inner buffer is not used outside directly.
+func (b *UpdateRecordBuffer) GetRowToCheck() []types.Datum {
+	return b.rowToCheck
+}
+
+// AddColValToCheck adds a column value to the buffer for checking.
+func (b *UpdateRecordBuffer) AddColValToCheck(val types.Datum) {
+	b.rowToCheck = append(b.rowToCheck, val)
+}
+
+// Reset resets the inner buffers to a capacity.
+func (b *UpdateRecordBuffer) Reset(capacity int) {
+	b.encodeRowBuffer.reset(capacity)
+	b.rowToCheck = ensureCapacityAndReset(b.rowToCheck, 0, capacity)
+}
+
+// ColSizeDeltaBuffer is a buffer to store the change of column size.
+type ColSizeDeltaBuffer struct {
+	delta []variable.ColSize
+}
+
+// Reset resets the inner buffers to a capacity.
+func (b *ColSizeDeltaBuffer) Reset(capacity int) {
+	b.delta = ensureCapacityAndReset(b.delta, 0, capacity)
+}
+
+// AddColSizeDelta adds the column size delta to the buffer.
+func (b *ColSizeDeltaBuffer) AddColSizeDelta(colID int64, size int64) {
+	b.delta = append(b.delta, variable.ColSize{ColID: colID, Size: size})
+}
+
+// GetColSizeDelta gets the column size delta.
+// TODO: make sure the inner buffer is not used outside directly.
+func (b *ColSizeDeltaBuffer) GetColSizeDelta() []variable.ColSize {
+	return b.delta
+}
+
+// MutateBuffers is used to get the buffers for table mutating.
+type MutateBuffers struct {
+	addRecord    *AddRecordBuffer
+	update       *UpdateRecordBuffer
+	colSizeDelta *ColSizeDeltaBuffer
+}
+
+// NewMutateBuffers creates a new `MutateBuffers`.
+func NewMutateBuffers() *MutateBuffers {
+	return &MutateBuffers{
+		addRecord:    &AddRecordBuffer{},
+		update:       &UpdateRecordBuffer{},
+		colSizeDelta: &ColSizeDeltaBuffer{},
+	}
+}
+
+// GetAddRecordBufferWithCap gets the buffer for AddRecord operation and resets the capacity of its inner slices.
+func (b *MutateBuffers) GetAddRecordBufferWithCap(capacity int) *AddRecordBuffer {
+	buffer := b.addRecord
+	buffer.Reset(capacity)
+	return buffer
+}
+
+// GetUpdateRecordBufferWithCap gets the buffer for AddRecord operation and resets the capacity of its inner slices.
+func (b *MutateBuffers) GetUpdateRecordBufferWithCap(capacity int) *UpdateRecordBuffer {
+	buffer := b.update
+	buffer.Reset(capacity)
+	return buffer
+}
+
+// GetColSizeDeltaBufferWithCap gets the buffer for column size delta collection
+// and resets the capacity of its inner slice.
+func (b *MutateBuffers) GetColSizeDeltaBufferWithCap(capacity int) *ColSizeDeltaBuffer {
+	buffer := b.colSizeDelta
+	buffer.Reset(capacity)
+	return buffer
+}
+
+// ensureCapacityAndReset is similar to the built-in make(),
+// but it reuses the given slice if it has enough capacity.
+func ensureCapacityAndReset[T any](slice []T, size int, optCap ...int) []T {
+	capacity := size
+	if len(optCap) > 0 {
+		capacity = optCap[0]
+	}
+	if cap(slice) < capacity {
+		return make([]T, size, capacity)
+	}
+	return slice[:size]
+}

--- a/pkg/table/context/buffers_test.go
+++ b/pkg/table/context/buffers_test.go
@@ -1,0 +1,219 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/rowcodec"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockMemBuffer struct {
+	kv.MemBuffer
+	mock.Mock
+}
+
+func (b *mockMemBuffer) SetWithFlags(key kv.Key, value []byte, flags ...kv.FlagsOp) error {
+	args := b.Called(key, value, flags)
+	return args.Error(0)
+}
+
+func (b *mockMemBuffer) Set(key kv.Key, value []byte) error {
+	args := b.Called(key, value)
+	return args.Error(0)
+}
+
+func TestEncodeRow(t *testing.T) {
+	buffer := &encodeRowBuffer{}
+	tm := types.NewTime(
+		types.FromDate(2021, 1, 1, 1, 2, 3, 4),
+		mysql.TypeDatetime, 6,
+	)
+	d1 := types.NewBytesDatum([]byte{1, 2, 3})
+	d2 := types.NewIntDatum(20)
+	d3 := types.NewTimeDatum(tm)
+	buffer.AddColVal(1, d1)
+	buffer.AddColVal(2, d2)
+	buffer.AddColVal(3, d3)
+	require.Equal(t, []int64{1, 2, 3}, buffer.colIDs)
+	require.Equal(t, []types.Datum{d1, d2, d3}, buffer.row)
+
+	for _, c := range []struct {
+		loc              *time.Location
+		rowLevelChecksum bool
+		oldFormat        bool
+		flags            []kv.FlagsOp
+	}{
+		{
+			loc: time.UTC,
+		},
+		{
+			loc:              time.FixedZone("fixed1", 3600),
+			rowLevelChecksum: true,
+			flags:            []kv.FlagsOp{kv.SetPresumeKeyNotExists},
+		},
+		{
+			loc:       time.FixedZone("fixed2", 3600*2),
+			oldFormat: true,
+		},
+	} {
+		cfg := RowEncodingConfig{
+			RowEncoder:                &rowcodec.Encoder{Enable: !c.oldFormat},
+			IsRowLevelChecksumEnabled: c.rowLevelChecksum,
+		}
+
+		var checksum rowcodec.Checksum
+		if cfg.IsRowLevelChecksumEnabled {
+			checksum = rowcodec.RawChecksum{Key: kv.Key("key1")}
+		}
+
+		expectedVal, err := tablecodec.EncodeRow(
+			c.loc, []types.Datum{d1, d2, d3}, []int64{1, 2, 3}, nil, nil, checksum,
+			&rowcodec.Encoder{Enable: !c.oldFormat},
+		)
+		require.NoError(t, err)
+
+		memBuffer := &mockMemBuffer{}
+		if len(c.flags) == 0 {
+			memBuffer.On("Set", kv.Key("key1"), expectedVal).Return(nil).Once()
+		} else {
+			memBuffer.On("SetWithFlags", kv.Key("key1"), expectedVal, c.flags).Return(nil).Once()
+		}
+		err = buffer.WriteMemBufferEncoded(cfg, time.UTC, errctx.StrictNoWarningContext, memBuffer, kv.Key("key1"), c.flags...)
+		require.NoError(t, err)
+		memBuffer.AssertExpectations(t)
+
+		// the encoding result should be cached as a buffer
+		require.Equal(t, expectedVal, buffer.encoded)
+	}
+}
+
+func TestEncodeBufferReserve(t *testing.T) {
+	for _, item := range []any{&AddRecordBuffer{}, &UpdateRecordBuffer{}} {
+		var buffer *encodeRowBuffer
+		var reset func(int)
+		var encode func()
+		cfg := RowEncodingConfig{
+			RowEncoder: &rowcodec.Encoder{Enable: true},
+		}
+		mb := &mockMemBuffer{}
+		mb.On("Set", kv.Key("key1"), mock.Anything).Return(nil).Once()
+		switch b := item.(type) {
+		case *UpdateRecordBuffer:
+			reset = b.reset
+			buffer = &b.encodeRowBuffer
+			encode = func() {
+				err := buffer.WriteMemBufferEncoded(cfg, time.UTC, errctx.StrictNoWarningContext, mb, kv.Key("key1"))
+				require.NoError(t, err)
+				mb.AssertExpectations(t)
+			}
+		case *AddRecordBuffer:
+			reset = b.reset
+			buffer = &b.encodeRowBuffer
+			encode = func() {
+				err := buffer.WriteMemBufferEncoded(cfg, time.UTC, errctx.StrictNoWarningContext, mb, kv.Key("key1"))
+				require.NoError(t, err)
+				mb.AssertExpectations(t)
+			}
+		}
+		reset(6)
+		// data buffer should be reset to the capacity and length is 0
+		require.Equal(t, 6, cap(buffer.colIDs))
+		require.Equal(t, 0, len(buffer.colIDs))
+		require.Equal(t, 6, cap(buffer.row))
+		require.Equal(t, 0, len(buffer.row))
+		// tempValues and encoded should be postponed to encode phase to reset
+		require.Equal(t, 0, cap(buffer.tempValues))
+		require.Equal(t, 0, cap(buffer.encoded))
+
+		// add some data and encode
+		buffer.AddColVal(1, types.NewIntDatum(1))
+		buffer.AddColVal(2, types.NewIntDatum(2))
+		require.Equal(t, 2, len(buffer.colIDs))
+		require.Equal(t, 2, len(buffer.row))
+		encode()
+		encodedCap := cap(buffer.encoded)
+		require.Greater(t, encodedCap, 0)
+		require.Equal(t, 4, len(buffer.tempValues))
+
+		// GetColDataBuffer should return the underlying buffer
+		if b, ok := item.(*AddRecordBuffer); ok {
+			colIDs, row := b.GetColDataBuffer()
+			require.Equal(t, buffer.colIDs, colIDs)
+			require.Equal(t, buffer.row, row)
+		}
+
+		// reset should not shrink the capacity
+		reset(2)
+		require.Equal(t, 6, cap(buffer.colIDs))
+		require.Equal(t, 0, len(buffer.colIDs))
+		require.Equal(t, 6, cap(buffer.row))
+		require.Equal(t, 0, len(buffer.row))
+		require.Equal(t, 4, cap(buffer.tempValues))
+		require.Equal(t, encodedCap, cap(buffer.encoded))
+	}
+}
+
+func TestUpdateRecordRowToCheckBuffer(t *testing.T) {
+	buffer := &UpdateRecordBuffer{}
+	buffer.Reset(6)
+	require.Equal(t, 0, len(buffer.rowToCheck))
+	require.Equal(t, 6, cap(buffer.rowToCheck))
+	buffer.AddColValToCheck(types.NewIntDatum(1))
+	buffer.AddColValToCheck(types.NewIntDatum(2))
+	require.Equal(t, []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)}, buffer.rowToCheck)
+	require.Equal(t, buffer.rowToCheck, buffer.GetRowToCheck())
+
+	// reset should not shrink the capacity
+	buffer.Reset(2)
+	require.Equal(t, 0, len(buffer.rowToCheck))
+	require.Equal(t, 6, cap(buffer.rowToCheck))
+}
+
+func TestColSizeDeltaBuffer(t *testing.T) {
+	buffer := &ColSizeDeltaBuffer{}
+	buffer.Reset(6)
+	require.Equal(t, 0, len(buffer.delta))
+	require.Equal(t, 6, cap(buffer.delta))
+	buffer.AddColSizeDelta(1, 2)
+	buffer.AddColSizeDelta(3, 4)
+	require.Equal(t, []variable.ColSize{{ColID: 1, Size: 2}, {ColID: 3, Size: 4}}, buffer.delta)
+	require.Equal(t, buffer.delta, buffer.GetColSizeDelta())
+
+	// reset should not shrink the capacity
+	buffer.Reset(2)
+	require.Equal(t, 0, len(buffer.delta))
+	require.Equal(t, 6, cap(buffer.delta))
+}
+
+func TestMutateBuffersGetter(t *testing.T) {
+	buffers := NewMutateBuffers()
+	add := buffers.GetAddRecordBufferWithCap(6)
+	require.Equal(t, 6, cap(add.row))
+	update := buffers.GetUpdateRecordBufferWithCap(6)
+	require.Equal(t, 6, cap(update.row))
+	require.Equal(t, 6, cap(update.rowToCheck))
+	colSize := buffers.GetColSizeDeltaBufferWithCap(6)
+	require.Equal(t, 6, cap(colSize.delta))
+}

--- a/pkg/table/context/table.go
+++ b/pkg/table/context/table.go
@@ -20,12 +20,20 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
-	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tidb/pkg/util/tableutil"
 	"github.com/pingcap/tipb/go-binlog"
 )
 
 var _ AllocatorContext = MutateContext(nil)
+
+// RowEncodingConfig is used to provide config for row encoding.
+type RowEncodingConfig struct {
+	// IsRowLevelChecksumEnabled indicates whether the row level checksum is enabled.
+	IsRowLevelChecksumEnabled bool
+	// RowEncoder is used to encode a row
+	RowEncoder *rowcodec.Encoder
+}
 
 // MutateContext is used to when mutating a table.
 type MutateContext interface {
@@ -46,38 +54,12 @@ type MutateContext interface {
 	// TxnRecordTempTable record the temporary table to the current transaction.
 	// This method will be called when the temporary table is modified or should allocate id in the transaction.
 	TxnRecordTempTable(tbl *model.TableInfo) tableutil.TempTable
-	// GetTablesBuffer returns the TablesBuffer,
+	// GetRowEncodingConfig returns the RowEncodingConfig.
+	GetRowEncodingConfig() RowEncodingConfig
+	// GetMutateBuffers returns the MutateBuffers,
 	// which is a buffer for table related structures that aims to reuse memory and
 	// saves allocation.
-	GetTablesBuffer() *TablesBuffer
-}
-
-// TablesBuffer is a memory pool for table related memory allocation that aims to reuse memory
-// and saves allocation
-type TablesBuffer struct {
-	Update *UpdateRecordBuffer
-	Add    *AddRecordBuffer
-	Remove *RemoveRecordBuffer
-}
-
-// RemoveRecordBuffer is for RemoveRecord
-type RemoveRecordBuffer struct {
-	ColSize []variable.ColSize
-}
-
-// AddRecordBuffer is for AddRecord
-type AddRecordBuffer struct {
-	ColIDs  []int64
-	Row     []types.Datum
-	ColSize []variable.ColSize
-}
-
-// UpdateRecordBuffer is for UpdateRecord
-type UpdateRecordBuffer struct {
-	ColIDs     []int64
-	Row        []types.Datum
-	RowToCheck []types.Datum
-	ColSize    []variable.ColSize
+	GetMutateBuffers() *MutateBuffers
 }
 
 // AllocatorContext is used to provide context for method `table.Allocators`.

--- a/pkg/table/contextimpl/table.go
+++ b/pkg/table/contextimpl/table.go
@@ -30,24 +30,18 @@ var _ context.AllocatorContext = &TableContextImpl{}
 type TableContextImpl struct {
 	sessionctx.Context
 	exprCtx exprctx.ExprContext
-
-	// TablesBuffer is a memory pool for table related memory allocation that aims to reuse memory
+	// mutateBuffers is a memory pool for table related memory allocation that aims to reuse memory
 	// and saves allocation
 	// The buffers are supposed to be used inside AddRecord/UpdateRecord/RemoveRecord.
-	// It's users duty to reset them before use.
-	TablesBuffer *context.TablesBuffer
+	mutateBuffers *context.MutateBuffers
 }
 
 // NewTableContextImpl creates a new TableContextImpl.
 func NewTableContextImpl(sctx sessionctx.Context, exprCtx exprctx.ExprContext) *TableContextImpl {
 	return &TableContextImpl{
-		Context: sctx,
-		exprCtx: exprCtx,
-		TablesBuffer: &context.TablesBuffer{
-			Add:    &context.AddRecordBuffer{},
-			Update: &context.UpdateRecordBuffer{},
-			Remove: &context.RemoveRecordBuffer{},
-		},
+		Context:       sctx,
+		exprCtx:       exprCtx,
+		mutateBuffers: context.NewMutateBuffers(),
 	}
 }
 
@@ -62,11 +56,20 @@ func (ctx *TableContextImpl) GetExprCtx() exprctx.ExprContext {
 	return ctx.exprCtx
 }
 
-func (ctx *TableContextImpl) vars() *variable.SessionVars {
-	return ctx.Context.GetSessionVars()
+// GetRowEncodingConfig returns the RowEncodingConfig.
+func (ctx *TableContextImpl) GetRowEncodingConfig() context.RowEncodingConfig {
+	vars := ctx.vars()
+	return context.RowEncodingConfig{
+		IsRowLevelChecksumEnabled: vars.IsRowLevelChecksumEnabled(),
+		RowEncoder:                &vars.RowEncoder,
+	}
 }
 
-// GetTablesBuffer implements the MutateContext interface.
-func (ctx *TableContextImpl) GetTablesBuffer() *context.TablesBuffer {
-	return ctx.TablesBuffer
+// GetMutateBuffers implements the MutateContext interface.
+func (ctx *TableContextImpl) GetMutateBuffers() *context.MutateBuffers {
+	return ctx.mutateBuffers
+}
+
+func (ctx *TableContextImpl) vars() *variable.SessionVars {
+	return ctx.Context.GetSessionVars()
 }

--- a/pkg/table/contextimpl/table.go
+++ b/pkg/table/contextimpl/table.go
@@ -41,7 +41,7 @@ func NewTableContextImpl(sctx sessionctx.Context, exprCtx exprctx.ExprContext) *
 	return &TableContextImpl{
 		Context:       sctx,
 		exprCtx:       exprCtx,
-		mutateBuffers: context.NewMutateBuffers(),
+		mutateBuffers: context.NewMutateBuffers(sctx.GetSessionVars().GetWriteStmtBufs()),
 	}
 }
 

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -713,17 +713,6 @@ func (t *TableCommon) rebuildIndices(ctx table.MutateContext, txn kv.Transaction
 	return nil
 }
 
-// adjustRowValuesBuf adjust writeBufs.AddRowValues length, AddRowValues stores the inserting values that is used
-// by tablecodec.EncodeRow, the encoded row format is `id1, colval, id2, colval`, so the correct length is rowLen * 2. If
-// the inserting row has null value, AddRecord will skip it, so the rowLen will be different, so we need to adjust it.
-func adjustRowValuesBuf(writeBufs *variable.WriteStmtBufs, rowLen int) {
-	adjustLen := rowLen * 2
-	if writeBufs.AddRowValues == nil || cap(writeBufs.AddRowValues) < adjustLen {
-		writeBufs.AddRowValues = make([]types.Datum, adjustLen)
-	}
-	writeBufs.AddRowValues = writeBufs.AddRowValues[:adjustLen]
-}
-
 // FindPrimaryIndex uses to find primary index in tableInfo.
 func FindPrimaryIndex(tblInfo *model.TableInfo) *model.IndexInfo {
 	var pkIdx *model.IndexInfo
@@ -2212,17 +2201,4 @@ func (t *TemporaryTable) SetSize(v int64) {
 // GetMeta gets the table meta.
 func (t *TemporaryTable) GetMeta() *model.TableInfo {
 	return t.meta
-}
-
-// ensureCapacityAndReset is similar to the built-in make(),
-// but it reuses the given slice if it has enough capacity.
-func ensureCapacityAndReset[T any](slice []T, size int, optCap ...int) []T {
-	capacity := size
-	if len(optCap) > 0 {
-		capacity = optCap[0]
-	}
-	if cap(slice) < capacity {
-		return make([]T, size, capacity)
-	}
-	return slice[:size]
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54392, ref #54397

### What changed and how does it work?

This PR introduces a better way to manage buffers  in `AddRecord/UpdateRecord/DeleteRecord`. It renamed `TablesBuffer` to `MutateBuffers` and returns buffers by methods instead of accessing the inner object directly. `MutateBuffers` is defined as:

```go
type MutateBuffers struct {
	addRecord    *AddRecordBuffer
	update       *UpdateRecordBuffer
	colSizeDelta *ColSizeDeltaBuffer
}

func NewMutateBuffers(stmtBufs *variable.WriteStmtBufs) *MutateBuffers {
	return &MutateBuffers{
		addRecord: &AddRecordBuffer{
			encodeRowBuffer: encodeRowBuffer{
				writeStmtBufs: stmtBufs,
			},
		},
		updateRecord: &UpdateRecordBuffer{
			encodeRowBuffer: encodeRowBuffer{
				writeStmtBufs: stmtBufs,
			},
		},
		colSizeDelta: &ColSizeDeltaBuffer{},
	}
}

func (b *MutateBuffers) GetAddRecordBufferWithCap(cap int) *AddRecordBuffer {
	buffer := b.addRecord
	buffer.Reset(cap)
	return buffer
}

...
```

The internal buffers are defined as private fields that can only be fetched by methods like `GetAddRecordBufferWithCap` which also does some works to make sure the buffers are inited when using it.  `AddRecordBuffer` also provides some methods:

```go
type AddRecordBuffer struct {
	encodeRowBuffer
}

type encodeRowBuffer struct {
	// colIDs is the column ids for a row to be encoded.
	colIDs []int64
	// row is the column data for a row to be encoded.
	row []types.Datum
	// writeStmtBufs refs the `WriteStmtBufs` in session
	writeStmtBufs *variable.WriteStmtBufs
}


func (b *encodeRowBuffer) AddColVal(colID int64, val types.Datum) {
	b.colIDs = append(b.colIDs, colID)
	b.row = append(b.row, val)
}

func (b *encodeRowBuffer) WriteMemBufferEncoded(
	cfg RowEncodingConfig, loc *time.Location, ec errctx.Context,
	memBuffer kv.MemBuffer, key kv.Key, flags ...kv.FlagsOp,
) error {
	// ... encode the data and write the result to membuffer.
}
```

You can see that the outside code cannot access the inner slices directly. We can call `AddColVal` when we want to add new column data to the buffer and call `WriteMemBufferEncoded` when we want to write a encoded row to membuffer. Because the inner slices are private, we can ensure that those slices will not be cached somewhere else by mistake only if the `WriteMemBufferEncoded` is implemented correctly.

TODO:

Some methods are still exposing the inner slices to the outside such as `GetColDataBuffer` or `GetRowToCheck`, we should avoid it in the future PRs.




### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
