### PR TITLE
executor: fix unstable test TestPointGetForTemporaryTable

### DIFF
--- a/pkg/executor/batch_point_get_test.go
+++ b/pkg/executor/batch_point_get_test.go
@@ -206,8 +206,6 @@ func TestPointGetForTemporaryTable(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-
-
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create global temporary table t1 (id int primary key, val int) on commit delete rows")
 	tk.MustExec("begin")

--- a/pkg/executor/batch_point_get_test.go
+++ b/pkg/executor/batch_point_get_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor"
+	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -201,16 +202,23 @@ func TestCacheSnapShot(t *testing.T) {
 }
 
 func TestPointGetForTemporaryTable(t *testing.T) {
-	store := testkit.CreateMockStore(t)
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
+
+
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create global temporary table t1 (id int primary key, val int) on commit delete rows")
 	tk.MustExec("begin")
 	tk.MustExec("insert into t1 values (1,1)")
 	tk.MustQuery("explain format = 'brief' select * from t1 where id in (1, 2, 3)").
 		Check(testkit.Rows("Batch_Point_Get 3.00 root table:t1 handle:[1 2 3], keep order:false, desc:false"))
+
+	isV2, _ := infoschema.IsV2(dom.InfoSchema())
+	if isV2 {
+		t.Skip("This test can not run under infoschema v2, because the later would always visit network")
+	}
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/rpcServerBusy", "return(true)"))
 	defer func() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54702

Problem Summary:

### What changed and how does it work?

The test tests temporary table does not visit network. But when infoschema v2 is used, table by name also visit network. 
So the test is not appliabl to infoschema v2, just skip it in that case.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
