### PR TITLE
tools/ut.go: replace path with filepath

### DIFF
--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -26,7 +26,6 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -546,7 +545,7 @@ func collectCoverProfileFile() {
 }
 
 func collectOneCoverProfileFile(result map[string]*cover.Profile, file os.DirEntry) {
-	f, err := os.Open(path.Join(coverFileTempDir, file.Name()))
+	f, err := os.Open(filepath.Join(coverFileTempDir, file.Name()))
 	if err != nil {
 		fmt.Println("open temp cover file error:", err)
 		os.Exit(-1)
@@ -749,7 +748,7 @@ type testResult struct {
 func (n *numa) runTestCase(pkg string, fn string) testResult {
 	res := testResult{
 		JUnitTestCase: JUnitTestCase{
-			Classname: path.Join(modulePath, pkg),
+			Classname: filepath.Join(modulePath, pkg),
 			Name:      fn,
 		},
 	}
@@ -759,7 +758,7 @@ func (n *numa) runTestCase(pkg string, fn string) testResult {
 	var start time.Time
 	for i := 0; i < 3; i++ {
 		cmd := n.testCommand(pkg, fn)
-		cmd.Dir = path.Join(workDir, pkg)
+		cmd.Dir = filepath.Join(workDir, pkg)
 		// Combine the test case output, so the run result for failed cases can be displayed.
 		cmd.Stdout = &buf
 		cmd.Stderr = &buf
@@ -849,7 +848,7 @@ func (n *numa) testCommand(pkg string, fn string) *exec.Cmd {
 	exe := "./" + testFileName(pkg)
 	if coverprofile != "" {
 		fileName := strings.ReplaceAll(pkg, "/", "_") + "." + fn
-		tmpFile := path.Join(coverFileTempDir, fileName)
+		tmpFile := filepath.Join(coverFileTempDir, fileName)
 		args = append(args, "-test.coverprofile", tmpFile)
 	}
 	args = append(args, "-test.cpu", "1")
@@ -888,7 +887,7 @@ func buildTestBinary(pkg string) error {
 	if short {
 		cmd.Args = append(cmd.Args, "--test.short")
 	}
-	cmd.Dir = path.Join(workDir, pkg)
+	cmd.Dir = filepath.Join(workDir, pkg)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -902,7 +901,7 @@ func generateBuildCache() error {
 	cmd := exec.Command("go", "test", "-tags=intest", "-exec=true", "-vet=off")
 	goCompileWithoutLink := fmt.Sprintf("-toolexec=%s/tools/check/go-compile-without-link.sh", workDir)
 	cmd.Args = append(cmd.Args, goCompileWithoutLink)
-	cmd.Dir = path.Join(workDir, "cmd/tidb-server")
+	cmd.Dir = filepath.Join(workDir, "cmd/tidb-server")
 	if err := cmd.Run(); err != nil {
 		return withTrace(err)
 	}
@@ -918,10 +917,10 @@ func buildTestBinaryMulti(pkgs []string) error {
 	}
 
 	// go test --exec=xprog -cover -vet=off --count=0 $(pkgs)
-	xprogPath := path.Join(workDir, "tools/bin/xprog")
+	xprogPath := filepath.Join(workDir, "tools/bin/xprog")
 	packages := make([]string, 0, len(pkgs))
 	for _, pkg := range pkgs {
-		packages = append(packages, path.Join(modulePath, pkg))
+		packages = append(packages, filepath.Join(modulePath, pkg))
 	}
 
 	var cmd *exec.Cmd
@@ -957,12 +956,12 @@ func testBinaryExist(pkg string) (bool, error) {
 }
 
 func testFileName(pkg string) string {
-	_, file := path.Split(pkg)
+	_, file := filepath.Split(pkg)
 	return file + ".test.bin"
 }
 
 func testFileFullPath(pkg string) string {
-	return path.Join(workDir, pkg, testFileName(pkg))
+	return filepath.Join(workDir, pkg, testFileName(pkg))
 }
 
 func listNewTestCases(pkg string) ([]string, error) {
@@ -970,7 +969,7 @@ func listNewTestCases(pkg string) ([]string, error) {
 
 	// session.test -test.list Test
 	cmd := exec.Command(exe, "-test.list", "Test")
-	cmd.Dir = path.Join(workDir, pkg)
+	cmd.Dir = filepath.Join(workDir, pkg)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	err := cmd.Run()

--- a/tools/check/xprog.go
+++ b/tools/check/xprog.go
@@ -43,7 +43,7 @@ func main() {
 	// Extract the package info from /tmp/go-build2662369829/b1382/importcfg.link
 	pkg := getPackageInfo(dir)
 
-	const prefix = filepath.Join("github.com", "pingcap", "tidb")
+	var prefix = filepath.Join("github.com", "pingcap", "tidb")
 	if !strings.HasPrefix(pkg, prefix) {
 		os.Exit(-3)
 	}

--- a/tools/check/xprog.go
+++ b/tools/check/xprog.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Extract the current work directory
 	cwd := os.Args[0]
-	cwd = cwd[:len(cwd)-len("tools/bin/xprog")]
+	cwd = cwd[:len(cwd)-len(filepath.Join("tools", "bin", "xprog"))]
 
 	testBinaryPath := filepath.Clean(os.Args[1])
 	dir, _ := filepath.Split(testBinaryPath)
@@ -43,7 +43,7 @@ func main() {
 	// Extract the package info from /tmp/go-build2662369829/b1382/importcfg.link
 	pkg := getPackageInfo(dir)
 
-	const prefix = "github.com/pingcap/tidb/"
+	const prefix = filepath.Join("github.com", "pingcap", "tidb")
 	if !strings.HasPrefix(pkg, prefix) {
 		os.Exit(-3)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

`filepath.Join` is platform dependent and joins paths based on the operating system's path separator (e.g., `/` on Windows and `/` on Unix).
`path.Join` is platform-independent and always uses `/` as the path separator.

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Ref #30822

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
