### PR TITLE
executor: remove `HashJoinV2Exec.needUsedFlag()`

### DIFF
--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -255,10 +255,6 @@ func (e *HashJoinV2Exec) Close() error {
 	return err
 }
 
-func (e *HashJoinV2Exec) needUsedFlag() bool {
-	return e.JoinType == plannercore.LeftOuterJoin && !e.RightAsBuildSide
-}
-
 // Open implements the Executor Open interface.
 func (e *HashJoinV2Exec) Open(ctx context.Context) error {
 	if err := e.BaseExecutor.Open(ctx); err != nil {
@@ -267,14 +263,15 @@ func (e *HashJoinV2Exec) Open(ctx context.Context) error {
 		return err
 	}
 	e.prepared = false
+	needScanRowTableAfterProbeDone := e.ProbeWorkers[0].JoinProbe.NeedScanRowTable()
+	e.HashJoinCtxV2.needScanRowTableAfterProbeDone = needScanRowTableAfterProbeDone
 	if e.RightAsBuildSide {
 		e.hashTableMeta = newTableMeta(e.BuildWorkers[0].BuildKeyColIdx, e.BuildWorkers[0].BuildTypes,
-			e.BuildKeyTypes, e.ProbeKeyTypes, e.RUsedInOtherCondition, e.RUsed, e.needUsedFlag())
+			e.BuildKeyTypes, e.ProbeKeyTypes, e.RUsedInOtherCondition, e.RUsed, needScanRowTableAfterProbeDone)
 	} else {
 		e.hashTableMeta = newTableMeta(e.BuildWorkers[0].BuildKeyColIdx, e.BuildWorkers[0].BuildTypes,
-			e.BuildKeyTypes, e.ProbeKeyTypes, e.LUsedInOtherCondition, e.LUsed, e.needUsedFlag())
+			e.BuildKeyTypes, e.ProbeKeyTypes, e.LUsedInOtherCondition, e.LUsed, needScanRowTableAfterProbeDone)
 	}
-	e.HashJoinCtxV2.needScanRowTableAfterProbeDone = e.ProbeWorkers[0].JoinProbe.NeedScanRowTable()
 	e.HashJoinCtxV2.ChunkAllocPool = e.AllocPool
 	if e.memTracker != nil {
 		e.memTracker.Reset()

--- a/pkg/executor/join/hash_table_v2.go
+++ b/pkg/executor/join/hash_table_v2.go
@@ -55,7 +55,7 @@ func newSubTable(table *rowTable) *subTable {
 	if table.validKeyCount() == 0 {
 		ret.isHashTableEmpty = true
 	}
-	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(1024))
+	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(32))
 	ret.hashTable = make([]uintptr, hashTableLength)
 	ret.posMask = hashTableLength - 1
 	return ret

--- a/pkg/executor/join/hash_table_v2.go
+++ b/pkg/executor/join/hash_table_v2.go
@@ -55,7 +55,7 @@ func newSubTable(table *rowTable) *subTable {
 	if table.validKeyCount() == 0 {
 		ret.isHashTableEmpty = true
 	}
-	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(32))
+	hashTableLength := max(nextPowerOfTwo(table.validKeyCount()), uint64(1024))
 	ret.hashTable = make([]uintptr, hashTableLength)
 	ret.posMask = hashTableLength - 1
 	return ret

--- a/pkg/executor/test/jointest/hashjoin/BUILD.bazel
+++ b/pkg/executor/test/jointest/hashjoin/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/config",
         "//pkg/executor/join",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54755

Problem Summary:

In `HashJoinV2Exec`, there is a method `needUsedFlag`, which means if the row entry need to reserve a piece of memory to hold used flag, if yes, then during probe stage, if a build row is matched, its used flag will be set to true. This used flag is only used for join probe that need to scan the row table after probe is done.
In BaseJoinProbe, there is an interface `NeedScanRowTable`, which will return true if current join probe need to scan the row table after probe is done. So basically, `needUsedFlag` and `NeedScanRowTable` is the same thing. The pr remove `needUsedFlag`
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
