### PR TITLE
br: fix get snapshot response pointer deref panic

### DIFF
--- a/br/pkg/aws/BUILD.bazel
+++ b/br/pkg/aws/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//br/pkg/config",
         "//br/pkg/glue",
+        "//br/pkg/utils",
         "//pkg/util",
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//aws/awserr",

--- a/br/pkg/aws/ebs.go
+++ b/br/pkg/aws/ebs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/config"
 	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/pkg/util"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -252,7 +253,7 @@ func (e *EC2Session) WaitSnapshotsCreated(snapIDMap map[string]string, progress 
 				log.Info("snapshot completed", zap.String("id", *s.SnapshotId))
 				totalVolumeSize += *s.VolumeSize
 			} else if *s.State == ec2.SnapshotStateError {
-				log.Error("snapshot failed", zap.String("id", *s.SnapshotId), zap.String("error", (*s.StateMessage)))
+				log.Error("snapshot failed", zap.String("id", *s.SnapshotId), zap.String("error", utils.GetOrZero(s.StateMessage)))
 				return 0, errors.Errorf("snapshot %s failed", *s.SnapshotId)
 			} else {
 				log.Debug("snapshot creating...", zap.Stringer("snap", s))

--- a/br/pkg/aws/ebs_test.go
+++ b/br/pkg/aws/ebs_test.go
@@ -146,6 +146,25 @@ func TestWaitSnapshotsCreated(t *testing.T) {
 			expectErr:    true,
 		},
 		{
+			desc: "snapshot failed w/out state message",
+			snapshotsOutput: ec2.DescribeSnapshotsOutput{
+				Snapshots: []*ec2.Snapshot{
+					{
+						SnapshotId: awsapi.String("snap-1"),
+						VolumeSize: awsapi.Int64(1),
+						State:      awsapi.String(ec2.SnapshotStateCompleted),
+					},
+					{
+						SnapshotId:   awsapi.String("snap-2"),
+						State:        awsapi.String(ec2.SnapshotStateError),
+						StateMessage: nil,
+					},
+				},
+			},
+			expectedSize: 0,
+			expectErr:    true,
+		},
+		{
 			desc: "snapshots pending",
 			snapshotsOutput: ec2.DescribeSnapshotsOutput{
 				Snapshots: []*ec2.Snapshot{

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "key.go",
         "misc.go",
         "permission.go",
+        "pointer.go",
         "pprof.go",
         "progress.go",
         "register.go",

--- a/br/pkg/utils/pointer.go
+++ b/br/pkg/utils/pointer.go
@@ -5,9 +5,9 @@ package utils
 // GetOrZero returns the value pointed to by p, or a zero value of
 // its type if p is nil.
 func GetOrZero[T any](p *T) T {
-	var val T
+	var zero T
 	if p == nil {
-		return val
+		return zero
 	}
 	return *p
 }

--- a/br/pkg/utils/pointer.go
+++ b/br/pkg/utils/pointer.go
@@ -1,0 +1,13 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package utils
+
+// GetOrZero returns the value pointed to by p, or a zero value of
+// its type if p is nil.
+func GetOrZero[T any](p *T) T {
+	var val T
+	if p == nil {
+		return val
+	}
+	return *p
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #54511

Problem Summary:

EC2 DescribeSnapshots API doesn't always return StateMessage in response for errored snapshot. Example response:

```
{
    "Snapshots": [
        {
            "Description": "",
            "Encrypted": true,
            "KmsKeyId": "...",
            "OwnerId": "...",
            "Progress": "99%",
            "SnapshotId": "snap-04c5f87d0a2b069b0",
            "StartTime": "2024-07-08T15:07:01.437000+00:00",
            "State": "error",
            "VolumeId": "vol-0377214577dd710de",
            "VolumeSize": 50,
            "Tags": [
                ...
            ],
            "StorageTier": "standard"
        }
    ]
}
```

In these cases, snapshot backup process panics due to nil pointer dereference. End result is the same (failed backup), but we still want to correctly process these errors

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4474931]

goroutine 1 [running]:
github.com/pingcap/tidb/br/pkg/aws.(*EC2Session).WaitSnapshotsCreated(0xc03e03f660, 0xc0073997d0, {0x5c81370, 0xc00c4a6b00})
  /tidb/br/pkg/aws/ebs.go:255 +0xa71
github.com/pingcap/tidb/br/pkg/task.RunBackupEBS({0x5c814f8, 0xc000193b80}, {0x5c940b8?, 0x86bcdc0?}, 0xc000c1fc00)
  /tidb/br/pkg/task/backup_ebs.go:255 +0x1c8a
main.runBackupCommand(0xc000c20000, {0x53bfc8f, 0xb})
  /tidb/br/cmd/br/backup.go:36 +0x1d4
main.newFullBackupCommand.func1(0xc00079a800?, {0xc000c480c0?, 0x4?, 0x53adfc5?})
  /tidb/br/cmd/br/backup.go:117 +0x1f
github.com/spf13/cobra.(*Command).execute(0xc000c20000, {0xc00026e030, 0xc, 0xc})
  /go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x87c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000c04000)
  /go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
  /go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
  /tidb/br/cmd/br/main.go:36 +0x212
```
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->



### What changed and how does it work?

Check state message ptr is defined before deref

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

test panics prior to fix, success w/ fix

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
