### PR TITLE
session, executor, domain: use the SQL start time to calculate the runaway deadline

### DIFF
--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1118,7 +1118,7 @@ type SessionVars struct {
 	// NoopFuncsMode allows OFF/ON/WARN values as 0/1/2.
 	NoopFuncsMode int
 
-	// StartTime is the start time of the last query.
+	// StartTime is the start time of the last query. It's set after the query is parsed and before the query is compiled.
 	StartTime time.Time
 
 	// DurationParse is the duration of parsing SQL string to AST of the last query.
@@ -1831,6 +1831,16 @@ func (s *SessionVars) BuildParserConfig() parser.ParserConfig {
 // AllocNewPlanID alloc new ID
 func (s *SessionVars) AllocNewPlanID() int {
 	return int(s.PlanID.Add(1))
+}
+
+// GetTotalCostDuration returns the total cost duration of the last statement in the current session.
+func (s *SessionVars) GetTotalCostDuration() time.Duration {
+	return time.Since(s.StartTime) + s.DurationParse
+}
+
+// GetExecuteDuration returns the execute duration of the last statement in the current session.
+func (s *SessionVars) GetExecuteDuration() time.Duration {
+	return time.Since(s.StartTime) - s.DurationCompile
 }
 
 const (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54434.

### What changed and how does it work?

Use the `StartTime` in `SessionVars` to calculate the runaway deadline.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
