### PR TITLE
planner: use ordered index with is null predicate

### DIFF
--- a/pkg/planner/core/casetest/index/BUILD.bazel
+++ b/pkg/planner/core/casetest/index/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -183,8 +183,12 @@ func getPotentialEqOrInColOffset(sctx *rangerctx.RangerContext, expr expression.
 			}
 		}
 	case ast.IsNull:
-		if _, ok := f.GetArgs()[0].(*expression.Column); ok {
-			return 0
+		if c, ok := f.GetArgs()[0].(*expression.Column); ok {
+			for i, col := range cols {
+				if col.EqualColumn(c) {
+					return i
+				}
+			}
 		}
 	}
 	return -1
@@ -648,7 +652,8 @@ func allEqOrIn(expr expression.Expression) bool {
 func extractValueInfo(expr expression.Expression) *valueInfo {
 	if f, ok := expr.(*expression.ScalarFunction); ok {
 		if f.FuncName.L == ast.IsNull {
-			return &valueInfo{mutable: false}
+			var value = types.NewDatum(nil)
+			return &valueInfo{&value, false}
 		}
 		if f.FuncName.L == ast.EQ || f.FuncName.L == ast.NullEQ {
 			getValueInfo := func(c *expression.Constant) *valueInfo {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54188

Problem Summary:
Properly classify columns with null predicates (e.g. WHERE a IS NULL) as constant so index selection can take advantage of that to satisfy a sort in
as constant so index selection can take advantage of that to satisfy a sort in:

[tidb/pkg/planner/core/find_best_task.go](https://github.com/pingcap/tidb/blob/432bb79f9732cb89a0be220ca93415df37a4849e/pkg/planner/core/find_best_task.go#L791)

Dupe of https://github.com/pingcap/tidb/pull/54253  and https://github.com/pingcap/tidb/pull/54290 with CI failure fixes. @ari-e is out for a bit so attempting to unblock this while he is out.


### What changed and how does it work?
Added checks for is null predicate during planning and fill corresponding data structures marking that column as a constant.
### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
