### PR TITLE
planner: incorrect query result using ISNULL

### DIFF
--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -36,7 +36,10 @@ func getPlanRows(planStr string) []string {
 }
 
 func compareStringSlice(t *testing.T, ss1, ss2 []string) {
-	require.Equal(t, ss1, ss2)
+	require.Equal(t, len(ss1), len(ss2))
+	for i, s := range ss1 {
+		require.Equal(t, len(s), len(ss2[i]))
+	}
 }
 
 func TestPreferRangeScan(t *testing.T) {

--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -36,10 +36,7 @@ func getPlanRows(planStr string) []string {
 }
 
 func compareStringSlice(t *testing.T, ss1, ss2 []string) {
-	require.Equal(t, len(ss1), len(ss2))
-	for i, s := range ss1 {
-		require.Equal(t, len(s), len(ss2[i]))
-	}
+	require.Equal(t, ss1, ss2)
 }
 
 func TestPreferRangeScan(t *testing.T) {

--- a/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
+++ b/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
@@ -426,8 +426,8 @@
         "Plan": [
           " TableReader         root         ",
           " └─ExchangeSender    cop[tiflash] ",
-          "   └─Selection       cop[tiflash] gt(test.t1.b, ?)",
-          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.a, ?), gt(test.t1.c, ?), keep order:false"
+          "   └─Selection       cop[tiflash] gt(test.t1.c, ?)",
+          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.a, ?), gt(test.t1.b, ?), keep order:false"
         ]
       },
       {

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -756,7 +756,7 @@ func ExtractEqAndInCondition(sctx *rangerctx.RangerContext, conditions []express
 		} else {
 			// All Intervals are single points
 			if f, ok := accesses[i].(*expression.ScalarFunction); !ok || (ok && f.FuncName.L != ast.IsNull) {
-				// isnull is nut equal to a = NULL
+				// isnull is not equal to a = NULL
 				accesses[i] = points2EqOrInCond(sctx.ExprCtx, points[i], cols[i])
 				newConditions = append(newConditions, accesses[i])
 			}

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -755,8 +755,11 @@ func ExtractEqAndInCondition(sctx *rangerctx.RangerContext, conditions []express
 			return nil, nil, nil, nil, true
 		} else {
 			// All Intervals are single points
-			accesses[i] = points2EqOrInCond(sctx.ExprCtx, points[i], cols[i])
-			newConditions = append(newConditions, accesses[i])
+			if f, ok := accesses[i].(*expression.ScalarFunction); !ok || (ok && f.FuncName.L != ast.IsNull) {
+				// isnull is nut equal to a = NULL
+				accesses[i] = points2EqOrInCond(sctx.ExprCtx, points[i], cols[i])
+				newConditions = append(newConditions, accesses[i])
+			}
 			if f, ok := accesses[i].(*expression.ScalarFunction); ok && f.FuncName.L == ast.EQ {
 				// Actually the constant column value may not be mutable. Here we assume it is mutable to keep it simple.
 				// Maybe we can improve it later.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54803

Problem Summary:

### What changed and how does it work?

```points2EqOrInCond``` will generate the ```Equal```/```IN``` expression according the column info and const value. but we cannot regard ```isnull()``` and ```= null``` as equivalent. so ```isnull``` should skip the ```points2EqOrInCond```.


 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
