### PR TITLE
meta: fix memory leak when loading infoschema v2

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1062,7 +1062,8 @@ func GetAllNameToIDAndSpecialAttributeInfo(m *Meta, dbID int64) (map[string]int6
 			return errors.Trace(err)
 		}
 
-		res[Unescape(nameLMatch[1])] = int64(id)
+		key := Unescape(nameLMatch[1])
+		res[strings.Clone(key)] = int64(id)
 		if CheckSpecialAttributes(string(hack.String(value))) {
 			tbInfo := &model.TableInfo{}
 			err = json.Unmarshal(value, tbInfo)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 

Problem Summary:

Start tidb with 1M tables, I found some unexpected memory usage.
That could be a leak.

![image](https://github.com/user-attachments/assets/de6c5137-c6f3-4acb-9b71-a1c6d2db598b)


### What changed and how does it work?

When TiDB start up using infoschema v2, it builds the name-> id mapping by loading the meta data, and store the mapping in memory.
The map key (name) is a []byte slice taken from the original kvpair, and we use hack.String for optimization.
So the key references the original  kvrpcpb.Response causing the Go GC can't release it, result in a memory leak.



### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Get the heap profile and compare them.
After this commit, the occpuation of kvrpcpb.XXX is gone:


<img width="1398" alt="image" src="https://github.com/user-attachments/assets/b622f9ae-b629-4de6-bcdc-33d61d1ec1df">




- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
