### PR TITLE
ddl: fix prepare stmt with partition related ddl stmts

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2317,7 +2317,7 @@ func (e *executor) AddTablePartitions(ctx sessionctx.Context, ident ast.Ident, s
 			syntacticStart := strings.Index(query, syntacticSugar)
 			if syntacticStart == -1 {
 				logutil.DDLLogger().Error("Can't find related PARTITION definition in prepare stmt",
-					zap.String("PARTITION defiition", syntacticSugar), zap.String("prepare stmt", query))
+					zap.String("PARTITION definition", syntacticSugar), zap.String("prepare stmt", query))
 				return errors.Errorf("Can't find related PARTITION definition in PREPARE STMT")
 			}
 			newQuery := query[:syntacticStart] + "ADD PARTITION (" + buf.String() + ")" + query[syntacticStart+len(syntacticSugar):]

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1028,8 +1028,8 @@ func (e *executor) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (
 		return errors.Trace(err)
 	}
 
-	if s.Partition != nil {
-		rewritePartitionQueryString(ctx, s.Partition, tbInfo)
+	if err = rewritePartitionQueryString(ctx, s.Partition, tbInfo); err != nil {
+		return err
 	}
 
 	if err = checkTableInfoValidWithStmt(metaBuildCtx, tbInfo, s); err != nil {
@@ -2443,7 +2443,9 @@ func (e *executor) AlterTablePartitioning(ctx sessionctx.Context, ident ast.Iden
 	}
 
 	newPartInfo := newMeta.Partition
-	rewritePartitionQueryString(ctx, spec.Partition, newMeta)
+	if err = rewritePartitionQueryString(ctx, spec.Partition, newMeta); err != nil {
+		return errors.Trace(err)
+	}
 
 	if err = handlePartitionPlacement(ctx, newPartInfo); err != nil {
 		return errors.Trace(err)
@@ -5630,8 +5632,8 @@ func (e *executor) RepairTable(ctx sessionctx.Context, createStmt *ast.CreateTab
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if createStmt.Partition != nil {
-		rewritePartitionQueryString(ctx, createStmt.Partition, newTableInfo)
+	if err = rewritePartitionQueryString(ctx, createStmt.Partition, newTableInfo); err != nil {
+		return errors.Trace(err)
 	}
 	// Override newTableInfo with oldTableInfo's element necessary.
 	// TODO: There may be more element assignments here, and the new TableInfo should be verified with the actual data.

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -648,9 +648,9 @@ func buildTablePartitionInfo(ctx *metabuild.Context, s *ast.PartitionOptions, tb
 	return nil
 }
 
-func rewritePartitionQueryString(ctx sessionctx.Context, s *ast.PartitionOptions, tbInfo *model.TableInfo) {
+func rewritePartitionQueryString(ctx sessionctx.Context, s *ast.PartitionOptions, tbInfo *model.TableInfo) error {
 	if s == nil {
-		return
+		return nil
 	}
 
 	if s.Interval != nil {
@@ -673,6 +673,7 @@ func rewritePartitionQueryString(ctx sessionctx.Context, s *ast.PartitionOptions
 			ctx.SetValue(sessionctx.QueryString, newQuery)
 		}
 	}
+	return nil
 }
 
 func getPartitionColSlices(sctx expression.BuildContext, tblInfo *model.TableInfo, s *ast.PartitionOptions) (partCols stringSlice, err error) {

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -666,7 +666,7 @@ func rewritePartitionQueryString(ctx sessionctx.Context, s *ast.PartitionOptions
 			syntacticStart := strings.Index(query, syntacticSugar)
 			if syntacticStart == -1 {
 				logutil.DDLLogger().Error("Can't find INTERVAL definition in prepare stmt",
-					zap.String("INTERVAL defiition", syntacticSugar), zap.String("prepare stmt", query))
+					zap.String("INTERVAL definition", syntacticSugar), zap.String("prepare stmt", query))
 				return errors.Errorf("Can't find INTERVAL definition in PREPARE STMT")
 			}
 			newQuery := query[:syntacticStart] + "(" + buf.String() + ")" + query[syntacticStart+len(syntacticSugar):]

--- a/pkg/parser/ast/ast.go
+++ b/pkg/parser/ast/ast.go
@@ -44,6 +44,7 @@ type Node interface {
 	// SetText sets original text to the Node.
 	SetText(enc charset.Encoding, text string)
 	// SetOriginTextPosition set the start offset of this node in the origin text.
+	// Only be called when `parser.lexer.skipPositionRecording` equals to false.
 	SetOriginTextPosition(offset int)
 	// OriginTextPosition get the start offset of this node in the origin text.
 	OriginTextPosition() int

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -2124,7 +2124,6 @@ AlterTableSpecSingleOpt:
 		startOffset := parser.yyVAL.offset
 		endOffset := parser.yylval.offset
 		partitionMethod.SetText(parser.lexer.client, parser.src[startOffset:endOffset])
-		partitionMethod.SetOriginTextPosition(startOffset)
 		$$ = &ast.AlterTableSpec{
 			Tp:        ast.AlterTableReorganizeLastPartition,
 			Partition: &ast.PartitionOptions{PartitionMethod: partitionMethod},
@@ -2136,8 +2135,6 @@ AlterTableSpecSingleOpt:
 		startOffset := parser.yyVAL.offset
 		endOffset := parser.yylval.offset
 		partitionMethod.SetText(parser.lexer.client, parser.src[startOffset:endOffset])
-		// Needed for replacing syntactic sugar with generated partitioning definition string
-		partitionMethod.SetOriginTextPosition(startOffset)
 		$$ = &ast.AlterTableSpec{
 			Tp:        ast.AlterTableReorganizeFirstPartition,
 			Partition: &ast.PartitionOptions{PartitionMethod: partitionMethod},
@@ -2318,8 +2315,6 @@ AlterTableSpec:
 		startOffset := parser.yyVAL.offset
 		endOffset := parser.yylval.offset
 		partitionMethod.SetText(parser.lexer.client, parser.src[startOffset:endOffset])
-		// Needed for replacing syntactic sugar with generated partitioning definition string
-		partitionMethod.SetOriginTextPosition(startOffset)
 		$$ = &ast.AlterTableSpec{
 			NoWriteToBinlog: noWriteToBinlog,
 			Tp:              ast.AlterTableAddLastPartition,
@@ -2406,8 +2401,6 @@ AlterTableSpec:
 		startOffset := parser.yyVAL.offset
 		endOffset := parser.yylval.offset
 		partitionMethod.SetText(parser.lexer.client, parser.src[startOffset:endOffset])
-		// Needed for replacing syntactic sugar with generated partitioning definition string
-		partitionMethod.SetOriginTextPosition(startOffset)
 		$$ = &ast.AlterTableSpec{
 			IfExists:  $8.(bool),
 			Tp:        ast.AlterTableDropFirstPartition,
@@ -4713,8 +4706,6 @@ PartitionIntervalOpt:
 		startOffset := parser.yyVAL.offset
 		endOffset := parser.yylval.offset
 		partitionInterval.SetText(parser.lexer.client, parser.src[startOffset:endOffset])
-		// Needed for replacing syntactic sugar with generated partitioning definition string
-		partitionInterval.SetOriginTextPosition(startOffset)
 		$$ = partitionInterval
 	}
 

--- a/tests/integrationtest/r/ddl/db_partition.result
+++ b/tests/integrationtest/r/ddl/db_partition.result
@@ -3270,3 +3270,76 @@ id	store_id	_tidb_rowid
 0	18	30257
 1	1	30001
 drop table t, t1;
+drop table if exists aaa;
+prepare stmt from "\ncreate table aaa(id bigint primary key) partition by range (id) interval (100) first partition less than (100) last partition less than (500)";
+execute stmt;
+show create table aaa;
+Table	Create Table
+aaa	CREATE TABLE `aaa` (
+  `id` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id`)
+(PARTITION `P_LT_100` VALUES LESS THAN (100),
+ PARTITION `P_LT_200` VALUES LESS THAN (200),
+ PARTITION `P_LT_300` VALUES LESS THAN (300),
+ PARTITION `P_LT_400` VALUES LESS THAN (400),
+ PARTITION `P_LT_500` VALUES LESS THAN (500))
+prepare stmt2 from "\nalter table aaa last partition less than (600)";
+execute stmt2;
+show create table aaa;
+Table	Create Table
+aaa	CREATE TABLE `aaa` (
+  `id` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id`)
+(PARTITION `P_LT_100` VALUES LESS THAN (100),
+ PARTITION `P_LT_200` VALUES LESS THAN (200),
+ PARTITION `P_LT_300` VALUES LESS THAN (300),
+ PARTITION `P_LT_400` VALUES LESS THAN (400),
+ PARTITION `P_LT_500` VALUES LESS THAN (500),
+ PARTITION `P_LT_600` VALUES LESS THAN (600))
+prepare stmt3 from "\nalter table aaa first partition less than (300)";
+execute stmt3;
+show create table aaa;
+Table	Create Table
+aaa	CREATE TABLE `aaa` (
+  `id` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id`)
+(PARTITION `P_LT_300` VALUES LESS THAN (300),
+ PARTITION `P_LT_400` VALUES LESS THAN (400),
+ PARTITION `P_LT_500` VALUES LESS THAN (500),
+ PARTITION `P_LT_600` VALUES LESS THAN (600))
+drop table if exists aaa;
+prepare stmt from "create table aaa(id bigint primary key) partition by range (id)\n interval (100) first partition less than (100) last partition less than (500)";
+execute stmt;
+show create table aaa;
+Table	Create Table
+aaa	CREATE TABLE `aaa` (
+  `id` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id`)
+(PARTITION `P_LT_100` VALUES LESS THAN (100),
+ PARTITION `P_LT_200` VALUES LESS THAN (200),
+ PARTITION `P_LT_300` VALUES LESS THAN (300),
+ PARTITION `P_LT_400` VALUES LESS THAN (400),
+ PARTITION `P_LT_500` VALUES LESS THAN (500))
+drop table if exists aaa;
+prepare stmt from "create table aaa(id bigint primary key) partition by range (id) interval (100) first partition\n less than (100) last partition less than (500)";
+execute stmt;
+show create table aaa;
+Table	Create Table
+aaa	CREATE TABLE `aaa` (
+  `id` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (`id`)
+(PARTITION `P_LT_100` VALUES LESS THAN (100),
+ PARTITION `P_LT_200` VALUES LESS THAN (200),
+ PARTITION `P_LT_300` VALUES LESS THAN (300),
+ PARTITION `P_LT_400` VALUES LESS THAN (400),
+ PARTITION `P_LT_500` VALUES LESS THAN (500))

--- a/tests/integrationtest/t/ddl/db_partition.test
+++ b/tests/integrationtest/t/ddl/db_partition.test
@@ -2266,3 +2266,4 @@ drop table if exists aaa;
 prepare stmt from "create table aaa(id bigint primary key) partition by range (id) interval (100) first partition\n less than (100) last partition less than (500)";
 execute stmt;
 show create table aaa;
+

--- a/tests/integrationtest/t/ddl/db_partition.test
+++ b/tests/integrationtest/t/ddl/db_partition.test
@@ -2242,3 +2242,27 @@ select * from t;
 --sorted_result
 select *,_tidb_rowid from t;
 drop table t, t1;
+
+# TestCreateAndAlterIntervalPartitionWithPerpareStmt
+drop table if exists aaa;
+prepare stmt from "\ncreate table aaa(id bigint primary key) partition by range (id) interval (100) first partition less than (100) last partition less than (500)";
+execute stmt;
+show create table aaa;
+
+prepare stmt2 from "\nalter table aaa last partition less than (600)";
+execute stmt2;
+show create table aaa;
+
+prepare stmt3 from "\nalter table aaa first partition less than (300)";
+execute stmt3;
+show create table aaa;
+
+drop table if exists aaa;
+prepare stmt from "create table aaa(id bigint primary key) partition by range (id)\n interval (100) first partition less than (100) last partition less than (500)";
+execute stmt;
+show create table aaa;
+
+drop table if exists aaa;
+prepare stmt from "create table aaa(id bigint primary key) partition by range (id) interval (100) first partition\n less than (100) last partition less than (500)";
+execute stmt;
+show create table aaa;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54283

Problem Summary: We use `OriginTextPosition` to split prepared ddl stmts. But it is wrong when query has prefixed blank, like '\ncreate ...'. So we should call `strings.index` to regenerate it.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
