### PR TITLE
runaway: change `tidb_runaway_watch` time type to UTC

### DIFF
--- a/pkg/domain/resourcegroup/runaway.go
+++ b/pkg/domain/resourcegroup/runaway.go
@@ -110,12 +110,13 @@ func GenRunawayQueriesStmt(records []*RunawayRecord) (string, []any) {
 type QuarantineRecord struct {
 	ID                int64
 	ResourceGroupName string
-	StartTime         time.Time
-	EndTime           time.Time
-	Watch             rmpb.RunawayWatchType
-	WatchText         string
-	Source            string
-	Action            rmpb.RunawayAction
+	// startTime and endTime are in UTC.
+	StartTime time.Time
+	EndTime   time.Time
+	Watch     rmpb.RunawayWatchType
+	WatchText string
+	Source    string
+	Action    rmpb.RunawayAction
 }
 
 // GetRecordKey is used to get the key in ttl cache.

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3466,8 +3466,8 @@ func (e *memtableRetriever) setDataFromRunawayWatches(sctx sessionctx.Context) e
 		row := types.MakeDatums(
 			watch.ID,
 			watch.ResourceGroupName,
-			watch.StartTime.Local().Format(time.DateTime),
-			watch.EndTime.Local().Format(time.DateTime),
+			watch.StartTime.Format(time.DateTime),
+			watch.EndTime.Format(time.DateTime),
 			rmpb.RunawayWatchType_name[int32(watch.Watch)],
 			watch.WatchText,
 			watch.Source,

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3466,8 +3466,8 @@ func (e *memtableRetriever) setDataFromRunawayWatches(sctx sessionctx.Context) e
 		row := types.MakeDatums(
 			watch.ID,
 			watch.ResourceGroupName,
-			watch.StartTime.Format(time.DateTime),
-			watch.EndTime.Format(time.DateTime),
+			watch.StartTime.UTC().Format(time.DateTime),
+			watch.EndTime.UTC().Format(time.DateTime),
 			rmpb.RunawayWatchType_name[int32(watch.Watch)],
 			watch.WatchText,
 			watch.Source,

--- a/pkg/executor/internal/querywatch/query_watch_test.go
+++ b/pkg/executor/internal/querywatch/query_watch_test.go
@@ -104,6 +104,13 @@ func TestQueryWatch(t *testing.T) {
 			"rg2 d08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57 Kill Plan",
 		), maxWaitDuration, tryInterval)
 
+	rs, err := tk.Exec("select SQL_NO_CACHE start_time from mysql.tidb_runaway_watch where resource_group_name = 'rg2'")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	// check start_time in `mysql.tidb_runaway_watch` and `information_schema.runaway_watches`
+	tk.EventuallyMustQueryAndCheck("select SQL_NO_CACHE DATE_FORMAT(start_time, '%Y-%m-%d %H:%i:%s') as start_time from mysql.tidb_runaway_watch where resource_group_name = 'rg2'", nil,
+		tk.MustQuery("select SQL_NO_CACHE start_time from information_schema.runaway_watches where resource_group_name = 'rg2'").Rows(), maxWaitDuration, tryInterval)
+
 	// avoid the default resource group to be recorded.
 	tk.MustExec("alter resource group default QUERY_LIMIT=(EXEC_ELAPSED='1000ms' ACTION=DRYRUN)")
 
@@ -151,7 +158,7 @@ func TestQueryWatch(t *testing.T) {
 		), maxWaitDuration, tryInterval)
 
 	// test remove
-	rs, err := tk.Exec("query watch remove 1")
+	rs, err = tk.Exec("query watch remove 1")
 	require.NoError(t, err)
 	require.Nil(t, rs)
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Close #54770, Ref #54434

Problem Summary: runaway: change `tidb_runaway_watch` to UTC

### What changed and how does it work?

Currently `tidb_runaway_watch` relies on struct `QuarantineRecord` to store time as UTC, while `runaway_watch` directly selects `tidb_runaway_watch` to convert to local time. Let's change `tidb_runaway_watch` to UTC as well.
> **why not change `tidb_runaway_watch` to local time?**
because `tidb_runaway_watch` is `datetime`, which is different from `timestamp`, and can not convert UTC to local time automatically.
https://github.com/pingcap/tidb/blob/e5a8a23e836a99b95db201f412cb7fdd9c811c5f/pkg/session/bootstrap.go#L635-L646
This means the timezone information will be lost, and the user will not know which timezone to switch to when in crossing time zones (the user needs to confirm the local time zone on the server side).

before
```bash
mysql> SELECT * FROM mysql.tidb_runaway_watch limit 1\G
*************************** 1. row ***************************
                 id: 1
resource_group_name: default
         start_time: 2024-07-16 07:34:14.137009
           end_time: 2024-07-16 07:44:14.137009
              watch: 1
         watch_text: select  count(*) from orders where o_orderdate = '1994-11-12'
             source: 127.0.0.1:4000
             action: 3
1 row in set (0.00 sec)

mysql> SELECT * FROM INFORMATION_SCHEMA.RUNAWAY_WATCHES where id =1\G
*************************** 1. row ***************************
                 ID: 1
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-07-16 15:34:14
           END_TIME: 2024-07-16 15:44:14
              WATCH: Exact
         WATCH_TEXT: select  count(*) from orders where o_orderdate = '1994-11-12'
             SOURCE: 127.0.0.1:4000
             ACTION: Kill
1 row in set (0.01 sec)
```

After
```bash
mysql> SELECT * FROM mysql.tidb_runaway_watch limit 1\G
*************************** 1. row ***************************
                 id: 1
resource_group_name: default
         start_time: 2024-07-19 07:18:36.572748
           end_time: 2024-07-19 07:28:36.572748
              watch: 1
         watch_text: select  count(*) from orders where o_orderdate = '1992-07-03'
             source: 127.0.0.1:4000
             action: 3
1 row in set (0.00 sec)

mysql> SELECT * FROM INFORMATION_SCHEMA.RUNAWAY_WATCHES where id =1\G
*************************** 1. row ***************************
                 ID: 1
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-07-19 07:18:36
           END_TIME: 2024-07-19 07:28:36
              WATCH: Exact
         WATCH_TEXT: select  count(*) from orders where o_orderdate = '1992-07-03'
             SOURCE: 127.0.0.1:4000
             ACTION: Kill
1 row in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
runaway: change tidb_runaway_watch time type to UTC
```
