### PR TITLE
ddl: record get owner TS and compare it before runReorgJob quit

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -823,8 +823,12 @@ func (dc *ddlCtx) writePhysicalTableRecord(
 	reorgInfo *reorgInfo,
 ) error {
 	startKey, endKey := reorgInfo.StartKey, reorgInfo.EndKey
-
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
+		if errors.ErrorEqual(err, dbterror.ErrNotOwner) {
+			// This instance is not DDL owner, we remove reorgctx proactively
+			// to avoid being used later.
+			dc.removeReorgCtx(reorgInfo.ID)
+		}
 		return errors.Trace(err)
 	}
 

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -824,11 +824,6 @@ func (dc *ddlCtx) writePhysicalTableRecord(
 ) error {
 	startKey, endKey := reorgInfo.StartKey, reorgInfo.EndKey
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
-		if errors.ErrorEqual(err, dbterror.ErrNotOwner) {
-			// This instance is not DDL owner, we remove reorgctx proactively
-			// to avoid being used later.
-			dc.removeReorgCtx(reorgInfo.ID)
-		}
 		return errors.Trace(err)
 	}
 

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -823,6 +823,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(
 	reorgInfo *reorgInfo,
 ) error {
 	startKey, endKey := reorgInfo.StartKey, reorgInfo.EndKey
+
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -549,7 +549,7 @@ func (dc *ddlCtx) newReorgCtx(jobID int64, rowCount int64) *reorgCtx {
 		return existedRC
 	}
 	rc := &reorgCtx{}
-	rc.doneCh = make(chan error, 1)
+	rc.doneCh = make(chan reorgFnResult, 1)
 	// initial reorgCtx
 	rc.setRowCount(rowCount)
 	rc.mu.warnings = make(map[errors.ErrorID]*terror.Error)

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -519,6 +519,19 @@ type reorgContexts struct {
 	sync.RWMutex
 	// reorgCtxMap maps job ID to reorg context.
 	reorgCtxMap map[int64]*reorgCtx
+	beOwnerTS   int64
+}
+
+func (r *reorgContexts) getOwnerTS() int64 {
+	r.RLock()
+	defer r.RUnlock()
+	return r.beOwnerTS
+}
+
+func (r *reorgContexts) setOwnerTS(ts int64) {
+	r.Lock()
+	r.beOwnerTS = ts
+	r.Unlock()
 }
 
 func (dc *ddlCtx) getReorgCtx(jobID int64) *reorgCtx {

--- a/pkg/ddl/job_scheduler.go
+++ b/pkg/ddl/job_scheduler.go
@@ -112,6 +112,7 @@ func (l *ownerListener) OnBecomeOwner() {
 		sessPool:       l.ddl.sessPool,
 		delRangeMgr:    l.ddl.delRangeMgr,
 	}
+	l.ddl.reorgCtx.setOwnerTS(time.Now().Unix())
 	l.scheduler.start()
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54897 

Problem Summary:

Timeline:
1. tidb-0 run ingest backfill workers as the DDL owner.
2. Inject network latency to tidb-0.
3. tidb-1 get DDL owner, and switch to merge temp index step.
4. Inject network latency to tidb-1. tidb-1's merge temp index backfill workers failed with "DDL is not owner"
5. tidb-0 get DDL owner AGAIN, but `reorgCtx` is the one added in step(1).
6. Merge temp index step is skipped because the `reorgCtx` is done.

### What changed and how does it work?

Record get owner TS and compare it before runReorgJob quit.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
  Here is the log from HA test:
  ![image](https://github.com/user-attachments/assets/34e9c131-83b8-4c6d-9688-8c60e68b3014)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
