### PR TITLE
dumpling: fix the inaccurate calculation of file size in csv format writer

### DIFF
--- a/dumpling/export/writer_util.go
+++ b/dumpling/export/writer_util.go
@@ -380,9 +380,8 @@ func WriteInsertInCsv(
 			row.WriteToBufferInCsv(bf, escapeBackslash, opt)
 		}
 		counter++
-		wp.currentFileSize += uint64(bf.Len()-lastBfSize) + 1 // 1 is for "\n"
-
 		bf.Write(opt.lineTerminator)
+		wp.currentFileSize += uint64(bf.Len() - lastBfSize)
 		if bf.Len() >= lengthLimit {
 			select {
 			case <-pCtx.Done():


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54624

Problem Summary:

### What changed and how does it work?

Fix the inaccurate calculation of file size in CSV format writer

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
