### PR TITLE
planner: use code-gen to generate CloneForPlanCache method for Point/BatchPoint/Limit

### DIFF
--- a/pkg/kv/key.go
+++ b/pkg/kv/key.go
@@ -312,6 +312,9 @@ func NewCommonHandle(encoded []byte) (*CommonHandle, error) {
 
 // Copy implements the Handle interface.
 func (ch *CommonHandle) Copy() Handle {
+	if ch == nil {
+		return nil
+	}
 	encoded := make([]byte, len(ch.encoded))
 	copy(encoded, ch.encoded)
 	colEndOffsets := make([]uint16, len(ch.colEndOffsets))

--- a/pkg/planner/core/operator/baseimpl/plan.go
+++ b/pkg/planner/core/operator/baseimpl/plan.go
@@ -138,6 +138,14 @@ func (p *Plan) BuildPlanTrace() *tracing.PlanTrace {
 	return planTrace
 }
 
+// CloneWithNewCtx clones the plan with new context.
+func (p *Plan) CloneWithNewCtx(newCtx base.PlanContext) *Plan {
+	cloned := new(Plan)
+	*cloned = *p
+	cloned.ctx = newCtx
+	return cloned
+}
+
 // CloneForPlanCache clones the plan for Plan Cache.
 func (*Plan) CloneForPlanCache(base.PlanContext) (cloned base.Plan, ok bool) {
 	return nil, false

--- a/pkg/planner/core/plan_clone_generated.go
+++ b/pkg/planner/core/plan_clone_generated.go
@@ -232,6 +232,12 @@ func (op *PointGetPlan) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, b
 	cloned := new(PointGetPlan)
 	*cloned = *op
 	cloned.Plan = *op.Plan.CloneWithNewCtx(newCtx)
+	probeParents, ok := clonePhysicalPlansForPlanCache(newCtx, op.probeParents)
+	if !ok {
+		return nil, false
+	}
+	cloned.probeParents = probeParents
+	cloned.PartitionNames = util.CloneCIStrs(op.PartitionNames)
 	cloned.schema = op.schema.Clone()
 	if op.PartitionIdx != nil {
 		cloned.PartitionIdx = new(int)
@@ -251,12 +257,6 @@ func (op *PointGetPlan) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, b
 	cloned.AccessConditions = util.CloneExpressions(op.AccessConditions)
 	cloned.ctx = newCtx
 	cloned.accessCols = util.CloneColumns(op.accessCols)
-	probeParents, ok := clonePhysicalPlansForPlanCache(newCtx, op.probeParents)
-	if !ok {
-		return nil, false
-	}
-	cloned.probeParents = probeParents
-	cloned.PartitionNames = util.CloneCIStrs(op.PartitionNames)
 	return cloned, true
 }
 
@@ -265,6 +265,12 @@ func (op *BatchPointGetPlan) CloneForPlanCache(newCtx base.PlanContext) (base.Pl
 	cloned := new(BatchPointGetPlan)
 	*cloned = *op
 	cloned.baseSchemaProducer = *op.baseSchemaProducer.CloneWithNewCtx(newCtx)
+	probeParents, ok := clonePhysicalPlansForPlanCache(newCtx, op.probeParents)
+	if !ok {
+		return nil, false
+	}
+	cloned.probeParents = probeParents
+	cloned.PartitionNames = util.CloneCIStrs(op.PartitionNames)
 	cloned.ctx = newCtx
 	cloned.Handles = util.CloneHandles(op.Handles)
 	cloned.HandleParams = util.CloneConstants(op.HandleParams)
@@ -277,12 +283,6 @@ func (op *BatchPointGetPlan) CloneForPlanCache(newCtx base.PlanContext) (base.Pl
 	cloned.PartitionIdxs = make([]int, len(op.PartitionIdxs))
 	copy(cloned.PartitionIdxs, op.PartitionIdxs)
 	cloned.accessCols = util.CloneColumns(op.accessCols)
-	probeParents, ok := clonePhysicalPlansForPlanCache(newCtx, op.probeParents)
-	if !ok {
-		return nil, false
-	}
-	cloned.probeParents = probeParents
-	cloned.PartitionNames = util.CloneCIStrs(op.PartitionNames)
 	return cloned, true
 }
 

--- a/pkg/planner/core/plan_clone_generated.go
+++ b/pkg/planner/core/plan_clone_generated.go
@@ -31,16 +31,16 @@ func (op *PhysicalTableScan) CloneForPlanCache(newCtx base.PlanContext) (base.Pl
 		return nil, false
 	}
 	cloned.physicalSchemaProducer = *basePlan
-	cloned.AccessCondition = util.CloneExprs(op.AccessCondition)
-	cloned.filterCondition = util.CloneExprs(op.filterCondition)
-	cloned.LateMaterializationFilterCondition = util.CloneExprs(op.LateMaterializationFilterCondition)
+	cloned.AccessCondition = util.CloneExpressions(op.AccessCondition)
+	cloned.filterCondition = util.CloneExpressions(op.filterCondition)
+	cloned.LateMaterializationFilterCondition = util.CloneExpressions(op.LateMaterializationFilterCondition)
 	cloned.Ranges = util.CloneRanges(op.Ranges)
 	cloned.HandleIdx = make([]int, len(op.HandleIdx))
 	copy(cloned.HandleIdx, op.HandleIdx)
 	if op.HandleCols != nil {
 		cloned.HandleCols = op.HandleCols.Clone(newCtx.GetSessionVars().StmtCtx)
 	}
-	cloned.ByItems = util.CloneByItems(op.ByItems)
+	cloned.ByItems = util.CloneByItemss(op.ByItems)
 	cloned.PlanPartInfo = op.PlanPartInfo.Clone()
 	if op.SampleInfo != nil {
 		return nil, false
@@ -62,15 +62,15 @@ func (op *PhysicalIndexScan) CloneForPlanCache(newCtx base.PlanContext) (base.Pl
 		return nil, false
 	}
 	cloned.physicalSchemaProducer = *basePlan
-	cloned.AccessCondition = util.CloneExprs(op.AccessCondition)
-	cloned.IdxCols = util.CloneCols(op.IdxCols)
+	cloned.AccessCondition = util.CloneExpressions(op.AccessCondition)
+	cloned.IdxCols = util.CloneColumns(op.IdxCols)
 	cloned.IdxColLens = make([]int, len(op.IdxColLens))
 	copy(cloned.IdxColLens, op.IdxColLens)
 	cloned.Ranges = util.CloneRanges(op.Ranges)
 	if op.GenExprs != nil {
 		return nil, false
 	}
-	cloned.ByItems = util.CloneByItems(op.ByItems)
+	cloned.ByItems = util.CloneByItemss(op.ByItems)
 	if op.pkIsHandleCol != nil {
 		cloned.pkIsHandleCol = op.pkIsHandleCol.Clone().(*expression.Column)
 	}
@@ -88,7 +88,7 @@ func (op *PhysicalSelection) CloneForPlanCache(newCtx base.PlanContext) (base.Pl
 		return nil, false
 	}
 	cloned.basePhysicalPlan = *basePlan
-	cloned.Conditions = util.CloneExprs(op.Conditions)
+	cloned.Conditions = util.CloneExpressions(op.Conditions)
 	return cloned, true
 }
 
@@ -101,7 +101,7 @@ func (op *PhysicalProjection) CloneForPlanCache(newCtx base.PlanContext) (base.P
 		return nil, false
 	}
 	cloned.physicalSchemaProducer = *basePlan
-	cloned.Exprs = util.CloneExprs(op.Exprs)
+	cloned.Exprs = util.CloneExpressions(op.Exprs)
 	return cloned, true
 }
 
@@ -114,7 +114,7 @@ func (op *PhysicalSort) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, b
 		return nil, false
 	}
 	cloned.basePhysicalPlan = *basePlan
-	cloned.ByItems = util.CloneByItems(op.ByItems)
+	cloned.ByItems = util.CloneByItemss(op.ByItems)
 	return cloned, true
 }
 
@@ -127,8 +127,8 @@ func (op *PhysicalTopN) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, b
 		return nil, false
 	}
 	cloned.basePhysicalPlan = *basePlan
