### PR TITLE
table: provide some binlog related methods for binlog in `MutateContext`

### DIFF
--- a/pkg/lightning/backend/kv/session.go
+++ b/pkg/lightning/backend/kv/session.go
@@ -363,7 +363,7 @@ func NewSession(options *encode.SessionOptions, logger log.Logger) *Session {
 		Session:             s,
 		PlanCtxExtendedImpl: planctximpl.NewPlanCtxExtendedImpl(s),
 	}
-	s.tblctx = tbctximpl.NewTableContextImpl(s, s.exprCtx)
+	s.tblctx = tbctximpl.NewTableContextImpl(s)
 	s.txn.kvPairs = &Pairs{}
 
 	return s

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -156,7 +156,7 @@ func TestBootstrapWithError(t *testing.T) {
 		}
 		se.exprctx = contextsession.NewSessionExprContext(se)
 		se.pctx = newPlanContextImpl(se)
-		se.tblctx = tbctximpl.NewTableContextImpl(se, se.exprctx)
+		se.tblctx = tbctximpl.NewTableContextImpl(se)
 		globalVarsAccessor := variable.NewMockGlobalAccessor4Tests()
 		se.GetSessionVars().GlobalVarsAccessor = globalVarsAccessor
 		se.txn.init()

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3701,7 +3701,7 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 	s.sessionVars = variable.NewSessionVars(s)
 	s.exprctx = contextsession.NewSessionExprContext(s)
 	s.pctx = newPlanContextImpl(s)
-	s.tblctx = tbctximpl.NewTableContextImpl(s, s.exprctx)
+	s.tblctx = tbctximpl.NewTableContextImpl(s)
 
 	if opt != nil && opt.PreparedPlanCache != nil {
 		s.sessionPlanCache = opt.PreparedPlanCache
@@ -3764,7 +3764,7 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 	}
 	s.exprctx = contextsession.NewSessionExprContext(s)
 	s.pctx = newPlanContextImpl(s)
-	s.tblctx = tbctximpl.NewTableContextImpl(s, s.exprctx)
+	s.tblctx = tbctximpl.NewTableContextImpl(s)
 	s.mu.values = make(map[fmt.Stringer]any)
 	s.lockedTables = make(map[int64]model.TableLockTpInfo)
 	domain.BindDomain(s, dom)

--- a/pkg/table/context/buffers.go
+++ b/pkg/table/context/buffers.go
@@ -80,10 +80,15 @@ func (b *EncodeRowBuffer) WriteMemBufferEncoded(
 	return memBuffer.SetWithFlags(key, encoded, flags...)
 }
 
