### PR TITLE
table: expose some fields to `MutateContext` from `GetSessionVars()`

### DIFF
--- a/pkg/table/context/buffers.go
+++ b/pkg/table/context/buffers.go
@@ -148,6 +148,7 @@ func (b *ColSizeDeltaBuffer) UpdateColSizeMap(m map[int64]int64) map[int64]int64
 // Because inner slices are reused, you should not call the get methods again before finishing the previous usage.
 // Otherwise, the previous data will be overwritten.
 type MutateBuffers struct {
+	stmtBufs     *variable.WriteStmtBufs
 	encodeRow    *EncodeRowBuffer
 	checkRow     *CheckRowBuffer
 	colSizeDelta *ColSizeDeltaBuffer
@@ -156,6 +157,7 @@ type MutateBuffers struct {
 // NewMutateBuffers creates a new `MutateBuffers`.
 func NewMutateBuffers(stmtBufs *variable.WriteStmtBufs) *MutateBuffers {
 	return &MutateBuffers{
+		stmtBufs: stmtBufs,
 		encodeRow: &EncodeRowBuffer{
 			writeStmtBufs: stmtBufs,
 		},
@@ -202,6 +204,11 @@ func (b *MutateBuffers) GetColSizeDeltaBufferWithCap(capacity int) *ColSizeDelta
 	buffer := b.colSizeDelta
 	buffer.Reset(capacity)
 	return buffer
+}
+
+// GetWriteStmtBufs returns the `*variable.WriteStmtBufs`
+func (b *MutateBuffers) GetWriteStmtBufs() *variable.WriteStmtBufs {
+	return b.stmtBufs
 }
 
 // ensureCapacityAndReset is similar to the built-in make(),

--- a/pkg/table/context/buffers_test.go
+++ b/pkg/table/context/buffers_test.go
@@ -243,6 +243,8 @@ func TestMutateBuffersGetter(t *testing.T) {
 
 	colSize := buffers.GetColSizeDeltaBufferWithCap(6)
 	require.Equal(t, 6, cap(colSize.delta))
+
+	require.Same(t, stmtBufs, buffers.GetWriteStmtBufs())
 }
 
 func TestEnsureCapacityAndReset(t *testing.T) {

--- a/pkg/table/context/table.go
+++ b/pkg/table/context/table.go
@@ -56,8 +56,15 @@ type MutateContext interface {
 	// TxnRecordTempTable record the temporary table to the current transaction.
 	// This method will be called when the temporary table is modified or should allocate id in the transaction.
 	TxnRecordTempTable(tbl *model.TableInfo) tableutil.TempTable
+	// ConnectionID returns the id of the current connection.
+	// If the current environment is not in a query from the client, the return value is 0.
+	ConnectionID() uint64
 	// InRestrictedSQL returns whether the current context is used in restricted SQL.
 	InRestrictedSQL() bool
+	// TxnAssertionLevel returns the assertion level of the current transaction.
+	TxnAssertionLevel() variable.AssertionLevel
+	// EnableMutationChecker returns whether to check data consistency for mutations.
+	EnableMutationChecker() bool
 	// GetRowEncodingConfig returns the RowEncodingConfig.
 	GetRowEncodingConfig() RowEncodingConfig
 	// GetMutateBuffers returns the MutateBuffers,

--- a/pkg/table/contextimpl/BUILD.bazel
+++ b/pkg/table/contextimpl/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     deps = [
         ":contextimpl",
         "//pkg/sessionctx/binloginfo",
+        "//pkg/sessionctx/variable",
         "//pkg/testkit",
         "//pkg/util/mock",
         "@com_github_pingcap_tipb//go-binlog",

--- a/pkg/table/contextimpl/table.go
+++ b/pkg/table/contextimpl/table.go
@@ -55,9 +55,24 @@ func (ctx *TableContextImpl) GetExprCtx() exprctx.ExprContext {
 	return ctx.Context.GetExprCtx()
 }
 
+// ConnectionID implements the MutateContext interface.
+func (ctx *TableContextImpl) ConnectionID() uint64 {
+	return ctx.vars().ConnectionID
+}
+
 // InRestrictedSQL returns whether the current context is used in restricted SQL.
 func (ctx *TableContextImpl) InRestrictedSQL() bool {
-	return ctx.vars().StmtCtx.InRestrictedSQL
+	return ctx.vars().InRestrictedSQL
+}
+
+// TxnAssertionLevel implements the MutateContext interface.
+func (ctx *TableContextImpl) TxnAssertionLevel() variable.AssertionLevel {
+	return ctx.vars().AssertionLevel
+}
+
+// EnableMutationChecker implements the MutateContext interface.
+func (ctx *TableContextImpl) EnableMutationChecker() bool {
+	return ctx.vars().EnableMutationChecker
 }
 
 // BinlogEnabled returns whether the binlog is enabled.

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -177,7 +177,7 @@ func (c *index) Create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 		ctx = context.TODO()
 	}
 	vars := sctx.GetSessionVars()
-	writeBufs := vars.GetWriteStmtBufs()
+	writeBufs := sctx.GetMutateBuffers().GetWriteStmtBufs()
 	skipCheck := vars.StmtCtx.BatchCheck
 	evalCtx := sctx.GetExprCtx().GetEvalCtx()
 	loc, ec := evalCtx.Location(), evalCtx.ErrCtx()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54397

### What changed and how does it work?

expose some fields from `SessionVars` to `MutateContext`. This PR added:

- `WriteStmtBufs` for `MutateBuffers`
- `ConnectionID` for `MutateContext`
- `TxnAssertionLevel` for `MutateContext`
- `EnableMutationChecker` for `MutateContext`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
