### PR TITLE
ddl, partition: report error when interval partition create partition numbers exceed limit number

### DIFF
--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -1200,6 +1200,10 @@ func GeneratePartDefsFromInterval(ctx expression.BuildContext, tp ast.AlterTable
 			// Last partition!
 			break
 		}
+		// The last loop still not reach the max value, return error.
+		if i == mysql.PartitionCountLimit - 1 {
+			return errors.Trace(dbterror.ErrTooManyPartitions)
+		}
 	}
 	if len(tbInfo.Partition.Definitions)+len(partDefs) > mysql.PartitionCountLimit {
 		return errors.Trace(dbterror.ErrTooManyPartitions)

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -1201,7 +1201,7 @@ func GeneratePartDefsFromInterval(ctx expression.BuildContext, tp ast.AlterTable
 			break
 		}
 		// The last loop still not reach the max value, return error.
-		if i == mysql.PartitionCountLimit - 1 {
+		if i == mysql.PartitionCountLimit-1 {
 			return errors.Trace(dbterror.ErrTooManyPartitions)
 		}
 	}

--- a/tests/integrationtest/r/ddl/partition.result
+++ b/tests/integrationtest/r/ddl/partition.result
@@ -378,3 +378,6 @@ create table t(a int, b datetime, c varchar(8)) PARTITION BY RANGE COLUMNS(`c`,`
 alter table t add partition (PARTITION `p20240521A` VALUES LESS THAN ('A','2024-05-21 00:00:00'));
 Error 1493 (HY000): VALUES LESS THAN value must be strictly increasing for each partition
 alter table t add partition (PARTITION `p20240521Z` VALUES LESS THAN ('Z','2024-05-21 00:00:00'));
+CREATE TABLE employees (id int unsigned NOT NULL) PARTITION BY RANGE (id) INTERVAL (1) FIRST PARTITION LESS THAN (1) LAST PARTITION LESS THAN (8193);
+Error 1499 (HY000): Too many partitions (including subpartitions) were defined
+CREATE TABLE employees (id int unsigned NOT NULL) PARTITION BY RANGE (id) INTERVAL (1) FIRST PARTITION LESS THAN (1) LAST PARTITION LESS THAN (8192);

--- a/tests/integrationtest/t/ddl/partition.test
+++ b/tests/integrationtest/t/ddl/partition.test
@@ -184,3 +184,8 @@ create table t(a int, b datetime, c varchar(8)) PARTITION BY RANGE COLUMNS(`c`,`
 alter table t add partition (PARTITION `p20240521A` VALUES LESS THAN ('A','2024-05-21 00:00:00'));
 alter table t add partition (PARTITION `p20240521Z` VALUES LESS THAN ('Z','2024-05-21 00:00:00'));
 
+# TestIntervalPartitionCreateTooManyPartitions
+-- error 1499
+CREATE TABLE employees (id int unsigned NOT NULL) PARTITION BY RANGE (id) INTERVAL (1) FIRST PARTITION LESS THAN (1) LAST PARTITION LESS THAN (8193);
+CREATE TABLE employees (id int unsigned NOT NULL) PARTITION BY RANGE (id) INTERVAL (1) FIRST PARTITION LESS THAN (1) LAST PARTITION LESS THAN (8192);
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55093

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix create interval partition not report error when partition numbers exceed limit number.
```