-// GetColDataBuffer returns the buffer for column data.
-// TODO: make sure the inner buffer is not used outside directly.
-func (b *EncodeRowBuffer) GetColDataBuffer() ([]int64, []types.Datum) {
-	return b.colIDs, b.row
+// EncodeBinlogRowData encodes the row data for binlog and returns the encoded row value.
+// The returned slice is not referenced in the buffer, so you can cache and modify them freely.
+func (b *EncodeRowBuffer) EncodeBinlogRowData(loc *time.Location, ec errctx.Context) ([]byte, error) {
+	value, err := tablecodec.EncodeOldRow(loc, b.row, b.colIDs, nil, nil)
+	err = ec.HandleError(err)
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
 }
 
 // CheckRowBuffer is used to check row constraints

--- a/pkg/table/context/table.go
+++ b/pkg/table/context/table.go
@@ -47,13 +47,17 @@ type MutateContext interface {
 	// If the active parameter is true, call this function will wait for the pending txn
 	// to become valid.
 	Txn(active bool) (kv.Transaction, error)
-	// StmtGetMutation gets the binlog mutation for current statement.
-	StmtGetMutation(int64) *binlog.TableMutation
+	// BinlogEnabled returns whether the binlog is enabled.
+	BinlogEnabled() bool
+	// GetBinlogMutation returns a `binlog.TableMutation` object for a table.
+	GetBinlogMutation(tblID int64) *binlog.TableMutation
 	// GetDomainInfoSchema returns the latest information schema in domain
 	GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema
 	// TxnRecordTempTable record the temporary table to the current transaction.
 	// This method will be called when the temporary table is modified or should allocate id in the transaction.
 	TxnRecordTempTable(tbl *model.TableInfo) tableutil.TempTable
+	// InRestrictedSQL returns whether the current context is used in restricted SQL.
+	InRestrictedSQL() bool
 	// GetRowEncodingConfig returns the RowEncodingConfig.
 	GetRowEncodingConfig() RowEncodingConfig
 	// GetMutateBuffers returns the MutateBuffers,

--- a/pkg/table/contextimpl/BUILD.bazel
+++ b/pkg/table/contextimpl/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "contextimpl",
@@ -12,5 +12,21 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/table/context",
         "//pkg/util/tableutil",
+        "@com_github_pingcap_tipb//go-binlog",
+    ],
+)
+
+go_test(
+    name = "contextimpl_test",
+    timeout = "short",
+    srcs = ["table_test.go"],
+    flaky = True,
+    deps = [
+        ":contextimpl",
+        "//pkg/sessionctx/binloginfo",
+        "//pkg/testkit",
+        "//pkg/util/mock",
+        "@com_github_pingcap_tipb//go-binlog",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/table/contextimpl/table_test.go
+++ b/pkg/table/contextimpl/table_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contextimpl_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/sessionctx/binloginfo"
+	"github.com/pingcap/tidb/pkg/table/contextimpl"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/pingcap/tipb/go-binlog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutateContextImplFields(t *testing.T) {
+	sctx := mock.NewContext()
+	sctx.Mutations = make(map[int64]*binlog.TableMutation)
+	ctx := contextimpl.NewTableContextImpl(sctx)
+	// expression
+	require.True(t, sctx.GetExprCtx() == ctx.GetExprCtx())
+	// binlog
+	sctx.GetSessionVars().BinlogClient = nil
+	require.False(t, ctx.BinlogEnabled())
+	sctx.GetSessionVars().BinlogClient = binloginfo.MockPumpsClient(&testkit.MockPumpClient{})
+	require.True(t, ctx.BinlogEnabled())
+	binlogMutation := ctx.GetBinlogMutation(1234)
+	require.NotNil(t, binlogMutation)
+	require.Same(t, sctx.StmtGetMutation(1234), binlogMutation)
+	// restricted SQL
+	sctx.GetSessionVars().StmtCtx.InRestrictedSQL = false
+	require.False(t, ctx.InRestrictedSQL())
+	sctx.GetSessionVars().StmtCtx.InRestrictedSQL = true
+	require.True(t, ctx.InRestrictedSQL())
+	// encoding config
+	sctx.GetSessionVars().EnableRowLevelChecksum = true
+	sctx.GetSessionVars().RowEncoder.Enable = true
+	sctx.GetSessionVars().InRestrictedSQL = false
+	cfg := ctx.GetRowEncodingConfig()
+	require.True(t, cfg.IsRowLevelChecksumEnabled)
+	require.Equal(t, sctx.GetSessionVars().IsRowLevelChecksumEnabled(), cfg.IsRowLevelChecksumEnabled)
+	require.True(t, cfg.IsRowLevelChecksumEnabled)
+	require.Same(t, &sctx.GetSessionVars().RowEncoder, cfg.RowEncoder)
+	sctx.GetSessionVars().RowEncoder.Enable = false
+	cfg = ctx.GetRowEncodingConfig()
+	require.False(t, cfg.IsRowLevelChecksumEnabled)
+	require.Equal(t, sctx.GetSessionVars().IsRowLevelChecksumEnabled(), cfg.IsRowLevelChecksumEnabled)
+	require.Same(t, &sctx.GetSessionVars().RowEncoder, cfg.RowEncoder)
+	require.False(t, cfg.IsRowLevelChecksumEnabled)
+	sctx.GetSessionVars().RowEncoder.Enable = true
+	sctx.GetSessionVars().InRestrictedSQL = true
+	require.Equal(t, sctx.GetSessionVars().IsRowLevelChecksumEnabled(), cfg.IsRowLevelChecksumEnabled)
+	require.False(t, cfg.IsRowLevelChecksumEnabled)
+	sctx.GetSessionVars().InRestrictedSQL = false
+	sctx.GetSessionVars().EnableRowLevelChecksum = false
+	require.Equal(t, sctx.GetSessionVars().IsRowLevelChecksumEnabled(), cfg.IsRowLevelChecksumEnabled)
+	// mutate buffers
+	require.NotNil(t, ctx.GetMutateBuffers())
+}

--- a/pkg/table/tables/BUILD.bazel
+++ b/pkg/table/tables/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/table",
+        "//pkg/table/context",
         "//pkg/tablecodec",
         "//pkg/types",
         "//pkg/util",

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -68,6 +68,7 @@ type Context struct {
 	sm            util.SessionManager
 	is            infoschema.MetaOnlyInfoSchema
 	values        map[fmt.Stringer]any
+	Mutations     map[int64]*binlog.TableMutation
 	sessionVars   *variable.SessionVars
 	tblctx        *tbctximpl.TableContextImpl
 	cancel        context.CancelFunc
@@ -480,8 +481,16 @@ func (*Context) StmtCommit(context.Context) {}
 func (*Context) StmtRollback(context.Context, bool) {}
 
 // StmtGetMutation implements the sessionctx.Context interface.
-func (*Context) StmtGetMutation(_ int64) *binlog.TableMutation {
-	return nil
+func (c *Context) StmtGetMutation(tblID int64) *binlog.TableMutation {
+	if c.Mutations == nil {
+		return nil
+	}
+	m, ok := c.Mutations[tblID]
+	if !ok {
+		m = &binlog.TableMutation{}
+		c.Mutations[tblID] = m
+	}
+	return m
 }
 
 // AddTableLock implements the sessionctx.Context interface.
@@ -624,7 +633,7 @@ func NewContext() *Context {
 	vars := variable.NewSessionVars(sctx)
 	sctx.sessionVars = vars
 	sctx.SessionExprContext = exprctximpl.NewSessionExprContext(sctx)
-	sctx.tblctx = tbctximpl.NewTableContextImpl(sctx, sctx)
+	sctx.tblctx = tbctximpl.NewTableContextImpl(sctx)
 	vars.InitChunkSize = 2
 	vars.MaxChunkSize = 32
 	vars.TimeZone = time.UTC


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54392, ref #54397

### What changed and how does it work?

- Add a new method `EncodeBinlogRowData` to `EncodeRowBuffer` to encode row data for binlog. And remove method `GetColDataBuffer` to ensure the inner slices are private. 
- Add `BinlogEnabled` and `GetBinlogMutation` to remove some references of `SessionVars` in `MutateContext`.
- Add some unit tests

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
