### PR TITLE
table: Add `GetStatisticsSupport` and `GetBinlogSupport` for `MutateContext`

### DIFF
--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -33,8 +33,8 @@ import (
 func TestInsertOnDuplicateKeyWithBinlog(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	failpoint.Enable("github.com/pingcap/tidb/pkg/table/tables/forceWriteBinlog", "return")
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/table/tables/forceWriteBinlog")
+	failpoint.Enable("github.com/pingcap/tidb/pkg/table/contextimpl/forceWriteBinlog", "return")
+	defer failpoint.Disable("github.com/pingcap/tidb/pkg/table/contextimpl/forceWriteBinlog")
 	testInsertOnDuplicateKey(t, tk)
 }
 

--- a/pkg/table/contextimpl/BUILD.bazel
+++ b/pkg/table/contextimpl/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/table/context",
         "//pkg/util/tableutil",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_tipb//go-binlog",
     ],
 )

--- a/pkg/table/contextimpl/table_test.go
+++ b/pkg/table/contextimpl/table_test.go
@@ -34,10 +34,14 @@ func TestMutateContextImplFields(t *testing.T) {
 	require.True(t, sctx.GetExprCtx() == ctx.GetExprCtx())
 	// binlog
 	sctx.GetSessionVars().BinlogClient = nil
-	require.False(t, ctx.BinlogEnabled())
+	binlogSupport, ok := ctx.GetBinlogSupport()
+	require.False(t, ok)
+	require.Nil(t, binlogSupport)
 	sctx.GetSessionVars().BinlogClient = binloginfo.MockPumpsClient(&testkit.MockPumpClient{})
-	require.True(t, ctx.BinlogEnabled())
-	binlogMutation := ctx.GetBinlogMutation(1234)
+	binlogSupport, ok = ctx.GetBinlogSupport()
+	require.True(t, ok)
+	require.NotNil(t, binlogSupport)
+	binlogMutation := binlogSupport.GetBinlogMutation(1234)
 	require.NotNil(t, binlogMutation)
 	require.Same(t, sctx.StmtGetMutation(1234), binlogMutation)
 	// ConnectionID
@@ -82,4 +86,25 @@ func TestMutateContextImplFields(t *testing.T) {
 	require.Equal(t, sctx.GetSessionVars().IsRowLevelChecksumEnabled(), cfg.IsRowLevelChecksumEnabled)
 	// mutate buffers
 	require.NotNil(t, ctx.GetMutateBuffers())
+	// statistics support
+	txnCtx := sctx.GetSessionVars().TxnCtx
+	txnCtx.TableDeltaMap = make(map[int64]variable.TableDelta)
+	sctx.GetSessionVars().TxnCtx = nil
+	statisticsSupport, ok := ctx.GetStatisticsSupport()
+	require.False(t, ok)
+	require.Nil(t, statisticsSupport)
+	sctx.GetSessionVars().TxnCtx = txnCtx
+	statisticsSupport, ok = ctx.GetStatisticsSupport()
+	require.True(t, ok)
+	require.NotNil(t, statisticsSupport)
+	require.Equal(t, 0, len(txnCtx.TableDeltaMap))
+	statisticsSupport.UpdatePhysicalTableDelta(
+		12, 1, 2, variable.DeltaColsMap(map[int64]int64{3: 4, 5: 6}),
+	)
+	require.Equal(t, 1, len(txnCtx.TableDeltaMap))
+	deltaMap := txnCtx.TableDeltaMap[12]
+	require.Equal(t, int64(12), deltaMap.TableID)
+	require.Equal(t, int64(1), deltaMap.Delta)
+	require.Equal(t, int64(2), deltaMap.Count)
+	require.Equal(t, map[int64]int64{3: 4, 5: 6}, deltaMap.ColSize)
 }

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -1295,9 +1295,6 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 		}
 		err = t.addDeleteBinlog(ctx, binlogSupport, binlogRow, colIDs)
 	}
