### PR TITLE
executor: Add more comments for collecting stats on generated column index

### DIFF
--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -65,6 +65,10 @@ func (e *AnalyzeColumnsExecV2) analyzeColumnsPushDownV2(gp *gp.Pool) *statistics
 	}
 
 	collExtStats := e.ctx.GetSessionVars().EnableExtendedStats
+	// specialIndexes holds indexes that include virtual or prefix columns. For these indexes,
+	// only the number of distinct values (NDV) is computed using TiKV. Other statistic
+	// are derived from sample data processed within TiDB.
+	// The reason is that we want to keep the same row sampling for all columns.
 	specialIndexes := make([]*model.IndexInfo, 0, len(e.indexes))
 	specialIndexesOffsets := make([]int, 0, len(e.indexes))
 	for i, idx := range e.indexes {
@@ -304,6 +308,7 @@ func (e *AnalyzeColumnsExecV2) buildSamplingStats(
 
 	// Decode the data from sample collectors.
 	virtualColIdx := buildVirtualColumnIndex(e.schemaForVirtualColEval, e.colsInfo)
+	// Filling virtual columns is necessary here because these samples are used to build statistics for indexes that constructed by virtual columns.
 	if len(virtualColIdx) > 0 {
 		fieldTps := make([]*types.FieldType, 0, len(virtualColIdx))
 		for _, colOffset := range virtualColIdx {
@@ -314,7 +319,7 @@ func (e *AnalyzeColumnsExecV2) buildSamplingStats(
 			return 0, nil, nil, nil, nil, err
 		}
 	} else {
-		// If there's no virtual column or we meet error during eval virtual column, we fallback to normal decode otherwise.
+		// If there's no virtual column, normal decode way is enough.
 		for _, sample := range rootRowCollector.Base().Samples {
 			for i := range sample.Columns {
 				sample.Columns[i], err = tablecodec.DecodeColumnValue(sample.Columns[i].GetBytes(), &e.colsInfo[i].FieldType, sc.TimeZone())

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -146,8 +146,7 @@ func (e *AnalyzeColumnsExecV2) analyzeColumnsPushDownV2(gp *gp.Pool) *statistics
 	}
 }
 
-// decodeSampleDataWithVirtualColumn constructs the virtual column by evaluating from the deocded normal columns.
-// If it failed, it would return false to trigger normal decoding way without the virtual column.
+// decodeSampleDataWithVirtualColumn constructs the virtual column by evaluating from the decoded normal columns.
 func (e *AnalyzeColumnsExecV2) decodeSampleDataWithVirtualColumn(
 	collector statistics.RowSampleCollector,
 	fieldTps []*types.FieldType,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:

### What changed and how does it work?

More comments were added to collect stats on the generated column index.

We collect the stats for the generated column index. But we ignore the generated columns themselves because we don't store them on TiKV and we can't calculate the NDV from TiKV.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
