### PR TITLE
ddl: fix a data race on localRowCntListener Written()

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -752,8 +752,8 @@ type localRowCntListener struct {
 }
 
 func (s *localRowCntListener) Written(rowCnt int) {
-	s.curPhysicalRowCnt += int64(rowCnt)
-	s.reorgCtx.setRowCount(s.prevPhysicalRowCnt + s.curPhysicalRowCnt)
+	newCurPhysicalRowCnt := atomic.AddInt64(&s.curPhysicalRowCnt, int64(rowCnt))
+	s.reorgCtx.setRowCount(s.prevPhysicalRowCnt + newCurPhysicalRowCnt)
 	s.counter.Add(float64(rowCnt))
 }
 

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -748,12 +748,17 @@ type localRowCntListener struct {
 	// prevPhysicalRowCnt records the row count from previous physical tables (partitions).
 	prevPhysicalRowCnt int64
 	// curPhysicalRowCnt records the row count of current physical table.
-	curPhysicalRowCnt int64
+	curPhysicalRowCnt struct {
+		cnt int64
+		mu  sync.Mutex
+	}
 }
 
 func (s *localRowCntListener) Written(rowCnt int) {
-	newCurPhysicalRowCnt := atomic.AddInt64(&s.curPhysicalRowCnt, int64(rowCnt))
-	s.reorgCtx.setRowCount(s.prevPhysicalRowCnt + newCurPhysicalRowCnt)
+	s.curPhysicalRowCnt.mu.Lock()
+	s.curPhysicalRowCnt.cnt += int64(rowCnt)
+	s.reorgCtx.setRowCount(s.prevPhysicalRowCnt + s.curPhysicalRowCnt.cnt)
+	s.curPhysicalRowCnt.mu.Unlock()
 	s.counter.Add(float64(rowCnt))
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54373

Problem Summary:

### What changed and how does it work?
`localRowCntListener` can create tasks by `HandleTask()`, which can be read/write `curPhysicalRowCnt`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
