### PR TITLE
ddl: remove reorg ctx when current instance is not owner

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -674,8 +674,12 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sess.Pool, t table.Physical
 	totalAddedCount := job.GetRowCount()
 
 	startKey, endKey := reorgInfo.StartKey, reorgInfo.EndKey
-
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
+		if errors.ErrorEqual(err, dbterror.ErrNotOwner) {
+			// This instance is not DDL owner, we remove reorgctx proactively
+			// to avoid being used later.
+			dc.removeReorgCtx(reorgInfo.ID)
+		}
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
Cherry-pick #55049 to v7.5.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54897 

Problem Summary:

Timeline:
1. tidb-0 run ingest backfill workers as the DDL owner.
2. Inject network latency to tidb-0.
3. tidb-1 get DDL owner, and switch to merge temp index step.
4. Inject network latency to tidb-1. tidb-1's merge temp index backfill workers failed with "DDL is not owner"
5. tidb-0 get DDL owner AGAIN, but `reorgCtx` is the one added in step(1).
6. Merge temp index step is skipped because the `reorgCtx` is done.

### What changed and how does it work?

Remove `reorgCtx` before quiting because of `DDLNotOwner` error.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
