### PR TITLE
gctuner: check intest flag in tests

### DIFF
--- a/pkg/util/gctuner/BUILD.bazel
+++ b/pkg/util/gctuner/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     race = "on",
     shard_count = 5,
     deps = [
+        "//pkg/util/intest",
         "//pkg/util/memory",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",

--- a/pkg/util/gctuner/finalizer_test.go
+++ b/pkg/util/gctuner/finalizer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,6 +30,7 @@ type testState struct {
 }
 
 func TestFinalizer(t *testing.T) {
+	require.True(t, intest.InTest)
 	debug.SetGCPercent(1000)
 	maxCount := int32(8)
 	state := &testState{}

--- a/pkg/util/gctuner/memory_limit_tuner_test.go
+++ b/pkg/util/gctuner/memory_limit_tuner_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/require"
 )
@@ -45,6 +46,7 @@ func (a *mockAllocator) freeAll() {
 }
 
 func TestGlobalMemoryTuner(t *testing.T) {
+	require.True(t, intest.InTest)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/gctuner/testMemoryLimitTuner", "return(true)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/util/gctuner/testMemoryLimitTuner"))
@@ -125,6 +127,7 @@ func TestGlobalMemoryTuner(t *testing.T) {
 }
 
 func TestIssue48741(t *testing.T) {
+	require.True(t, intest.InTest)
 	// Close GOGCTuner
 	gogcTuner := EnableGOGCTuner.Load()
 	EnableGOGCTuner.Store(false)

--- a/pkg/util/gctuner/tuner_test.go
+++ b/pkg/util/gctuner/tuner_test.go
@@ -18,12 +18,14 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/stretchr/testify/require"
 )
 
 var testHeap []byte
 
 func TestTuner(t *testing.T) {
+	require.True(t, intest.InTest)
 	EnableGOGCTuner.Store(true)
 	memLimit := uint64(1000 * 1024 * 1024) //1000 MB
 	threshold := memLimit / 2
@@ -93,6 +95,7 @@ func TestTuner(t *testing.T) {
 }
 
 func TestCalcGCPercent(t *testing.T) {
+	require.True(t, intest.InTest)
 	const gb = 1024 * 1024 * 1024
 	// use default value when invalid params
 	require.Equal(t, defaultGCPercent, calcGCPercent(0, 0))


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #54836

Problem Summary: sometime when we run test manually, we may forget to add `intest` flag

### What changed and how does it work?

check intest flag is set in tests

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
