### PR TITLE
context, hack: add more comments/tests to warn the developers to update `Detach` and `IntoStatic`.

### DIFF
--- a/pkg/util/context/BUILD.bazel
+++ b/pkg/util/context/BUILD.bazel
@@ -18,11 +18,21 @@ go_library(
 go_test(
     name = "context_test",
     timeout = "short",
-    srcs = ["warn_test.go"],
+    srcs = [
+        "checksum_test.go",
+        "warn_test.go",
+    ],
     embed = [":context"],
     flaky = True,
     deps = [
+        "//pkg/distsql/context",
+        "//pkg/expression/context",
+        "//pkg/expression/contextsession",
+        "//pkg/expression/contextstatic",
         "//pkg/parser/terror",
+        "//pkg/planner/context",
+        "//pkg/util/hack",
+        "//pkg/util/ranger/context",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/context/checksum_test.go
+++ b/pkg/util/context/checksum_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context_test
+
+import (
+	"testing"
+
+	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
+	exprctx "github.com/pingcap/tidb/pkg/expression/context"
+	"github.com/pingcap/tidb/pkg/expression/contextsession"
+	"github.com/pingcap/tidb/pkg/expression/contextstatic"
+	planctx "github.com/pingcap/tidb/pkg/planner/context"
+	"github.com/pingcap/tidb/pkg/util/hack"
+	rangerctx "github.com/pingcap/tidb/pkg/util/ranger/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImplementDetach(t *testing.T) {
+	// This test will fail when the type of `ExprContext`, `BuildContext` or any other interface below
+	// changed. Before update the checksum and make the test pass, please consider the following comments:
+
+	// The `IntoStatic` method should be modified for the new fields, and make sure the generated
+	// 	static interface is correct.
+	require.Equal(t, uint64(0xc97c250887ab24c9), hack.CalcTypeChecksum[exprctx.ExprContext]())
+	require.Equal(t, uint64(0xf4cf9344dcf26343), hack.CalcTypeChecksum[exprctx.BuildContext]())
+	require.Equal(t, uint64(0x45cbd7a388d1a9b8), hack.CalcTypeChecksum[exprctx.EvalContext]())
+	require.Equal(t, uint64(0xc0c84f99907c4285), hack.CalcTypeChecksum[contextsession.SessionExprContext]())
+	require.Equal(t, uint64(0x947a42f0886ff057), hack.CalcTypeChecksum[contextsession.SessionEvalContext]())
+	require.Equal(t, uint64(0xc40611086e3216cd), hack.CalcTypeChecksum[contextstatic.StaticExprContext]())
+	require.Equal(t, uint64(0xdcf72f3125c9ed3b), hack.CalcTypeChecksum[contextstatic.StaticEvalContext]())
+
+	// The `Detach` method shloud be modofied for the new fields
+	require.Equal(t, uint64(0xfc9772c1ea0e7410), hack.CalcTypeChecksum[rangerctx.RangerContext]())
+	require.Equal(t, uint64(0xc9373d8c26029076), hack.CalcTypeChecksum[distsqlctx.DistSQLContext]())
+	require.Equal(t, uint64(0x5d0f526263a0d8f2), hack.CalcTypeChecksum[planctx.BuildPBContext]())
+}

--- a/pkg/util/hack/BUILD.bazel
+++ b/pkg/util/hack/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "hack",
-    srcs = ["hack.go"],
+    srcs = [
+        "hack.go",
+        "type_checksum.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/util/hack",
     visibility = ["//visibility:public"],
 )
@@ -13,11 +16,13 @@ go_test(
     srcs = [
         "hack_test.go",
         "main_test.go",
+        "type_checksum_test.go",
     ],
     embed = [":hack"],
     flaky = True,
     deps = [
         "//pkg/testkit/testsetup",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/util/hack/type_checksum.go
+++ b/pkg/util/hack/type_checksum.go
@@ -1,0 +1,96 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hack
+
+import (
+	"encoding/binary"
+	"hash"
+	"hash/crc64"
+	"reflect"
+)
+
+// CalcTypeChecksum return a value which can represent the change of the type T
+// It's used in the test to make sure the developer can read some comments or
+// make some related changes when the type T is changed.
+func CalcTypeChecksum[T any]() uint64 {
+	// Cannot use the type of `var t T` directly, because when the type T is an interface,
+	// the type will be `nil`. The following method is copied from `reflect.TypeFor`. When
+	// the go compiler version is upgraded, it can be replace by `reflect.TypeFor[T]` instead.
+	typ := reflect.TypeOf((*T)(nil)).Elem()
+	h := crc64.New(crc64.MakeTable(crc64.ECMA))
+
+	hashType(h, typ, nil)
+
+	return h.Sum64()
+}
+
+func hashType(h hash.Hash64, typ reflect.Type, visited map[reflect.Type]struct{}) {
+	if typ == nil {
+		h.Write([]byte("nil type"))
+		return
+	}
+	if visited == nil {
+		visited = make(map[reflect.Type]struct{})
+	}
+	_, ok := visited[typ]
+	if ok {
+		h.Write([]byte("recursive"))
+		h.Write([]byte(typ.String()))
+		return
+	}
+	visited[typ] = struct{}{}
+
+	switch typ.Kind() {
+	case reflect.Struct:
+		h.Write([]byte("struct"))
+		for i := 0; i < typ.NumField(); i++ {
+			h.Write([]byte(typ.Field(i).Name))
+			hashType(h, typ.Field(i).Type, visited)
+		}
+	case reflect.Interface:
+		h.Write([]byte("interface"))
+		for i := 0; i < typ.NumMethod(); i++ {
+			h.Write([]byte(typ.Method(i).Name))
+			hashType(h, typ.Method(i).Type, visited)
+		}
+	case reflect.Func:
+		h.Write([]byte("func"))
+		for i := 0; i < typ.NumIn(); i++ {
+			hashType(h, typ.In(i), visited)
+		}
+		for i := 0; i < typ.NumOut(); i++ {
+			hashType(h, typ.Out(i), visited)
+		}
+	case reflect.Array:
+		h.Write([]byte("array"))
+		h.Write(binary.LittleEndian.AppendUint64(nil, uint64(typ.Len())))
+		hashType(h, typ.Elem(), visited)
+	case reflect.Slice:
+		h.Write([]byte("slice"))
+		hashType(h, typ.Elem(), visited)
+	case reflect.Chan:
+		h.Write([]byte("chan"))
+		hashType(h, typ.Elem(), visited)
+	case reflect.Map:
+		h.Write([]byte("map"))
+		hashType(h, typ.Key(), visited)
+		hashType(h, typ.Elem(), visited)
+	case reflect.Pointer:
+		h.Write([]byte("ptr"))
+		hashType(h, typ.Elem(), visited)
+	default:
+		h.Write([]byte(typ.String()))
+	}
+}

--- a/pkg/util/hack/type_checksum_test.go
+++ b/pkg/util/hack/type_checksum_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func assertNotConflict(t *testing.T, checkSum uint64, conflictCheckMap map[uint64]struct{}) {
+	_, ok := conflictCheckMap[checkSum]
+	require.False(t, ok)
+	conflictCheckMap[checkSum] = struct{}{}
+}
+
+func TestTypeChecksum(t *testing.T) {
+	conflictCheck := map[uint64]struct{}{}
+	assertNotConflict(t, CalcTypeChecksum[struct{ a int }](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[*struct{ a int }](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[struct{ a int32 }](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[int](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[int64](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[interface{ a() bool }](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[interface{ b() bool }](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[chan int](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[chan int32](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[map[string]string](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[[]string](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[[5]string](), conflictCheck)
+
+	type recursiveStruct struct {
+		_ int
+		_ *recursiveStruct
+	}
+	assertNotConflict(t, CalcTypeChecksum[recursiveStruct](), conflictCheck)
+	assertNotConflict(t, CalcTypeChecksum[*recursiveStruct](), conflictCheck)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55130

Problem Summary:

As described in the issue, we need to make sure the developers know that the `Detach` or `IntoStatic` should be changed if the interface or struct structure changed. 

### What changed and how does it work?

1. Implement a function `hack.CalcTypeChecksum` to calculate the checksum of a type to fail a test when the type changed.
2. Add a test for many context types.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
