### PR TITLE
infoschema: optimize the performance of TableByName for infoschemav2

### DIFF
--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -458,7 +458,7 @@ func (is *infoschemaV2) EvictTable(schema, tbl string) {
 type tableByNameHelper struct {
 	end           tableItem
 	schemaVersion int64
-	found            bool
+	found         bool
 	res           tableItem
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959 


Problem Summary:

### What changed and how does it work?

I find some performance issue of the TableByName API.
As the flamegraph shows, all the calling of `TableByName` goes to `mallocgc`
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/5fcf4a94-c917-4178-a08b-d9cb50025d5f">

It's cause by the old style of writting like:

```
var end tableItem
var schemaVersion
var ok bool
var itm tableItem

is.byName.Descend(end, func() {             //   <-  this closure is allocated every time!
       if item.dbName != h.end.dbName || item.tableName != end.tableName {
               ok = false
               return false
       }
       if item.schemaVersion <= schemaVersion {
               if !item.tomb { // If the item is a tomb record, the database is dropped.
                       ok = true
                       itm = item
               }
               return false
       }
       return true
}
```

This closure function is a large burden for GC, it need to be allocated every time.

In this PR, we use and the closure allocation is avoid.

```
is.byName.Descend(end, helper.iter)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test

```
cd pkg/infoschema/test/infoschemav2test
go test -tags intest -run XXX -bench BenchmarkTableByName -benchmem
```

Before VS After:

```
 2533712               450.9 ns/op           195 B/op          3 allocs/op
 3274862               360.9 ns/op             2 B/op          0 allocs/op
```

- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

You might think the differ is not much? No!
I tested some integration test scenario, one goroutine run "truncate table t" in a loop, 
the other goroutine run "select * from t" and observe the latency.

The QPS before and after this commit:

<img width="729" alt="image" src="https://github.com/user-attachments/assets/a239ca50-ba0d-467e-9eb0-d3bf7d5b383b">

TableByName metrics before fix:

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/3adf54e7-9379-4568-b693-0aa3a72e863b">

TableByName metrics after fix:

<img width="1445" alt="image" src="https://github.com/user-attachments/assets/82a92f94-f18d-46a0-8a8e-ba1656a5c559">


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
