### PR TITLE
infoschema: fix a snapshot infoschema cache bug after v1 v2 switch

### DIFF
--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -37,6 +37,9 @@ type InfoCache struct {
 
 	r    autoid.Requirement
 	Data *Data
+
+	// upserted is true if Upsert() is called on InfoCache
+	upserted bool
 }
 
 type schemaAndTimestamp struct {
@@ -97,6 +100,7 @@ func (h *InfoCache) Upsert(is InfoSchema, schemaTS uint64) func() {
 		infoschema: is,
 		timestamp:  int64(schemaTS),
 	})
+	h.upserted = true
 
 	return func() {
 		// TODO: It's a bit tricky here, somewhere is holding the reference of the old infoschema.
@@ -223,10 +227,27 @@ func (h *InfoCache) getByVersionNoLock(version int64) InfoSchema {
 	//			return h.cache[i]
 	//		}
 	// ```
-
-	if i < len(h.cache) && (i != 0 || h.cache[i].infoschema.SchemaMetaVersion() == version) {
-		infoschema_metrics.HitVersionCounter.Inc()
-		return h.cache[i].infoschema
+	// upsert is a full reset of InfoCache, after upsert, the DDL history might lost and the assumption does not hold anymore.
+	// For example:
+	//     Before
+	//              infoschema 51
+	//              infoschema 52
+	//              infoschema 53
+	//              infoschema 54
+	//              infoschema 55
+	//              infoschema 56
+	//     After Upsert()
+	//              infoschema 56
+	//     Then load historial snapshot version 51
+	//              infoschema 51
+	//              infoschema 56
+	// Now, request for schema version 55, return infoschem 51 would be wrong!
+	//
+	if i < len(h.cache) {
+		if (i != 0 && !h.upserted) || h.cache[i].infoschema.SchemaMetaVersion() == version {
+			infoschema_metrics.HitVersionCounter.Inc()
+			return h.cache[i].infoschema
+		}
 	}
 	return nil
 }

--- a/pkg/infoschema/test/infoschemav2test/BUILD.bazel
+++ b/pkg/infoschema/test/infoschemav2test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "v2_test.go",
     ],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",
@@ -21,6 +21,7 @@ go_test(
         "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testsetup",
         "@com_github_stretchr_testify//require",
+        "@com_github_tikv_client_go_v2//oracle",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/infoschema/test/infoschemav2test/v2_test.go
+++ b/pkg/infoschema/test/infoschemav2test/v2_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 )
 
 func TestSpecialSchemas(t *testing.T) {
@@ -374,4 +375,46 @@ func TestFullLoadAndSnapshot(t *testing.T) {
 	tk.MustQuery("show tables").Check(testkit.Rows())
 	tk.MustExec("use db1")
 	tk.MustQuery("show tables").Check(testkit.Rows("t"))
+}
+
+func TestIssue54926(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_schema_cache_size = 0")
+	// For mocktikv, safe point is not initialized, we manually insert it for snapshot to use.
+	safePointName := "tikv_gc_safe_point"
+	safePointValue := "20160102-15:04:05 -0700"
+	safePointComment := "All versions after safe point can be accessed. (DO NOT EDIT)"
+	updateSafePoint := fmt.Sprintf(`INSERT INTO mysql.tidb VALUES ('%[1]s', '%[2]s', '%[3]s')
+	ON DUPLICATE KEY
+	UPDATE variable_value = '%[2]s', comment = '%[3]s'`, safePointName, safePointValue, safePointComment)
+	tk.MustExec(updateSafePoint)
+
+	time1 := time.Now()
+	time1TS := oracle.GoTimeToTS(time1)
+	schemaVer1 := tk.Session().GetInfoSchema().SchemaMetaVersion()
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (id int primary key);")
+	tk.MustExec(`drop table if exists t`)
+	time.Sleep(50 * time.Millisecond)
+	time2 := time.Now()
+	time2TS := oracle.GoTimeToTS(time2)
+	schemaVer2 := tk.Session().GetInfoSchema().SchemaMetaVersion()
+
+	tk2.MustExec("create table test.t (id int primary key)")
+	tk.MustExec("set @@global.tidb_schema_cache_size = 1073741824")
+	dom.Reload()
+
+	// test set txn as of will flush/mutex tidb_snapshot
+	tk.MustExec(fmt.Sprintf(`set @@tidb_snapshot="%s"`, time1.Format("2006-1-2 15:04:05.000")))
+	require.Equal(t, time1TS, tk.Session().GetSessionVars().SnapshotTS)
+	require.NotNil(t, tk.Session().GetSessionVars().SnapshotInfoschema)
+	require.Equal(t, schemaVer1, tk.Session().GetInfoSchema().SchemaMetaVersion())
+	tk.MustExec(fmt.Sprintf(`SET TRANSACTION READ ONLY AS OF TIMESTAMP '%s'`, time2.Format("2006-1-2 15:04:05.000")))
+	require.Equal(t, uint64(0), tk.Session().GetSessionVars().SnapshotTS)
+	require.NotNil(t, tk.Session().GetSessionVars().SnapshotInfoschema)
+	require.Equal(t, time2TS, tk.Session().GetSessionVars().TxnReadTS.PeakTxnReadTS())
+	require.Equal(t, schemaVer2, tk.Session().GetInfoSchema().SchemaMetaVersion())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54926

Problem Summary:

In infoschema cache.go, we maintain the infoschema snapsht history.
As the comment says:

```
	// `GetByVersion` is allowed to load the latest schema that is less than argument
	// `version` when the argument `version` <= the latest schema version.
	// if `version` > the latest schema version, always return nil, loadInfoSchema
	// will use this behavior to decide whether to load schema diffs or full reload.
	// Consider cache has values [10, 9, _, _, 6, 5, 4, 3, 2, 1], version 8 and 7 is empty because of the diff is empty.
	// If we want to get version 8, we can return version 6 because v7 and v8 do not change anything, they are totally the same,
	// in this case the `i` will not be 0.
```

However, when v1 & v2 infoschema switch, we reset the history (because co-exists of v1 and v2 would make the memory usage double), that change break the assumption.

```
	// For example:
	//     Before
	//              infoschema 51
	//              infoschema 52
	//              infoschema 53
	//              infoschema 54
	//              infoschema 55
	//              infoschema 56
	//     After Upsert()
	//              infoschema 56
	//     Then load historial snapshot version 51
	//              infoschema 51
	//              infoschema 56
	// Now, request for schema version 55, return infoschem 51 would be wrong!
```

### What changed and how does it work?

If upsert is called, use exact match for schema version compare.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
