### PR TITLE
br:  disk space check follow up

### DIFF
--- a/br/pkg/errors/errors.go
+++ b/br/pkg/errors/errors.go
@@ -97,6 +97,7 @@ var (
 	ErrKVClusterIDMismatch = errors.Normalize("tikv cluster ID mismatch", errors.RFCCodeText("BR:KV:ErrKVClusterIDMismatch"))
 	ErrKVNotLeader         = errors.Normalize("not leader", errors.RFCCodeText("BR:KV:ErrKVNotLeader"))
 	ErrKVNotTiKV           = errors.Normalize("storage is not tikv", errors.RFCCodeText("BR:KV:ErrNotTiKVStorage"))
+	ErrKVDiskFull          = errors.Normalize("disk is full", errors.RFCCodeText("BR:KV:ErrKVDiskFull"))
 
 	// ErrKVEpochNotMatch is the error raised when ingestion failed with "epoch
 	// not match". This error is retryable.

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -135,6 +135,7 @@ go_test(
         "//pkg/testkit",
         "//pkg/types",
         "//pkg/util/table-filter",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_gogo_protobuf//proto",
         "@com_github_golang_protobuf//proto",
         "@com_github_pingcap_errors//:errors",

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -92,17 +92,17 @@ const (
 
 	FlagResetSysUsers = "reset-sys-users"
 
-	defaultPiTRBatchCount     = 8
-	defaultPiTRBatchSize      = 16 * 1024 * 1024
-	defaultRestoreConcurrency = 128
-	defaultPiTRConcurrency    = 16
-	defaultPDConcurrency      = 1
-	defaultStatsConcurrency   = 12
-	defaultBatchFlushInterval = 16 * time.Second
-	defaultFlagDdlBatchSize   = 128
-	resetSpeedLimitRetryTimes = 3
-	maxRestoreBatchSizeLimit  = 10240
-	pb                        = 1024 * 1024 * 1024 * 1024 * 1024
+	defaultPiTRBatchCount            = 8
+	defaultPiTRBatchSize             = 16 * 1024 * 1024
+	defaultRestoreConcurrency        = 128
+	defaultPiTRConcurrency           = 16
+	defaultPDConcurrency             = 1
+	defaultStatsConcurrency          = 12
+	defaultBatchFlushInterval        = 16 * time.Second
+	defaultFlagDdlBatchSize          = 128
+	resetSpeedLimitRetryTimes        = 3
+	maxRestoreBatchSizeLimit         = 10240
+	pb                        uint64 = 1024 * 1024 * 1024 * 1024 * 1024
 )
 
 const (
@@ -1251,7 +1251,7 @@ func EstimateTikvUsage(files []*backuppb.File, replicaCnt uint64, storeCnt uint6
 	for _, file := range files {
 		totalSize += file.GetSize_()
 	}
-	log.Info("estimate tikv usage", zap.Uint64("total size", totalSize), zap.Uint64("replicaCnt",replicaCnt), zap.Uint64("store count", storeCnt))
+	log.Info("estimate tikv usage", zap.Uint64("total size", totalSize), zap.Uint64("replicaCnt", replicaCnt), zap.Uint64("store count", storeCnt))
 	return totalSize * replicaCnt / storeCnt
 }
 
@@ -1261,7 +1261,7 @@ func EstimateTiflashUsage(tables []*metautil.Table, storeCnt uint64) uint64 {
 	}
 	tiflashTotal := uint64(0)
 	for _, table := range tables {
-		if table.Info.TiFlashReplica == nil ||table.Info.TiFlashReplica.Count <= 0 {
+		if table.Info.TiFlashReplica == nil || table.Info.TiFlashReplica.Count <= 0 {
 			continue
 		}
 		tableBytes := uint64(0)
@@ -1284,7 +1284,7 @@ func CheckStoreSpace(necessary uint64, store *http.StoreInfo) error {
 		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s", store.Store.ID, store.Status.Available)
 	}
 	if uint64(available) < necessary {
-		return errors.Errorf("store %d has no space left on device, available %s, necessary %s",
+		return errors.Annotatef(berrors.ErrKVDiskFull, "store %d has no space left on device, available %s, necessary %s",
 			store.Store.ID, units.BytesSize(float64(available)), units.BytesSize(float64(necessary)))
 	}
 	return nil

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1275,7 +1275,6 @@ func EstimateTiflashUsage(tables []*metautil.Table, storeCnt uint64) uint64 {
 }
 
 func CheckStoreSpace(necessary uint64, store *http.StoreInfo) error {
-	// Be careful editing the message, it is used in DiskCheckBackoffer
 	available, err := units.RAMInBytes(store.Status.Available)
 	if err != nil {
 		return errors.Annotatef(berrors.ErrPDInvalidResponse, "store %d has invalid available space %s", store.Store.ID, store.Status.Available)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -92,17 +92,17 @@ const (
 
 	FlagResetSysUsers = "reset-sys-users"
 
-	defaultPiTRBatchCount            = 8
-	defaultPiTRBatchSize             = 16 * 1024 * 1024
-	defaultRestoreConcurrency        = 128
-	defaultPiTRConcurrency           = 16
-	defaultPDConcurrency             = 1
-	defaultStatsConcurrency          = 12
-	defaultBatchFlushInterval        = 16 * time.Second
-	defaultFlagDdlBatchSize          = 128
-	resetSpeedLimitRetryTimes        = 3
-	maxRestoreBatchSizeLimit         = 10240
-	pb                        uint64 = 1024 * 1024 * 1024 * 1024 * 1024
+	defaultPiTRBatchCount     = 8
+	defaultPiTRBatchSize      = 16 * 1024 * 1024
+	defaultRestoreConcurrency = 128
+	defaultPiTRConcurrency    = 16
+	defaultPDConcurrency      = 1
+	defaultStatsConcurrency   = 12
+	defaultBatchFlushInterval = 16 * time.Second
+	defaultFlagDdlBatchSize   = 128
+	resetSpeedLimitRetryTimes = 3
+	maxRestoreBatchSizeLimit  = 10240
+	pb                        = 1024 * 1024 * 1024 * 1024 * 1024
 )
 
 const (
@@ -1268,7 +1268,7 @@ func EstimateTiflashUsage(tables []*metautil.Table, storeCnt uint64) uint64 {
 		for _, file := range table.Files {
 			tableBytes += file.GetSize_()
 		}
-		tiflashTotal += tableBytes * uint64(table.Info.TiFlashReplica.Count)
+		tiflashTotal += tableBytes * table.Info.TiFlashReplica.Count
 	}
 	log.Info("estimate tiflash usage", zap.Uint64("total size", tiflashTotal), zap.Uint64("store count", storeCnt))
 	return tiflashTotal / storeCnt

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -102,7 +102,6 @@ const (
 	defaultFlagDdlBatchSize   = 128
 	resetSpeedLimitRetryTimes = 3
 	maxRestoreBatchSizeLimit  = 10240
-	pb                        = 1024 * 1024 * 1024 * 1024 * 1024
 )
 
 const (
@@ -1311,7 +1310,7 @@ func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File, 
 
 	// We won't need to restore more than 1800 PB data at one time, right?
 	preserve := func(base uint64, ratio float32) uint64 {
-		if base > 1000*pb {
+		if base > 1000*units.PB {
 			return base
 		}
 		return base * uint64(ratio*10) / 10

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1316,7 +1316,7 @@ func checkDiskSpace(ctx context.Context, mgr *conn.Mgr, files []*backuppb.File, 
 		return base * uint64(ratio*10) / 10
 	}
 	tikvUsage := preserve(EstimateTikvUsage(files, maxReplica, tikvCnt), 1.1)
-	tiflashUsage := preserve(EstimateTiflashUsage(tables, tiflashCnt), 1.3)
+	tiflashUsage := preserve(EstimateTiflashUsage(tables, tiflashCnt), 1.4)
 	log.Info("preserved disk space", zap.Uint64("tikv", tikvUsage), zap.Uint64("tiflash", tiflashUsage))
 
 	err = utils.WithRetry(ctx, func() error {

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -498,7 +498,7 @@ func TestTikvUsage(t *testing.T) {
 		total += f.GetSize_()
 	}
 	ret := task.EstimateTikvUsage(files, replica, storeCnt)
-	require.Equal(t, total*replica/uint64(storeCnt), ret)
+	require.Equal(t, total*replica/storeCnt, ret)
 }
 
 func TestTiflashUsage(t *testing.T) {

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -492,7 +492,7 @@ func TestTikvUsage(t *testing.T) {
 		{Name: "F5", Size_: 5 * pb},
 	}
 	replica := uint64(3)
-	storeCnt := 6
+	storeCnt := uint64(6)
 	total := uint64(0)
 	for _, f := range files {
 		total += f.GetSize_()
@@ -508,7 +508,7 @@ func TestTiflashUsage(t *testing.T) {
 		{TiFlashReplicas: 2, Files: []*backuppb.File{{Size_: 3 * pb}}},
 	}
 
-	storeCnt := 3
+	var storeCnt uint64 = 3
 	ret := task.EstimateTiflashUsage(tables, storeCnt)
 	require.Equal(t, 8*pb/3, ret)
 }

--- a/br/pkg/task/restore_test.go
+++ b/br/pkg/task/restore_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/docker/go-units"
 	"github.com/gogo/protobuf/proto"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/encryptionpb"
@@ -32,7 +33,7 @@ import (
 	pdhttp "github.com/tikv/pd/client/http"
 )
 
-const pb uint64 = 1024 * 1024 * 1024 * 1024 * 1024
+const pb uint64 = units.PB
 
 func TestPreCheckTableTiFlashReplicas(t *testing.T) {
 	mockStores := []*metapb.Store{
@@ -503,9 +504,12 @@ func TestTikvUsage(t *testing.T) {
 
 func TestTiflashUsage(t *testing.T) {
 	tables := []*metautil.Table{
-		{TiFlashReplicas: 0, Files: []*backuppb.File{{Size_: 1 * pb}}},
-		{TiFlashReplicas: 1, Files: []*backuppb.File{{Size_: 2 * pb}}},
-		{TiFlashReplicas: 2, Files: []*backuppb.File{{Size_: 3 * pb}}},
+		{Info: &model.TableInfo{TiFlashReplica: &model.TiFlashReplicaInfo{Count: 0}},
+			Files: []*backuppb.File{{Size_: 1 * pb}}},
+		{Info: &model.TableInfo{TiFlashReplica: &model.TiFlashReplicaInfo{Count: 1}},
+			Files: []*backuppb.File{{Size_: 2 * pb}}},
+		{Info: &model.TableInfo{TiFlashReplica: &model.TiFlashReplicaInfo{Count: 2}},
+			Files: []*backuppb.File{{Size_: 3 * pb}}},
 	}
 
 	var storeCnt uint64 = 3

--- a/errors.toml
+++ b/errors.toml
@@ -111,6 +111,11 @@ error = '''
 tikv cluster ID mismatch
 '''
 
+["BR:KV:ErrKVDiskFull"]
+error = '''
+disk is full
+'''
+
 ["BR:KV:ErrKVDownloadFailed"]
 error = '''
 download sst failed


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/54316, https://github.com/pingcap/tidb/issues/54470

Problem Summary:

### What changed and how does it work?

Now, the preserve rate of tiflash is set 1.3
Add more log and normalized errors
Fix the error that `TiFlashReplicas` is not set

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Now, the preserve rate of tiflash is set 1.3
Add more log and normalized errors
Fix the error that `TiFlashReplicas` is not se
```
