### PR TITLE
planner: fix index out of range in constructIndexJoinInnerSideTask

### DIFF
--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1464,12 +1464,13 @@ func constructIndexJoinInnerSideTask(p *LogicalJoin, dsCopTask *CopTask, ds *Dat
 		ds.TableInfo.GetPartitionInfo() == nil {
 		if len(path.IdxCols) < len(groupByCols) {
 			preferStream = false
-		}
-		sctx := p.SCtx()
-		for i, groupbyCol := range groupByCols {
-			if path.IdxColLens[i] != types.UnspecifiedLength ||
-				!groupbyCol.EqualByExprAndID(sctx.GetExprCtx().GetEvalCtx(), path.IdxCols[i]) {
-				preferStream = false
+		} else {
+			sctx := p.SCtx()
+			for i, groupbyCol := range groupByCols {
+				if path.IdxColLens[i] != types.UnspecifiedLength ||
+					!groupbyCol.EqualByExprAndID(sctx.GetExprCtx().GetEvalCtx(), path.IdxCols[i]) {
+					preferStream = false
+				}
 			}
 		}
 	} else {

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
+    shard_count = 3,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -87,7 +87,7 @@ func Test53726(t *testing.T) {
 			"    └─TableFullScan_10 2.00 cop[tikv] table:t7 keep order:false"))
 }
 
-func Test54535(t *testing.T) {
+func TestIssue54535(t *testing.T) {
 	// test for tidb_enable_inl_join_inner_multi_pattern system variable
 	store, domain := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -89,7 +89,7 @@ func Test53726(t *testing.T) {
 
 func TestIssue54535(t *testing.T) {
 	// test for tidb_enable_inl_join_inner_multi_pattern system variable
-	store, domain := testkit.CreateMockStoreAndDomain(t)
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("set session tidb_enable_inl_join_inner_multi_pattern='ON'")
@@ -98,21 +98,17 @@ func TestIssue54535(t *testing.T) {
 	tk.MustExec("analyze table ta")
 	tk.MustExec("analyze table tb")
 
-	stmt, err := parser.New().ParseOneStmt("SELECT /*+ inl_join(tmp) */ * FROM ta, (SELECT b1, COUNT(b3) AS cnt FROM tb GROUP BY b1, b2) as tmp where ta.a1 = tmp.b1", "", "")
-	require.NoError(t, err)
-
-	p, _, err := planner.Optimize(context.TODO(), tk.Session(), stmt, domain.InfoSchema())
-	require.NoError(t, err)
-	require.NotNil(t, p)
-
-	// The optimizer should choose IndexJoin
-	var ok bool
-	for {
-		_, ok = p.(*core.PhysicalIndexJoin)
-		if ok || len(p.(base.PhysicalPlan).Children()) == 0 {
-			break
-		}
-		p = p.(base.PhysicalPlan).Children()[0]
-	}
-	require.True(t, ok)
+	tk.MustQuery("explain SELECT /*+ inl_join(tmp) */ * FROM ta, (SELECT b1, COUNT(b3) AS cnt FROM tb GROUP BY b1, b2) as tmp where ta.a1 = tmp.b1").
+		Check(testkit.Rows(
+			"Projection_9 9990.00 root  test.ta.a1, test.ta.a2, test.ta.a3, test.tb.b1, Column#9",
+			"└─IndexJoin_16 9990.00 root  inner join, inner:HashAgg_14, outer key:test.ta.a1, inner key:test.tb.b1, equal cond:eq(test.ta.a1, test.tb.b1)",
+			"  ├─TableReader_43(Build) 9990.00 root  data:Selection_42",
+			"  │ └─Selection_42 9990.00 cop[tikv]  not(isnull(test.ta.a1))",
+			"  │   └─TableFullScan_41 10000.00 cop[tikv] table:ta keep order:false, stats:pseudo",
+			"  └─HashAgg_14(Probe) 79840080.00 root  group by:test.tb.b1, test.tb.b2, funcs:count(Column#11)->Column#9, funcs:firstrow(test.tb.b1)->test.tb.b1",
+			"    └─IndexLookUp_15 79840080.00 root  ",
+			"      ├─Selection_12(Build) 9990.00 cop[tikv]  not(isnull(test.tb.b1))",
+			"      │ └─IndexRangeScan_10 10000.00 cop[tikv] table:tb, index:idx_b(b1) range: decided by [eq(test.tb.b1, test.ta.a1)], keep order:false, stats:pseudo",
+			"      └─HashAgg_13(Probe) 79840080.00 cop[tikv]  group by:test.tb.b1, test.tb.b2, funcs:count(test.tb.b3)->Column#11",
+			"        └─TableRowIDScan_11 9990.00 cop[tikv] table:tb keep order:false, stats:pseudo"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54535

Problem Summary:

When set system variable `tidb_enable_inl_join_inner_multi_pattern` to `ON`, the following SQL will get an error.

```SQL
set GLOBAL tidb_enable_inl_join_inner_multi_pattern='ON';
create table ta(a1 int, a2 int, a3 int, index idx_a(a1));
create table tb(b1 int, b2 int, b3 int, index idx_b(b1));
explain SELECT /*+ inl_join(tmp) */ * FROM ta, (SELECT b1, COUNT(b3) AS cnt FROM tb GROUP BY b1, b2) as tmp where ta.a1 = tmp.b1;

ERROR 1105 (HY000): runtime error: index out of range [1] with length 1
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
