### PR TITLE
*: support tidb_redact_log for explain

### DIFF
--- a/pkg/executor/aggfuncs/func_group_concat.go
+++ b/pkg/executor/aggfuncs/func_group_concat.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/types"
@@ -74,9 +75,9 @@ func (e *baseGroupConcat4String) handleTruncateError(ctx AggFuncUpdateContext) (
 
 	if atomic.CompareAndSwapInt32(e.truncated, 0, 1) {
 		if !tc.Flags().TruncateAsWarning() {
-			return expression.ErrCutValueGroupConcat.GenWithStackByArgs(e.args[0].StringWithCtx(ctx))
+			return expression.ErrCutValueGroupConcat.GenWithStackByArgs(e.args[0].StringWithCtx(ctx, errors.RedactLogDisable))
 		}
-		tc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(e.args[0].StringWithCtx(ctx)))
+		tc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(e.args[0].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return nil
 }

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -815,7 +815,7 @@ func (p *Plan) initParameters(plan *plannercore.ImportInto) error {
 	}
 	for _, opt := range plan.Options {
 		if opt.Value != nil {
-			val := opt.Value.StringWithCtx(evalCtx)
+			val := opt.Value.StringWithCtx(evalCtx, errors.RedactLogDisable)
 			if opt.Name == cloudStorageURIOption {
 				val = ast.RedactURL(val)
 			}

--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -111,6 +111,7 @@ go_library(
         "//pkg/util/password-validation",
         "//pkg/util/plancodec",
         "//pkg/util/printer",
+        "//pkg/util/redact",
         "//pkg/util/sem",
         "//pkg/util/set",
         "//pkg/util/size",

--- a/pkg/expression/aggregation/agg_to_pb.go
+++ b/pkg/expression/aggregation/agg_to_pb.go
@@ -107,7 +107,7 @@ func AggFuncToPBExpr(ctx expression.PushDownContext, aggFunc *AggFuncDesc, store
 	for _, arg := range aggFunc.Args {
 		pbArg := pc.ExprToPB(arg)
 		if pbArg == nil {
-			return nil, errors.New(aggFunc.StringWithCtx(ctx.EvalCtx()) + " can't be converted to PB.")
+			return nil, errors.New(aggFunc.StringWithCtx(ctx.EvalCtx(), errors.RedactLogDisable) + " can't be converted to PB.")
 		}
 		children = append(children, pbArg)
 	}
@@ -121,7 +121,7 @@ func AggFuncToPBExpr(ctx expression.PushDownContext, aggFunc *AggFuncDesc, store
 		for _, arg := range aggFunc.OrderByItems {
 			pbArg := expression.SortByItemToPB(ctx.EvalCtx(), client, arg.Expr, arg.Desc)
 			if pbArg == nil {
-				return nil, errors.New(aggFunc.StringWithCtx(ctx.EvalCtx()) + " can't be converted to PB.")
+				return nil, errors.New(aggFunc.StringWithCtx(ctx.EvalCtx(), errors.RedactLogDisable) + " can't be converted to PB.")
 			}
 			orderBy = append(orderBy, pbArg)
 		}

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -71,11 +71,11 @@ func (a *baseFuncDesc) clone() *baseFuncDesc {
 }
 
 // StringWithCtx returns the string within given context.
-func (a *baseFuncDesc) StringWithCtx(ctx expression.ParamValues) string {
+func (a *baseFuncDesc) StringWithCtx(ctx expression.ParamValues, redact string) string {
 	buffer := bytes.NewBufferString(a.Name)
 	buffer.WriteString("(")
 	for i, arg := range a.Args {
-		buffer.WriteString(arg.StringWithCtx(ctx))
+		buffer.WriteString(arg.StringWithCtx(ctx, redact))
 		if i+1 != len(a.Args) {
 			buffer.WriteString(", ")
 		}
@@ -149,7 +149,7 @@ func (a *baseFuncDesc) typeInfer4ApproxPercentile(ctx expression.EvalContext) er
 	}
 	percent, isNull, err := a.Args[1].EvalInt(ctx, chunk.Row{})
 	if err != nil {
-		return fmt.Errorf("APPROX_PERCENTILE: Invalid argument %s", a.Args[1].StringWithCtx(ctx))
+		return fmt.Errorf("APPROX_PERCENTILE: Invalid argument %s", a.Args[1].StringWithCtx(ctx, errors.RedactLogDisable))
 	}
 	if percent <= 0 || percent > 100 || isNull {
 		if isNull {

--- a/pkg/expression/aggregation/concat.go
+++ b/pkg/expression/aggregation/concat.go
@@ -104,7 +104,7 @@ func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		}
 		evalCtx.Buffer.Truncate(i)
 		if !cf.truncated {
-			sc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(cf.Args[0].StringWithCtx(evalCtx.Ctx)))
+			sc.AppendWarning(expression.ErrCutValueGroupConcat.FastGenByArgs(cf.Args[0].StringWithCtx(evalCtx.Ctx, errors.RedactLogDisable)))
 		}
 		cf.truncated = true
 	}

--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -60,14 +60,14 @@ func NewAggFuncDescForWindowFunc(ctx expression.BuildContext, desc *WindowFuncDe
 }
 
 // StringWithCtx returns the string representation within given ctx.
-func (a *AggFuncDesc) StringWithCtx(ctx expression.ParamValues) string {
+func (a *AggFuncDesc) StringWithCtx(ctx expression.ParamValues, redact string) string {
 	buffer := bytes.NewBufferString(a.Name)
 	buffer.WriteString("(")
 	if a.HasDistinct {
 		buffer.WriteString("distinct ")
 	}
 	for i, arg := range a.Args {
-		buffer.WriteString(arg.StringWithCtx(ctx))
+		buffer.WriteString(arg.StringWithCtx(ctx, redact))
 		if i+1 != len(a.Args) {
 			buffer.WriteString(", ")
 		}
@@ -76,7 +76,7 @@ func (a *AggFuncDesc) StringWithCtx(ctx expression.ParamValues) string {
 		buffer.WriteString(" order by ")
 	}
 	for i, arg := range a.OrderByItems {
-		buffer.WriteString(arg.StringWithCtx(ctx))
+		buffer.WriteString(arg.StringWithCtx(ctx, redact))
 		if i+1 != len(a.OrderByItems) {
 			buffer.WriteString(", ")
 		}

--- a/pkg/expression/bench_test.go
+++ b/pkg/expression/bench_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/charset"
@@ -1375,7 +1376,7 @@ func benchmarkVectorizedEvalOneVec(b *testing.B, vecExprCases vecExprBenchCases)
 	for funcName, testCases := range vecExprCases {
 		for _, testCase := range testCases {
 			expr, _, input, output := genVecExprBenchCase(ctx, funcName, testCase)
-			exprName := expr.StringWithCtx(ctx)
+			exprName := expr.StringWithCtx(ctx, perrors.RedactLogDisable)
 			if sf, ok := expr.(*ScalarFunction); ok {
 				exprName = fmt.Sprintf("%v", reflect.TypeOf(sf.Function))
 				tmp := strings.Split(exprName, ".")

--- a/pkg/expression/builtin_arithmetic.go
+++ b/pkg/expression/builtin_arithmetic.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/types"
@@ -225,25 +226,25 @@ func (s *builtinArithmeticPlusIntSig) evalInt(ctx EvalContext, row chunk.Row) (v
 	switch {
 	case isLHSUnsigned && isRHSUnsigned:
 		if uint64(a) > math.MaxUint64-uint64(b) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	case isLHSUnsigned && !isRHSUnsigned:
 		if b < 0 && uint64(-b) > uint64(a) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		if b > 0 && uint64(a) > math.MaxUint64-uint64(b) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	case !isLHSUnsigned && isRHSUnsigned:
 		if a < 0 && uint64(-a) > uint64(b) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		if a > 0 && uint64(b) > math.MaxUint64-uint64(a) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	case !isLHSUnsigned && !isRHSUnsigned:
 		if (a > 0 && b > math.MaxInt64-a) || (a < 0 && b < math.MinInt64-a) {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	}
 
@@ -273,7 +274,7 @@ func (s *builtinArithmeticPlusDecimalSig) evalDecimal(ctx EvalContext, row chunk
 	err = types.DecimalAdd(a, b, c)
 	if err != nil {
 		if err == types.ErrOverflow {
-			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		return nil, true, err
 	}
@@ -303,7 +304,7 @@ func (s *builtinArithmeticPlusRealSig) evalReal(ctx EvalContext, row chunk.Row) 
 		return 0, true, nil
 	}
 	if !mathutil.IsFinite(a + b) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return a + b, false, nil
 }
@@ -368,7 +369,7 @@ func (s *builtinArithmeticMinusRealSig) evalReal(ctx EvalContext, row chunk.Row)
 		return 0, isNull, err
 	}
 	if !mathutil.IsFinite(a - b) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return a - b, false, nil
 }
@@ -396,7 +397,7 @@ func (s *builtinArithmeticMinusDecimalSig) evalDecimal(ctx EvalContext, row chun
 	err = types.DecimalSub(a, b, c)
 	if err != nil {
 		if err == types.ErrOverflow {
-			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		return nil, true, err
 	}
@@ -434,7 +435,7 @@ func (s *builtinArithmeticMinusIntSig) evalInt(ctx EvalContext, row chunk.Row) (
 	}
 	overflow := s.overflowCheck(isLHSUnsigned, isRHSUnsigned, signed, a, b)
 	if overflow {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 
 	return a - b, false, nil
@@ -578,7 +579,7 @@ func (s *builtinArithmeticMultiplyRealSig) evalReal(ctx EvalContext, row chunk.R
 	}
 	result := a * b
 	if math.IsInf(result, 0) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return result, false, nil
 }
@@ -596,7 +597,7 @@ func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(ctx EvalContext, row c
 	err = types.DecimalMul(a, b, c)
 	if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
 		if err == types.ErrOverflow {
-			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		return nil, true, err
 	}
@@ -616,7 +617,7 @@ func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(ctx EvalContext, row c
 	unsignedB := uint64(b)
 	result := unsignedA * unsignedB
 	if unsignedA != 0 && result/unsignedA != unsignedB {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return int64(result), false, nil
 }
@@ -632,7 +633,7 @@ func (s *builtinArithmeticMultiplyIntSig) evalInt(ctx EvalContext, row chunk.Row
 	}
 	result := a * b
 	if (a != 0 && result/a != b) || (result == math.MinInt64 && a == -1) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return result, false, nil
 }
@@ -697,7 +698,7 @@ func (s *builtinArithmeticDivideRealSig) evalReal(ctx EvalContext, row chunk.Row
 	}
 	result := a / b
 	if math.IsInf(result, 0) {
-		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return result, false, nil
 }
@@ -726,7 +727,7 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(ctx EvalContext, row chu
 			err = c.Round(c, s.baseBuiltinFunc.tp.GetDecimal(), types.ModeHalfUp)
 		}
 	} else if err == types.ErrOverflow {
-		err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+		err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 	}
 	return c, false, err
 }
@@ -857,14 +858,14 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(ctx EvalContext, row chun
 				ret = int64(0)
 				return ret, false, nil
 			}
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s DIV %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s DIV %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		ret = int64(val)
 	} else {
 		ret, err = c.ToInt()
 		// err returned by ToInt may be ErrTruncated or ErrOverflow, only handle ErrOverflow, ignore ErrTruncated.
 		if err == types.ErrOverflow {
-			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s DIV %s)", s.args[0].StringWithCtx(ctx), s.args[1].StringWithCtx(ctx)))
+			return 0, true, types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s DIV %s)", s.args[0].StringWithCtx(ctx, errors.RedactLogDisable), s.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	}
 

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/types"
@@ -53,7 +54,7 @@ func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(ctx EvalContext, input *c
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	}
 	return nil
@@ -106,7 +107,7 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx EvalContext, inpu
 				}
 			}
 		} else if err == types.ErrOverflow {
-			return types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		} else {
 			return err
 		}
@@ -313,7 +314,7 @@ func (b *builtinArithmeticMinusRealSig) vecEvalReal(ctx EvalContext, input *chun
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		x[i] = x[i] - y[i]
 	}
@@ -348,7 +349,7 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(ctx EvalContext, input
 		}
 		if err = types.DecimalSub(&x[i], &y[i], &to); err != nil {
 			if err == types.ErrOverflow {
-				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 			}
 			return err
 		}
@@ -400,7 +401,7 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs(errType, fmt.Sprintf("(%s - %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 
 		resulti64s[i] = lh - rh
@@ -514,7 +515,7 @@ func (b *builtinArithmeticPlusRealSig) vecEvalReal(ctx EvalContext, input *chunk
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		x[i] = x[i] + y[i]
 	}
@@ -550,7 +551,7 @@ func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(ctx EvalContext, in
 		err = types.DecimalMul(&x[i], &y[i], &to)
 		if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
 			if err == types.ErrOverflow {
-				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 			}
 			return err
 		}
@@ -668,7 +669,7 @@ func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(ctx EvalContext, input *chu
 				continue
 			}
 			result.SetNull(i, true)
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 
 		x[i] = tmp
@@ -712,7 +713,7 @@ func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx EvalContext, input *chu
 
 		x[i] = x[i] / y[i]
 		if math.IsInf(x[i], 0) {
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 	}
 	return nil
@@ -898,7 +899,7 @@ func (b *builtinArithmeticPlusIntSig) plusUU(ctx EvalContext, result *chunk.Colu
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -914,13 +915,13 @@ func (b *builtinArithmeticPlusIntSig) plusUS(ctx EvalContext, result *chunk.Colu
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		if rh > 0 && uint64(lh) > math.MaxUint64-uint64(rh) {
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -936,13 +937,13 @@ func (b *builtinArithmeticPlusIntSig) plusSU(ctx EvalContext, result *chunk.Colu
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		if lh > 0 && uint64(rh) > math.MaxUint64-uint64(lh) {
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -957,7 +958,7 @@ func (b *builtinArithmeticPlusIntSig) plusSS(ctx EvalContext, result *chunk.Colu
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 
 		resulti64s[i] = lh + rh
@@ -993,7 +994,7 @@ func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 		}
 		if err = types.DecimalAdd(&x[i], &y[i], to); err != nil {
 			if err == types.ErrOverflow {
-				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 			}
 			return err
 		}
@@ -1031,7 +1032,7 @@ func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(ctx EvalContext, in
 			if result.IsNull(i) {
 				continue
 			}
-			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx), b.args[1].StringWithCtx(ctx)))
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT UNSIGNED", fmt.Sprintf("(%s * %s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable), b.args[1].StringWithCtx(ctx, errors.RedactLogDisable)))
 		}
 		x[i] = res
 	}

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	gotime "time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -1011,7 +1012,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(ctx EvalContext, row chunk.Row
 	if !b.inUnion || val >= 0 {
 		err = res.FromFloat64(val)
 		if types.ErrOverflow.Equal(err) {
-			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0].StringWithCtx(ctx))
+			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable))
 			err = ec.HandleErrorWithAlias(err, err, warnErr)
 		} else if types.ErrTruncated.Equal(err) {
 			// This behavior is consistent with MySQL.

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -1446,7 +1447,7 @@ func TestWrapWithCastAsString(t *testing.T) {
 	}
 
 	expr := BuildCastFunction(ctx, &Constant{RetType: types.NewFieldType(mysql.TypeEnum)}, types.NewFieldType(mysql.TypeVarString))
-	require.NotContains(t, expr.StringWithCtx(ctx), "to_binary")
+	require.NotContains(t, expr.StringWithCtx(ctx, errors.RedactLogDisable), "to_binary")
 }
 
 func TestWrapWithCastAsJSON(t *testing.T) {

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	gotime "time"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -916,7 +917,7 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 		if !b.inUnion || bufreal[i] >= 0 {
 			if err = resdecimal[i].FromFloat64(bufreal[i]); err != nil {
 				if types.ErrOverflow.Equal(err) {
-					warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0].StringWithCtx(ctx))
+					warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", b.args[0].StringWithCtx(ctx, perrors.RedactLogDisable))
 					err = ec.HandleErrorWithAlias(err, err, warnErr)
 				} else if types.ErrTruncated.Equal(err) {
 					// This behavior is consistent with MySQL.

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/opcode"
@@ -1535,7 +1536,7 @@ func allowCmpArgsRefining4PlanCache(ctx BuildContext, args []Expression) (allowR
 		exprType := args[1-conIdx].GetType(ctx.GetEvalCtx())
 		exprEvalType := exprType.EvalType()
 		if exprType.GetType() == mysql.TypeYear {
-			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].StringWithCtx(ctx.GetEvalCtx())))
+			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 			return true
 		}
 
@@ -1544,7 +1545,7 @@ func allowCmpArgsRefining4PlanCache(ctx BuildContext, args []Expression) (allowR
 		conEvalType := args[conIdx].GetType(ctx.GetEvalCtx()).EvalType()
 		if exprEvalType == types.ETInt &&
 			(conEvalType == types.ETString || conEvalType == types.ETReal || conEvalType == types.ETDecimal) {
-			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].StringWithCtx(ctx.GetEvalCtx())))
+			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", args[conIdx].StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 			return true
 		}
 
@@ -1553,7 +1554,7 @@ func allowCmpArgsRefining4PlanCache(ctx BuildContext, args []Expression) (allowR
 		// see https://github.com/pingcap/tidb/issues/38361 for more details
 		_, exprIsCon := args[1-conIdx].(*Constant)
 		if !exprIsCon && matchRefineRule3Pattern(conEvalType, exprType) {
-			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to datetime", args[conIdx].StringWithCtx(ctx.GetEvalCtx())))
+			ctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to datetime", args[conIdx].StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 			return true
 		}
 	}

--- a/pkg/expression/builtin_compare_test.go
+++ b/pkg/expression/builtin_compare_test.go
@@ -73,7 +73,7 @@ func TestCompareFunctionWithRefine(t *testing.T) {
 	for _, test := range tests {
 		f, err := ParseSimpleExpr(ctx, test.exprStr, WithTableInfo("", tblInfo))
 		require.NoError(t, err)
-		require.Equal(t, test.result, f.StringWithCtx(ctx))
+		require.Equal(t, test.result, f.StringWithCtx(ctx, errors.RedactLogDisable))
 	}
 }
 

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
@@ -1739,7 +1740,7 @@ func (b *builtinExpSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool,
 	}
 	exp := math.Exp(val)
 	if math.IsInf(exp, 0) || math.IsNaN(exp) {
-		s := fmt.Sprintf("exp(%s)", b.args[0].StringWithCtx(ctx))
+		s := fmt.Sprintf("exp(%s)", b.args[0].StringWithCtx(ctx, perrors.RedactLogDisable))
 		return 0, false, types.ErrOverflow.GenWithStackByArgs("DOUBLE", s)
 	}
 	return exp, false, nil

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -290,7 +291,7 @@ func (b *builtinExpSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result 
 		}
 		exp := math.Exp(f64s[i])
 		if math.IsInf(exp, 0) || math.IsNaN(exp) {
-			s := fmt.Sprintf("exp(%s)", b.args[0].StringWithCtx(ctx))
+			s := fmt.Sprintf("exp(%s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable))
 			if err := types.ErrOverflow.GenWithStackByArgs("DOUBLE", s); err != nil {
 				return err
 			}

--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -2311,7 +2311,7 @@ func (c *charFunctionClass) getFunction(ctx BuildContext, args []Expression) (bu
 	// The last argument represents the charset name after "using".
 	if _, ok := args[len(args)-1].(*Constant); !ok {
 		// If we got there, there must be something wrong in other places.
-		logutil.BgLogger().Warn(fmt.Sprintf("The last argument in char function must be constant, but got %T", args[len(args)-1].StringWithCtx(ctx.GetEvalCtx())))
+		logutil.BgLogger().Warn(fmt.Sprintf("The last argument in char function must be constant, but got %T", args[len(args)-1].StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 		return nil, errIncorrectArgs
 	}
 	charsetName, isNull, err := args[len(args)-1].EvalString(ctx.GetEvalCtx(), chunk.Row{})
@@ -3867,11 +3867,11 @@ func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expressio
 	length := 0
 	if l == 3 {
 		if args[1].GetType(ctx).EvalType() != types.ETString {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx, errors.RedactLogDisable), c.funcName)
 		}
 		c1, ok := args[1].(*Constant)
 		if !ok {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx, errors.RedactLogDisable), c.funcName)
 		}
 		switch x := c1.Value.GetString(); x {
 		case "CHAR":
@@ -3884,15 +3884,15 @@ func (c *weightStringFunctionClass) verifyArgs(ctx EvalContext, args []Expressio
 			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(x, c.funcName)
 		}
 		if args[2].GetType(ctx).EvalType() != types.ETInt {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].StringWithCtx(ctx), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].StringWithCtx(ctx, errors.RedactLogDisable), c.funcName)
 		}
 		c2, ok := args[2].(*Constant)
 		if !ok {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[1].StringWithCtx(ctx, errors.RedactLogDisable), c.funcName)
 		}
 		length = int(c2.Value.GetInt64())
 		if length == 0 {
-			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].StringWithCtx(ctx), c.funcName)
+			return weightStringPaddingNone, 0, ErrIncorrectType.GenWithStackByArgs(args[2].StringWithCtx(ctx, errors.RedactLogDisable), c.funcName)
 		}
 	}
 	return padding, length, nil

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -390,16 +390,20 @@ func (col *Column) VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chun
 const columnPrefix = "Column#"
 
 // StringWithCtx implements Expression interface.
-func (col *Column) StringWithCtx(ctx ParamValues) string {
-	return col.String()
+func (col *Column) StringWithCtx(_ ParamValues, redact string) string {
+	return col.string(redact)
 }
 
 // String implements Stringer interface.
 func (col *Column) String() string {
+	return col.string(errors.RedactLogDisable)
+}
+
+func (col *Column) string(redact string) string {
 	if col.IsHidden && col.VirtualExpr != nil {
 		// A hidden column without virtual expression indicates it's a stored type.
 		// a virtual column should be able to be stringified without context.
-		return col.VirtualExpr.StringWithCtx(exprctx.EmptyParamValues)
+		return col.VirtualExpr.StringWithCtx(exprctx.EmptyParamValues, redact)
 	}
 	if col.OrigName != "" {
 		return col.OrigName

--- a/pkg/expression/constant_test.go
+++ b/pkg/expression/constant_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -185,7 +186,7 @@ func TestConstantPropagation(t *testing.T) {
 			newConds := solver.PropagateConstant(ctx, conds)
 			var result []string
 			for _, v := range newConds {
-				result = append(result, v.StringWithCtx(ctx))
+				result = append(result, v.StringWithCtx(ctx, errors.RedactLogDisable))
 			}
 			sort.Strings(result)
 			require.Equalf(t, tt.result, strings.Join(result, ", "), "different for expr %s", tt.conditions)
@@ -253,7 +254,7 @@ func TestConstantFolding(t *testing.T) {
 			require.True(t, ctx.IsInNullRejectCheck())
 		}
 		newConds := FoldConstant(ctx, expr)
-		require.Equalf(t, tt.result, newConds.StringWithCtx(ctx.GetEvalCtx()), "different for expr %s", tt.condition)
+		require.Equalf(t, tt.result, newConds.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable), "different for expr %s", tt.condition)
 	}
 }
 
@@ -315,7 +316,7 @@ func TestConstantFoldingCharsetConvert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		newConds := FoldConstant(ctx, tt.condition)
-		require.Equalf(t, tt.result, newConds.StringWithCtx(ctx), "different for expr %s", tt.condition)
+		require.Equalf(t, tt.result, newConds.StringWithCtx(ctx, errors.RedactLogDisable), "different for expr %s", tt.condition)
 	}
 }
 

--- a/pkg/expression/context.go
+++ b/pkg/expression/context.go
@@ -121,5 +121,5 @@ func (ctx *assertionEvalContext) GetOptionalPropProvider(key OptionalEvalPropKey
 type StringerWithCtx interface {
 	// StringWithCtx returns the string representation of the expression with context.
 	// NOTE: any implementation of `StringWithCtx` should not panic if the context is nil.
-	StringWithCtx(ctx ParamValues) string
+	StringWithCtx(ctx ParamValues, redact string) string
 }

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -71,6 +71,8 @@ type EvalContext interface {
 	CurrentTime() (time.Time, error)
 	// GetMaxAllowedPacket returns the value of the 'max_allowed_packet' system variable.
 	GetMaxAllowedPacket() uint64
+	// GetTiDBRedactLog returns the value of the 'tidb_redact_log' system variable.
+	GetTiDBRedactLog() string
 	// GetDefaultWeekFormatMode returns the value of the 'default_week_format' system variable.
 	GetDefaultWeekFormatMode() string
 	// GetDivPrecisionIncrement returns the specified value of DivPrecisionIncrement.

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -257,6 +257,11 @@ func (ctx *SessionEvalContext) GetMaxAllowedPacket() uint64 {
 	return ctx.sctx.GetSessionVars().MaxAllowedPacket
 }
 
+// GetTiDBRedactLog returns the value of the 'tidb_redact_log' system variable.
+func (ctx *SessionEvalContext) GetTiDBRedactLog() string {
+	return ctx.sctx.GetSessionVars().EnableRedactLog
+}
+
 // GetDefaultWeekFormatMode returns the value of the 'default_week_format' system variable.
 func (ctx *SessionEvalContext) GetDefaultWeekFormatMode() string {
 	mode, ok := ctx.sctx.GetSessionVars().GetSystemVar(variable.DefaultWeekFormat)

--- a/pkg/expression/contextstatic/evalctx.go
+++ b/pkg/expression/contextstatic/evalctx.go
@@ -75,6 +75,7 @@ type staticEvalCtxState struct {
 	currentDB                    string
 	currentTime                  *timeOnce
 	maxAllowedPacket             uint64
+	enableRedactLog              string
 	defaultWeekFormatMode        string
 	divPrecisionIncrement        int
 	requestVerificationFn        func(db, table, column string, priv mysql.PrivilegeType) bool
@@ -226,6 +227,7 @@ func NewStaticEvalContext(opt ...StaticEvalCtxOption) *StaticEvalContext {
 			currentTime:           &timeOnce{},
 			sqlMode:               defaultSQLMode,
 			maxAllowedPacket:      variable.DefMaxAllowedPacket,
+			enableRedactLog:       variable.DefTiDBRedactLog,
 			defaultWeekFormatMode: variable.DefDefaultWeekFormat,
 			divPrecisionIncrement: variable.DefDivPrecisionIncrement,
 		},
@@ -314,6 +316,11 @@ func (ctx *StaticEvalContext) CurrentTime() (tm time.Time, err error) {
 // GetMaxAllowedPacket returns the value of the 'max_allowed_packet' system variable.
 func (ctx *StaticEvalContext) GetMaxAllowedPacket() uint64 {
 	return ctx.maxAllowedPacket
+}
+
+// GetTiDBRedactLog returns the value of the 'tidb_redact_log' system variable.
+func (ctx *StaticEvalContext) GetTiDBRedactLog() string {
+	return ctx.enableRedactLog
 }
 
 // GetDefaultWeekFormatMode returns the value of the 'default_week_format' system variable.

--- a/pkg/expression/expr_to_pb.go
+++ b/pkg/expression/expr_to_pb.go
@@ -39,7 +39,7 @@ func ExpressionsToPBList(ctx EvalContext, exprs []Expression, client kv.Client) 
 	for _, expr := range exprs {
 		v := pc.ExprToPB(expr)
 		if v == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr.StringWithCtx(ctx))
+			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr.StringWithCtx(ctx, errors.RedactLogDisable))
 		}
 		pbExpr = append(pbExpr, v)
 	}
@@ -58,7 +58,7 @@ func ProjectionExpressionsToPBList(ctx EvalContext, exprs []Expression, client k
 			v = pc.ExprToPB(expr)
 		}
 		if v == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr.StringWithCtx(ctx))
+			return nil, plannererrors.ErrInternal.GenWithStack("expression %v cannot be pushed down", expr.StringWithCtx(ctx, errors.RedactLogDisable))
 		}
 		pbExpr = append(pbExpr, v)
 	}

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -866,7 +866,7 @@ func SplitDNFItems(onExpr Expression) []Expression {
 // If the Expression is a non-constant value, it means the result is unknown.
 func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression) Expression {
 	if MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
-		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx())))
+		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 	}
 	if ctx.IsInNullRejectCheck() {
 		expr, _ = evaluateExprWithNullInNullRejectCheck(ctx, schema, expr)
@@ -1234,7 +1234,7 @@ func StringifyExpressionsWithCtx(ctx EvalContext, exprs []Expression) string {
 	var sb strings.Builder
 	sb.WriteString("[")
 	for i, expr := range exprs {
-		sb.WriteString(expr.StringWithCtx(ctx))
+		sb.WriteString(expr.StringWithCtx(ctx, errors.RedactLogDisable))
 
 		if i != len(exprs)-1 {
 			sb.WriteString(" ")

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -17,6 +17,7 @@ package expression
 import (
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -48,7 +49,9 @@ func TestEvaluateExprWithNull(t *testing.T) {
 	require.NoError(t, err)
 
 	res := EvaluateExprWithNull(ctx, schema, outerIfNull)
-	require.Equal(t, "ifnull(Column#1, 1)", res.StringWithCtx(ctx))
+	require.Equal(t, "ifnull(Column#1, 1)", res.StringWithCtx(ctx, errors.RedactLogDisable))
+	require.Equal(t, "ifnull(Column#1, ?)", res.StringWithCtx(ctx, errors.RedactLogEnable))
+	require.Equal(t, "ifnull(Column#1, ‹1›)", res.StringWithCtx(ctx, errors.RedactLogMarker))
 	schema.Columns = append(schema.Columns, col1)
 	// ifnull(null, ifnull(null, 1))
 	res = EvaluateExprWithNull(ctx, schema, outerIfNull)
@@ -147,7 +150,7 @@ func TestConstLevel(t *testing.T) {
 		{newFunctionWithMockCtx(ast.Plus, NewOne(), newColumn(1)), ConstNone},
 		{newFunctionWithMockCtx(ast.Plus, NewOne(), ctxConst), ConstOnlyInContext},
 	} {
-		require.Equal(t, c.level, c.exp.ConstLevel(), c.exp.StringWithCtx(ctx))
+		require.Equal(t, c.level, c.exp.ConstLevel(), c.exp.StringWithCtx(ctx, errors.RedactLogDisable))
 	}
 }
 

--- a/pkg/expression/grouping_sets.go
+++ b/pkg/expression/grouping_sets.go
@@ -262,14 +262,14 @@ func (gs GroupingSet) Clone() GroupingSet {
 }
 
 // StringWithCtx is used to output a string which simply described current grouping set.
-func (gs GroupingSet) StringWithCtx(ctx ParamValues) string {
+func (gs GroupingSet) StringWithCtx(ctx ParamValues, redact string) string {
 	var str strings.Builder
 	str.WriteString("{")
 	for i, one := range gs {
 		if i != 0 {
 			str.WriteString(",")
 		}
-		str.WriteString(one.StringWithCtx(ctx))
+		str.WriteString(one.StringWithCtx(ctx, redact))
 	}
 	str.WriteString("}")
 	return str.String()
@@ -320,14 +320,14 @@ func (gss GroupingSets) AllSetsColIDs() *intset.FastIntSet {
 }
 
 // StringWithCtx is used to output a string which simply described current grouping sets.
-func (gss GroupingSets) StringWithCtx(ctx ParamValues) string {
+func (gss GroupingSets) StringWithCtx(ctx ParamValues, redact string) string {
 	var str strings.Builder
 	str.WriteString("[")
 	for i, gs := range gss {
 		if i != 0 {
 			str.WriteString(",")
 		}
-		str.WriteString(gs.StringWithCtx(ctx))
+		str.WriteString(gs.StringWithCtx(ctx, redact))
 	}
 	str.WriteString("]")
 	return str.String()
@@ -389,14 +389,14 @@ func (g GroupingExprs) Clone() GroupingExprs {
 }
 
 // StringWithCtx is used to output a string which simply described current grouping expressions.
-func (g GroupingExprs) StringWithCtx(ctx ParamValues) string {
+func (g GroupingExprs) StringWithCtx(ctx ParamValues, redact string) string {
 	var str strings.Builder
 	str.WriteString("<")
 	for i, one := range g {
 		if i != 0 {
 			str.WriteString(",")
 		}
-		str.WriteString(one.StringWithCtx(ctx))
+		str.WriteString(one.StringWithCtx(ctx, redact))
 	}
 	str.WriteString(">")
 	return str.String()

--- a/pkg/expression/grouping_sets_test.go
+++ b/pkg/expression/grouping_sets_test.go
@@ -17,6 +17,7 @@ package expression
 import (
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -355,9 +356,9 @@ func TestDistinctGroupingSets(t *testing.T) {
 	rawRollupExprs = []Expression{a, b, b, c}
 	deduplicateExprs, pos = DeduplicateGbyExpression(rawRollupExprs)
 	require.Equal(t, len(deduplicateExprs), 3)
-	require.Equal(t, deduplicateExprs[0].StringWithCtx(ctx), "Column#1")
-	require.Equal(t, deduplicateExprs[1].StringWithCtx(ctx), "Column#2")
-	require.Equal(t, deduplicateExprs[2].StringWithCtx(ctx), "Column#3")
+	require.Equal(t, deduplicateExprs[0].StringWithCtx(ctx, errors.RedactLogDisable), "Column#1")
+	require.Equal(t, deduplicateExprs[1].StringWithCtx(ctx, errors.RedactLogDisable), "Column#2")
+	require.Equal(t, deduplicateExprs[2].StringWithCtx(ctx, errors.RedactLogDisable), "Column#3")
 	deduplicateColumns := make([]*Column, 0, len(deduplicateExprs))
 	for _, one := range deduplicateExprs {
 		deduplicateColumns = append(deduplicateColumns, one.(*Column))
@@ -375,10 +376,10 @@ func TestDistinctGroupingSets(t *testing.T) {
 	// so that why restore gby expression according to their pos is necessary.
 	restoreGbyExpressions := RestoreGbyExpression(deduplicateColumns, pos)
 	require.Equal(t, len(restoreGbyExpressions), 4)
-	require.Equal(t, restoreGbyExpressions[0].StringWithCtx(ctx), "Column#1")
-	require.Equal(t, restoreGbyExpressions[1].StringWithCtx(ctx), "Column#2")
-	require.Equal(t, restoreGbyExpressions[2].StringWithCtx(ctx), "Column#2")
-	require.Equal(t, restoreGbyExpressions[3].StringWithCtx(ctx), "Column#3")
+	require.Equal(t, restoreGbyExpressions[0].StringWithCtx(ctx, errors.RedactLogDisable), "Column#1")
+	require.Equal(t, restoreGbyExpressions[1].StringWithCtx(ctx, errors.RedactLogDisable), "Column#2")
+	require.Equal(t, restoreGbyExpressions[2].StringWithCtx(ctx, errors.RedactLogDisable), "Column#2")
+	require.Equal(t, restoreGbyExpressions[3].StringWithCtx(ctx, errors.RedactLogDisable), "Column#3")
 
 	// rollup grouping sets (build grouping sets on the restored gby expression, because all the
 	// complicated expressions have been projected as simple columns at this time).

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -127,12 +127,12 @@ func canExprPushDown(ctx PushDownContext, expr Expression, storeType kv.StoreTyp
 			if expr.GetType(ctx.EvalCtx()).GetType() == mysql.TypeEnum && canEnumPush {
 				break
 			}
-			warnErr := errors.NewNoStackError("Expression about '" + expr.StringWithCtx(ctx.EvalCtx()) + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType(ctx.EvalCtx()).GetType()) + "'.")
+			warnErr := errors.NewNoStackError("Expression about '" + expr.StringWithCtx(ctx.EvalCtx(), errors.RedactLogDisable) + "' can not be pushed to TiFlash because it contains unsupported calculation of type '" + types.TypeStr(expr.GetType(ctx.EvalCtx()).GetType()) + "'.")
 			ctx.AppendWarning(warnErr)
 			return false
 		case mysql.TypeNewDecimal:
 			if !expr.GetType(ctx.EvalCtx()).IsDecimalValid() {
-				warnErr := errors.NewNoStackError("Expression about '" + expr.StringWithCtx(ctx.EvalCtx()) + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetFlen()) + "','" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetDecimal()) + "').")
+				warnErr := errors.NewNoStackError("Expression about '" + expr.StringWithCtx(ctx.EvalCtx(), errors.RedactLogDisable) + "' can not be pushed to TiFlash because it contains invalid decimal('" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetFlen()) + "','" + strconv.Itoa(expr.GetType(ctx.EvalCtx()).GetDecimal()) + "').")
 				ctx.AppendWarning(warnErr)
 				return false
 			}

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -120,19 +120,19 @@ func (sf *ScalarFunction) Vectorized() bool {
 }
 
 // StringWithCtx implements Expression interface.
-func (sf *ScalarFunction) StringWithCtx(ctx ParamValues) string {
+func (sf *ScalarFunction) StringWithCtx(ctx ParamValues, redact string) string {
 	var buffer bytes.Buffer
 	fmt.Fprintf(&buffer, "%s(", sf.FuncName.L)
 	switch sf.FuncName.L {
 	case ast.Cast:
 		for _, arg := range sf.GetArgs() {
-			buffer.WriteString(arg.StringWithCtx(ctx))
+			buffer.WriteString(arg.StringWithCtx(ctx, redact))
 			buffer.WriteString(", ")
 			buffer.WriteString(sf.RetType.String())
 		}
 	default:
 		for i, arg := range sf.GetArgs() {
-			buffer.WriteString(arg.StringWithCtx(ctx))
+			buffer.WriteString(arg.StringWithCtx(ctx, redact))
 			if i+1 != len(sf.GetArgs()) {
 				buffer.WriteString(", ")
 			}
@@ -144,7 +144,7 @@ func (sf *ScalarFunction) StringWithCtx(ctx ParamValues) string {
 
 // String returns the string representation of the function
 func (sf *ScalarFunction) String() string {
-	return sf.StringWithCtx(exprctx.EmptyParamValues)
+	return sf.StringWithCtx(exprctx.EmptyParamValues, errors.RedactLogDisable)
 }
 
 // typeInferForNull infers the NULL constants field type and set the field type

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1018,7 +1018,7 @@ func Contains(ectx EvalContext, exprs []Expression, e Expression) bool {
 		// Check string equivalence if one of the expressions is a clone.
 		sameString := false
 		if e != nil && expr != nil {
-			sameString = (e.StringWithCtx(ectx) == expr.StringWithCtx(ectx))
+			sameString = (e.StringWithCtx(ectx, errors.RedactLogDisable) == expr.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		if e == expr || sameString {
 			return true
@@ -1871,7 +1871,7 @@ func ExprsToStringsForDisplay(ctx EvalContext, exprs []Expression) []string {
 		// so we trim the \" prefix and suffix here.
 		strs[i] = strings.TrimSuffix(
 			strings.TrimPrefix(
-				strconv.Quote(cond.StringWithCtx(ctx)),
+				strconv.Quote(cond.StringWithCtx(ctx, errors.RedactLogDisable)),
 				quote),
 			quote)
 	}

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -558,7 +558,7 @@ func (m *MockExpr) VecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chun
 	return nil
 }
 
-func (m *MockExpr) StringWithCtx(ParamValues) string { return "" }
+func (m *MockExpr) StringWithCtx(ParamValues, string) string { return "" }
 func (m *MockExpr) Eval(ctx EvalContext, row chunk.Row) (types.Datum, error) {
 	return types.NewDatum(m.i), m.err
 }

--- a/pkg/parser/digester_test.go
+++ b/pkg/parser/digester_test.go
@@ -110,6 +110,11 @@ func TestNormalizeRedact(t *testing.T) {
 		{"select * from t where a in (1)", "select * from `t` where `a` in ( ‹1› )"},
 		{"select * from t where a in (1, 3)", "select * from `t` where `a` in ( ‹1› , ‹3› )"},
 		{"select ? from b order by 2", "select ? from `b` order by ‹2›"},
+		{"select ? from b order by 2 limit 10 offset 10", "select ? from `b` order by ‹2› limit ‹10› offset ‹10›"},
+		{"with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 100 offset 100) select * from cte1;",
+			"with recursive `cte1` ( `c1` ) as ( select `c1` from `t1` union select `c1` + ‹1› `c1` from `cte1` limit ‹100› offset ‹100› ) select * from `cte1`"},
+		{"select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range",
+			"select * , `first_value` ( `v` ) `over` ( partition by `p` order by `o` range between ‹3› preceding and ‹0› following ) as `a` from `test` . `first_range`"},
 	}
 
 	for _, c := range cases {

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -110,7 +110,7 @@ func Selectivity(
 			sel = 1.0 / pseudoEqualRate
 		}
 		if sc.EnableOptimizerDebugTrace {
-			debugtrace.RecordAnyValuesWithNames(ctx, "Expression", expr.StringWithCtx(ctx.GetExprCtx().GetEvalCtx()), "Selectivity", sel)
+			debugtrace.RecordAnyValuesWithNames(ctx, "Expression", expr.StringWithCtx(ctx.GetExprCtx().GetEvalCtx(), errors.RedactLogDisable), "Selectivity", sel)
 		}
 		ret *= sel
 	}

--- a/pkg/planner/cardinality/trace.go
+++ b/pkg/planner/cardinality/trace.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
@@ -95,7 +96,7 @@ func exprToString(ctx expression.EvalContext, e expression.Expression) (string, 
 		buffer.WriteString(")")
 		return buffer.String(), nil
 	case *expression.Column:
-		return expr.StringWithCtx(ctx), nil
+		return expr.StringWithCtx(ctx, perrors.RedactLogDisable), nil
 	case *expression.CorrelatedColumn:
 		return "", errors.New("tracing for correlated columns not supported now")
 	case *expression.Constant:

--- a/pkg/planner/cascades/BUILD.bazel
+++ b/pkg/planner/cascades/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/dbterror/plannererrors",
         "//pkg/util/ranger",
         "//pkg/util/set",
+        "@com_github_pingcap_errors//:errors",
     ],
 )
 

--- a/pkg/planner/cascades/stringer.go
+++ b/pkg/planner/cascades/stringer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/memo"
 )
@@ -67,7 +68,7 @@ func groupToString(ctx expression.EvalContext, g *memo.Group, idMap map[*memo.Gr
 	schema := g.Prop.Schema
 	colStrs := make([]string, 0, len(schema.Columns))
 	for _, col := range schema.Columns {
-		colStrs = append(colStrs, col.StringWithCtx(ctx))
+		colStrs = append(colStrs, col.StringWithCtx(ctx, errors.RedactLogDisable))
 	}
 
 	groupLine := bytes.NewBufferString("")
@@ -78,7 +79,7 @@ func groupToString(ctx expression.EvalContext, g *memo.Group, idMap map[*memo.Gr
 		for _, key := range schema.Keys {
 			ukColStrs := make([]string, 0, len(key))
 			for _, col := range key {
-				ukColStrs = append(ukColStrs, col.StringWithCtx(ctx))
+				ukColStrs = append(ukColStrs, col.StringWithCtx(ctx, errors.RedactLogDisable))
 			}
 			ukStrs = append(ukStrs, strings.Join(ukColStrs, ","))
 		}

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -202,6 +202,7 @@ go_library(
         "//pkg/util/plancodec",
         "//pkg/util/ranger",
         "//pkg/util/ranger/context",
+        "//pkg/util/redact",
         "//pkg/util/rowcodec",
         "//pkg/util/sem",
         "//pkg/util/set",

--- a/pkg/planner/core/casetest/integration_test.go
+++ b/pkg/planner/core/casetest/integration_test.go
@@ -315,17 +315,24 @@ func TestTiFlashFineGrainedShuffle(t *testing.T) {
 	tbl1.Meta().TiFlashReplica = &model.TiFlashReplicaInfo{Count: 1, Available: true}
 	var input []string
 	var output []struct {
-		SQL  string
-		Plan []string
+		SQL    string
+		Plan   []string
+		Redact []string
 	}
 	integrationSuiteData := GetIntegrationSuiteData()
 	integrationSuiteData.LoadTestCases(t, &input, &output)
 	for i, tt := range input {
 		testdata.OnRecord(func() {
 			output[i].SQL = tt
+			tk.MustExec("set session tidb_redact_log=off")
 			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+			tk.MustExec("set session tidb_redact_log=on")
+			output[i].Redact = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
 		})
+		tk.MustExec("set session tidb_redact_log=off")
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+		tk.MustExec("set session tidb_redact_log=on")
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Redact...))
 	}
 }
 

--- a/pkg/planner/core/casetest/testdata/integration_suite_out.json
+++ b/pkg/planner/core/casetest/testdata/integration_suite_out.json
@@ -1070,11 +1070,35 @@
           "        └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
           "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
           "            └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  Column#5->Column#6, stream_count: 8",
+          "    └─Window 10000.00 mpp[tiflash]  row_number()->Column#5 over(partition by test.t1.c1 order by test.t1.c1 rows between current row and current row), stream_count: 8",
+          "      └─Sort 10000.00 mpp[tiflash]  test.t1.c1, test.t1.c1, stream_count: 8",
+          "        └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
+          "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
+          "            └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "explain format = 'brief' select row_number() over w1, rank() over w2 from t1 window w1 as (partition by c1 order by c1), w2 as (partition by c2);",
         "Plan": [
+          "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  Column#7->Column#8, Column#6->Column#9, stream_count: 8",
+          "    └─Window 10000.00 mpp[tiflash]  row_number()->Column#7 over(partition by test.t1.c1 order by test.t1.c1 rows between current row and current row), stream_count: 8",
+          "      └─Sort 10000.00 mpp[tiflash]  test.t1.c1, test.t1.c1, stream_count: 8",
+          "        └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
+          "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
+          "            └─Window 10000.00 mpp[tiflash]  rank()->Column#6 over(partition by test.t1.c2), stream_count: 8",
+          "              └─Sort 10000.00 mpp[tiflash]  test.t1.c2, stream_count: 8",
+          "                └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
+          "                  └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c2, collate: binary], stream_count: 8",
+          "                    └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Redact": [
           "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
           "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 10000.00 mpp[tiflash]  Column#7->Column#8, Column#6->Column#9, stream_count: 8",
@@ -1106,6 +1130,22 @@
           "                    └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
           "                      └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c2, collate: binary], stream_count: 8",
           "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "Projection 10.00 root  Column#7->Column#8, Column#6->Column#9",
+          "└─TopN 10.00 root  Column#7, Column#6, offset:?, count:?",
+          "  └─TableReader 10.00 root  MppVersion: 2, data:ExchangeSender",
+          "    └─ExchangeSender 10.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "      └─TopN 10.00 mpp[tiflash]  Column#7, Column#6, offset:?, count:?",
+          "        └─Window 10000.00 mpp[tiflash]  row_number()->Column#7 over(partition by test.t1.c1 order by test.t1.c1 rows between current row and current row), stream_count: 8",
+          "          └─Sort 10000.00 mpp[tiflash]  test.t1.c1, test.t1.c1, stream_count: 8",
+          "            └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
+          "              └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
+          "                └─Window 10000.00 mpp[tiflash]  rank()->Column#6 over(partition by test.t1.c2), stream_count: 8",
+          "                  └─Sort 10000.00 mpp[tiflash]  test.t1.c2, stream_count: 8",
+          "                    └─ExchangeReceiver 10000.00 mpp[tiflash]  stream_count: 8",
+          "                      └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c2, collate: binary], stream_count: 8",
+          "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1124,6 +1164,22 @@
           "                  └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary]",
           "                    └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c1, funcs:count(test.t1.c2)->Column#9, funcs:firstrow(test.t1.c2)->Column#10",
           "                      └─Selection 3333.33 mpp[tiflash]  gt(test.t1.c1, 10)",
+          "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "TableReader 2666.67 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 2666.67 mpp[tiflash]  Column#6->Column#7, Column#4->Column#8, stream_count: 8",
+          "    └─Window 2666.67 mpp[tiflash]  row_number()->Column#6 over(partition by test.t1.c2 order by test.t1.c2 rows between current row and current row), stream_count: 8",
+          "      └─Sort 2666.67 mpp[tiflash]  test.t1.c2, test.t1.c2, stream_count: 8",
+          "        └─ExchangeReceiver 2666.67 mpp[tiflash]  stream_count: 8",
+          "          └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c2, collate: binary], stream_count: 8",
+          "            └─Projection 2666.67 mpp[tiflash]  Column#4, test.t1.c2",
+          "              └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c1, funcs:sum(Column#9)->Column#4, funcs:firstrow(Column#10)->test.t1.c2",
+          "                └─ExchangeReceiver 2666.67 mpp[tiflash]  ",
+          "                  └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary]",
+          "                    └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c1, funcs:count(test.t1.c2)->Column#9, funcs:firstrow(test.t1.c2)->Column#10",
+          "                      └─Selection 3333.33 mpp[tiflash]  gt(test.t1.c1, ?)",
           "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ]
       },
@@ -1144,11 +1200,44 @@
           "                    └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c2, funcs:count(test.t1.c1)->Column#9, funcs:firstrow(test.t1.c1)->Column#10",
           "                      └─Selection 3333.33 mpp[tiflash]  gt(test.t1.c2, 10)",
           "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "TableReader 2666.67 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 2666.67 mpp[tiflash]  Column#6->Column#7, Column#4->Column#8, stream_count: 8",
+          "    └─Window 2666.67 mpp[tiflash]  row_number()->Column#6 over(partition by test.t1.c1 order by test.t1.c2 rows between current row and current row), stream_count: 8",
+          "      └─Sort 2666.67 mpp[tiflash]  test.t1.c1, test.t1.c2, stream_count: 8",
+          "        └─ExchangeReceiver 2666.67 mpp[tiflash]  stream_count: 8",
+          "          └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
+          "            └─Projection 2666.67 mpp[tiflash]  Column#4, test.t1.c1, test.t1.c2",
+          "              └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c2, funcs:sum(Column#9)->Column#4, funcs:firstrow(Column#10)->test.t1.c1, funcs:firstrow(test.t1.c2)->test.t1.c2",
+          "                └─ExchangeReceiver 2666.67 mpp[tiflash]  ",
+          "                  └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c2, collate: binary]",
+          "                    └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c2, funcs:count(test.t1.c1)->Column#9, funcs:firstrow(test.t1.c1)->Column#10",
+          "                      └─Selection 3333.33 mpp[tiflash]  gt(test.t1.c2, ?)",
+          "                        └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "explain format = 'brief' select row_number() over w1 from t1 a join t1 b on a.c1 = b.c2 window w1 as (partition by a.c1);",
         "Plan": [
+          "TableReader 12487.50 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 12487.50 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 12487.50 mpp[tiflash]  Column#8->Column#9, stream_count: 8",
+          "    └─Window 12487.50 mpp[tiflash]  row_number()->Column#8 over(partition by test.t1.c1 rows between current row and current row), stream_count: 8",
+          "      └─Sort 12487.50 mpp[tiflash]  test.t1.c1, stream_count: 8",
+          "        └─ExchangeReceiver 12487.50 mpp[tiflash]  stream_count: 8",
+          "          └─ExchangeSender 12487.50 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
+          "            └─Projection 12487.50 mpp[tiflash]  test.t1.c1",
+          "              └─HashJoin 12487.50 mpp[tiflash]  inner join, equal:[eq(test.t1.c1, test.t1.c2)]",
+          "                ├─ExchangeReceiver(Build) 9990.00 mpp[tiflash]  ",
+          "                │ └─ExchangeSender 9990.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "                │   └─Selection 9990.00 mpp[tiflash]  not(isnull(test.t1.c1))",
+          "                │     └─TableFullScan 10000.00 mpp[tiflash] table:a pushed down filter:empty, keep order:false, stats:pseudo",
+          "                └─Selection(Probe) 9990.00 mpp[tiflash]  not(isnull(test.t1.c2))",
+          "                  └─TableFullScan 10000.00 mpp[tiflash] table:b pushed down filter:empty, keep order:false, stats:pseudo"
+        ],
+        "Redact": [
           "TableReader 12487.50 root  MppVersion: 2, data:ExchangeSender",
           "└─ExchangeSender 12487.50 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 12487.50 mpp[tiflash]  Column#8->Column#9, stream_count: 8",
@@ -1178,6 +1267,17 @@
           "          └─ExchangeSender 3323.33 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
           "            └─Selection 3323.33 mpp[tiflash]  lt(test.t1.c1, 100)",
           "              └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "TableReader 3323.33 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 3323.33 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 3323.33 mpp[tiflash]  Column#5->Column#6, stream_count: 8",
+          "    └─Window 3323.33 mpp[tiflash]  row_number()->Column#5 over(partition by test.t1.c1 order by test.t1.c1 rows between current row and current row), stream_count: 8",
+          "      └─Sort 3323.33 mpp[tiflash]  test.t1.c1, test.t1.c1, stream_count: 8",
+          "        └─ExchangeReceiver 3323.33 mpp[tiflash]  stream_count: 8",
+          "          └─ExchangeSender 3323.33 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary], stream_count: 8",
+          "            └─Selection 3323.33 mpp[tiflash]  lt(test.t1.c1, ?)",
+          "              └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1186,11 +1286,26 @@
           "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
           "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "explain format = 'brief' select row_number() over w1 from t1 window w1 as (order by c1);",
         "Plan": [
+          "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  Column#5->Column#6",
+          "    └─Window 10000.00 mpp[tiflash]  row_number()->Column#5 over(order by test.t1.c1 rows between current row and current row)",
+          "      └─Sort 10000.00 mpp[tiflash]  test.t1.c1",
+          "        └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough, Compression: FAST",
+          "            └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Redact": [
           "TableReader 10000.00 root  MppVersion: 2, data:ExchangeSender",
           "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 10000.00 mpp[tiflash]  Column#5->Column#6",
@@ -1215,6 +1330,20 @@
           "              └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary]",
           "                └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c1, funcs:count(test.t1.c2)->Column#9, funcs:firstrow(test.t1.c2)->Column#11",
           "                  └─Selection 3333.33 mpp[tiflash]  gt(test.t1.c1, 10)",
+          "                    └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
+        ],
+        "Redact": [
+          "TableReader 2666.67 root  MppVersion: 2, data:ExchangeSender",
+          "└─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 2666.67 mpp[tiflash]  Column#6->Column#7, Column#4->Column#8",
+          "    └─Window 2666.67 mpp[tiflash]  row_number()->Column#6 over(partition by test.t1.c1 order by test.t1.c2 rows between current row and current row)",
+          "      └─Sort 2666.67 mpp[tiflash]  test.t1.c1, test.t1.c2",
+          "        └─Projection 2666.67 mpp[tiflash]  Column#4, test.t1.c1, test.t1.c2",
+          "          └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c1, funcs:sum(Column#9)->Column#4, funcs:firstrow(test.t1.c1)->test.t1.c1, funcs:firstrow(Column#11)->test.t1.c2",
+          "            └─ExchangeReceiver 2666.67 mpp[tiflash]  ",
+          "              └─ExchangeSender 2666.67 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.c1, collate: binary]",
+          "                └─HashAgg 2666.67 mpp[tiflash]  group by:test.t1.c1, funcs:count(test.t1.c2)->Column#9, funcs:firstrow(test.t1.c2)->Column#11",
+          "                  └─Selection 3333.33 mpp[tiflash]  gt(test.t1.c1, ?)",
           "                    └─TableFullScan 10000.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false, stats:pseudo"
         ]
       }

--- a/pkg/planner/core/debugtrace.go
+++ b/pkg/planner/core/debugtrace.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -107,7 +108,7 @@ func DebugTraceReceivedCommand(s base.PlanContext, cmd byte, stmtNode ast.StmtNo
 		execInfo.BinaryParamsInfo = make([]binaryParamInfo, len(binaryParams))
 		for i, param := range binaryParams {
 			execInfo.BinaryParamsInfo[i].Type = param.GetType(s.GetExprCtx().GetEvalCtx()).String()
-			execInfo.BinaryParamsInfo[i].Value = param.StringWithCtx(s.GetExprCtx().GetEvalCtx())
+			execInfo.BinaryParamsInfo[i].Value = param.StringWithCtx(s.GetExprCtx().GetEvalCtx(), errors.RedactLogDisable)
 		}
 	}
 }

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1018,6 +1018,7 @@ func (ijHelper *indexJoinBuildHelper) buildRangeDecidedByInformation(idxCols []*
 		fmt.Fprintf(buffer, "eq(%v, %v)", idxCols[idxOff], outerJoinKeys[keyOff])
 	}
 	ectx := ijHelper.join.SCtx().GetExprCtx().GetEvalCtx()
+	// It is to build the range info which is used in explain. It is necessary to redact the range info.
 	redact := ectx.GetTiDBRedactLog()
 	for _, access := range ijHelper.chosenAccess {
 		if !isFirst {

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -886,7 +886,7 @@ func buildIndexJoinInner2TableScan(
 			if i != 0 {
 				buffer.WriteString(" ")
 			}
-			buffer.WriteString(key.StringWithCtx(p.SCtx().GetExprCtx().GetEvalCtx()))
+			buffer.WriteString(key.StringWithCtx(p.SCtx().GetExprCtx().GetEvalCtx(), errors.RedactLogDisable))
 		}
 		buffer.WriteString("]")
 		rangeInfo := buffer.String()
@@ -1018,13 +1018,14 @@ func (ijHelper *indexJoinBuildHelper) buildRangeDecidedByInformation(idxCols []*
 		fmt.Fprintf(buffer, "eq(%v, %v)", idxCols[idxOff], outerJoinKeys[keyOff])
 	}
 	ectx := ijHelper.join.SCtx().GetExprCtx().GetEvalCtx()
+	redact := ectx.GetTiDBRedactLog()
 	for _, access := range ijHelper.chosenAccess {
 		if !isFirst {
 			buffer.WriteString(" ")
 		} else {
 			isFirst = false
 		}
-		fmt.Fprintf(buffer, "%v", access.StringWithCtx(ectx))
+		fmt.Fprintf(buffer, "%v", access.StringWithCtx(ectx, redact))
 	}
 	buffer.WriteString("]")
 	return buffer.String()

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -376,7 +376,9 @@ func (p *PhysicalSelection) ExplainNormalizedInfo() string {
 
 // ExplainInfo implements Plan interface.
 func (p *PhysicalProjection) ExplainInfo() string {
-	exprStr := expression.ExplainExpressionList(p.SCtx().GetExprCtx().GetEvalCtx(), p.Exprs, p.schema)
+	evalCtx := p.SCtx().GetExprCtx().GetEvalCtx()
+	enableRedactLog := p.SCtx().GetSessionVars().EnableRedactLog
+	exprStr := expression.ExplainExpressionList(evalCtx, p.Exprs, p.schema, enableRedactLog)
 	if p.TiFlashFineGrainedShuffleStreamCount > 0 {
 		exprStr += fmt.Sprintf(", stream_count: %d", p.TiFlashFineGrainedShuffleStreamCount)
 	}
@@ -386,15 +388,16 @@ func (p *PhysicalProjection) ExplainInfo() string {
 func (p *PhysicalExpand) explainInfoV2() string {
 	sb := strings.Builder{}
 	evalCtx := p.SCtx().GetExprCtx().GetEvalCtx()
+	enableRedactLog := p.SCtx().GetSessionVars().EnableRedactLog
 	for i, oneL := range p.LevelExprs {
 		if i == 0 {
 			sb.WriteString("level-projection:")
 			sb.WriteString("[")
-			sb.WriteString(expression.ExplainExpressionList(evalCtx, oneL, p.schema))
+			sb.WriteString(expression.ExplainExpressionList(evalCtx, oneL, p.schema, enableRedactLog))
 			sb.WriteString("]")
 		} else {
 			sb.WriteString(",[")
-			sb.WriteString(expression.ExplainExpressionList(evalCtx, oneL, p.schema))
+			sb.WriteString(expression.ExplainExpressionList(evalCtx, oneL, p.schema, enableRedactLog))
 			sb.WriteString("]")
 		}
 	}

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -213,7 +213,6 @@ func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
 		if normalized {
 			buffer.WriteString("range:[?,?], ")
 		} else if !p.isFullScan() {
-			redact := p.SCtx().GetSessionVars().EnableRedactLog
 			buffer.WriteString("range:")
 			for _, idxRange := range p.Ranges {
 				buffer.WriteString(idxRange.Redact(redact))

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1898,7 +1898,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 					if c.GetType(er.sctx.GetEvalCtx()).EvalType() == types.ETInt {
 						continue // no need to refine it
 					}
-					er.sctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", c.StringWithCtx(er.sctx.GetEvalCtx())))
+					er.sctx.SetSkipPlanCache(fmt.Sprintf("'%v' may be converted to INT", c.StringWithCtx(er.sctx.GetEvalCtx(), errors.RedactLogDisable)))
 					if err := expression.RemoveMutableConst(er.sctx, []expression.Expression{c}); err != nil {
 						er.err = err
 						return

--- a/pkg/planner/core/indexmerge_test.go
+++ b/pkg/planner/core/indexmerge_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -60,7 +61,7 @@ func getIndexMergePathDigest(ctx expression.EvalContext, paths []*util.AccessPat
 			if j > 0 {
 				idxMergeDisgest += ","
 			}
-			idxMergeDisgest += path.TableFilters[j].StringWithCtx(ctx)
+			idxMergeDisgest += path.TableFilters[j].StringWithCtx(ctx, errors.RedactLogDisable)
 		}
 		idxMergeDisgest += "]}"
 	}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -1153,7 +1153,7 @@ func buildExpandFieldName(ctx expression.EvalContext, expr expression.Expression
 	var origTblName, origColName, dbName, colName, tblName model.CIStr
 	if genName != "" {
 		// for case like: gid_, gpos_
-		colName = model.NewCIStr(expr.StringWithCtx(ctx))
+		colName = model.NewCIStr(expr.StringWithCtx(ctx, errors.RedactLogDisable))
 	} else if isCol {
 		// col ref to original col, while its nullability may be changed.
 		origTblName, origColName, dbName = name.OrigTblName, name.OrigColName, name.DBName
@@ -1161,7 +1161,7 @@ func buildExpandFieldName(ctx expression.EvalContext, expr expression.Expression
 		tblName = model.NewCIStr("ex_" + name.TblName.O)
 	} else {
 		// Other: complicated expression.
-		colName = model.NewCIStr("ex_" + expr.StringWithCtx(ctx))
+		colName = model.NewCIStr("ex_" + expr.StringWithCtx(ctx, errors.RedactLogDisable))
 	}
 	newName := &types.FieldName{
 		TblName:     tblName,

--- a/pkg/planner/core/logical_projection.go
+++ b/pkg/planner/core/logical_projection.go
@@ -66,7 +66,8 @@ func (p LogicalProjection) Init(ctx base.PlanContext, qbOffset int) *LogicalProj
 // ExplainInfo implements Plan interface.
 func (p *LogicalProjection) ExplainInfo() string {
 	eCtx := p.SCtx().GetExprCtx().GetEvalCtx()
-	return expression.ExplainExpressionList(eCtx, p.Exprs, p.Schema())
+	enableRedactLog := p.SCtx().GetSessionVars().EnableRedactLog
+	return expression.ExplainExpressionList(eCtx, p.Exprs, p.Schema(), enableRedactLog)
 }
 
 // ReplaceExprColumns implements base.LogicalPlan interface.

--- a/pkg/planner/core/logical_table_scan.go
+++ b/pkg/planner/core/logical_table_scan.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -51,7 +50,7 @@ func (ts *LogicalTableScan) ExplainInfo() string {
 	ectx := ts.SCtx().GetExprCtx().GetEvalCtx()
 	buffer := bytes.NewBufferString(ts.Source.ExplainInfo())
 	if ts.Source.HandleCols != nil {
-		fmt.Fprintf(buffer, ", pk col:%s", ts.Source.HandleCols.StringWithCtx(ectx, errors.RedactLogDisable))
+		fmt.Fprintf(buffer, ", pk col:%s", ts.Source.HandleCols.StringWithCtx(ectx, ts.SCtx().GetSessionVars().EnableRedactLog))
 	}
 	if len(ts.AccessConds) > 0 {
 		fmt.Fprintf(buffer, ", cond:%v", ts.AccessConds)

--- a/pkg/planner/core/logical_table_scan.go
+++ b/pkg/planner/core/logical_table_scan.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -50,7 +51,7 @@ func (ts *LogicalTableScan) ExplainInfo() string {
 	ectx := ts.SCtx().GetExprCtx().GetEvalCtx()
 	buffer := bytes.NewBufferString(ts.Source.ExplainInfo())
 	if ts.Source.HandleCols != nil {
-		fmt.Fprintf(buffer, ", pk col:%s", ts.Source.HandleCols.StringWithCtx(ectx))
+		fmt.Fprintf(buffer, ", pk col:%s", ts.Source.HandleCols.StringWithCtx(ectx, errors.RedactLogDisable))
 	}
 	if len(ts.AccessConds) > 0 {
 		fmt.Fprintf(buffer, ", cond:%v", ts.AccessConds)

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -515,5 +516,5 @@ func TestPhysicalTableScanExtractCorrelatedCols(t *testing.T) {
 	// make sure the correlated columns are extracted correctly
 	correlated := ts.ExtractCorrelatedCols()
 	require.Equal(t, 1, len(correlated))
-	require.Equal(t, "test.t2.company_no", correlated[0].StringWithCtx(tk.Session().GetExprCtx().GetEvalCtx()))
+	require.Equal(t, "test.t2.company_no", correlated[0].StringWithCtx(tk.Session().GetExprCtx().GetEvalCtx(), errors.RedactLogDisable))
 }

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -2743,7 +2743,15 @@ func (p *CTEDefinition) ExplainInfo() string {
 		res = "Non-Recursive CTE"
 	}
 	if p.CTE.HasLimit {
-		res += fmt.Sprintf(", limit(offset:%v, count:%v)", p.CTE.LimitBeg, p.CTE.LimitEnd-p.CTE.LimitBeg)
+		offset, count := p.CTE.LimitBeg, p.CTE.LimitEnd-p.CTE.LimitBeg
+		switch p.SCtx().GetSessionVars().EnableRedactLog {
+		case errors.RedactLogMarker:
+			res += fmt.Sprintf(", limit(offset:‹%v›, count:‹%v›)", offset, count)
+		case errors.RedactLogDisable:
+			res += fmt.Sprintf(", limit(offset:%v, count:%v)", offset, count)
+		case errors.RedactLogEnable:
+			res += ", limit(offset:?, count:?)"
+		}
 	}
 	return res
 }

--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -71,12 +71,28 @@ func TestNonPreparedPlanCachePlanString(t *testing.T) {
 		require.NoError(t, err)
 		return plannercore.ToString(p)
 	}
-
+	defer func() {
+		tk.MustExec("set session tidb_redact_log=MARKER")
+	}()
 	require.Equal(t, planString("select a from t where a < 1"), "IndexReader(Index(t.a)[[-inf,1)])")
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	require.Equal(t, planString("select a from t where a < 10"), "IndexReader(Index(t.a)[[-inf,10)])") // range 1 -> 10
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_redact_log=MARKER")
+	require.Equal(t, planString("select a from t where a < 10"), "IndexReader(Index(t.a)[[-inf,10)])") // range 1 -> 10
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_redact_log=ON")
 	require.Equal(t, planString("select a from t where a < 10"), "IndexReader(Index(t.a)[[-inf,10)])") // range 1 -> 10
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
 
 	require.Equal(t, planString("select * from t where b < 1"), "TableReader(Table(t)->Sel([lt(test.t.b, 1)]))")
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	require.Equal(t, planString("select * from t where b < 10"), "TableReader(Table(t)->Sel([lt(test.t.b, 10)]))") // filter 1 -> 10
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_redact_log=MARKER")
+	require.Equal(t, planString("select * from t where b < 10"), "TableReader(Table(t)->Sel([lt(test.t.b, 10)]))") // filter 1 -> 10
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_redact_log=ON")
 	require.Equal(t, planString("select * from t where b < 10"), "TableReader(Table(t)->Sel([lt(test.t.b, 10)]))") // filter 1 -> 10
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
 }
@@ -258,12 +274,22 @@ func TestIssue38269(t *testing.T) {
 	tk.MustExec("prepare stmt1 from 'select /*+ inl_join(t2) */ * from t1 join t2 on t1.a = t2.a where t2.b in (?, ?, ?)'")
 	tk.MustExec("set @a = 10, @b = 20, @c = 30, @d = 40, @e = 50, @f = 60")
 	tk.MustExec("execute stmt1 using @a, @b, @c")
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
+	tk.MustExec("set session tidb_redact_log=MARKER")
 	tk.MustExec("execute stmt1 using @d, @e, @f")
 	tkProcess := tk.Session().ShowProcess()
 	ps := []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	rows := tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Rows()
-	require.Contains(t, rows[6][4], "range: decided by [eq(test.t2.a, test.t1.a) in(test.t2.b, 40, 50, 60)]")
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
+	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows(
+		"IndexJoin_12 37.46 root  inner join, inner:IndexLookUp_11, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+		"├─TableReader_24(Build) 9990.00 root  data:Selection_23",
+		"│ └─Selection_23 9990.00 cop[tikv]  not(isnull(test.t1.a))",
+		"│   └─TableFullScan_22 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+		"└─IndexLookUp_11(Probe) 37.46 root  ",
+		"  ├─Selection_10(Build) 37.46 cop[tikv]  not(isnull(test.t2.a))",
+		"  │ └─IndexRangeScan_8 37.50 cop[tikv] table:t2, index:idx(a, b) range: decided by [eq(test.t2.a, test.t1.a) in(test.t2.b, ‹40›, ‹50›, ‹60›)], keep order:false, stats:pseudo",
+		"  └─TableRowIDScan_9(Probe) 37.46 cop[tikv] table:t2 keep order:false, stats:pseudo"))
 }
 
 func TestIssue38533(t *testing.T) {

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -726,7 +726,7 @@ func parseParamTypes(sctx sessionctx.Context, params []expression.Expression) (p
 		}
 
 		// from text protocol, there must be a GetVar function
-		name := param.(*expression.ScalarFunction).GetArgs()[0].StringWithCtx(ectx)
+		name := param.(*expression.ScalarFunction).GetArgs()[0].StringWithCtx(ectx, errors.RedactLogDisable)
 		tp, ok := sctx.GetSessionVars().GetUserVarType(name)
 		if !ok {
 			tp = types.NewFieldType(mysql.TypeNull)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -196,11 +196,15 @@ func (p *PointGetPlan) OperatorInfo(normalized bool) string {
 		if normalized {
 			buffer.WriteString("handle:?")
 		} else {
+			redactMode := p.SCtx().GetSessionVars().EnableRedactLog
+			redactOn := redactMode == errors.RedactLogEnable
 			buffer.WriteString("handle:")
-			if p.UnsignedHandle {
-				buffer.WriteString(strconv.FormatUint(uint64(p.Handle.IntValue()), 10))
+			if redactOn {
+				buffer.WriteString("?")
+			} else if p.UnsignedHandle {
+				writeRedactMarker(&buffer, strconv.FormatUint(uint64(p.Handle.IntValue()), 10), redactMode)
 			} else {
-				buffer.WriteString(p.Handle.String())
+				writeRedactMarker(&buffer, p.Handle.String(), redactMode)
 			}
 		}
 	}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -55,6 +55,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
+	"github.com/pingcap/tidb/pkg/util/redact"
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 	"github.com/pingcap/tidb/pkg/util/tracing"
@@ -202,9 +203,9 @@ func (p *PointGetPlan) OperatorInfo(normalized bool) string {
 			if redactOn {
 				buffer.WriteString("?")
 			} else if p.UnsignedHandle {
-				writeRedactMarker(&buffer, strconv.FormatUint(uint64(p.Handle.IntValue()), 10), redactMode)
+				redact.WriteRedact(&buffer, strconv.FormatUint(uint64(p.Handle.IntValue()), 10), redactMode)
 			} else {
-				writeRedactMarker(&buffer, p.Handle.String(), redactMode)
+				redact.WriteRedact(&buffer, p.Handle.String(), redactMode)
 			}
 		}
 	}

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -694,7 +695,7 @@ func appendAggPushDownAcrossJoinTraceStep(oldAgg, newAgg *LogicalAggregation, ag
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(aggFunc.StringWithCtx(evalCtx))
+			buffer.WriteString(aggFunc.StringWithCtx(evalCtx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("] are decomposable with join")
 		return buffer.String()
@@ -720,7 +721,7 @@ func appendAggPushDownAcrossProjTraceStep(agg *LogicalAggregation, proj *Logical
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(aggFunc.StringWithCtx(evalCtx))
+			buffer.WriteString(aggFunc.StringWithCtx(evalCtx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("]")
 		return buffer.String()
@@ -739,7 +740,7 @@ func appendAggPushDownAcrossUnionTraceStep(union *LogicalUnionAll, agg *LogicalA
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(aggFunc.StringWithCtx(evalCtx))
+			buffer.WriteString(aggFunc.StringWithCtx(evalCtx, errors.RedactLogDisable))
 		}
 		fmt.Fprintf(buffer, "] are decomposable with %v_%v", union.TP(), union.ID())
 		return buffer.String()

--- a/pkg/planner/core/rule_decorrelate.go
+++ b/pkg/planner/core/rule_decorrelate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -533,21 +534,21 @@ func appendModifyAggTraceStep(outerPlan base.LogicalPlan, p *LogicalApply, agg *
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(col.StringWithCtx(evalCtx))
+			buffer.WriteString(col.StringWithCtx(evalCtx, perrors.RedactLogDisable))
 		}
 		buffer.WriteString("], and functions added [")
 		for i, f := range appendedAggFuncs {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(f.StringWithCtx(evalCtx))
+			buffer.WriteString(f.StringWithCtx(evalCtx, perrors.RedactLogDisable))
 		}
 		fmt.Fprintf(buffer, "], and %v_%v's conditions added [", p.TP(), p.ID())
 		for i, cond := range eqCondWithCorCol {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.StringWithCtx(evalCtx))
+			buffer.WriteString(cond.StringWithCtx(evalCtx, perrors.RedactLogDisable))
 		}
 		buffer.WriteString("]")
 		return buffer.String()
@@ -558,7 +559,7 @@ func appendModifyAggTraceStep(outerPlan base.LogicalPlan, p *LogicalApply, agg *
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.StringWithCtx(evalCtx))
+			buffer.WriteString(cond.StringWithCtx(evalCtx, perrors.RedactLogDisable))
 		}
 		fmt.Fprintf(buffer, "] are correlated to %v_%v and pulled up as %v_%v's join key",
 			outerPlan.TP(), outerPlan.ID(), p.TP(), p.ID())

--- a/pkg/planner/core/rule_eliminate_projection.go
+++ b/pkg/planner/core/rule_eliminate_projection.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -277,7 +278,7 @@ func appendDupProjEliminateTraceStep(parent, child *LogicalProjection, opt *opti
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(expr.StringWithCtx(ectx))
+			buffer.WriteString(expr.StringWithCtx(ectx, perrors.RedactLogDisable))
 		}
 		buffer.WriteString("]")
 		return buffer.String()

--- a/pkg/planner/core/rule_generate_column_substitute.go
+++ b/pkg/planner/core/rule_generate_column_substitute.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -104,10 +105,10 @@ func appendSubstituteColumnStep(lp base.LogicalPlan, candidateExpr expression.Ex
 	ectx := lp.SCtx().GetExprCtx().GetEvalCtx()
 	action := func() string {
 		buffer := bytes.NewBufferString("expression:")
-		buffer.WriteString(candidateExpr.StringWithCtx(ectx))
+		buffer.WriteString(candidateExpr.StringWithCtx(ectx, errors.RedactLogDisable))
 		buffer.WriteString(" substituted by")
 		buffer.WriteString(" column:")
-		buffer.WriteString(col.StringWithCtx(ectx))
+		buffer.WriteString(col.StringWithCtx(ectx, errors.RedactLogDisable))
 		return buffer.String()
 	}
 	opt.AppendStepToCurrent(lp.ID(), lp.TP(), reason, action)

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -266,14 +267,14 @@ func appendOuterJoinEliminateTraceStep(join *LogicalJoin, outerPlan base.Logical
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(col.StringWithCtx(ectx))
+			buffer.WriteString(col.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("] are from outer table, and the inner join keys[")
 		for i, key := range innerJoinKeys.Columns {
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(key.StringWithCtx(ectx))
+			buffer.WriteString(key.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("] are unique")
 		return buffer.String()
@@ -292,7 +293,7 @@ func appendOuterJoinEliminateAggregationTraceStep(join *LogicalJoin, outerPlan b
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(col.StringWithCtx(ectx))
+			buffer.WriteString(col.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("] in agg are from outer table, and the agg functions are duplicate agnostic")
 		return buffer.String()

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -492,7 +492,7 @@ func (*partitionProcessor) reconstructTableColNames(ds *DataSource) ([]*types.Fi
 		}
 
 		ectx := ds.SCtx().GetExprCtx().GetEvalCtx()
-		return nil, errors.Trace(fmt.Errorf("information of column %v is not found", colExpr.StringWithCtx(ectx)))
+		return nil, errors.Trace(fmt.Errorf("information of column %v is not found", colExpr.StringWithCtx(ectx, errors.RedactLogDisable)))
 	}
 	return names, nil
 }

--- a/pkg/planner/core/rule_predicate_push_down.go
+++ b/pkg/planner/core/rule_predicate_push_down.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -252,7 +253,7 @@ func appendTableDualTraceStep(replaced base.LogicalPlan, dual base.LogicalPlan, 
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.StringWithCtx(ectx))
+			buffer.WriteString(cond.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("] are constant false or null")
 		return buffer.String()
@@ -275,7 +276,7 @@ func appendSelectionPredicatePushDownTraceStep(p *LogicalSelection, conditions [
 				if i > 0 {
 					buffer.WriteString(",")
 				}
-				buffer.WriteString(cond.StringWithCtx(evalCtx))
+				buffer.WriteString(cond.StringWithCtx(evalCtx, errors.RedactLogDisable))
 			}
 			fmt.Fprintf(buffer, "] in %v_%v are pushed down", p.TP(), p.ID())
 			return buffer.String()
@@ -298,7 +299,7 @@ func appendDataSourcePredicatePushDownTraceStep(ds *DataSource, opt *optimizetra
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(cond.StringWithCtx(ectx))
+			buffer.WriteString(cond.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		fmt.Fprintf(buffer, "] are pushed down across %v_%v", ds.TP(), ds.ID())
 		return buffer.String()

--- a/pkg/planner/core/rule_topn_push_down.go
+++ b/pkg/planner/core/rule_topn_push_down.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
@@ -84,7 +85,7 @@ func appendTopNPushDownJoinTraceStep(p *LogicalJoin, topN *LogicalTopN, idx int,
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(item.StringWithCtx(ectx))
+			buffer.WriteString(item.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		buffer.WriteString("] contained in ")
 		if idx == 0 {
@@ -106,7 +107,7 @@ func appendSortPassByItemsTraceStep(sort *LogicalSort, topN *LogicalTopN, opt *o
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(item.StringWithCtx(ectx))
+			buffer.WriteString(item.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		fmt.Fprintf(buffer, "] to %v_%v", topN.TP(), topN.ID())
 		return buffer.String()

--- a/pkg/planner/core/runtime_filter.go
+++ b/pkg/planner/core/runtime_filter.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -222,7 +223,7 @@ func (rf *RuntimeFilter) ToPB(ctx *base.BuildPBContext, client kv.Client) (*tipb
 	for _, srcExpr := range rf.srcExprList {
 		srcExprPB := pc.ExprToPB(srcExpr)
 		if srcExprPB == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform src expr %s to pb in runtime filter", srcExpr.StringWithCtx(ectx))
+			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform src expr %s to pb in runtime filter", srcExpr.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		srcExprListPB = append(srcExprListPB, srcExprPB)
 	}
@@ -230,7 +231,7 @@ func (rf *RuntimeFilter) ToPB(ctx *base.BuildPBContext, client kv.Client) (*tipb
 	for _, targetExpr := range rf.targetExprList {
 		targetExprPB := pc.ExprToPB(targetExpr)
 		if targetExprPB == nil {
-			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform target expr %s to pb in runtime filter", targetExpr.StringWithCtx(ectx))
+			return nil, plannererrors.ErrInternal.GenWithStack("failed to transform target expr %s to pb in runtime filter", targetExpr.StringWithCtx(ectx, errors.RedactLogDisable))
 		}
 		targetExprListPB = append(targetExprListPB, targetExprPB)
 	}

--- a/pkg/planner/core/runtime_filter_generator.go
+++ b/pkg/planner/core/runtime_filter_generator.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -185,7 +186,7 @@ func (*RuntimeFilterGenerator) matchEQPredicate(ctx expression.EvalContext, eqPr
 	// exclude null safe equal predicate
 	if eqPredicate.FuncName.L == ast.NullEQ {
 		logutil.BgLogger().Debug("The runtime filter doesn't support null safe eq predicate",
-			zap.String("EQPredicate", eqPredicate.StringWithCtx(ctx)))
+			zap.String("EQPredicate", eqPredicate.StringWithCtx(ctx, errors.RedactLogDisable)))
 		return false
 	}
 	var targetColumn, srcColumn *expression.Column
@@ -202,7 +203,7 @@ func (*RuntimeFilterGenerator) matchEQPredicate(ctx expression.EvalContext, eqPr
 	// todo: cast expr in target column
 	if targetColumn.IsHidden || targetColumn.OrigName == "" {
 		logutil.BgLogger().Debug("Target column does not match RF pattern",
-			zap.String("EQPredicate", eqPredicate.StringWithCtx(ctx)),
+			zap.String("EQPredicate", eqPredicate.StringWithCtx(ctx, errors.RedactLogDisable)),
 			zap.String("TargetColumn", targetColumn.String()),
 			zap.Bool("IsHidden", targetColumn.IsHidden),
 			zap.String("OrigName", targetColumn.OrigName))
@@ -214,7 +215,7 @@ func (*RuntimeFilterGenerator) matchEQPredicate(ctx expression.EvalContext, eqPr
 		srcColumnType == mysql.TypeLongBlob || srcColumnType == mysql.TypeMediumBlob ||
 		srcColumnType == mysql.TypeTinyBlob || srcColumn.GetStaticType().Hybrid() || srcColumn.GetStaticType().IsArray() {
 		logutil.BgLogger().Debug("Src column type does not match RF pattern",
-			zap.String("EQPredicate", eqPredicate.StringWithCtx(ctx)),
+			zap.String("EQPredicate", eqPredicate.StringWithCtx(ctx, errors.RedactLogDisable)),
 			zap.String("SrcColumn", srcColumn.String()),
 			zap.String("SrcColumnType", srcColumn.GetStaticType().String()))
 		return false

--- a/pkg/planner/core/stringer.go
+++ b/pkg/planner/core/stringer.go
@@ -388,16 +388,3 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 	strs = append(strs, str)
 	return strs, idxs
 }
-
-func writeRedactMarker(build *strings.Builder, v string, redact string) {
-	if redact == perrors.RedactLogMarker {
-		build.WriteString("‹")
-		build.WriteString(v)
-		build.WriteString("›")
-		return
-	} else if redact == perrors.RedactLogEnable {
-		build.WriteString("?")
-		return
-	}
-	build.WriteString(v)
-}

--- a/pkg/planner/core/stringer.go
+++ b/pkg/planner/core/stringer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/util"
@@ -125,8 +126,8 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 			str = "LeftHashJoin{" + strings.Join(children, "->") + "}"
 		}
 		for _, eq := range x.EqualConditions {
-			l := eq.GetArgs()[0].StringWithCtx(ectx)
-			r := eq.GetArgs()[1].StringWithCtx(ectx)
+			l := eq.GetArgs()[0].StringWithCtx(ectx, perrors.RedactLogDisable)
+			r := eq.GetArgs()[1].StringWithCtx(ectx, perrors.RedactLogDisable)
 			str += fmt.Sprintf("(%s,%s)", l, r)
 		}
 	case *PhysicalMergeJoin:
@@ -154,8 +155,8 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 		}
 		str = id + "{" + strings.Join(children, "->") + "}"
 		for i := range x.LeftJoinKeys {
-			l := x.LeftJoinKeys[i].StringWithCtx(ectx)
-			r := x.RightJoinKeys[i].StringWithCtx(ectx)
+			l := x.LeftJoinKeys[i].StringWithCtx(ectx, perrors.RedactLogDisable)
+			r := x.RightJoinKeys[i].StringWithCtx(ectx, perrors.RedactLogDisable)
 			str += fmt.Sprintf("(%s,%s)", l, r)
 		}
 	case *LogicalApply, *PhysicalApply:
@@ -195,8 +196,8 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 		str = "Join{" + strings.Join(children, "->") + "}"
 		idxs = idxs[:last]
 		for _, eq := range x.EqualConditions {
-			l := eq.GetArgs()[0].StringWithCtx(ectx)
-			r := eq.GetArgs()[1].StringWithCtx(ectx)
+			l := eq.GetArgs()[0].StringWithCtx(ectx, perrors.RedactLogDisable)
+			r := eq.GetArgs()[1].StringWithCtx(ectx, perrors.RedactLogDisable)
 			str += fmt.Sprintf("(%s,%s)", l, r)
 		}
 	case *LogicalUnionAll, *PhysicalUnionAll, *LogicalPartitionUnionAll:
@@ -249,7 +250,7 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 	case *LogicalAggregation:
 		str = "Aggr("
 		for i, aggFunc := range x.AggFuncs {
-			str += aggFunc.StringWithCtx(ectx)
+			str += aggFunc.StringWithCtx(ectx, perrors.RedactLogDisable)
 			if i != len(x.AggFuncs)-1 {
 				str += ","
 			}
@@ -317,7 +318,7 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 		for _, col := range x.ColTasks {
 			var colNames []string
 			if col.HandleCols != nil {
-				colNames = append(colNames, col.HandleCols.StringWithCtx(ectx))
+				colNames = append(colNames, col.HandleCols.StringWithCtx(ectx, perrors.RedactLogDisable))
 			}
 			for _, c := range col.ColsInfo {
 				colNames = append(colNames, c.Name.O)
@@ -386,4 +387,17 @@ func toString(in base.Plan, strs []string, idxs []int) ([]string, []int) {
 	}
 	strs = append(strs, str)
 	return strs, idxs
+}
+
+func writeRedactMarker(build *strings.Builder, v string, redact string) {
+	if redact == perrors.RedactLogMarker {
+		build.WriteString("‹")
+		build.WriteString(v)
+		build.WriteString("›")
+		return
+	} else if redact == perrors.RedactLogEnable {
+		build.WriteString("?")
+		return
+	}
+	build.WriteString(v)
 }

--- a/pkg/planner/core/tests/redact/BUILD.bazel
+++ b/pkg/planner/core/tests/redact/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "redact_test",
+    timeout = "short",
+    srcs = [
+        "main_test.go",
+        "redact_test.go",
+    ],
+    flaky = True,
+    shard_count = 4,
+    deps = [
+        "//pkg/planner/util/coretestsdk",
+        "//pkg/testkit",
+        "//pkg/testkit/testsetup",
+        "@org_uber_go_goleak//:goleak",
+    ],
+)

--- a/pkg/planner/core/tests/redact/main_test.go
+++ b/pkg/planner/core/tests/redact/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redact
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit/testsetup"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	testsetup.SetupForCommonTest()
+	flag.Parse()
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
+		goleak.IgnoreTopFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
+		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
+	}
+	goleak.VerifyTestMain(m, opts...)
+}

--- a/pkg/planner/core/tests/redact/redact_test.go
+++ b/pkg/planner/core/tests/redact/redact_test.go
@@ -1,0 +1,271 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redact
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestRedactExplain(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t2(id int, a int, b int, primary key(id, a)) partition by hash(id + a) partitions 10;")
+	tk.MustExec("create table t1(id int primary key, a int, b int) partition by hash(id) partitions 10;")
+	tk.MustExec("create table t(a int primary key, b int);")
+	tk.MustExec(`create table tlist (a int) partition by list (a) (
+    partition p0 values in (0, 1, 2),
+    partition p1 values in (3, 4, 5),
+    partition p2 values in (6, 7, 8),
+    partition p3 values in (9, 10, 11))`)
+	tk.MustExec("create table employee (empid int, deptid int, salary decimal(10,2))")
+	tk.MustExec("CREATE TABLE person (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,name VARCHAR(255) NOT NULL,address_info JSON,city_no INT AS (JSON_EXTRACT(address_info, '$.city_no')) VIRTUAL,KEY(city_no));")
+
+	coretestsdk.SetTiFlashReplica(t, dom, "test", "employee")
+	// ---------------------------------------------------------------------------
+	// tidb_redact_log=MARKER
+	// ---------------------------------------------------------------------------
+	tk.MustExec("set session tidb_redact_log=MARKER")
+	// in multi-value
+	tk.MustQuery("explain select 1 from t left join tlist on tlist.a=t.a where t.a in (12, 13)").
+		Check(testkit.Rows(
+			"Projection_7 2.50 root  ‹1›->Column#5",
+			"└─HashJoin_9 2.50 root  left outer join, equal:[eq(test.t.a, test.tlist.a)]",
+			"  ├─Batch_Point_Get_10(Build) 2.00 root table:t handle:[12 13], keep order:false, desc:false",
+			"  └─TableReader_13(Probe) 20.00 root partition:dual data:Selection_12",
+			"    └─Selection_12 20.00 cop[tikv]  in(test.tlist.a, ‹12›, ‹13›), not(isnull(test.tlist.a))",
+			"      └─TableFullScan_11 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+	// TableRangeScan + Limit
+	tk.MustQuery("explain select * from t where a > 1 limit 10 offset 10;").
+		Check(testkit.Rows(
+			"Limit_8 10.00 root  offset:‹10›, count:‹10›",
+			"└─TableReader_12 20.00 root  data:Limit_11",
+			"  └─Limit_11 20.00 cop[tikv]  offset:‹0›, count:‹20›",
+			"    └─TableRangeScan_10 20.00 cop[tikv] table:t range:(‹1›,+inf], keep order:false, stats:pseudo"))
+	tk.MustQuery("explain select * from t where a < 1;").
+		Check(testkit.Rows(
+			"TableReader_6 3333.33 root  data:TableRangeScan_5",
+			"└─TableRangeScan_5 3333.33 cop[tikv] table:t range:[-inf,‹1›), keep order:false, stats:pseudo"))
+	// PointGet + order by
+	tk.MustQuery("explain select b+1 as vt from t where a = 1 order by vt;").
+		Check(testkit.Rows(
+			"Sort_5 1.00 root  Column#3",
+			"└─Projection_7 1.00 root  plus(test.t.b, ‹1›)->Column#3",
+			"  └─Point_Get_8 1.00 root table:t handle:‹1›"))
+	// expression partition key
+	tk.MustQuery("explain select *, row_number() over (partition by deptid+1) FROM employee").Check(testkit.Rows(
+		"TableReader_31 10000.00 root  MppVersion: 2, data:ExchangeSender_30",
+		"└─ExchangeSender_30 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Projection_7 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column#7, stream_count: 8",
+		"    └─Window_29 10000.00 mpp[tiflash]  row_number()->Column#7 over(partition by Column#6 rows between current row and current row), stream_count: 8",
+		"      └─Sort_14 10000.00 mpp[tiflash]  Column#6, stream_count: 8",
+		"        └─ExchangeReceiver_13 10000.00 mpp[tiflash]  stream_count: 8",
+		"          └─ExchangeSender_12 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#6, collate: binary], stream_count: 8",
+		"            └─Projection_10 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, plus(test.employee.deptid, ‹1›)->Column#6", // <- here
+		"              └─TableFullScan_11 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format = 'brief' select * from tlist where a in (2)").Check(testkit.Rows(
+		"TableReader 10.00 root partition:p0 data:Selection",
+		"└─Selection 10.00 cop[tikv]  eq(test.tlist.a, ‹2›)",
+		"  └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+	// CTE
+	tk.MustQuery("explain with recursive cte(a) as (select 1 union select a + 1 from cte where a < 1000) select * from cte, t limit 100 offset 100;").Check(
+		testkit.Rows(
+			"Limit_25 100.00 root  offset:‹100›, count:‹100›",
+			"└─HashJoin_27 200.00 root  CARTESIAN inner join",
+			"  ├─CTEFullScan_31(Build) 2.00 root CTE:cte data:CTE_0",
+			"  └─TableReader_33(Probe) 100.00 root  data:TableFullScan_32",
+			"    └─TableFullScan_32 100.00 cop[tikv] table:t keep order:false, stats:pseudo",
+			"CTE_0 2.00 root  Recursive CTE",
+			"├─Projection_16(Seed Part) 1.00 root  ‹1›->Column#2",
+			"│ └─TableDual_17 1.00 root  rows:1",
+			"└─Projection_18(Recursive Part) 0.80 root  cast(plus(Column#3, ‹1›), bigint(1) BINARY)->Column#5",
+			"  └─Selection_19 0.80 root  lt(Column#3, ‹1000›)",
+			"    └─CTETable_20 1.00 root  Scan on CTE_0"))
+	// virtual generated column
+	tk.MustQuery("EXPLAIN format = 'brief' SELECT name FROM person where city_no=1").Check(testkit.Rows(
+		"Projection 10.00 root  test.person.name",
+		"└─Projection 10.00 root  test.person.name, test.person.city_no",
+		"  └─IndexLookUp 10.00 root  ",
+		"    ├─IndexRangeScan(Build) 10.00 cop[tikv] table:person, index:city_no(city_no) range:[‹1›,‹1›], keep order:false, stats:pseudo",
+		"    └─TableRowIDScan(Probe) 10.00 cop[tikv] table:person keep order:false, stats:pseudo"))
+	// group by
+	tk.MustQuery(" explain select 1 from test.t group by 1").Check(testkit.Rows(
+		"Projection_4 1.00 root  ‹1›->Column#3",
+		"└─HashAgg_9 1.00 root  group by:Column#7, funcs:firstrow(Column#8)->Column#6",
+		"  └─TableReader_10 1.00 root  data:HashAgg_5",
+		"    └─HashAgg_5 1.00 cop[tikv]  group by:‹1›, funcs:firstrow(‹1›)->Column#8",
+		"      └─TableFullScan_8 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+	// ---------------------------------------------------------------------------
+	// tidb_redact_log=ON
+	// ---------------------------------------------------------------------------
+	tk.MustExec("set session tidb_redact_log=ON")
+	// in multi-value
+	tk.MustQuery("explain select 1 from t left join tlist on tlist.a=t.a where t.a in (12, 13)").
+		Check(testkit.Rows(
+			"Projection_7 2.50 root  ?->Column#5",
+			"└─HashJoin_9 2.50 root  left outer join, equal:[eq(test.t.a, test.tlist.a)]",
+			"  ├─Batch_Point_Get_10(Build) 2.00 root table:t handle:[12 13], keep order:false, desc:false",
+			"  └─TableReader_13(Probe) 20.00 root partition:dual data:Selection_12",
+			"    └─Selection_12 20.00 cop[tikv]  in(test.tlist.a, ?, ?), not(isnull(test.tlist.a))",
+			"      └─TableFullScan_11 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+	// TableRangeScan + Limit
+	tk.MustQuery("explain select * from t where a > 1 limit 10 offset 10;").
+		Check(testkit.Rows(
+			"Limit_8 10.00 root  offset:?, count:?",
+			"└─TableReader_12 20.00 root  data:Limit_11",
+			"  └─Limit_11 20.00 cop[tikv]  offset:?, count:?",
+			"    └─TableRangeScan_10 20.00 cop[tikv] table:t range:(?,+inf], keep order:false, stats:pseudo"))
+	tk.MustQuery("explain select * from t where a < 1;").
+		Check(testkit.Rows(
+			"TableReader_6 3333.33 root  data:TableRangeScan_5",
+			"└─TableRangeScan_5 3333.33 cop[tikv] table:t range:[-inf,?), keep order:false, stats:pseudo"))
+	// PointGet + order by
+	tk.MustQuery("explain select b+1 as vt from t where a = 1 order by vt;").
+		Check(testkit.Rows(
+			"Sort_5 1.00 root  Column#3",
+			"└─Projection_7 1.00 root  plus(test.t.b, ?)->Column#3",
+			"  └─Point_Get_8 1.00 root table:t handle:?"))
+	// expression partition key
+	tk.MustQuery("explain select *, row_number() over (partition by deptid+1) FROM employee").Check(testkit.Rows(
+		"TableReader_31 10000.00 root  MppVersion: 2, data:ExchangeSender_30",
+		"└─ExchangeSender_30 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Projection_7 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, Column#7, stream_count: 8",
+		"    └─Window_29 10000.00 mpp[tiflash]  row_number()->Column#7 over(partition by Column#6 rows between current row and current row), stream_count: 8",
+		"      └─Sort_14 10000.00 mpp[tiflash]  Column#6, stream_count: 8",
+		"        └─ExchangeReceiver_13 10000.00 mpp[tiflash]  stream_count: 8",
+		"          └─ExchangeSender_12 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: Column#6, collate: binary], stream_count: 8",
+		"            └─Projection_10 10000.00 mpp[tiflash]  test.employee.empid, test.employee.deptid, test.employee.salary, plus(test.employee.deptid, ?)->Column#6", // <- here
+		"              └─TableFullScan_11 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo"))
+	tk.MustQuery("explain format = 'brief' select * from tlist where a in (2)").Check(testkit.Rows(
+		"TableReader 10.00 root partition:p0 data:Selection",
+		"└─Selection 10.00 cop[tikv]  eq(test.tlist.a, ?)",
+		"  └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
+	// CTE
+	tk.MustQuery("explain with recursive cte(a) as (select 1 union select a + 1 from cte where a < 1000) select * from cte, t limit 100 offset 100;").Check(
+		testkit.Rows("Limit_25 100.00 root  offset:?, count:?",
+			"└─HashJoin_27 200.00 root  CARTESIAN inner join",
+			"  ├─CTEFullScan_31(Build) 2.00 root CTE:cte data:CTE_0",
+			"  └─TableReader_33(Probe) 100.00 root  data:TableFullScan_32",
+			"    └─TableFullScan_32 100.00 cop[tikv] table:t keep order:false, stats:pseudo",
+			"CTE_0 2.00 root  Recursive CTE",
+			"├─Projection_16(Seed Part) 1.00 root  ?->Column#2",
+			"│ └─TableDual_17 1.00 root  rows:1",
+			"└─Projection_18(Recursive Part) 0.80 root  cast(plus(Column#3, ?), bigint(1) BINARY)->Column#5",
+			"  └─Selection_19 0.80 root  lt(Column#3, ?)",
+			"    └─CTETable_20 1.00 root  Scan on CTE_0"))
+	// virtual generated column
+	tk.MustQuery("EXPLAIN format = 'brief' SELECT name FROM person where city_no=1").Check(testkit.Rows(
+		"Projection 10.00 root  test.person.name",
+		"└─Projection 10.00 root  test.person.name, test.person.city_no",
+		"  └─IndexLookUp 10.00 root  ",
+		"    ├─IndexRangeScan(Build) 10.00 cop[tikv] table:person, index:city_no(city_no) range:[?,?], keep order:false, stats:pseudo",
+		"    └─TableRowIDScan(Probe) 10.00 cop[tikv] table:person keep order:false, stats:pseudo"))
+	// group by
+	tk.MustQuery(" explain select 1 from test.t group by 1").Check(testkit.Rows(
+		"Projection_4 1.00 root  ?->Column#3",
+		"└─HashAgg_9 1.00 root  group by:Column#7, funcs:firstrow(Column#8)->Column#6",
+		"  └─TableReader_10 1.00 root  data:HashAgg_5",
+		"    └─HashAgg_5 1.00 cop[tikv]  group by:?, funcs:firstrow(?)->Column#8",
+		"      └─TableFullScan_8 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+}
+
+func TestRedactForRangeInfo(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`set @@tidb_enable_prepared_plan_cache=1`)
+	tk.MustExec("set @@tidb_enable_collect_execution_info=0")
+	tk.MustExec(`set @@tidb_opt_advanced_join_hint=0`)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("create table t2(a int, b int, c int, index idx(a, b))")
+	tk.MustExec("set session tidb_redact_log=ON")
+	tk.MustQuery("explain select /*+ inl_join(t2) */ * from t1 join t2 on t1.a = t2.a where t2.b in (10, 20, 30)").Check(
+		testkit.Rows(
+			"IndexJoin_12 37.46 root  inner join, inner:IndexLookUp_11, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+			"├─TableReader_24(Build) 9990.00 root  data:Selection_23",
+			"│ └─Selection_23 9990.00 cop[tikv]  not(isnull(test.t1.a))",
+			"│   └─TableFullScan_22 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+			"└─IndexLookUp_11(Probe) 37.46 root  ",
+			"  ├─Selection_10(Build) 37.46 cop[tikv]  not(isnull(test.t2.a))",
+			"  │ └─IndexRangeScan_8 37.50 cop[tikv] table:t2, index:idx(a, b) range: decided by [eq(test.t2.a, test.t1.a) in(test.t2.b, ?, ?, ?)], keep order:false, stats:pseudo",
+			"  └─TableRowIDScan_9(Probe) 37.46 cop[tikv] table:t2 keep order:false, stats:pseudo",
+		))
+}
+
+func TestJoinNotSupportedByTiFlash(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists table_1")
+	tk.MustExec("create table table_1(id int not null, bit_col bit(2) not null, datetime_col datetime not null, index idx(id, bit_col, datetime_col))")
+	tk.MustExec("insert into table_1 values(1,b'1','2020-01-01 00:00:00'),(2,b'0','2020-01-01 00:00:00')")
+	tk.MustExec("analyze table table_1")
+
+	tk.MustExec("insert into mysql.expr_pushdown_blacklist values('dayofmonth', 'tiflash', '');")
+	tk.MustExec("admin reload expr_pushdown_blacklist;")
+	tk.MustExec("set session tidb_redact_log=ON")
+	tk.MustQuery("explain format = 'brief' select * from table_1 a left join table_1 b on a.id = b.id and dayofmonth(a.datetime_col) > 100").Check(testkit.Rows(
+		"MergeJoin 2.00 root  left outer join, left key:test.table_1.id, right key:test.table_1.id, left cond:gt(dayofmonth(test.table_1.datetime_col), ?)",
+		"├─IndexReader(Build) 2.00 root  index:IndexFullScan",
+		"│ └─IndexFullScan 2.00 cop[tikv] table:b, index:idx(id, bit_col, datetime_col) keep order:true",
+		"└─IndexReader(Probe) 2.00 root  index:IndexFullScan",
+		"  └─IndexFullScan 2.00 cop[tikv] table:a, index:idx(id, bit_col, datetime_col) keep order:true"))
+	tk.MustExec("set session tidb_redact_log=MARKER")
+	tk.MustQuery("explain format = 'brief' select * from table_1 a left join table_1 b on a.id = b.id and dayofmonth(a.datetime_col) > 100").Check(testkit.Rows(
+		"MergeJoin 2.00 root  left outer join, left key:test.table_1.id, right key:test.table_1.id, left cond:gt(dayofmonth(test.table_1.datetime_col), ‹100›)",
+		"├─IndexReader(Build) 2.00 root  index:IndexFullScan",
+		"│ └─IndexFullScan 2.00 cop[tikv] table:b, index:idx(id, bit_col, datetime_col) keep order:true",
+		"└─IndexReader(Probe) 2.00 root  index:IndexFullScan",
+		"  └─IndexFullScan 2.00 cop[tikv] table:a, index:idx(id, bit_col, datetime_col) keep order:true"))
+}
+
+func TestRedactTiFlash(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create table test.first_range(p int not null, o int not null, v int not null, o_datetime datetime not null, o_time time not null);")
+	tk.MustExec("insert into test.first_range (p, o, v, o_datetime, o_time) values (0, 0, 0, '2023-9-20 11:17:10', '11:17:10');")
+	tk.MustExec("create table test.first_range_d64(p int not null, o decimal(17,1) not null, v int not null);")
+	tk.MustExec("insert into test.first_range_d64 (p, o, v) values (0, 0.1, 0), (1, 1.0, 1), (1, 2.1, 2), (1, 4.1, 4), (1, 8.1, 8), (2, 0.0, 0), (2, 3.1, 3), (2, 10.0, 10), (2, 13.1, 13), (2, 15.1, 15), (3, 1.1, 1), (3, 2.9, 3), (3, 5.1, 5), (3, 9.1, 9), (3, 15.0, 15), (3, 20.1, 20), (3, 31.1, 31);")
+	tk.MustExec("set @@tidb_allow_mpp=1; set @@tidb_enforce_mpp=1")
+	tk.MustExec("set @@tidb_isolation_read_engines = 'tiflash'")
+	// Create virtual tiflash replica info.
+	coretestsdk.SetTiFlashReplica(t, dom, "test", "first_range")
+	coretestsdk.SetTiFlashReplica(t, dom, "test", "first_range_d64")
+
+	tk.MustExec(`set @@tidb_max_tiflash_threads=20`)
+	tk.MustExec("set session tidb_redact_log=ON")
+	tk.MustQuery("explain select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range;").Check(testkit.Rows(
+		"TableReader_23 10000.00 root  MppVersion: 2, data:ExchangeSender_22",
+		"└─ExchangeSender_22 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Window_21 10000.00 mpp[tiflash]  first_value(test.first_range.v)->Column#8 over(partition by test.first_range.p order by test.first_range.o range between ? preceding and ? following), stream_count: 20",
+		"    └─Sort_13 10000.00 mpp[tiflash]  test.first_range.p, test.first_range.o, stream_count: 20",
+		"      └─ExchangeReceiver_12 10000.00 mpp[tiflash]  stream_count: 20",
+		"        └─ExchangeSender_11 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.first_range.p, collate: binary], stream_count: 20",
+		"          └─TableFullScan_10 10000.00 mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
+	tk.MustExec("set session tidb_redact_log=MARKER")
+	tk.MustQuery("explain select *, first_value(v) over (partition by p order by o range between 3 preceding and 0 following) as a from test.first_range;").Check(testkit.Rows(
+		"TableReader_23 10000.00 root  MppVersion: 2, data:ExchangeSender_22",
+		"└─ExchangeSender_22 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─Window_21 10000.00 mpp[tiflash]  first_value(test.first_range.v)->Column#8 over(partition by test.first_range.p order by test.first_range.o range between ‹3› preceding and ‹0› following), stream_count: 20",
+		"    └─Sort_13 10000.00 mpp[tiflash]  test.first_range.p, test.first_range.o, stream_count: 20",
+		"      └─ExchangeReceiver_12 10000.00 mpp[tiflash]  stream_count: 20",
+		"        └─ExchangeSender_11 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.first_range.p, collate: binary], stream_count: 20",
+		"          └─TableFullScan_10 10000.00 mpp[tiflash] table:first_range keep order:false, stats:pseudo"))
+}

--- a/pkg/planner/util/BUILD.bazel
+++ b/pkg/planner/util/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/collate",
         "//pkg/util/ranger",
         "//pkg/util/size",
+        "@com_github_pingcap_errors//:errors",
     ],
 )
 

--- a/pkg/planner/util/byitem.go
+++ b/pkg/planner/util/byitem.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/util/size"
 )
@@ -29,11 +30,11 @@ type ByItems struct {
 }
 
 // StringWithCtx implements expression.StringerWithCtx interface.
-func (by *ByItems) StringWithCtx(ctx expression.ParamValues) string {
+func (by *ByItems) StringWithCtx(ctx expression.ParamValues, redact string) string {
 	if by.Desc {
-		return fmt.Sprintf("%s true", by.Expr.StringWithCtx(ctx))
+		return fmt.Sprintf("%s true", by.Expr.StringWithCtx(ctx, redact))
 	}
-	return by.Expr.StringWithCtx(ctx)
+	return by.Expr.StringWithCtx(ctx, redact)
 }
 
 // Clone makes a copy of ByItems.
@@ -64,7 +65,7 @@ func StringifyByItemsWithCtx(ctx expression.EvalContext, byItems []*ByItems) str
 	sb := strings.Builder{}
 	sb.WriteString("[")
 	for i, item := range byItems {
-		sb.WriteString(item.StringWithCtx(ctx))
+		sb.WriteString(item.StringWithCtx(ctx, perrors.RedactLogDisable))
 		if i != len(byItems)-1 {
 			sb.WriteString(" ")
 		}

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -178,7 +178,7 @@ func (cb *CommonHandleCols) NumCols() int {
 }
 
 // StringWithCtx implements the kv.HandleCols interface.
-func (cb *CommonHandleCols) StringWithCtx(ctx expression.ParamValues) string {
+func (cb *CommonHandleCols) StringWithCtx(ctx expression.ParamValues, _ string) string {
 	b := new(strings.Builder)
 	b.WriteByte('[')
 	for i, col := range cb.columns {
@@ -305,7 +305,7 @@ func (*IntHandleCols) IsInt() bool {
 }
 
 // StringWithCtx implements the kv.HandleCols interface.
-func (ib *IntHandleCols) StringWithCtx(ctx expression.ParamValues) string {
+func (ib *IntHandleCols) StringWithCtx(ctx expression.ParamValues, _ string) string {
 	return ib.col.ColumnExplainInfo(ctx, false)
 }
 

--- a/pkg/planner/util/optimizetrace/logicaltrace/BUILD.bazel
+++ b/pkg/planner/util/optimizetrace/logicaltrace/BUILD.bazel
@@ -11,5 +11,6 @@ go_library(
         "//pkg/planner/core/base",
         "//pkg/planner/util",
         "//pkg/planner/util/optimizetrace",
+        "@com_github_pingcap_errors//:errors",
     ],
 )

--- a/pkg/planner/util/optimizetrace/logicaltrace/logical_tracer.go
+++ b/pkg/planner/util/optimizetrace/logicaltrace/logical_tracer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -36,7 +37,7 @@ func appendItemPruneTraceStep(p base.LogicalPlan, itemType string, prunedObjects
 			if i > 0 {
 				buffer.WriteString(",")
 			}
-			buffer.WriteString(item.StringWithCtx(p.SCtx().GetExprCtx().GetEvalCtx()))
+			buffer.WriteString(item.StringWithCtx(p.SCtx().GetExprCtx().GetEvalCtx(), errors.RedactLogDisable))
 		}
 		buffer.WriteString("] have been pruned")
 		return buffer.String()

--- a/pkg/table/tables/test/partition/BUILD.bazel
+++ b/pkg/table/tables/test/partition/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/logutil",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_zap//:zap",

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	gotime "time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -260,7 +261,7 @@ func TestGeneratePartitionExpr(t *testing.T) {
 		"1",
 	}
 	for i, expr := range pe.UpperBounds {
-		require.Equal(t, upperBounds[i], expr.StringWithCtx(tk.Session().GetExprCtx().GetEvalCtx()))
+		require.Equal(t, upperBounds[i], expr.StringWithCtx(tk.Session().GetExprCtx().GetEvalCtx(), errors.RedactLogDisable))
 	}
 }
 

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -664,12 +664,12 @@ func (r *builder) buildFromIn(
 	for _, e := range list {
 		v, ok := e.(*expression.Constant)
 		if !ok {
-			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not constant", e.StringWithCtx(evalCtx))
+			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not constant", e.StringWithCtx(evalCtx, errors.RedactLogDisable))
 			return getFullRange(), hasNull
 		}
 		dt, err := v.Eval(evalCtx, chunk.Row{})
 		if err != nil {
-			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not evaluated", e.StringWithCtx(evalCtx))
+			r.err = plannererrors.ErrUnsupportedType.GenWithStack("expr:%v is not evaluated", e.StringWithCtx(evalCtx, errors.RedactLogDisable))
 			return getFullRange(), hasNull
 		}
 		if dt.IsNull() {

--- a/pkg/util/ranger/types.go
+++ b/pkg/util/ranger/types.go
@@ -173,15 +173,38 @@ func HasFullRange(ranges []*Range, unsignedIntHandle bool) bool {
 	return false
 }
 
+func dealWithRedact(input string, redact string) string {
+	if input == "-inf" || input == "+inf" {
+		return input
+	}
+	if redact == errors.RedactLogDisable {
+		return input
+	} else if redact == errors.RedactLogEnable {
+		return "?"
+	}
+	return fmt.Sprintf("‹%s›", input)
+}
+
 // String implements the Stringer interface.
+// don't use it in the product.
 func (ran *Range) String() string {
+	return ran.string(errors.RedactLogDisable)
+}
+
+// Redact is to print the range with redacting sensitive data.
+func (ran *Range) Redact(redact string) string {
+	return ran.string(redact)
+}
+
+// String implements the Stringer interface.
+func (ran *Range) string(redact string) string {
 	lowStrs := make([]string, 0, len(ran.LowVal))
 	for _, d := range ran.LowVal {
-		lowStrs = append(lowStrs, formatDatum(d, true))
+		lowStrs = append(lowStrs, dealWithRedact(formatDatum(d, true), redact))
 	}
 	highStrs := make([]string, 0, len(ran.LowVal))
 	for _, d := range ran.HighVal {
-		highStrs = append(highStrs, formatDatum(d, false))
+		highStrs = append(highStrs, dealWithRedact(formatDatum(d, false), redact))
 	}
 	l, r := "[", "]"
 	if ran.LowExclude {

--- a/pkg/util/redact/redact.go
+++ b/pkg/util/redact/redact.go
@@ -209,3 +209,17 @@ func Key(key []byte) string {
 	}
 	return strings.ToUpper(hex.EncodeToString(key))
 }
+
+// WriteRedact is to write string with redact into `strings.Builder`
+func WriteRedact(build *strings.Builder, v string, redact string) {
+	if redact == errors.RedactLogMarker {
+		build.WriteString("‹")
+		build.WriteString(v)
+		build.WriteString("›")
+		return
+	} else if redact == errors.RedactLogEnable {
+		build.WriteString("?")
+		return
+	}
+	build.WriteString(v)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54565

Problem Summary:

### What changed and how does it work?

The main issue is that TiDB's explain function does not support tidb_redact_log, which has caused this problem to occur.

Due to the substantial size of this PR, I will outline the modifications made and the tests conducted.

#### The changement of ```StringCtx```

```StringCtx``` is used to generate information in the explain function and is also utilized in log generation. Therefore, it cannot directly read ```ctx``` to determine the redact mode.

So the changement of expression package is to add the ```redact``` parameter into ```StringCtx``` and force using the ```redactDisable``` mode when to raise the error.

so I refactor the  ```StringWithCtx```'s implementation of ```Constant```,```Column```. but ```planner/core.ToString/StringifyExpressionsWithCtx``` is to print the debug info for testing. so it forces to use the ```redactDisable```

```pkg/util/ranger/types.go``` is to support the redact for the ```ranger```.

#### the changement of the ```planner```

The main focus is on the physical operator to resolve the explain output. The primary modifications include enabling the expression to support redaction by passing the redact parameter into the expression's explain method. Additionally, some parameters of the operator itself are subjected to redaction.


#### the changement of the ```ranger```

Enable the range to support redaction mode.

#### the main test cases 

- [x] pkg/planner/core/tests/redact
- [x] pkg/planner/core/plan_cache_test.go  
      - avoid plan cache polluting by the redact.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

1. I add some test cases to make redact results right
2. To prevent redaction from affecting the plan cache and plan digest tests, specific tests were conducted for different redaction scenarios to observe the plan cache hit rate.


- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
