### PR TITLE
server: add protocol support for lazy cursor fetch

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -233,7 +233,7 @@ func (a *recordSet) OnFetchReturned() {
 	a.stmt.LogSlowQuery(a.txnStartTS, len(a.lastErrs) == 0, true)
 }
 
-// Detach creates a new `RecordSet` which doesn't depend on the current session context.
+// TryDetach creates a new `RecordSet` which doesn't depend on the current session context.
 func (a *recordSet) TryDetach() (sqlexec.RecordSet, bool, error) {
 	// TODO: also detach the executor. Currently, the executor inside may contain the session context. Once
 	// the executor itself supports detach, we should also detach it here.

--- a/pkg/executor/staticrecordset/BUILD.bazel
+++ b/pkg/executor/staticrecordset/BUILD.bazel
@@ -25,11 +25,12 @@ go_test(
     timeout = "short",
     srcs = ["integration_test.go"],
     flaky = True,
-    shard_count = 6,
+    shard_count = 7,
     deps = [
         "//pkg/session/cursor",
         "//pkg/testkit",
         "//pkg/util/sqlexec",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",
     ],

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2435,10 +2435,10 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 		start = time.Now()
 	}
 
-	iter := rs.GetRowContainerReader()
+	iter := rs.GetRowIterator()
 	// send the rows to the client according to fetchSize.
-	for i := 0; i < fetchSize && iter.Current() != iter.End(); i++ {
-		row := iter.Current()
+	for i := 0; i < fetchSize && iter.Current(ctx) != iter.End(); i++ {
+		row := iter.Current(ctx)
 
 		data = data[0:4]
 		data, err = column.DumpBinaryRow(data, rs.Columns(), row, cc.rsEncoder)
@@ -2449,7 +2449,7 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 			return err
 		}
 
-		iter.Next()
+		iter.Next(ctx)
 	}
 	if iter.Error() != nil {
 		return iter.Error()
@@ -2457,7 +2457,7 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs resultset
 
 	// tell the client COM_STMT_FETCH has finished by setting proper serverStatus,
 	// and close ResultSet.
-	if iter.Current() == iter.End() {
+	if iter.Current(ctx) == iter.End() {
 		serverStatus &^= mysql.ServerStatusCursorExists
 		serverStatus |= mysql.ServerStatusLastRowSend
 	}

--- a/pkg/server/conn_stmt_test.go
+++ b/pkg/server/conn_stmt_test.go
@@ -129,11 +129,11 @@ func TestCursorWithParams(t *testing.T) {
 		0x0, 0x1, 0x3, 0x0, 0x3, 0x0,
 		0x1, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0,
 	)))
-	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowContainerReader()
-	require.Equal(t, int64(1), rows.Current().GetInt64(0))
-	require.Equal(t, int64(2), rows.Current().GetInt64(1))
-	rows.Next()
-	require.Equal(t, rows.End(), rows.Current())
+	rows := c.Context().stmts[stmt1.ID()].GetResultSet().GetRowIterator()
+	require.Equal(t, int64(1), rows.Current(context.Background()).GetInt64(0))
+	require.Equal(t, int64(2), rows.Current(context.Background()).GetInt64(1))
+	rows.Next(context.Background())
+	require.Equal(t, rows.End(), rows.Current(context.Background()))
 
 	// `execute stmt2 using 1` with cursor
 	require.NoError(t, c.Dispatch(ctx, append(
@@ -142,13 +142,13 @@ func TestCursorWithParams(t *testing.T) {
 		0x0, 0x1, 0x3, 0x0,
 		0x1, 0x0, 0x0, 0x0,
 	)))
-	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowContainerReader()
-	require.Equal(t, int64(1), rows.Current().GetInt64(0))
-	require.Equal(t, int64(1), rows.Current().GetInt64(1))
-	require.Equal(t, int64(1), rows.Next().GetInt64(0))
-	require.Equal(t, int64(2), rows.Current().GetInt64(1))
-	rows.Next()
-	require.Equal(t, rows.End(), rows.Current())
+	rows = c.Context().stmts[stmt2.ID()].GetResultSet().GetRowIterator()
+	require.Equal(t, int64(1), rows.Current(context.Background()).GetInt64(0))
+	require.Equal(t, int64(1), rows.Current(context.Background()).GetInt64(1))
+	require.Equal(t, int64(1), rows.Next(context.Background()).GetInt64(0))
+	require.Equal(t, int64(2), rows.Current(context.Background()).GetInt64(1))
+	rows.Next(context.Background())
+	require.Equal(t, rows.End(), rows.Current(context.Background()))
 
 	// fetch stmt2 with fetch size 256
 	require.NoError(t, c.Dispatch(ctx, append(

--- a/pkg/server/driver_tidb.go
+++ b/pkg/server/driver_tidb.go
@@ -150,8 +150,8 @@ func (ts *TiDBStatement) Reset() error {
 	}
 	ts.hasActiveCursor = false
 
-	if ts.rs != nil && ts.rs.GetRowContainerReader() != nil {
-		ts.rs.GetRowContainerReader().Close()
+	if ts.rs != nil && ts.rs.GetRowIterator() != nil {
+		ts.rs.GetRowIterator().Close()
 	}
 	ts.rs = nil
 
@@ -173,8 +173,8 @@ func (ts *TiDBStatement) Reset() error {
 
 // Close implements PreparedStatement Close method.
 func (ts *TiDBStatement) Close() error {
-	if ts.rs != nil && ts.rs.GetRowContainerReader() != nil {
-		ts.rs.GetRowContainerReader().Close()
+	if ts.rs != nil && ts.rs.GetRowIterator() != nil {
+		ts.rs.GetRowIterator().Close()
 	}
 
 	if ts.rowContainer != nil {

--- a/pkg/server/internal/resultset/cursor.go
+++ b/pkg/server/internal/resultset/cursor.go
@@ -14,37 +14,70 @@
 
 package resultset
 
-import "github.com/pingcap/tidb/pkg/util/chunk"
+import (
+	"context"
+
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+// RowIterator has similar method with `chunk.RowContainerReader`. The only difference is that
+// it needs a `context.Context` for the `Next` and `Current` method.
+type RowIterator interface {
+	// Next returns the next Row.
+	Next(context.Context) chunk.Row
+
+	// Current returns the current Row.
+	Current(context.Context) chunk.Row
+
+	// End returns the invalid end Row.
+	End() chunk.Row
+
+	// Error returns none-nil error if anything wrong happens during the iteration.
+	Error() error
+
+	// Close closes the dumper
+	Close()
+}
 
 // CursorResultSet extends the `ResultSet` to provide the ability to store an iterator
 type CursorResultSet interface {
 	ResultSet
 
-	StoreRowContainerReader(reader chunk.RowContainerReader)
-	GetRowContainerReader() chunk.RowContainerReader
+	GetRowIterator() RowIterator
 }
 
-// WrapWithCursor wraps a ResultSet into a CursorResultSet
-func WrapWithCursor(rs ResultSet) CursorResultSet {
+// WrapWithRowContainerCursor wraps a ResultSet into a CursorResultSet
+func WrapWithRowContainerCursor(rs ResultSet, rowContainer chunk.RowContainerReader) CursorResultSet {
 	return &tidbCursorResultSet{
-		rs, nil,
+		ResultSet: rs,
+		reader: rowContainerReaderIter{
+			RowContainerReader: rowContainer,
+		},
 	}
 }
-
-var _ CursorResultSet = &tidbCursorResultSet{}
 
 type tidbCursorResultSet struct {
 	ResultSet
 
-	reader chunk.RowContainerReader
+	reader rowContainerReaderIter
 }
 
-func (tcrs *tidbCursorResultSet) StoreRowContainerReader(reader chunk.RowContainerReader) {
-	tcrs.reader = reader
+func (tcrs *tidbCursorResultSet) GetRowIterator() RowIterator {
+	return &tcrs.reader
 }
 
-func (tcrs *tidbCursorResultSet) GetRowContainerReader() chunk.RowContainerReader {
-	return tcrs.reader
+var _ RowIterator = &rowContainerReaderIter{}
+
+type rowContainerReaderIter struct {
+	chunk.RowContainerReader
+}
+
+func (iter *rowContainerReaderIter) Next(context.Context) chunk.Row {
+	return iter.RowContainerReader.Next()
+}
+
+func (iter *rowContainerReaderIter) Current(context.Context) chunk.Row {
+	return iter.RowContainerReader.Current()
 }
 
 // FetchNotifier represents notifier will be called in COM_FETCH.
@@ -52,4 +85,85 @@ type FetchNotifier interface {
 	// OnFetchReturned be called when COM_FETCH returns.
 	// it will be used in server-side cursor.
 	OnFetchReturned()
+}
+
+var _ CursorResultSet = &tidbLazyCursorResultSet{}
+
+type tidbLazyCursorResultSet struct {
+	ResultSet
+	iter lazyRowIterator
+}
+
+// WrapWithLazyCursor wraps a ResultSet into a CursorResultSet
+func WrapWithLazyCursor(rs ResultSet, capacity, maxChunkSize int) CursorResultSet {
+	chk := chunk.New(rs.FieldTypes(), capacity, maxChunkSize)
+
+	return &tidbLazyCursorResultSet{
+		ResultSet: rs,
+		iter: lazyRowIterator{
+			rs:  rs,
+			chk: chk,
+		},
+	}
+}
+
+func (tcrs *tidbLazyCursorResultSet) GetRowIterator() RowIterator {
+	return &tcrs.iter
+}
+
+type lazyRowIterator struct {
+	rs       ResultSet
+	err      error
+	chk      *chunk.Chunk
+	idxInChk int
+	started  bool
+}
+
+func (iter *lazyRowIterator) Next(ctx context.Context) chunk.Row {
+	if !iter.started {
+		iter.started = true
+	}
+
+	iter.idxInChk++
+
+	if iter.idxInChk >= iter.chk.NumRows() {
+		// Reached the end, update the chunk
+		err := iter.rs.Next(ctx, iter.chk)
+		if err != nil {
+			iter.err = err
+			return chunk.Row{}
+		}
+
+		if iter.chk.NumRows() == 0 {
+			// reached the end
+			return chunk.Row{}
+		}
+		iter.idxInChk = 0
+	}
+
+	return iter.chk.GetRow(iter.idxInChk)
+}
+
+func (iter *lazyRowIterator) Current(ctx context.Context) chunk.Row {
+	if !iter.started {
+		return iter.Next(ctx)
+	}
+
+	if iter.chk.NumRows() == 0 {
+		return chunk.Row{}
+	}
+
+	return iter.chk.GetRow(iter.idxInChk)
+}
+
+func (*lazyRowIterator) End() chunk.Row {
+	return chunk.Row{}
+}
+
+func (iter *lazyRowIterator) Error() error {
+	return iter.err
+}
+
+func (iter *lazyRowIterator) Close() {
+	iter.rs.Close()
 }

--- a/pkg/server/tests/commontest/BUILD.bazel
+++ b/pkg/server/tests/commontest/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "commontest_test",
     timeout = "short",
     srcs = [
+        "cursor_test.go",
         "main_test.go",
         "tidb_test.go",
     ],

--- a/pkg/server/tests/commontest/cursor_test.go
+++ b/pkg/server/tests/commontest/cursor_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commontest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/server/internal/resultset"
+	"github.com/pingcap/tidb/pkg/server/tests/servertestkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyRowIterator(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	qctx, err := ts.Tidbdrv.OpenCtx(uint64(0), 0, uint8(mysql.DefaultCollationID), "test", nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = Execute(ctx, qctx, "use test")
+	require.NoError(t, err)
+	_, err = Execute(ctx, qctx, "create table t (id int)")
+	require.NoError(t, err)
+	// insert 1000 rows
+	for i := 0; i < 1000; i++ {
+		_, err = Execute(ctx, qctx, fmt.Sprintf("insert into t values (%d)", i))
+		require.NoError(t, err)
+	}
+
+	for _, chkSize := range []struct{ initSize, maxSize int }{
+		{1024, 1024}, {512, 512}, {256, 256}, {100, 100}} {
+		rs, err := Execute(ctx, qctx, "select * from t")
+		require.NoError(t, err)
+		crs := resultset.WrapWithLazyCursor(rs, chkSize.initSize, chkSize.maxSize)
+		iter := crs.GetRowIterator()
+		for i := 0; i < 1000; i++ {
+			row := iter.Current(ctx)
+			require.Equal(t, int64(i), row.GetInt64(0))
+			row = iter.Next(ctx)
+			if i+1 >= 1000 {
+				require.True(t, row.IsEmpty())
+			} else {
+				require.Equal(t, int64(i+1), row.GetInt64(0))
+			}
+		}
+		require.True(t, iter.Current(ctx).IsEmpty())
+		iter.Close()
+	}
+}

--- a/pkg/server/tests/cursor/BUILD.bazel
+++ b/pkg/server/tests/cursor/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/config",
         "//pkg/metrics",

--- a/pkg/server/tests/cursor/cursor_test.go
+++ b/pkg/server/tests/cursor/cursor_test.go
@@ -190,7 +190,7 @@ outerLoop:
 		require.NoError(t, err)
 		stmt := rawStmt.(mysqlcursor.Statement)
 
-		// This query will return 10000 rows and use cursor fetch.
+		// This query will return `rowCount` rows and use cursor fetch.
 		rows, err := stmt.QueryContext(context.Background(), nil)
 		require.NoError(t, err)
 
@@ -223,6 +223,69 @@ outerLoop:
 				require.NoError(t, err)
 				require.NoError(t, rows.Close())
 			}
+		}
+	}
+}
+
+func TestSerialLazyExecuteAndFetch(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	mysqldriver := &mysqlcursor.MySQLDriver{}
+	rawConn, err := mysqldriver.Open(ts.GetDSNWithCursor(10))
+	require.NoError(t, err)
+	conn := rawConn.(mysqlcursor.Connection)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(), "drop table if exists t1", nil)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(context.Background(), "create table t1(id int primary key, v int)", nil)
+	require.NoError(t, err)
+	rowCount := 1000
+	for i := 0; i < rowCount; i++ {
+		_, err = conn.ExecContext(context.Background(), fmt.Sprintf("insert into t1 values(%d, %d)", i, i), nil)
+		require.NoError(t, err)
+	}
+
+	_, err = conn.ExecContext(context.Background(), "set tidb_enable_lazy_cursor_fetch = 'ON'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch", "return"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch"))
+	}()
+
+	// Normal execute. Simple table reader.
+	execTimes := 0
+outerLoop:
+	for execTimes < 50 {
+		execTimes++
+		rawStmt, err := conn.Prepare("select * from t1")
+		require.NoError(t, err)
+		stmt := rawStmt.(mysqlcursor.Statement)
+
+		// This query will return `rowCount` rows and use cursor fetch.
+		rows, err := stmt.QueryContext(context.Background(), nil)
+		require.NoError(t, err)
+
+		dest := make([]driver.Value, 2)
+		fetchRowCount := int64(0)
+
+		for {
+			// it'll send `FETCH` commands for every 10 rows.
+			err := rows.Next(dest)
+			if err != nil {
+				switch err {
+				case io.EOF:
+					require.Equal(t, int64(rowCount), fetchRowCount)
+					rows.Close()
+					break outerLoop
+				default:
+					require.NoError(t, err)
+				}
+			}
+			require.Equal(t, fetchRowCount, dest[0])
+			require.Equal(t, fetchRowCount, dest[1])
+			fetchRowCount++
 		}
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2412,7 +2412,7 @@ func (rs *execStmtResult) TryDetach() (sqlexec.RecordSet, bool, error) {
 		if err2 != nil {
 			logutil.BgLogger().Error("close detached record set failed", zap.Error(err2))
 		}
-		return nil, false, err
+		return nil, true, err
 	}
 
 	return crs, true, nil

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/schematracker"
@@ -224,6 +225,9 @@ func recordAbortTxnDuration(sessVars *variable.SessionVars, isInternal bool) {
 }
 
 func finishStmt(ctx context.Context, se *session, meetsErr error, sql sqlexec.Statement) error {
+	failpoint.Inject("finishStmtError", func() {
+		failpoint.Return(errors.New("occur an error after finishStmt"))
+	})
 	sessVars := se.sessionVars
 	if !sql.IsReadOnly(sessVars) {
 		// All the history should be added here.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1622,6 +1622,9 @@ type SessionVars struct {
 
 	// GroupConcatMaxLen represents the maximum length of the result of GROUP_CONCAT.
 	GroupConcatMaxLen uint64
+
+	// EnableLazyCursorFetch defines whether to enable the lazy cursor fetch.
+	EnableLazyCursorFetch bool
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3254,6 +3254,10 @@ var defaultSysVars = []*SysVar{
 		},
 		IsHintUpdatableVerified: true,
 	},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableLazyCursorFetch, Value: BoolToOnOff(DefTiDBEnableLazyCursorFetch), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnableLazyCursorFetch = TiDBOptOn(val)
+		return nil
+	}},
 }
 
 // GlobalSystemVariableInitialValue gets the default value for a system variable including ones that are dynamically set (e.g. based on the store)

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -1171,6 +1171,9 @@ const (
 	// The value can be STANDARD, BULK.
 	// Currently, the BULK mode only affects auto-committed DML.
 	TiDBDMLType = "tidb_dml_type"
+	// TiDBEnableLazyCursorFetch defines whether to enable the lazy cursor fetch. If it's `OFF`, all results of
+	// of a cursor will be stored in the tidb node in `EXECUTE` command.
+	TiDBEnableLazyCursorFetch = "tidb_enable_lazy_cursor_fetch"
 )
 
 // TiDB intentional limits
@@ -1503,6 +1506,7 @@ const (
 	DefTiDBDMLType                                    = "STANDARD"
 	DefGroupConcatMaxLen                              = uint64(1024)
 	DefDefaultWeekFormat                              = "0"
+	DefTiDBEnableLazyCursorFetch                      = false
 )
 
 // Process global variables.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #54526

Problem Summary:

Previously, all cursor fetch requests will load the data to the TiDB. Now, we can support lazily fetch results in a limited scope.

### What changed and how does it work?

1. Add a new system variable `tidb_enable_lazy_cursor_fetch`.
2. Add a new implementation of `ResultSet` to give similar interface like the one for eager cursor fetch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add a new system variable `tidb_enable_lazy_cursor_fetch` to indicate whether to try to fetch data lazily for cursor fetch requests.
```
