### PR TITLE
metrics: add per-query-statement RPC count and scan processed key count metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -171,6 +171,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(PseudoEstimation)
 	prometheus.MustRegister(PacketIOCounter)
 	prometheus.MustRegister(QueryDurationHistogram)
+	prometheus.MustRegister(QueryRPCHistogram)
+	prometheus.MustRegister(QueryProcessedKeyHistogram)
 	prometheus.MustRegister(QueryTotalCounter)
 	prometheus.MustRegister(AffectedRowsCounter)
 	prometheus.MustRegister(SchemaLeaseErrorCounter)

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -27,15 +27,17 @@ var (
 
 // Metrics
 var (
-	PacketIOCounter        *prometheus.CounterVec
-	QueryDurationHistogram *prometheus.HistogramVec
-	QueryTotalCounter      *prometheus.CounterVec
-	AffectedRowsCounter    *prometheus.CounterVec
-	ConnGauge              *prometheus.GaugeVec
-	DisconnectionCounter   *prometheus.CounterVec
-	PreparedStmtGauge      prometheus.Gauge
-	ExecuteErrorCounter    *prometheus.CounterVec
-	CriticalErrorCounter   prometheus.Counter
+	PacketIOCounter            *prometheus.CounterVec
+	QueryDurationHistogram     *prometheus.HistogramVec
+	QueryRPCHistogram          *prometheus.HistogramVec
+	QueryProcessedKeyHistogram *prometheus.HistogramVec
+	QueryTotalCounter          *prometheus.CounterVec
+	AffectedRowsCounter        *prometheus.CounterVec
+	ConnGauge                  *prometheus.GaugeVec
+	DisconnectionCounter       *prometheus.CounterVec
+	PreparedStmtGauge          prometheus.Gauge
+	ExecuteErrorCounter        *prometheus.CounterVec
+	CriticalErrorCounter       prometheus.Counter
 
 	ServerStart = "server-start"
 	ServerStop  = "server-stop"
@@ -91,6 +93,24 @@ func InitServerMetrics() {
 			Help:      "Bucketed histogram of processing time (s) of handled queries.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
 		}, []string{LblSQLType, LblDb, LblResourceGroup})
+
+	QueryRPCHistogram = NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "query_statement_rpc_count",
+			Help:      "Bucketed histogram of execution rpc count of handled query statements.",
+			Buckets:   prometheus.ExponentialBuckets(1, 1.5, 23), // 1 ~ 8388608
+		}, []string{LblSQLType, LblDb})
+
+	QueryProcessedKeyHistogram = NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "query_statment_processed_keys",
+			Help:      "Bucketed histogram of processed key count during the scan of handled query statements.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 32),
+		}, []string{LblSQLType, LblDb})
 
 	QueryTotalCounter = NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1265,6 +1265,10 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 
 	for _, dbName := range session.GetDBNames(vars) {
 		metrics.QueryDurationHistogram.WithLabelValues(sqlType, dbName, vars.StmtCtx.ResourceGroupName).Observe(cost.Seconds())
+		metrics.QueryRPCHistogram.WithLabelValues(sqlType, dbName).Observe(float64(vars.StmtCtx.GetExecDetails().RequestCount))
+		if vars.StmtCtx.GetExecDetails().ScanDetail != nil {
+			metrics.QueryProcessedKeyHistogram.WithLabelValues(sqlType, dbName).Observe(float64(vars.StmtCtx.GetExecDetails().ScanDetail.ProcessedKeys))
+		}
 	}
 }
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #54887

Problem Summary:
Per-query-statement RPC count and processed key count are useful metrics to understand the TiKV request fan-out when debugging expensive queries.

Added two new server metrics(query_statement_rpc_count and query_statment_processed_keys) to keep track of the per query statement TiKV RPC count and scan processed key count information.  
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Tested the metrics by adding the p99, p80 prometheus queries to the two metrics in the local grafana dashboard.


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
