### PR TITLE
planner: refactor a few code of plan cache

### DIFF
--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -303,7 +303,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 
 	// check whether this plan is cacheable.
 	if stmtCtx.UseCache() {
-		if cacheable, reason := isPlanCacheable(sctx.GetPlanCtx(), p, len(matchOpts.ParamTypes), len(matchOpts.LimitOffsetAndCount), matchOpts.HasSubQuery); !cacheable {
+		if cacheable, reason := isPlanCacheable(sctx.GetPlanCtx(), p, len(matchOpts.ParamTypes), len(matchOpts.LimitOffsetAndCount), stmt.QueryFeatures.hasSubquery); !cacheable {
 			stmtCtx.SetSkipPlanCache(reason)
 		}
 	}

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -319,6 +319,30 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 	hash = append(hash, hack.Slice(strconv.FormatBool(variable.VarTiDBSuperReadOnly.Load()))...)
 	// expr-pushdown-blacklist can affect query optimization, so we need to consider it in plan cache.
 	hash = codec.EncodeInt(hash, expression.ExprPushDownBlackListReloadTimeStamp.Load())
+	if sctx.GetSessionVars().ForeignKeyChecks {
+		hash = append(hash, '1')
+	} else {
+		hash = append(hash, '0')
+	}
+
+	// stats version can affect the Plan
+	if sctx.GetSessionVars().PlanCacheInvalidationOnFreshStats {
+		var statsVerHash uint64
+		for _, t := range stmt.tbls {
+			statsVerHash += getLatestVersionFromStatsTable(sctx, t.Meta(), t.Meta().ID) // use '+' as the hash function for simplicity
+		}
+		hash = codec.EncodeUint(hash, statsVerHash)
+	}
+
+	// whether this query has sub-query can affect the plan cache
+	if sctx.GetSessionVars().EnablePlanCacheForSubquery {
+		if stmt.QueryFeatures.hasSubquery {
+			hash = append(hash, '1')
+		} else {
+			hash = append(hash, '0')
+		}
+	}
+
 	dirtyTables := vars.StmtCtx.TblInfo2UnionScan
 	if len(dirtyTables) > 0 {
 		dirtyTableIDs := make([]int64, 0, len(dirtyTables)) // TODO: a Pool for this
@@ -414,13 +438,6 @@ type PlanCacheMatchOpts struct {
 	// limitOffsetAndCount stores all the offset and key parameters extract from limit statement
 	// only used for cache and pick plan with parameters in limit
 	LimitOffsetAndCount []uint64
-	// HasSubQuery indicate whether this query has sub query
-	HasSubQuery bool
-	// StatsVersionHash is the hash value of the statistics version
-	StatsVersionHash uint64
-
-	// Below are some variables that can affect the plan
-	ForeignKeyChecks bool
 }
 
 // PlanCacheQueryFeatures records all query features which may affect plan selection.
@@ -524,18 +541,9 @@ func GetPreparedStmt(stmt *ast.ExecuteStmt, vars *variable.SessionVars) (*PlanCa
 // GetMatchOpts get options to fetch plan or generate new plan
 // we can add more options here
 func GetMatchOpts(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt, params []expression.Expression) *PlanCacheMatchOpts {
-	var statsVerHash uint64
 	var limitOffsetAndCount []uint64
 
 	if stmt.QueryFeatures != nil {
-		for _, node := range stmt.QueryFeatures.tables {
-			t, err := is.TableByName(node.Schema, node.Name)
-			if err != nil { // CTE in this case
-				continue
-			}
-			statsVerHash += getLatestVersionFromStatsTable(sctx, t.Meta(), t.Meta().ID) // use '+' as the hash function for simplicity
-		}
-
 		for _, node := range stmt.QueryFeatures.limits {
 			if node.Count != nil {
 				if count, isParamMarker := node.Count.(*driver.ParamMarkerExpr); isParamMarker {
@@ -566,10 +574,7 @@ func GetMatchOpts(sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanC
 
 	return &PlanCacheMatchOpts{
 		LimitOffsetAndCount: limitOffsetAndCount,
-		HasSubQuery:         stmt.QueryFeatures.hasSubquery,
-		StatsVersionHash:    statsVerHash,
 		ParamTypes:          parseParamTypes(sctx, params),
-		ForeignKeyChecks:    sctx.GetSessionVars().ForeignKeyChecks,
 	}
 }
 
@@ -723,21 +728,6 @@ func matchCachedPlan(sctx sessionctx.Context, value *PlanCacheValue, matchOpts *
 	}
 	if len(value.matchOpts.LimitOffsetAndCount) > 0 && !sctx.GetSessionVars().EnablePlanCacheForParamLimit {
 		// offset and key slice matched, but it is a plan with param limit and the switch is disabled
-		return false
-	}
-	// check subquery switch state
-	if value.matchOpts.HasSubQuery && !sctx.GetSessionVars().EnablePlanCacheForSubquery {
-		return false
-	}
-
-	// table stats has changed
-	// this check can be disabled by turning off system variable tidb_plan_cache_invalidation_on_fresh_stats
-	if sctx.GetSessionVars().PlanCacheInvalidationOnFreshStats &&
-		value.matchOpts.StatsVersionHash != matchOpts.StatsVersionHash {
-		return false
-	}
-	// below are some SQL variables that can affect the plan
-	if value.matchOpts.ForeignKeyChecks != matchOpts.ForeignKeyChecks {
 		return false
 	}
 	return true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54057

Problem Summary: planner: refactor a few code of plan cache

### What changed and how does it work?

Add table dirty flags into the plan cache key

No regression

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