-	cloned.ByItems = util.CloneByItems(op.ByItems)
-	cloned.PartitionBy = util.CloneSortItem(op.PartitionBy)
+	cloned.ByItems = util.CloneByItemss(op.ByItems)
+	cloned.PartitionBy = util.CloneSortItems(op.PartitionBy)
 	return cloned, true
 }
 
@@ -222,8 +222,80 @@ func (op *PhysicalIndexReader) CloneForPlanCache(newCtx base.PlanContext) (base.
 	}
 	cloned.indexPlan = indexPlan.(base.PhysicalPlan)
 	cloned.IndexPlans = flattenPushDownPlan(cloned.indexPlan)
-	cloned.OutputColumns = util.CloneCols(op.OutputColumns)
+	cloned.OutputColumns = util.CloneColumns(op.OutputColumns)
 	cloned.PlanPartInfo = op.PlanPartInfo.Clone()
+	return cloned, true
+}
+
+// CloneForPlanCache implements the base.Plan interface.
+func (op *PointGetPlan) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
+	cloned := new(PointGetPlan)
+	*cloned = *op
+	cloned.Plan = *op.Plan.CloneWithNewCtx(newCtx)
+	cloned.schema = op.schema.Clone()
+	if op.PartitionIdx != nil {
+		cloned.PartitionIdx = new(int)
+		*cloned.PartitionIdx = *op.PartitionIdx
+	}
+	if op.Handle != nil {
+		cloned.Handle = op.Handle.Copy()
+	}
+	if op.HandleConstant != nil {
+		cloned.HandleConstant = op.HandleConstant.Clone().(*expression.Constant)
+	}
+	cloned.IndexValues = util.CloneDatums(op.IndexValues)
+	cloned.IndexConstants = util.CloneConstants(op.IndexConstants)
+	cloned.IdxCols = util.CloneColumns(op.IdxCols)
+	cloned.IdxColLens = make([]int, len(op.IdxColLens))
+	copy(cloned.IdxColLens, op.IdxColLens)
+	cloned.AccessConditions = util.CloneExpressions(op.AccessConditions)
+	cloned.ctx = newCtx
+	cloned.accessCols = util.CloneColumns(op.accessCols)
+	probeParents, ok := clonePhysicalPlansForPlanCache(newCtx, op.probeParents)
+	if !ok {
+		return nil, false
+	}
+	cloned.probeParents = probeParents
+	cloned.PartitionNames = util.CloneCIStrs(op.PartitionNames)
+	return cloned, true
+}
+
+// CloneForPlanCache implements the base.Plan interface.
+func (op *BatchPointGetPlan) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
+	cloned := new(BatchPointGetPlan)
+	*cloned = *op
+	cloned.baseSchemaProducer = *op.baseSchemaProducer.CloneWithNewCtx(newCtx)
+	cloned.ctx = newCtx
+	cloned.Handles = util.CloneHandles(op.Handles)
+	cloned.HandleParams = util.CloneConstants(op.HandleParams)
+	cloned.IndexValues = util.CloneDatum2D(op.IndexValues)
+	cloned.IndexValueParams = util.CloneConstant2D(op.IndexValueParams)
+	cloned.AccessConditions = util.CloneExpressions(op.AccessConditions)
+	cloned.IdxCols = util.CloneColumns(op.IdxCols)
+	cloned.IdxColLens = make([]int, len(op.IdxColLens))
+	copy(cloned.IdxColLens, op.IdxColLens)
+	cloned.PartitionIdxs = make([]int, len(op.PartitionIdxs))
+	copy(cloned.PartitionIdxs, op.PartitionIdxs)
+	cloned.accessCols = util.CloneColumns(op.accessCols)
+	probeParents, ok := clonePhysicalPlansForPlanCache(newCtx, op.probeParents)
+	if !ok {
+		return nil, false
+	}
+	cloned.probeParents = probeParents
+	cloned.PartitionNames = util.CloneCIStrs(op.PartitionNames)
+	return cloned, true
+}
+
+// CloneForPlanCache implements the base.Plan interface.
+func (op *PhysicalLimit) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
+	cloned := new(PhysicalLimit)
+	*cloned = *op
+	basePlan, baseOK := op.physicalSchemaProducer.cloneForPlanCacheWithSelf(newCtx, cloned)
+	if !baseOK {
+		return nil, false
+	}
+	cloned.physicalSchemaProducer = *basePlan
+	cloned.PartitionBy = util.CloneSortItems(op.PartitionBy)
 	return cloned, true
 }
 
