### PR TITLE
executor: support detaching the `IndexReader` and `IndexLookUp`

### DIFF
--- a/pkg/executor/detach.go
+++ b/pkg/executor/detach.go
@@ -63,12 +63,55 @@ func (treCtx tableReaderExecutorContext) Detach() tableReaderExecutorContext {
 	return treCtx
 }
 
+func (ireCtx indexReaderExecutorContext) Detach() indexReaderExecutorContext {
+	newCtx := ireCtx
+
+	if ctx, ok := ireCtx.ectx.(*contextsession.SessionExprContext); ok {
+		staticExprCtx := ctx.IntoStatic()
+
+		newCtx.dctx = newCtx.dctx.Detach()
+		newCtx.rctx = newCtx.rctx.Detach(staticExprCtx)
+		newCtx.buildPBCtx = newCtx.buildPBCtx.Detach(staticExprCtx)
+		newCtx.ectx = staticExprCtx
+		return newCtx
+	}
+
+	return ireCtx
+}
+
+func (iluCtx indexLookUpExecutorContext) Detach() indexLookUpExecutorContext {
+	newCtx := iluCtx
+	newCtx.tableReaderExecutorContext = newCtx.tableReaderExecutorContext.Detach()
+
+	return iluCtx
+}
+
 // Detach detaches the current executor from the session context.
 func (e *TableReaderExecutor) Detach() (exec.Executor, bool) {
 	newExec := new(TableReaderExecutor)
 	*newExec = *e
 
 	newExec.tableReaderExecutorContext = newExec.tableReaderExecutorContext.Detach()
+
+	return newExec, true
+}
+
+// Detach detaches the current executor from the session context.
+func (e *IndexReaderExecutor) Detach() (exec.Executor, bool) {
+	newExec := new(IndexReaderExecutor)
+	*newExec = *e
+
+	newExec.indexReaderExecutorContext = newExec.indexReaderExecutorContext.Detach()
+
+	return newExec, true
+}
+
+// Detach detaches the current executor from the session context.
+func (e *IndexLookUpExecutor) Detach() (exec.Executor, bool) {
+	newExec := new(IndexLookUpExecutor)
+	*newExec = *e
+
+	newExec.indexLookUpExecutorContext = newExec.indexLookUpExecutorContext.Detach()
 
 	return newExec, true
 }

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -467,8 +467,8 @@ type IndexLookUpExecutor struct {
 
 	// All fields above are immutable.
 
-	idxWorkerWg sync.WaitGroup
-	tblWorkerWg sync.WaitGroup
+	idxWorkerWg *sync.WaitGroup
+	tblWorkerWg *sync.WaitGroup
 	finished    chan struct{}
 
 	resultCh   chan *lookupTableTask
@@ -620,6 +620,9 @@ func (e *IndexLookUpExecutor) open(_ context.Context) error {
 			return err
 		}
 	}
+
+	e.idxWorkerWg = &sync.WaitGroup{}
+	e.tblWorkerWg = &sync.WaitGroup{}
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #54799

Problem Summary:

Previously, the `IndexReader` and `IndexLookUp` didn't support lazy cursor fetch.

### What changed and how does it work?

Now, the lazy cursor fetch function should also support `IndexReader` and `IndexLookUp` executors. It's implemented by adding `Detach` function on these executors.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
None
```
