### PR TITLE
table: `CheckRowBuffer.GetRowToCheck` returns `chunk.Row` to protect inner slices

### DIFF
--- a/pkg/table/context/BUILD.bazel
+++ b/pkg/table/context/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/tablecodec",
         "//pkg/types",
+        "//pkg/util/chunk",
         "//pkg/util/rowcodec",
         "//pkg/util/tableutil",
         "@com_github_pingcap_tipb//go-binlog",

--- a/pkg/table/context/buffers.go
+++ b/pkg/table/context/buffers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 )
 
@@ -97,9 +98,8 @@ type CheckRowBuffer struct {
 }
 
 // GetRowToCheck gets the row data for constraint check.
-// TODO: make sure the inner buffer is not used outside directly.
-func (b *CheckRowBuffer) GetRowToCheck() []types.Datum {
-	return b.rowToCheck
+func (b *CheckRowBuffer) GetRowToCheck() chunk.Row {
+	return chunk.MutRowFromDatums(b.rowToCheck).ToRow()
 }
 
 // AddColVal adds a column value to the buffer for checking.

--- a/pkg/table/context/buffers_test.go
+++ b/pkg/table/context/buffers_test.go
@@ -190,7 +190,10 @@ func TestCheckRowBuffer(t *testing.T) {
 	buffer.AddColVal(types.NewIntDatum(1))
 	buffer.AddColVal(types.NewIntDatum(2))
 	require.Equal(t, []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)}, buffer.rowToCheck)
-	require.Equal(t, buffer.rowToCheck, buffer.GetRowToCheck())
+	rowToCheck := buffer.GetRowToCheck()
+	require.Equal(t, 2, rowToCheck.Len())
+	require.Equal(t, int64(1), rowToCheck.GetInt64(0))
+	require.Equal(t, int64(2), rowToCheck.GetInt64(1))
 
 	// reset should not shrink the capacity
 	buffer.Reset(2)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54392

### What changed and how does it work?

The previous implementation of `CheckRowBuffer.GetRowToCheck` returns the inner slice which is not safe to use if the outside code keeps the code somewhere. This PR returns `chunk.Row` instead to make the inner slice not accessed by the out code, so it is safe to use.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
