### PR TITLE
br: Use full name instead of prefix in integration test

### DIFF
--- a/br/tests/br_shuffle_leader/run.sh
+++ b/br/tests/br_shuffle_leader/run.sh
@@ -26,7 +26,7 @@ go-ycsb load mysql -P $CUR/workload -p mysql.host=$TIDB_IP -p mysql.port=$TIDB_P
 row_count_ori=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print $2}')
 
 # add shuffle leader scheduler
-run_pd_ctl -u https://$PD_ADDR sched add shuffle-leader-scheduler
+run_pd_ctl -u https://$PD_ADDR scheduler add shuffle-leader-scheduler
 
 # backup with shuffle leader
 echo "backup start..."
@@ -39,7 +39,7 @@ echo "restore start..."
 run_br restore table --db $DB --table $TABLE -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 
 # remove shuffle leader scheduler
-run_pd_ctl -u https://$PD_ADDR sched remove shuffle-leader-scheduler
+run_pd_ctl -u https://$PD_ADDR scheduler remove shuffle-leader-scheduler
 
 row_count_new=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print $2}')
 

--- a/br/tests/br_shuffle_region/run.sh
+++ b/br/tests/br_shuffle_region/run.sh
@@ -27,7 +27,7 @@ row_count_ori=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print 
 
 # add shuffle region scheduler
 echo "add shuffle-region-scheduler"
-run_pd_ctl -u https://$PD_ADDR sched add shuffle-region-scheduler
+run_pd_ctl -u https://$PD_ADDR scheduler add shuffle-region-scheduler
 
 # backup with shuffle region
 echo "backup start..."
@@ -40,7 +40,7 @@ echo "restore start..."
 run_br restore table --db $DB --table $TABLE -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
 
 # remove shuffle region scheduler
-run_pd_ctl -u https://$PD_ADDR sched remove shuffle-region-scheduler
+run_pd_ctl -u https://$PD_ADDR scheduler remove shuffle-region-scheduler
 
 row_count_new=$(run_sql "SELECT COUNT(*) FROM $DB.$TABLE;" | awk '/COUNT/{print $2}')
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54820

Problem Summary:

Pd-ctl now disabled the prefix matching, we may need to adapt the modification.
ref: https://github.com/tikv/pd/pull/8414

### What changed and how does it work?

Use full command instead of prefix matching in pd-ctl command.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
