### PR TITLE
ddl: combine table/db id allocation with job id

### DIFF
--- a/br/pkg/glue/glue.go
+++ b/br/pkg/glue/glue.go
@@ -44,7 +44,7 @@ type Session interface {
 	ExecuteInternal(ctx context.Context, sql string, args ...any) error
 	CreateDatabase(ctx context.Context, schema *model.DBInfo) error
 	CreateTable(ctx context.Context, dbName model.CIStr, table *model.TableInfo,
-		cs ...ddl.CreateTableWithInfoConfigurier) error
+		cs ...ddl.CreateTableOption) error
 	CreatePlacementPolicy(ctx context.Context, policy *model.PolicyInfo) error
 	Close()
 	GetGlobalVariable(name string) (string, error)
@@ -54,7 +54,7 @@ type Session interface {
 // BatchCreateTableSession is an interface to batch create table parallelly
 type BatchCreateTableSession interface {
 	CreateTables(ctx context.Context, tables map[string][]*model.TableInfo,
-		cs ...ddl.CreateTableWithInfoConfigurier) error
+		cs ...ddl.CreateTableOption) error
 }
 
 // Progress is an interface recording the current execution progress.

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -212,13 +212,13 @@ func (gs *tidbSession) CreatePlacementPolicy(ctx context.Context, policy *model.
 
 // CreateTables implements glue.BatchCreateTableSession.
 func (gs *tidbSession) CreateTables(_ context.Context,
-	tables map[string][]*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+	tables map[string][]*model.TableInfo, cs ...ddl.CreateTableOption) error {
 	return errors.Trace(executor.BRIECreateTables(gs.se, tables, brComment, cs...))
 }
 
 // CreateTable implements glue.Session.
 func (gs *tidbSession) CreateTable(_ context.Context, dbName model.CIStr,
-	table *model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+	table *model.TableInfo, cs ...ddl.CreateTableOption) error {
 	return errors.Trace(executor.BRIECreateTable(gs.se, dbName, table, brComment, cs...))
 }
 

--- a/br/pkg/gluetidb/mock/mock.go
+++ b/br/pkg/gluetidb/mock/mock.go
@@ -79,14 +79,14 @@ func (*mockSession) CreatePlacementPolicy(_ context.Context, _ *model.PolicyInfo
 
 // CreateTables implements glue.BatchCreateTableSession.
 func (*mockSession) CreateTables(_ context.Context, _ map[string][]*model.TableInfo,
-	_ ...ddl.CreateTableWithInfoConfigurier) error {
+	_ ...ddl.CreateTableOption) error {
 	log.Fatal("unimplemented CreateDatabase for mock session")
 	return nil
 }
 
 // CreateTable implements glue.Session.
 func (*mockSession) CreateTable(_ context.Context, _ model.CIStr,
-	_ *model.TableInfo, _ ...ddl.CreateTableWithInfoConfigurier) error {
+	_ *model.TableInfo, _ ...ddl.CreateTableOption) error {
 	log.Fatal("unimplemented CreateDatabase for mock session")
 	return nil
 }

--- a/pkg/ddl/db_table_test.go
+++ b/pkg/ddl/db_table_test.go
@@ -322,9 +322,7 @@ func TestCreateTableWithInfo(t *testing.T) {
 		Name: model.NewCIStr("t"),
 	}}
 
-	require.NoError(t, d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), info, ddl.OnExistError, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
-		return false
-	})))
+	require.NoError(t, d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), info, ddl.WithOnExist(ddl.OnExistError), ddl.WithIDAllocated(true)))
 	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 't'").Check(testkit.Rows("42042"))
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
 
@@ -342,9 +340,7 @@ func TestCreateTableWithInfo(t *testing.T) {
 		Name: model.NewCIStr("tt"),
 	}}
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	require.NoError(t, d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), info, ddl.OnExistError, ddl.AllocTableIDIf(func(ti *model.TableInfo) bool {
-		return true
-	})))
+	require.NoError(t, d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), info, ddl.WithOnExist(ddl.OnExistError)))
 	idGen, ok := tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'tt'").Rows()[0][0].(string)
 	require.True(t, ok)
 	idGenNum, err := strconv.ParseInt(idGen, 10, 64)
@@ -374,7 +370,7 @@ func TestBatchCreateTable(t *testing.T) {
 
 	// correct name
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err := d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), infos, ddl.OnExistError)
+	err := d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), infos, ddl.WithOnExist(ddl.OnExistError))
 	require.NoError(t, err)
 
 	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
@@ -389,7 +385,7 @@ func TestBatchCreateTable(t *testing.T) {
 	// duplicated name
 	infos[1].Name = model.NewCIStr("tables_1")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), infos, ddl.OnExistError)
