### PR TITLE
statistics: move history-related functions into the stats handle

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -41,12 +40,10 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics/handle"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
-	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
-	"github.com/pingcap/tidb/pkg/util/sqlexec"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/tiancaiamao/gp"
 	"go.uber.org/zap"
@@ -432,7 +429,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	resultsCh <-chan *statistics.AnalyzeResults,
 ) error {
 	partitionStatsConcurrency := len(subSctxs)
-
+	statsHandle := domain.GetDomain(e.Ctx()).StatsHandle()
 	wg := util.NewWaitGroupPool(e.gp)
 	saveResultsCh := make(chan *statistics.AnalyzeResults, partitionStatsConcurrency)
 	errCh := make(chan error, partitionStatsConcurrency)
@@ -440,7 +437,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 		worker := newAnalyzeSaveStatsWorker(saveResultsCh, subSctxs[i], errCh, &e.Ctx().GetSessionVars().SQLKiller)
 		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 		wg.Run(func() {
-			worker.run(ctx1, e.Ctx().GetSessionVars().EnableAnalyzeSnapshot)
+			worker.run(ctx1, statsHandle, e.Ctx().GetSessionVars().EnableAnalyzeSnapshot)
 		})
 	}
 	tableIDs := map[int64]struct{}{}
@@ -462,7 +459,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 			} else {
 				logutil.Logger(ctx).Error("analyze failed", zap.Error(err))
 			}
-			finishJobWithLog(e.Ctx(), results.Job, err)
+			finishJobWithLog(statsHandle, results.Job, err)
 			continue
 		}
 		handleGlobalStats(needGlobalStats, globalStatsMap, results)
@@ -569,97 +566,8 @@ func AddNewAnalyzeJob(ctx sessionctx.Context, job *statistics.AnalyzeJob) {
 	}
 }
 
