### PR TITLE
planner: explanation of the left condition remains consistent with the others

### DIFF
--- a/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
+++ b/pkg/planner/core/casetest/enforcempp/testdata/enforce_mpp_suite_out.json
@@ -649,7 +649,7 @@
       {
         "SQL": "explain select a from t where t.a not in (select a from s where t.a<1); -- 9. non left join has left conditions",
         "Plan": [
-          "MergeJoin_10 8000.00 root  anti semi join, left key:test.t.a, right key:test.s.a, left cond:[lt(test.t.a, 1)]",
+          "MergeJoin_10 8000.00 root  anti semi join, left key:test.t.a, right key:test.s.a, left cond:lt(test.t.a, 1)",
           "├─TableReader_26(Build) 10000.00 root  data:TableFullScan_25",
           "│ └─TableFullScan_25 10000.00 cop[tikv] table:s keep order:true, stats:pseudo",
           "└─TableReader_23(Probe) 10000.00 root  data:TableFullScan_22",

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -706,11 +706,8 @@ func (p *PhysicalMergeJoin) explainInfo(normalized bool) string {
 			expression.ExplainColumnList(evalCtx, p.RightJoinKeys))
 	}
 	if len(p.LeftConditions) > 0 {
-		if normalized {
-			fmt.Fprintf(buffer, ", left cond:%s", expression.SortedExplainNormalizedExpressionList(p.LeftConditions))
-		} else {
-			fmt.Fprintf(buffer, ", left cond:%s", p.LeftConditions)
-		}
+		fmt.Fprintf(buffer, ", left cond:%s",
+			sortedExplainExpressionList(evalCtx, p.LeftConditions))
 	}
 	if len(p.RightConditions) > 0 {
 		fmt.Fprintf(buffer, ", right cond:%s",

--- a/tests/integrationtest/r/executor/jointest/join.result
+++ b/tests/integrationtest/r/executor/jointest/join.result
@@ -220,7 +220,7 @@ insert into t1 values(1, 100), (2, 100), (3, 100), (4, 100), (5, 100);
 insert into t2 select a*100, b*100 from t1;
 explain format = 'brief' select /*+ TIDB_SMJ(t2) */ * from t1 left outer join t2 on t1.a=t2.a and t1.a!=3 order by t1.a;
 id	estRows	task	access object	operator info
-MergeJoin	10000.00	root		left outer join, left key:executor__jointest__join.t1.a, right key:executor__jointest__join.t2.a, left cond:[ne(executor__jointest__join.t1.a, 3)]
+MergeJoin	10000.00	root		left outer join, left key:executor__jointest__join.t1.a, right key:executor__jointest__join.t2.a, left cond:ne(executor__jointest__join.t1.a, 3)
 ├─TableReader(Build)	6666.67	root		data:TableRangeScan
 │ └─TableRangeScan	6666.67	cop[tikv]	table:t2	range:[-inf,3), (3,+inf], keep order:true, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan

--- a/tests/integrationtest/r/executor/merge_join.result
+++ b/tests/integrationtest/r/executor/merge_join.result
@@ -61,7 +61,7 @@ c1	c2	c1	c2
 explain format = 'brief' select /*+ TIDB_SMJ(t) */ * from t left outer join t1 on t.c1 = t1.c1 and t.c1 != 1 order by t1.c1;
 id	estRows	task	access object	operator info
 Sort	10000.00	root		executor__merge_join.t1.c1
-└─MergeJoin	10000.00	root		left outer join, left key:executor__merge_join.t.c1, right key:executor__merge_join.t1.c1, left cond:[ne(executor__merge_join.t.c1, 1)]
+└─MergeJoin	10000.00	root		left outer join, left key:executor__merge_join.t.c1, right key:executor__merge_join.t1.c1, left cond:ne(executor__merge_join.t.c1, 1)
   ├─Sort(Build)	6656.67	root		executor__merge_join.t1.c1
   │ └─TableReader	6656.67	root		data:Selection
   │   └─Selection	6656.67	cop[tikv]		ne(executor__merge_join.t1.c1, 1), not(isnull(executor__merge_join.t1.c1))
@@ -338,7 +338,7 @@ explain format = 'brief' select /*+ TIDB_SMJ(t) */ * from t left outer join t1 o
 id	estRows	task	access object	operator info
 Sort	10000.00	root		executor__merge_join.t1.c1
 └─Shuffle	10000.00	root		execution info: concurrency:4, data sources:[TableReader TableReader]
-  └─MergeJoin	10000.00	root		left outer join, left key:executor__merge_join.t.c1, right key:executor__merge_join.t1.c1, left cond:[ne(executor__merge_join.t.c1, 1)]
+  └─MergeJoin	10000.00	root		left outer join, left key:executor__merge_join.t.c1, right key:executor__merge_join.t1.c1, left cond:ne(executor__merge_join.t.c1, 1)
     ├─Sort(Build)	6656.67	root		executor__merge_join.t1.c1
     │ └─ShuffleReceiver	6656.67	root		
     │   └─TableReader	6656.67	root		data:Selection


### PR DESCRIPTION
…

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54656

Problem Summary:

### What changed and how does it work?

When to explain, The left condition uses [], while other conditions do not. From the code, it's evident that the left condition is handled with special code. This can be standardized.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