+	err = d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), infos, ddl.WithOnExist(ddl.OnExistError))
 	require.True(t, terror.ErrorEqual(err, infoschema.ErrTableExists))
 
 	newinfo := &model.TableInfo{
@@ -418,7 +414,7 @@ func TestBatchCreateTable(t *testing.T) {
 
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), []*model.TableInfo{newinfo}, ddl.OnExistError)
+	err = d.BatchCreateTableWithInfo(tk.Session(), model.NewCIStr("test"), []*model.TableInfo{newinfo}, ddl.WithOnExist(ddl.OnExistError))
 	require.NoError(t, err)
 }
 

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -279,6 +279,7 @@ type JobWrapper struct {
 	cacheErr error
 }
 
+// NotifyError notifies the error to all error channels.
 func (t *JobWrapper) NotifyError(err error) {
 	for _, errCh := range t.errChs {
 		errCh <- err

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -209,15 +209,7 @@ func (d *ddl) CreateSchemaWithInfo(
 		return errors.Trace(err)
 	}
 
-	// FIXME: support `tryRetainID`.
-	genIDs, err := d.genGlobalIDs(1)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	dbInfo.ID = genIDs[0]
-
 	job := &model.Job{
-		SchemaID:       dbInfo.ID,
 		SchemaName:     dbInfo.Name.L,
 		Type:           model.ActionCreateSchema,
 		BinlogInfo:     &model.HistoryInfo{},
@@ -236,7 +228,7 @@ func (d *ddl) CreateSchemaWithInfo(
 		})
 	}
 
-	err = d.DoDDLJob(ctx, job)
+	err := d.DoDDLJob(ctx, job)
 	err = d.callHookOnChanged(job, err)
 
 	if infoschema.ErrDatabaseExists.Equal(err) && onExist == OnExistIgnore {
@@ -2716,15 +2708,6 @@ func BuildTableInfoWithStmt(ctx sessionctx.Context, s *ast.CreateTableStmt, dbCh
 	return tbInfo, nil
 }
 
-func (d *ddl) assignTableID(tbInfo *model.TableInfo) error {
-	genIDs, err := d.genGlobalIDs(1)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	tbInfo.ID = genIDs[0]
-	return nil
-}
-
 func (d *ddl) assignPartitionIDs(defs []model.PartitionDefinition) error {
 	genIDs, err := d.genGlobalIDs(len(defs))
 	if err != nil {
@@ -2788,7 +2771,7 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 		onExist = OnExistIgnore
 	}
 
-	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, involvingRef, onExist)
+	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, involvingRef, WithOnExist(onExist))
 }
 
 func setTemporaryType(_ sessionctx.Context, tbInfo *model.TableInfo, s *ast.CreateTableStmt) error {
@@ -2809,15 +2792,12 @@ func setTemporaryType(_ sessionctx.Context, tbInfo *model.TableInfo, s *ast.Crea
 
 // createTableWithInfoJob returns the table creation job.
 // WARNING: it may return a nil job, which means you don't need to submit any DDL job.
-// WARNING!!!: if retainID == true, it will not allocate ID by itself. That means if the caller
-// can not promise ID is unique, then we got inconsistency.
 func (d *ddl) createTableWithInfoJob(
 	ctx sessionctx.Context,
 	dbName model.CIStr,
 	tbInfo *model.TableInfo,
 	involvingRef []model.InvolvingSchemaInfo,
 	onExist OnExist,
-	retainID bool,
 ) (job *model.Job, err error) {
 	is := d.GetInfoSchemaWithInterceptor(ctx)
 	schema, ok := is.SchemaByName(dbName)
@@ -2849,18 +2829,6 @@ func (d *ddl) createTableWithInfoJob(
 			return nil, err
 		default:
 			return nil, err
-		}
-	}
-
-	if !retainID {
-		if err := d.assignTableID(tbInfo); err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		if tbInfo.Partition != nil {
-			if err := d.assignPartitionIDs(tbInfo.Partition.Definitions); err != nil {
-				return nil, errors.Trace(err)
-			}
 		}
 	}
 
@@ -2896,7 +2864,6 @@ func (d *ddl) createTableWithInfoJob(
 
 	job = &model.Job{
 		SchemaID:            schema.ID,
-		TableID:             tbInfo.ID,
 		SchemaName:          schema.Name.L,
 		TableName:           tbInfo.Name.L,
 		Type:                actionType,
@@ -2972,12 +2939,12 @@ func (d *ddl) CreateTableWithInfo(
 	dbName model.CIStr,
 	tbInfo *model.TableInfo,
 	involvingRef []model.InvolvingSchemaInfo,
-	cs ...CreateTableWithInfoConfigurier,
+	cs ...CreateTableOption,
 ) (err error) {
-	c := GetCreateTableWithInfoConfig(cs)
+	c := GetCreateTableConfig(cs)
 
 	job, err := d.createTableWithInfoJob(
-		ctx, dbName, tbInfo, involvingRef, c.OnExist, !c.ShouldAllocTableID(tbInfo),
+		ctx, dbName, tbInfo, involvingRef, c.OnExist,
 	)
 	if err != nil {
 		return err
@@ -2986,7 +2953,13 @@ func (d *ddl) CreateTableWithInfo(
 		return nil
 	}
 
-	err = d.DoDDLJob(ctx, job)
+	jobW := &JobWrapper{
+		Job:         job,
+		IDAllocated: c.IDAllocated,
+		errChs:      []chan error{make(chan error)},
+	}
+
+	err = d.doDDLJobWrapper(ctx, jobW)
 	if err != nil {
 		// table exists, but if_not_exists flags is true, so we ignore this error.
 		if c.OnExist == OnExistIgnore && infoschema.ErrTableExists.Equal(err) {
@@ -3004,7 +2977,7 @@ func (d *ddl) CreateTableWithInfo(
 func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 	dbName model.CIStr,
 	infos []*model.TableInfo,
-	cs ...CreateTableWithInfoConfigurier,
+	cs ...CreateTableOption,
 ) error {
 	failpoint.Inject("RestoreBatchCreateTableEntryTooLarge", func(val failpoint.Value) {
 		injectBatchSize := val.(int)
@@ -3012,21 +2985,24 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 			failpoint.Return(kv.ErrEntryTooLarge)
 		}
 	})
-	c := GetCreateTableWithInfoConfig(cs)
+	c := GetCreateTableConfig(cs)
 
-	jobs := &model.Job{
-		BinlogInfo:     &model.HistoryInfo{},
-		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
-		SQLMode:        ctx.GetSessionVars().SQLMode,
+	theJob := &JobWrapper{
+		Job: &model.Job{
+			BinlogInfo:     &model.HistoryInfo{},
+			CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
+			SQLMode:        ctx.GetSessionVars().SQLMode,
+		},
+		IDAllocated: c.IDAllocated,
+		errChs:      []chan error{make(chan error)},
 	}
 	args := make([]*model.TableInfo, 0, len(infos))
 
 	var err error
 
-	// 1. counts how many IDs are there
-	// 2. if there is any duplicated table name
-	totalID := 0
+	// check if there are any duplicated table names
 	duplication := make(map[string]struct{})
+	// TODO filter those duplicated info out.
 	for _, info := range infos {
 		if _, ok := duplication[info.Name.L]; ok {
 			err = infoschema.ErrTableExists.FastGenByArgs("can not batch create tables with same name")
@@ -3040,31 +3016,10 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 		}
 
 		duplication[info.Name.L] = struct{}{}
-
-		totalID++
-		parts := info.GetPartitionInfo()
-		if parts != nil {
-			totalID += len(parts.Definitions)
-		}
-	}
-
-	genIDs, err := d.genGlobalIDs(totalID)
-	if err != nil {
-		return errors.Trace(err)
 	}
 
 	for _, info := range infos {
-		if c.ShouldAllocTableID(info) {
-			info.ID, genIDs = genIDs[0], genIDs[1:]
-
-			if parts := info.GetPartitionInfo(); parts != nil {
-				for i := range parts.Definitions {
-					parts.Definitions[i].ID, genIDs = genIDs[0], genIDs[1:]
-				}
-			}
-		}
-
-		job, err := d.createTableWithInfoJob(ctx, dbName, info, nil, c.OnExist, true)
+		job, err := d.createTableWithInfoJob(ctx, dbName, info, nil, c.OnExist)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -3072,12 +3027,12 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 			continue
 		}
 
-		// if jobs.Type == model.ActionCreateTables, it is initialized
-		// if not, initialize jobs by job.XXXX
-		if jobs.Type != model.ActionCreateTables {
-			jobs.Type = model.ActionCreateTables
-			jobs.SchemaID = job.SchemaID
-			jobs.SchemaName = job.SchemaName
+		// if theJob.Type == model.ActionCreateTables, it is initialized
+		// if not, initialize theJob by job.XXXX
+		if theJob.Type != model.ActionCreateTables {
+			theJob.Type = model.ActionCreateTables
+			theJob.SchemaID = job.SchemaID
+			theJob.SchemaName = job.SchemaName
 		}
 
 		// append table job args
@@ -3086,37 +3041,37 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 			return errors.Trace(fmt.Errorf("except table info"))
 		}
 		args = append(args, info)
+		theJob.InvolvingSchemaInfo = append(theJob.InvolvingSchemaInfo, model.InvolvingSchemaInfo{
+			Database: dbName.L,
+			Table:    info.Name.L,
+		})
 		if sharedInv := getSharedInvolvingSchemaInfo(info); len(sharedInv) > 0 {
-			jobs.InvolvingSchemaInfo = append(jobs.InvolvingSchemaInfo, model.InvolvingSchemaInfo{
-				Database: dbName.L,
-				Table:    info.Name.L,
-			})
-			jobs.InvolvingSchemaInfo = append(jobs.InvolvingSchemaInfo, sharedInv...)
+			theJob.InvolvingSchemaInfo = append(theJob.InvolvingSchemaInfo, sharedInv...)
 		}
 	}
 	if len(args) == 0 {
 		return nil
 	}
-	jobs.Args = append(jobs.Args, args)
-	jobs.Args = append(jobs.Args, ctx.GetSessionVars().ForeignKeyChecks)
+	theJob.Args = append(theJob.Args, args)
+	theJob.Args = append(theJob.Args, ctx.GetSessionVars().ForeignKeyChecks)
 
-	err = d.DoDDLJob(ctx, jobs)
+	err = d.doDDLJobWrapper(ctx, theJob)
 	if err != nil {
 		// table exists, but if_not_exists flags is true, so we ignore this error.
 		if c.OnExist == OnExistIgnore && infoschema.ErrTableExists.Equal(err) {
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
 			err = nil
 		}
-		return errors.Trace(d.callHookOnChanged(jobs, err))
+		return errors.Trace(d.callHookOnChanged(theJob.Job, err))
 	}
 
 	for j := range args {
-		if err = d.createTableWithInfoPost(ctx, args[j], jobs.SchemaID); err != nil {
-			return errors.Trace(d.callHookOnChanged(jobs, err))
+		if err = d.createTableWithInfoPost(ctx, args[j], theJob.SchemaID); err != nil {
+			return errors.Trace(d.callHookOnChanged(theJob.Job, err))
 		}
 	}
 
-	return d.callHookOnChanged(jobs, err)
+	return d.callHookOnChanged(theJob.Job, err)
 }
 
 // BuildQueryStringFromJobs takes a slice of Jobs and concatenates their
@@ -3389,7 +3344,7 @@ func (d *ddl) CreateView(ctx sessionctx.Context, s *ast.CreateViewStmt) (err err
 		onExist = OnExistReplace
 	}
 
-	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, nil, onExist)
+	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, nil, WithOnExist(onExist))
 }
 
 // BuildViewInfo builds a ViewInfo structure from an ast.CreateViewStmt.
@@ -8769,7 +8724,7 @@ func (d *ddl) CreateSequence(ctx sessionctx.Context, stmt *ast.CreateSequenceStm
 		onExist = OnExistIgnore
 	}
 
-	return d.CreateTableWithInfo(ctx, ident.Schema, tbInfo, nil, onExist)
+	return d.CreateTableWithInfo(ctx, ident.Schema, tbInfo, nil, WithOnExist(onExist))
 }
 
 func (d *ddl) AlterSequence(ctx sessionctx.Context, stmt *ast.AlterSequenceStmt) error {

--- a/pkg/ddl/executor_test.go
+++ b/pkg/ddl/executor_test.go
@@ -35,6 +35,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func getGlobalID(t *testing.T, ctx context.Context, store kv.Storage) int64 {
+	res := int64(0)
+	require.NoError(t, kv.RunInNewTxn(ctx, store, true, func(_ context.Context, txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		id, err := m.GetGlobalID()
+		require.NoError(t, err)
+		res = id
+		return nil
+	}))
+	return res
+}
+
 func TestGenIDAndInsertJobsWithRetry(t *testing.T) {
 	store := testkit.CreateMockStore(t, mockstore.WithStoreType(mockstore.EmbedUnistore))
 	// disable DDL to avoid it interfere the test
@@ -50,40 +62,227 @@ func TestGenIDAndInsertJobsWithRetry(t *testing.T) {
 		kv.MaxRetryCnt = bak
 	})
 
-	jobs := []*model.Job{
-		{
+	jobs := []*ddl.JobWrapper{{
+		Job: &model.Job{
 			Type:       model.ActionCreateTable,
 			SchemaName: "test",
 			TableName:  "t1",
+			Args:       []interface{}{&model.TableInfo{}},
 		},
-	}
+	}}
+	initialGID := getGlobalID(t, ctx, store)
+	threads, iterations := 10, 500
 	var wg util.WaitGroupWrapper
-	for i := 0; i < 10; i++ {
+	for i := 0; i < threads; i++ {
 		wg.Run(func() {
 			kit := testkit.NewTestKit(t, store)
 			ddlSe := sess.NewSession(kit.Session())
-			for i := 0; i < 1000; i++ {
+			for j := 0; j < iterations; j++ {
 				require.NoError(t, ddl.GenIDAndInsertJobsWithRetry(ctx, ddlSe, jobs))
 			}
 		})
 	}
 	wg.Wait()
 
-	jobs, err := ddl.GetAllDDLJobs(tk.Session())
+	jobCount := threads * iterations
+	gotJobs, err := ddl.GetAllDDLJobs(tk.Session())
 	require.NoError(t, err)
-	require.Len(t, jobs, 10000)
-	var maxID, currUsedGID int64
-	for _, j := range jobs {
-		maxID = max(maxID, j.ID)
+	require.Len(t, gotJobs, jobCount)
+	currGID := getGlobalID(t, ctx, store)
+	require.Greater(t, currGID-initialGID, int64(jobCount))
+	uniqueJobIDs := make(map[int64]struct{}, jobCount)
+	for _, j := range gotJobs {
+		require.Greater(t, j.ID, initialGID)
+		uniqueJobIDs[j.ID] = struct{}{}
 	}
-	require.NoError(t, kv.RunInNewTxn(ctx, store, false, func(ctx context.Context, txn kv.Transaction) error {
-		m := meta.NewMeta(txn)
-		currUsedGID, err = m.GetGlobalID()
+	require.Len(t, uniqueJobIDs, jobCount)
+}
+
+type idAllocationCase struct {
+	jobW            *ddl.JobWrapper
+	requiredIDCount int
+}
+
+func TestCombinedIDAllocation(t *testing.T) {
+	store := testkit.CreateMockStore(t, mockstore.WithStoreType(mockstore.EmbedUnistore))
+	// disable DDL to avoid it interfere the test
+	tk := testkit.NewTestKit(t, store)
+	dom := domain.GetDomain(tk.Session())
+	dom.DDL().OwnerManager().CampaignCancel()
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
+
+	// avoid outer retry
+	bak := kv.MaxRetryCnt
+	kv.MaxRetryCnt = 1
+	t.Cleanup(func() {
+		kv.MaxRetryCnt = bak
+	})
+
+	genTblInfo := func(partitionCnt int) *model.TableInfo {
+		info := &model.TableInfo{Partition: &model.PartitionInfo{}}
+		for i := 0; i < partitionCnt; i++ {
+			info.Partition.Enable = true
+			info.Partition.Definitions = append(info.Partition.Definitions, model.PartitionDefinition{})
+		}
+		return info
+	}
+
+	genCreateTblJob := func(tp model.ActionType, partitionCnt int) *model.Job {
+		return &model.Job{
+			Type: tp,
+			Args: []interface{}{genTblInfo(partitionCnt)},
+		}
+	}
+
+	genCreateTblsJob := func(partitionCounts ...int) *model.Job {
+		infos := make([]*model.TableInfo, 0, len(partitionCounts))
+		for _, c := range partitionCounts {
+			infos = append(infos, genTblInfo(c))
+		}
+		return &model.Job{
+			Type: model.ActionCreateTables,
+			Args: []interface{}{infos},
+		}
+	}
+
+	genCreateDBJob := func() *model.Job {
+		info := &model.DBInfo{}
+		return &model.Job{
+			Type: model.ActionCreateSchema,
+			Args: []interface{}{info},
+		}
+	}
+
+	cases := []idAllocationCase{
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblsJob(1, 2, 0)},
+			requiredIDCount: 1 + 3 + 1 + 2,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblsJob(3, 4), IDAllocated: true},
+			requiredIDCount: 1,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateTable, 3)},
+			requiredIDCount: 1 + 1 + 3,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateTable, 0)},
+			requiredIDCount: 1 + 1,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateTable, 8), IDAllocated: true},
+			requiredIDCount: 1,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateSequence, 0)},
+			requiredIDCount: 2,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateSequence, 0), IDAllocated: true},
+			requiredIDCount: 1,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateView, 0)},
+			requiredIDCount: 2,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateTblJob(model.ActionCreateView, 0), IDAllocated: true},
+			requiredIDCount: 1,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateDBJob()},
+			requiredIDCount: 2,
+		},
+		{
+			jobW:            &ddl.JobWrapper{Job: genCreateDBJob(), IDAllocated: true},
+			requiredIDCount: 1,
+		},
+	}
+
+	t.Run("process one by one", func(t *testing.T) {
+		tk.MustExec("delete from mysql.tidb_ddl_job")
+		for _, c := range cases {
+			currentGlobalID := getGlobalID(t, ctx, store)
+			require.NoError(t, ddl.GenIDAndInsertJobsWithRetry(ctx, sess.NewSession(tk.Session()), []*ddl.JobWrapper{c.jobW}))
+			require.Equal(t, currentGlobalID+int64(c.requiredIDCount), getGlobalID(t, ctx, store))
+		}
+		gotJobs, err := ddl.GetAllDDLJobs(tk.Session())
 		require.NoError(t, err)
-		return nil
-	}))
-	require.Greater(t, currUsedGID, int64(10000))
-	require.Equal(t, currUsedGID, maxID)
+		require.Len(t, gotJobs, len(cases))
+	})
+
+	t.Run("process together", func(t *testing.T) {
+		tk.MustExec("delete from mysql.tidb_ddl_job")
+
+		totalRequiredCnt := 0
+		jobWs := make([]*ddl.JobWrapper, 0, len(cases))
+		for _, c := range cases {
+			totalRequiredCnt += c.requiredIDCount
+			jobWs = append(jobWs, c.jobW)
+		}
+		currentGlobalID := getGlobalID(t, ctx, store)
+		require.NoError(t, ddl.GenIDAndInsertJobsWithRetry(ctx, sess.NewSession(tk.Session()), jobWs))
+		require.Equal(t, currentGlobalID+int64(totalRequiredCnt), getGlobalID(t, ctx, store))
+
+		gotJobs, err := ddl.GetAllDDLJobs(tk.Session())
+		require.NoError(t, err)
+		require.Len(t, gotJobs, len(cases))
+	})
+
+	t.Run("process IDAllocated = false", func(t *testing.T) {
+		tk.MustExec("delete from mysql.tidb_ddl_job")
+
+		initialGlobalID := getGlobalID(t, ctx, store)
+		allocIDCaseCount, allocatedIDCount := 0, 0
+		for _, c := range cases {
+			if !c.jobW.IDAllocated {
+				allocIDCaseCount++
+				allocatedIDCount += c.requiredIDCount
+				require.NoError(t, ddl.GenIDAndInsertJobsWithRetry(ctx, sess.NewSession(tk.Session()), []*ddl.JobWrapper{c.jobW}))
+			}
+		}
+		require.EqualValues(t, 6, allocIDCaseCount)
+		uniqueIDs := make(map[int64]struct{}, len(cases))
+		checkTableInfo := func(info *model.TableInfo) {
+			uniqueIDs[info.ID] = struct{}{}
+			require.Greater(t, info.ID, initialGlobalID)
+			if pInfo := info.GetPartitionInfo(); pInfo != nil {
+				for _, def := range pInfo.Definitions {
+					uniqueIDs[def.ID] = struct{}{}
+					require.Greater(t, def.ID, initialGlobalID)
+				}
+			}
+		}
+		gotJobs, err := ddl.GetAllDDLJobs(tk.Session())
+		require.NoError(t, err)
+		require.Len(t, gotJobs, allocIDCaseCount)
+		for _, j := range gotJobs {
+			uniqueIDs[j.ID] = struct{}{}
+			require.Greater(t, j.ID, initialGlobalID)
+			switch j.Type {
+			case model.ActionCreateTable, model.ActionCreateView, model.ActionCreateSequence:
+				require.Greater(t, j.TableID, initialGlobalID)
+				info := &model.TableInfo{}
+				require.NoError(t, j.DecodeArgs(info))
+				require.Equal(t, j.TableID, info.ID)
+				checkTableInfo(info)
+			case model.ActionCreateTables:
+				var infos []*model.TableInfo
+				require.NoError(t, j.DecodeArgs(&infos))
+				for _, info := range infos {
+					checkTableInfo(info)
+				}
+			case model.ActionCreateSchema:
+				require.Greater(t, j.SchemaID, initialGlobalID)
+				info := &model.DBInfo{}
+				require.NoError(t, j.DecodeArgs(info))
+				uniqueIDs[info.ID] = struct{}{}
+				require.Equal(t, j.SchemaID, info.ID)
+			}
+		}
+		require.Len(t, uniqueIDs, allocatedIDCount)
+	})
 }
 
 var (
@@ -102,15 +301,15 @@ func TestGenIDAndInsertJobsWithRetryQPS(t *testing.T) {
 	dom.DDL().OwnerManager().CampaignCancel()
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
 
-	payload := []byte(strings.Repeat("a", payloadSize))
-	jobs := []*model.Job{
-		{
+	payload := strings.Repeat("a", payloadSize)
+	jobs := []*ddl.JobWrapper{{
+		Job: &model.Job{
 			Type:       model.ActionCreateTable,
 			SchemaName: "test",
 			TableName:  "t1",
-			Args:       []any{payload},
+			Args:       []interface{}{&model.TableInfo{Comment: payload}},
 		},
-	}
+	}}
 	counters := make([]atomic.Int64, thread+1)
 	var wg util.WaitGroupWrapper
 	for i := 0; i < thread; i++ {

--- a/pkg/ddl/job_table.go
+++ b/pkg/ddl/job_table.go
@@ -469,8 +469,8 @@ func (s *jobScheduler) mustReloadSchemas() {
 // delivery2LocalWorker runs the DDL job of v2 in local.
 // send the result to the error channels in the task.
 // delivery2Localworker owns the worker, need to put it back to the pool in this function.
-func (d *ddl) delivery2LocalWorker(pool *workerPool, task *limitJobTask) {
-	job := task.job
+func (d *ddl) delivery2LocalWorker(pool *workerPool, task *JobWrapper) {
+	job := task.Job
 	wk, err := pool.get()
 	if err != nil {
 		task.NotifyError(err)
@@ -667,26 +667,28 @@ const (
 	updateDDLJobSQL = "update mysql.tidb_ddl_job set job_meta = %s where job_id = %d"
 )
 
-func insertDDLJobs2Table(ctx context.Context, se *sess.Session, jobs ...*model.Job) error {
+func insertDDLJobs2Table(ctx context.Context, se *sess.Session, jobWs ...*JobWrapper) error {
 	failpoint.Inject("mockAddBatchDDLJobsErr", func(val failpoint.Value) {
 		if val.(bool) {
 			failpoint.Return(errors.Errorf("mockAddBatchDDLJobsErr"))
 		}
 	})
-	if len(jobs) == 0 {
+	if len(jobWs) == 0 {
 		return nil
 	}
 	var sql bytes.Buffer
 	sql.WriteString(addDDLJobSQL)
-	for i, job := range jobs {
-		b, err := job.Encode(true)
+	for i, jobW := range jobWs {
+		b, err := jobW.Encode(true)
 		if err != nil {
 			return err
 		}
 		if i != 0 {
 			sql.WriteString(",")
 		}
-		fmt.Fprintf(&sql, "(%d, %t, %s, %s, %s, %d, %t)", job.ID, job.MayNeedReorg(), strconv.Quote(job2SchemaIDs(job)), strconv.Quote(job2TableIDs(job)), util.WrapKey2String(b), job.Type, !job.NotStarted())
+		fmt.Fprintf(&sql, "(%d, %t, %s, %s, %s, %d, %t)", jobW.ID, jobW.MayNeedReorg(),
+			strconv.Quote(job2SchemaIDs(jobW.Job)), strconv.Quote(job2TableIDs(jobW.Job)),
+			util.WrapKey2String(b), jobW.Type, !jobW.NotStarted())
 	}
 	se.GetSessionVars().SetDiskFullOpt(kvrpcpb.DiskFullOpt_AllowedOnAlmostFull)
 	_, err := se.Execute(ctx, sql.String(), "insert_job")

--- a/pkg/ddl/placement_policy_test.go
+++ b/pkg/ddl/placement_policy_test.go
@@ -770,7 +770,7 @@ func TestCreateTableWithInfoPlacement(t *testing.T) {
 	tk.MustExec("drop placement policy p1")
 	tk.MustExec("create placement policy p1 followers=2")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	require.Nil(t, dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl, nil, ddl.OnExistError))
+	require.Nil(t, dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl, nil, ddl.WithOnExist(ddl.OnExistError)))
 	tk.MustQuery("show create table t1").Check(testkit.Rows("t1 CREATE TABLE `t1` (\n" +
 		"  `a` int(11) DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
@@ -791,7 +791,7 @@ func TestCreateTableWithInfoPlacement(t *testing.T) {
 	tbl2.Name = model.NewCIStr("t3")
 	tbl2.PlacementPolicyRef.Name = model.NewCIStr("pxx")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl2, nil, ddl.OnExistError)
+	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test2"), tbl2, nil, ddl.WithOnExist(ddl.OnExistError))
 	require.Equal(t, "[schema:8239]Unknown placement policy 'pxx'", err.Error())
 }
 

--- a/pkg/ddl/placement_sql_test.go
+++ b/pkg/ddl/placement_sql_test.go
@@ -535,7 +535,7 @@ func TestPlacementMode(t *testing.T) {
 	require.NotNil(t, tbl.PlacementPolicyRef)
 	tbl.Name = model.NewCIStr("t2")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, nil, ddl.OnExistError)
+	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, nil, ddl.WithOnExist(ddl.OnExistError))
 	require.NoError(t, err)
 	tk.MustQuery("show create table t2").Check(testkit.Rows("t2 CREATE TABLE `t2` (\n" +
 		"  `id` int(11) DEFAULT NULL\n" +
@@ -549,7 +549,7 @@ func TestPlacementMode(t *testing.T) {
 	tbl.Name = model.NewCIStr("t2")
 	tbl.PlacementPolicyRef.Name = model.NewCIStr("pxx")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, nil, ddl.OnExistError)
+	err = dom.DDL().CreateTableWithInfo(tk.Session(), model.NewCIStr("test"), tbl, nil, ddl.WithOnExist(ddl.OnExistError))
 	require.NoError(t, err)
 	tk.MustQuery("show create table t2").Check(testkit.Rows("t2 CREATE TABLE `t2` (\n" +
 		"  `id` int(11) DEFAULT NULL\n" +

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -463,13 +463,13 @@ func (d *Checker) CreateSchemaWithInfo(ctx sessionctx.Context, info *model.DBInf
 }
 
 // CreateTableWithInfo implements the DDL interface.
-func (*Checker) CreateTableWithInfo(_ sessionctx.Context, _ model.CIStr, _ *model.TableInfo, _ []model.InvolvingSchemaInfo, _ ...ddl.CreateTableWithInfoConfigurier) error {
+func (*Checker) CreateTableWithInfo(_ sessionctx.Context, _ model.CIStr, _ *model.TableInfo, _ []model.InvolvingSchemaInfo, _ ...ddl.CreateTableOption) error {
 	//TODO implement me
 	panic("implement me")
 }
 
 // BatchCreateTableWithInfo implements the DDL interface.
-func (*Checker) BatchCreateTableWithInfo(_ sessionctx.Context, _ model.CIStr, _ []*model.TableInfo, _ ...ddl.CreateTableWithInfoConfigurier) error {
+func (*Checker) BatchCreateTableWithInfo(_ sessionctx.Context, _ model.CIStr, _ []*model.TableInfo, _ ...ddl.CreateTableOption) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -230,7 +230,7 @@ func (d SchemaTracker) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStm
 		onExist = ddl.OnExistIgnore
 	}
 
-	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, nil, onExist)
+	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, nil, ddl.WithOnExist(onExist))
 }
 
 // CreateTableWithInfo implements the DDL interface.
@@ -239,9 +239,9 @@ func (d SchemaTracker) CreateTableWithInfo(
 	dbName model.CIStr,
 	info *model.TableInfo,
 	_ []model.InvolvingSchemaInfo,
-	cs ...ddl.CreateTableWithInfoConfigurier,
+	cs ...ddl.CreateTableOption,
 ) error {
-	c := ddl.GetCreateTableWithInfoConfig(cs)
+	c := ddl.GetCreateTableConfig(cs)
 
 	schema := d.SchemaByName(dbName)
 	if schema == nil {
@@ -291,7 +291,7 @@ func (d SchemaTracker) CreateView(ctx sessionctx.Context, s *ast.CreateViewStmt)
 		onExist = ddl.OnExistReplace
 	}
 
-	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, nil, onExist)
+	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, nil, ddl.WithOnExist(onExist))
 }
 
 // DropTable implements the DDL interface.
@@ -1188,7 +1188,7 @@ func (SchemaTracker) AlterResourceGroup(_ sessionctx.Context, _ *ast.AlterResour
 }
 
 // BatchCreateTableWithInfo implements the DDL interface, it will call CreateTableWithInfo for each table.
-func (d SchemaTracker) BatchCreateTableWithInfo(ctx sessionctx.Context, schema model.CIStr, info []*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+func (d SchemaTracker) BatchCreateTableWithInfo(ctx sessionctx.Context, schema model.CIStr, info []*model.TableInfo, cs ...ddl.CreateTableOption) error {
 	for _, tableInfo := range info {
 		if err := d.CreateTableWithInfo(ctx, schema, tableInfo, nil, cs...); err != nil {
 			return err

--- a/pkg/executor/brie.go
+++ b/pkg/executor/brie.go
@@ -781,13 +781,13 @@ func (gs *tidbGlueSession) CreateDatabase(_ context.Context, schema *model.DBInf
 }
 
 // CreateTable implements glue.Session
-func (gs *tidbGlueSession) CreateTable(_ context.Context, dbName model.CIStr, table *model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+func (gs *tidbGlueSession) CreateTable(_ context.Context, dbName model.CIStr, table *model.TableInfo, cs ...ddl.CreateTableOption) error {
 	return BRIECreateTable(gs.se, dbName, table, "", cs...)
 }
 
 // CreateTables implements glue.BatchCreateTableSession.
 func (gs *tidbGlueSession) CreateTables(_ context.Context,
-	tables map[string][]*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+	tables map[string][]*model.TableInfo, cs ...ddl.CreateTableOption) error {
 	return BRIECreateTables(gs.se, tables, "", cs...)
 }
 

--- a/pkg/executor/brie_utils.go
+++ b/pkg/executor/brie_utils.go
@@ -90,7 +90,7 @@ func BRIECreateTable(
 	dbName model.CIStr,
 	table *model.TableInfo,
 	brComment string,
-	cs ...ddl.CreateTableWithInfoConfigurier,
+	cs ...ddl.CreateTableOption,
 ) error {
 	d := domain.GetDomain(sctx).DDL()
 	query, err := showRestoredCreateTable(sctx, table, brComment)
@@ -109,7 +109,7 @@ func BRIECreateTable(
 
 	table = table.Clone()
 
-	return d.CreateTableWithInfo(sctx, dbName, table, nil, append(cs, ddl.OnExistIgnore)...)
+	return d.CreateTableWithInfo(sctx, dbName, table, nil, append(cs, ddl.WithOnExist(ddl.OnExistIgnore))...)
 }
 
 // BRIECreateTables creates the tables with OnExistIgnore option in batch
@@ -117,7 +117,7 @@ func BRIECreateTables(
 	sctx sessionctx.Context,
 	tables map[string][]*model.TableInfo,
 	brComment string,
-	cs ...ddl.CreateTableWithInfoConfigurier,
+	cs ...ddl.CreateTableOption,
 ) error {
 	// Disable foreign key check when batch create tables.
 	originForeignKeyChecks := sctx.GetSessionVars().ForeignKeyChecks
@@ -159,10 +159,10 @@ func BRIECreateTables(
 // The raft entry has limit size of 6 MB, a batch of CreateTables may hit this limitation
 // TODO: shall query string be set for each split batch create, it looks does not matter if we set once for all.
 func splitBatchCreateTable(sctx sessionctx.Context, schema model.CIStr,
-	infos []*model.TableInfo, cs ...ddl.CreateTableWithInfoConfigurier) error {
+	infos []*model.TableInfo, cs ...ddl.CreateTableOption) error {
 	var err error
 	d := domain.GetDomain(sctx).DDL()
-	err = d.BatchCreateTableWithInfo(sctx, schema, infos, append(cs, ddl.OnExistIgnore)...)
+	err = d.BatchCreateTableWithInfo(sctx, schema, infos, append(cs, ddl.WithOnExist(ddl.OnExistIgnore))...)
 	if kv.ErrEntryTooLarge.Equal(err) {
 		log.Info("entry too large, split batch create table", zap.Int("num table", len(infos)))
 		if len(infos) == 1 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54436

Problem Summary:

### What changed and how does it work?
- refactor CreateTableWithInfoConfigurier and related config, now all table created in a single call must all reuse ID or none. and change this part for BR
- some renaming
- fix the issue when batch create table, tables might not put into InvolvingSchemaInfo when shared involve is empty
- combine table/db id allocation with job id

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
