### PR TITLE
pkg/parser: use clearer structures for RESOURCE GROUP ASTs

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -3772,9 +3772,9 @@ func SetDirectResourceGroupRunawayOption(resourceGroupSettings *model.ResourceGr
 		}
 		settings.ExecElapsedTimeMs = uint64(dur.Milliseconds())
 	case ast.RunawayAction:
-		settings.Action = model.RunawayActionType(opt.ActionOption.Type)
+		settings.Action = opt.ActionOption.Type
 	case ast.RunawayWatch:
-		settings.WatchType = model.RunawayWatchType(opt.WatchOption.Type)
+		settings.WatchType = opt.WatchOption.Type
 		if dur := opt.WatchOption.Duration; len(dur) > 0 {
 			dur, err := time.ParseDuration(dur)
 			if err != nil {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -3734,7 +3734,7 @@ func SetDirectResourceGroupSettings(groupInfo *model.ResourceGroupInfo, opt *ast
 			resourceGroupSettings.Runaway = nil
 		}
 		for _, opt := range opt.RunawayOptionList {
-			if err := SetDirectResourceGroupRunawayOption(resourceGroupSettings, opt.Tp, opt.StrValue, opt.IntValue); err != nil {
+			if err := SetDirectResourceGroupRunawayOption(resourceGroupSettings, opt); err != nil {
 				return err
 			}
 		}
@@ -3758,25 +3758,25 @@ func SetDirectResourceGroupSettings(groupInfo *model.ResourceGroupInfo, opt *ast
 }
 
 // SetDirectResourceGroupRunawayOption tries to set runaway part of the ResourceGroupSettings.
-func SetDirectResourceGroupRunawayOption(resourceGroupSettings *model.ResourceGroupSettings, typ ast.RunawayOptionType, stringVal string, intVal int32) error {
+func SetDirectResourceGroupRunawayOption(resourceGroupSettings *model.ResourceGroupSettings, opt *ast.ResourceGroupRunawayOption) error {
 	if resourceGroupSettings.Runaway == nil {
 		resourceGroupSettings.Runaway = &model.ResourceGroupRunawaySettings{}
 	}
 	settings := resourceGroupSettings.Runaway
-	switch typ {
+	switch opt.Tp {
 	case ast.RunawayRule:
 		// because execute time won't be too long, we use `time` pkg which does not support to parse unit 'd'.
-		dur, err := time.ParseDuration(stringVal)
+		dur, err := time.ParseDuration(opt.RuleOption.ExecElapsed)
 		if err != nil {
 			return err
 		}
 		settings.ExecElapsedTimeMs = uint64(dur.Milliseconds())
 	case ast.RunawayAction:
-		settings.Action = model.RunawayActionType(intVal)
+		settings.Action = model.RunawayActionType(opt.ActionOption.Type)
 	case ast.RunawayWatch:
-		settings.WatchType = model.RunawayWatchType(intVal)
-		if len(stringVal) > 0 {
-			dur, err := time.ParseDuration(stringVal)
+		settings.WatchType = model.RunawayWatchType(opt.WatchOption.Type)
+		if dur := opt.WatchOption.Duration; len(dur) > 0 {
+			dur, err := time.ParseDuration(dur)
 			if err != nil {
 				return err
 			}

--- a/pkg/executor/internal/querywatch/query_watch.go
+++ b/pkg/executor/internal/querywatch/query_watch.go
@@ -42,8 +42,9 @@ func setWatchOption(ctx context.Context,
 ) error {
 	switch op.Tp {
 	case ast.QueryWatchResourceGroup:
-		if op.ExprValue != nil {
-			expr, err := plannerutil.RewriteAstExprWithPlanCtx(sctx.GetPlanCtx(), op.ExprValue, nil, nil, false)
+		resourceGroupOption := op.ResourceGroupOption
+		if resourceGroupOption.GroupNameExpr != nil {
+			expr, err := plannerutil.RewriteAstExprWithPlanCtx(sctx.GetPlanCtx(), resourceGroupOption.GroupNameExpr, nil, nil, false)
 			if err != nil {
 				return err
 			}
@@ -56,12 +57,13 @@ func setWatchOption(ctx context.Context,
 			}
 			record.ResourceGroupName = name
 		} else {
-			record.ResourceGroupName = op.StrValue.L
+			record.ResourceGroupName = resourceGroupOption.GroupNameStr.L
 		}
 	case ast.QueryWatchAction:
-		record.Action = rmpb.RunawayAction(op.IntValue)
+		record.Action = rmpb.RunawayAction(op.ActionOption.Type)
 	case ast.QueryWatchType:
-		expr, err := plannerutil.RewriteAstExprWithPlanCtx(sctx.GetPlanCtx(), op.ExprValue, nil, nil, false)
+		textOption := op.TextOption
+		expr, err := plannerutil.RewriteAstExprWithPlanCtx(sctx.GetPlanCtx(), textOption.PatternExpr, nil, nil, false)
 		if err != nil {
 			return err
 		}
@@ -72,8 +74,9 @@ func setWatchOption(ctx context.Context,
 		if isNull {
 			return errors.Errorf("invalid watch text expression")
 		}
-		record.Watch = rmpb.RunawayWatchType(op.IntValue)
-		if op.BoolValue {
+		watchType := textOption.Type
+		record.Watch = rmpb.RunawayWatchType(watchType)
+		if textOption.SpecifiedType {
 			p := parser.New()
 			stmts, _, err := p.ParseSQL(strval)
 			if err != nil {
@@ -83,7 +86,7 @@ func setWatchOption(ctx context.Context,
 				return errors.Errorf("only support one SQL")
 			}
 			sql := stmts[0].Text()
-			switch model.RunawayWatchType(op.IntValue) {
+			switch model.RunawayWatchType(watchType) {
 			case model.WatchNone:
 				return errors.Errorf("watch type must be specified")
 			case model.WatchExact:

--- a/pkg/executor/internal/querywatch/query_watch.go
+++ b/pkg/executor/internal/querywatch/query_watch.go
@@ -86,7 +86,7 @@ func setWatchOption(ctx context.Context,
 				return errors.Errorf("only support one SQL")
 			}
 			sql := stmts[0].Text()
-			switch model.RunawayWatchType(watchType) {
+			switch watchType {
 			case model.WatchNone:
 				return errors.Errorf("watch type must be specified")
 			case model.WatchExact:

--- a/pkg/executor/internal/querywatch/query_watch.go
+++ b/pkg/executor/internal/querywatch/query_watch.go
@@ -76,7 +76,7 @@ func setWatchOption(ctx context.Context,
 		}
 		watchType := textOption.Type
 		record.Watch = rmpb.RunawayWatchType(watchType)
-		if textOption.SpecifiedType {
+		if textOption.TypeSpecified {
 			p := parser.New()
 			stmts, _, err := p.ParseSQL(strval)
 			if err != nil {

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -933,3 +933,55 @@ func TestTableOptionTTLRestoreWithTTLEnableOffFlag(t *testing.T) {
 		runNodeRestoreTestWithFlagsStmtChange(t, testCases, "%s", extractNodeFunc, ca.flags)
 	}
 }
+
+func TestResourceGroupDDLStmtRestore(t *testing.T) {
+	createTestCases := []NodeRestoreTestCase{
+		{
+			"CREATE RESOURCE GROUP IF NOT EXISTS rg1 RU_PER_SEC = 500 BURSTABLE",
+			"CREATE RESOURCE GROUP IF NOT EXISTS `rg1` RU_PER_SEC = 500, BURSTABLE = TRUE",
+		},
+		{
+			"CREATE RESOURCE GROUP IF NOT EXISTS rg2 RU_PER_SEC = 600",
+			"CREATE RESOURCE GROUP IF NOT EXISTS `rg2` RU_PER_SEC = 600",
+		},
+		{
+			"CREATE RESOURCE GROUP IF NOT EXISTS rg3 RU_PER_SEC = 100 PRIORITY = HIGH",
+			"CREATE RESOURCE GROUP IF NOT EXISTS `rg3` RU_PER_SEC = 100, PRIORITY = HIGH",
+		},
+		{
+			"CREATE RESOURCE GROUP IF NOT EXISTS rg1 RU_PER_SEC = 500 QUERY_LIMIT=(EXEC_ELAPSED='60s', ACTION=COOLDOWN)",
+			"CREATE RESOURCE GROUP IF NOT EXISTS `rg1` RU_PER_SEC = 500, QUERY_LIMIT = (EXEC_ELAPSED = '60s' ACTION = COOLDOWN)",
+		},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node.(*CreateResourceGroupStmt)
+	}
+	runNodeRestoreTest(t, createTestCases, "%s", extractNodeFunc)
+
+	alterTestCase := []NodeRestoreTestCase{
+		{
+			"ALTER RESOURCE GROUP rg1 QUERY_LIMIT=(EXEC_ELAPSED='60s', ACTION=KILL, WATCH=SIMILAR DURATION='10m')",
+			"ALTER RESOURCE GROUP `rg1` QUERY_LIMIT = (EXEC_ELAPSED = '60s' ACTION = KILL WATCH = SIMILAR DURATION = '10m')",
+		},
+		{
+			"ALTER RESOURCE GROUP rg1 QUERY_LIMIT=NULL",
+			"ALTER RESOURCE GROUP `rg1` QUERY_LIMIT = NULL",
+		},
+		{
+			"ALTER RESOURCE GROUP `default` BACKGROUND=(TASK_TYPES='br,ddl')",
+			"ALTER RESOURCE GROUP `default` BACKGROUND = (TASK_TYPES = 'br,ddl')",
+		},
+		{
+			"ALTER RESOURCE GROUP `default` BACKGROUND=NULL",
+			"ALTER RESOURCE GROUP `default` BACKGROUND = NULL",
+		},
+		{
+			"ALTER RESOURCE GROUP `default` BACKGROUND=(TASK_TYPES='')",
+			"ALTER RESOURCE GROUP `default` BACKGROUND = (TASK_TYPES = '')",
+		},
+	}
+	extractNodeFunc = func(node Node) Node {
+		return node.(*AlterResourceGroupStmt)
+	}
+	runNodeRestoreTest(t, alterTestCase, "%s", extractNodeFunc)
+}

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -4086,44 +4086,21 @@ const (
 // QueryWatchOption is used for parsing manual management of watching runaway queries option.
 type QueryWatchOption struct {
 	stmtNode
-	Tp        QueryWatchOptionType
-	StrValue  model.CIStr
-	IntValue  int32
-	ExprValue ExprNode
-	BoolValue bool
+	Tp                  QueryWatchOptionType
+	ResourceGroupOption *QueryWatchResourceGroupOption
+	ActionOption        *ResourceGroupRunawayActionOption
+	TextOption          *QueryWatchTextOption
 }
 
+// Restore implements Node interface.
 func (n *QueryWatchOption) Restore(ctx *format.RestoreCtx) error {
 	switch n.Tp {
 	case QueryWatchResourceGroup:
-		ctx.WriteKeyWord("RESOURCE GROUP ")
-		if n.ExprValue != nil {
-			if err := n.ExprValue.Restore(ctx); err != nil {
-				return errors.Annotatef(err, "An error occurred while splicing ExprValue: [%v]", n.ExprValue)
-			}
-		} else {
-			ctx.WriteName(n.StrValue.O)
-		}
+		return n.ResourceGroupOption.restore(ctx)
 	case QueryWatchAction:
-		ctx.WriteKeyWord("ACTION ")
-		ctx.WritePlain("= ")
-		ctx.WriteKeyWord(model.RunawayActionType(n.IntValue).String())
+		return n.ActionOption.Restore(ctx)
 	case QueryWatchType:
-		if n.BoolValue {
-			ctx.WriteKeyWord("SQL TEXT ")
-			ctx.WriteKeyWord(model.RunawayWatchType(n.IntValue).String())
-			ctx.WriteKeyWord(" TO ")
-		} else {
-			switch n.IntValue {
-			case int32(model.WatchSimilar):
-				ctx.WriteKeyWord("SQL DIGEST ")
-			case int32(model.WatchPlan):
-				ctx.WriteKeyWord("PLAN DIGEST ")
-			}
-		}
-		if err := n.ExprValue.Restore(ctx); err != nil {
-			return errors.Annotatef(err, "An error occurred while splicing ExprValue: [%v]", n.ExprValue)
-		}
+		return n.TextOption.Restore(ctx)
 	}
 	return nil
 }
@@ -4135,12 +4112,26 @@ func (n *QueryWatchOption) Accept(v Visitor) (Node, bool) {
 		return v.Leave(newNode)
 	}
 	n = newNode.(*QueryWatchOption)
-	if n.ExprValue != nil {
-		node, ok := n.ExprValue.Accept(v)
+	if n.ResourceGroupOption != nil && n.ResourceGroupOption.GroupNameExpr != nil {
+		node, ok := n.ResourceGroupOption.GroupNameExpr.Accept(v)
 		if !ok {
 			return n, false
 		}
-		n.ExprValue = node.(ExprNode)
+		n.ResourceGroupOption.GroupNameExpr = node.(ExprNode)
+	}
+	if n.ActionOption != nil {
+		node, ok := n.ActionOption.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.ActionOption = node.(*ResourceGroupRunawayActionOption)
+	}
+	if n.TextOption != nil {
+		node, ok := n.TextOption.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.TextOption = node.(*QueryWatchTextOption)
 	}
 	return v.Leave(n)
 }
@@ -4152,4 +4143,67 @@ func CheckQueryWatchAppend(ops []*QueryWatchOption, newOp *QueryWatchOption) boo
 		}
 	}
 	return true
+}
+
+// QueryWatchResourceGroupOption is used for parsing the query watch resource group name.
+type QueryWatchResourceGroupOption struct {
+	GroupNameStr  model.CIStr
+	GroupNameExpr ExprNode
+}
+
+func (n *QueryWatchResourceGroupOption) restore(ctx *format.RestoreCtx) error {
+	ctx.WriteKeyWord("RESOURCE GROUP ")
+	if n.GroupNameExpr != nil {
+		if err := n.GroupNameExpr.Restore(ctx); err != nil {
+			return errors.Annotatef(err, "An error occurred while splicing ExprValue: [%v]", n.GroupNameExpr)
+		}
+	} else {
+		ctx.WriteName(n.GroupNameStr.String())
+	}
+	return nil
+}
+
+// QueryWatchTextOption is used for parsing the query watch text option.
+type QueryWatchTextOption struct {
+	node
+	Type          model.RunawayWatchType
+	PatternExpr   ExprNode
+	SpecifiedType bool
+}
+
+// Restore implements Node interface.
+func (n *QueryWatchTextOption) Restore(ctx *format.RestoreCtx) error {
+	if n.SpecifiedType {
+		ctx.WriteKeyWord("SQL TEXT ")
+		ctx.WriteKeyWord(n.Type.String())
+		ctx.WriteKeyWord(" TO ")
+	} else {
+		switch n.Type {
+		case model.WatchSimilar:
+			ctx.WriteKeyWord("SQL DIGEST ")
+		case model.WatchPlan:
+			ctx.WriteKeyWord("PLAN DIGEST ")
+		}
+	}
+	if err := n.PatternExpr.Restore(ctx); err != nil {
+		return errors.Annotatef(err, "An error occurred while splicing ExprValue: [%v]", n.PatternExpr)
+	}
+	return nil
+}
+
+// Accept implements Node Accept interface.
+func (n *QueryWatchTextOption) Accept(v Visitor) (Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*QueryWatchTextOption)
+	if n.PatternExpr != nil {
+		node, ok := n.PatternExpr.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.PatternExpr = node.(ExprNode)
+	}
+	return v.Leave(n)
 }

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -4168,12 +4168,12 @@ type QueryWatchTextOption struct {
 	node
 	Type          model.RunawayWatchType
 	PatternExpr   ExprNode
-	SpecifiedType bool
+	TypeSpecified bool
 }
 
 // Restore implements Node interface.
 func (n *QueryWatchTextOption) Restore(ctx *format.RestoreCtx) error {
-	if n.SpecifiedType {
+	if n.TypeSpecified {
 		ctx.WriteKeyWord("SQL TEXT ")
 		ctx.WriteKeyWord(n.Type.String())
 		ctx.WriteKeyWord(" TO ")

--- a/pkg/parser/ast/misc_test.go
+++ b/pkg/parser/ast/misc_test.go
@@ -813,3 +813,24 @@ func TestDeniedByBDR(t *testing.T) {
 		assert.Equal(t, tc.expected, ast.DeniedByBDR(tc.role, tc.action, tc.job), fmt.Sprintf("role: %v, action: %v", tc.role, tc.action))
 	}
 }
+
+func TestAddQueryWatchStmtRestore(t *testing.T) {
+	testCases := []NodeRestoreTestCase{
+		{
+			"QUERY WATCH ADD ACTION KILL SQL TEXT EXACT TO 'select * from test.t2'",
+			"QUERY WATCH ADD ACTION = KILL SQL TEXT EXACT TO _UTF8MB4'select * from test.t2'",
+		},
+		{
+			"QUERY WATCH ADD RESOURCE GROUP rg1 SQL TEXT SIMILAR TO 'select * from test.t2'",
+			"QUERY WATCH ADD RESOURCE GROUP `rg1` SQL TEXT SIMILAR TO _UTF8MB4'select * from test.t2'",
+		},
+		{
+			"QUERY WATCH ADD RESOURCE GROUP rg1 ACTION COOLDOWN PLAN DIGEST 'd08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57'",
+			"QUERY WATCH ADD RESOURCE GROUP `rg1` ACTION = COOLDOWN PLAN DIGEST _UTF8MB4'd08bc323a934c39dc41948b0a073725be3398479b6fa4f6dd1db2a9b115f7f57'",
+		},
+	}
+	extractNodeFunc := func(node ast.Node) ast.Node {
+		return node.(*ast.AddQueryWatchStmt)
+	}
+	runNodeRestoreTest(t, testCases, "%s", extractNodeFunc)
+}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1793,29 +1793,29 @@ ResourceGroupRunawayOptionList:
 ResourceGroupRunawayWatchOption:
 	"EXACT"
 	{
-		$$ = int32(model.WatchExact)
+		$$ = model.WatchExact
 	}
 |	"SIMILAR"
 	{
-		$$ = int32(model.WatchSimilar)
+		$$ = model.WatchSimilar
 	}
 |	"PLAN"
 	{
-		$$ = int32(model.WatchPlan)
+		$$ = model.WatchPlan
 	}
 
 ResourceGroupRunawayActionOption:
 	"DRYRUN"
 	{
-		$$ = int32(model.RunawayActionDryRun)
+		$$ = &ast.ResourceGroupRunawayActionOption{Type: model.RunawayActionDryRun}
 	}
 |	"COOLDOWN"
 	{
-		$$ = int32(model.RunawayActionCooldown)
+		$$ = &ast.ResourceGroupRunawayActionOption{Type: model.RunawayActionCooldown}
 	}
 |	"KILL"
 	{
-		$$ = int32(model.RunawayActionKill)
+		$$ = &ast.ResourceGroupRunawayActionOption{Type: model.RunawayActionKill}
 	}
 
 DirectResourceGroupRunawayOption:
@@ -1826,11 +1826,19 @@ DirectResourceGroupRunawayOption:
 			yylex.AppendError(yylex.Errorf("The EXEC_ELAPSED option is not a valid duration: %s", err.Error()))
 			return 1
 		}
-		$$ = &ast.ResourceGroupRunawayOption{Tp: ast.RunawayRule, StrValue: $3}
+		$$ = &ast.ResourceGroupRunawayOption{
+			Tp: ast.RunawayRule,
+			RuleOption: &ast.ResourceGroupRunawayRuleOption{
+				ExecElapsed: $3,
+			},
+		}
 	}
 |	"ACTION" EqOpt ResourceGroupRunawayActionOption
 	{
-		$$ = &ast.ResourceGroupRunawayOption{Tp: ast.RunawayAction, IntValue: $3.(int32)}
+		$$ = &ast.ResourceGroupRunawayOption{
+			Tp:           ast.RunawayAction,
+			ActionOption: $3.(*ast.ResourceGroupRunawayActionOption),
+		}
 	}
 |	"WATCH" EqOpt ResourceGroupRunawayWatchOption WatchDurationOption
 	{
@@ -1845,7 +1853,13 @@ DirectResourceGroupRunawayOption:
 				return 1
 			}
 		}
-		$$ = &ast.ResourceGroupRunawayOption{Tp: ast.RunawayWatch, StrValue: dur, IntValue: $3.(int32)}
+		$$ = &ast.ResourceGroupRunawayOption{
+			Tp: ast.RunawayWatch,
+			WatchOption: &ast.ResourceGroupRunawayWatchOption{
+				Type:     $3.(model.RunawayWatchType),
+				Duration: dur,
+			},
+		}
 	}
 
 WatchDurationOption:
@@ -16250,33 +16264,59 @@ QueryWatchOptionList:
 QueryWatchOption:
 	"RESOURCE" "GROUP" ResourceGroupName
 	{
-		$$ = &ast.QueryWatchOption{Tp: ast.QueryWatchResourceGroup, StrValue: model.NewCIStr($3)}
+		$$ = &ast.QueryWatchOption{
+			Tp: ast.QueryWatchResourceGroup,
+			ResourceGroupOption: &ast.QueryWatchResourceGroupOption{
+				GroupNameStr: model.NewCIStr($3),
+			},
+		}
 	}
 |	"RESOURCE" "GROUP" UserVariable
 	{
-		$$ = &ast.QueryWatchOption{Tp: ast.QueryWatchResourceGroup, ExprValue: $3}
+		$$ = &ast.QueryWatchOption{
+			Tp: ast.QueryWatchResourceGroup,
+			ResourceGroupOption: &ast.QueryWatchResourceGroupOption{
+				GroupNameExpr: $3,
+			},
+		}
 	}
 |	"ACTION" EqOpt ResourceGroupRunawayActionOption
 	{
-		$$ = &ast.QueryWatchOption{Tp: ast.QueryWatchAction, IntValue: $3.(int32)}
+		$$ = &ast.QueryWatchOption{
+			Tp:           ast.QueryWatchAction,
+			ActionOption: $3.(*ast.ResourceGroupRunawayActionOption),
+		}
 	}
 |	QueryWatchTextOption
 	{
-		$$ = $1.(*ast.QueryWatchOption)
+		$$ = &ast.QueryWatchOption{
+			Tp:         ast.QueryWatchType,
+			TextOption: $1.(*ast.QueryWatchTextOption),
+		}
 	}
 
 QueryWatchTextOption:
 	"SQL" "DIGEST" SimpleExpr
 	{
-		$$ = &ast.QueryWatchOption{Tp: ast.QueryWatchType, IntValue: int32(model.WatchSimilar), ExprValue: $3}
+		$$ = &ast.QueryWatchTextOption{
+			Type:        model.WatchSimilar,
+			PatternExpr: $3,
+		}
 	}
 |	"PLAN" "DIGEST" SimpleExpr
 	{
-		$$ = &ast.QueryWatchOption{Tp: ast.QueryWatchType, IntValue: int32(model.WatchPlan), ExprValue: $3}
+		$$ = &ast.QueryWatchTextOption{
+			Type:        model.WatchPlan,
+			PatternExpr: $3,
+		}
 	}
 |	"SQL" "TEXT" ResourceGroupRunawayWatchOption "TO" SimpleExpr
 	{
-		$$ = &ast.QueryWatchOption{Tp: ast.QueryWatchType, IntValue: $3.(int32), ExprValue: $5, BoolValue: true}
+		$$ = &ast.QueryWatchTextOption{
+			Type:          $3.(model.RunawayWatchType),
+			PatternExpr:   $5,
+			SpecifiedType: true,
+		}
 	}
 
 DropQueryWatchStmt:

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -16315,7 +16315,7 @@ QueryWatchTextOption:
 		$$ = &ast.QueryWatchTextOption{
 			Type:          $3.(model.RunawayWatchType),
 			PatternExpr:   $5,
-			SpecifiedType: true,
+			TypeSpecified: true,
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54434.

### What changed and how does it work?

Before this PR, many `RESOURCE GROUP` and `QUERY WATCH` ASTs used ambiguous union struct fields to parse different options. This PR makes them use clearer structures to improve readability and extensibility.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
