### PR TITLE
infoschema: fix a data race on infoschema v2 addSpecialDB()

### DIFF
--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -106,7 +106,7 @@ type Data struct {
 	}
 
 	// For information_schema/metrics_schema/performance_schema etc
-	specials map[string]*schemaTables
+	specials sync.Map
 
 	// pid2tid is used by FindTableInfoByPartitionID, it stores {partitionID, schemaVersion} => table ID
 	// Need full data in memory!
@@ -184,7 +184,6 @@ func NewData() *Data {
 		schemaMap:         btree.NewBTreeG[schemaItem](compareSchemaItem),
 		schemaID2Name:     btree.NewBTreeG[schemaIDName](compareSchemaByID),
 		tableCache:        newSieve[tableCacheKey, table.Table](1024 * 1024 * size.MB),
-		specials:          make(map[string]*schemaTables),
 		pid2tid:           btree.NewBTreeG[partitionItem](comparePartitionItem),
 		tableInfoResident: btree.NewBTreeG[tableInfoItem](compareTableInfoItem),
 	}
@@ -223,7 +222,7 @@ func (isd *Data) add(item tableItem, tbl table.Table) {
 }
 
 func (isd *Data) addSpecialDB(di *model.DBInfo, tables *schemaTables) {
-	isd.specials[di.Name.L] = tables
+	isd.specials.LoadOrStore(di.Name.L, tables)
 }
 
 func (isd *Data) addDB(schemaVersion int64, dbInfo *model.DBInfo) {
@@ -410,7 +409,8 @@ func (is *infoschemaV2) tableByID(id int64, noRefill bool) (val table.Table, ok 
 	}
 
 	if isTableVirtual(id) {
-		if schTbls, exist := is.Data.specials[itm.dbName]; exist {
+		if raw, exist := is.Data.specials.Load(itm.dbName); exist {
+			schTbls := raw.(*schemaTables)
 			val, ok = schTbls.tables[itm.tableName]
 			return
 		}
@@ -446,7 +446,8 @@ func isSpecialDB(dbName string) bool {
 
 func (is *infoschemaV2) TableByName(schema, tbl model.CIStr) (t table.Table, err error) {
 	if isSpecialDB(schema.L) {
-		if tbNames, ok := is.specials[schema.L]; ok {
+		if raw, ok := is.specials.Load(schema.L); ok {
+			tbNames := raw.(*schemaTables)
 			if t, ok = tbNames.tables[tbl.L]; ok {
 				return
 			}
@@ -500,12 +501,16 @@ func (is *infoschemaV2) TableInfoByID(id int64) (*model.TableInfo, bool) {
 // SchemaTableInfos implements InfoSchema.FindTableInfoByPartitionID
 func (is *infoschemaV2) SchemaTableInfos(schema model.CIStr) []*model.TableInfo {
 	if isSpecialDB(schema.L) {
-		schTbls := is.Data.specials[schema.L]
-		tables := make([]table.Table, 0, len(schTbls.tables))
-		for _, tbl := range schTbls.tables {
-			tables = append(tables, tbl)
+		raw, ok := is.Data.specials.Load(schema.L)
+		if ok {
+			schTbls := raw.(*schemaTables)
+			tables := make([]table.Table, 0, len(schTbls.tables))
+			for _, tbl := range schTbls.tables {
+				tables = append(tables, tbl)
+			}
+			return getTableInfoList(tables)
 		}
-		return getTableInfoList(tables)
+		return nil // something wrong?
 	}
 
 retry:
@@ -546,7 +551,12 @@ func (is *infoschemaV2) FindTableInfoByPartitionID(
 
 func (is *infoschemaV2) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok bool) {
 	if isSpecialDB(schema.L) {
-		return is.Data.specials[schema.L].dbInfo, true
+		raw, ok := is.Data.specials.Load(schema.L)
+		if !ok {
+			return nil, false
+		}
+		schTbls, ok := raw.(*schemaTables)
+		return schTbls.dbInfo, ok
 	}
 
 	var dbInfo model.DBInfo
@@ -590,9 +600,11 @@ func (is *infoschemaV2) allSchemas(visit func(*model.DBInfo)) {
 		}
 		return true
 	})
-	for _, sc := range is.Data.specials {
+	is.Data.specials.Range(func(key, value any) bool {
+		sc := value.(*schemaTables)
 		visit(sc.dbInfo)
-	}
+		return true
+	})
 }
 
 func (is *infoschemaV2) AllSchemas() (schemas []*model.DBInfo) {
@@ -671,13 +683,19 @@ func (is *infoschemaV2) TableExists(schema, table model.CIStr) bool {
 
 func (is *infoschemaV2) SchemaByID(id int64) (*model.DBInfo, bool) {
 	if isTableVirtual(id) {
-		for _, st := range is.Data.specials {
+		var st *schemaTables
+		is.Data.specials.Range(func(key, value any) bool {
 			if st.dbInfo.ID == id {
-				return st.dbInfo, true
+				// return st.dbInfo, true
+				st = value.(*schemaTables)
+				return false
 			}
+			return true
+		})
+		if st == nil {
+			return nil, false
 		}
-		// Something wrong?
-		return nil, false
+		return st.dbInfo, true
 	}
 	var ok bool
 	var name string
@@ -706,12 +724,15 @@ func (is *infoschemaV2) SchemaByID(id int64) (*model.DBInfo, bool) {
 
 func (is *infoschemaV2) SchemaTables(schema model.CIStr) (tables []table.Table) {
 	if isSpecialDB(schema.L) {
-		schTbls := is.Data.specials[schema.L]
-		tables := make([]table.Table, 0, len(schTbls.tables))
-		for _, tbl := range schTbls.tables {
-			tables = append(tables, tbl)
+		raw, ok := is.Data.specials.Load(schema.L)
+		if ok {
+			schTbls := raw.(*schemaTables)
+			tables := make([]table.Table, 0, len(schTbls.tables))
+			for _, tbl := range schTbls.tables {
+				tables = append(tables, tbl)
+			}
+			return tables
 		}
-		return tables
 	}
 
 retry:

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -685,9 +685,9 @@ func (is *infoschemaV2) SchemaByID(id int64) (*model.DBInfo, bool) {
 	if isTableVirtual(id) {
 		var st *schemaTables
 		is.Data.specials.Range(func(key, value any) bool {
-			if st.dbInfo.ID == id {
-				// return st.dbInfo, true
-				st = value.(*schemaTables)
+			tmp := value.(*schemaTables)
+			if tmp.dbInfo.ID == id {
+				st = tmp
 				return false
 			}
 			return true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54423

Problem Summary:

### What changed and how does it work?

Infoschema V2 *Data is a shared object, use sync.Map to replace builtin map to avoid data race.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
