### PR TITLE
executor: fix correctness of hash join v2 when there are multiple var-length keys

### DIFF
--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -232,11 +232,10 @@ func (rt *rowTable) getValidJoinKeyPos(rowIndex int) int {
 }
 
 type keyProp struct {
-	canBeInlined        bool
-	keyLength           int
-	isStringRelatedType bool
-	isKeyInteger        bool
-	isKeyUnsigned       bool
+	canBeInlined  bool
+	keyLength     int
+	isKeyInteger  bool
+	isKeyUnsigned bool
 }
 
 func getKeyProp(tp *types.FieldType) *keyProp {
@@ -251,31 +250,31 @@ func getKeyProp(tp *types.FieldType) *keyProp {
 			// duration type is always signed
 			isKeyUnsigned = false
 		}
-		return &keyProp{canBeInlined: true, keyLength: chunk.GetFixedLen(tp), isStringRelatedType: false, isKeyInteger: true, isKeyUnsigned: isKeyUnsigned}
+		return &keyProp{canBeInlined: true, keyLength: chunk.GetFixedLen(tp), isKeyInteger: true, isKeyUnsigned: isKeyUnsigned}
 	case mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
 		collator := collate.GetCollator(tp.GetCollate())
-		return &keyProp{canBeInlined: collate.CanUseRawMemAsKey(collator), keyLength: chunk.VarElemLen, isStringRelatedType: true, isKeyInteger: false, isKeyUnsigned: false}
+		return &keyProp{canBeInlined: collate.CanUseRawMemAsKey(collator), keyLength: chunk.VarElemLen, isKeyInteger: false, isKeyUnsigned: false}
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
 		// date related type will use uint64 as serialized key
-		return &keyProp{canBeInlined: false, keyLength: int(serialization.Uint64Len), isStringRelatedType: false, isKeyInteger: true, isKeyUnsigned: true}
+		return &keyProp{canBeInlined: false, keyLength: int(serialization.Uint64Len), isKeyInteger: true, isKeyUnsigned: true}
 	case mysql.TypeFloat:
 		// float will use float64 as serialized key
-		return &keyProp{canBeInlined: false, keyLength: int(serialization.Float64Len), isStringRelatedType: false, isKeyInteger: false, isKeyUnsigned: false}
+		return &keyProp{canBeInlined: false, keyLength: int(serialization.Float64Len), isKeyInteger: false, isKeyUnsigned: false}
 	case mysql.TypeNewDecimal:
 		// Although decimal is fixed length, but its key is not fixed length
-		return &keyProp{canBeInlined: false, keyLength: chunk.VarElemLen, isStringRelatedType: false, isKeyInteger: false, isKeyUnsigned: false}
+		return &keyProp{canBeInlined: false, keyLength: chunk.VarElemLen, isKeyInteger: false, isKeyUnsigned: false}
 	case mysql.TypeEnum:
 		if mysql.HasEnumSetAsIntFlag(tp.GetFlag()) {
 			// enum int type is always unsigned
-			return &keyProp{canBeInlined: false, keyLength: int(serialization.Uint64Len), isStringRelatedType: false, isKeyInteger: true, isKeyUnsigned: true}
+			return &keyProp{canBeInlined: false, keyLength: int(serialization.Uint64Len), isKeyInteger: true, isKeyUnsigned: true}
 		}
-		return &keyProp{canBeInlined: false, keyLength: chunk.VarElemLen, isStringRelatedType: false, isKeyInteger: false, isKeyUnsigned: false}
+		return &keyProp{canBeInlined: false, keyLength: chunk.VarElemLen, isKeyInteger: false, isKeyUnsigned: false}
 	case mysql.TypeBit:
 		// bit type is always unsigned
-		return &keyProp{canBeInlined: false, keyLength: int(serialization.Uint64Len), isStringRelatedType: false, isKeyInteger: true, isKeyUnsigned: true}
+		return &keyProp{canBeInlined: false, keyLength: int(serialization.Uint64Len), isKeyInteger: true, isKeyUnsigned: true}
 	default:
 		keyLength := chunk.GetFixedLen(tp)
-		return &keyProp{canBeInlined: false, keyLength: keyLength, isStringRelatedType: false, isKeyInteger: false, isKeyUnsigned: false}
+		return &keyProp{canBeInlined: false, keyLength: keyLength, isKeyInteger: false, isKeyUnsigned: false}
 	}
 }
 
