### PR TITLE
runaway: change `tidb_runaway_watch` to local time

### DIFF
--- a/pkg/domain/resourcegroup/BUILD.bazel
+++ b/pkg/domain/resourcegroup/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/metrics",
+        "//pkg/types",
         "//pkg/util/dbterror/exeerrors",
         "//pkg/util/generic",
         "//pkg/util/logutil",

--- a/pkg/domain/runaway.go
+++ b/pkg/domain/runaway.go
@@ -545,15 +545,15 @@ func getRunawayWatchRecord(exec sqlexec.RestrictedSQLExecutor, reader *SystemTab
 		return nil, err
 	}
 	ret := make([]*resourcegroup.QuarantineRecord, 0, len(rs))
-	now := time.Now().UTC()
+	now := time.Now().Local()
 	for _, r := range rs {
-		startTime, err := r.GetTime(2).GoTime(time.UTC)
+		startTime, err := r.GetTime(2).GoTime(time.Local)
 		if err != nil {
 			continue
 		}
 		var endTime time.Time
 		if !r.IsNull(3) {
-			endTime, err = r.GetTime(3).GoTime(time.UTC)
+			endTime, err = r.GetTime(3).GoTime(time.Local)
 			if err != nil {
 				continue
 			}
@@ -585,15 +585,15 @@ func getRunawayWatchDoneRecord(exec sqlexec.RestrictedSQLExecutor, reader *Syste
 	}
 	length := len(rs)
 	ret := make([]*resourcegroup.QuarantineRecord, 0, length)
-	now := time.Now().UTC()
+	now := time.Now().Local()
 	for _, r := range rs {
-		startTime, err := r.GetTime(3).GoTime(time.UTC)
+		startTime, err := r.GetTime(3).GoTime(time.Local)
 		if err != nil {
 			continue
 		}
 		var endTime time.Time
 		if !r.IsNull(4) {
-			endTime, err = r.GetTime(4).GoTime(time.UTC)
+			endTime, err = r.GetTime(4).GoTime(time.Local)
 			if err != nil {
 				continue
 			}
@@ -645,7 +645,7 @@ func (r *SystemTableReader) genSelectStmt() (string, []any) {
 	builder.WriteString(r.KeyCol)
 	builder.WriteString(" > %? order by ")
 	builder.WriteString(r.KeyCol)
-	params = append(params, r.CheckPoint)
+	params = append(params, r.CheckPoint.Local())
 	return builder.String(), params
 }
 

--- a/pkg/executor/internal/querywatch/query_watch.go
+++ b/pkg/executor/internal/querywatch/query_watch.go
@@ -116,7 +116,7 @@ func setWatchOption(ctx context.Context,
 func fromQueryWatchOptionList(ctx context.Context, sctx, newSctx sessionctx.Context, optionList []*ast.QueryWatchOption) (*resourcegroup.QuarantineRecord, error) {
 	record := &resourcegroup.QuarantineRecord{
 		Source:    resourcegroup.ManualSource,
-		StartTime: time.Now(),
+		StartTime: time.Now().UTC(),
 		EndTime:   resourcegroup.NullTime,
 	}
 	for _, op := range optionList {

--- a/pkg/executor/internal/querywatch/query_watch_test.go
+++ b/pkg/executor/internal/querywatch/query_watch_test.go
@@ -104,6 +104,13 @@ func TestQueryWatch(t *testing.T) {
 			"rg2 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 		), maxWaitDuration, tryInterval)
 
+	rs, err := tk.Exec("select SQL_NO_CACHE start_time from mysql.tidb_runaway_watch where resource_group_name = 'rg2'")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	// check start_time in `mysql.tidb_runaway_watch` and `information_schema.runaway_watches`
+	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE DATE_FORMAT(start_time, '%Y-%m-%d %H:%i:%s') as start_time from mysql.tidb_runaway_watch where resource_group_name = 'rg2'", nil,
+		tk.MustQuery("select SQL_NO_CACHE start_time from information_schema.runaway_watches where resource_group_name = 'rg2'").Rows(), maxWaitDuration, tryInterval)
+
 	// avoid the default resource group to be recorded.
 	tk.MustExec("alter resource group default QUERY_LIMIT=(EXEC_ELAPSED='1000ms' ACTION=DRYRUN)")
 
@@ -151,7 +158,7 @@ func TestQueryWatch(t *testing.T) {
 		), maxWaitDuration, tryInterval)
 
 	// test remove
-	rs, err := tk.Exec("query watch remove 1")
+	rs, err = tk.Exec("query watch remove 1")
 	require.NoError(t, err)
 	require.Nil(t, rs)
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->


Issue Number: Ref #54434

Problem Summary: runaway: change `tidb_runaway_watch` to local time

Currently `tidb_runaway_watch` relies on struct `QuarantineRecord` to store time as utc, which is not converted to local time when writing to the table, while `runaway_watch` directly selects `tidb_runaway_watch` to convert to local time.

It should be changed to: `QuarantineRecord` keeps `utc time`, table operations (select/insert/...) represents local time.

### What changed and how does it work?
before
```bash
mysql> SELECT * FROM mysql.tidb_runaway_watch limit 1\G
*************************** 1. row ***************************
                 id: 1
resource_group_name: default
         start_time: 2024-07-16 07:34:14.137009
           end_time: 2024-07-16 07:44:14.137009
              watch: 1
         watch_text: select  count(*) from orders where o_orderdate = '1994-11-12'
             source: 127.0.0.1:4000
             action: 3
1 row in set (0.00 sec)

mysql> SELECT * FROM INFORMATION_SCHEMA.RUNAWAY_WATCHES where id =1\G
*************************** 1. row ***************************
                 ID: 1
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-07-16 15:34:14
           END_TIME: 2024-07-16 15:44:14
              WATCH: Exact
         WATCH_TEXT: select  count(*) from orders where o_orderdate = '1994-11-12'
             SOURCE: 127.0.0.1:4000
             ACTION: Kill
1 row in set (0.01 sec)
```

After
```bash
mysql> SELECT * FROM mysql.tidb_runaway_watch limit 1\G
*************************** 1. row ***************************
                 id: 1
resource_group_name: default
         start_time: 2024-07-16 15:19:34.000000
           end_time: 2024-07-16 15:29:34.000000
              watch: 1
         watch_text: select o_orderdate from orders limit 10000
             source: 127.0.0.1:4000
             action: 3
1 row in set (0.00 sec)

mysql> SELECT * FROM INFORMATION_SCHEMA.RUNAWAY_WATCHES where id =1\G
*************************** 1. row ***************************
                 ID: 1
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-07-16 15:19:34
           END_TIME: 2024-07-16 15:29:34
              WATCH: Exact
         WATCH_TEXT: select o_orderdate from orders limit 10000
             SOURCE: 127.0.0.1:4000
             ACTION: Kill
1 row in set (0.00 sec)

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
