### PR TITLE
executor: Optimize slow log parsing's splitByColon function

### DIFF
--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -525,9 +525,9 @@ func getLineIndex(offset offset, index int) int {
 // findMatchedRightBracket returns the rightBracket index which matchs line[leftBracketIdx]
 // leftBracketIdx should be valid string index for line
 // Returns -1 if invalid inputs are given
-func findMatchedRightBracket(line string, leftBracketIdx int) int {
+func findMatchedRightBracket(line []rune, leftBracketIdx int) int {
 	leftBracket := line[leftBracketIdx]
-	rightBracket := byte('}')
+	rightBracket := '}'
 	if leftBracket == '[' {
 		rightBracket = ']'
 	} else if leftBracket != '{' {
@@ -556,54 +556,55 @@ func findMatchedRightBracket(line string, leftBracketIdx int) int {
 	return -1
 }
 
-func isLetterOrNumeric(b byte) bool {
-	return ('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9')
+func isLetterOrNumeric(r rune) bool {
+	return ('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z') || ('0' <= r && r <= '9')
 }
 
 // splitByColon split a line like "field: value field: value..."
 // Note:
-// 1. Both field and value string contain only ANSI characters
-// 2. value string may be surrounded by brackets, allowed brackets includes "[]" and "{}",  like {key: value,{key: value}}
+// 1. value string may be surrounded by brackets, allowed brackets includes "[]" and "{}",  like {key: value,{key: value}}
 // "[]" can only be nested inside "[]"; "{}" can only be nested inside "{}"
-// 3. value string can't contain ' ' character unless it is inside brackets
+// 2. value string can't contain ' ' character unless it is inside brackets
 func splitByColon(line string) (fields []string, values []string) {
 	fields = make([]string, 0, 1)
 	values = make([]string, 0, 1)
 
+	lineInRune := []rune(line)
+	runeCnt := len(lineInRune)
 	parseKey := true
 	start := 0
 	errMsg := ""
-	for current := 0; current < len(line); {
+	for current := 0; current < runeCnt; {
 		if parseKey {
 			// Find key start
-			for current < len(line) && !isLetterOrNumeric(line[current]) {
+			for current < runeCnt && !isLetterOrNumeric(lineInRune[current]) {
 				current++
 			}
 			start = current
-			if current >= len(line) {
+			if current >= runeCnt {
 				break
 			}
-			for current < len(line) && line[current] != ':' {
+			for current < runeCnt && lineInRune[current] != ':' {
 				current++
 			}
-			fields = append(fields, line[start:current])
+			fields = append(fields, string(lineInRune[start:current]))
 			parseKey = false
 			current += 2 // bypass ": "
 		} else {
 			start = current
-			if current < len(line) && (line[current] == '{' || line[current] == '[') {
-				rBraceIdx := findMatchedRightBracket(line, current)
+			if current < runeCnt && (lineInRune[current] == '{' || lineInRune[current] == '[') {
+				rBraceIdx := findMatchedRightBracket(lineInRune, current)
 				if rBraceIdx == -1 {
 					errMsg = "Unmatched left brace"
 					break
 				}
 				current = rBraceIdx + 1
 			} else {
-				for current < len(line) && line[current] != ' ' {
+				for current < runeCnt && lineInRune[current] != ' ' {
 					current++
 				}
 			}
-			values = append(values, line[start:min(current, len(line))])
+			values = append(values, string(lineInRune[start:min(current, len(line))]))
 			parseKey = true
 		}
 	}

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -562,7 +562,7 @@ func isLetterOrNumeric(b byte) bool {
 
 // splitByColon split a line like "field: value field: value..."
 // Note:
-// 1. Both field and value string contains only ANSI characters
+// 1. Both field and value string contain only ANSI characters
 // 2. value string may be surrounded by brackets, allowed brackets includes "[]" and "{}",  like {key: value,{key: value}}
 // "[]" can only be nested inside "[]"; "{}" can only be nested inside "{}"
 // 3. value string can't contain ' ' character unless it is inside brackets

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -546,7 +546,7 @@ func findMatchedRightBracket(line string, leftBracketIdx int) int {
 			if leftBracketCnt > 0 {
 				current++
 			} else if leftBracketCnt == 0 {
-				if current + 1 < lineLength && line[current + 1] != ' ' {
+				if current+1 < lineLength && line[current+1] != ' ' {
 					return -1
 				}
 				return current

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -599,7 +599,7 @@ func splitByColon(line string) (fields []string, values []string) {
 			if current < lineLength && (line[current] == '{' || line[current] == '[') {
 				rBraceIdx := findMatchedRightBracket(line, current)
 				if rBraceIdx == -1 {
-					errMsg = "Unmatched braces"
+					errMsg = "Braces matched error"
 					break
 				}
 				current = rBraceIdx + 1

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -546,6 +546,9 @@ func findMatchedRightBracket(line string, leftBracketIdx int) int {
 			if leftBracketCnt > 0 {
 				current++
 			} else if leftBracketCnt == 0 {
+				if current + 1 < lineLength && line[current + 1] != ' ' {
+					return -1
+				}
 				return current
 			} else {
 				return -1
@@ -596,7 +599,7 @@ func splitByColon(line string) (fields []string, values []string) {
 			if current < lineLength && (line[current] == '{' || line[current] == '[') {
 				rBraceIdx := findMatchedRightBracket(line, current)
 				if rBraceIdx == -1 {
-					errMsg = "Unmatched left brace"
+					errMsg = "Unmatched braces"
 					break
 				}
 				current = rBraceIdx + 1

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"slices"
 	"strconv"
@@ -523,32 +522,94 @@ func getLineIndex(offset offset, index int) int {
 	return fileLine
 }
 
-// kvSplitRegex: it was just for split "field: value field: value..."
-var kvSplitRegex = regexp.MustCompile(`\w+: `)
+// findMatchedRightBracket returns the rightBracket index which matchs line[leftBracketIdx]
+// leftBracketIdx should be valid string index for line
+// Returns -1 if invalid inputs are given
+func findMatchedRightBracket(line string, leftBracketIdx int) int {
+	var leftBracket byte = line[leftBracketIdx]
+	var rightBracket byte = '}'
+	if leftBracket == '[' {
+		rightBracket = ']'
+	} else if leftBracket != '{' {
+		return -1
+	}
+	current := leftBracketIdx
+	leftBracketCnt := 0
+	for current < len(line) {
+		b := line[current]
+		if b == leftBracket {
+			leftBracketCnt++
+			current++
+		} else if b == rightBracket {
+			leftBracketCnt--
+			if leftBracketCnt > 0 {
+				current++
+			} else if leftBracketCnt == 0 {
+				return current
+			} else {
+				return -1
+			}
+		} else {
+			current++
+		}
+	}
+	return -1
+}
+
+func isLetterOrNumeric(b byte) bool {
+	return ('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9')
+}
 
 // splitByColon split a line like "field: value field: value..."
+// Note:
+// 1. Both field and value string contains only ANSI characters
+// 2. value string may be surrounded by brackets, allowed brackets includes "[]" and "{}",  like {key: value,{key: value}}
+// "[]" can only be nested inside "[]"; "{}" can only be nested inside "{}"
+// 3. value string can't contain ' ' character unless it is inside brackets
 func splitByColon(line string) (fields []string, values []string) {
-	matches := kvSplitRegex.FindAllStringIndex(line, -1)
-	fields = make([]string, 0, len(matches))
-	values = make([]string, 0, len(matches))
+	fields = make([]string, 0, 1)
+	values = make([]string, 0, 1)
 
-	beg := 0
-	end := 0
-	for _, match := range matches {
-		// trim ": "
-		fields = append(fields, line[match[0]:match[1]-2])
-
-		end = match[0]
-		if beg != 0 {
-			// trim " "
-			values = append(values, line[beg:end-1])
+	parseKey := true
+	start := 0
+	errMsg := ""
+	for current := 0; current < len(line); {
+		if parseKey {
+			// Find key start
+			for current < len(line) && !isLetterOrNumeric(line[current]) {
+				current++
+			}
+			start = current
+			if current >= len(line) {
+				break
+			}
+			for current < len(line) && line[current] != ':' {
+				current++
+			}
+			fields = append(fields, line[start:current])
+			parseKey = false
+			current += 2 // bypass ": "
+		} else {
+			start = current
+			if current < len(line) && (line[current] == '{' || line[current] == '[') {
+				rBraceIdx := findMatchedRightBracket(line, current)
+				if rBraceIdx == -1 {
+					errMsg = "Unmatched left brace"
+					break
+				}
+				current = rBraceIdx + 1
+			} else {
+				for current < len(line) && line[current] != ' ' {
+					current++
+				}
+			}
+			values = append(values, line[start:current])
+			parseKey = true
 		}
-		beg = match[1]
 	}
-
-	if end != len(line) {
-		// " " does not exist in the end
-		values = append(values, line[beg:])
+	if len(errMsg) > 0 {
+		logutil.BgLogger().Warn("slow query parse slow log error", zap.String("Error", errMsg), zap.String("Log", line))
+		return nil, nil
 	}
 	return fields, values
 }

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -563,7 +563,7 @@ func isLetterOrNumeric(b byte) bool {
 
 // splitByColon split a line like "field: value field: value..."
 // Note:
-// 1. field string contains only ASCII characters
+// 1. field string's first character can only be ASCII letters or digits, and can't contain ':'
 // 2. value string may be surrounded by brackets, allowed brackets includes "[]" and "{}",  like {key: value,{key: value}}
 // "[]" can only be nested inside "[]"; "{}" can only be nested inside "{}"
 // 3. value string can't contain ' ' character unless it is inside brackets

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -603,7 +603,7 @@ func splitByColon(line string) (fields []string, values []string) {
 					current++
 				}
 			}
-			values = append(values, line[start:current])
+			values = append(values, line[start:min(current, len(line))])
 			parseKey = true
 		}
 	}

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -526,8 +526,8 @@ func getLineIndex(offset offset, index int) int {
 // leftBracketIdx should be valid string index for line
 // Returns -1 if invalid inputs are given
 func findMatchedRightBracket(line string, leftBracketIdx int) int {
-	var leftBracket byte = line[leftBracketIdx]
-	var rightBracket byte = '}'
+	leftBracket := line[leftBracketIdx]
+	rightBracket := byte('}')
 	if leftBracket == '[' {
 		rightBracket = ']'
 	} else if leftBracket != '{' {

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -532,8 +532,8 @@ func TestSplitbyColon(t *testing.T) {
 		},
 		{
 			"123a",
-			[]string{},
 			[]string{"123a"},
+			[]string{},
 		},
 		{
 			"1a: 2b",
@@ -549,6 +549,26 @@ func TestSplitbyColon(t *testing.T) {
 			"1a: [2b,3c] 4d: 5e",
 			[]string{"1a", "4d"},
 			[]string{"[2b,3c]", "5e"},
+		},
+		{
+			"1a: [2b,[3c: 3cc]] 4d: 5e",
+			[]string{"1a", "4d"},
+			[]string{"[2b,[3c: 3cc]]", "5e"},
+		},
+		{
+			"1a: {2b 3c} 4d: 5e",
+			[]string{"1a", "4d"},
+			[]string{"{2b 3c}", "5e"},
+		},
+		{
+			"1a: {2b,3c} 4d: 5e",
+			[]string{"1a", "4d"},
+			[]string{"{2b,3c}", "5e"},
+		},
+		{
+			"1a: {2b,{3c: 3cc}} 4d: 5e",
+			[]string{"1a", "4d"},
+			[]string{"{2b,{3c: 3cc}}", "5e"},
 		},
 		{
 

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -571,6 +571,16 @@ func TestSplitbyColon(t *testing.T) {
 			[]string{"{2b,{3c: 3cc}}", "5e"},
 		},
 		{
+			"1a: {{{2b,{3c: 3cc}} 4d: 5e",
+			nil,
+			nil,
+		},
+		{
+			"1a: [2b,[3c: 3cc]]]] 4d: 5e",
+			nil,
+			nil,
+		},
+		{
 
 			"Time: 2021-09-08T14:39:54.506967433+08:00",
 			[]string{"Time"},

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -3304,6 +3304,7 @@ type SlowQueryLogItems struct {
 }
 
 // SlowLogFormat uses for formatting slow log.
+// Note: Please do check slowQueryRetriever::parseLog function if you intend to modify this function
 // The slow log output is like below:
 // # Time: 2019-04-28T15:24:04.309074+08:00
 // # Txn_start_ts: 406315658548871171

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -3304,7 +3304,6 @@ type SlowQueryLogItems struct {
 }
 
 // SlowLogFormat uses for formatting slow log.
-// Note: Please do check slowQueryRetriever::parseLog function if you intend to modify this function
 // The slow log output is like below:
 // # Time: 2019-04-28T15:24:04.309074+08:00
 // # Txn_start_ts: 406315658548871171


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54538

Problem Summary:

### What changed and how does it work?
Replace regexp matching with simple string comparison operations. Besides, previously, ":=" inside "{}" are not handled correctly, fix it in this PR also.
In local mannual test, performance will improve about 10x, from 24s to 2.2s for the following sql:
```SELECT   Digest,   Query,   Conn_ID,   (UNIX_TIMESTAMP(Time) + 0E0) AS timestamp,   Query_time,   Mem_max,   Process_keys FROM   `INFORMATION_SCHEMA`.`CLUSTER_SLOW_QUERY` WHERE   Time BETWEEN FROM_UNIXTIME(1720471890)   AND FROM_UNIXTIME(1720515091) ORDER BY   Query_time DESC LIMIT   100;```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