@@ -322,6 +321,7 @@ func newTableMeta(buildKeyIndex []int, buildTypes, buildKeyTypes, probeKeyTypes 
 	meta.serializeModes = make([]codec.SerializeMode, 0, len(buildKeyIndex))
 	isAllKeyInteger := true
 	hasFixedSizeKeyColumn := false
+	varLengthKeyNumber := 0
 	for index, keyIndex := range buildKeyIndex {
 		keyType := buildKeyTypes[index]
 		prop := getKeyProp(keyType)
@@ -330,6 +330,7 @@ func newTableMeta(buildKeyIndex []int, buildTypes, buildKeyTypes, probeKeyTypes 
 			hasFixedSizeKeyColumn = true
 		} else {
 			meta.isJoinKeysFixedLength = false
+			varLengthKeyNumber++
 		}
 		if !prop.canBeInlined {
 			meta.isJoinKeysInlined = false
@@ -355,8 +356,9 @@ func newTableMeta(buildKeyIndex []int, buildTypes, buildKeyTypes, probeKeyTypes 
 			if !prop.isKeyInteger {
 				isAllKeyInteger = false
 			}
-			if meta.isJoinKeysInlined && prop.isStringRelatedType {
-				meta.serializeModes = append(meta.serializeModes, codec.KeepStringLength)
+			if prop.keyLength == chunk.VarElemLen {
+				// keep var column by default for var length column
+				meta.serializeModes = append(meta.serializeModes, codec.KeepVarColumnLength)
 			} else {
 				meta.serializeModes = append(meta.serializeModes, codec.Normal)
 			}
@@ -371,9 +373,12 @@ func newTableMeta(buildKeyIndex []int, buildTypes, buildKeyTypes, probeKeyTypes 
 		meta.isJoinKeysInlined = false
 	}
 	if !meta.isJoinKeysInlined {
-		for i := 0; i < len(buildKeyIndex); i++ {
-			if meta.serializeModes[i] == codec.KeepStringLength {
-				meta.serializeModes[i] = codec.Normal
+		if varLengthKeyNumber == 1 {
+			// if key is not inlined and there is only one var-length key, then don't need to record the var length
+			for i := 0; i < len(buildKeyIndex); i++ {
+				if meta.serializeModes[i] == codec.KeepVarColumnLength {
+					meta.serializeModes[i] = codec.Normal
+				}
 			}
 		}
 	} else {

--- a/pkg/executor/join/join_row_table_test.go
+++ b/pkg/executor/join/join_row_table_test.go
@@ -174,6 +174,11 @@ func TestJoinTableMetaSerializedMode(t *testing.T) {
 	stringTp := types.NewFieldType(mysql.TypeVarString)
 	binaryStringTp := types.NewFieldType(mysql.TypeBlob)
 	decimalTp := types.NewFieldType(mysql.TypeNewDecimal)
+	enumTp := types.NewFieldType(mysql.TypeEnum)
+	enumWithIntFlag := types.NewFieldType(mysql.TypeEnum)
+	enumWithIntFlag.AddFlag(mysql.EnumSetAsIntFlag)
+	setTp := types.NewFieldType(mysql.TypeSet)
+	jsonTp := types.NewFieldType(mysql.TypeJSON)
 
 	type testCase struct {
 		buildKeyIndex  []int
@@ -188,12 +193,23 @@ func TestJoinTableMetaSerializedMode(t *testing.T) {
 		// test NeedSignFlag
 		{[]int{0, 1}, []*types.FieldType{uintTp, intTp}, []*types.FieldType{uintTp, intTp}, []*types.FieldType{intTp, intTp}, []codec.SerializeMode{codec.NeedSignFlag, codec.Normal}},
 		{[]int{0}, []*types.FieldType{uintTp}, []*types.FieldType{uintTp}, []*types.FieldType{intTp}, []codec.SerializeMode{codec.NeedSignFlag}},
-		// test KeepStringLength
-		{[]int{0, 1}, []*types.FieldType{intTp, binaryStringTp}, []*types.FieldType{intTp, binaryStringTp}, []*types.FieldType{intTp, binaryStringTp}, []codec.SerializeMode{codec.Normal, codec.KeepStringLength}},
-		{[]int{0}, []*types.FieldType{binaryStringTp}, []*types.FieldType{binaryStringTp}, []*types.FieldType{binaryStringTp}, []codec.SerializeMode{codec.KeepStringLength}},
-		// binaryString is not inlined, no need to keep string length
+		// test KeepVarColumnLength
+		{[]int{0, 1}, []*types.FieldType{intTp, binaryStringTp}, []*types.FieldType{intTp, binaryStringTp}, []*types.FieldType{intTp, binaryStringTp}, []codec.SerializeMode{codec.Normal, codec.KeepVarColumnLength}},
+		{[]int{0}, []*types.FieldType{binaryStringTp}, []*types.FieldType{binaryStringTp}, []*types.FieldType{binaryStringTp}, []codec.SerializeMode{codec.KeepVarColumnLength}},
+		// binaryString is not inlined, no need to keep var column length
 		{[]int{0, 1}, []*types.FieldType{intTp, binaryStringTp}, []*types.FieldType{intTp, binaryStringTp}, []*types.FieldType{uintTp, binaryStringTp}, []codec.SerializeMode{codec.NeedSignFlag, codec.Normal}},
-		{[]int{0, 1}, []*types.FieldType{stringTp, binaryStringTp}, []*types.FieldType{stringTp, binaryStringTp}, []*types.FieldType{stringTp, binaryStringTp}, []codec.SerializeMode{codec.Normal, codec.Normal}},
+		// multiple var-length column, need keep var column length
+		{[]int{0, 1}, []*types.FieldType{stringTp, binaryStringTp}, []*types.FieldType{stringTp, binaryStringTp}, []*types.FieldType{stringTp, binaryStringTp}, []codec.SerializeMode{codec.KeepVarColumnLength, codec.KeepVarColumnLength}},
+		{[]int{0, 1}, []*types.FieldType{stringTp, decimalTp}, []*types.FieldType{stringTp, decimalTp}, []*types.FieldType{stringTp, decimalTp}, []codec.SerializeMode{codec.KeepVarColumnLength, codec.KeepVarColumnLength}},
+		// set/json/decimal/enum is treated as var-length column
+		{[]int{0, 1}, []*types.FieldType{setTp, jsonTp, decimalTp, enumTp}, []*types.FieldType{setTp, jsonTp, decimalTp, enumTp}, []*types.FieldType{setTp, jsonTp, decimalTp, enumTp}, []codec.SerializeMode{codec.KeepVarColumnLength, codec.KeepVarColumnLength, codec.KeepVarColumnLength, codec.KeepVarColumnLength}},
+		{[]int{0, 1}, []*types.FieldType{setTp, jsonTp, decimalTp}, []*types.FieldType{setTp, jsonTp, decimalTp}, []*types.FieldType{setTp, jsonTp, decimalTp}, []codec.SerializeMode{codec.KeepVarColumnLength, codec.KeepVarColumnLength, codec.KeepVarColumnLength}},
+		{[]int{0, 1}, []*types.FieldType{jsonTp, decimalTp}, []*types.FieldType{jsonTp, decimalTp}, []*types.FieldType{jsonTp, decimalTp}, []codec.SerializeMode{codec.KeepVarColumnLength, codec.KeepVarColumnLength}},
+		{[]int{0, 1}, []*types.FieldType{setTp, enumTp}, []*types.FieldType{setTp, enumTp}, []*types.FieldType{setTp, enumTp}, []codec.SerializeMode{codec.KeepVarColumnLength, codec.KeepVarColumnLength}},
+		// enumWithIntFlag is fix length column
+		{[]int{0, 1}, []*types.FieldType{enumWithIntFlag, enumTp}, []*types.FieldType{enumWithIntFlag, enumTp}, []*types.FieldType{enumWithIntFlag, enumTp}, []codec.SerializeMode{codec.Normal, codec.Normal}},
+		// single non-inlined var length column don't need keep var column length
+		{[]int{0, 1}, []*types.FieldType{setTp, enumWithIntFlag}, []*types.FieldType{setTp, enumWithIntFlag}, []*types.FieldType{setTp, enumWithIntFlag}, []codec.SerializeMode{codec.Normal, codec.Normal}},
 	}
 	for index, test := range testCases {
 		meta := newTableMeta(test.buildKeyIndex, test.buildTypes, test.buildKeyTypes, test.probeKeyTypes, nil, []int{}, false)

--- a/pkg/executor/test/jointest/hashjoin/BUILD.bazel
+++ b/pkg/executor/test/jointest/hashjoin/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 19,
+    shard_count = 20,
     deps = [
         "//pkg/config",
         "//pkg/executor/join",

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -55,6 +55,8 @@ const IntHandleFlag = intFlag
 
 const (
 	sizeUint64  = unsafe.Sizeof(uint64(0))
+	sizeUint8   = unsafe.Sizeof(uint8(0))
+	sizeUint32  = unsafe.Sizeof(uint32(0))
 	sizeFloat64 = unsafe.Sizeof(float64(0))
 )
 
@@ -401,9 +403,9 @@ const (
 	// the unsigned flag can be ignored, if the join key is <unsigned, signed> or <signed, unsigned>
 	// the unsigned flag can not be ignored, if the unsigned flag can not be ignored, the key can not be inlined
 	NeedSignFlag
-	// KeepStringLength when serialize string column, if the string column can use raw data as the key, then it can be inlined,
-	// in this case, the string length should be included in the serialized key
-	KeepStringLength
+	// KeepVarColumnLength when serialize var-length column, whether record the column length or not. If the join key only contains one var-length
+	// column, and the key is not inlined, then no need to record the column length, otherwise, always need to record the column length
+	KeepVarColumnLength
 )
 
 // SerializeKeys is used in join
@@ -414,6 +416,10 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			nullVector[index] = true
 		}
 		return (filterVector != nil && !filterVector[index]) || (nullVector != nil && nullVector[index])
+	}
+	var jsonHashBuffer []byte
+	if tp.GetType() == mysql.TypeJSON {
+		jsonHashBuffer = make([]byte, 0)
 	}
 	switch tp.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
@@ -466,7 +472,7 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			}
 			data := ConvertByCollation(column.GetBytes(physicalRowIndex), tp)
 			size := uint64(len(data))
-			if serializeMode == KeepStringLength {
+			if serializeMode == KeepVarColumnLength {
 				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint64)...)
 			}
 			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], data...)
@@ -504,6 +510,11 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			if err != nil {
 				return err
 			}
+			if serializeMode == KeepVarColumnLength {
+				// for decimal, the size must be less than uint8.MAX, so use uint8 here
+				size := uint8(len(b))
+				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint8)...)
+			}
 			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], b...)
 		}
 	case mysql.TypeEnum:
@@ -523,7 +534,13 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 				if enum, err := types.ParseEnumValue(tp.GetElems(), v); err == nil {
 					str = enum.Name
 				}
-				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], ConvertByCollation(hack.Slice(str), tp)...)
+				b := ConvertByCollation(hack.Slice(str), tp)
+				if serializeMode == KeepVarColumnLength {
+					// for enum, the size must be less than uint32.MAX, so use uint32 here
+					size := uint32(len(b))
+					serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint32)...)
+				}
+				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], b...)
 			}
 		}
 	case mysql.TypeSet:
