### PR TITLE
planner: add some output when a flaky test fails

### DIFF
--- a/pkg/planner/core/plan_cost_ver1_test.go
+++ b/pkg/planner/core/plan_cost_ver1_test.go
@@ -121,7 +121,9 @@ func TestScanOnSmallTable(t *testing.T) {
 		}
 	}
 
-	rs := tk.MustQuery("explain select * from t").Rows()
+	result := tk.MustQuery("explain select * from t")
+	resStr := result.String()
+	rs := result.Rows()
 	useTiKVScan := false
 	for _, r := range rs {
 		op := r[0].(string)
@@ -130,5 +132,5 @@ func TestScanOnSmallTable(t *testing.T) {
 			useTiKVScan = true
 		}
 	}
-	require.True(t, useTiKVScan)
+	require.True(t, useTiKVScan, "should use tikv scan, but got:\n%s", resStr)
 }

--- a/pkg/testkit/result.go
+++ b/pkg/testkit/result.go
@@ -160,10 +160,27 @@ func (res *Result) CheckContain(expected string) {
 	res.require.Equal(true, false, comment)
 }
 
+func (res *Result) String() string {
+	var result strings.Builder
+	for i, row := range res.rows {
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		for j, colValue := range row {
+			if j > 0 {
+				result.WriteString(" ")
+			}
+			result.WriteString(colValue)
+		}
+	}
+	return result.String()
+}
+
 // MultiCheckContain checks whether the result contains strings in `expecteds`
 func (res *Result) MultiCheckContain(expecteds []string) {
+	result := res.String()
 	for _, expected := range expecteds {
-		res.CheckContain(expected)
+		res.require.True(strings.Contains(result, expected), "the result doesn't contain the exepected %s\n%s", expected, result)
 	}
 }
 
@@ -181,7 +198,8 @@ func (res *Result) CheckNotContain(unexpected string) {
 
 // MultiCheckNotContain checks whether the result doesn't contain the strings in `expected`
 func (res *Result) MultiCheckNotContain(unexpecteds []string) {
+	result := res.String()
 	for _, unexpected := range unexpecteds {
-		res.CheckNotContain(unexpected)
+		res.require.False(strings.Contains(result, unexpected), "the result contain the unexepected %s\n%s", unexpected, result)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

![image](https://github.com/user-attachments/assets/bb747c6b-57fe-4858-ae9e-bb22b38c8636)
This test is unstable in CI.

### What changed and how does it work?

Add some output when it fails, and try to make it stable later.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
