### PR TITLE
ddl: consider paused job when check runnable

### DIFF
--- a/pkg/ddl/callback.go
+++ b/pkg/ddl/callback.go
@@ -60,9 +60,9 @@ type Callback interface {
 	// OnWatched is called after watching owner is completed.
 	OnWatched(ctx context.Context)
 	// OnGetJobBefore is called before getting job.
-	OnGetJobBefore(jobType string)
+	OnGetJobBefore()
 	// OnGetJobAfter is called after getting job.
-	OnGetJobAfter(jobType string, job *model.Job)
+	OnGetJobAfter(job *model.Job)
 }
 
 // BaseCallback implements Callback.OnChanged interface.
@@ -100,12 +100,12 @@ func (*BaseCallback) OnWatched(_ context.Context) {
 }
 
 // OnGetJobBefore implements Callback.OnGetJobBefore interface.
-func (*BaseCallback) OnGetJobBefore(_ string) {
+func (*BaseCallback) OnGetJobBefore() {
 	// Nothing to do.
 }
 
 // OnGetJobAfter implements Callback.OnGetJobAfter interface.
-func (*BaseCallback) OnGetJobAfter(_ string, _ *model.Job) {
+func (*BaseCallback) OnGetJobAfter(_ *model.Job) {
 	// Nothing to do.
 }
 

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -752,6 +752,7 @@ func (w *worker) doModifyColumnTypeWithData(
 			return ver, errors.Trace(err)
 		}
 		job.SchemaState = model.StateWriteOnly
+		failpoint.InjectCall("afterModifyColumnStateDeleteOnly", job.ID)
 	case model.StateWriteOnly:
 		// write only -> reorganization
 		updateChangingObjState(changingCol, changingIdxs, model.StateWriteReorganization)

--- a/pkg/ddl/ddl_running_jobs.go
+++ b/pkg/ddl/ddl_running_jobs.go
@@ -233,11 +233,23 @@ func (j *runningJobs) addRunning(jobID int64, involves []model.InvolvingSchemaIn
 	}
 }
 
+func (j *runningJobs) removeRunningOrPending(jobID int64, involves []model.InvolvingSchemaInfo, moveToPending bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.removeRunningWithoutLock(jobID, involves)
+	if moveToPending {
+		j.addPendingWithoutLock(involves)
+	}
+}
+
 // removeRunning can be concurrently called with add and checkRunnable.
 func (j *runningJobs) removeRunning(jobID int64, involves []model.InvolvingSchemaInfo) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
+	j.removeRunningWithoutLock(jobID, involves)
+}
 
