### PR TITLE
table: make slices in `ColSizeDeltaBuffer` private

### DIFF
--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1363,7 +1363,7 @@ func getDataSourceType(p *plannercore.ImportInto) DataSourceType {
 type JobImportResult struct {
 	Affected   uint64
 	Warnings   []contextutil.SQLWarn
-	ColSizeMap map[int64]int64
+	ColSizeMap variable.DeltaColsMap
 }
 
 // GetMsgFromBRError get msg from BR error.

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -332,7 +332,7 @@ func (e *BaseExecutor) Ctx() sessionctx.Context {
 // UpdateDeltaForTableID updates the delta info for the table with tableID.
 func (e *BaseExecutor) UpdateDeltaForTableID(id int64) {
 	txnCtx := e.ctx.GetSessionVars().TxnCtx
-	txnCtx.UpdateDeltaForTable(id, 0, 0, map[int64]int64{})
+	txnCtx.UpdateDeltaForTable(id, 0, 0, nil)
 }
 
 // GetSysSession gets a system session context from executor.

--- a/pkg/table/context/buffers.go
+++ b/pkg/table/context/buffers.go
@@ -112,6 +112,9 @@ func (b *CheckRowBuffer) Reset(capacity int) {
 	b.rowToCheck = ensureCapacityAndReset(b.rowToCheck, 0, capacity)
 }
 
+// ColSizeDeltaBuffer implements variable.DeltaCols
+var _ variable.DeltaCols = &ColSizeDeltaBuffer{}
+
 // ColSizeDeltaBuffer is a buffer to store the change of column size.
 type ColSizeDeltaBuffer struct {
 	delta []variable.ColSize
@@ -127,10 +130,15 @@ func (b *ColSizeDeltaBuffer) AddColSizeDelta(colID int64, size int64) {
 	b.delta = append(b.delta, variable.ColSize{ColID: colID, Size: size})
 }
 
-// GetColSizeDelta gets the column size delta.
-// TODO: make sure the inner buffer is not used outside directly.
-func (b *ColSizeDeltaBuffer) GetColSizeDelta() []variable.ColSize {
-	return b.delta
+// UpdateColSizeMap updates the column size map which uses columID as the map key and column size as the value.
+func (b *ColSizeDeltaBuffer) UpdateColSizeMap(m map[int64]int64) map[int64]int64 {
+	if m == nil && len(b.delta) > 0 {
+		m = make(map[int64]int64, len(b.delta))
+	}
+	for _, delta := range b.delta {
+		m[delta.ColID] += delta.Size
+	}
+	return m
 }
 
 // MutateBuffers is a memory pool for table related memory allocation that aims to reuse memory
@@ -187,7 +195,7 @@ func (b *MutateBuffers) GetCheckRowBufferWithCap(capacity int) *CheckRowBuffer {
 // Usage:
 // 1. Call `GetColSizeDeltaBufferWithCap` to get the buffer.
 // 2. Call `ColSizeDeltaBuffer.AddColSizeDelta` for every column to add column size delta.
-// 3. Call `ColSizeDeltaBuffer.ColSizeDeltaBuffer` to get deltas for all columns.
+// 3. Call `ColSizeDeltaBuffer.UpdateColSizeMap` to update a column size map.
 // Because the inner slices are reused, you should not call this method again before finishing the previous usage.
 // Otherwise, the previous data will be overwritten.
 func (b *MutateBuffers) GetColSizeDeltaBufferWithCap(capacity int) *ColSizeDeltaBuffer {

--- a/pkg/table/context/buffers_test.go
+++ b/pkg/table/context/buffers_test.go
@@ -203,10 +203,23 @@ func TestColSizeDeltaBuffer(t *testing.T) {
 	buffer.Reset(6)
 	require.Equal(t, 0, len(buffer.delta))
 	require.Equal(t, 6, cap(buffer.delta))
+	require.Nil(t, buffer.UpdateColSizeMap(nil))
+
 	buffer.AddColSizeDelta(1, 2)
-	buffer.AddColSizeDelta(3, 4)
-	require.Equal(t, []variable.ColSize{{ColID: 1, Size: 2}, {ColID: 3, Size: 4}}, buffer.delta)
-	require.Equal(t, buffer.delta, buffer.GetColSizeDelta())
+	buffer.AddColSizeDelta(3, -4)
+	buffer.AddColSizeDelta(10, 11)
+	require.Equal(t, []variable.ColSize{{ColID: 1, Size: 2}, {ColID: 3, Size: -4}, {ColID: 10, Size: 11}}, buffer.delta)
+
+	require.Equal(t, map[int64]int64{1: 2, 3: -4, 10: 11}, buffer.UpdateColSizeMap(nil))
+	m := make(map[int64]int64)
+	m2 := buffer.UpdateColSizeMap(m)
+	require.Equal(t, map[int64]int64{1: 2, 3: -4, 10: 11}, m2)
+	require.Equal(t, m2, m)
+
+	m = map[int64]int64{1: 3, 3: 5, 5: 7}
+	m2 = buffer.UpdateColSizeMap(m)
+	require.Equal(t, map[int64]int64{1: 5, 3: 1, 5: 7, 10: 11}, m2)
+	require.Equal(t, m2, m)
 
 	// reset should not shrink the capacity
 	buffer.Reset(2)

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -657,7 +657,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 		oldLen := size - 1
 		colSizeBuffer.AddColSizeDelta(col.ID, int64(newLen-oldLen))
 	}
-	sessVars.TxnCtx.UpdateDeltaForTableFromColSlice(t.physicalTableID, 0, 1, colSizeBuffer.GetColSizeDelta())
+	sessVars.TxnCtx.UpdateDeltaForTable(t.physicalTableID, 0, 1, colSizeBuffer)
 	return nil
 }
 
@@ -1073,7 +1073,7 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 		}
 		colSizeBuffer.AddColSizeDelta(col.ID, int64(size-1))
 	}
-	sessVars.TxnCtx.UpdateDeltaForTableFromColSlice(t.physicalTableID, 1, 1, colSizeBuffer.GetColSizeDelta())
+	sessVars.TxnCtx.UpdateDeltaForTable(t.physicalTableID, 1, 1, colSizeBuffer)
 	return recordID, nil
 }
 
@@ -1352,8 +1352,8 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 		}
 		colSizeBuffer.AddColSizeDelta(col.ID, -int64(size-1))
 	}
-	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTableFromColSlice(
-		t.physicalTableID, -1, 1, colSizeBuffer.GetColSizeDelta(),
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(
+		t.physicalTableID, -1, 1, colSizeBuffer,
 	)
 	return err
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54392

### What changed and how does it work?

The inner slices in `ColSizeDeltaBuffer` should not be accessed directly for safe. This PR makes inner slices in `ColSizeDeltaBuffer` private and exposes another method `UpdateColSizeMap` to update col size.

This PR also removes `UpdateDeltaForTableFromColSlice` and use a unique function `UpdateDeltaForTable` to update the table delta.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
