### PR TITLE
infoschema,server: let SchemaSimpleTableInfos return error instead of panic

### DIFF
--- a/pkg/infoschema/context/infoschema.go
+++ b/pkg/infoschema/context/infoschema.go
@@ -36,7 +36,7 @@ type MetaOnlyInfoSchema interface {
 	AllSchemas() []*model.DBInfo
 	AllSchemaNames() []model.CIStr
 	SchemaTableInfos(ctx stdctx.Context, schema model.CIStr) ([]*model.TableInfo, error)
-	SchemaSimpleTableInfos(ctx stdctx.Context, schema model.CIStr) []*model.TableNameInfo
+	SchemaSimpleTableInfos(ctx stdctx.Context, schema model.CIStr) ([]*model.TableNameInfo, error)
 	Misc
 }
 

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -332,10 +332,10 @@ func (is *infoSchema) SchemaTableInfos(ctx stdctx.Context, schema model.CIStr) (
 }
 
 // SchemaSimpleTableInfos implements MetaOnlyInfoSchema.
-func (is *infoSchema) SchemaSimpleTableInfos(ctx stdctx.Context, schema model.CIStr) []*model.TableNameInfo {
+func (is *infoSchema) SchemaSimpleTableInfos(ctx stdctx.Context, schema model.CIStr) ([]*model.TableNameInfo, error) {
 	schemaTables, ok := is.schemaMap[schema.L]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	ret := make([]*model.TableNameInfo, 0, len(schemaTables.tables))
 	for _, t := range schemaTables.tables {
@@ -344,7 +344,7 @@ func (is *infoSchema) SchemaSimpleTableInfos(ctx stdctx.Context, schema model.CI
 			Name: t.Meta().Name,
 		})
 	}
-	return ret
+	return ret, nil
 }
 
 type tableInfoResult struct {

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -574,7 +574,7 @@ retry:
 }
 
 // SchemaSimpleTableInfos implements MetaOnlyInfoSchema.
-func (is *infoschemaV2) SchemaSimpleTableInfos(ctx context.Context, schema model.CIStr) []*model.TableNameInfo {
+func (is *infoschemaV2) SchemaSimpleTableInfos(ctx context.Context, schema model.CIStr) ([]*model.TableNameInfo, error) {
 	if IsSpecialDB(schema.L) {
 		raw, ok := is.Data.specials.Load(schema.L)
 		if ok {
@@ -586,15 +586,15 @@ func (is *infoschemaV2) SchemaSimpleTableInfos(ctx context.Context, schema model
 					Name: tbl.Meta().Name,
 				})
 			}
-			return ret
+			return ret, nil
 		}
-		return nil // something wrong?
+		return nil, nil // something wrong?
 	}
 
 retry:
 	dbInfo, ok := is.SchemaByName(schema)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	snapshot := is.r.Store().GetSnapshot(kv.NewVersion(is.ts))
 	// Using the KV timeout read feature to address the issue of potential DDL lease expiration when
@@ -604,7 +604,7 @@ retry:
 	tblInfos, err := m.ListSimpleTables(dbInfo.ID)
 	if err != nil {
 		if meta.ErrDBNotExists.Equal(err) {
-			return nil
+			return nil, nil
 		}
 		// Flashback statement could cause such kind of error.
 		// In theory that error should be handled in the lower layer, like client-go.
@@ -613,10 +613,9 @@ retry:
 			time.Sleep(200 * time.Millisecond)
 			goto retry
 		}
-		// TODO: error could happen, so do not panic!
-		panic(err)
+		return nil, errors.Trace(err)
 	}
-	return tblInfos
+	return tblInfos, nil
 }
 
 // FindTableInfoByPartitionID implements InfoSchema.FindTableInfoByPartitionID

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -1013,7 +1013,11 @@ func (h SchemaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// all table schemas in a specified database
 		if schema.SchemaExists(cDBName) {
 			if a := req.FormValue(handler.IDNameOnly); a == "true" {
-				tbs := schema.SchemaSimpleTableInfos(context.Background(), cDBName)
+				tbs, err := schema.SchemaSimpleTableInfos(context.Background(), cDBName)
+				if err != nil {
+					handler.WriteError(w, err)
+					return
+				}
 				writeDBSimpleTablesData(w, tbs)
 				return
 			}


### PR DESCRIPTION
… 

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54508

Problem Summary:

### What changed and how does it work?

Similiar issue, if tikv is unavailable, error is returnned. 
In that case, we should return error rather than panic.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
