### PR TITLE
infoschema: use maps.Clone to replace iterating

### DIFF
--- a/pkg/ddl/callback.go
+++ b/pkg/ddl/callback.go
@@ -118,29 +118,6 @@ type DefaultCallback struct {
 	do SchemaLoader
 }
 
-// OnChanged overrides ddl Callback interface.
-func (c *DefaultCallback) OnChanged(err error) error {
-	if err != nil {
-		return err
-	}
-	logutil.DDLLogger().Info("performing DDL change, must reload")
-
-	err = c.do.Reload()
-	if err != nil {
-		logutil.DDLLogger().Error("performing DDL change failed", zap.Error(err))
-	}
-
-	return nil
-}
-
-// OnSchemaStateChanged overrides the ddl Callback interface.
-func (c *DefaultCallback) OnSchemaStateChanged(_ int64) {
-	err := c.do.Reload()
-	if err != nil {
-		logutil.DDLLogger().Error("domain callback failed on schema state changed", zap.Error(err))
-	}
-}
-
 func newDefaultCallBack(do SchemaLoader) Callback {
 	return &DefaultCallback{BaseCallback: &BaseCallback{}, do: do}
 }
@@ -154,28 +131,6 @@ func newDefaultCallBack(do SchemaLoader) Callback {
 type ctcCallback struct {
 	*BaseCallback
 	do SchemaLoader
-}
-
-// OnChanged overrides ddl Callback interface.
-func (c *ctcCallback) OnChanged(err error) error {
-	if err != nil {
-		return err
-	}
-	logutil.DDLLogger().Info("performing DDL change, must reload")
-
-	err = c.do.Reload()
-	if err != nil {
-		logutil.DDLLogger().Error("performing DDL change failed", zap.Error(err))
-	}
-	return nil
-}
-
-// OnSchemaStateChanged overrides the ddl Callback interface.
-func (c *ctcCallback) OnSchemaStateChanged(_ int64) {
-	err := c.do.Reload()
-	if err != nil {
-		logutil.DDLLogger().Error("domain callback failed on schema state changed", zap.Error(err))
-	}
 }
 
 // OnJobRunBefore is used to run the user customized logic of `onJobRunBefore` first.

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -1391,9 +1391,6 @@ func waitSchemaChanged(ctx context.Context, d *ddlCtx, waitTime time.Duration, l
 	if !job.IsRunning() && !job.IsRollingback() && !job.IsDone() && !job.IsRollbackDone() {
 		return nil
 	}
-	if waitTime == 0 {
-		return nil
-	}
 
 	timeStart := time.Now()
 	var err error

--- a/pkg/ddl/ddl_worker.go
+++ b/pkg/ddl/ddl_worker.go
@@ -1387,7 +1387,7 @@ func toTError(err error) *terror.Error {
 
 // waitSchemaChanged waits for the completion of updating all servers' schema or MDL synced. In order to make sure that happens,
 // we wait at most 2 * lease time(sessionTTL, 90 seconds).
-func waitSchemaChanged(ctx context.Context, d *ddlCtx, waitTime time.Duration, latestSchemaVersion int64, job *model.Job) error {
+func waitSchemaChanged(ctx context.Context, d *ddlCtx, latestSchemaVersion int64, job *model.Job) error {
 	if !job.IsRunning() && !job.IsRollingback() && !job.IsDone() && !job.IsRollbackDone() {
 		return nil
 	}

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -596,7 +596,7 @@ func (s *jobScheduler) runOneJobStep(wk *worker, job *model.Job) error {
 				return err
 			}
 		} else {
-			err := waitSchemaSynced(wk.ctx, s.ddlCtx, job, 2*s.lease)
+			err := waitSchemaSynced(wk.ctx, s.ddlCtx, job)
 			if err != nil {
 				time.Sleep(time.Second)
 				return err

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -619,10 +619,11 @@ func (s *jobScheduler) runOneJobStep(wk *worker, job *model.Job) error {
 		}
 	})
 
+	failpoint.InjectCall("beforeWaitSchemaChanged", job)
 	// Here means the job enters another state (delete only, write only, public, etc...) or is cancelled.
 	// If the job is done or still running or rolling back, we will wait 2 * lease time or util MDL synced to guarantee other servers to update
 	// the newest schema.
-	if err = waitSchemaChanged(wk.ctx, s.ddlCtx, s.lease*2, schemaVer, job); err != nil {
+	if err = waitSchemaChanged(wk.ctx, s.ddlCtx, schemaVer, job); err != nil {
 		return err
 	}
 	s.cleanMDLInfo(job, ownerID)

--- a/pkg/ddl/schema_version.go
+++ b/pkg/ddl/schema_version.go
@@ -390,7 +390,7 @@ func checkAllVersions(ctx context.Context, d *ddlCtx, job *model.Job, latestSche
 // but schema version might not sync.
 // So here we get the latest schema version to make sure all servers' schema version
 // update to the latest schema version in a cluster.
-func waitSchemaSynced(ctx context.Context, d *ddlCtx, job *model.Job, waitTime time.Duration) error {
+func waitSchemaSynced(ctx context.Context, d *ddlCtx, job *model.Job) error {
 	if !job.IsRunning() && !job.IsRollingback() && !job.IsDone() && !job.IsRollbackDone() {
 		return nil
 	}

--- a/pkg/ddl/schema_version.go
+++ b/pkg/ddl/schema_version.go
@@ -413,5 +413,5 @@ func waitSchemaSynced(ctx context.Context, d *ddlCtx, job *model.Job, waitTime t
 		}
 	})
 
-	return waitSchemaChanged(ctx, d, waitTime, latestSchemaVersion, job)
+	return waitSchemaChanged(ctx, d, latestSchemaVersion, job)
 }

--- a/pkg/ddl/tests/indexmerge/BUILD.bazel
+++ b/pkg/ddl/tests/indexmerge/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/parser/model",
         "//pkg/tablecodec",
         "//pkg/testkit",
+        "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testsetup",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//assert",

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1341,6 +1341,12 @@ func (do *Domain) Init(
 		return err
 	}
 
+	// TODO there are many place set ddlLease to 0, remove them completely, we want
+	//  UT to run similar code path as normal.
+	if intest.InTest && ddlLease == 0 {
+		ddlLease = time.Second
+	}
+
 	// Only when the store is local that the lease value is 0.
 	// If the store is local, it doesn't need loadSchemaInLoop.
 	if ddlLease > 0 {

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -983,6 +983,9 @@ func (do *Domain) loadSchemaInLoop(ctx context.Context, lease time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
+			failpoint.Inject("disableOnTickReload", func() {
+				failpoint.Continue()
+			})
 			err := do.Reload()
 			if err != nil {
 				logutil.BgLogger().Error("reload schema in loop failed", zap.Error(err))

--- a/pkg/infoschema/builder_misc.go
+++ b/pkg/infoschema/builder_misc.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/parser/model"
 )
@@ -100,46 +99,6 @@ func (b *Builder) addTemporaryTable(tblID int64) {
 		b.infoSchema.temporaryTableIDs = make(map[int64]struct{})
 	}
 	b.infoSchema.temporaryTableIDs[tblID] = struct{}{}
-}
-
-func (b *Builder) copyBundlesMap(oldIS *infoSchema) {
-	b.infoSchema.ruleBundleMap = make(map[int64]*placement.Bundle)
-	for id, v := range oldIS.ruleBundleMap {
-		b.infoSchema.ruleBundleMap[id] = v
-	}
-}
-
-func (b *Builder) copyPoliciesMap(oldIS *infoSchema) {
-	is := b.infoSchema
-	for _, v := range oldIS.AllPlacementPolicies() {
-		is.policyMap[v.Name.L] = v
-	}
-}
-
-func (b *Builder) copyResourceGroupMap(oldIS *infoSchema) {
-	is := b.infoSchema
-	for _, v := range oldIS.AllResourceGroups() {
-		is.resourceGroupMap[v.Name.L] = v
-	}
-}
-
-func (b *Builder) copyTemporaryTableIDsMap(oldIS *infoSchema) {
-	is := b.infoSchema
-	if len(oldIS.temporaryTableIDs) == 0 {
-		is.temporaryTableIDs = nil
-		return
-	}
-
-	is.temporaryTableIDs = make(map[int64]struct{})
-	for tblID := range oldIS.temporaryTableIDs {
-		is.temporaryTableIDs[tblID] = struct{}{}
-	}
-}
-
-func (b *Builder) copyReferredForeignKeyMap(oldIS *infoSchema) {
-	for k, v := range oldIS.referredForeignKeyMap {
-		b.infoSchema.referredForeignKeyMap[k] = v
-	}
 }
 
 func (b *Builder) initMisc(dbInfos []*model.DBInfo, policies []*model.PolicyInfo, resourceGroups []*model.ResourceGroupInfo) {

--- a/pkg/infoschema/context/infoschema.go
+++ b/pkg/infoschema/context/infoschema.go
@@ -47,8 +47,11 @@ type Misc interface {
 	AllPlacementBundles() []*placement.Bundle
 	// AllPlacementPolicies returns all placement policies
 	AllPlacementPolicies() []*model.PolicyInfo
+	ClonePlacementPolicies() map[string]*model.PolicyInfo
 	// AllResourceGroups returns all resource groups
 	AllResourceGroups() []*model.ResourceGroupInfo
+	// CloneResourceGroups returns a copy of all resource groups.
+	CloneResourceGroups() map[string]*model.ResourceGroupInfo
 	// HasTemporaryTable returns whether information schema has temporary table
 	HasTemporaryTable() bool
 	// GetTableReferredForeignKeys gets the table's ReferredFKInfo by lowercase schema and table name.

--- a/pkg/infoschema/context/infoschema.go
+++ b/pkg/infoschema/context/infoschema.go
@@ -47,6 +47,7 @@ type Misc interface {
 	AllPlacementBundles() []*placement.Bundle
 	// AllPlacementPolicies returns all placement policies
 	AllPlacementPolicies() []*model.PolicyInfo
+	// ClonePlacementPolicies returns a copy of all placement policies.
 	ClonePlacementPolicies() map[string]*model.PolicyInfo
 	// AllResourceGroups returns all resource groups
 	AllResourceGroups() []*model.ResourceGroupInfo

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	stdctx "context"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"sync"
@@ -513,6 +514,12 @@ func (is *infoSchemaMisc) AllResourceGroups() []*model.ResourceGroupInfo {
 	return groups
 }
 
+func (is *infoSchemaMisc) CloneResourceGroups() map[string]*model.ResourceGroupInfo {
+	is.resourceGroupMutex.RLock()
+	defer is.resourceGroupMutex.RUnlock()
+	return maps.Clone(is.resourceGroupMap)
+}
+
 // AllPlacementPolicies returns all placement policies
 func (is *infoSchemaMisc) AllPlacementPolicies() []*model.PolicyInfo {
 	is.policyMutex.RLock()
@@ -522,6 +529,12 @@ func (is *infoSchemaMisc) AllPlacementPolicies() []*model.PolicyInfo {
 		policies = append(policies, policy)
 	}
 	return policies
+}
+
+func (is *infoSchemaMisc) ClonePlacementPolicies() map[string]*model.PolicyInfo {
+	is.policyMutex.RLock()
+	defer is.policyMutex.RUnlock()
+	return maps.Clone(is.policyMap)
 }
 
 func (is *infoSchemaMisc) PlacementBundleByPhysicalTableID(id int64) (*placement.Bundle, bool) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54436

Problem Summary:

### What changed and how does it work?
- in https://go-review.googlesource.com/c/go/+/471400, maps.Clone is optimized to clone underlying buckets, not iterating each item as before. our info schema load part is the perfect place for this
- remove the Reload inside OnChangedof DefaultCallback which is used in normal code path, we have already waited each instance to reload, no need to call it again, will remove it in later refactor. reload inside OnSchemaStateChanged is for test, but i don't see the need to do so, as we have waited schema change before this call, so remove it too. And as fast-create depends on reload after DDL execution, we add a reload for it separately
https://github.com/pingcap/tidb/blob/a4908820a38f6e893c1882fdcf2c3a6d56141dba/pkg/ddl/job_table.go#L625-L636

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

same test as in https://github.com/pingcap/tidb/pull/54438, run 3 times, takes 22m30/21m40/20m44. unlike prev PR, the speed is quite stable. 

compare the time to load schema diff, before
![image](https://github.com/pingcap/tidb/assets/3312245/bd3363b5-e992-4f87-a01a-8bd9e96ee0b6)
after
![img_v3_02cm_0b13db42-e823-43bc-a792-8f0df25baccg](https://github.com/pingcap/tidb/assets/3312245/8cba0a6f-0ead-4146-8208-41be588aa061)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
