### PR TITLE
test: fix flaky test TestFailSchemaSyncer

### DIFF
--- a/pkg/ddl/tests/fail/fail_db_test.go
+++ b/pkg/ddl/tests/fail/fail_db_test.go
@@ -48,6 +48,10 @@ type failedSuite struct {
 }
 
 func createFailDBSuite(t *testing.T) (s *failedSuite) {
+	return createFailDBSuiteWithLease(t, 200*time.Millisecond)
+}
+
+func createFailDBSuiteWithLease(t *testing.T, lease time.Duration) (s *failedSuite) {
 	s = new(failedSuite)
 	var err error
 	s.store, err = mockstore.NewMockStore(
@@ -57,7 +61,7 @@ func createFailDBSuite(t *testing.T) (s *failedSuite) {
 		}),
 	)
 	require.NoError(t, err)
-	session.SetSchemaLease(200 * time.Millisecond)
+	session.SetSchemaLease(lease)
 	s.dom, err = session.BootstrapSession(s.store)
 	require.NoError(t, err)
 
@@ -220,7 +224,7 @@ func TestAddIndexFailed(t *testing.T) {
 // TestFailSchemaSyncer test when the schema syncer is done,
 // should prohibit DML executing until the syncer is restartd by loadSchemaInLoop.
 func TestFailSchemaSyncer(t *testing.T) {
-	s := createFailDBSuite(t)
+	s := createFailDBSuiteWithLease(t, 10*time.Second)
 	tk := testkit.NewTestKit(t, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #48758

Problem Summary:

### What changed and how does it work?
if after schema validator restart, there is no `reload` within 200ms which is the ddllease before this pr, `schemaValidator.latestSchemaExpire` will expire, so later insert will fail with `schema changed`
https://github.com/pingcap/tidb/blob/e0e8f89336e442e9cf6aa002469d291d075ace47/pkg/domain/domain.go#L1076
```
        	Error Trace:	/Users/xiedong/repos/tidb/pkg/testkit/testkit.go:157
        	            				/Users/xiedong/repos/tidb/pkg/testkit/testkit.go:150
        	            				/Users/xiedong/repos/tidb/pkg/ddl/tests/partition/db_partition_test.go:2674
        	Error:      	Received unexpected error:
        	            	[domain:8028]Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`. [try again later]
        	            	github.com/tikv/client-go/v2/txnkv/transaction.(*twoPhaseCommitter).checkSchemaValid
        	            		/Users/xiedong/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20240626064248-4a72526f6c30/txnkv/transaction/2pc.go:1871
        	            	github.com/tikv/client-go/v2/txnkv/transaction.(*twoPhaseCommitter).execute
        	            		/Users/xiedong/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20240626064248-4a72526f6c30/txnkv/transaction/2pc.go:1694
        	            	github.com/tikv/client-go/v2/txnkv/transaction.(*KVTxn).Commit
        	            		/Users/xiedong/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20240626064248-4a72526f6c30/txnkv/transaction/txn.go:714
        	            	github.com/pingcap/tidb/pkg/store/driver/txn.(*tikvTxn).Commit
        	            		/Users/xiedong/repos/tidb/pkg/store/driver/txn/txn_driver.go:117
        	            	github.com/pingcap/tidb/pkg/session.(*LazyTxn).Commit
        	            		/Users/xiedong/repos/tidb/pkg/session/txn.go:449
        	            	github.com/pingcap/tidb/pkg/session.(*session).commitTxnWithTemporaryData
        	            		/Users/xiedong/repos/tidb/pkg/session/session.go:670
        	            	github.com/pingcap/tidb/pkg/session.(*session).doCommit
        	            		/Users/xiedong/repos/tidb/pkg/session/session.go:550
        	            	github.com/pingcap/tidb/pkg/session.(*session).doCommitWithRetry
        	            		/Users/xiedong/repos/tidb/pkg/session/session.go:792
        	            	github.com/pingcap/tidb/pkg/session.(*session).CommitTxn
        	            		/Users/xiedong/repos/tidb/pkg/session/session.go:922
        	            	github.com/pingcap/tidb/pkg/session.autoCommitAfterStmt
        	            		/Users/xiedong/repos/tidb/pkg/session/tidb.go:281
        	            	github.com/pingcap/tidb/pkg/session.finishStmt
        	            		/Users/xiedong/repos/tidb/pkg/session/tidb.go:243
        	            	github.com/pingcap/tidb/pkg/session.runStmt
        	            		/Users/xiedong/repos/tidb/pkg/session/session.go:2320
        	            	github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt
        	            		/Users/xiedong/repos/tidb/pkg/session/session.go:2150
        	            	github.com/pingcap/tidb/pkg/testkit.(*TestKit).ExecWithContext
        	            		/Users/xiedong/repos/tidb/pkg/testkit/testkit.go:383
        	            	github.com/pingcap/tidb/pkg/testkit.(*TestKit).MustExecWithContext
        	            		/Users/xiedong/repos/tidb/pkg/testkit/testkit.go:155
        	            	github.com/pingcap/tidb/pkg/testkit.(*TestKit).MustExec
        	            		/Users/xiedong/repos/tidb/pkg/testkit/testkit.go:150
        	            	github.com/pingcap/tidb/pkg/ddl/tests/partition.TestPartitionErrorCode
        	            		/Users/xiedong/repos/tidb/pkg/ddl/tests/partition/db_partition_test.go:2674
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
