### PR TITLE
*: Update client-go to fix fair locking panic when executing a query after OOM kill in a transaction

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7041,13 +7041,13 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sha256 = "48097286e81b799d8cc8612879e4d3fa569be79a1be93ed77131c04052c3a069",
-        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20240531122021-7a74511a5241",
+        sha256 = "24e9d31e6a51a3f40274a541b6ef93af8172d93e5ebf5ee5a66692473dd1a98a",
+        strip_prefix = "github.com/tikv/client-go/v2@v2.0.8-0.20240716121331-2cd3a741ea8e",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240531122021-7a74511a5241.zip",
-            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240531122021-7a74511a5241.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240531122021-7a74511a5241.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240531122021-7a74511a5241.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240716121331-2cd3a741ea8e.zip",
+            "http://ats.apps.svc/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240716121331-2cd3a741ea8e.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240716121331-2cd3a741ea8e.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/tikv/client-go/v2/com_github_tikv_client_go_v2-v2.0.8-0.20240716121331-2cd3a741ea8e.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tdakkota/asciicheck v0.2.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.8-0.20240531122021-7a74511a5241
+	github.com/tikv/client-go/v2 v2.0.8-0.20240716121331-2cd3a741ea8e
 	github.com/tikv/pd/client v0.0.0-20240708075403-19f65c59bb89
 	github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966
 	github.com/twmb/murmur3 v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -993,8 +993,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJf
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/client-go/v2 v2.0.8-0.20240531122021-7a74511a5241 h1:iwqchfXkd1pfUDSnCKxXAeaR7FzyHA+yRdr5PtTwvvg=
-github.com/tikv/client-go/v2 v2.0.8-0.20240531122021-7a74511a5241/go.mod h1:37p0ryKaieJbBpVDWnaPi2ZS6UFqkgpsemBLkGX2FvM=
+github.com/tikv/client-go/v2 v2.0.8-0.20240716121331-2cd3a741ea8e h1:ur26ezzDOlosuuRxc4kadqaLLYfeLp7VoStu+p7gnow=
+github.com/tikv/client-go/v2 v2.0.8-0.20240716121331-2cd3a741ea8e/go.mod h1:37p0ryKaieJbBpVDWnaPi2ZS6UFqkgpsemBLkGX2FvM=
 github.com/tikv/pd/client v0.0.0-20240708075403-19f65c59bb89 h1:wkZLrptJ7T+EZ4JjLfvmHfV5yXnPP9x/fooQ1ok6DuE=
 github.com/tikv/pd/client v0.0.0-20240708075403-19f65c59bb89/go.mod h1:NW6Af689Jw1FDxjq+WL0nqOdmQ1XT0ly2R1SIKfQuUw=
 github.com/timakin/bodyclose v0.0.0-20230421092635-574207250966 h1:quvGphlmUVU+nhpFa4gg4yJyTRJ13reZMDHrKwYw53M=


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

This is a reopened PR of https://github.com/pingcap/tidb/pull/54574 which cherry-picks https://github.com/pingcap/tidb/pull/53698

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53540

Problem Summary:

### What changed and how does it work?

Update client-go to fix the problem that when query OOM kill happens in a transaction, the next query in the transaction may encounter panic when starting fair locking.

Also includes https://github.com/tikv/client-go/pull/1381 (ref: https://github.com/pingcap/tidb/issues/54375)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the problem that when query OOM kill happens in a transaction, the next query in the transaction may encounter panic when trying to start fair locking
```
