### PR TITLE
expression: expose the optional property on EvaluatorSuit

### DIFF
--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -15,6 +15,7 @@
 package expression
 
 import (
+	"github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 )
 
@@ -72,6 +73,30 @@ func (e *defaultEvaluator) run(ctx EvalContext, vecEnabled bool, input, output *
 		}
 	}
 	return nil
+}
+
+// RequiredOptionalEvalProps exposes all optional evaluation properties that this evaluator requires.
+func (e *defaultEvaluator) RequiredOptionalEvalProps() context.OptionalEvalPropKeySet {
+	props := context.OptionalEvalPropKeySet(0)
+	for _, expr := range e.exprs {
+		props = props | getOptionalEvalPropsForExpr(expr)
+	}
+
+	return props
+}
+
+func getOptionalEvalPropsForExpr(expr Expression) context.OptionalEvalPropKeySet {
+	switch e := expr.(type) {
+	case *ScalarFunction:
+		props := e.Function.RequiredOptionalEvalProps()
+		for _, arg := range e.GetArgs() {
+			props = props | getOptionalEvalPropsForExpr(arg)
+		}
+
+		return props
+	default:
+		return 0
+	}
 }
 
 // EvaluatorSuite is responsible for the evaluation of a list of expressions.

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -19,8 +19,10 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -605,4 +607,54 @@ func TestMod(t *testing.T) {
 	r, err = evalBuiltinFunc(f, ctx, chunk.Row{})
 	require.NoError(t, err)
 	require.Equal(t, types.NewDatum(1.5), r)
+}
+
+func TestOptionalProp(t *testing.T) {
+	ctx := createContext(t)
+
+	fc := funcs[ast.Plus]
+	arg1fc := funcs[ast.CurrentUser]
+	arg1f, err := arg1fc.getFunction(ctx, nil)
+	require.NoError(t, err)
+	arg1 := &ScalarFunction{
+		FuncName: model.NewCIStr(ast.CurrentUser),
+		Function: arg1f,
+		RetType:  arg1f.getRetTp(),
+	}
+	arg2fc := funcs[ast.TiDBIsDDLOwner]
+	arg2f, err := arg2fc.getFunction(ctx, nil)
+	require.NoError(t, err)
+	arg2 := &ScalarFunction{
+		FuncName: model.NewCIStr(ast.TiDBIsDDLOwner),
+		Function: arg2f,
+		RetType:  arg2f.getRetTp(),
+	}
+
+	f, err := fc.getFunction(ctx, []Expression{arg1, arg2})
+	require.NoError(t, err)
+	fe := &ScalarFunction{
+		FuncName: model.NewCIStr(ast.Plus),
+		Function: f,
+		RetType:  f.getRetTp(),
+	}
+
+	fc2 := funcs[ast.GetLock]
+	f2, err := fc2.getFunction(ctx, datumsToConstants(types.MakeDatums("tidb_distsql_scan_concurrency", 10)))
+	require.NoError(t, err)
+	fe2 := &ScalarFunction{
+		FuncName: model.NewCIStr(ast.GetLock),
+		Function: f2,
+		RetType:  f2.getRetTp(),
+	}
+
+	require.Equal(t, context.OptionalEvalPropKeySet(0), f.RequiredOptionalEvalProps())
+	require.Equal(t, context.OptPropCurrentUser.AsPropKeySet()|context.OptPropDDLOwnerInfo.AsPropKeySet(),
+		getOptionalEvalPropsForExpr(fe))
+	require.Equal(t, context.OptPropCurrentUser.AsPropKeySet()|context.OptPropDDLOwnerInfo.AsPropKeySet()|
+		context.OptPropAdvisoryLock.AsPropKeySet(),
+		getOptionalEvalPropsForExpr(fe)|getOptionalEvalPropsForExpr(fe2))
+
+	evalSuit := NewEvaluatorSuite([]Expression{fe, fe2}, false)
+	require.Equal(t, context.OptPropCurrentUser.AsPropKeySet()|context.OptPropDDLOwnerInfo.AsPropKeySet()|
+		context.OptPropAdvisoryLock.AsPropKeySet(), evalSuit.RequiredOptionalEvalProps())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #54797

Problem Summary:

Expose the optional property on the `EvaluatorSuit`. It can help us to implement the `Detach` function for `ProjectionExec` and `SelectionExec`.

### What changed and how does it work?

It recursively reads the optional property of all expressions and their arguments.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
None
```
