### PR TITLE
statistics: fix sync load fails after disabling lite init stats

### DIFF
--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -834,6 +834,19 @@ func (t *TableInfo) Cols() []*ColumnInfo {
 	return publicColumns[0 : maxOffset+1]
 }
 
+// GetColumnByID finds the column by ID.
+func (t *TableInfo) GetColumnByID(id int64) *ColumnInfo {
+	for _, col := range t.Columns {
+		if col.State != StatePublic {
+			continue
+		}
+		if col.ID == id {
+			return col
+		}
+	}
+	return nil
+}
+
 // FindIndexByName finds index by name.
 func (t *TableInfo) FindIndexByName(idxName string) *IndexInfo {
 	for _, idx := range t.Indices {

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1315,31 +1315,43 @@ func TestBuiltinInEstWithoutStats(t *testing.T) {
 	h := dom.StatsHandle()
 
 	tk.MustExec("use test")
-	tk.MustExec("create table t(a int)")
+	tk.MustExec("create table t(a int, b int)")
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
-	tk.MustExec("insert into t values(1), (2), (3), (4), (5), (6), (7), (8), (9), (10)")
+	tk.MustExec("insert into t values(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)")
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	is := dom.InfoSchema()
 	require.NoError(t, h.Update(context.Background(), is))
-
-	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(testkit.Rows(
+	expectedA := testkit.Rows(
 		"TableReader 0.08 root  data:Selection",
 		"└─Selection 0.08 cop[tikv]  in(test.t.a, 1, 2, 3, 4, 5, 6, 7, 8)",
 		"  └─TableFullScan 10.00 cop[tikv] table:t keep order:false, stats:pseudo",
-	))
+	)
+	expectedB := testkit.Rows(
+		"TableReader 0.08 root  data:Selection",
+		"└─Selection 0.08 cop[tikv]  in(test.t.b, 1, 2, 3, 4, 5, 6, 7, 8)",
+		"  └─TableFullScan 10.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	)
+	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(expectedA)
+	// try again with other column
+	tk.MustQuery("explain format='brief' select * from t where b in (1, 2, 3, 4, 5, 6, 7, 8)").Check(expectedB)
 
 	h.Clear()
 	require.NoError(t, h.InitStatsLite(context.Background(), is))
-	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(testkit.Rows(
-		"TableReader 0.08 root  data:Selection",
-		"└─Selection 0.08 cop[tikv]  in(test.t.a, 1, 2, 3, 4, 5, 6, 7, 8)",
-		"  └─TableFullScan 10.00 cop[tikv] table:t keep order:false, stats:pseudo",
-	))
+	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(expectedA)
+	tk.MustQuery("explain format='brief' select * from t where b in (1, 2, 3, 4, 5, 6, 7, 8)").Check(expectedB)
+
 	h.Clear()
 	require.NoError(t, h.InitStats(context.Background(), is))
-	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(testkit.Rows(
-		"TableReader 0.08 root  data:Selection",
-		"└─Selection 0.08 cop[tikv]  in(test.t.a, 1, 2, 3, 4, 5, 6, 7, 8)",
-		"  └─TableFullScan 10.00 cop[tikv] table:t keep order:false, stats:pseudo",
-	))
+	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(expectedA)
+	tk.MustQuery("explain format='brief' select * from t where b in (1, 2, 3, 4, 5, 6, 7, 8)").Check(expectedB)
+	require.NoError(t, h.Update(context.Background(), is))
+	tbl, err := is.TableByName(context.Background(), model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	statsTbl, found := h.Get(tbl.Meta().ID)
+	require.True(t, found)
+	require.False(t, statsTbl.ColAndIdxExistenceMap.IsEmpty())
+	for _, col := range tbl.Cols() {
+		require.True(t, statsTbl.ColAndIdxExistenceMap.Has(col.ID, false))
+		require.False(t, statsTbl.ColAndIdxExistenceMap.HasAnalyzed(col.ID, false))
+	}
 }

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1338,8 +1338,8 @@ func TestBuiltinInEstWithoutStats(t *testing.T) {
 	h.Clear()
 	require.NoError(t, h.InitStats(context.Background(), is))
 	tk.MustQuery("explain format='brief' select * from t where a in (1, 2, 3, 4, 5, 6, 7, 8)").Check(testkit.Rows(
-		"TableReader 8.00 root  data:Selection",
-		"└─Selection 8.00 cop[tikv]  in(test.t.a, 1, 2, 3, 4, 5, 6, 7, 8)",
+		"TableReader 0.08 root  data:Selection",
+		"└─Selection 0.08 cop[tikv]  in(test.t.a, 1, 2, 3, 4, 5, 6, 7, 8)",
 		"  └─TableFullScan 10.00 cop[tikv] table:t keep order:false, stats:pseudo",
 	))
 }

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -216,12 +216,6 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		id, ndv, nullCount, version, totColSize := row.GetInt64(2), row.GetInt64(3), row.GetInt64(5), row.GetUint64(4), row.GetInt64(7)
 		lastAnalyzePos := row.GetDatum(11, types.NewFieldType(mysql.TypeBlob))
 		tbl, _ := h.TableInfoByID(is, table.PhysicalID)
-		for _, col := range tbl.Meta().Columns {
-			table.ColAndIdxExistenceMap.InsertCol(col.ID, col, statsVer != statistics.Version0)
-		}
-		for _, col := range tbl.Meta().Indices {
-			table.ColAndIdxExistenceMap.InsertIndex(col.ID, col, statsVer != statistics.Version0)
-		}
 		if row.GetInt64(1) > 0 {
 			var idxInfo *model.IndexInfo
 			for _, idx := range tbl.Meta().Indices {

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -216,6 +216,12 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		id, ndv, nullCount, version, totColSize := row.GetInt64(2), row.GetInt64(3), row.GetInt64(5), row.GetUint64(4), row.GetInt64(7)
 		lastAnalyzePos := row.GetDatum(11, types.NewFieldType(mysql.TypeBlob))
 		tbl, _ := h.TableInfoByID(is, table.PhysicalID)
+		for _, col := range tbl.Meta().Columns {
+			table.ColAndIdxExistenceMap.InsertCol(col.ID, col, statsVer != statistics.Version0)
+		}
+		for _, col := range tbl.Meta().Indices {
+			table.ColAndIdxExistenceMap.InsertIndex(col.ID, col, statsVer != statistics.Version0)
+		}
 		if row.GetInt64(1) > 0 {
 			var idxInfo *model.IndexInfo
 			for _, idx := range tbl.Meta().Indices {

--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/metrics",
         "//pkg/parser/model",

--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/statistics",
         "//pkg/statistics/handle/storage",
         "//pkg/statistics/handle/types",
+        "//pkg/table",
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/intest",

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
+	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -304,6 +305,7 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 	if !ok {
 		return nil
 	}
+	var tblInfo table.Table
 	wrapper := &statsWrapper{}
 	if item.IsIndex {
 		index, loadNeeded := tbl.IndexIsLoadNeeded(item.ID)
@@ -323,12 +325,13 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 		if col != nil {
 			wrapper.colInfo = col.Info
 		} else if colInfo := tbl.ColAndIdxExistenceMap.GetCol(item.ID); colInfo != nil {
-			wrapper.colInfo = tbl.ColAndIdxExistenceMap.GetCol(item.ID)
+			wrapper.colInfo = colInfo
 		} else {
+			// Now, we cannot init the column info in the ColAndIdxExistenceMap when to disable lite-init-stats.
+			// so we have to get the column info from the domain.
 			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-			tblInfo, ok := s.statsHandle.TableInfoByID(is, item.TableID)
+			tblInfo, ok = s.statsHandle.TableInfoByID(is, item.TableID)
 			if !ok {
-				fmt.Println("fuck")
 				return nil
 			}
 			wrapper.colInfo = tblInfo.Meta().GetColumnByID(item.ID)
@@ -554,14 +557,13 @@ func (s *statsSyncLoad) updateCachedItem(item model.TableItemID, colHist *statis
 		}
 		tbl = tbl.Copy()
 		tbl.SetCol(item.ID, colHist)
-		// If the column is analyzed we refresh the map for the possible change.
-		if colHist.StatsAvailable() {
-			tbl.ColAndIdxExistenceMap.InsertCol(item.ID, colHist.Info, true)
-		}
+
 		// All the objects shares the same stats version. Update it here.
 		if colHist.StatsVer != statistics.Version0 {
 			tbl.StatsVer = statistics.Version0
 		}
+		// we have to refresh the map for the possible change to ensure that the map information is not missing.
+		tbl.ColAndIdxExistenceMap.InsertCol(item.ID, colHist.Info, colHist.StatsAvailable())
 	} else if item.IsIndex && idxHist != nil {
 		index := tbl.GetIdx(item.ID)
 		// - If the stats is fully loaded,

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -824,12 +824,10 @@ func (t *Table) ColumnIsLoadNeeded(id int64, fullLoad bool) (*Column, bool, bool
 
 	// If it's not analyzed yet.
 	if !hasAnalyzed {
-		// If we don't have it in memory, we create a fake hist for pseudo estimation (see handleOneItemTask()).
-		// If we don't have this column. We skip it.
-		// It's something ridiculous. But it's possible that the stats don't have some ColumnInfo.
-		// We need to find a way to maintain it more correctly.
 		// Otherwise we don't need to load it.
-		return nil, t.ColAndIdxExistenceMap.Has(id, false), false
+		result := t.ColAndIdxExistenceMap.Has(id, false)
+		// If the column is not in the ColAndIdxExistenceMap, we need to load it.
+		return nil, !result, !result
 	}
 
 	// Restore the condition from the simplified form:

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -824,6 +824,9 @@ func (t *Table) ColumnIsLoadNeeded(id int64, fullLoad bool) (*Column, bool, bool
 
 	// If it's not analyzed yet.
 	if !hasAnalyzed {
+		// If we don't have it in memory, we create a fake hist for pseudo estimation (see handleOneItemTask()).
+		// It's something ridiculous. But it's possible that the stats don't have some ColumnInfo.
+		// We need to find a way to maintain it more correctly.
 		// Otherwise we don't need to load it.
 		result := t.ColAndIdxExistenceMap.Has(id, false)
 		// If the column is not in the ColAndIdxExistenceMap, we need to load it.

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -167,11 +167,6 @@ func (m *ColAndIdxExistenceMap) IsEmpty() bool {
 	return len(m.colInfoMap)+len(m.idxInfoMap) == 0
 }
 
-// IsColEmpty checks whether the column map is empty.
-func (m *ColAndIdxExistenceMap) IsColEmpty() bool {
-	return len(m.colInfoMap) == 0
-}
-
 // Clone deeply copies the map.
 func (m *ColAndIdxExistenceMap) Clone() *ColAndIdxExistenceMap {
 	mm := NewColAndIndexExistenceMap(len(m.colInfoMap), len(m.idxInfoMap))

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -809,6 +809,9 @@ func (t *Table) ColumnIsLoadNeeded(id int64, fullLoad bool) (*Column, bool, bool
 	if t.Pseudo {
 		return nil, false, false
 	}
+	if len(t.columns) == 0 {
+		return nil, true, true
+	}
 	col, ok := t.columns[id]
 	hasAnalyzed := t.ColAndIdxExistenceMap.HasAnalyzed(id, false)
 
@@ -819,7 +822,7 @@ func (t *Table) ColumnIsLoadNeeded(id int64, fullLoad bool) (*Column, bool, bool
 			// If we don't have this column. We skip it.
 			// It's something ridiculous. But it's possible that the stats don't have some ColumnInfo.
 			// We need to find a way to maintain it more correctly.
-			return nil, t.ColAndIdxExistenceMap.Has(id, false), false
+			return nil, false, true
 		}
 		// Otherwise we don't need to load it.
 		return nil, false, false

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -145,9 +145,6 @@ Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 100 YEAR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1d' */
-show histograms_in_flight;
-HistogramsInFlight
-0
 show open tables;
 Database	Table	In_use	Name_locked
 show open tables in executor__show;

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -145,6 +145,9 @@ Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 100 YEAR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1d' */
+show histograms_in_flight;
+HistogramsInFlight
+0
 show open tables;
 Database	Table	In_use	Name_locked
 show open tables in executor__show;

--- a/tests/integrationtest/t/executor/show.test
+++ b/tests/integrationtest/t/executor/show.test
@@ -64,7 +64,7 @@ create table t (created_at datetime) TTL = created_at + INTERVAL 100 YEAR TTL_JO
 show create table t;
 
 # TestShowHistogramsInFlight
-show histograms_in_flight;
+# show histograms_in_flight;  // it is unstable.
 
 # TestShowOpenTables
 show open tables;

--- a/tests/integrationtest/t/executor/show.test
+++ b/tests/integrationtest/t/executor/show.test
@@ -64,7 +64,7 @@ create table t (created_at datetime) TTL = created_at + INTERVAL 100 YEAR TTL_JO
 show create table t;
 
 # TestShowHistogramsInFlight
-show histograms_in_flight;
+# show histograms_in_flight; TODO(hawkingrei): it is unstable, Please fix it after removing the infoschema in the stats.
 
 # TestShowOpenTables
 show open tables;

--- a/tests/integrationtest/t/executor/show.test
+++ b/tests/integrationtest/t/executor/show.test
@@ -64,7 +64,7 @@ create table t (created_at datetime) TTL = created_at + INTERVAL 100 YEAR TTL_JO
 show create table t;
 
 # TestShowHistogramsInFlight
-# show histograms_in_flight; TODO(hawkingrei): it is unstable, Please fix it after removing the infoschema in the stats.
+show histograms_in_flight;
 
 # TestShowOpenTables
 show open tables;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54532

Problem Summary:

### What changed and how does it work?

after https://github.com/pingcap/tidb/pull/53399,  we don't load the common column's stats into the cache. so it also cannot init the infoschema in the stats structure. so it will lead the problem, which cannot sync load 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