-	if ctx.GetSessionVars().TxnCtx == nil {
-		return nil
-	}
 
 	if s, ok := ctx.GetStatisticsSupport(); ok {
 		// a reusable buffer to save malloc

--- a/pkg/table/tables/tables.go
+++ b/pkg/table/tables/tables.go
@@ -479,7 +479,8 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 	mutateBuffers := sctx.GetMutateBuffers()
 	encodeRowBuffer := mutateBuffers.GetEncodeRowBufferWithCap(numColsCap)
 	checkRowBuffer := mutateBuffers.GetCheckRowBufferWithCap(numColsCap)
-	if shouldWriteBinlog(sctx, t.meta) {
+	binlogSupport, shouldWriteBinlog := getBinlogSupport(sctx, t.meta)
+	if shouldWriteBinlog {
 		binlogColIDs = make([]int64, 0, numColsCap)
 		binlogOldRow = make([]types.Datum, 0, numColsCap)
 		binlogNewRow = make([]types.Datum, 0, numColsCap)
@@ -522,7 +523,7 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 			encodeRowBuffer.AddColVal(col.ID, value)
 		}
 		checkRowBuffer.AddColVal(value)
-		if shouldWriteBinlog(sctx, t.meta) && !t.canSkipUpdateBinlog(col, value) {
+		if shouldWriteBinlog && !t.canSkipUpdateBinlog(col, value) {
 			binlogColIDs = append(binlogColIDs, col.ID)
 			binlogOldRow = append(binlogOldRow, oldData[col.Offset])
 			binlogNewRow = append(binlogNewRow, value)
@@ -535,7 +536,6 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 			return err
 		}
 	}
-	sessVars := sctx.GetSessionVars()
 	// rebuild index
 	err = t.rebuildIndices(sctx, txn, h, touched, oldData, newData, table.WithCtx(ctx))
 	if err != nil {
@@ -580,32 +580,35 @@ func (t *TableCommon) UpdateRecord(ctx context.Context, sctx table.MutateContext
 	}
 
 	memBuffer.Release(sh)
-	if shouldWriteBinlog(sctx, t.meta) {
+	if shouldWriteBinlog {
 		if !t.meta.PKIsHandle && !t.meta.IsCommonHandle {
 			binlogColIDs = append(binlogColIDs, model.ExtraHandleID)
 			binlogOldRow = append(binlogOldRow, types.NewIntDatum(h.IntValue()))
 			binlogNewRow = append(binlogNewRow, types.NewIntDatum(h.IntValue()))
 		}
-		err = t.addUpdateBinlog(sctx, binlogOldRow, binlogNewRow, binlogColIDs)
+		err = t.addUpdateBinlog(sctx, binlogSupport, binlogOldRow, binlogNewRow, binlogColIDs)
 		if err != nil {
 			return err
 		}
 	}
-	colSizeBuffer := mutateBuffers.GetColSizeDeltaBufferWithCap(len(t.Cols()))
-	for id, col := range t.Cols() {
-		size, err := codec.EstimateValueSize(tc, newData[id])
-		if err != nil {
-			continue
+
+	if s, ok := sctx.GetStatisticsSupport(); ok {
+		colSizeBuffer := mutateBuffers.GetColSizeDeltaBufferWithCap(len(t.Cols()))
+		for id, col := range t.Cols() {
+			size, err := codec.EstimateValueSize(tc, newData[id])
+			if err != nil {
+				continue
+			}
+			newLen := size - 1
+			size, err = codec.EstimateValueSize(tc, oldData[id])
+			if err != nil {
+				continue
+			}
+			oldLen := size - 1
+			colSizeBuffer.AddColSizeDelta(col.ID, int64(newLen-oldLen))
 		}
-		newLen := size - 1
-		size, err = codec.EstimateValueSize(tc, oldData[id])
-		if err != nil {
-			continue
-		}
-		oldLen := size - 1
-		colSizeBuffer.AddColSizeDelta(col.ID, int64(newLen-oldLen))
+		s.UpdatePhysicalTableDelta(t.physicalTableID, 0, 1, colSizeBuffer)
 	}
-	sessVars.TxnCtx.UpdateDeltaForTable(t.physicalTableID, 0, 1, colSizeBuffer)
 	return nil
 }
 
@@ -1004,27 +1007,26 @@ func (t *TableCommon) AddRecord(sctx table.MutateContext, r []types.Datum, opts 
 
 	memBuffer.Release(sh)
 
-	if shouldWriteBinlog(sctx, t.meta) {
+	binlogSupport, shouldWriteBinlog := getBinlogSupport(sctx, t.meta)
+	if shouldWriteBinlog {
 		// For insert, TiDB and Binlog can use same row and schema.
-		err = t.addInsertBinlog(sctx, recordID, encodeRowBuffer)
+		err = t.addInsertBinlog(sctx, binlogSupport, recordID, encodeRowBuffer)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if sessVars.TxnCtx == nil {
-		return recordID, nil
-	}
-
-	colSizeBuffer := sctx.GetMutateBuffers().GetColSizeDeltaBufferWithCap(len(t.Cols()))
-	for id, col := range t.Cols() {
-		size, err := codec.EstimateValueSize(tc, r[id])
-		if err != nil {
-			continue
+	if s, ok := sctx.GetStatisticsSupport(); ok {
+		colSizeBuffer := sctx.GetMutateBuffers().GetColSizeDeltaBufferWithCap(len(t.Cols()))
+		for id, col := range t.Cols() {
+			size, err := codec.EstimateValueSize(tc, r[id])
+			if err != nil {
+				continue
+			}
+			colSizeBuffer.AddColSizeDelta(col.ID, int64(size-1))
 		}
-		colSizeBuffer.AddColSizeDelta(col.ID, int64(size-1))
+		s.UpdatePhysicalTableDelta(t.physicalTableID, 1, 1, colSizeBuffer)
 	}
-	sessVars.TxnCtx.UpdateDeltaForTable(t.physicalTableID, 1, 1, colSizeBuffer)
 	return recordID, nil
 }
 
@@ -1271,7 +1273,8 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 	}
 	memBuffer.Release(sh)
 
-	if shouldWriteBinlog(ctx, t.meta) {
+	binlogSupport, shouldWriteBinlog := getBinlogSupport(ctx, t.meta)
+	if shouldWriteBinlog {
 		cols := t.DeletableCols()
 		colIDs := make([]int64, 0, len(cols)+1)
 		for _, col := range cols {
@@ -1290,30 +1293,32 @@ func (t *TableCommon) RemoveRecord(ctx table.MutateContext, h kv.Handle, r []typ
 		} else {
 			binlogRow = r
 		}
-		err = t.addDeleteBinlog(ctx, binlogRow, colIDs)
+		err = t.addDeleteBinlog(ctx, binlogSupport, binlogRow, colIDs)
 	}
 	if ctx.GetSessionVars().TxnCtx == nil {
 		return nil
 	}
 
-	// a reusable buffer to save malloc
-	// Note: The buffer should not be referenced or modified outside this function.
-	// It can only act as a temporary buffer for the current function call.
-	colSizeBuffer := ctx.GetMutateBuffers().GetColSizeDeltaBufferWithCap(len(t.Cols()))
-	for id, col := range t.Cols() {
-		size, err := codec.EstimateValueSize(tc, r[id])
-		if err != nil {
-			continue
+	if s, ok := ctx.GetStatisticsSupport(); ok {
+		// a reusable buffer to save malloc
+		// Note: The buffer should not be referenced or modified outside this function.
+		// It can only act as a temporary buffer for the current function call.
+		colSizeBuffer := ctx.GetMutateBuffers().GetColSizeDeltaBufferWithCap(len(t.Cols()))
+		for id, col := range t.Cols() {
+			size, err := codec.EstimateValueSize(tc, r[id])
+			if err != nil {
+				continue
+			}
+			colSizeBuffer.AddColSizeDelta(col.ID, -int64(size-1))
 		}
-		colSizeBuffer.AddColSizeDelta(col.ID, -int64(size-1))
+		s.UpdatePhysicalTableDelta(
+			t.physicalTableID, -1, 1, colSizeBuffer,
+		)
 	}
-	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(
-		t.physicalTableID, -1, 1, colSizeBuffer,
-	)
 	return err
 }
 
-func (t *TableCommon) addInsertBinlog(ctx table.MutateContext, h kv.Handle, encodeRowBuffer *tbctx.EncodeRowBuffer) error {
+func (t *TableCommon) addInsertBinlog(ctx table.MutateContext, support tbctx.BinlogSupport, h kv.Handle, encodeRowBuffer *tbctx.EncodeRowBuffer) error {
 	evalCtx := ctx.GetExprCtx().GetEvalCtx()
 	loc, ec := evalCtx.Location(), evalCtx.ErrCtx()
 	handleData, err := h.Data()
@@ -1330,13 +1335,13 @@ func (t *TableCommon) addInsertBinlog(ctx table.MutateContext, h kv.Handle, enco
 		return err
 	}
 	bin := append(pk, value...)
-	mutation := ctx.GetBinlogMutation(t.tableID)
+	mutation := support.GetBinlogMutation(t.tableID)
 	mutation.InsertedRows = append(mutation.InsertedRows, bin)
 	mutation.Sequence = append(mutation.Sequence, binlog.MutationType_Insert)
 	return nil
 }
 
-func (t *TableCommon) addUpdateBinlog(ctx table.MutateContext, oldRow, newRow []types.Datum, colIDs []int64) error {
+func (t *TableCommon) addUpdateBinlog(ctx table.MutateContext, support tbctx.BinlogSupport, oldRow, newRow []types.Datum, colIDs []int64) error {
 	evalCtx := ctx.GetExprCtx().GetEvalCtx()
 	loc, ec := evalCtx.Location(), evalCtx.ErrCtx()
 	old, err := tablecodec.EncodeOldRow(loc, oldRow, colIDs, nil, nil)
@@ -1350,13 +1355,13 @@ func (t *TableCommon) addUpdateBinlog(ctx table.MutateContext, oldRow, newRow []
 		return err
 	}
 	bin := append(old, newVal...)
-	mutation := ctx.GetBinlogMutation(t.tableID)
+	mutation := support.GetBinlogMutation(t.tableID)
 	mutation.UpdatedRows = append(mutation.UpdatedRows, bin)
 	mutation.Sequence = append(mutation.Sequence, binlog.MutationType_Update)
 	return nil
 }
 
-func (t *TableCommon) addDeleteBinlog(ctx table.MutateContext, r []types.Datum, colIDs []int64) error {
+func (t *TableCommon) addDeleteBinlog(ctx table.MutateContext, support tbctx.BinlogSupport, r []types.Datum, colIDs []int64) error {
 	evalCtx := ctx.GetExprCtx().GetEvalCtx()
 	loc, ec := evalCtx.Location(), evalCtx.ErrCtx()
 	data, err := tablecodec.EncodeOldRow(loc, r, colIDs, nil, nil)
@@ -1364,7 +1369,7 @@ func (t *TableCommon) addDeleteBinlog(ctx table.MutateContext, r []types.Datum, 
 	if err != nil {
 		return err
 	}
-	mutation := ctx.GetBinlogMutation(t.tableID)
+	mutation := support.GetBinlogMutation(t.tableID)
 	mutation.DeletedRows = append(mutation.DeletedRows, data)
 	mutation.Sequence = append(mutation.Sequence, binlog.MutationType_DeleteRow)
 	return nil
@@ -1679,19 +1684,11 @@ func (t *TableCommon) Type() table.Type {
 	return table.NormalTable
 }
 
-func shouldWriteBinlog(ctx table.MutateContext, tblInfo *model.TableInfo) bool {
-	failpoint.Inject("forceWriteBinlog", func() {
-		// Just to cover binlog related code in this package, since the `BinlogClient` is
-		// still nil, mutations won't be written to pump on commit.
-		failpoint.Return(true)
-	})
-	if !ctx.BinlogEnabled() {
-		return false
+func getBinlogSupport(ctx table.MutateContext, tblInfo *model.TableInfo) (tbctx.BinlogSupport, bool) {
+	if tblInfo.TempTableType != model.TempTableNone || ctx.InRestrictedSQL() {
+		return nil, false
 	}
-	if tblInfo.TempTableType != model.TempTableNone {
-		return false
-	}
-	return !ctx.InRestrictedSQL()
+	return ctx.GetBinlogSupport()
 }
 
 func (t *TableCommon) canSkip(col *table.Column, value *types.Datum) bool {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54397

Some fields/operations provided by `MutateContext` are optional. For example, binlog is not used in lighting import and all binlog operations should be skipped in this scene.

To make the `MutateContext` easy to construct and better decouple with `sessionctx.Context`. We can add some "optional" design for some fields or methods.

### What changed and how does it work?

We name some operational information with "XXXSupport" and provide methods "GetXXXSupport" to return them. These methods return two values, the first value is the optional object implements `XXXSupport` and the second value is a boolean that indicates whether it is supported.

In this PR, two optional objects are defined to support binlog and statistics update:

```go
// BinlogSupport is used for binlog operations
type BinlogSupport interface {
	// GetBinlogMutation returns a `binlog.TableMutation` object for a table.
	GetBinlogMutation(tblID int64) *binlog.TableMutation
}

// StatisticsSupport is used for statistics update operations.
type StatisticsSupport interface {
	// UpdatePhysicalTableDelta updates the physical table delta.
	UpdatePhysicalTableDelta(physicalTableID int64, delta int64, count int64, cols variable.DeltaCols)
}
```

The `MutateContext` also provides methods to get them:

```go
type MutateContext interface {
	// ...
	// GetBinlogSupport returns a `BinlogSupport` if the context supports it.
	// If the context does not support binlog, the second return value will be false.
	GetBinlogSupport() (BinlogSupport, bool)
	// GetStatisticsSupport returns a `StatisticsSupport` if the context supports it.
	// If the context does not support statistics update, the second return value will be false.
	GetStatisticsSupport() (StatisticsSupport, bool)
	// ...
}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