-// FinishAnalyzeMergeJob finishes analyze merge job
-func FinishAnalyzeMergeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, analyzeErr error) {
-	if job == nil || job.ID == nil {
-		return
-	}
-
-	job.EndTime = time.Now()
-	var sql string
-	var args []any
-	if analyzeErr != nil {
-		failReason := analyzeErr.Error()
-		const textMaxLength = 65535
-		if len(failReason) > textMaxLength {
-			failReason = failReason[:textMaxLength]
-		}
-		sql = "UPDATE mysql.analyze_jobs SET end_time = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE), state = %?, fail_reason = %?, process_id = NULL WHERE id = %?"
-		args = []any{job.EndTime.UTC().Format(types.TimeFormat), statistics.AnalyzeFailed, failReason, *job.ID}
-	} else {
-		sql = "UPDATE mysql.analyze_jobs SET end_time = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE), state = %?, process_id = NULL WHERE id = %?"
-		args = []any{job.EndTime.UTC().Format(types.TimeFormat), statistics.AnalyzeFinished, *job.ID}
-	}
-	exec := sctx.GetRestrictedSQLExecutor()
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
-	_, _, err := exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseSessionPool}, sql, args...)
-	if err != nil {
-		var state string
-		if analyzeErr != nil {
-			state = statistics.AnalyzeFailed
-		} else {
-			state = statistics.AnalyzeFinished
-		}
-		logutil.BgLogger().Warn("failed to update analyze job", zap.String("update", fmt.Sprintf("%s->%s", statistics.AnalyzeRunning, state)), zap.Error(err))
-	}
-	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
-		if val.(bool) {
-			logutil.BgLogger().Info("FinishAnalyzeMergeJob",
-				zap.Time("end_time", job.EndTime),
-				zap.Uint64("job id", *job.ID),
-			)
-		}
-	})
-}
-
-// FinishAnalyzeJob updates the state of the analyze job to finished/failed according to `meetError` and sets the end time.
-func FinishAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, analyzeErr error) {
-	if job == nil || job.ID == nil {
-		return
-	}
-	job.EndTime = time.Now()
-	var sql string
-	var args []any
-	// process_id is used to see which process is running the analyze job and kill the analyze job. After the analyze job
-	// is finished(or failed), process_id is useless and we set it to NULL to avoid `kill tidb process_id` wrongly.
-	if analyzeErr != nil {
-		failReason := analyzeErr.Error()
-		const textMaxLength = 65535
-		if len(failReason) > textMaxLength {
-			failReason = failReason[:textMaxLength]
-		}
-		sql = "UPDATE mysql.analyze_jobs SET processed_rows = processed_rows + %?, end_time = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE), state = %?, fail_reason = %?, process_id = NULL WHERE id = %?"
-		args = []any{job.Progress.GetDeltaCount(), job.EndTime.UTC().Format(types.TimeFormat), statistics.AnalyzeFailed, failReason, *job.ID}
-	} else {
-		sql = "UPDATE mysql.analyze_jobs SET processed_rows = processed_rows + %?, end_time = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE), state = %?, process_id = NULL WHERE id = %?"
-		args = []any{job.Progress.GetDeltaCount(), job.EndTime.UTC().Format(types.TimeFormat), statistics.AnalyzeFinished, *job.ID}
-	}
-	exec := sctx.GetRestrictedSQLExecutor()
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
-	_, _, err := exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseSessionPool}, sql, args...)
-	if err != nil {
-		var state string
-		if analyzeErr != nil {
-			state = statistics.AnalyzeFailed
-		} else {
-			state = statistics.AnalyzeFinished
-		}
-		logutil.BgLogger().Warn("failed to update analyze job", zap.String("update", fmt.Sprintf("%s->%s", statistics.AnalyzeRunning, state)), zap.Error(err))
-	}
-	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
-		if val.(bool) {
-			logutil.BgLogger().Info("FinishAnalyzeJob",
-				zap.Int64("increase processed_rows", job.Progress.GetDeltaCount()),
-				zap.Time("end_time", job.EndTime),
-				zap.Uint64("job id", *job.ID),
-				zap.Error(analyzeErr),
-			)
-		}
-	})
-}
-
-func finishJobWithLog(sctx sessionctx.Context, job *statistics.AnalyzeJob, analyzeErr error) {
-	FinishAnalyzeJob(sctx, job, analyzeErr)
+func finishJobWithLog(statsHandle *handle.Handle, job *statistics.AnalyzeJob, analyzeErr error) {
+	statsHandle.FinishAnalyzeJob(job, analyzeErr, statistics.TableAnalysisJob)
 	if job != nil {
 		var state string
 		if analyzeErr != nil {

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -229,7 +229,7 @@ func (e *AnalyzeColumnsExec) buildStats(ranges []*ranger.Range, needExtStats boo
 			rowCount = respSample.Count + respSample.NullCount
 			collectors[i].MergeSampleCollector(sc, respSample)
 		}
-		statsHandle.UpdateAnalyzeJobProcess(e.job, rowCount)
+		statsHandle.UpdateAnalyzeJobProgress(e.job, rowCount)
 	}
 	timeZone := e.ctx.GetSessionVars().Location()
 	if hasPkHist(e.handleCols) {

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -229,7 +229,7 @@ func (e *AnalyzeColumnsExec) buildStats(ranges []*ranger.Range, needExtStats boo
 			rowCount = respSample.Count + respSample.NullCount
 			collectors[i].MergeSampleCollector(sc, respSample)
 		}
-		statsHandle.UpdateAnalyzeJob(e.job, rowCount)
+		statsHandle.UpdateAnalyzeJobProcess(e.job, rowCount)
 	}
 	timeZone := e.ctx.GetSessionVars().Location()
 	if hasPkHist(e.handleCols) {

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -174,6 +174,7 @@ func (e *AnalyzeColumnsExec) buildStats(ranges []*ranger.Range, needExtStats boo
 			CMSketch:      statistics.NewCMSketch(int32(e.opts[ast.AnalyzeOptCMSketchDepth]), int32(e.opts[ast.AnalyzeOptCMSketchWidth])),
 		}
 	}
+	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	for {
 		failpoint.Inject("mockKillRunningV1AnalyzeJob", func() {
 			dom := domain.GetDomain(e.ctx)
@@ -228,7 +229,7 @@ func (e *AnalyzeColumnsExec) buildStats(ranges []*ranger.Range, needExtStats boo
 			rowCount = respSample.Count + respSample.NullCount
 			collectors[i].MergeSampleCollector(sc, respSample)
 		}
-		UpdateAnalyzeJob(e.ctx, e.job, rowCount)
+		statsHandle.UpdateAnalyzeJob(e.job, rowCount)
 	}
 	timeZone := e.ctx.GetSessionVars().Location()
 	if hasPkHist(e.handleCols) {

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -473,6 +473,7 @@ func (e *AnalyzeColumnsExecV2) handleNDVForSpecialIndexes(indexInfos []*model.In
 		results: make(map[int64]*statistics.AnalyzeResults, len(indexInfos)),
 	}
 	var err error
+	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	for panicCnt < statsConcurrncy {
 		results, ok := <-resultsCh
 		if !ok {
@@ -480,13 +481,13 @@ func (e *AnalyzeColumnsExecV2) handleNDVForSpecialIndexes(indexInfos []*model.In
 		}
 		if results.Err != nil {
 			err = results.Err
-			FinishAnalyzeJob(e.ctx, results.Job, err)
+			statsHandle.FinishAnalyzeJob(results.Job, err, statistics.TableAnalysisJob)
 			if isAnalyzeWorkerPanic(err) {
 				panicCnt++
 			}
 			continue
 		}
-		FinishAnalyzeJob(e.ctx, results.Job, nil)
+		statsHandle.FinishAnalyzeJob(results.Job, nil, statistics.TableAnalysisJob)
 		totalResult.results[results.Ars[0].Hist[0].ID] = results
 	}
 	if err != nil {

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -652,7 +652,7 @@ func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResu
 		// Update processed rows.
 		subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
 		subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
-		statsHandle.UpdateAnalyzeJob(e.job, subCollector.Base().Count)
+		statsHandle.UpdateAnalyzeJobProcess(e.job, subCollector.Base().Count)
 
 		// Print collect log.
 		oldRetCollectorSize := retCollector.Base().MemSize

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -652,7 +652,7 @@ func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResu
 		// Update processed rows.
 		subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
 		subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
-		statsHandle.UpdateAnalyzeJobProcess(e.job, subCollector.Base().Count)
+		statsHandle.UpdateAnalyzeJobProgress(e.job, subCollector.Base().Count)
 
 		// Print collect log.
 		oldRetCollectorSize := retCollector.Base().MemSize

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -498,6 +498,7 @@ func (e *AnalyzeColumnsExecV2) handleNDVForSpecialIndexes(indexInfos []*model.In
 // subIndexWorker receive the task for each index and return the result for them.
 func (e *AnalyzeColumnsExecV2) subIndexWorkerForNDV(taskCh chan *analyzeTask, resultsCh chan *statistics.AnalyzeResults) {
 	var task *analyzeTask
+	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	defer func() {
 		if r := recover(); r != nil {
 			logutil.BgLogger().Error("analyze worker panicked", zap.Any("recover", r), zap.Stack("stack"))
@@ -514,7 +515,7 @@ func (e *AnalyzeColumnsExecV2) subIndexWorkerForNDV(taskCh chan *analyzeTask, re
 		if !ok {
 			break
 		}
-		StartAnalyzeJob(e.ctx, task.job)
+		statsHandle.StartAnalyzeJob(task.job)
 		if task.taskType != idxTask {
 			resultsCh <- &statistics.AnalyzeResults{
 				Err: errors.Errorf("incorrect analyze type"),

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -629,6 +629,7 @@ func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResu
 	for i := 0; i < l; i++ {
 		retCollector.Base().FMSketches = append(retCollector.Base().FMSketches, statistics.NewFMSketch(statistics.MaxSketchSize))
 	}
+	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	for {
 		data, ok := <-taskCh
 		if !ok {
@@ -650,7 +651,7 @@ func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResu
 		// Update processed rows.
 		subCollector := statistics.NewRowSampleCollector(int(e.analyzePB.ColReq.SampleSize), e.analyzePB.ColReq.GetSampleRate(), l)
 		subCollector.Base().FromProto(colResp.RowCollector, e.memTracker)
-		UpdateAnalyzeJob(e.ctx, e.job, subCollector.Base().Count)
+		statsHandle.UpdateAnalyzeJob(e.job, subCollector.Base().Count)
 
 		// Print collect log.
 		oldRetCollectorSize := retCollector.Base().MemSize

--- a/pkg/executor/analyze_global_stats.go
+++ b/pkg/executor/analyze_global_stats.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/statistics"
+	"github.com/pingcap/tidb/pkg/statistics/handle"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
@@ -35,13 +36,12 @@ type globalStatsKey struct {
 // The meaning of value in map is some additional information needed to build global-level stats.
 type globalStatsMap map[globalStatsKey]statstypes.GlobalStatsInfo
 
-func (e *AnalyzeExec) handleGlobalStats(globalStatsMap globalStatsMap) error {
+func (e *AnalyzeExec) handleGlobalStats(statsHandle *handle.Handle, globalStatsMap globalStatsMap) error {
 	globalStatsTableIDs := make(map[int64]struct{}, len(globalStatsMap))
 	for globalStatsID := range globalStatsMap {
 		globalStatsTableIDs[globalStatsID.tableID] = struct{}{}
 	}
 
-	statsHandle := domain.GetDomain(e.Ctx()).StatsHandle()
 	tableIDs := make(map[int64]struct{}, len(globalStatsTableIDs))
 	for tableID := range globalStatsTableIDs {
 		tableIDs[tableID] = struct{}{}
@@ -55,7 +55,7 @@ func (e *AnalyzeExec) handleGlobalStats(globalStatsMap globalStatsMap) error {
 				continue
 			}
 			AddNewAnalyzeJob(e.Ctx(), job)
-			StartAnalyzeJob(e.Ctx(), job)
+			statsHandle.StartAnalyzeJob(job)
 
 			mergeStatsErr := func() error {
 				globalOpts := e.opts

--- a/pkg/executor/analyze_global_stats.go
+++ b/pkg/executor/analyze_global_stats.go
@@ -76,7 +76,7 @@ func (e *AnalyzeExec) handleGlobalStats(statsHandle *handle.Handle, globalStatsM
 				}
 				return err
 			}()
-			FinishAnalyzeMergeJob(e.Ctx(), job, mergeStatsErr)
+			statsHandle.FinishAnalyzeJob(job, mergeStatsErr, statistics.GlobalStatsMergeJob)
 		}
 	}
 

--- a/pkg/executor/analyze_idx.go
+++ b/pkg/executor/analyze_idx.go
@@ -319,7 +319,8 @@ func updateIndexResult(
 	needCMS := cms != nil
 	respHist := statistics.HistogramFromProto(resp.Hist)
 	if job != nil {
-		UpdateAnalyzeJob(ctx, job, int64(respHist.TotalRowCount()))
+		statsHandle := domain.GetDomain(ctx).StatsHandle()
+		statsHandle.UpdateAnalyzeJob(job, int64(respHist.TotalRowCount()))
 	}
 	hist, err = statistics.MergeHistograms(ctx.GetSessionVars().StmtCtx, hist, respHist, numBuckets, statsVer)
 	if err != nil {

--- a/pkg/executor/analyze_idx.go
+++ b/pkg/executor/analyze_idx.go
@@ -320,7 +320,7 @@ func updateIndexResult(
 	respHist := statistics.HistogramFromProto(resp.Hist)
 	if job != nil {
 		statsHandle := domain.GetDomain(ctx).StatsHandle()
-		statsHandle.UpdateAnalyzeJobProcess(job, int64(respHist.TotalRowCount()))
+		statsHandle.UpdateAnalyzeJobProgress(job, int64(respHist.TotalRowCount()))
 	}
 	hist, err = statistics.MergeHistograms(ctx.GetSessionVars().StmtCtx, hist, respHist, numBuckets, statsVer)
 	if err != nil {

--- a/pkg/executor/analyze_idx.go
+++ b/pkg/executor/analyze_idx.go
@@ -320,7 +320,7 @@ func updateIndexResult(
 	respHist := statistics.HistogramFromProto(resp.Hist)
 	if job != nil {
 		statsHandle := domain.GetDomain(ctx).StatsHandle()
-		statsHandle.UpdateAnalyzeJob(job, int64(respHist.TotalRowCount()))
+		statsHandle.UpdateAnalyzeJobProcess(job, int64(respHist.TotalRowCount()))
 	}
 	hist, err = statistics.MergeHistograms(ctx.GetSessionVars().StmtCtx, hist, respHist, numBuckets, statsVer)
 	if err != nil {

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2806,9 +2806,9 @@ func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
 // TestAnalyzeMVIndex tests analyzing the mv index use some real data in the table.
 // It checks the analyze jobs, async loading and the stats content in the memory.
 func TestAnalyzeMVIndex(t *testing.T) {
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/DebugAnalyzeJobOperations", "return(true)"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/DebugAnalyzeJobOperations", "return(true)"))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/DebugAnalyzeJobOperations"))
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/DebugAnalyzeJobOperations"))
 	}()
 	// 1. prepare the table and insert data
 	store, dom := testkit.CreateMockStoreAndDomain(t)

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2111,7 +2111,7 @@ func TestAnalyzeJob(t *testing.T) {
 		if result == statistics.AnalyzeFailed {
 			analyzeErr = errors.Errorf("analyze meets error")
 		}
-		executor.FinishAnalyzeJob(se, job, analyzeErr)
+		statsHandle.FinishAnalyzeJob(job, analyzeErr, statistics.TableAnalysisJob)
 		rows = tk.MustQuery("show analyze status").Rows()
 		require.Equal(t, strconv.FormatInt(smallCount+2*largeCount, 10), rows[0][4])
 		checkTime(rows[0][6])
@@ -2806,10 +2806,8 @@ func TestAnalyzeColumnsSkipMVIndexJsonCol(t *testing.T) {
 // TestAnalyzeMVIndex tests analyzing the mv index use some real data in the table.
 // It checks the analyze jobs, async loading and the stats content in the memory.
 func TestAnalyzeMVIndex(t *testing.T) {
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/DebugAnalyzeJobOperations", "return(true)"))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/DebugAnalyzeJobOperations", "return(true)"))
 	defer func() {
-		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/DebugAnalyzeJobOperations"))
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/DebugAnalyzeJobOperations"))
 	}()
 	// 1. prepare the table and insert data

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2084,7 +2084,7 @@ func TestAnalyzeJob(t *testing.T) {
 		lastDumpTime := time.Now().Add(-10 * time.Second)
 		job.Progress.SetLastDumpTime(lastDumpTime)
 		const smallCount int64 = 100
-		executor.UpdateAnalyzeJob(se, job, smallCount)
+		statsHandle.UpdateAnalyzeJob(job, smallCount)
 		// Delta count doesn't reach threshold so we don't dump it to mysql.analyze_jobs
 		require.Equal(t, smallCount, job.Progress.GetDeltaCount())
 		require.Equal(t, lastDumpTime, job.Progress.GetLastDumpTime())
@@ -2092,7 +2092,7 @@ func TestAnalyzeJob(t *testing.T) {
 		require.Equal(t, "0", rows[0][4])
 
 		const largeCount int64 = 15000000
-		executor.UpdateAnalyzeJob(se, job, largeCount)
+		statsHandle.UpdateAnalyzeJob(job, largeCount)
 		// Delta count reaches threshold so we dump it to mysql.analyze_jobs and update last dump time.
 		require.Equal(t, int64(0), job.Progress.GetDeltaCount())
 		require.True(t, job.Progress.GetLastDumpTime().After(lastDumpTime))
@@ -2100,7 +2100,7 @@ func TestAnalyzeJob(t *testing.T) {
 		rows = tk.MustQuery("show analyze status").Rows()
 		require.Equal(t, strconv.FormatInt(smallCount+largeCount, 10), rows[0][4])
 
-		executor.UpdateAnalyzeJob(se, job, largeCount)
+		statsHandle.UpdateAnalyzeJob(job, largeCount)
 		// We have just updated mysql.analyze_jobs in the previous step so we don't update it until 5 second passes or the analyze job is over.
 		require.Equal(t, largeCount, job.Progress.GetDeltaCount())
 		require.Equal(t, lastDumpTime, job.Progress.GetLastDumpTime())

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2079,12 +2079,12 @@ func TestAnalyzeJob(t *testing.T) {
 		require.Equal(t, "0.1", rows[0][12])  // PROGRESS
 		require.Equal(t, "0", rows[0][13])    // ESTIMATED_TOTAL_ROWS
 
-		// UpdateAnalyzeJobProcess requires the interval between two updates to mysql.analyze_jobs is more than 5 second.
+		// UpdateAnalyzeJobProgress requires the interval between two updates to mysql.analyze_jobs is more than 5 second.
 		// Hence we fake last dump time as 10 second ago in order to make update to mysql.analyze_jobs happen.
 		lastDumpTime := time.Now().Add(-10 * time.Second)
 		job.Progress.SetLastDumpTime(lastDumpTime)
 		const smallCount int64 = 100
-		statsHandle.UpdateAnalyzeJobProcess(job, smallCount)
+		statsHandle.UpdateAnalyzeJobProgress(job, smallCount)
 		// Delta count doesn't reach threshold so we don't dump it to mysql.analyze_jobs
 		require.Equal(t, smallCount, job.Progress.GetDeltaCount())
 		require.Equal(t, lastDumpTime, job.Progress.GetLastDumpTime())
@@ -2092,7 +2092,7 @@ func TestAnalyzeJob(t *testing.T) {
 		require.Equal(t, "0", rows[0][4])
 
 		const largeCount int64 = 15000000
-		statsHandle.UpdateAnalyzeJobProcess(job, largeCount)
+		statsHandle.UpdateAnalyzeJobProgress(job, largeCount)
 		// Delta count reaches threshold so we dump it to mysql.analyze_jobs and update last dump time.
 		require.Equal(t, int64(0), job.Progress.GetDeltaCount())
 		require.True(t, job.Progress.GetLastDumpTime().After(lastDumpTime))
@@ -2100,7 +2100,7 @@ func TestAnalyzeJob(t *testing.T) {
 		rows = tk.MustQuery("show analyze status").Rows()
 		require.Equal(t, strconv.FormatInt(smallCount+largeCount, 10), rows[0][4])
 
-		statsHandle.UpdateAnalyzeJobProcess(job, largeCount)
+		statsHandle.UpdateAnalyzeJobProgress(job, largeCount)
 		// We have just updated mysql.analyze_jobs in the previous step so we don't update it until 5 second passes or the analyze job is over.
 		require.Equal(t, largeCount, job.Progress.GetDeltaCount())
 		require.Equal(t, lastDumpTime, job.Progress.GetLastDumpTime())

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -2063,8 +2063,8 @@ func TestAnalyzeJob(t *testing.T) {
 		require.Equal(t, addr, rows[0][9])
 		connID := strconv.FormatUint(tk.Session().GetSessionVars().ConnectionID, 10)
 		require.Equal(t, connID, rows[0][10])
-
-		executor.StartAnalyzeJob(se, job)
+		statsHandle := domain.GetDomain(tk.Session()).StatsHandle()
+		statsHandle.StartAnalyzeJob(job)
 		ctx := context.WithValue(context.Background(), executor.AnalyzeProgressTest, 100)
 		rows = tk.MustQueryWithContext(ctx, "show analyze status").Rows()
 		checkTime := func(val any) {

--- a/pkg/statistics/analyze_jobs.go
+++ b/pkg/statistics/analyze_jobs.go
@@ -31,10 +31,13 @@ const (
 	AnalyzeFailed = "failed"
 )
 
+// JobType is the type of the analyze job.
 type JobType int
 
 const (
+	// TableAnalysisJob means the job is to analyze a table or partition.
 	TableAnalysisJob JobType = iota + 1
+	// GlobalStatsMergeJob means the job is to merge the global-level stats.
 	GlobalStatsMergeJob
 )
 

--- a/pkg/statistics/analyze_jobs.go
+++ b/pkg/statistics/analyze_jobs.go
@@ -31,6 +31,13 @@ const (
 	AnalyzeFailed = "failed"
 )
 
+type JobType int
+
+const (
+	TableAnalysisJob JobType = iota + 1
+	GlobalStatsMergeJob
+)
+
 const (
 	// maxDelta is the threshold of delta count. If the delta count reaches this threshold, it will be dumped into
 	// mysql.analyze_jobs.

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -77,7 +77,7 @@ func (sa *statsAnalyze) StartAnalyzeJob(job *statistics.AnalyzeJob) {
 	})
 }
 
-func (sa *statsAnalyze) UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int64) {
+func (sa *statsAnalyze) UpdateAnalyzeJobProcess(job *statistics.AnalyzeJob, rowCount int64) {
 	_ = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		updateAnalyzeJob(sctx, job, rowCount)
 		return nil
@@ -763,7 +763,7 @@ func updateAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, rowCo
 	}
 	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
 		if val.(bool) {
-			logutil.BgLogger().Info("UpdateAnalyzeJob",
+			logutil.BgLogger().Info("UpdateAnalyzeJobProcess",
 				zap.Int64("increase processed_rows", delta),
 				zap.Uint64("job id", *job.ID),
 			)

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -82,7 +82,7 @@ func (sa *statsAnalyze) StartAnalyzeJob(job *statistics.AnalyzeJob) {
 
 func (sa *statsAnalyze) UpdateAnalyzeJobProgress(job *statistics.AnalyzeJob, rowCount int64) {
 	err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
-		updateAnalyzeJob(sctx, job, rowCount)
+		updateAnalyzeJobProgress(sctx, job, rowCount)
 		return nil
 	})
 	if err != nil {
@@ -756,8 +756,8 @@ func startAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob) {
 	})
 }
 
-// updateAnalyzeJob updates count of the processed rows when increment reaches a threshold.
-func updateAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, rowCount int64) {
+// updateAnalyzeJobProgress updates count of the processed rows when increment reaches a threshold.
+func updateAnalyzeJobProgress(sctx sessionctx.Context, job *statistics.AnalyzeJob, rowCount int64) {
 	if job == nil || job.ID == nil {
 		return
 	}

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -790,6 +790,8 @@ func finishAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, analy
 	var sql string
 	var args []any
 
+	// process_id is used to see which process is running the analyze job and kill the analyze job. After the analyze job
+	// is finished(or failed), process_id is useless and we set it to NULL to avoid `kill tidb process_id` wrongly.
 	if analyzeErr != nil {
 		failReason := analyzeErr.Error()
 		const textMaxLength = 65535

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -71,24 +71,33 @@ func (sa *statsAnalyze) InsertAnalyzeJob(job *statistics.AnalyzeJob, instance st
 }
 
 func (sa *statsAnalyze) StartAnalyzeJob(job *statistics.AnalyzeJob) {
-	_ = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+	err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		startAnalyzeJob(sctx, job)
 		return nil
 	})
+	if err != nil {
+		statslogutil.StatsLogger().Warn("failed to start analyze job", zap.Error(err))
+	}
 }
 
 func (sa *statsAnalyze) UpdateAnalyzeJobProgress(job *statistics.AnalyzeJob, rowCount int64) {
-	_ = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+	err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		updateAnalyzeJob(sctx, job, rowCount)
 		return nil
 	})
+	if err != nil {
+		statslogutil.StatsLogger().Warn("failed to update analyze job progress", zap.Error(err))
+	}
 }
 
 func (sa *statsAnalyze) FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason error, analyzeType statistics.JobType) {
-	_ = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+	err := statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		finishAnalyzeJob(sctx, job, failReason, analyzeType)
 		return nil
 	})
+	if err != nil {
+		statslogutil.StatsLogger().Warn("failed to finish analyze job", zap.Error(err))
+	}
 }
 
 // DeleteAnalyzeJobs deletes the analyze jobs whose update time is earlier than updateTime.

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -77,7 +77,7 @@ func (sa *statsAnalyze) StartAnalyzeJob(job *statistics.AnalyzeJob) {
 	})
 }
 
-func (sa *statsAnalyze) UpdateAnalyzeJobProcess(job *statistics.AnalyzeJob, rowCount int64) {
+func (sa *statsAnalyze) UpdateAnalyzeJobProgress(job *statistics.AnalyzeJob, rowCount int64) {
 	_ = statsutil.CallWithSCtx(sa.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		updateAnalyzeJob(sctx, job, rowCount)
 		return nil
@@ -763,7 +763,7 @@ func updateAnalyzeJob(sctx sessionctx.Context, job *statistics.AnalyzeJob, rowCo
 	}
 	failpoint.Inject("DebugAnalyzeJobOperations", func(val failpoint.Value) {
 		if val.(bool) {
-			logutil.BgLogger().Info("UpdateAnalyzeJobProcess",
+			logutil.BgLogger().Info("UpdateAnalyzeJobProgress",
 				zap.Int64("increase processed_rows", delta),
 				zap.Uint64("job id", *job.ID),
 			)

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -122,12 +122,18 @@ type StatsAnalyze interface {
 	InsertAnalyzeJob(job *statistics.AnalyzeJob, instance string, procID uint64) error
 
 	// StartAnalyzeJob updates the job status to `running` and sets the start time.
+	// There is no guarantee that the job will actually start. If the job fails to start, an error will be logged.
+	// It is OK because this won't affect the analysis job's success.
 	StartAnalyzeJob(job *statistics.AnalyzeJob)
 
 	// UpdateAnalyzeJob updates the current progress of the analyze job.
+	// There is no guarantee that the job will actually update. If the job fails to update, an error will be logged.
+	// It is OK because this won't affect the analysis job's success.
 	UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int64)
 
 	// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
+	// There is no guarantee that the job will actually finish. If the job fails to finish, an error will be logged.
+	// It is OK because this won't affect the analysis job's success.
 	FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason error, analyzeType statistics.JobType)
 
 	// DeleteAnalyzeJobs deletes the analyze jobs whose update time is earlier than updateTime.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -126,9 +126,9 @@ type StatsAnalyze interface {
 
 	// UpdateAnalyzeJob updates the current progress of the analyze job.
 	UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int64)
-	//
-	//// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
-	//FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason string) error
+
+	// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
+	FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason error, analyzeType statistics.JobType)
 
 	// DeleteAnalyzeJobs deletes the analyze jobs whose update time is earlier than updateTime.
 	DeleteAnalyzeJobs(updateTime time.Time) error

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -126,10 +126,10 @@ type StatsAnalyze interface {
 	// It is OK because this won't affect the analysis job's success.
 	StartAnalyzeJob(job *statistics.AnalyzeJob)
 
-	// UpdateAnalyzeJobProcess updates the current progress of the analyze job.
+	// UpdateAnalyzeJobProgress updates the current progress of the analyze job.
 	// There is no guarantee that the job will actually update. If the job fails to update, an error will be logged.
 	// It is OK because this won't affect the analysis job's success.
-	UpdateAnalyzeJobProcess(job *statistics.AnalyzeJob, rowCount int64)
+	UpdateAnalyzeJobProgress(job *statistics.AnalyzeJob, rowCount int64)
 
 	// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
 	// There is no guarantee that the job will actually finish. If the job fails to finish, an error will be logged.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -126,10 +126,10 @@ type StatsAnalyze interface {
 	// It is OK because this won't affect the analysis job's success.
 	StartAnalyzeJob(job *statistics.AnalyzeJob)
 
-	// UpdateAnalyzeJob updates the current progress of the analyze job.
+	// UpdateAnalyzeJobProcess updates the current progress of the analyze job.
 	// There is no guarantee that the job will actually update. If the job fails to update, an error will be logged.
 	// It is OK because this won't affect the analysis job's success.
-	UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int64)
+	UpdateAnalyzeJobProcess(job *statistics.AnalyzeJob, rowCount int64)
 
 	// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
 	// There is no guarantee that the job will actually finish. If the job fails to finish, an error will be logged.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -121,6 +121,15 @@ type StatsAnalyze interface {
 	// InsertAnalyzeJob inserts analyze job into mysql.analyze_jobs and gets job ID for further updating job.
 	InsertAnalyzeJob(job *statistics.AnalyzeJob, instance string, procID uint64) error
 
+	// StartAnalyzeJob updates the job status to `running` and sets the start time.
+	StartAnalyzeJob(job *statistics.AnalyzeJob)
+
+	//// UpdateAnalyzeJob updates the current progress of the analyze job.
+	//UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int) error
+	//
+	//// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
+	//FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason string) error
+
 	// DeleteAnalyzeJobs deletes the analyze jobs whose update time is earlier than updateTime.
 	DeleteAnalyzeJobs(updateTime time.Time) error
 

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -124,8 +124,8 @@ type StatsAnalyze interface {
 	// StartAnalyzeJob updates the job status to `running` and sets the start time.
 	StartAnalyzeJob(job *statistics.AnalyzeJob)
 
-	//// UpdateAnalyzeJob updates the current progress of the analyze job.
-	//UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int) error
+	// UpdateAnalyzeJob updates the current progress of the analyze job.
+	UpdateAnalyzeJob(job *statistics.AnalyzeJob, rowCount int64)
 	//
 	//// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
 	//FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason string) error

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -122,17 +122,17 @@ type StatsAnalyze interface {
 	InsertAnalyzeJob(job *statistics.AnalyzeJob, instance string, procID uint64) error
 
 	// StartAnalyzeJob updates the job status to `running` and sets the start time.
-	// There is no guarantee that the job will actually start. If the job fails to start, an error will be logged.
+	// There is no guarantee that the job record will actually be updated. If the job fails to start, an error will be logged.
 	// It is OK because this won't affect the analysis job's success.
 	StartAnalyzeJob(job *statistics.AnalyzeJob)
 
 	// UpdateAnalyzeJobProgress updates the current progress of the analyze job.
-	// There is no guarantee that the job will actually update. If the job fails to update, an error will be logged.
+	// There is no guarantee that the job record will actually be updated. If the job fails to update, an error will be logged.
 	// It is OK because this won't affect the analysis job's success.
 	UpdateAnalyzeJobProgress(job *statistics.AnalyzeJob, rowCount int64)
 
 	// FinishAnalyzeJob updates the job status to `finished`, sets the end time, and updates the job info.
-	// There is no guarantee that the job will actually finish. If the job fails to finish, an error will be logged.
+	// There is no guarantee that the job record will actually be updated. If the job fails to finish, an error will be logged.
 	// It is OK because this won't affect the analysis job's success.
 	FinishAnalyzeJob(job *statistics.AnalyzeJob, failReason error, analyzeType statistics.JobType)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55043#issuecomment-2264674742

Problem Summary:

In the above issue comment, we decided to remove the dedicated analyze sessions. But after we removed them we need to find a better way to write the analysis job history. Theoretically we can call `_, _, err := exec.ExecRestrictedSQL(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseSessionPool}, sql, args...)` concurrently to do it. But it is counterintuitive because we need to use the same session to get the executor and then use it to exec SQL with the session pool.

Because we already moved `InsertAnalyzeJob` into the stats handle, so I decided to move other job history-related functions into it as well.

### What changed and how does it work?

- Moved startAnalyzeJob into the stats handle.
- Moved UpdateAnalyzeJob into the stats handle.
- Moved FinishAnalyzeMergeJob and FinishAnalyzeJob into the stats handle. Reused the common code to reduce code duplication.

For the single thread code, I decided to pass the stats handle to it. For workers, every worker will load it by themself.



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test 1. https://github.com/pingcap/tidb/pull/55163#issuecomment-2268286562 2.https://github.com/pingcap/tidb/pull/55163#issuecomment-2268246200
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
