### PR TITLE
statistics: avoid frequantly syncing stats simultaneously

### DIFF
--- a/pkg/ddl/tests/partition/db_partition_test.go
+++ b/pkg/ddl/tests/partition/db_partition_test.go
@@ -3012,7 +3012,7 @@ func TestRemoveKeyPartitioning(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	// And also cached and lazy loaded
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery(`show stats_meta where db_name = 'RemovePartitioning' and table_name = 't'`).Sort().CheckAt([]int{0, 1, 2, 4, 5}, [][]any{
 		{"RemovePartitioning", "t", "", "0", "95"}})
 	tk.MustExec(`analyze table t`)
@@ -3058,7 +3058,7 @@ func TestRemoveListPartitioning(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	// And also cached and lazy loaded
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery(`show stats_meta where db_name = 'RemoveListPartitioning' and table_name = 't'`).Sort().CheckAt([]int{0, 1, 2, 4, 5}, [][]any{
 		{"RemoveListPartitioning", "t", "", "0", "95"}})
 	tk.MustExec(`analyze table t`)
@@ -3104,7 +3104,7 @@ func TestRemoveListColumnPartitioning(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	// And also cached and lazy loaded
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery(`show stats_meta where db_name = 'RemoveListPartitioning' and table_name = 't'`).Sort().CheckAt([]int{0, 1, 2, 4, 5}, [][]any{
 		{"RemoveListPartitioning", "t", "", "0", "95"}})
 	tk.MustExec(`analyze table t`)
@@ -3150,7 +3150,7 @@ func TestRemoveListColumnsPartitioning(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	// And also cached and lazy loaded
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery(`show stats_meta where db_name = 'RemoveListPartitioning' and table_name = 't'`).Sort().CheckAt([]int{0, 1, 2, 4, 5}, [][]any{
 		{"RemoveListPartitioning", "t", "", "0", "95"}})
 	tk.MustExec(`analyze table t`)

--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -62,8 +62,12 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle",
+<<<<<<< HEAD
         "//pkg/statistics/handle/autoanalyze",
         "//pkg/statistics/handle/initstats",
+=======
+        "//pkg/statistics/handle/cache",
+>>>>>>> 189e9fb66b (statistics: avoid frequantly syncing stats simultaneously)
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/util",
         "//pkg/store/helper",

--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -62,12 +62,9 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle",
-<<<<<<< HEAD
         "//pkg/statistics/handle/autoanalyze",
-        "//pkg/statistics/handle/initstats",
-=======
         "//pkg/statistics/handle/cache",
->>>>>>> 189e9fb66b (statistics: avoid frequantly syncing stats simultaneously)
+        "//pkg/statistics/handle/initstats",
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/util",
         "//pkg/store/helper",

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -69,12 +69,9 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/sysproctrack"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/handle"
-<<<<<<< HEAD
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze"
-	"github.com/pingcap/tidb/pkg/statistics/handle/initstats"
-=======
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache"
->>>>>>> 189e9fb66b (statistics: avoid frequantly syncing stats simultaneously)
+	"github.com/pingcap/tidb/pkg/statistics/handle/initstats"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/store/helper"

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -69,8 +69,12 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/sysproctrack"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/handle"
+<<<<<<< HEAD
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze"
 	"github.com/pingcap/tidb/pkg/statistics/handle/initstats"
+=======
+	"github.com/pingcap/tidb/pkg/statistics/handle/cache"
+>>>>>>> 189e9fb66b (statistics: avoid frequantly syncing stats simultaneously)
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/store/helper"
@@ -2297,6 +2301,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 		return nil
 	}
 	do.SetStatsUpdating(true)
+	do.wg.Run(func() { do.syncStatsWorker() }, "syncStatsWorker")
 	// The stats updated worker doesn't require the stats initialization to be completed.
 	// This is because the updated worker's primary responsibilities are to update the change delta and handle DDL operations.
 	// These tasks do not interfere with or depend on the initialization process.
@@ -2357,6 +2362,29 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 func quitStatsOwner(do *Domain, mgr owner.Manager) {
 	<-do.exit
 	mgr.Cancel()
+}
+
+func (do *Domain) syncStatsWorker() {
+	defer util.Recover(metrics.LabelDomain, "syncStatsWorker", nil, false)
+	logutil.BgLogger().Info("syncStatsWorker started.")
+	defer func() {
+		logutil.BgLogger().Info("syncStatsWorker exited.")
+	}()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	do.cancelFns.mu.Lock()
+	do.cancelFns.fns = append(do.cancelFns.fns, cancelFunc)
+	do.cancelFns.mu.Unlock()
+	for {
+		select {
+		case <-do.exit:
+			return
+		case <-cache.StatsCacheUpdateChan:
+			err := do.StatsHandle().UpdateWorker(ctx, do.InfoSchema())
+			if err != nil {
+				logutil.BgLogger().Warn("update stats info failed", zap.Error(err))
+			}
+		}
+	}
 }
 
 // StartLoadStatsSubWorkers starts sub workers with new sessions to load stats concurrently.
@@ -2436,7 +2464,7 @@ func (do *Domain) loadStatsWorker() {
 	for {
 		select {
 		case <-loadTicker.C:
-			err = statsHandle.Update(ctx, do.InfoSchema())
+			err = statsHandle.Update()
 			if err != nil {
 				logutil.BgLogger().Debug("update stats info failed", zap.Error(err))
 			}

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -173,7 +173,7 @@ TASKLOOP:
 	if err != nil {
 		sessionVars.StmtCtx.AppendWarning(err)
 	}
-	return statsHandle.Update(ctx, infoSchema)
+	return statsHandle.UpdateWorker(ctx, infoSchema)
 }
 
 func (e *AnalyzeExec) waitFinish(ctx context.Context, g *errgroup.Group, resultsCh chan *statistics.AnalyzeResults) error {

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -175,22 +175,22 @@ func TestDataForTableStatsField(t *testing.T) {
 		testkit.Rows("0 0 0 0"))
 	tk.MustExec(`insert into t(c, d, e) values(1, 2, "c"), (2, 3, "d"), (3, 4, "e")`)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustQuery("select table_rows, avg_row_length, data_length, index_length from information_schema.tables where table_name='t'").Check(
 		testkit.Rows("3 18 54 6"))
 	tk.MustExec(`insert into t(c, d, e) values(4, 5, "f")`)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustQuery("select table_rows, avg_row_length, data_length, index_length from information_schema.tables where table_name='t'").Check(
 		testkit.Rows("4 18 72 8"))
 	tk.MustExec("delete from t where c >= 3")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustQuery("select table_rows, avg_row_length, data_length, index_length from information_schema.tables where table_name='t'").Check(
 		testkit.Rows("2 18 36 4"))
 	tk.MustExec("delete from t where c=3")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustQuery("select table_rows, avg_row_length, data_length, index_length from information_schema.tables where table_name='t'").Check(
 		testkit.Rows("2 18 36 4"))
 
@@ -200,7 +200,7 @@ func TestDataForTableStatsField(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	tk.MustExec(`insert into t(a, b, c) values(1, 2, "c"), (7, 3, "d"), (12, 4, "e")`)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustQuery("select table_rows, avg_row_length, data_length, index_length from information_schema.tables where table_name='t'").Check(
 		testkit.Rows("3 18 54 6"))
 }
@@ -231,7 +231,7 @@ func TestPartitionsTable(t *testing.T) {
 				"[0 0 0 0]\n" +
 				"[0 0 0 0"))
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		tk.MustQuery("select table_rows, avg_row_length, data_length, index_length from information_schema.PARTITIONS where table_name='test_partitions';").Check(
 			testkit.Rows("" +
 				"1 18 18 2]\n" +
@@ -245,7 +245,7 @@ func TestPartitionsTable(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	tk.MustExec(`insert into test_partitions_1(a, b, c) values(1, 2, "c"), (7, 3, "d"), (12, 4, "e");`)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustQuery("select PARTITION_NAME, TABLE_ROWS, AVG_ROW_LENGTH, DATA_LENGTH, INDEX_LENGTH from information_schema.PARTITIONS where table_name='test_partitions_1';").Check(
 		testkit.Rows("<nil> 3 18 54 6"))
 
@@ -803,7 +803,7 @@ func TestReferencedTableSchemaWithForeignKey(t *testing.T) {
 	tk.MustExec("create table test.t1(id int primary key);")
 	tk.MustExec("create table test2.t2(i int, id int, foreign key (id) references test.t1(id));")
 
-	tk.MustQuery(`SELECT column_name, referenced_column_name, referenced_table_name, table_schema, referenced_table_schema 
+	tk.MustQuery(`SELECT column_name, referenced_column_name, referenced_table_name, table_schema, referenced_table_schema
 	FROM information_schema.key_column_usage
 	WHERE table_name = 't2' AND table_schema = 'test2';`).Check(testkit.Rows(
 		"id id t1 test2 test"))

--- a/pkg/executor/show_stats_test.go
+++ b/pkg/executor/show_stats_test.go
@@ -354,7 +354,7 @@ func TestShowStatsExtended(t *testing.T) {
 		"s1 2",
 		"s2 2",
 	))
-	dom.StatsHandle().Update(context.Background(), dom.InfoSchema())
+	dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema())
 	result = tk.MustQuery("show stats_extended where db_name = 'test' and table_name = 't'")
 	require.Len(t, result.Rows(), 0)
 }

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -2778,7 +2778,7 @@ func (e *SimpleExec) executeDropStats(ctx context.Context, s *ast.DropStatsStmt)
 	if err := h.DeleteTableStatsFromKV(statsIDs); err != nil {
 		return err
 	}
-	return h.Update(ctx, e.Ctx().GetInfoSchema().(infoschema.InfoSchema))
+	return h.UpdateWorker(ctx, e.Ctx().GetInfoSchema().(infoschema.InfoSchema))
 }
 
 func (e *SimpleExec) autoNewTxn() bool {

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -503,7 +503,7 @@ func TestAdjustSampleRateNote(t *testing.T) {
 	tblInfo := tbl.Meta()
 	tid := tblInfo.ID
 	tk.MustExec(fmt.Sprintf("update mysql.stats_meta set count = 220000 where table_id=%d", tid))
-	require.NoError(t, statsHandle.Update(context.Background(), is))
+	require.NoError(t, statsHandle.UpdateWorker(context.Background(), is))
 	result := tk.MustQuery("show stats_meta where table_name = 't'")
 	require.Equal(t, "220000", result.Rows()[0][5])
 	tk.MustExec("analyze table t")
@@ -513,7 +513,7 @@ func TestAdjustSampleRateNote(t *testing.T) {
 	))
 	tk.MustExec("insert into t values(1),(1),(1)")
 	require.NoError(t, statsHandle.DumpStatsDeltaToKV(true))
-	require.NoError(t, statsHandle.Update(context.Background(), is))
+	require.NoError(t, statsHandle.UpdateWorker(context.Background(), is))
 	result = tk.MustQuery("show stats_meta where table_name = 't'")
 	require.Equal(t, "3", result.Rows()[0][5])
 	tk.MustExec("analyze table t")
@@ -745,7 +745,7 @@ func TestSavedAnalyzeOptions(t *testing.T) {
 	// auto-analyze uses the table-level options
 	tk.MustExec("insert into t values (10,10,10)")
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	h.HandleAutoAnalyze()
 	tbl = h.GetTableStats(tableInfo)
 	require.Greater(t, tbl.Version, lastVersion)
@@ -1097,7 +1097,7 @@ func TestSavedAnalyzeColumnOptions(t *testing.T) {
 
 	tk.MustExec("insert into t values (5,5,5),(6,6,6)")
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	// auto analyze uses the saved option(predicate columns).
 	h.HandleAutoAnalyze()
 	tblStats = h.GetTableStats(tblInfo)
@@ -1905,7 +1905,7 @@ func testKillAutoAnalyze(t *testing.T, ver int) {
 	tk.MustExec("analyze table t")
 	tk.MustExec("insert into t values (5,6), (7,8), (9, 10)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	table, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
@@ -2725,7 +2725,7 @@ func TestAutoAnalyzeAwareGlobalVariableChange(t *testing.T) {
 	tid := tbl.Meta().ID
 	tk.MustExec("insert into t values(1),(2),(3)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	err = h.Update(context.Background(), dom.InfoSchema())
+	err = h.UpdateWorker(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 	tk.MustExec("analyze table t")
 	tk.MustQuery(fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tid)).Check(testkit.Rows(
@@ -2749,7 +2749,7 @@ func TestAutoAnalyzeAwareGlobalVariableChange(t *testing.T) {
 
 	tk.MustExec("insert into t values(4),(5),(6)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	err = h.Update(context.Background(), dom.InfoSchema())
+	err = h.UpdateWorker(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 
 	// Simulate that the analyze would start before and finish after the second insert.

--- a/pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
+++ b/pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
@@ -162,7 +162,7 @@ func TestGlobalMemoryControlForAutoAnalyze(t *testing.T) {
 
 	tk.MustExec("insert into t values(4),(5),(6)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	err := h.Update(context.Background(), dom.InfoSchema())
+	err := h.UpdateWorker(context.Background(), dom.InfoSchema())
 	require.NoError(t, err)
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/memory/ReadMemStats", `return(536870912)`))

--- a/pkg/executor/test/seqtest/seq_executor_test.go
+++ b/pkg/executor/test/seqtest/seq_executor_test.go
@@ -623,7 +623,7 @@ func TestShowStatsHealthy(t *testing.T) {
 	tk.MustExec("insert into t values (3), (4), (5), (6), (7), (8), (9), (10)")
 	err = do.StatsHandle().DumpStatsDeltaToKV(true)
 	require.NoError(t, err)
-	err = do.StatsHandle().Update(context.Background(), do.InfoSchema())
+	err = do.StatsHandle().UpdateWorker(context.Background(), do.InfoSchema())
 	require.NoError(t, err)
 	tk.MustQuery("show stats_healthy").Check(testkit.Rows("test t  0"))
 	tk.MustExec("analyze table t")
@@ -631,7 +631,7 @@ func TestShowStatsHealthy(t *testing.T) {
 	tk.MustExec("delete from t")
 	err = do.StatsHandle().DumpStatsDeltaToKV(true)
 	require.NoError(t, err)
-	err = do.StatsHandle().Update(context.Background(), do.InfoSchema())
+	err = do.StatsHandle().UpdateWorker(context.Background(), do.InfoSchema())
 	require.NoError(t, err)
 	tk.MustQuery("show stats_healthy").Check(testkit.Rows("test t  0"))
 }

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -581,7 +581,7 @@ func TestDropStats(t *testing.T) {
 	require.False(t, statsTbl.Pseudo)
 
 	testKit.MustExec("drop stats t")
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo)
 
@@ -591,7 +591,7 @@ func TestDropStats(t *testing.T) {
 
 	h.SetLease(1)
 	testKit.MustExec("drop stats t")
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.Pseudo)
 	h.SetLease(0)
@@ -622,7 +622,7 @@ func TestDropStatsForMultipleTable(t *testing.T) {
 	require.False(t, statsTbl2.Pseudo)
 
 	testKit.MustExec("drop stats t1, t2")
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl1 = h.GetTableStats(tableInfo1)
 	require.True(t, statsTbl1.Pseudo)
 	statsTbl2 = h.GetTableStats(tableInfo2)
@@ -636,7 +636,7 @@ func TestDropStatsForMultipleTable(t *testing.T) {
 
 	h.SetLease(1)
 	testKit.MustExec("drop stats t1, t2")
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl1 = h.GetTableStats(tableInfo1)
 	require.True(t, statsTbl1.Pseudo)
 	statsTbl2 = h.GetTableStats(tableInfo2)

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -187,7 +187,7 @@ func TestOutOfRangeEstimationAfterDelete(t *testing.T) {
 	// 2000 rows left.
 	testKit.MustExec("delete from t where a < 500")
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	var (
 		input  []string
 		output []struct {
@@ -230,7 +230,7 @@ func TestEstimationForUnknownValues(t *testing.T) {
 		testKit.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i+10, i+10))
 	}
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	table, err := dom.InfoSchema().TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	statsTbl := h.GetTableStats(table.Meta())
@@ -856,7 +856,7 @@ func TestGlobalStatsOutOfRangeEstimationAfterDelete(t *testing.T) {
 	testKit.MustExec("analyze table t all columns with 1 samplerate, 0 topn")
 	testKit.MustExec("delete from t where a < 500")
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	var (
 		input  []string
 		output []struct {
@@ -874,7 +874,7 @@ func TestGlobalStatsOutOfRangeEstimationAfterDelete(t *testing.T) {
 		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i].Result...))
 	}
 	testKit.MustExec("analyze table t partition p4 all columns with 1 samplerate, 0 topn")
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	for i := range input {
 		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i].Result...))
 	}
@@ -1212,7 +1212,7 @@ func TestIgnoreRealtimeStats(t *testing.T) {
 	// 1. Insert 11 rows of data without ANALYZE.
 	testKit.MustExec("insert into t values(1,1),(1,2),(1,3),(1,4),(1,5),(2,1),(2,2),(2,3),(2,4),(2,5),(3,1)")
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	// 1-1. use real-time stats.
 	// From the real-time stats, we are able to know the total count is 11.
@@ -1234,7 +1234,7 @@ func TestIgnoreRealtimeStats(t *testing.T) {
 
 	// 2. After ANALYZE.
 	testKit.MustExec("analyze table t all columns with 1 samplerate")
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	// The execution plans are the same no matter we ignore the real-time stats or not.
 	analyzedPlan := []string{
@@ -1250,7 +1250,7 @@ func TestIgnoreRealtimeStats(t *testing.T) {
 	// 3. Insert another 4 rows of data.
 	testKit.MustExec("insert into t values(3,2),(3,3),(3,4),(3,5)")
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	// 3-1. use real-time stats.
 	// From the real-time stats, we are able to know the total count is 15.
@@ -1325,7 +1325,7 @@ func TestBuiltinInEstWithoutStats(t *testing.T) {
 	tk.MustExec("insert into t values(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	expectedA := testkit.Rows(
 		"TableReader 0.08 root  data:Selection",
 		"└─Selection 0.08 cop[tikv]  in(test.t.a, 1, 2, 3, 4, 5, 6, 7, 8)",

--- a/pkg/planner/cardinality/trace_test.go
+++ b/pkg/planner/cardinality/trace_test.go
@@ -163,7 +163,7 @@ func TestTraceDebugSelectivity(t *testing.T) {
 	}
 	require.Nil(t, statsHandle.DumpStatsDeltaToKV(true))
 	tk.MustExec("analyze table t with 1 samplerate, 20 topn")
-	require.Nil(t, statsHandle.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, statsHandle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// Add 100 modify count
 	sql := "insert into t values "
 	topNValue := fmt.Sprintf("(%d,%d) ,", 5000, 5000)
@@ -171,7 +171,7 @@ func TestTraceDebugSelectivity(t *testing.T) {
 	sql = sql[0 : len(sql)-1]
 	tk.MustExec(sql)
 	require.Nil(t, statsHandle.DumpStatsDeltaToKV(true))
-	require.Nil(t, statsHandle.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, statsHandle.UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	var (
 		in  []string
@@ -244,7 +244,7 @@ func TestTraceDebugSelectivity(t *testing.T) {
 
 	tk.MustExec("set tidb_analyze_version = 1")
 	tk.MustExec("analyze table t with 20 topn")
-	require.Nil(t, statsHandle.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, statsHandle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	statsTbl = statsHandle.GetTableStats(tblInfo)
 
 	// Test using ver1 stats.

--- a/pkg/planner/core/casetest/cbotest/cbo_test.go
+++ b/pkg/planner/core/casetest/cbotest/cbo_test.go
@@ -70,7 +70,7 @@ func TestCBOWithoutAnalyze(t *testing.T) {
 	testKit.MustExec("insert into t1 values (1), (2), (3), (4), (5), (6)")
 	testKit.MustExec("insert into t2 values (1), (2), (3), (4), (5), (6)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	var input []string
 	var output []struct {
 		SQL  string
@@ -120,7 +120,7 @@ func TestTableDual(t *testing.T) {
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	var input []string
 	var output []struct {
 		SQL  string
@@ -157,7 +157,7 @@ func TestEstimation(t *testing.T) {
 		testKit.MustExec("delete from t where a = ?", i)
 	}
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	var input []string
 	var output []struct {
 		SQL  string
@@ -343,7 +343,7 @@ func TestOutdatedAnalyze(t *testing.T) {
 	testKit.MustExec("insert into t select * from t")
 	testKit.MustExec("insert into t select * from t")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	var input []struct {
 		SQL                          string
 		EnablePseudoForOutdatedStats bool
@@ -391,7 +391,7 @@ func TestNullCount(t *testing.T) {
 	}
 	h := dom.StatsHandle()
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	for i := 2; i < 4; i++ {
 		testdata.OnRecord(func() {
 			output[i] = testdata.ConvertRowsToStrings(testKit.MustQuery(input[i]).Rows())
@@ -438,7 +438,7 @@ func TestInconsistentEstimation(t *testing.T) {
 	// Force using the histogram to estimate.
 	tk.MustExec("update mysql.stats_histograms set stats_ver = 0")
 	dom.StatsHandle().Clear()
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 	var input []string
 	var output []struct {
 		SQL  string

--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -210,7 +210,7 @@ func TestPlanStatsLoad(t *testing.T) {
 		}
 		is := dom.InfoSchema()
 		dom.StatsHandle().Clear() // clear statsCache
-		require.NoError(t, dom.StatsHandle().Update(context.Background(), is))
+		require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), is))
 		stmt, err := p.ParseOneStmt(testCase.sql, "", "")
 		require.NoError(t, err)
 		err = executor.ResetContextOfStmt(ctx, stmt)
@@ -269,7 +269,7 @@ func TestPlanStatsLoadTimeout(t *testing.T) {
 	}()
 	tk.MustExec("analyze table t all columns")
 	is := dom.InfoSchema()
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), is))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), is))
 	tbl, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
@@ -439,7 +439,7 @@ func TestPartialStatsInExplain(t *testing.T) {
 	tk.MustExec("analyze table t all columns")
 	tk.MustExec("analyze table t2")
 	tk.MustExec("analyze table tp all columns")
-	tk.RequireNoError(dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	tk.RequireNoError(dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery("explain select * from tp where a = 1")
 	tk.MustExec("set @@tidb_stats_load_sync_wait = 0")
 	var (

--- a/pkg/planner/core/indexmerge_intersection_test.go
+++ b/pkg/planner/core/indexmerge_intersection_test.go
@@ -148,10 +148,10 @@ func TestHintForIntersectionIndexMerge(t *testing.T) {
 		"('啊aabb', 'abcdc', 'aaaa', '??', '2')")
 
 	require.NoError(t, handle.HandleDDLEvent(<-handle.DDLEventCh()))
-	require.Nil(t, handle.Update(context.Background(), domain.InfoSchema()))
+	require.Nil(t, handle.UpdateWorker(context.Background(), domain.InfoSchema()))
 	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")
 	tk.MustExec("analyze table t1,t2,t3,t4")
-	require.Nil(t, handle.Update(context.Background(), domain.InfoSchema()))
+	require.Nil(t, handle.UpdateWorker(context.Background(), domain.InfoSchema()))
 
 	var (
 		input  []string

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2168,7 +2168,7 @@ func TestIssue48257(t *testing.T) {
 	tk.MustExec("create table t(a int)")
 	tk.MustExec("insert into t value(1)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t all columns")
 	tk.MustQuery("explain format = brief select * from t").Check(testkit.Rows(
 		"TableReader 1.00 root  data:TableFullScan",
@@ -2176,7 +2176,7 @@ func TestIssue48257(t *testing.T) {
 	))
 	tk.MustExec("insert into t value(1)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery("explain format = brief select * from t").Check(testkit.Rows(
 		"TableReader 2.00 root  data:TableFullScan",
 		"└─TableFullScan 2.00 cop[tikv] table:t keep order:false",
@@ -2193,7 +2193,7 @@ func TestIssue48257(t *testing.T) {
 	tk.MustExec("create table t1(a int)")
 	tk.MustExec("insert into t1 value(1)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t1 all columns")
 	tk.MustQuery("explain format = brief select * from t1").Check(testkit.Rows(
 		"TableReader 1.00 root  data:TableFullScan",
@@ -2201,7 +2201,7 @@ func TestIssue48257(t *testing.T) {
 	))
 	tk.MustExec("insert into t1 value(1)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	tk.MustQuery("explain format = brief select * from t1").Check(testkit.Rows(
 		"TableReader 2.00 root  data:TableFullScan",
 		"└─TableFullScan 2.00 cop[tikv] table:t1 keep order:false, stats:pseudo",

--- a/pkg/server/handler/optimizor/statistics_handler_test.go
+++ b/pkg/server/handler/optimizor/statistics_handler_test.go
@@ -160,7 +160,7 @@ func prepareData(t *testing.T, client *testserverclient.TestServerClient, statHa
 	tk.MustExec("insert into test(a,b) values (1, 'v'),(3, 'vvv'),(5, 'vv')")
 	is := statHandle.Domain().InfoSchema()
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 }
 
 func testDumpPartitionTableStats(t *testing.T, client *testserverclient.TestServerClient, handler *optimizor.StatsHandler) {
@@ -202,7 +202,7 @@ func preparePartitionData(t *testing.T, client *testserverclient.TestServerClien
 	tk.MustExec("analyze table test2")
 	is := statHandle.Domain().InfoSchema()
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 }
 
 func prepare4DumpHistoryStats(t *testing.T, client *testserverclient.TestServerClient) {

--- a/pkg/statistics/handle/autoanalyze/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sessionctx",
         "//pkg/sessionctx/sysproctrack",
         "//pkg/sessionctx/variable",
+        "//pkg/sessiontxn",
         "//pkg/statistics",
         "//pkg/statistics/handle/autoanalyze/exec",
         "//pkg/statistics/handle/autoanalyze/refresher",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/sysproctrack"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/exec"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/refresher"
@@ -308,8 +309,13 @@ func HandleAutoAnalyze(
 		}
 	}()
 	if variable.EnableAutoAnalyzePriorityQueue.Load() {
+		infoSchema := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
+		err := statsHandle.UpdateWorker(context.Background(), infoSchema)
+		if err != nil {
+			return false
+		}
 		r := refresher.NewRefresher(statsHandle, sysProcTracker)
-		err := r.RebuildTableAnalysisJobQueue()
+		err = r.RebuildTableAnalysisJobQueue()
 		if err != nil {
 			statslogutil.StatsLogger().Error("rebuild table analysis job queue failed", zap.Error(err))
 			return false

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -56,7 +56,7 @@ func TestEnableAutoAnalyzePriorityQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statistics.AutoAnalyzeMinCnt = 0
 	defer func() {
 		statistics.AutoAnalyzeMinCnt = 1000
@@ -77,7 +77,7 @@ func TestAutoAnalyzeLockedTable(t *testing.T) {
 	// Lock the table.
 	tk.MustExec("lock stats t")
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statistics.AutoAnalyzeMinCnt = 0
 	defer func() {
 		statistics.AutoAnalyzeMinCnt = 1000
@@ -105,7 +105,7 @@ func TestAutoAnalyzeWithPredicateColumns(t *testing.T) {
 	require.NoError(t, h.DumpColStatsUsageToKV())
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statistics.AutoAnalyzeMinCnt = 0
 	defer func() {
 		statistics.AutoAnalyzeMinCnt = 1000
@@ -153,7 +153,7 @@ func disableAutoAnalyzeCase(t *testing.T, tk *testkit.TestKit, dom *domain.Domai
 	require.NoError(t, err)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 
 	tk.MustExec("set @@global.tidb_enable_auto_analyze = 0")
 	statistics.AutoAnalyzeMinCnt = 0
@@ -162,7 +162,7 @@ func disableAutoAnalyzeCase(t *testing.T, tk *testkit.TestKit, dom *domain.Domai
 	}()
 	// Even auto analyze ratio is set to 0, we still need to analyze the unanalyzed tables.
 	require.True(t, dom.StatsHandle().HandleAutoAnalyze())
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 
 	// Try again, it should not analyze the table because it's already analyzed and auto analyze ratio is 0.
 	require.False(t, dom.StatsHandle().HandleAutoAnalyze())
@@ -190,10 +190,10 @@ func TestAutoAnalyzeOnChangeAnalyzeVer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := do.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// Auto analyze when global ver is 1.
 	h.HandleAutoAnalyze()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	statsTbl1 := h.GetTableStats(tbl.Meta())
@@ -210,10 +210,10 @@ func TestAutoAnalyzeOnChangeAnalyzeVer(t *testing.T) {
 	tk.MustExec("set @@global.tidb_analyze_version = 2")
 	tk.MustExec("insert into t values(1), (2), (3), (4)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// Auto analyze t whose version is 1 after setting global ver to 2.
 	h.HandleAutoAnalyze()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl1 = h.GetTableStats(tbl.Meta())
 	require.Equal(t, int64(5), statsTbl1.RealtimeCount)
 	// All of its statistics should still be version 1.
@@ -235,9 +235,9 @@ func TestAutoAnalyzeOnChangeAnalyzeVer(t *testing.T) {
 	is = do.InfoSchema()
 	tbl2, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("tt"))
 	require.NoError(t, err)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	h.HandleAutoAnalyze()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl2 := h.GetTableStats(tbl2.Meta())
 	// Since it's a newly created table. Auto analyze should analyze it's statistics to version2.
 	statsTbl2.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
@@ -265,12 +265,12 @@ func TestTableAnalyzed(t *testing.T) {
 	tableInfo := tbl.Meta()
 	h := dom.StatsHandle()
 
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.False(t, statsTbl.LastAnalyzeVersion > 0)
 
 	testKit.MustExec("analyze table t")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.LastAnalyzeVersion > 0)
 
@@ -281,7 +281,7 @@ func TestTableAnalyzed(t *testing.T) {
 	defer func() {
 		h.SetLease(oriLease)
 	}()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.True(t, statsTbl.LastAnalyzeVersion > 0)
 }
@@ -347,7 +347,7 @@ func TestAutoAnalyzeSkipColumnTypes(t *testing.T) {
 	tk.MustExec("select * from t where a = 1 and b = 1 and c = '1'")
 	h := dom.StatsHandle()
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	require.NoError(t, h.DumpColStatsUsageToKV())
 	tk.MustExec("set @@global.tidb_analyze_skip_column_types = 'json,blob,mediumblob,text,mediumtext'")
 
@@ -385,7 +385,7 @@ func TestAutoAnalyzeOnEmptyTable(t *testing.T) {
 	// to pass the AutoAnalyzeMinCnt check in autoAnalyzeTable
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", int(statistics.AutoAnalyzeMinCnt)))
 	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	// test if it will be limited by the time range
 	require.False(t, dom.StatsHandle().HandleAutoAnalyze())
@@ -420,7 +420,7 @@ func TestAutoAnalyzeOutOfSpecifiedTime(t *testing.T) {
 	// to pass the AutoAnalyzeMinCnt check in autoAnalyzeTable
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", int(statistics.AutoAnalyzeMinCnt)))
 	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	require.False(t, dom.StatsHandle().HandleAutoAnalyze())
 	tk.MustExec("analyze table t")

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -61,14 +61,14 @@ func TestSkipAnalyzeTableWhenAutoAnalyzeRatioIsZero(t *testing.T) {
 	tk.MustExec("update mysql.global_variables set variable_value = '0' where variable_name = 'tidb_auto_analyze_ratio'")
 	handle := dom.StatsHandle()
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// Analyze those tables first.
 	tk.MustExec("analyze table t1")
 	tk.MustExec("analyze table t2")
 	// Insert more data into t1.
 	tk.MustExec("insert into t1 values (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9)")
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
 	r := refresher.NewRefresher(handle, sysProcTracker)
 	r.RebuildTableAnalysisJobQueue()
@@ -138,12 +138,12 @@ func TestIgnoreTinyTable(t *testing.T) {
 	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
 	handle := dom.StatsHandle()
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// Analyze those tables first.
 	tk.MustExec("analyze table t1")
 	tk.MustExec("analyze table t2")
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// Make sure table stats are not pseudo.
 	tbl1, err := dom.InfoSchema().TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t1"))
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestIgnoreTinyTable(t *testing.T) {
 	tk.MustExec("insert into t1 values (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13)")
 	tk.MustExec("insert into t2 values (4, 4)")
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
 	r := refresher.NewRefresher(handle, sysProcTracker)
 	r.RebuildTableAnalysisJobQueue()
@@ -184,17 +184,17 @@ func TestAnalyzeHighestPriorityTables(t *testing.T) {
 	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
 	handle := dom.StatsHandle()
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// Analyze those tables first.
 	tk.MustExec("analyze table t1")
 	tk.MustExec("analyze table t2")
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// Insert more data into t1 and t2, but more data is inserted into t1.
 	tk.MustExec("insert into t1 values (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13)")
 	tk.MustExec("insert into t2 values (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9)")
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
 	r := refresher.NewRefresher(handle, sysProcTracker)
 	r.RebuildTableAnalysisJobQueue()
@@ -202,7 +202,7 @@ func TestAnalyzeHighestPriorityTables(t *testing.T) {
 	// Analyze t1 first.
 	require.True(t, r.AnalyzeHighestPriorityTables())
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
-	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// The table is analyzed.
 	tbl1, err := dom.InfoSchema().TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t1"))
 	require.NoError(t, err)
@@ -411,7 +411,7 @@ func TestRebuildTableAnalysisJobQueue(t *testing.T) {
 	handle := dom.StatsHandle()
 	require.Nil(t, handle.DumpStatsDeltaToKV(true))
 	tk.MustExec("analyze table t1")
-	require.Nil(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	sysProcTracker := dom.SysProcTracker()
 	r := refresher.NewRefresher(handle, sysProcTracker)
@@ -423,7 +423,7 @@ func TestRebuildTableAnalysisJobQueue(t *testing.T) {
 	// Insert more data into t1.
 	tk.MustExec("insert into t1 values (4, 4), (5, 5), (6, 6)")
 	require.Nil(t, handle.DumpStatsDeltaToKV(true))
-	require.Nil(t, handle.Update(context.Background(), dom.InfoSchema()))
+	require.Nil(t, handle.UpdateWorker(context.Background(), dom.InfoSchema()))
 	err = r.RebuildTableAnalysisJobQueue()
 	require.NoError(t, err)
 	require.Equal(t, 1, r.Jobs.Len())

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -63,8 +63,20 @@ func NewStatsCacheImplForTest() (types.StatsCache, error) {
 	return NewStatsCacheImpl(nil)
 }
 
+// StatsCacheUpdateChan is a channel for updating stats cache.
+var StatsCacheUpdateChan = make(chan struct{}, 1)
+
 // Update reads stats meta from store and updates the stats map.
-func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) error {
+func (*StatsCacheImpl) Update() error {
+	select {
+	case StatsCacheUpdateChan <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+// UpdateWorker reads stats meta from store and updates the stats map.
+func (s *StatsCacheImpl) UpdateWorker(ctx context.Context, is infoschema.InfoSchema) error {
 	start := time.Now()
 	lastVersion := s.getLastVersion()
 	var (

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -74,7 +74,7 @@ func TestDDLTable(t *testing.T) {
 	h := do.StatsHandle()
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl := h.GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
 
@@ -85,7 +85,7 @@ func TestDDLTable(t *testing.T) {
 	tableInfo = tbl.Meta()
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
 
@@ -98,7 +98,7 @@ func TestDDLTable(t *testing.T) {
 	tableInfo = tbl.Meta()
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
 
@@ -109,7 +109,7 @@ func TestDDLTable(t *testing.T) {
 	tableInfo = tbl.Meta()
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
 }
@@ -164,7 +164,7 @@ func TestTruncateTable(t *testing.T) {
 	// Insert some data.
 	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
 	testKit.MustExec("analyze table t")
-	err = h.Update(context.Background(), do.InfoSchema())
+	err = h.UpdateWorker(context.Background(), do.InfoSchema())
 	require.NoError(t, err)
 	statsTbl := h.GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
@@ -237,7 +237,7 @@ func TestTruncateAPartitionedTable(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0's and p1's stats update version.
@@ -299,7 +299,7 @@ func TestDDLHistogram(t *testing.T) {
 	err := h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	is := do.InfoSchema()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	tbl, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
@@ -314,7 +314,7 @@ func TestDDLHistogram(t *testing.T) {
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	is = do.InfoSchema()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	tbl, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo = tbl.Meta()
@@ -334,7 +334,7 @@ func TestDDLHistogram(t *testing.T) {
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	is = do.InfoSchema()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	tbl, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo = tbl.Meta()
@@ -347,7 +347,7 @@ func TestDDLHistogram(t *testing.T) {
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	is = do.InfoSchema()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	tbl, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo = tbl.Meta()
@@ -361,7 +361,7 @@ func TestDDLHistogram(t *testing.T) {
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	is = do.InfoSchema()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	tbl, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo = tbl.Meta()
@@ -415,7 +415,7 @@ PARTITION BY RANGE ( a ) (
 		tableInfo := tbl.Meta()
 		err = h.HandleDDLEvent(<-h.DDLEventCh())
 		require.NoError(t, err)
-		require.Nil(t, h.Update(context.Background(), is))
+		require.Nil(t, h.UpdateWorker(context.Background(), is))
 		pi := tableInfo.GetPartitionInfo()
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
@@ -428,7 +428,7 @@ PARTITION BY RANGE ( a ) (
 		err = h.HandleDDLEvent(<-h.DDLEventCh())
 		require.NoError(t, err)
 		is = do.InfoSchema()
-		require.Nil(t, h.Update(context.Background(), is))
+		require.Nil(t, h.UpdateWorker(context.Background(), is))
 		tbl, err = is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 		require.NoError(t, err)
 		tableInfo = tbl.Meta()
@@ -447,7 +447,7 @@ PARTITION BY RANGE ( a ) (
 		tableInfo = tbl.Meta()
 		err = h.HandleDDLEvent(<-h.DDLEventCh())
 		require.NoError(t, err)
-		require.Nil(t, h.Update(context.Background(), is))
+		require.Nil(t, h.UpdateWorker(context.Background(), is))
 		pi = tableInfo.GetPartitionInfo()
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
@@ -489,7 +489,7 @@ func TestReorgPartitions(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	// Get all the partition IDs.
 	partitionIDs := make(map[int64]struct{}, len(pi.Definitions))
@@ -514,7 +514,7 @@ func TestReorgPartitions(t *testing.T) {
 	reorganizePartitionEvent := findEvent(h.DDLEventCh(), model.ActionReorganizePartition)
 	err = h.HandleDDLEvent(reorganizePartitionEvent)
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	// Check the version again.
 	rows = testKit.MustQuery(
@@ -546,7 +546,7 @@ func TestIncreasePartitionCountOfHashPartitionTable(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0 and p1's stats update version.
@@ -566,7 +566,7 @@ func TestIncreasePartitionCountOfHashPartitionTable(t *testing.T) {
 	reorganizePartitionEvent := findEvent(h.DDLEventCh(), model.ActionReorganizePartition)
 	err = h.HandleDDLEvent(reorganizePartitionEvent)
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	// Check new partitions are added.
 	is = do.InfoSchema()
@@ -615,7 +615,7 @@ func TestDecreasePartitionCountOfHashPartitionTable(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0 and p1's stats update version.
@@ -640,7 +640,7 @@ func TestDecreasePartitionCountOfHashPartitionTable(t *testing.T) {
 	reorganizePartitionEvent := findEvent(h.DDLEventCh(), model.ActionReorganizePartition)
 	err = h.HandleDDLEvent(reorganizePartitionEvent)
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	// Check new partitions are added.
 	is = do.InfoSchema()
@@ -703,7 +703,7 @@ func TestTruncateAPartition(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0's stats update version.
@@ -766,7 +766,7 @@ func TestTruncateAHashPartition(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0's stats update version.
@@ -833,7 +833,7 @@ func TestTruncatePartitions(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0 and p1's stats update version.
@@ -904,7 +904,7 @@ func TestDropAPartition(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	testKit.MustExec("alter table t drop partition p0")
@@ -971,7 +971,7 @@ func TestDropPartitions(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Get partition p0 and p1's stats update version.
@@ -1102,7 +1102,7 @@ func TestExchangeAPartition(t *testing.T) {
 	tableInfo2 := tbl2.Meta()
 	statsTbl2 := h.GetTableStats(tableInfo2)
 	require.False(t, statsTbl2.Pseudo)
-	err = h.Update(context.Background(), do.InfoSchema())
+	err = h.UpdateWorker(context.Background(), do.InfoSchema())
 	require.NoError(t, err)
 
 	// Insert some data to partition p1 before exchange partition.
@@ -1146,7 +1146,7 @@ func TestExchangeAPartition(t *testing.T) {
 	tableInfo3 := tbl3.Meta()
 	statsTbl3 := h.GetTableStats(tableInfo3)
 	require.False(t, statsTbl3.Pseudo)
-	err = h.Update(context.Background(), do.InfoSchema())
+	err = h.UpdateWorker(context.Background(), do.InfoSchema())
 	require.NoError(t, err)
 
 	testKit.MustExec("alter table t exchange partition p2 with table t3")

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -237,13 +237,13 @@ partition by range (a) (
 
 	tk.MustExec("insert into t values (1), (2)") // update p0
 	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 	checkModifyAndCount(2, 2, 2, 2, 0, 0)
 	checkHealthy(0, 0, 100)
 
 	tk.MustExec("insert into t values (11), (12), (13), (14)") // update p1
 	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 	checkModifyAndCount(6, 6, 2, 2, 4, 4)
 	checkHealthy(0, 0, 0)
 
@@ -253,7 +253,7 @@ partition by range (a) (
 
 	tk.MustExec("insert into t values (4), (5), (15), (16)") // update p0 and p1 together
 	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 	checkModifyAndCount(4, 10, 2, 4, 2, 6)
 	checkHealthy(33, 0, 50)
 }
@@ -542,7 +542,7 @@ partition by range (a) (
 	do := dom
 	is := do.InfoSchema()
 	h := do.StatsHandle()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
@@ -587,12 +587,12 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	h := do.StatsHandle()
 	err := h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustExec("insert into t values (1), (2), (3), (4), (5), " +
 		"(11), (21), (31), (41), (51)," +
 		"(12), (22), (32), (42), (52);")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustExec("analyze table t")
 	result := tk.MustQuery("show stats_meta where table_name = 't';").Rows()
 	require.Len(t, result, 7)
@@ -605,7 +605,7 @@ func TestDDLPartition4GlobalStats(t *testing.T) {
 	tk.MustExec("alter table t truncate partition p2, p4;")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// We will update the global-stats after the truncate operation.
 	globalStats = h.GetTableStats(tableInfo)
 	require.Equal(t, int64(11), globalStats.RealtimeCount)
@@ -882,7 +882,7 @@ func TestGlobalIndexStatistics(t *testing.T) {
 		tk.MustExec("ALTER TABLE t ADD UNIQUE INDEX idx(b) GLOBAL")
 		require.Nil(t, h.DumpStatsDeltaToKV(true))
 		tk.MustExec("analyze table t")
-		require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+		require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 		tk.MustQuery("SELECT b FROM t use index(idx) WHERE b < 16 ORDER BY b").
 			Check(testkit.Rows("1", "2", "3", "15"))
 		tk.MustQuery("EXPLAIN format='brief' SELECT b FROM t use index(idx) WHERE b < 16 ORDER BY b").
@@ -903,7 +903,7 @@ func TestGlobalIndexStatistics(t *testing.T) {
 		tk.MustExec("ALTER TABLE t ADD UNIQUE INDEX idx(b) GLOBAL")
 		require.Nil(t, h.DumpStatsDeltaToKV(true))
 		tk.MustExec("analyze table t index idx")
-		require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+		require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 		rows := tk.MustQuery("EXPLAIN SELECT b FROM t use index(idx) WHERE b < 16 ORDER BY b;").Rows()
 		require.Equal(t, "4.00", rows[0][1])
 
@@ -921,7 +921,7 @@ func TestGlobalIndexStatistics(t *testing.T) {
 		tk.MustExec("ALTER TABLE t ADD UNIQUE INDEX idx(b) GLOBAL")
 		require.Nil(t, h.DumpStatsDeltaToKV(true))
 		tk.MustExec("analyze table t index")
-		require.Nil(t, h.Update(context.Background(), dom.InfoSchema()))
+		require.Nil(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 		tk.MustQuery("EXPLAIN format='brief' SELECT b FROM t use index(idx) WHERE b < 16 ORDER BY b;").
 			Check(testkit.Rows("IndexReader 4.00 root partition:all index:IndexRangeScan",
 				"└─IndexRangeScan 4.00 cop[tikv] table:t, index:idx(b) range:[-inf,16), keep order:true"))

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -86,7 +86,7 @@ func TestColumnIDs(t *testing.T) {
 	testKit.MustExec("alter table t drop column c1")
 	is = do.InfoSchema()
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	tbl, err = is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestVersion(t *testing.T) {
 	unit := oracle.ComposeTS(1, 0)
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", 2*unit, tableInfo1.ID)
 
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, 2*unit, h.MaxTableStatsVersion())
 	statsTbl1 := h.GetTableStats(tableInfo1)
 	require.False(t, statsTbl1.Pseudo)
@@ -139,7 +139,7 @@ func TestVersion(t *testing.T) {
 	tableInfo2 := tbl2.Meta()
 	// A smaller version write, and we can still read it.
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", unit, tableInfo2.ID)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, 2*unit, h.MaxTableStatsVersion())
 	statsTbl2 := h.GetTableStats(tableInfo2)
 	require.False(t, statsTbl2.Pseudo)
@@ -148,7 +148,7 @@ func TestVersion(t *testing.T) {
 	testKit.MustExec("analyze table t1")
 	offset := 3 * unit
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", offset+4, tableInfo1.ID)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, offset+uint64(4), h.MaxTableStatsVersion())
 	statsTbl1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(1), statsTbl1.RealtimeCount)
@@ -157,7 +157,7 @@ func TestVersion(t *testing.T) {
 	testKit.MustExec("analyze table t2")
 	// A smaller version write, and we can still read it.
 	testKit.MustExec("update mysql.stats_meta set version = ? where table_id = ?", offset+3, tableInfo2.ID)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, offset+uint64(4), h.MaxTableStatsVersion())
 	statsTbl2 = h.GetTableStats(tableInfo2)
 	require.Equal(t, int64(1), statsTbl2.RealtimeCount)
@@ -166,7 +166,7 @@ func TestVersion(t *testing.T) {
 	testKit.MustExec("analyze table t2")
 	// A smaller version write, and we cannot read it. Because at this time, lastThree Version is 4.
 	testKit.MustExec("update mysql.stats_meta set version = 1 where table_id = ?", tableInfo2.ID)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, offset+uint64(4), h.MaxTableStatsVersion())
 	statsTbl2 = h.GetTableStats(tableInfo2)
 	require.Equal(t, int64(1), statsTbl2.RealtimeCount)
@@ -175,13 +175,13 @@ func TestVersion(t *testing.T) {
 	testKit.MustExec("alter table t2 add column c3 int")
 	testKit.MustExec("analyze table t2 all columns")
 	// load it with old schema.
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl2 = h.GetTableStats(tableInfo2)
 	require.False(t, statsTbl2.Pseudo)
 	require.Nil(t, statsTbl2.GetCol(int64(3)))
 	// Next time DDL updated.
 	is = do.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl2 = h.GetTableStats(tableInfo2)
 	require.False(t, statsTbl2.Pseudo)
 	require.Nil(t, statsTbl2.GetCol(int64(3)))
@@ -216,7 +216,7 @@ func TestLoadHist(t *testing.T) {
 		testKit.MustExec("insert into t values('bb','sdfga')")
 	}
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	err = h.Update(context.Background(), do.InfoSchema())
+	err = h.UpdateWorker(context.Background(), do.InfoSchema())
 	require.NoError(t, err)
 	newStatsTbl := h.GetTableStats(tableInfo)
 	// The stats table is updated.
@@ -242,7 +242,7 @@ func TestLoadHist(t *testing.T) {
 	tbl, err = is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo = tbl.Meta()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	newStatsTbl2 := h.GetTableStats(tableInfo)
 	require.False(t, newStatsTbl2 == newStatsTbl)
 	// The histograms is not updated.
@@ -455,7 +455,7 @@ func TestExtendedStatsOps(t *testing.T) {
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl)
@@ -464,7 +464,7 @@ func TestExtendedStatsOps(t *testing.T) {
 
 	tk.MustExec("update mysql.stats_extended set status = 1 where name = 's1'")
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl)
@@ -475,7 +475,7 @@ func TestExtendedStatsOps(t *testing.T) {
 	tk.MustQuery("select type, column_ids, stats, status from mysql.stats_extended where name = 's1'").Check(testkit.Rows(
 		"2 [2,3] <nil> 2",
 	))
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl.ExtendedStats)
@@ -499,7 +499,7 @@ func TestAdminReloadStatistics1(t *testing.T) {
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl)
@@ -508,7 +508,7 @@ func TestAdminReloadStatistics1(t *testing.T) {
 
 	tk.MustExec("update mysql.stats_extended set status = 1 where name = 's1'")
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl)
@@ -516,7 +516,7 @@ func TestAdminReloadStatistics1(t *testing.T) {
 	require.Len(t, statsTbl.ExtendedStats.Stats, 1)
 
 	tk.MustExec("delete from mysql.stats_extended where name = 's1'")
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl.ExtendedStats)
@@ -545,7 +545,7 @@ func TestAdminReloadStatistics2(t *testing.T) {
 
 	tk.MustExec("delete from mysql.stats_extended where name = 's1'")
 	is := dom.InfoSchema()
-	dom.StatsHandle().Update(context.Background(), is)
+	dom.StatsHandle().UpdateWorker(context.Background(), is)
 	tk.MustQuery("select stats, status from mysql.stats_extended where name = 's1'").Check(testkit.Rows())
 	rows = tk.MustQuery("show stats_extended where stats_name = 's1'").Rows()
 	require.Len(t, rows, 1)
@@ -576,7 +576,7 @@ func TestCorrelationStatsCompute(t *testing.T) {
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl)
@@ -594,7 +594,7 @@ func TestCorrelationStatsCompute(t *testing.T) {
 		"2 [1,2] 1.000000 1",
 		"2 [1,3] -1.000000 1",
 	))
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.NotNil(t, statsTbl)
@@ -1147,7 +1147,7 @@ func TestStatsCacheUpdateSkip(t *testing.T) {
 	tableInfo := tbl.Meta()
 	statsTbl1 := h.GetTableStats(tableInfo)
 	require.False(t, statsTbl1.Pseudo)
-	h.Update(context.Background(), is)
+	h.UpdateWorker(context.Background(), is)
 	statsTbl2 := h.GetTableStats(tableInfo)
 	require.Equal(t, statsTbl2, statsTbl1)
 }
@@ -1175,7 +1175,7 @@ func testIncrementalModifyCountUpdateHelper(analyzeSnapshot bool) func(*testing.
 
 		tk.MustExec("insert into t values(1),(2),(3)")
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		err = h.Update(context.Background(), dom.InfoSchema())
+		err = h.UpdateWorker(context.Background(), dom.InfoSchema())
 		require.NoError(t, err)
 		tk.MustExec("analyze table t")
 		tk.MustQuery(fmt.Sprintf("select count, modify_count from mysql.stats_meta where table_id = %d", tid)).Check(testkit.Rows(
@@ -1190,7 +1190,7 @@ func testIncrementalModifyCountUpdateHelper(analyzeSnapshot bool) func(*testing.
 
 		tk.MustExec("insert into t values(4),(5),(6)")
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		err = h.Update(context.Background(), dom.InfoSchema())
+		err = h.UpdateWorker(context.Background(), dom.InfoSchema())
 		require.NoError(t, err)
 
 		// Simulate that the analyze would start before and finish after the second insert.
@@ -1298,7 +1298,7 @@ func TestUninitializedStatsStatus(t *testing.T) {
 	tk.MustExec("insert into t values (1,2,2), (3,4,4), (5,6,6), (7,8,8), (9,10,10)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tblInfo := tbl.Meta()

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -63,7 +63,7 @@ func TestStatsCache(t *testing.T) {
 	testKit.MustExec("alter table t drop column c2")
 	is = do.InfoSchema()
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
@@ -73,7 +73,7 @@ func TestStatsCache(t *testing.T) {
 	is = do.InfoSchema()
 
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
@@ -117,7 +117,7 @@ func TestStatsCacheMemTracker(t *testing.T) {
 	testKit.MustExec("alter table t drop column c2")
 	is = do.InfoSchema()
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
@@ -129,7 +129,7 @@ func TestStatsCacheMemTracker(t *testing.T) {
 	is = do.InfoSchema()
 
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo)
 	require.False(t, statsTbl.Pseudo)
@@ -156,7 +156,7 @@ func TestStatsStoreAndLoad(t *testing.T) {
 	statsTbl1 := do.StatsHandle().GetTableStats(tableInfo)
 
 	do.StatsHandle().Clear()
-	err = do.StatsHandle().Update(context.Background(), is)
+	err = do.StatsHandle().UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 	statsTbl2 := do.StatsHandle().GetTableStats(tableInfo)
 	require.False(t, statsTbl2.Pseudo)
@@ -270,7 +270,7 @@ func TestInitStats(t *testing.T) {
 	table0 := h.GetTableStats(tbl.Meta())
 	require.Equal(t, uint8(0x3), table0.GetIdx(1).LastAnalyzePos.GetBytes()[0])
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// Index and pk are loaded.
 	needed := fmt.Sprintf(`Table:%v RealtimeCount:6
 index:1 ndv:6

--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -95,7 +95,7 @@ func TestConversion(t *testing.T) {
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
 	require.Nil(t, h.DumpStatsDeltaToKV(true))
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	tableInfo, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestConversion(t *testing.T) {
 	cleanStats(tk, dom)
 	var wg util.WaitGroupWrapper
 	wg.Run(func() {
-		require.Nil(t, h.Update(context.Background(), is))
+		require.Nil(t, h.UpdateWorker(context.Background(), is))
 	})
 	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl, 0)
 	wg.Wait()
@@ -121,7 +121,7 @@ func TestConversion(t *testing.T) {
 func getStatsJSON(t *testing.T, dom *domain.Domain, db, tableName string) *handleutil.JSONTable {
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	table, err := is.TableByName(context.Background(), pmodel.NewCIStr(db), pmodel.NewCIStr(tableName))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
@@ -133,7 +133,7 @@ func getStatsJSON(t *testing.T, dom *domain.Domain, db, tableName string) *handl
 func persistStats(ctx context.Context, t *testing.T, dom *domain.Domain, db, tableName string, persist statstypes.PersistFunc) {
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	table, err := is.TableByName(context.Background(), pmodel.NewCIStr(db), pmodel.NewCIStr(tableName))
 	require.NoError(t, err)
 	tableInfo := table.Meta()
@@ -250,7 +250,7 @@ func TestLoadPredicateColumns(t *testing.T) {
 	tk.MustExec("select * from t where b = 1")
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.NoError(t, h.DumpColStatsUsageToKV())
 	tk.MustExec("analyze table t")
 
@@ -337,7 +337,7 @@ PARTITION BY RANGE ( a ) (
 	tk.MustExec("analyze table t")
 	is := dom.InfoSchema()
 	h := dom.StatsHandle()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	table, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDumpCMSketchWithTopN(t *testing.T) {
 	require.NoError(t, err)
 	tableInfo := tbl.Meta()
 	h := dom.StatsHandle()
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	// Insert 30 fake data
 	fakeData := make([][]byte, 0, 30)
@@ -408,7 +408,7 @@ func TestDumpCMSketchWithTopN(t *testing.T) {
 	stat := h.GetTableStats(tableInfo)
 	err = h.SaveStatsToStorage(tableInfo.ID, 1, 0, 0, &stat.GetCol(tableInfo.Columns[0].ID).Histogram, cms, nil, statistics.Version1, 1, false, handleutil.StatsMetaHistorySourceLoadStats)
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 
 	stat = h.GetTableStats(tableInfo)
 	cmsFromStore := stat.GetCol(tableInfo.Columns[0].ID).CMSketch
@@ -467,7 +467,7 @@ func TestDumpExtendedStats(t *testing.T) {
 	cleanStats(tk, dom)
 	wg := util.WaitGroupWrapper{}
 	wg.Run(func() {
-		require.Nil(t, h.Update(context.Background(), is))
+		require.Nil(t, h.UpdateWorker(context.Background(), is))
 	})
 	err = h.LoadStatsFromJSON(context.Background(), is, jsonTbl, 0)
 	wg.Wait()
@@ -520,7 +520,7 @@ func TestDumpVer2Stats(t *testing.T) {
 
 	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable, 0)
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsCacheTbl = h.GetTableStats(tableInfo.Meta())
 	// assert that after the JSONTable above loaded into storage then updated into the stats cache,
 	// the statistics.Table in the stats cache is the same as the unmarshalled statistics.Table
@@ -572,7 +572,7 @@ func TestLoadStatsForNewCollation(t *testing.T) {
 
 	err = h.LoadStatsFromJSON(context.Background(), is, loadJSONTable, 0)
 	require.NoError(t, err)
-	require.Nil(t, h.Update(context.Background(), is))
+	require.Nil(t, h.UpdateWorker(context.Background(), is))
 	statsCacheTbl = h.GetTableStats(tableInfo.Meta())
 	// assert that after the JSONTable above loaded into storage then updated into the stats cache,
 	// the statistics.Table in the stats cache is the same as the unmarshalled statistics.Table
@@ -623,7 +623,7 @@ func TestLoadStatsFromOldVersion(t *testing.T) {
 	h := dom.StatsHandle()
 	is := dom.InfoSchema()
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 
 	statsJSONFromOldVersion := `{
  "database_name": "test",

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -685,7 +685,7 @@ func (s *statsReadWriter) LoadStatsFromJSON(ctx context.Context, is infoschema.I
 	if err := s.LoadStatsFromJSONNoUpdate(ctx, is, jsonTbl, concurrencyForPartition); err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(s.statsHandler.Update(ctx, is))
+	return errors.Trace(s.statsHandler.UpdateWorker(ctx, is))
 }
 
 func (s *statsReadWriter) loadStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl *util.JSONTable) error {

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -56,7 +56,7 @@ func TestUpdateStatsMetaVersionForGC(t *testing.T) {
 		statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 		require.False(t, statsTbl.Pseudo)
 	}
-	err = h.Update(context.Background(), is)
+	err = h.UpdateWorker(context.Background(), is)
 	require.NoError(t, err)
 
 	// Reset one partition stats.

--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -194,7 +194,7 @@ func TestConcurrentLoadHistWithPanicAndFail(t *testing.T) {
 	for _, fp := range failpoints {
 		// clear statsCache
 		h.Clear()
-		require.NoError(t, dom.StatsHandle().Update(context.Background(), is))
+		require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), is))
 
 		// no stats at beginning
 		stat := h.GetTableStats(tableInfo)
@@ -295,7 +295,7 @@ func TestRetry(t *testing.T) {
 
 	// clear statsCache
 	h.Clear()
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), is))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), is))
 
 	// no stats at beginning
 	stat := h.GetTableStats(tableInfo)

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -166,8 +166,11 @@ type StatsCache interface {
 	// Clear clears this cache.
 	Clear()
 
+	// Update is to trigger UpdateWorker to work
+	Update() error
+
 	// Update reads stats meta from store and updates the stats map.
-	Update(ctx context.Context, is infoschema.InfoSchema) error
+	UpdateWorker(ctx context.Context, is infoschema.InfoSchema) error
 
 	// MemConsumed returns its memory usage.
 	MemConsumed() (size int64)

--- a/pkg/statistics/handle/updatetest/update_test.go
+++ b/pkg/statistics/handle/updatetest/update_test.go
@@ -70,7 +70,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 := h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
@@ -86,7 +86,7 @@ func TestSingleSessionInsert(t *testing.T) {
 		testKit.MustExec("insert into t1 values(1, 2)")
 	}
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1*2), stats1.RealtimeCount)
 
@@ -101,7 +101,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	}
 	testKit.MustExec("commit")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1*3), stats1.RealtimeCount)
 
@@ -117,7 +117,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	}
 	testKit.MustExec("commit")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1*3), stats1.RealtimeCount)
 	stats2 = h.GetTableStats(tableInfo2)
@@ -127,7 +127,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	testKit.MustExec("delete from t1")
 	testKit.MustExec("commit")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(0), stats1.RealtimeCount)
 
@@ -149,7 +149,7 @@ func TestSingleSessionInsert(t *testing.T) {
 	}
 	err = h.DumpStatsDeltaToKV(false)
 	require.NoError(t, err)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
@@ -157,12 +157,12 @@ func TestSingleSessionInsert(t *testing.T) {
 	testKit.MustExec("insert into t1 values (1,2)")
 	err = h.DumpStatsDeltaToKV(false)
 	require.NoError(t, err)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	h.FlushStats()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1+1), stats1.RealtimeCount)
 }
@@ -184,7 +184,7 @@ func TestRollback(t *testing.T) {
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 
 	stats := h.GetTableStats(tableInfo)
 	require.Equal(t, int64(0), stats.RealtimeCount)
@@ -220,7 +220,7 @@ func TestMultiSession(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 := h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
@@ -240,7 +240,7 @@ func TestMultiSession(t *testing.T) {
 	testKit2.Session().Close()
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1*2), stats1.RealtimeCount)
 	testKit.RefreshSession()
@@ -269,14 +269,14 @@ func TestTxnWithFailure(t *testing.T) {
 		testKit.MustExec("insert into t1 values(?, 2)", i)
 	}
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 := h.GetTableStats(tableInfo1)
 	// have not commit
 	require.Equal(t, int64(0), stats1.RealtimeCount)
 	testKit.MustExec("commit")
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
@@ -284,13 +284,13 @@ func TestTxnWithFailure(t *testing.T) {
 	require.Error(t, err)
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1), stats1.RealtimeCount)
 
 	testKit.MustExec("insert into t1 values(-1, 2)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(rowCount1+1), stats1.RealtimeCount)
 }
@@ -321,7 +321,7 @@ func TestUpdatePartition(t *testing.T) {
 
 		testKit.MustExec(`insert into t values (1, "a"), (7, "a")`)
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.Equal(t, int64(1), statsTbl.ModifyCount)
@@ -331,7 +331,7 @@ func TestUpdatePartition(t *testing.T) {
 
 		testKit.MustExec(`update t set a = a + 1, b = "aa"`)
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.Equal(t, int64(2), statsTbl.ModifyCount)
@@ -341,7 +341,7 @@ func TestUpdatePartition(t *testing.T) {
 
 		testKit.MustExec("delete from t")
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		for _, def := range pi.Definitions {
 			statsTbl := h.GetPartitionStats(tableInfo, def.ID)
 			require.Equal(t, int64(3), statsTbl.ModifyCount)
@@ -382,16 +382,16 @@ func TestAutoUpdate(t *testing.T) {
 
 		err = h.HandleDDLEvent(<-h.DDLEventCh())
 		require.NoError(t, err)
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		stats := h.GetTableStats(tableInfo)
 		require.Equal(t, int64(0), stats.RealtimeCount)
 
 		_, err = testKit.Exec("insert into t values ('ss'), ('ss'), ('ss'), ('ss'), ('ss')")
 		require.NoError(t, err)
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		h.HandleAutoAnalyze()
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		stats = h.GetTableStats(tableInfo)
 		require.Equal(t, int64(5), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)
@@ -407,9 +407,9 @@ func TestAutoUpdate(t *testing.T) {
 		_, err = testKit.Exec("insert into t values ('fff')")
 		require.NoError(t, err)
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		h.HandleAutoAnalyze()
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		stats = h.GetTableStats(tableInfo)
 		require.Equal(t, int64(6), stats.RealtimeCount)
 		require.Equal(t, int64(1), stats.ModifyCount)
@@ -417,9 +417,9 @@ func TestAutoUpdate(t *testing.T) {
 		_, err = testKit.Exec("insert into t values ('fff')")
 		require.NoError(t, err)
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		h.HandleAutoAnalyze()
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		stats = h.GetTableStats(tableInfo)
 		require.Equal(t, int64(7), stats.RealtimeCount)
 		require.Equal(t, int64(0), stats.ModifyCount)
@@ -427,9 +427,9 @@ func TestAutoUpdate(t *testing.T) {
 		_, err = testKit.Exec("insert into t values ('eee')")
 		require.NoError(t, err)
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		h.HandleAutoAnalyze()
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		stats = h.GetTableStats(tableInfo)
 		require.Equal(t, int64(8), stats.RealtimeCount)
 		// Modify count is non-zero means that we do not analyze the table.
@@ -448,7 +448,7 @@ func TestAutoUpdate(t *testing.T) {
 		require.NoError(t, err)
 		tableInfo = tbl.Meta()
 		h.HandleAutoAnalyze()
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		testKit.MustExec("explain select * from t where a > 'a'")
 		require.NoError(t, h.LoadNeededHistograms())
 		stats = h.GetTableStats(tableInfo)
@@ -486,13 +486,13 @@ func TestAutoUpdatePartition(t *testing.T) {
 		pi := tableInfo.GetPartitionInfo()
 		h := do.StatsHandle()
 
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		stats := h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
 		require.Equal(t, int64(0), stats.RealtimeCount)
 
 		testKit.MustExec("insert into t values (1)")
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		h.HandleAutoAnalyze()
 		stats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
 		require.Equal(t, int64(1), stats.RealtimeCount)
@@ -518,7 +518,7 @@ func TestIssue25700(t *testing.T) {
 	tk.MustExec("analyze table t")
 	tk.MustExec("INSERT INTO `t` (`ldecimal`, `rdecimal`, `col_timestamp`) VALUES (2265.2200, 9843.4100, '1999-12-31 16:00:00')" + strings.Repeat(", (2265.2200, 9843.4100, '1999-12-31 16:00:00')", int(statistics.AutoAnalyzeMinCnt)))
 	require.NoError(t, dom.StatsHandle().DumpStatsDeltaToKV(true))
-	require.NoError(t, dom.StatsHandle().Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, dom.StatsHandle().UpdateWorker(context.Background(), dom.InfoSchema()))
 
 	require.True(t, dom.StatsHandle().HandleAutoAnalyze())
 	require.Equal(t, "finished", tk.MustQuery("show analyze status").Rows()[1][7])
@@ -633,7 +633,7 @@ func TestLoadHistCorrelation(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	testKit.MustExec("analyze table t")
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	result := testKit.MustQuery("show stats_histograms where Table_name = 't'")
 	require.Len(t, result.Rows(), 0)
 	testKit.MustExec("explain select * from t where c = 1")
@@ -811,7 +811,7 @@ func TestAutoUpdatePartitionInDynamicOnlyMode(t *testing.T) {
 			testKit.MustExec("set global tidb_auto_analyze_ratio = 0.5")
 		}()
 
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 		require.NoError(t, err)
 		tableInfo := tbl.Meta()
@@ -825,7 +825,7 @@ func TestAutoUpdatePartitionInDynamicOnlyMode(t *testing.T) {
 
 		testKit.MustExec("insert into t values (3, 'g')")
 		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		globalStats = h.GetTableStats(tableInfo)
 		partitionStats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
 		require.Equal(t, int64(7), globalStats.RealtimeCount)
@@ -834,7 +834,7 @@ func TestAutoUpdatePartitionInDynamicOnlyMode(t *testing.T) {
 		require.Equal(t, int64(1), partitionStats.ModifyCount)
 
 		h.HandleAutoAnalyze()
-		require.NoError(t, h.Update(context.Background(), is))
+		require.NoError(t, h.UpdateWorker(context.Background(), is))
 		globalStats = h.GetTableStats(tableInfo)
 		partitionStats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
 		require.Equal(t, int64(7), globalStats.RealtimeCount)
@@ -864,7 +864,7 @@ func TestAutoAnalyzeRatio(t *testing.T) {
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 19))
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// To pass the stats.Pseudo check in autoAnalyzeTable
 	tk.MustExec("analyze table t")
 	tk.MustExec("explain select * from t where a = 1")
@@ -882,19 +882,19 @@ func TestAutoAnalyzeRatio(t *testing.T) {
 
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 10))
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 44)
 	require.True(t, h.HandleAutoAnalyze())
 
 	tk.MustExec("delete from t limit 12")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 61)
 	require.False(t, h.HandleAutoAnalyze())
 
 	tk.MustExec("delete from t limit 4")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 48)
 	require.True(t, h.HandleAutoAnalyze())
 }
@@ -1066,7 +1066,7 @@ func TestStatsLockUnlockForAutoAnalyze(t *testing.T) {
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 19))
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// To pass the stats.Pseudo check in autoAnalyzeTable
 	tk.MustExec("analyze table t")
 	tk.MustExec("explain select * from t where a = 1")
@@ -1076,7 +1076,7 @@ func TestStatsLockUnlockForAutoAnalyze(t *testing.T) {
 
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 10))
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.True(t, h.HandleAutoAnalyze())
 
 	tbl, err := dom.InfoSchema().TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
@@ -1092,7 +1092,7 @@ func TestStatsLockUnlockForAutoAnalyze(t *testing.T) {
 
 	tk.MustExec("delete from t limit 12")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.False(t, h.HandleAutoAnalyze())
 
 	tblStats1 := h.GetTableStats(tbl.Meta())
@@ -1143,7 +1143,7 @@ func TestStatsLockForDelta(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 := h.GetTableStats(tableInfo1)
 	require.Equal(t, stats1.RealtimeCount, int64(0))
 
@@ -1158,7 +1158,7 @@ func TestStatsLockForDelta(t *testing.T) {
 		testKit.MustExec("insert into t1 values(1, 2)")
 	}
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, stats1.RealtimeCount, int64(0))
 
@@ -1172,7 +1172,7 @@ func TestStatsLockForDelta(t *testing.T) {
 		testKit.MustExec("insert into t1 values(1, 2)")
 	}
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	stats1 = h.GetTableStats(tableInfo1)
 	require.Equal(t, int64(30), stats1.RealtimeCount)
 }
@@ -1211,22 +1211,22 @@ func TestFillMissingStatsMeta(t *testing.T) {
 
 	tk.MustExec("insert into t1 values (1, 2), (3, 4)")
 	require.NoError(t, h.DumpStatsDeltaToKV(false))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	ver1 := checkStatsMeta(tbl1ID, "2", "2")
 	tk.MustExec("delete from t1 where a = 1")
 	require.NoError(t, h.DumpStatsDeltaToKV(false))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	ver2 := checkStatsMeta(tbl1ID, "3", "1")
 	require.Greater(t, ver2, ver1)
 
 	tk.MustExec("insert into t2 values (1, 2), (3, 4)")
 	require.NoError(t, h.DumpStatsDeltaToKV(false))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	checkStatsMeta(p0ID, "2", "2")
 	globalVer1 := checkStatsMeta(tbl2ID, "2", "2")
 	tk.MustExec("insert into t2 values (11, 12)")
 	require.NoError(t, h.DumpStatsDeltaToKV(false))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	checkStatsMeta(p1ID, "1", "1")
 	globalVer2 := checkStatsMeta(tbl2ID, "3", "3")
 	require.Greater(t, globalVer2, globalVer1)

--- a/pkg/statistics/integration_test.go
+++ b/pkg/statistics/integration_test.go
@@ -51,7 +51,7 @@ func TestChangeVerTo2Behavior(t *testing.T) {
 	tblT, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	h := dom.StatsHandle()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT := h.GetTableStats(tblT.Meta())
 	// Analyze table with version 1 success, all statistics are version 1.
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
@@ -65,7 +65,7 @@ func TestChangeVerTo2Behavior(t *testing.T) {
 	tk.MustExec("set @@session.tidb_analyze_version = 2")
 	tk.MustExec("analyze table t index idx")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead"))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(1), idx.GetStatsVer())
@@ -73,14 +73,14 @@ func TestChangeVerTo2Behavior(t *testing.T) {
 	})
 	tk.MustExec("analyze table t index")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead"))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(1), idx.GetStatsVer())
 		return false
 	})
 	tk.MustExec("analyze table t ")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
 		require.Equal(t, int64(2), col.GetStatsVer())
@@ -94,7 +94,7 @@ func TestChangeVerTo2Behavior(t *testing.T) {
 	tk.MustExec("analyze table t index idx")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead",
 		"Warning 1105 The version 2 would collect all statistics not only the selected indexes"))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(2), idx.GetStatsVer())
@@ -103,14 +103,14 @@ func TestChangeVerTo2Behavior(t *testing.T) {
 	tk.MustExec("analyze table t index")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead",
 		"Warning 1105 The version 2 would collect all statistics not only the selected indexes"))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(2), idx.GetStatsVer())
 		return false
 	})
 	tk.MustExec("analyze table t ")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
 		require.Equal(t, int64(1), col.GetStatsVer())
@@ -141,7 +141,7 @@ func TestChangeVerTo2BehaviorWithPersistedOptions(t *testing.T) {
 	tblT, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	h := dom.StatsHandle()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT := h.GetTableStats(tblT.Meta())
 	// Analyze table with version 1 success, all statistics are version 1.
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
@@ -155,7 +155,7 @@ func TestChangeVerTo2BehaviorWithPersistedOptions(t *testing.T) {
 	tk.MustExec("set @@session.tidb_analyze_version = 2")
 	tk.MustExec("analyze table t index idx")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead"))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(1), idx.GetStatsVer())
@@ -163,14 +163,14 @@ func TestChangeVerTo2BehaviorWithPersistedOptions(t *testing.T) {
 	})
 	tk.MustExec("analyze table t index")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead"))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(1), idx.GetStatsVer())
 		return false
 	})
 	tk.MustExec("analyze table t ")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
 		require.Equal(t, int64(2), col.GetStatsVer())
@@ -185,7 +185,7 @@ func TestChangeVerTo2BehaviorWithPersistedOptions(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead",
 		"Warning 1105 The version 2 would collect all statistics not only the selected indexes",
 		"Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is \"use min(1, 110000/3) as the sample-rate=1\"")) // since fallback to ver2 path, should do samplerate adjustment
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(2), idx.GetStatsVer())
@@ -195,14 +195,14 @@ func TestChangeVerTo2BehaviorWithPersistedOptions(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 The analyze version from the session is not compatible with the existing statistics of the table. Use the existing version instead",
 		"Warning 1105 The version 2 would collect all statistics not only the selected indexes",
 		"Note 1105 Analyze use auto adjusted sample rate 1.000000 for table test.t, reason to use this rate is \"use min(1, 110000/3) as the sample-rate=1\""))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		require.Equal(t, int64(2), idx.GetStatsVer())
 		return false
 	})
 	tk.MustExec("analyze table t ")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT = h.GetTableStats(tblT.Meta())
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
 		require.Equal(t, int64(1), col.GetStatsVer())
@@ -268,7 +268,7 @@ func TestNULLOnFullSampling(t *testing.T) {
 	tblT, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	h := dom.StatsHandle()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTblT := h.GetTableStats(tblT.Meta())
 	// Check the null count is 3.
 	statsTblT.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
@@ -348,7 +348,7 @@ func TestOutdatedStatsCheck(t *testing.T) {
 	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	// To pass the stats.Pseudo check in autoAnalyzeTable
 	tk.MustExec("analyze table t")
 	tk.MustExec("explain select * from t where a = 1")
@@ -364,12 +364,12 @@ func TestOutdatedStatsCheck(t *testing.T) {
 
 	tk.MustExec("insert into t values (1)" + strings.Repeat(", (1)", 13)) // 34 rows
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 30)
 	require.False(t, hasPseudoStats(tk.MustQuery("explain select * from t where a = 1").Rows()))
 	tk.MustExec("insert into t values (1)") // 35 rows
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 25)
 	require.True(t, hasPseudoStats(tk.MustQuery("explain select * from t where a = 1").Rows()))
 
@@ -377,13 +377,13 @@ func TestOutdatedStatsCheck(t *testing.T) {
 
 	tk.MustExec("delete from t limit 24") // 11 rows
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 31)
 	require.False(t, hasPseudoStats(tk.MustQuery("explain select * from t where a = 1").Rows()))
 
 	tk.MustExec("delete from t limit 1") // 10 rows
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Equal(t, getStatsHealthy(), 28)
 	require.True(t, hasPseudoStats(tk.MustQuery("explain select * from t where a = 1").Rows()))
 }
@@ -410,7 +410,7 @@ func TestShowHistogramsLoadStatus(t *testing.T) {
 	tk.MustExec("insert into t values (1,2,3), (4,5,6)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	tk.MustExec("analyze table t")
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	rows := tk.MustQuery("show stats_histograms where db_name = 'test' and table_name = 't'").Rows()
 	for _, row := range rows {
 		require.Equal(t, "allEvicted", row[10].(string))
@@ -487,7 +487,7 @@ func TestUpdateNotLoadIndexFMSketch(t *testing.T) {
 	require.Nil(t, h.GetPartitionStats(tblInfo, p0.ID).GetIdx(idxInfo.ID).FMSketch)
 	require.Nil(t, h.GetPartitionStats(tblInfo, p1.ID).GetIdx(idxInfo.ID).FMSketch)
 	h.Clear()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.Nil(t, h.GetPartitionStats(tblInfo, p0.ID).GetIdx(idxInfo.ID).FMSketch)
 	require.Nil(t, h.GetPartitionStats(tblInfo, p1.ID).GetIdx(idxInfo.ID).FMSketch)
 }
@@ -503,7 +503,7 @@ func TestIssue44369(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	tk.MustExec("analyze table t;")
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tk.MustExec("alter table t rename column b to bb;")
 	tk.MustExec("select * from t where a = 10 and bb > 20;")
 }
@@ -520,7 +520,7 @@ func TestColAndIdxExistenceMapChangedAfterAlterTable(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	tk.MustExec("analyze table t;")
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tbl, err := dom.InfoSchema().TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tblInfo := tbl.Meta()
@@ -532,7 +532,7 @@ func TestColAndIdxExistenceMapChangedAfterAlterTable(t *testing.T) {
 	tk.MustExec("alter table t modify column a double")
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	is = dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tbl, err = dom.InfoSchema().TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	tblInfo = tbl.Meta()
@@ -542,7 +542,7 @@ func TestColAndIdxExistenceMapChangedAfterAlterTable(t *testing.T) {
 	colInfo = statsTbl.ColAndIdxExistenceMap.GetCol(newColA.ID)
 	require.Equal(t, newColA, colInfo)
 	tk.MustExec("analyze table t;")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl = h.GetTableStats(tblInfo)
 	colInfo = statsTbl.ColAndIdxExistenceMap.GetCol(newColA.ID)
 	require.Equal(t, newColA, colInfo)
@@ -558,7 +558,7 @@ func TestTableLastAnalyzeVersion(t *testing.T) {
 	tk.MustExec("create table t(a int);")
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 	is := dom.InfoSchema()
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	statsTbl, found := h.Get(tbl.Meta().ID)
@@ -571,7 +571,7 @@ func TestTableLastAnalyzeVersion(t *testing.T) {
 	tbl, err = is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
 	require.NoError(t, err)
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl, found = h.Get(tbl.Meta().ID)
 	require.True(t, found)
 	require.Equal(t, uint64(0), statsTbl.LastAnalyzeVersion)
@@ -581,7 +581,7 @@ func TestTableLastAnalyzeVersion(t *testing.T) {
 	// We don't handle the ADD INDEX event in the HandleDDLEvent.
 	require.Equal(t, 0, len(h.DDLEventCh()))
 	require.NoError(t, err)
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl, found = h.Get(tbl.Meta().ID)
 	require.True(t, found)
 	require.Equal(t, uint64(0), statsTbl.LastAnalyzeVersion)
@@ -589,14 +589,14 @@ func TestTableLastAnalyzeVersion(t *testing.T) {
 	// INSERT and updating the modify_count should not set the last_analyze_version
 	tk.MustExec("insert into t values(1, 1)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl, found = h.Get(tbl.Meta().ID)
 	require.True(t, found)
 	require.Equal(t, uint64(0), statsTbl.LastAnalyzeVersion)
 
 	// After analyze, last_analyze_version is set.
 	tk.MustExec("analyze table t")
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	statsTbl, found = h.Get(tbl.Meta().ID)
 	require.True(t, found)
 	require.NotEqual(t, uint64(0), statsTbl.LastAnalyzeVersion)

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -266,7 +266,7 @@ func TestTTLAutoAnalyze(t *testing.T) {
 	h := dom.StatsHandle()
 	is := dom.InfoSchema()
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), is))
+	require.NoError(t, h.UpdateWorker(context.Background(), is))
 	require.True(t, h.HandleAutoAnalyze())
 }
 

--- a/tests/realtikvtest/statisticstest/statistics_test.go
+++ b/tests/realtikvtest/statisticstest/statistics_test.go
@@ -250,7 +250,7 @@ func TestNoNeedIndexStatsLoading(t *testing.T) {
 	tk.MustExec("insert into t value(1,1), (2,2);")
 	h := dom.StatsHandle()
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
-	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
+	require.NoError(t, h.UpdateWorker(context.Background(), dom.InfoSchema()))
 	// 4. Try to select some data from this table by ID, it would trigger an async load.
 	tk.MustExec("set tidb_opt_objective='determinate';")
 	tk.MustQuery("select * from t where a = 1 and b = 1;").Check(testkit.Rows("1 1"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54481

Problem Summary:

### What changed and how does it work?

Now, ```StatsCacheImpl.Update``` can sync stats by version from the storage. we have many scenarios to call it. such as ```domain.loadStatsWorker``` and ```Analyze```. When customers use lightning, lightning will trigger the multi-analyzed tasks simultaneously. so it also triggers multi  ```StatsCacheImpl.Update``` simultaneously. it is unnecessary.

add a singleflight for ```StatsCacheImpl.Update```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