@@ -535,7 +552,13 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			if err != nil {
 				return err
 			}
-			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], ConvertByCollation(hack.Slice(s.Name), tp)...)
+			b := ConvertByCollation(hack.Slice(s.Name), tp)
+			if serializeMode == KeepVarColumnLength {
+				// for enum, the size must be less than uint32.MAX, so use uint32 here
+				size := uint32(len(b))
+				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint32)...)
+			}
+			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], b...)
 		}
 	case mysql.TypeBit:
 		for logicalRowIndex, physicalRowindex := range usedRows {
@@ -544,7 +567,7 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			}
 			v, err1 := types.BinaryLiteral(column.GetBytes(physicalRowindex)).ToInt(typeCtx)
 			terror.Log(errors.Trace(err1))
-			// check serializeMode here because enum maybe compare to integer type directly
+			// check serializeMode here because bit maybe compare to integer type directly
 			if serializeMode == NeedSignFlag {
 				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], uintFlag)
 			}
@@ -555,7 +578,14 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			if canSkip(physicalRowindex) {
 				continue
 			}
-			serializedKeysVector[logicalRowIndex] = column.GetJSON(physicalRowindex).HashValue(serializedKeysVector[logicalRowIndex])
+			jsonHashBuffer = jsonHashBuffer[:0]
+			jsonHashBuffer = column.GetJSON(physicalRowindex).HashValue(jsonHashBuffer)
+			if serializeMode == KeepVarColumnLength {
+				// for enum, the size must be less than uint32.MAX, so use uint32 here
+				size := uint64(len(jsonHashBuffer))
+				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint64)...)
+			}
+			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], jsonHashBuffer...)
 		}
 	case mysql.TypeNull:
 		for _, physicalRowindex := range usedRows {

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -581,7 +581,6 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			jsonHashBuffer = jsonHashBuffer[:0]
 			jsonHashBuffer = column.GetJSON(physicalRowindex).HashValue(jsonHashBuffer)
 			if serializeMode == KeepVarColumnLength {
-				// for enum, the size must be less than uint32.MAX, so use uint32 here
 				size := uint64(len(jsonHashBuffer))
 				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint64)...)
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55016

Problem Summary:

HashJoinV2, it will first pack all the join keys into a byte array named `serializedKey`, and during the probe stage, it will compare `serializedKey` directly, if the `serializedKey` matches, the join think its original key matches. `codec.SerializeKeys` is used to generate `serializedKey`, for var-length column, if `SerializeMode` is not `keepStringLength`, it will not record string length in `serializedKey`.
Currently, only a string key is inlined, it need to record string length.
The problem is if the join key is 2 strings like `a = a and b = b`, if string length is not kept in `serializedKey`, then the following two pair of keys will generate same `serializedKey`
{a: `aa`, b: `a`}
{a: `a`, b: `aa`}
which is not expected.
In this pr, it always record var-column length into serialized key except all the following condition is true
* the join key only contains 1 var length column
* the join key is not inlined

In the above case, since there is only 1 var length column, it is ok to discard the var-column length in `serializedKey` because we will record the total length of `serializedKey`.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
