### PR TITLE
Makefile: add a lint for parser's keywords 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check-setup:tools/bin/revive
 precheck: fmt bazel_prepare
 
 .PHONY: check
-check: check-bazel-prepare parser_yacc check-parallel lint tidy testSuite errdoc license
+check: check-bazel-prepare parser_yacc parser_genkeywords check-parallel lint tidy testSuite errdoc license
 
 .PHONY: fmt
 fmt:
@@ -129,7 +129,7 @@ test_part_1: checklist integrationtest
 test_part_2: test_part_parser ut gogenerate br_unit_test dumpling_unit_test
 
 .PHONY: test_part_parser
-test_part_parser: parser_yacc test_part_parser_dev
+test_part_parser: parser_yacc parser_genkeywords test_part_parser_dev
 
 .PHONY: test_part_parser_dev
 test_part_parser_dev: parser_fmt parser_unit_test
@@ -141,6 +141,10 @@ parser:
 .PHONY: parser_yacc
 parser_yacc:
 	@cd pkg/parser && mv parser.go parser.go.committed && make parser && diff -u parser.go.committed parser.go && rm parser.go.committed
+
+.PHONY: parser_genkeywords
+parser_genkeywords:
+	@cd pkg/parser && mv keywords.go keywords.go.committed && make generate && diff -u keywords.go.committed keywords.go && rm keywords.go.committed
 
 .PHONY: parser_fmt
 parser_fmt:

--- a/pkg/parser/keywords.go
+++ b/pkg/parser/keywords.go
@@ -622,6 +622,7 @@ var Keywords = []KeywordsType{
 	{"VALIDATION", false, "unreserved"},
 	{"VALUE", false, "unreserved"},
 	{"VARIABLES", false, "unreserved"},
+	{"VECTOR", false, "unreserved"},
 	{"VIEW", false, "unreserved"},
 	{"VISIBLE", false, "unreserved"},
 	{"WAIT", false, "unreserved"},

--- a/pkg/parser/keywords_test.go
+++ b/pkg/parser/keywords_test.go
@@ -36,7 +36,7 @@ func TestKeywords(t *testing.T) {
 }
 
 func TestKeywordsLength(t *testing.T) {
-	require.Equal(t, 653, len(parser.Keywords))
+	require.Equal(t, 654, len(parser.Keywords))
 
 	reservedNr := 0
 	for _, kw := range parser.Keywords {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

https://github.com/pingcap/tidb/pull/54246  has not updated keywords, maybe we need a lint to check parser/keywords
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Ref #54245

Problem Summary:

### What changed and how does it work?

When meet error
```bash
$ make parser_genkeywords
make[1]: Entering directory '/data/nvme0n1/husharp/proj/tidb/pkg/parser'
go generate
make[1]: Leaving directory '/data/nvme0n1/husharp/proj/tidb/pkg/parser'
--- keywords.go.committed       2024-07-23 14:35:57.829246693 +0800
+++ keywords.go 2024-07-23 14:36:00.505309768 +0800
@@ -622,6 +622,7 @@
        {"VALIDATION", false, "unreserved"},
        {"VALUE", false, "unreserved"},
        {"VARIABLES", false, "unreserved"},
+       {"VECTOR", false, "unreserved"},
        {"VIEW", false, "unreserved"},
        {"VISIBLE", false, "unreserved"},
        {"WAIT", false, "unreserved"},
make: *** [Makefile:147: parser_genkeyword] Error 1
```
After fixing error
```bash
master* $ make parser_genkeywords
make[1]: Entering directory '/data/nvme0n1/husharp/proj/tidb/pkg/parser'
go generate
make[1]: Leaving directory '/data/nvme0n1/husharp/proj/tidb/pkg/parser'
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
