### PR TITLE
server: add tidb_enable_shared_lock_promotion to support for share lock upgrade

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1151,8 +1151,8 @@ func (e *SelectLockExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	if err != nil {
 		return err
 	}
-	// If there's no handle or it's not a `SELECT FOR UPDATE` statement.
-	if len(e.tblID2Handle) == 0 || (!logicalop.IsSelectForUpdateLockType(e.Lock.LockType)) {
+	// If there's no handle or it's not a `SELECT FOR UPDATE` or `SELECT FOR SHARE` statement.
+	if len(e.tblID2Handle) == 0 || (!logicalop.IsSupportedSelectLockType(e.Lock.LockType)) {
 		return nil
 	}
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1185,7 +1185,7 @@ func (e *SelectLockExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		return nil
 	}
 	lockWaitTime := e.Ctx().GetSessionVars().LockWaitTimeout
-	if e.Lock.LockType == ast.SelectLockForUpdateNoWait {
+	if e.Lock.LockType == ast.SelectLockForUpdateNoWait || e.Lock.LockType == ast.SelectLockForShareNoWait {
 		lockWaitTime = tikvstore.LockNoWait
 	} else if e.Lock.LockType == ast.SelectLockForUpdateWaitN {
 		lockWaitTime = int64(e.Lock.WaitSec) * 1000

--- a/pkg/parser/ast/util.go
+++ b/pkg/parser/ast/util.go
@@ -26,7 +26,8 @@ func IsReadOnly(node Node) bool {
 	case *SelectStmt:
 		if st.LockInfo != nil {
 			switch st.LockInfo.LockType {
-			case SelectLockForUpdate, SelectLockForUpdateNoWait, SelectLockForUpdateWaitN:
+			case SelectLockForUpdate, SelectLockForUpdateNoWait, SelectLockForUpdateWaitN,
+				SelectLockForShare, SelectLockForShareNoWait:
 				return false
 			}
 		}

--- a/pkg/planner/core/operator/logicalop/logical_lock.go
+++ b/pkg/planner/core/operator/logicalop/logical_lock.go
@@ -141,14 +141,26 @@ func (p *LogicalLock) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([]b
 // ConvertOuterToInnerJoin inherits BaseLogicalPlan.LogicalPlan.<24th> implementation.
 
 // *************************** end implementation of logicalPlan interface ***************************
-
-// IsSelectForUpdateLockType checks if the select lock type is for update type.
-func IsSelectForUpdateLockType(lockType ast.SelectLockType) bool {
+// isSelectForUpdateLockType checks if the select lock type is the supported for update type.
+func isSelectForUpdateLockType(lockType ast.SelectLockType) bool {
 	if lockType == ast.SelectLockForUpdate ||
-		lockType == ast.SelectLockForShare ||
 		lockType == ast.SelectLockForUpdateNoWait ||
 		lockType == ast.SelectLockForUpdateWaitN {
 		return true
 	}
 	return false
+}
+
+// isSelectForShareLockType checks if the select lock type is supported for  type.
+func isSelectForShareLockType(lockType ast.SelectLockType) bool {
+	if lockType == ast.SelectLockForShare ||
+		lockType == ast.SelectLockForShareNoWait {
+		return true
+	}
+	return false
+}
+
+// IsSupportedSelectLockType checks if the lockType is supported to acquire pessimsitic locks if necessary.
+func IsSupportedSelectLockType(lockType ast.SelectLockType) bool {
+	return isSelectForUpdateLockType(lockType) || isSelectForShareLockType(lockType)
 }

--- a/pkg/planner/core/operator/logicalop/logical_lock.go
+++ b/pkg/planner/core/operator/logicalop/logical_lock.go
@@ -53,7 +53,7 @@ func (p LogicalLock) Init(ctx base.PlanContext) *LogicalLock {
 // PruneColumns implements base.LogicalPlan.<2nd> interface.
 func (p *LogicalLock) PruneColumns(parentUsedCols []*expression.Column, opt *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, error) {
 	var err error
-	if !IsSelectForUpdateLockType(p.Lock.LockType) {
+	if !IsSupportedSelectLockType(p.Lock.LockType) {
 		// when use .baseLogicalPlan to call the PruneColumns, it means current plan itself has
 		// nothing to pruning or plan change, so they resort to its children's column pruning logic.
 		// so for the returned logical plan here, p is definitely determined, we just need to collect

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -389,6 +389,8 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 	hash = append(hash, bool2Byte(vars.InTxn()))
 	hash = append(hash, bool2Byte(vars.IsAutocommit()))
 	hash = append(hash, bool2Byte(config.GetGlobalConfig().PessimisticTxn.PessimisticAutoCommit.Load()))
+	hash = append(hash, bool2Byte(vars.StmtCtx.ForShareLockEnabledByNoop))
+	hash = append(hash, bool2Byte(vars.SharedLockPromotion))
 
 	return string(hash), binding, true, "", nil
 }

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -944,33 +944,9 @@ func TryFastPlan(ctx base.PlanContext, node ast.Node) (p base.Plan) {
 	return nil
 }
 
-// isSelectForUpdateLockType checks if the select lock type is the supported for update type.
-func isSelectForUpdateLockType(lockType ast.SelectLockType) bool {
-	if lockType == ast.SelectLockForUpdate ||
-		lockType == ast.SelectLockForUpdateNoWait ||
-		lockType == ast.SelectLockForUpdateWaitN {
-		return true
-	}
-	return false
-}
-
-// isSelectForShareLockType checks if the select lock type is supported for  type.
-func isSelectForShareLockType(lockType ast.SelectLockType) bool {
-	if lockType == ast.SelectLockForShare ||
-		lockType == ast.SelectLockForShareNoWait {
-		return true
-	}
-	return false
-}
-
-// IsSupportedSelectLockType checks if the lockType is supported to acquire pessimsitic locks if necessary.
-func IsSupportedSelectLockType(lockType ast.SelectLockType) bool {
-	return isSelectForUpdateLockType(lockType) || isSelectForShareLockType(lockType)
-}
-
 func getLockWaitTime(ctx base.PlanContext, lockInfo *ast.SelectLockInfo) (lock bool, waitTime int64) {
 	if lockInfo != nil {
-		if logicalop.IsSelectForUpdateLockType(lockInfo.LockType) {
+		if logicalop.IsSupportedSelectLockType(lockInfo.LockType) {
 			// Locking of rows for update using SELECT FOR UPDATE only applies when autocommit
 			// is disabled (either by beginning transaction with START TRANSACTION or by setting
 			// autocommit to 0. If autocommit is enabled, the rows matching the specification are not locked.

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -15,7 +15,6 @@
 package core
 
 import (
-	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	math2 "math"
 	"strconv"
 	"strings"
@@ -35,6 +34,7 @@ import (
 	ptypes "github.com/pingcap/tidb/pkg/parser/types"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/baseimpl"
+	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/costusage"

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -963,6 +963,7 @@ func isSelectForShareLockType(lockType ast.SelectLockType) bool {
 	return false
 }
 
+// IsSupportedSelectLockType checks if the lockType is supported to acquire pessimsitic locks if necessary.
 func IsSupportedSelectLockType(lockType ast.SelectLockType) bool {
 	return isSelectForUpdateLockType(lockType) || isSelectForShareLockType(lockType)
 }

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1139,6 +1139,9 @@ func (p *preprocessor) checkCreateIndexGrammar(stmt *ast.CreateIndexStmt) {
 func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 	noopFuncsMode := p.sctx.GetSessionVars().NoopFuncsMode
 	if noopFuncsMode == variable.OnInt {
+		// Set `ForShareLockEnabledByNoop` properly before returning.
+		// When `tidb_enable_shared_lock_promotion` is enabled, the `for share` statements would be
+		// executed as `for update` statements despite setting of noop functions.
 		if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
 			stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
 			!p.sctx.GetSessionVars().SharedLockPromotion {

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1141,7 +1141,7 @@ func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 	if noopFuncsMode == variable.OnInt {
 		if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
 			stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
-			!p.sctx.GetSessionVars().SharedLockUpgrade {
+			!p.sctx.GetSessionVars().SharedLockPromotion {
 			p.sctx.GetSessionVars().StmtCtx.ForShareLockEnabledByNoop = true
 		}
 		return
@@ -1156,11 +1156,11 @@ func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 		p.sctx.GetSessionVars().StmtCtx.AppendWarning(err)
 	}
 
-	// When `tidb_enable_shared_lock_upgrade` is enabled, the `for share` statements would be
+	// When `tidb_enable_shared_lock_promotion` is enabled, the `for share` statements would be
 	// executed as `for update` statements.
 	if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
 		stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
-		!p.sctx.GetSessionVars().SharedLockUpgrade {
+		!p.sctx.GetSessionVars().SharedLockPromotion {
 		err := expression.ErrFunctionsNoopImpl.GenWithStackByArgs("LOCK IN SHARE MODE")
 		if noopFuncsMode == variable.OffInt {
 			p.err = err

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1139,6 +1139,11 @@ func (p *preprocessor) checkCreateIndexGrammar(stmt *ast.CreateIndexStmt) {
 func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 	noopFuncsMode := p.sctx.GetSessionVars().NoopFuncsMode
 	if noopFuncsMode == variable.OnInt {
+		if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
+			stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
+			!p.sctx.GetSessionVars().SharedLockUpgrade {
+			p.sctx.GetSessionVars().StmtCtx.ForShareLockEnabledByNoop = true
+		}
 		return
 	}
 	if stmt.SelectStmtOpts != nil && stmt.SelectStmtOpts.CalcFoundRows {
@@ -1150,7 +1155,12 @@ func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 		// NoopFuncsMode is Warn, append an error
 		p.sctx.GetSessionVars().StmtCtx.AppendWarning(err)
 	}
-	if stmt.LockInfo != nil && stmt.LockInfo.LockType == ast.SelectLockForShare {
+
+	// When `tidb_enable_shared_lock_upgrade` is enabled, the `for share` statements would be
+	// executed as `for update` statements.
+	if stmt.LockInfo != nil && (stmt.LockInfo.LockType == ast.SelectLockForShare ||
+		stmt.LockInfo.LockType == ast.SelectLockForShareNoWait) &&
+		!p.sctx.GetSessionVars().SharedLockUpgrade {
 		err := expression.ErrFunctionsNoopImpl.GenWithStackByArgs("LOCK IN SHARE MODE")
 		if noopFuncsMode == variable.OffInt {
 			p.err = err
@@ -1158,6 +1168,7 @@ func (p *preprocessor) checkSelectNoopFuncs(stmt *ast.SelectStmt) {
 		}
 		// NoopFuncsMode is Warn, append an error
 		p.sctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		p.sctx.GetSessionVars().StmtCtx.ForShareLockEnabledByNoop = true
 	}
 }
 

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -428,6 +428,11 @@ type StatementContext struct {
 
 	// MDLRelatedTableIDs is used to store the table IDs that are related to the current MDL lock.
 	MDLRelatedTableIDs map[int64]struct{}
+
+	// ForShareLockEnabledByNoop indicates whether the current statement contains `for share` clause
+	// and the `for share` execution is enabled by `tidb_enable_noop_functions`, no locks should be
+	// acquired in this case.
+	ForShareLockEnabledByNoop bool
 }
 
 // DefaultStmtErrLevels is the default error levels for statement

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1657,6 +1657,10 @@ type SessionVars struct {
 
 	// EnableLazyCursorFetch defines whether to enable the lazy cursor fetch.
 	EnableLazyCursorFetch bool
+
+	// SharedLockUpgrade indicates whether the `select for lock` statements would be executed as the
+	// `select for update` statements which do acquire pessimsitic locks.
+	SharedLockUpgrade bool
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.
@@ -3920,6 +3924,9 @@ func (s *SessionVars) UseLowResolutionTSO() bool {
 // statement execution. There are cases the `for update` clause should not take effect, like autocommit
 // statements with “pessimistic-auto-commit disabled.
 func (s *SessionVars) PessimisticLockEligible() bool {
+	if s.StmtCtx.ForShareLockEnabledByNoop {
+		return false
+	}
 	if !s.IsAutocommit() || s.InTxn() || (config.GetGlobalConfig().
 		PessimisticTxn.PessimisticAutoCommit.Load() && !s.BulkDMLEnabled) {
 		return true

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1658,9 +1658,9 @@ type SessionVars struct {
 	// EnableLazyCursorFetch defines whether to enable the lazy cursor fetch.
 	EnableLazyCursorFetch bool
 
-	// SharedLockUpgrade indicates whether the `select for lock` statements would be executed as the
+	// SharedLockPromotion indicates whether the `select for lock` statements would be executed as the
 	// `select for update` statements which do acquire pessimsitic locks.
-	SharedLockUpgrade bool
+	SharedLockPromotion bool
 }
 
 // GetOptimizerFixControlMap returns the specified value of the optimizer fix control.

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3291,7 +3291,7 @@ var defaultSysVars = []*SysVar{
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableSharedLockUpgrade, Value: BoolToOnOff(DefTiDBEnableSharedLockUpgrade), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		if s.NoopFuncsMode != OffInt && TiDBOptOn(val) {
-			return errors.Errorf("%v could not be set when %v is enabled", TiDBEnableSharedLockUpgrade, TiDBEnableNoopFuncs)
+			logutil.BgLogger().Warn("tidb_enable_shared_lock_upgrade set to on would override tidb_enable_noop_functions on")
 		}
 		s.SharedLockUpgrade = TiDBOptOn(val)
 		return nil

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3289,6 +3289,13 @@ var defaultSysVars = []*SysVar{
 		s.EnableLazyCursorFetch = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableSharedLockUpgrade, Value: BoolToOnOff(DefTiDBEnableSharedLockUpgrade), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		if s.NoopFuncsMode != OffInt && TiDBOptOn(val) {
+			return errors.Errorf("%v could not be set when %v is enabled", TiDBEnableSharedLockUpgrade, TiDBEnableNoopFuncs)
+		}
+		s.SharedLockUpgrade = TiDBOptOn(val)
+		return nil
+	}},
 }
 
 // GlobalSystemVariableInitialValue gets the default value for a system variable including ones that are dynamically set (e.g. based on the store)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3289,11 +3289,11 @@ var defaultSysVars = []*SysVar{
 		s.EnableLazyCursorFetch = TiDBOptOn(val)
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableSharedLockUpgrade, Value: BoolToOnOff(DefTiDBEnableSharedLockUpgrade), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableSharedLockPromotion, Value: BoolToOnOff(DefTiDBEnableSharedLockPromotion), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		if s.NoopFuncsMode != OffInt && TiDBOptOn(val) {
-			logutil.BgLogger().Warn("tidb_enable_shared_lock_upgrade set to on would override tidb_enable_noop_functions on")
+			logutil.BgLogger().Warn("tidb_enable_shared_lock_promotion set to on would override tidb_enable_noop_functions on")
 		}
-		s.SharedLockUpgrade = TiDBOptOn(val)
+		s.SharedLockPromotion = TiDBOptOn(val)
 		return nil
 	}},
 }

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -966,6 +966,10 @@ const (
 	// DivPrecisionIncrement indicates the number of digits by which to increase the scale of the result of
 	// division operations performed with the / operator.
 	DivPrecisionIncrement = "div_precision_increment"
+
+	// TiDBEnableSharedLockUpgrade indicates whether the `select for share` statement would be executed
+	// as `select for update` statements which do acquire pessimistic locks.
+	TiDBEnableSharedLockUpgrade = "tidb_enable_shared_lock_upgrade"
 )
 
 // TiDB vars that have only global scope
@@ -1525,6 +1529,7 @@ const (
 	DefDefaultWeekFormat                              = "0"
 	DefTiDBEnableLazyCursorFetch                      = false
 	DefOptEnableProjectionPushDown                    = true
+	DefTiDBEnableSharedLockUpgrade                    = false
 )
 
 // Process global variables.

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -967,9 +967,9 @@ const (
 	// division operations performed with the / operator.
 	DivPrecisionIncrement = "div_precision_increment"
 
-	// TiDBEnableSharedLockUpgrade indicates whether the `select for share` statement would be executed
+	// TiDBEnableSharedLockPromotion indicates whether the `select for share` statement would be executed
 	// as `select for update` statements which do acquire pessimistic locks.
-	TiDBEnableSharedLockUpgrade = "tidb_enable_shared_lock_upgrade"
+	TiDBEnableSharedLockPromotion = "tidb_enable_shared_lock_promotion"
 )
 
 // TiDB vars that have only global scope
@@ -1529,7 +1529,7 @@ const (
 	DefDefaultWeekFormat                              = "0"
 	DefTiDBEnableLazyCursorFetch                      = false
 	DefOptEnableProjectionPushDown                    = true
-	DefTiDBEnableSharedLockUpgrade                    = false
+	DefTiDBEnableSharedLockPromotion                  = false
 )
 
 // Process global variables.

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -3603,7 +3603,7 @@ func TestEndTxnOnLockExpire(t *testing.T) {
 	}
 }
 
-func TestForShareWithUpgrade(t *testing.T) {
+func TestForShareWithPromotion(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk1 := testkit.NewTestKit(t, store)
@@ -3623,7 +3623,7 @@ func TestForShareWithUpgrade(t *testing.T) {
 		{true, true},
 	} {
 		tk.MustExec(fmt.Sprintf("set @@tidb_enable_noop_functions = %v", tt.ForShareNoopEnable))
-		tk.MustExec(fmt.Sprintf("set @@tidb_enable_shared_lock_upgrade = %v", tt.ForShareUpgradeEnabled))
+		tk.MustExec(fmt.Sprintf("set @@tidb_enable_shared_lock_promotion = %v", tt.ForShareUpgradeEnabled))
 
 		tk1.MustExec("begin")
 		tk1.MustQuery("select * from t for update").Check(testkit.Rows("1 10"))

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -3623,23 +3623,13 @@ func TestForShareWithUpgrade(t *testing.T) {
 		{true, true},
 	} {
 		tk.MustExec(fmt.Sprintf("set @@tidb_enable_noop_functions = %v", tt.ForShareNoopEnable))
-		_, err := tk.Exec(fmt.Sprintf("set @@tidb_enable_shared_lock_upgrade = %v", tt.ForShareUpgradeEnabled))
-		if tt.ForShareNoopEnable && tt.ForShareUpgradeEnabled {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-		}
+		tk.MustExec(fmt.Sprintf("set @@tidb_enable_shared_lock_upgrade = %v", tt.ForShareUpgradeEnabled))
 
 		tk1.MustExec("begin")
 		tk1.MustQuery("select * from t for update").Check(testkit.Rows("1 10"))
 
 		tk.MustExec("begin")
-		if tt.ForShareNoopEnable {
-			tk.MustQuery("select * from t where a = 1 for share nowait").Check(testkit.Rows("1 10"))
-			tk.MustQuery("select * from t where a = 1 for share").Check(testkit.Rows("1 10"))
-			tk.MustQuery("select * from t for share").Check(testkit.Rows("1 10"))
-			tk.MustQuery("select * from t").Check(testkit.Rows("1 10"))
-		} else if tt.ForShareUpgradeEnabled {
+		if tt.ForShareUpgradeEnabled {
 			_, err := tk.Exec("select * from t where a = 1 for share nowait")
 			require.True(t, strings.Contains(err.Error(), "could not be acquired immediately and NOWAIT is set"))
 			_, err = tk.Exec("select * from t for share nowait")
@@ -3648,6 +3638,11 @@ func TestForShareWithUpgrade(t *testing.T) {
 			require.True(t, strings.Contains(err.Error(), "Lock wait timeout exceeded; try restarting transaction"))
 			_, err = tk.Exec("select * from t for share")
 			require.True(t, strings.Contains(err.Error(), "Lock wait timeout exceeded; try restarting transaction"))
+		} else if tt.ForShareNoopEnable {
+			tk.MustQuery("select * from t where a = 1 for share nowait").Check(testkit.Rows("1 10"))
+			tk.MustQuery("select * from t where a = 1 for share").Check(testkit.Rows("1 10"))
+			tk.MustQuery("select * from t for share").Check(testkit.Rows("1 10"))
+			tk.MustQuery("select * from t").Check(testkit.Rows("1 10"))
 		} else {
 			_, err := tk.Exec("select * from t where a = 1 for share nowait")
 			require.True(t, strings.Contains(err.Error(), "use tidb_enable_noop_functions to enable"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55022

Problem Summary:


1. Support `tidb_enable_shared_lock_promotion` to achive that the `for share` statements could be executed like `for update` statements which acquire pessimistic locks.
2. Fix serveral issues when `tidb_enable_noop_functions` is enabled, the behaviours of `select for share` are unexpected, including:
- When `nowait` is used, the execution is not `no-op` actually.
- When `tidb_enable_noop_functions` is set to `off`, the `select for share` **DOES** acquire locks, so is `on`.
3. Refactor the behaviours of `tidb_enable_noop_functions`, `tidb_enabled_shared_lock_promotion` and `for share` statements for executions with `PointGet` and `Coprocessor` pathes. 

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Introduce `tidb_enable_shared_lock_promotion` to support `for share` statements could be executed like `for update` statements which acquire pessimistic locks.
```
