### PR TITLE
planner: fix extract correlated column for expand in building phase will panic.

### DIFF
--- a/pkg/planner/core/logical_expand.go
+++ b/pkg/planner/core/logical_expand.go
@@ -144,6 +144,15 @@ func (p *LogicalExpand) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([
 
 // ExtractCorrelatedCols implements base.LogicalPlan.<15th> interface.
 func (p *LogicalExpand) ExtractCorrelatedCols() []*expression.CorrelatedColumn {
+	// if p.LevelExprs is nil, it means the GenLevelProjections has not been called yet,
+	// which is done in logical optimizing phase. While for building correlated subquery
+	// plan, the ExtractCorrelatedCols will be called once after building, so we should
+	// distinguish the case here.
+	if p.LevelExprs == nil {
+		// since level projections generation don't produce any correlated columns, just
+		// return nil.
+		return nil
+	}
 	corCols := make([]*expression.CorrelatedColumn, 0, len(p.LevelExprs[0]))
 	for _, lExpr := range p.LevelExprs {
 		for _, expr := range lExpr {

--- a/tests/integrationtest/r/executor/expand.result
+++ b/tests/integrationtest/r/executor/expand.result
@@ -300,3 +300,26 @@ GROUP BY product WITH ROLLUP) AS tmp
 WHERE product is null;
 product	SUM
 NULL	7785
+
+SELECT product FROM t1 WHERE EXISTS
+(SELECT product, country_id , SUM(profit) FROM t1 AS t2
+WHERE t1.product=t2.product GROUP BY product, country_id WITH ROLLUP
+HAVING SUM(profit) > 6000);
+product
+Computer
+Computer
+Computer
+Computer
+Computer
+
+SELECT product, country_id , year, SUM(profit) FROM t1
+GROUP BY product, country_id, year HAVING country_id is NULL;
+product	country_id	year	SUM(profit)
+SELECT CONCAT(':',product,':'), SUM(profit), AVG(profit) FROM t1
+GROUP BY product WITH ROLLUP;
+CONCAT(':',product,':')	SUM(profit)	AVG(profit)
+NULL	7785	519.0000
+:TV:	600	120.0000
+:Calculator:	275	68.7500
+:Phone:	10	10.0000
+:Computer:	6900	1380.0000

--- a/tests/integrationtest/r/executor/expand.result
+++ b/tests/integrationtest/r/executor/expand.result
@@ -315,11 +315,12 @@ Computer
 SELECT product, country_id , year, SUM(profit) FROM t1
 GROUP BY product, country_id, year HAVING country_id is NULL;
 product	country_id	year	SUM(profit)
+
 SELECT CONCAT(':',product,':'), SUM(profit), AVG(profit) FROM t1
 GROUP BY product WITH ROLLUP;
 CONCAT(':',product,':')	SUM(profit)	AVG(profit)
 NULL	7785	519.0000
-:TV:	600	120.0000
 :Calculator:	275	68.7500
-:Phone:	10	10.0000
 :Computer:	6900	1380.0000
+:Phone:	10	10.0000
+:TV:	600	120.0000

--- a/tests/integrationtest/t/executor/expand.test
+++ b/tests/integrationtest/t/executor/expand.test
@@ -131,3 +131,22 @@ t1.country_id=t2.country_id GROUP BY product, country, year WITH ROLLUP;
 SELECT product, `SUM` FROM (SELECT product, SUM(profit) AS 'sum' FROM t1
                             GROUP BY product WITH ROLLUP) AS tmp
 WHERE product is null;
+
+--echo
+--sorted_result
+SELECT product FROM t1 WHERE EXISTS
+(SELECT product, country_id , SUM(profit) FROM t1 AS t2
+ WHERE t1.product=t2.product GROUP BY product, country_id WITH ROLLUP
+ HAVING SUM(profit) > 6000);
+
+--echo
+--sorted_result
+# The following does not return the expected answer, but this is a limitation
+# in the implementation so we should just document it
+SELECT product, country_id , year, SUM(profit) FROM t1
+GROUP BY product, country_id, year HAVING country_id is NULL;
+
+--echo
+--sorted_result
+SELECT CONCAT(':',product,':'), SUM(profit), AVG(profit) FROM t1
+GROUP BY product WITH ROLLUP;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54983

Problem Summary:

### What changed and how does it work?
expand is an operator that will generate additional columns based on what the child outputs, so in the building phase, construct expand's proj exprs is too much earlier until the column pruning logic is done in the logical optimizing phase.

that's means `expand.exprs` will be nil in the plan building phase if we use it in the time, it will cause panic. For extracting correlated columns logic, we could simply return nil(what the correlated columns it may generate later must exist its child) because expand itself doesn't produce any correlated columns inside.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix extract correlated column for expand in building phase will panic.
优化器：修复在 build 子查询阶段抽取 expand 算子关联列时会 panic
```
