### PR TITLE
executor, expression: detach projection and selection operator

### DIFF
--- a/pkg/executor/projection.go
+++ b/pkg/executor/projection.go
@@ -95,7 +95,7 @@ type ProjectionExec struct {
 	parentReqRows int64
 
 	memTracker *memory.Tracker
-	wg         sync.WaitGroup
+	wg         *sync.WaitGroup
 
 	calculateNoDelay bool
 	prepared         bool
@@ -136,6 +136,8 @@ func (e *ProjectionExec) open(_ context.Context) error {
 		e.childResult = exec.TryNewCacheChunk(e.Children(0))
 		e.memTracker.Consume(e.childResult.MemoryUsage())
 	}
+
+	e.wg = &sync.WaitGroup{}
 
 	return nil
 }

--- a/pkg/expression/evaluator.go
+++ b/pkg/expression/evaluator.go
@@ -79,18 +79,19 @@ func (e *defaultEvaluator) run(ctx EvalContext, vecEnabled bool, input, output *
 func (e *defaultEvaluator) RequiredOptionalEvalProps() context.OptionalEvalPropKeySet {
 	props := context.OptionalEvalPropKeySet(0)
 	for _, expr := range e.exprs {
-		props = props | getOptionalEvalPropsForExpr(expr)
+		props = props | GetOptionalEvalPropsForExpr(expr)
 	}
 
 	return props
 }
 
-func getOptionalEvalPropsForExpr(expr Expression) context.OptionalEvalPropKeySet {
+// GetOptionalEvalPropsForExpr gets all optional evaluation properties that this expression requires.
+func GetOptionalEvalPropsForExpr(expr Expression) context.OptionalEvalPropKeySet {
 	switch e := expr.(type) {
 	case *ScalarFunction:
 		props := e.Function.RequiredOptionalEvalProps()
 		for _, arg := range e.GetArgs() {
-			props = props | getOptionalEvalPropsForExpr(arg)
+			props = props | GetOptionalEvalPropsForExpr(arg)
 		}
 
 		return props
@@ -156,4 +157,13 @@ func (e *EvaluatorSuite) Run(ctx EvalContext, vecEnabled bool, input, output *ch
 		return e.columnEvaluator.run(ctx, input, output)
 	}
 	return nil
+}
+
+// RequiredOptionalEvalProps exposes all optional evaluation properties that this evaluator requires.
+func (e *EvaluatorSuite) RequiredOptionalEvalProps() context.OptionalEvalPropKeySet {
+	if e.defaultEvaluator != nil {
+		return e.defaultEvaluator.RequiredOptionalEvalProps()
+	}
+
+	return 0
 }

--- a/pkg/expression/evaluator_test.go
+++ b/pkg/expression/evaluator_test.go
@@ -649,10 +649,10 @@ func TestOptionalProp(t *testing.T) {
 
 	require.Equal(t, context.OptionalEvalPropKeySet(0), f.RequiredOptionalEvalProps())
 	require.Equal(t, context.OptPropCurrentUser.AsPropKeySet()|context.OptPropDDLOwnerInfo.AsPropKeySet(),
-		getOptionalEvalPropsForExpr(fe))
+		GetOptionalEvalPropsForExpr(fe))
 	require.Equal(t, context.OptPropCurrentUser.AsPropKeySet()|context.OptPropDDLOwnerInfo.AsPropKeySet()|
 		context.OptPropAdvisoryLock.AsPropKeySet(),
-		getOptionalEvalPropsForExpr(fe)|getOptionalEvalPropsForExpr(fe2))
+		GetOptionalEvalPropsForExpr(fe)|GetOptionalEvalPropsForExpr(fe2))
 
 	evalSuit := NewEvaluatorSuite([]Expression{fe, fe2}, false)
 	require.Equal(t, context.OptPropCurrentUser.AsPropKeySet()|context.OptPropDDLOwnerInfo.AsPropKeySet()|

--- a/pkg/server/tests/cursor/BUILD.bazel
+++ b/pkg/server/tests/cursor/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 5,
+    shard_count = 8,
     deps = [
         "//pkg/config",
         "//pkg/metrics",

--- a/pkg/server/tests/cursor/cursor_test.go
+++ b/pkg/server/tests/cursor/cursor_test.go
@@ -304,3 +304,205 @@ outerLoop:
 		}
 	}
 }
+
+func TestLazyExecuteProjection(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	mysqldriver := &mysqlcursor.MySQLDriver{}
+	rawConn, err := mysqldriver.Open(ts.GetDSNWithCursor(10))
+	require.NoError(t, err)
+	conn := rawConn.(mysqlcursor.Connection)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(), "drop table if exists t1", nil)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(context.Background(), "create table t1(id int primary key, v int)", nil)
+	require.NoError(t, err)
+	rowCount := 1000
+	for i := 0; i < rowCount; i++ {
+		_, err = conn.ExecContext(context.Background(), fmt.Sprintf("insert into t1 values(%d, %d)", i, i), nil)
+		require.NoError(t, err)
+	}
+
+	_, err = conn.ExecContext(context.Background(), "set tidb_enable_lazy_cursor_fetch = 'ON'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch", "return"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch"))
+	}()
+
+	// Normal execute. Simple table reader.
+	execTimes := 0
+outerLoop:
+	for execTimes < 50 {
+		execTimes++
+		rawStmt, err := conn.Prepare("select id + v from t1 order by id")
+		require.NoError(t, err)
+		stmt := rawStmt.(mysqlcursor.Statement)
+
+		// This query will return `rowCount` rows and use cursor fetch.
+		rows, err := stmt.QueryContext(context.Background(), nil)
+		require.NoError(t, err)
+
+		dest := make([]driver.Value, 1)
+		fetchRowCount := int64(0)
+
+		for {
+			// it'll send `FETCH` commands for every 10 rows.
+			err := rows.Next(dest)
+			if err != nil {
+				switch err {
+				case io.EOF:
+					require.Equal(t, int64(rowCount), fetchRowCount)
+					rows.Close()
+					break outerLoop
+				default:
+					require.NoError(t, err)
+				}
+			}
+			require.Equal(t, fetchRowCount*2, dest[0])
+			fetchRowCount++
+		}
+	}
+}
+
+func TestLazyExecuteSelection(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	mysqldriver := &mysqlcursor.MySQLDriver{}
+	rawConn, err := mysqldriver.Open(ts.GetDSNWithCursor(10))
+	require.NoError(t, err)
+	conn := rawConn.(mysqlcursor.Connection)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(), "drop table if exists t1", nil)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(context.Background(), "create table t1(id int primary key, v int)", nil)
+	require.NoError(t, err)
+	rowCount := 1000
+	for i := 0; i < rowCount; i++ {
+		_, err = conn.ExecContext(context.Background(), fmt.Sprintf("insert into t1 values(%d, %d)", i, i), nil)
+		require.NoError(t, err)
+	}
+
+	_, err = conn.ExecContext(context.Background(), "set tidb_enable_lazy_cursor_fetch = 'ON'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch", "return"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch"))
+	}()
+
+	// Normal execute. Simple table reader.
+	execTimes := 0
+outerLoop:
+	for execTimes < 50 {
+		execTimes++
+		rawStmt, err := conn.Prepare("select id from t1 where v >= ? order by id")
+		require.NoError(t, err)
+		stmt := rawStmt.(mysqlcursor.Statement)
+
+		// This query will return `rowCount - 500` rows and use cursor fetch.
+		rows, err := stmt.QueryContext(context.Background(), []driver.NamedValue{{Value: int64(500)}})
+		require.NoError(t, err)
+
+		dest := make([]driver.Value, 1)
+		fetchRowCount := int64(0)
+
+		for {
+			// it'll send `FETCH` commands for every 10 rows.
+			err := rows.Next(dest)
+			if err != nil {
+				switch err {
+				case io.EOF:
+					require.Equal(t, int64(rowCount-500), fetchRowCount)
+					rows.Close()
+					break outerLoop
+				default:
+					require.NoError(t, err)
+				}
+			}
+			require.Equal(t, fetchRowCount+500, dest[0])
+			fetchRowCount++
+		}
+	}
+}
+
+func TestLazyExecuteWithParam(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	mysqldriver := &mysqlcursor.MySQLDriver{}
+	rawConn, err := mysqldriver.Open(ts.GetDSNWithCursor(10))
+	require.NoError(t, err)
+	conn := rawConn.(mysqlcursor.Connection)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(), "drop table if exists t1", nil)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(context.Background(), "create table t1(id int primary key, v int)", nil)
+	require.NoError(t, err)
+	rowCount := 1000
+	for i := 0; i < rowCount; i++ {
+		_, err = conn.ExecContext(context.Background(), fmt.Sprintf("insert into t1 values(%d, %d)", i, i), nil)
+		require.NoError(t, err)
+	}
+
+	_, err = conn.ExecContext(context.Background(), "set tidb_enable_lazy_cursor_fetch = 'ON'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch", "return"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/server/avoidEagerCursorFetch"))
+	}()
+
+	// Normal execute. Simple table reader.
+	execTimes := 0
+outerLoop:
+	for execTimes < 50 {
+		execTimes++
+		rawStmt, err := conn.Prepare("select id from t1 where v >= ? and v <= ? order by id")
+		require.NoError(t, err)
+		stmt := rawStmt.(mysqlcursor.Statement)
+
+		// This query will return `rowCount - 500` rows and use cursor fetch.
+		rows, err := stmt.QueryContext(context.Background(), []driver.NamedValue{{Value: int64(500)}, {Value: int64(10000)}})
+		require.NoError(t, err)
+
+		dest := make([]driver.Value, 1)
+		fetchRowCount := int64(0)
+
+		for {
+			// it'll send `FETCH` commands for every 10 rows.
+			err := rows.Next(dest)
+			if err != nil {
+				switch err {
+				case io.EOF:
+					require.Equal(t, int64(rowCount-500), fetchRowCount)
+					rows.Close()
+					break outerLoop
+				default:
+					require.NoError(t, err)
+				}
+			}
+			require.Equal(t, fetchRowCount+500, dest[0])
+			fetchRowCount++
+
+			if fetchRowCount%50 == 0 {
+				// Run another query with only one parameter.
+				rawStmt, err := conn.Prepare("select id from t1 where v = ?")
+				require.NoError(t, err)
+				stmt := rawStmt.(mysqlcursor.Statement)
+
+				// This query will return `rowCount` rows and use cursor fetch.
+				rows, err := stmt.QueryContext(context.Background(), []driver.NamedValue{{Value: int64(500)}})
+				require.NoError(t, err)
+
+				dest := make([]driver.Value, 2)
+				require.NoError(t, rows.Next(dest))
+				require.Equal(t, int64(500), dest[0])
+				require.NoError(t, rawStmt.Close())
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #54863

Problem Summary:

The lazy cursor fetch didn't support `Projection` and `Selection`. This PR enables it to handle most of the `Projection` and `Selection` operator.

### What changed and how does it work?

Implement the `Detach` function for these operators.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
