### PR TITLE
statistics: init LastAnalyzeVersion with snapshot timestamp

### DIFF
--- a/pkg/statistics/analyze.go
+++ b/pkg/statistics/analyze.go
@@ -88,6 +88,7 @@ type AnalyzeResults struct {
 	TableID  AnalyzeTableID
 	Count    int64
 	StatsVer int
+	// Snapshot is the snapshot timestamp when we start the analysis job.
 	Snapshot uint64
 	// BaseCount is the original count in mysql.stats_meta at the beginning of analyze.
 	BaseCount int64

--- a/pkg/statistics/handle/autoanalyze/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/BUILD.bazel
@@ -35,9 +35,10 @@ go_test(
     timeout = "short",
     srcs = ["autoanalyze_test.go"],
     flaky = True,
-    shard_count = 13,
+    shard_count = 14,
     deps = [
         ":autoanalyze",
+        "//pkg/domain",
         "//pkg/domain/infosync",
         "//pkg/parser/model",
         "//pkg/parser/mysql",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -137,11 +137,11 @@ func TestDisableAutoAnalyze(t *testing.T) {
 	disableAutoAnalyzeCase(t, tk, dom)
 }
 
-func TestDisableAutoAnalyzeWithoutAnyPredicateColumns(t *testing.T) {
+func TestDisableAutoAnalyzeWithAnalyzeAllColumnsOptions(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
-	// Set tidb_analyze_column_options to PREDICATE.
-	tk.MustExec("set global tidb_analyze_column_options='PREDICATE'")
+	// Set tidb_analyze_column_options to ALL.
+	tk.MustExec("set global tidb_analyze_column_options='ALL'")
 	disableAutoAnalyzeCase(t, tk, dom)
 }
 

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -73,11 +73,22 @@ func (h *Handle) initStatsMeta4Chunk(ctx context.Context, is infoschema.InfoSche
 		maxPhysicalID = max(physicalID, maxPhysicalID)
 		tableInfo := table.Meta()
 		newHistColl := *statistics.NewHistColl(physicalID, true, row.GetInt64(3), row.GetInt64(2), 4, 4)
+		snapshot := row.GetUint64(4)
 		tbl := &statistics.Table{
 			HistColl:              newHistColl,
 			Version:               row.GetUint64(0),
 			ColAndIdxExistenceMap: statistics.NewColAndIndexExistenceMap(len(tableInfo.Columns), len(tableInfo.Indices)),
 			IsPkIsHandle:          tableInfo.PKIsHandle,
+			// During the initialization phase, we need to initialize LastAnalyzeVersion with snapshots,
+			// which ensures that we don't duplicate the auto-analyze of a particular type of table.
+			// When the predicate columns feature is turned on, if a table has neither predicate columns nor an index,
+			// then auto-analyze will only analyze the _row_id and refresh stats_meta,
+			// but since we don't have any histograms or topn's created for _row_id at the moment.
+			// So if we don't initialize LastAnalyzeVersion with a snapshot here,
+			// it will stay at 0 and auto-analyze won't be able to detect that the table has been analyzed.
+			// But in the future, we maybe will create some records for _row_id, see:
+			// https://github.com/pingcap/tidb/issues/51098
+			LastAnalyzeVersion: snapshot,
 		}
 		cache.Put(physicalID, tbl) // put this table again since it is updated
 	}
@@ -90,7 +101,7 @@ func (h *Handle) initStatsMeta4Chunk(ctx context.Context, is infoschema.InfoSche
 
 func (h *Handle) initStatsMeta(ctx context.Context, is infoschema.InfoSchema) (statstypes.StatsCache, error) {
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnStats)
-	sql := "select HIGH_PRIORITY version, table_id, modify_count, count from mysql.stats_meta"
+	sql := "select HIGH_PRIORITY version, table_id, modify_count, count, snapshot from mysql.stats_meta"
 	rc, err := util.Exec(h.initStatsCtx, sql)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -79,12 +79,12 @@ func (h *Handle) initStatsMeta4Chunk(ctx context.Context, is infoschema.InfoSche
 			Version:               row.GetUint64(0),
 			ColAndIdxExistenceMap: statistics.NewColAndIndexExistenceMap(len(tableInfo.Columns), len(tableInfo.Indices)),
 			IsPkIsHandle:          tableInfo.PKIsHandle,
-			// During the initialization phase, we need to initialize LastAnalyzeVersion with snapshots,
+			// During the initialization phase, we need to initialize LastAnalyzeVersion with the snapshot,
 			// which ensures that we don't duplicate the auto-analyze of a particular type of table.
-			// When the predicate columns feature is turned on, if a table has neither predicate columns nor an index,
+			// When the predicate columns feature is turned on, if a table has neither predicate columns nor indexes,
 			// then auto-analyze will only analyze the _row_id and refresh stats_meta,
 			// but since we don't have any histograms or topn's created for _row_id at the moment.
-			// So if we don't initialize LastAnalyzeVersion with a snapshot here,
+			// So if we don't initialize LastAnalyzeVersion with the snapshot here,
 			// it will stay at 0 and auto-analyze won't be able to detect that the table has been analyzed.
 			// But in the future, we maybe will create some records for _row_id, see:
 			// https://github.com/pingcap/tidb/issues/51098

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -74,7 +74,7 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) e
 	if err := util.CallWithSCtx(s.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		rows, _, err = util.ExecRows(
 			sctx,
-			"SELECT version, table_id, modify_count, count from mysql.stats_meta where version > %? order by version",
+			"SELECT version, table_id, modify_count, count, snapshot from mysql.stats_meta where version > %? order by version",
 			lastVersion,
 		)
 		return err
@@ -90,6 +90,7 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) e
 		physicalID := row.GetInt64(1)
 		modifyCount := row.GetInt64(2)
 		count := row.GetInt64(3)
+		snapshot := row.GetUint64(4)
 
 		// Detect the context cancel signal, since it may take a long time for the loop.
 		// TODO: add context to TableInfoByID and remove this code block?
@@ -136,6 +137,16 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) e
 		tbl.RealtimeCount = count
 		tbl.ModifyCount = modifyCount
 		tbl.TblInfoUpdateTS = tableInfo.UpdateTS
+		// It only occurs in the following situations:
+		// 1. The table has already been analyzed,
+		//	but because the predicate columns feature is turned on, and it doesn't have any columns or indexes analyzed,
+		//	it only analyzes _row_id and refreshes stats_meta, in which case the snapshot is not zero.
+		// 2. LastAnalyzeVersion is 0 because it has never been loaded.
+		// In this case, we can initialise LastAnalyzeVersion to a snapshot,
+		//	otherwise auto-analyze will think that the table has never been analyzed and try to analyze it again.
+		if tbl.LastAnalyzeVersion == 0 && snapshot != 0 {
+			tbl.LastAnalyzeVersion = snapshot
+		}
 		tables = append(tables, tbl)
 	}
 

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -142,8 +142,8 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) e
 		//	but because the predicate columns feature is turned on, and it doesn't have any columns or indexes analyzed,
 		//	it only analyzes _row_id and refreshes stats_meta, in which case the snapshot is not zero.
 		// 2. LastAnalyzeVersion is 0 because it has never been loaded.
-		// In this case, we can initialize LastAnalyzeVersion to a snapshot,
-		//	otherwise auto-analyze will think that the table has never been analyzed and try to analyze it again.
+		// In this case, we can initialize LastAnalyzeVersion to the snapshot,
+		//	otherwise auto-analyze will assume that the table has never been analyzed and try to analyze it again.
 		if tbl.LastAnalyzeVersion == 0 && snapshot != 0 {
 			tbl.LastAnalyzeVersion = snapshot
 		}

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -142,7 +142,7 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) e
 		//	but because the predicate columns feature is turned on, and it doesn't have any columns or indexes analyzed,
 		//	it only analyzes _row_id and refreshes stats_meta, in which case the snapshot is not zero.
 		// 2. LastAnalyzeVersion is 0 because it has never been loaded.
-		// In this case, we can initialise LastAnalyzeVersion to a snapshot,
+		// In this case, we can initialize LastAnalyzeVersion to a snapshot,
 		//	otherwise auto-analyze will think that the table has never been analyzed and try to analyze it again.
 		if tbl.LastAnalyzeVersion == 0 && snapshot != 0 {
 			tbl.LastAnalyzeVersion = snapshot

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -66,7 +66,7 @@ type Table struct {
 	// We used it in auto-analyze to determine if this table has been analyzed.
 	// The source of this field comes from two parts:
 	// 1. Initialized by snapshot when loading stats_meta.
-	// 2. Updated by the analysis time of a more specific column or index when loading the histogram of the column or index.
+	// 2. Updated by the analysis time of a specific column or index when loading the histogram of the column or index.
 	LastAnalyzeVersion uint64
 	// TblInfoUpdateTS is the UpdateTS of the TableInfo used when filling this struct.
 	// It is the schema version of the corresponding table. It is used to skip redundant

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -63,6 +63,10 @@ type Table struct {
 	HistColl
 	Version uint64
 	// It's the timestamp of the last analyze time.
+	// We used it in auto-analyze to determine if this table has been analyzed.
+	// The source of this field comes from two parts:
+	// 1. Initialized by snapshot when loading stats_meta.
+	// 2. Updated by the analysis time of a more specific column or index when loading the histogram of the column or index.
 	LastAnalyzeVersion uint64
 	// TblInfoUpdateTS is the UpdateTS of the TableInfo used when filling this struct.
 	// It is the schema version of the corresponding table. It is used to skip redundant


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/53567

Problem Summary:

It only occurs in the following situations:
1. The table has already been analyzed, but because the predicate columns feature is turned on, and it doesn't have any columns or indexes analyzed, it only analyzes _row_id and refreshes stats_meta, in which case the snapshot is not zero.
2. LastAnalyzeVersion is 0 because this are no histogram(buckets) records for this table at all.

So in this case, the auto-analyze will try to analyze it again and again.

If you find an actual case and attempt to compare the snapshot from stats_meta with the version from the histogram, you will always find that this equation is true.

```sql
+------------------+--------+------------+-----+------------------+
|version           |table_id|modify_count|count|snapshot          |
+------------------+--------+------------+-----+------------------+
|450928595513638913|104     |0           |3000 |450928595500531720|
+------------------+--------+------------+-----+------------------+

+--------+--------+-------+--------------+----------+------------+------------+------------------+---------+---------+----+---------------------+--------------------------------------------------+
|table_id|is_index|hist_id|distinct_count|null_count|tot_col_size|modify_count|version           |cm_sketch|stats_ver|flag|correlation          |last_analyze_pos                                  |
+--------+--------+-------+--------------+----------+------------+------------+------------------+---------+---------+----+---------------------+--------------------------------------------------+
|104     |0       |1      |3000          |0         |24000       |0           |450928595513638913|null     |2        |1   |1                    |com.intellij.database.extractors.TextInfo@efb43b49|
|104     |0       |2      |504           |0         |24000       |0           |450928595513638913|null     |2        |1   |0.026502627833625315 |com.intellij.database.extractors.TextInfo@ee1d8593|
|104     |0       |3      |3000          |0         |363000      |0           |450928595513638913|null     |2        |1   |-0.007597387066376341|com.intellij.database.extractors.TextInfo@53641c4d|
|104     |0       |4      |3000          |0         |180000      |0           |450928595513638913|null     |2        |1   |-0.014492787832531981|com.intellij.database.extractors.TextInfo@f16e0d31|
|104     |1       |1      |504           |0         |24000       |0           |450928595513638913|null     |2        |1   |0                    |0x0380000000000008D1                              |
+--------+--------+-------+--------------+----------+------------+------------+------------------+---------+---------+----+---------------------+--------------------------------------------------+
```

`450928595500531720 - 450928595513638913 = -13,107,193`

So we can safely use the snapshot to initialize the LastAnalyzeVersion.

### What changed and how does it work?

- Initialized LastAnalyzeVersion with snapshot timestamp.
- Added a test case to cover it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/54465#issuecomment-2210172532)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
