### PR TITLE
executor: some minor refine for hash join v2 build

### DIFF
--- a/pkg/executor/join/BUILD.bazel
+++ b/pkg/executor/join/BUILD.bazel
@@ -79,7 +79,7 @@ go_test(
     ],
     embed = [":join"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/join/hash_table_v2_test.go
+++ b/pkg/executor/join/hash_table_v2_test.go
@@ -33,12 +33,12 @@ func createMockRowTable(maxRowsPerSeg int, segmentCount int, fixedSize bool) *ro
 		meta: nil,
 	}
 	for i := 0; i < segmentCount; i++ {
-		rowSeg := newRowTableSegment()
 		// no empty segment is allowed
 		rows := maxRowsPerSeg
 		if !fixedSize {
 			rows = int(rand.Int31n(int32(maxRowsPerSeg)) + 1)
 		}
+		rowSeg := newRowTableSegment(uint(rows))
 		rowSeg.rawData = make([]byte, rows)
 		for j := 0; j < rows; j++ {
 			rowSeg.rowStartOffset = append(rowSeg.rowStartOffset, uint64(j))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127

Problem Summary:

### What changed and how does it work?
1. During hash join v2 build, it will pre-allocate maxRowTableSegmentSize(which is 1024) rows for a new rowTableSegment
https://github.com/pingcap/tidb/blob/634ac69d272f117a0abea52f32a860e0078c0611/pkg/executor/join/join_row_table.go#L87-L95
For small queries, it is a waste to pre allocate so many memories and may hurt the performance in high concurrency scenarios.
In this pr, when constructing a new rowTableSegment, it will use `chunk_row_number/partition_number * 1.2` as the row size hint for the first rowTableSegment, but still use maxRowTableSegmentSize as the row size hint for the following rowTableSegment.

2. Add `maxRowTableSegmentByteSize` to control the max memory size of a rowTableSegment.
3. Since rowTableSegment saves `rowStartOffset` directly, there is no need to save row offset in `builder.startPosInRawData`, so remove `startPosInRawData` in `rowTableBuilder`
4. rename `crrntSizeOfRowTable` to `rowNumberInCurrentRowTableSeg`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
