### PR TITLE
ddl: record get owner TS and compare it before runReorgJob quit (#55049)

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -676,11 +676,6 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sess.Pool, t table.Physical
 	startKey, endKey := reorgInfo.StartKey, reorgInfo.EndKey
 
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
-		if errors.ErrorEqual(err, dbterror.ErrNotOwner) {
-			// This instance is not DDL owner, we remove reorgctx proactively
-			// to avoid being used later.
-			dc.removeReorgCtx(reorgInfo.ID)
-		}
 		return errors.Trace(err)
 	}
 

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -674,6 +674,7 @@ func (dc *ddlCtx) writePhysicalTableRecord(sessPool *sess.Pool, t table.Physical
 	totalAddedCount := job.GetRowCount()
 
 	startKey, endKey := reorgInfo.StartKey, reorgInfo.EndKey
+
 	if err := dc.isReorgRunnable(reorgInfo.Job.ID, false); err != nil {
 		if errors.ErrorEqual(err, dbterror.ErrNotOwner) {
 			// This instance is not DDL owner, we remove reorgctx proactively

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -493,6 +493,19 @@ type reorgContexts struct {
 	sync.RWMutex
 	// reorgCtxMap maps job ID to reorg context.
 	reorgCtxMap map[int64]*reorgCtx
+	beOwnerTS   int64
+}
+
+func (r *reorgContexts) getOwnerTS() int64 {
+	r.RLock()
+	defer r.RUnlock()
+	return r.beOwnerTS
+}
+
+func (r *reorgContexts) setOwnerTS(ts int64) {
+	r.Lock()
+	r.beOwnerTS = ts
+	r.Unlock()
 }
 
 func (dc *ddlCtx) getReorgCtx(jobID int64) *reorgCtx {
@@ -510,7 +523,7 @@ func (dc *ddlCtx) newReorgCtx(jobID int64, rowCount int64) *reorgCtx {
 		return existedRC
 	}
 	rc := &reorgCtx{}
-	rc.doneCh = make(chan error, 1)
+	rc.doneCh = make(chan reorgFnResult, 1)
 	// initial reorgCtx
 	rc.setRowCount(rowCount)
 	rc.mu.warnings = make(map[errors.ErrorID]*terror.Error)
@@ -747,6 +760,7 @@ func (d *ddl) Start(ctxPool *pools.ResourcePool) error {
 			logutil.BgLogger().Error("error when getting the ddl history count", zap.Error(err))
 		}
 		d.runningJobs.clear()
+		d.ddlCtx.reorgCtx.setOwnerTS(time.Now().Unix())
 	})
 
 	d.delRangeMgr = d.newDeleteRangeManager(ctxPool == nil)

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -59,7 +59,7 @@ type reorgCtx struct {
 	// If the reorganization job is done, we will use this channel to notify outer.
 	// TODO: Now we use goroutine to simulate reorganization jobs, later we may
 	// use a persistent job list.
-	doneCh chan error
+	doneCh chan reorgFnResult
 	// rowCount is used to simulate a job's row count.
 	rowCount int64
 	jobState model.JobState
@@ -72,6 +72,11 @@ type reorgCtx struct {
 	}
 
 	references atomicutil.Int32
+}
+
+type reorgFnResult struct {
+	ownerTS int64
+	err     error
 }
 
 // newContext gets a context. It is only used for adding column in reorganization state.
@@ -200,11 +205,13 @@ func (w *worker) runReorgJob(reorgInfo *reorgInfo, tblInfo *model.TableInfo,
 			return dbterror.ErrCancelledDDLJob
 		}
 
+		beOwnerTS := w.ddlCtx.reorgCtx.getOwnerTS()
 		rc = w.newReorgCtx(reorgInfo.Job.ID, reorgInfo.Job.GetRowCount())
 		w.wg.Add(1)
 		go func() {
 			defer w.wg.Done()
-			rc.doneCh <- f()
+			err := f()
+			rc.doneCh <- reorgFnResult{ownerTS: beOwnerTS, err: err}
 		}()
 	}
 
@@ -220,7 +227,16 @@ func (w *worker) runReorgJob(reorgInfo *reorgInfo, tblInfo *model.TableInfo,
 
 	// wait reorganization job done or timeout
 	select {
-	case err := <-rc.doneCh:
+	case res := <-rc.doneCh:
+		err := res.err
+		curTS := w.ddlCtx.reorgCtx.getOwnerTS()
+		if res.ownerTS != curTS {
+			d.removeReorgCtx(job.ID)
+			logutil.BgLogger().Warn("owner ts mismatch, return timeout error and retry",
+				zap.Int64("prevTS", res.ownerTS),
+				zap.Int64("curTS", curTS))
+			return dbterror.ErrWaitReorgTimeout
+		}
 		// Since job is cancelled，we don't care about its partial counts.
 		if rc.isReorgCanceled() || terror.ErrorEqual(err, dbterror.ErrCancelledDDLJob) {
 			d.removeReorgCtx(job.ID)


### PR DESCRIPTION
Cherry-pick #55049

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54897 

Problem Summary:

Timeline:
1. tidb-0 run ingest backfill workers as the DDL owner.
2. Inject network latency to tidb-0.
3. tidb-1 get DDL owner, and switch to merge temp index step.
4. Inject network latency to tidb-1. tidb-1's merge temp index backfill workers failed with "DDL is not owner"
5. tidb-0 get DDL owner AGAIN, but `reorgCtx` is the one added in step(1).
6. Merge temp index step is skipped because the `reorgCtx` is done.

### What changed and how does it work?

Record get owner TS and compare it before runReorgJob quit.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```