+func (j *runningJobs) removeRunningWithoutLock(jobID int64, involves []model.InvolvingSchemaInfo) {
 	if intest.InTest {
 		if _, ok := j.ids[jobID]; !ok {
 			panic(fmt.Sprintf("job %d is not running", jobID))
@@ -296,6 +308,10 @@ func (j *runningJobs) addPending(involves []model.InvolvingSchemaInfo) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
+	j.addPendingWithoutLock(involves)
+}
+
+func (j *runningJobs) addPendingWithoutLock(involves []model.InvolvingSchemaInfo) {
 	for _, info := range involves {
 		if info.Database != model.InvolvingNone {
 			if _, ok := j.pending.schemas[info.Database]; !ok {

--- a/pkg/ddl/ddl_running_jobs.go
+++ b/pkg/ddl/ddl_running_jobs.go
@@ -233,7 +233,7 @@ func (j *runningJobs) addRunning(jobID int64, involves []model.InvolvingSchemaIn
 	}
 }
 
-func (j *runningJobs) removeRunningOrPending(jobID int64, involves []model.InvolvingSchemaInfo, moveToPending bool) {
+func (j *runningJobs) finishOrPendJob(jobID int64, involves []model.InvolvingSchemaInfo, moveToPending bool) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	j.removeRunningWithoutLock(jobID, involves)

--- a/pkg/ddl/ddl_worker_test.go
+++ b/pkg/ddl/ddl_worker_test.go
@@ -135,7 +135,7 @@ func TestParallelDDL(t *testing.T) {
 	}
 
 	once1 := sync.Once{}
-	tc.OnGetJobBeforeExported = func(string) {
+	tc.OnGetJobBeforeExported = func() {
 		once1.Do(func() {
 			for {
 				tk := testkit.NewTestKit(t, store)

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -185,51 +185,47 @@ func (s *jobScheduler) close() {
 }
 
 // getJob reads tidb_ddl_job and returns the first runnable DDL job.
-func (s *jobScheduler) getJob(se *sess.Session, tp jobType) (*model.Job, error) {
+func (s *jobScheduler) getJob(se *sess.Session) (*model.Job, bool, error) {
 	defer s.runningJobs.resetAllPending()
 
-	not := "not"
-	label := "get_job_general"
-	if tp == jobTypeReorg {
-		not = ""
-		label = "get_job_reorg"
-	}
-	const getJobSQL = `select job_meta, processing from mysql.tidb_ddl_job where job_id in
+	const getJobSQL = `select job_meta, processing, reorg from mysql.tidb_ddl_job where job_id in
 		(select min(job_id) from mysql.tidb_ddl_job group by schema_ids, table_ids, processing)
-		and %s reorg %s order by processing desc, job_id`
+		%s order by processing desc, job_id`
 	var excludedJobIDs string
 	if ids := s.runningJobs.allIDs(); len(ids) > 0 {
 		excludedJobIDs = fmt.Sprintf("and job_id not in (%s)", ids)
 	}
-	sql := fmt.Sprintf(getJobSQL, not, excludedJobIDs)
-	rows, err := se.Execute(context.Background(), sql, label)
+	sql := fmt.Sprintf(getJobSQL, excludedJobIDs)
+	rows, err := se.Execute(context.Background(), sql, "get_job")
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, false, errors.Trace(err)
 	}
 	for _, row := range rows {
 		jobBinary := row.GetBytes(0)
 		isJobProcessing := row.GetInt64(1) == 1
+		isReorg := row.GetInt64(2) != 0
 
 		job := model.Job{}
 		err = job.Decode(jobBinary)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, isReorg, errors.Trace(err)
 		}
 
+		involving := job.GetInvolvingSchemaInfo()
 		isRunnable, err := s.processJobDuringUpgrade(se, &job)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, isReorg, errors.Trace(err)
 		}
 		if !isRunnable {
+			s.runningJobs.addPending(involving)
 			continue
 		}
 
 		// The job has already been picked up, just return to continue it.
 		if isJobProcessing {
-			return &job, nil
+			return &job, isReorg, nil
 		}
 
-		involving := job.GetInvolvingSchemaInfo()
 		if !s.runningJobs.checkRunnable(job.ID, involving) {
 			s.runningJobs.addPending(involving)
 			continue
@@ -241,11 +237,11 @@ func (s *jobScheduler) getJob(se *sess.Session, tp jobType) (*model.Job, error) 
 				zap.Error(err),
 				zap.Stringer("job", &job))
 			s.runningJobs.addPending(involving)
-			return nil, errors.Trace(err)
+			return nil, isReorg, errors.Trace(err)
 		}
-		return &job, nil
+		return &job, isReorg, nil
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 func hasSysDB(job *model.Job) bool {
@@ -394,8 +390,7 @@ func (s *jobScheduler) startDispatch() error {
 			continue
 		}
 		failpoint.InjectCall("beforeAllLoadDDLJobAndRun")
-		s.loadDDLJobAndRun(se, s.generalDDLWorkerPool, jobTypeGeneral)
-		s.loadDDLJobAndRun(se, s.reorgWorkerPool, jobTypeReorg)
+		s.loadDDLJobAndRun(se)
 	}
 }
 
@@ -436,30 +431,32 @@ func (s *jobScheduler) checkAndUpdateClusterState(needUpdate bool) error {
 	return nil
 }
 
-func (s *jobScheduler) loadDDLJobAndRun(se *sess.Session, pool *workerPool, tp jobType) {
+func (s *jobScheduler) loadDDLJobAndRun(se *sess.Session) {
+	s.mu.RLock()
+	s.mu.hook.OnGetJobBefore()
+	s.mu.RUnlock()
+
+	startTime := time.Now()
+	job, isReorg, err := s.getJob(se)
+	if job == nil || err != nil {
+		if err != nil {
+			logutil.DDLLogger().Warn("get job met error", zap.Duration("take time", time.Since(startTime)), zap.Error(err))
+		}
+		return
+	}
+	s.mu.RLock()
+	s.mu.hook.OnGetJobAfter(job)
+	s.mu.RUnlock()
+
+	pool := s.generalDDLWorkerPool
+	if isReorg {
+		pool = s.reorgWorkerPool
+	}
 	wk, err := pool.get()
 	if err != nil || wk == nil {
 		logutil.DDLLogger().Debug(fmt.Sprintf("[ddl] no %v worker available now", pool.tp()), zap.Error(err))
 		return
 	}
-
-	s.mu.RLock()
-	s.mu.hook.OnGetJobBefore(pool.tp().String())
-	s.mu.RUnlock()
-
-	startTime := time.Now()
-	job, err := s.getJob(se, tp)
-	if job == nil || err != nil {
-		if err != nil {
-			wk.jobLogger(job).Warn("get job met error", zap.Duration("take time", time.Since(startTime)), zap.Error(err))
-		}
-		pool.put(wk)
-		return
-	}
-	s.mu.RLock()
-	s.mu.hook.OnGetJobAfter(pool.tp().String(), job)
-	s.mu.RUnlock()
-
 	s.delivery2Worker(wk, pool, job)
 }
 
@@ -526,10 +523,15 @@ func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.
 	jobID, involvedSchemaInfos := job.ID, job.GetInvolvingSchemaInfo()
 	s.runningJobs.addRunning(jobID, involvedSchemaInfos)
 	metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Inc()
-	s.wg.RunWithLog(func() {
+	s.wg.Run(func() {
 		defer func() {
+			r := recover()
+			if r != nil {
+				logutil.DDLLogger().Error("panic in delivery2Worker", zap.Any("recover", r), zap.Stack("stack"))
+			}
 			failpoint.InjectCall("afterDelivery2Worker", job)
-			s.runningJobs.removeRunning(jobID, involvedSchemaInfos)
+			moveRunningJobsToPending := r != nil || job.IsPaused()
+			s.runningJobs.removeRunningOrPending(jobID, involvedSchemaInfos, moveRunningJobsToPending)
 			asyncNotify(s.ddlJobNotifyCh)
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()
 			pool.put(wk)

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -530,7 +530,7 @@ func (s *jobScheduler) delivery2Worker(wk *worker, pool *workerPool, job *model.
 				logutil.DDLLogger().Error("panic in delivery2Worker", zap.Any("recover", r), zap.Stack("stack"))
 			}
 			failpoint.InjectCall("afterDelivery2Worker", job)
-			moveRunningJobsToPending := r != nil || job.IsPaused()
+			moveRunningJobsToPending := r != nil || (job != nil && job.IsPaused())
 			s.runningJobs.removeRunningOrPending(jobID, involvedSchemaInfos, moveRunningJobsToPending)
 			asyncNotify(s.ddlJobNotifyCh)
 			metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Dec()

--- a/pkg/ddl/job_table_test.go
+++ b/pkg/ddl/job_table_test.go
@@ -65,7 +65,7 @@ func TestDDLScheduling(t *testing.T) {
 	var wg util.WaitGroupWrapper
 	wg.Add(1)
 	var once sync.Once
-	hook.OnGetJobBeforeExported = func(jobType string) {
+	hook.OnGetJobBeforeExported = func() {
 		once.Do(func() {
 			for i, job := range ddlJobs {
 				wg.Run(func() {
@@ -91,7 +91,7 @@ func TestDDLScheduling(t *testing.T) {
 	}
 
 	record := make([]int64, 0, 16)
-	hook.OnGetJobAfterExported = func(jobType string, job *model.Job) {
+	hook.OnGetJobAfterExported = func(job *model.Job) {
 		// record the job schedule order
 		record = append(record, job.ID)
 	}

--- a/pkg/ddl/tests/adminpause/BUILD.bazel
+++ b/pkg/ddl/tests/adminpause/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     ],
     embed = [":adminpause"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/ddl/util/callback/callback.go
+++ b/pkg/ddl/util/callback/callback.go
@@ -55,8 +55,8 @@ type TestDDLCallback struct {
 	onJobUpdated            func(*model.Job)
 	OnJobUpdatedExported    atomic.Pointer[func(*model.Job)]
 	onWatched               func(ctx context.Context)
-	OnGetJobBeforeExported  func(string)
-	OnGetJobAfterExported   func(string, *model.Job)
+	OnGetJobBeforeExported  func()
+	OnGetJobAfterExported   func(*model.Job)
 	OnJobSchemaStateChanged func(int64)
 
 	OnUpdateReorgInfoExported func(job *model.Job, pid int64)
@@ -146,21 +146,21 @@ func (tc *TestDDLCallback) OnWatched(ctx context.Context) {
 }
 
 // OnGetJobBefore implements Callback.OnGetJobBefore interface.
-func (tc *TestDDLCallback) OnGetJobBefore(jobType string) {
+func (tc *TestDDLCallback) OnGetJobBefore() {
 	if tc.OnGetJobBeforeExported != nil {
-		tc.OnGetJobBeforeExported(jobType)
+		tc.OnGetJobBeforeExported()
 		return
 	}
-	tc.BaseCallback.OnGetJobBefore(jobType)
+	tc.BaseCallback.OnGetJobBefore()
 }
 
 // OnGetJobAfter implements Callback.OnGetJobAfter interface.
-func (tc *TestDDLCallback) OnGetJobAfter(jobType string, job *model.Job) {
+func (tc *TestDDLCallback) OnGetJobAfter(job *model.Job) {
 	if tc.OnGetJobAfterExported != nil {
-		tc.OnGetJobAfterExported(jobType, job)
+		tc.OnGetJobAfterExported(job)
 		return
 	}
-	tc.BaseCallback.OnGetJobAfter(jobType, job)
+	tc.BaseCallback.OnGetJobAfter(job)
 }
 
 // Clone copies the callback and take its reference


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54383, ref #53246

Problem Summary:

|    | session 1                   | session 2                                       | session 3                    |
|----|-----------------------------|-------------------------------------------------|------------------------------|
| t1 | create table t (a int);  OK |                                                 |                              |
| t2 |                             | alter table t modify column a tinyint; -- job 1 |                              |
| t3 | admin pause ddl jobs 1;  OK | Paused                                          |                              |
| t4 |                             | Paused                                          | alter table t add column c int; |
|    |                             |                                                 | // Should be blocked!        |

As the table shown above, we run `add column` when the previous job `modify column` is not finished. This is unexpected because they reference the same table.

### What changed and how does it work?

This PR moves the unfinished jobs to pending jobs after `delivery2Worker()` complete, in order to prevent `getJob()` obtaining new jobs that affect the same table.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
