### PR TITLE
executor: fix index_hash_join hang when context canceled

### DIFF
--- a/pkg/executor/join/BUILD.bazel
+++ b/pkg/executor/join/BUILD.bazel
@@ -79,7 +79,7 @@ go_test(
     ],
     embed = [":join"],
     flaky = True,
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/config",
         "//pkg/domain",
@@ -88,6 +88,7 @@ go_test(
         "//pkg/parser/ast",
         "//pkg/parser/mysql",
         "//pkg/planner/core",
+        "//pkg/session",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",
         "//pkg/testkit",

--- a/pkg/executor/join/index_lookup_hash_join.go
+++ b/pkg/executor/join/index_lookup_hash_join.go
@@ -784,6 +784,7 @@ func (iw *indexHashJoinInnerWorker) joinMatchedInnerRow2Chunk(ctx context.Contex
 			case iw.resultCh <- joinResult:
 			case <-ctx.Done():
 			}
+			failpoint.InjectCall("joinMatchedInnerRow2Chunk")
 			joinResult, ok = iw.getNewJoinResult(ctx)
 			if !ok {
 				return false, joinResult

--- a/pkg/executor/join/index_lookup_hash_join.go
+++ b/pkg/executor/join/index_lookup_hash_join.go
@@ -563,6 +563,7 @@ func (iw *indexHashJoinInnerWorker) getNewJoinResult(ctx context.Context) (*inde
 	select {
 	case joinResult.chk, ok = <-iw.joinChkResourceCh:
 	case <-ctx.Done():
+		joinResult.err = ctx.Err()
 		return joinResult, false
 	}
 	return joinResult, ok
@@ -783,6 +784,8 @@ func (iw *indexHashJoinInnerWorker) joinMatchedInnerRow2Chunk(ctx context.Contex
 			select {
 			case iw.resultCh <- joinResult:
 			case <-ctx.Done():
+				joinResult.err = ctx.Err()
+				return false, joinResult
 			}
 			failpoint.InjectCall("joinMatchedInnerRow2Chunk")
 			joinResult, ok = iw.getNewJoinResult(ctx)

--- a/pkg/executor/join/index_lookup_join_test.go
+++ b/pkg/executor/join/index_lookup_join_test.go
@@ -170,7 +170,7 @@ func TestIssue54688(t *testing.T) {
 				cancel()
 			},
 		))
-		_, err = session.GetRows4Test(context, nil, rs)
+		_, _ = session.GetRows4Test(context, nil, rs)
 		rs.Close()
 	}
 }

--- a/pkg/executor/join/index_lookup_join_test.go
+++ b/pkg/executor/join/index_lookup_join_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
@@ -133,4 +135,42 @@ func TestIssue45716(t *testing.T) {
 	err := tk.QueryToErr("select /*+ inl_join(t2) */ * from t1 join t2 on t1.a = t2.a;")
 	require.Error(t, err)
 	tk.MustContainErrMsg(err.Error(), "test inlNewInnerPanic")
+}
+
+func TestIssue54688(t *testing.T) {
+	val := runtime.GOMAXPROCS(1)
+	defer func() {
+		runtime.GOMAXPROCS(val)
+	}()
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t, s;")
+	tk.MustExec("create table t(a int, index(a));")
+	tk.MustExec("create table s(a int, index(a));")
+	tk.MustExec("insert into t values(1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15), (16);")
+	tk.MustExec("insert into s values(1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15), (16);")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("insert into s select * from s")
+	tk.MustExec("set @@tidb_index_lookup_join_concurrency=1;")
+	tk.MustExec("set @@tidb_index_join_batch_size=1000000;")
+
+	for i := 0; i <= 100; i++ {
+		rs, err := tk.Exec("select /*+ INL_HASH_JOIN(s) */ * from t join s on t.a=s.a")
+		require.NoError(t, err)
+		context, cancel := context.WithCancel(context.Background())
+		require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/pkg/executor/join/joinMatchedInnerRow2Chunk",
+			func() {
+				cancel()
+			},
+		))
+		_, err = session.GetRows4Test(context, nil, rs)
+		rs.Close()
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54688

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that index_hash_join could not exit properly when SQL was interrupted abnormally.
```
