### PR TITLE
*: kill auto analyze out of the auto analyze time windows

### DIFF
--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle",
+        "//pkg/statistics/handle/autoanalyze",
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/util",
         "//pkg/store/helper",

--- a/pkg/statistics/handle/autoanalyze/exec/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/exec/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//pkg/parser/model",
         "//pkg/sessionctx",
         "//pkg/testkit",
+        "//pkg/util",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/statistics/handle/autoanalyze/exec/exec.go
+++ b/pkg/statistics/handle/autoanalyze/exec/exec.go
@@ -52,7 +52,7 @@ func AutoAnalyze(
 	params ...any,
 ) {
 	startTime := time.Now()
-	_, _, err := execAnalyzeStmt(sctx, statsHandle, sysProcTracker, statsVer, sql, params...)
+	_, _, err := RunAnalyzeStmt(sctx, statsHandle, sysProcTracker, statsVer, sql, params...)
 	dur := time.Since(startTime)
 	metrics.AutoAnalyzeHistogram.Observe(dur.Seconds())
 	if err != nil {
@@ -72,7 +72,8 @@ func AutoAnalyze(
 	}
 }
 
-func execAnalyzeStmt(
+// RunAnalyzeStmt executes the analyze statement.
+func RunAnalyzeStmt(
 	sctx sessionctx.Context,
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sysproctrack.Tracker,

--- a/pkg/statistics/handle/autoanalyze/exec/exec_test.go
+++ b/pkg/statistics/handle/autoanalyze/exec/exec_test.go
@@ -16,12 +16,15 @@ package exec_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/exec"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +53,36 @@ func TestExecAutoAnalyzes(t *testing.T) {
 	require.NoError(t, err)
 	tblStats := handle.GetTableStats(tbl.Meta())
 	require.Equal(t, int64(3), tblStats.RealtimeCount)
+}
+
+func TestKillInWindows(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int, b int, index idx(a)) partition by range (a) (partition p0 values less than (2), partition p1 values less than (14))")
+	tk.MustExec("insert into t1 values (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13)")
+	handle := dom.StatsHandle()
+	sysProcTracker := dom.SysProcTracker()
+	now := time.Now()
+	startTime := now.Add(1 * time.Hour).Format("15:04 -0700")
+	endTime := now.Add(2 * time.Hour).Format("15:04 -0700")
+	tk.MustExec(fmt.Sprintf("SET GLOBAL tidb_auto_analyze_start_time='%s'", startTime))
+	tk.MustExec(fmt.Sprintf("SET GLOBAL tidb_auto_analyze_end_time='%s'", endTime))
+	var wg util.WaitGroupWrapper
+	exitCh := make(chan struct{})
+	wg.Run(func() {
+		for {
+			select {
+			case <-exitCh:
+				return
+			default:
+				dom.CheckAutoAnalyzeWindows()
+			}
+		}
+	})
+	sctx := tk.Session()
+	_, _, err := exec.RunAnalyzeStmt(sctx, handle, sysProcTracker, 2, "analyze table %n", "t1")
+	require.ErrorContains(t, err, "[executor:1317]Query execution was interrupted")
+	close(exitCh)
+	wg.Wait()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55283

Problem Summary:

### What changed and how does it work?

TiDB forget to kill the anto analyze which is out of the time windows

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