@@ -252,7 +324,7 @@ func (op *PhysicalIndexLookUpReader) CloneForPlanCache(newCtx base.PlanContext) 
 		cloned.ExtraHandleCol = op.ExtraHandleCol.Clone().(*expression.Column)
 	}
 	cloned.PushedLimit = op.PushedLimit.Clone()
-	cloned.CommonHandleCols = util.CloneCols(op.CommonHandleCols)
+	cloned.CommonHandleCols = util.CloneColumns(op.CommonHandleCols)
 	cloned.PlanPartInfo = op.PlanPartInfo.Clone()
 	return cloned, true
 }
@@ -267,7 +339,7 @@ func (op *PhysicalIndexMergeReader) CloneForPlanCache(newCtx base.PlanContext) (
 	}
 	cloned.physicalSchemaProducer = *basePlan
 	cloned.PushedLimit = op.PushedLimit.Clone()
-	cloned.ByItems = util.CloneByItems(op.ByItems)
+	cloned.ByItems = util.CloneByItemss(op.ByItems)
 	partialPlans, ok := clonePhysicalPlansForPlanCache(newCtx, op.partialPlans)
 	if !ok {
 		return nil, false

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -73,16 +73,16 @@ type PointGetPlan struct {
 	baseimpl.Plan
 	dbName           string
 	schema           *expression.Schema
-	TblInfo          *model.TableInfo
-	IndexInfo        *model.IndexInfo
+	TblInfo          *model.TableInfo `plan-cache-clone:"shallow"`
+	IndexInfo        *model.IndexInfo `plan-cache-clone:"shallow"`
 	PartitionIdx     *int
 	Handle           kv.Handle
 	HandleConstant   *expression.Constant
-	handleFieldType  *types.FieldType
+	handleFieldType  *types.FieldType `plan-cache-clone:"shallow"`
 	HandleColOffset  int
 	IndexValues      []types.Datum
 	IndexConstants   []*expression.Constant
-	ColsFieldType    []*types.FieldType
+	ColsFieldType    []*types.FieldType `plan-cache-clone:"shallow"`
 	IdxCols          []*expression.Column
 	IdxColLens       []int
 	AccessConditions []expression.Expression
@@ -90,15 +90,15 @@ type PointGetPlan struct {
 	UnsignedHandle   bool
 	IsTableDual      bool
 	Lock             bool
-	outputNames      []*types.FieldName
+	outputNames      []*types.FieldName `plan-cache-clone:"shallow"`
 	LockWaitTime     int64
-	Columns          []*model.ColumnInfo
+	Columns          []*model.ColumnInfo `plan-cache-clone:"shallow"`
 	cost             float64
 
 	// required by cost model
 	planCostInit bool
 	planCost     float64
-	planCostVer2 costusage.CostVer2
+	planCostVer2 costusage.CostVer2 `plan-cache-clone:"shallow"`
 	// accessCols represents actual columns the PointGet will access, which are used to calculate row-size
 	accessCols []*expression.Column
 
@@ -425,14 +425,14 @@ type BatchPointGetPlan struct {
 
 	ctx              base.PlanContext
 	dbName           string
-	TblInfo          *model.TableInfo
-	IndexInfo        *model.IndexInfo
+	TblInfo          *model.TableInfo `plan-cache-clone:"shallow"`
+	IndexInfo        *model.IndexInfo `plan-cache-clone:"shallow"`
 	Handles          []kv.Handle
-	HandleType       *types.FieldType
+	HandleType       *types.FieldType       `plan-cache-clone:"shallow"`
 	HandleParams     []*expression.Constant // record all Parameters for Plan-Cache
 	IndexValues      [][]types.Datum
 	IndexValueParams [][]*expression.Constant // record all Parameters for Plan-Cache
-	IndexColTypes    []*types.FieldType
+	IndexColTypes    []*types.FieldType       `plan-cache-clone:"shallow"`
 	AccessConditions []expression.Expression
 	IdxCols          []*expression.Column
 	IdxColLens       []int
@@ -447,13 +447,13 @@ type BatchPointGetPlan struct {
 	Desc          bool
 	Lock          bool
 	LockWaitTime  int64
-	Columns       []*model.ColumnInfo
+	Columns       []*model.ColumnInfo `plan-cache-clone:"shallow"`
 	cost          float64
 
 	// required by cost model
 	planCostInit bool
 	planCost     float64
-	planCostVer2 costusage.CostVer2
+	planCostVer2 costusage.CostVer2 `plan-cache-clone:"shallow"`
 	// accessCols represents actual columns the PointGet will access, which are used to calculate row-size
 	accessCols []*expression.Column
 

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -71,6 +71,13 @@ const GlobalWithoutColumnPos = -1
 // This plan is much faster to build and to execute because it avoids the optimization and coprocessor cost.
 type PointGetPlan struct {
 	baseimpl.Plan
+
+	// probeParents records the IndexJoins and Applys with this operator in their inner children.
+	// Please see comments in PhysicalPlan for details.
+	probeParents []base.PhysicalPlan
+	// explicit partition selection
+	PartitionNames []model.CIStr
+
 	dbName           string
 	schema           *expression.Schema
 	TblInfo          *model.TableInfo `plan-cache-clone:"shallow"`
@@ -101,12 +108,6 @@ type PointGetPlan struct {
 	planCostVer2 costusage.CostVer2 `plan-cache-clone:"shallow"`
 	// accessCols represents actual columns the PointGet will access, which are used to calculate row-size
 	accessCols []*expression.Column
-
-	// probeParents records the IndexJoins and Applys with this operator in their inner children.
-	// Please see comments in PhysicalPlan for details.
-	probeParents []base.PhysicalPlan
-	// explicit partition selection
-	PartitionNames []model.CIStr
 }
 
 // GetEstRowCountForDisplay implements PhysicalPlan interface.
@@ -423,6 +424,12 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) bool {
 type BatchPointGetPlan struct {
 	baseSchemaProducer
 
+	// probeParents records the IndexJoins and Applys with this operator in their inner children.
+	// Please see comments in PhysicalPlan for details.
+	probeParents []base.PhysicalPlan
+	// explicit partition selection
+	PartitionNames []model.CIStr
+
 	ctx              base.PlanContext
 	dbName           string
 	TblInfo          *model.TableInfo `plan-cache-clone:"shallow"`
@@ -456,12 +463,6 @@ type BatchPointGetPlan struct {
 	planCostVer2 costusage.CostVer2 `plan-cache-clone:"shallow"`
 	// accessCols represents actual columns the PointGet will access, which are used to calculate row-size
 	accessCols []*expression.Column
-
-	// probeParents records the IndexJoins and Applys with this operator in their inner children.
-	// Please see comments in PhysicalPlan for details.
-	probeParents []base.PhysicalPlan
-	// explicit partition selection
-	PartitionNames []model.CIStr
 }
 
 // GetEstRowCountForDisplay implements PhysicalPlan interface.

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -153,8 +153,17 @@ func (s *physicalSchemaProducer) MemoryUsage() (sum int64) {
 // baseSchemaProducer stores the schema for the base plans who can produce schema directly.
 type baseSchemaProducer struct {
 	schema *expression.Schema
-	names  types.NameSlice
+	names  types.NameSlice `plan-cache-clone:"shallow"`
 	baseimpl.Plan
+}
+
+// CloneWithNewCtx clones the baseSchemaProducer with new context.
+func (s *baseSchemaProducer) CloneWithNewCtx(newCtx base.PlanContext) *baseSchemaProducer {
+	cloned := new(baseSchemaProducer)
+	cloned.Plan = *s.Plan.CloneWithNewCtx(newCtx)
+	cloned.schema = s.schema.Clone()
+	cloned.names = s.names
+	return cloned
 }
 
 // OutputNames returns the outputting names of each column.

--- a/pkg/planner/util/misc.go
+++ b/pkg/planner/util/misc.go
@@ -207,7 +207,6 @@ func CloneHandles(handles []kv.Handle) []kv.Handle {
 		cloned = append(cloned, h.Copy())
 	}
 	return cloned
-
 }
 
 // QueryTimeRange represents a time range specified by TIME_RANGE hint

--- a/pkg/planner/util/misc.go
+++ b/pkg/planner/util/misc.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/types"
@@ -62,6 +63,11 @@ func CloneExprs(exprs []expression.Expression) []expression.Expression {
 	return cloned
 }
 
+// CloneExpressions uses CloneExprs to clone a slice of expression.Expression.
+func CloneExpressions(exprs []expression.Expression) []expression.Expression {
+	return CloneExprs(exprs)
+}
+
 // CloneScalarFunctions uses (*ScalarFunction).Clone to clone a slice of *ScalarFunction.
 func CloneScalarFunctions(scalarFuncs []*expression.ScalarFunction) []*expression.ScalarFunction {
 	if scalarFuncs == nil {
@@ -90,6 +96,59 @@ func CloneCols(cols []*expression.Column) []*expression.Column {
 	return cloned
 }
 
+// CloneColumns uses CloneCols to clone a slice of expression.Column.
+func CloneColumns(cols []*expression.Column) []*expression.Column {
+	return CloneCols(cols)
+}
+
+// CloneConstants uses (*Constant).Clone to clone a slice of *Constant.
+func CloneConstants(constants []*expression.Constant) []*expression.Constant {
+	if constants == nil {
+		return nil
+	}
+	cloned := make([]*expression.Constant, 0, len(constants))
+	for _, c := range constants {
+		cloned = append(cloned, c.Clone().(*expression.Constant))
+	}
+	return cloned
+}
+
+// CloneConstant2D uses CloneConstants to clone a 2D slice of *Constant.
+func CloneConstant2D(constants [][]*expression.Constant) [][]*expression.Constant {
+	if constants == nil {
+		return nil
+	}
+	cloned := make([][]*expression.Constant, 0, len(constants))
+	for _, c := range constants {
+		cloned = append(cloned, CloneConstants(c))
+	}
+	return cloned
+}
+
+// CloneDatums uses Datum.Clone to clone a slice of Datum.
+func CloneDatums(datums []types.Datum) []types.Datum {
+	if datums == nil {
+		return nil
+	}
+	cloned := make([]types.Datum, 0, len(datums))
+	for _, d := range datums {
+		cloned = append(cloned, *d.Clone())
+	}
+	return cloned
+}
+
+// CloneDatum2D uses CloneDatums to clone a 2D slice of Datum.
+func CloneDatum2D(datums [][]types.Datum) [][]types.Datum {
+	if datums == nil {
+		return nil
+	}
+	cloned := make([][]types.Datum, 0, len(datums))
+	for _, d := range datums {
+		cloned = append(cloned, CloneDatums(d))
+	}
+	return cloned
+}
+
 // CloneColInfos uses (*ColumnInfo).Clone to clone a slice of *ColumnInfo.
 func CloneColInfos(cols []*model.ColumnInfo) []*model.ColumnInfo {
 	if cols == nil {
@@ -114,8 +173,8 @@ func CloneRanges(ranges []*ranger.Range) []*ranger.Range {
 	return cloned
 }
 
-// CloneByItems uses (*ByItems).Clone to clone a slice of *ByItems.
-func CloneByItems(byItems []*ByItems) []*ByItems {
+// CloneByItemss uses (*ByItems).Clone to clone a slice of *ByItems.
+func CloneByItemss(byItems []*ByItems) []*ByItems {
 	if byItems == nil {
 		return nil
 	}
@@ -126,8 +185,8 @@ func CloneByItems(byItems []*ByItems) []*ByItems {
 	return cloned
 }
 
-// CloneSortItem uses SortItem.Clone to clone a slice of SortItem.
-func CloneSortItem(items []property.SortItem) []property.SortItem {
+// CloneSortItems uses SortItem.Clone to clone a slice of SortItem.
+func CloneSortItems(items []property.SortItem) []property.SortItem {
 	if items == nil {
 		return nil
 	}
@@ -136,6 +195,19 @@ func CloneSortItem(items []property.SortItem) []property.SortItem {
 		cloned = append(cloned, item.Clone())
 	}
 	return cloned
+}
+
+// CloneHandles uses Handle.Copy to clone a slice of Handle.
+func CloneHandles(handles []kv.Handle) []kv.Handle {
+	if handles == nil {
+		return nil
+	}
+	cloned := make([]kv.Handle, 0, len(handles))
+	for _, h := range handles {
+		cloned = append(cloned, h.Copy())
+	}
+	return cloned
+
 }
 
 // QueryTimeRange represents a time range specified by TIME_RANGE hint


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54057

Problem Summary: planner: use code-gen to generate CloneForPlanCache method for some operators

### What changed and how does it work?

planner: use code-gen to generate CloneForPlanCache method for some operators

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
