### PR TITLE
*: Fix global index duplicate key during drop/truncate partition

### DIFF
--- a/pkg/executor/batch_checker.go
+++ b/pkg/executor/batch_checker.go
@@ -51,6 +51,51 @@ type toBeCheckedRow struct {
 
 // getKeysNeedCheck gets keys converted from to-be-insert rows to record keys and unique index keys,
 // which need to be checked whether they are duplicate keys.
+func getGlobalIndexKeysNeedCheck(sctx sessionctx.Context, t table.Table, rows [][]types.Datum) ([]toBeCheckedRow, error) {
+	nUnique := 0
+	for _, v := range t.Indices() {
+		if !tables.IsIndexWritable(v) {
+			continue
+		}
+		if v.Meta().Unique && v.Meta().Global {
+			nUnique++
+		} else {
+			continue
+		}
+	}
+	toBeCheckRows := make([]toBeCheckedRow, 0, len(rows))
+
+	var (
+		tblHandleCols []*table.Column
+		pkIdxInfo     *model.IndexInfo
+	)
+	// Get handle column if PK is handle.
+	if t.Meta().PKIsHandle {
+		for _, col := range t.Cols() {
+			if col.IsPKHandleColumn(t.Meta()) {
+				tblHandleCols = append(tblHandleCols, col)
+				break
+			}
+		}
+	} else if t.Meta().IsCommonHandle {
+		pkIdxInfo = tables.FindPrimaryIndex(t.Meta())
+		for _, idxCol := range pkIdxInfo.Columns {
+			tblHandleCols = append(tblHandleCols, t.Cols()[idxCol.Offset])
+		}
+	}
+
+	var err error
+	for _, row := range rows {
+		toBeCheckRows, err = getKeysNeedCheckOneRow(sctx, t, row, nUnique, tblHandleCols, pkIdxInfo, toBeCheckRows, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return toBeCheckRows, nil
+}
+
+// getKeysNeedCheck gets keys converted from to-be-insert rows to record keys and unique index keys,
+// which need to be checked whether they are duplicate keys.
 func getKeysNeedCheck(sctx sessionctx.Context, t table.Table, rows [][]types.Datum) ([]toBeCheckedRow, error) {
 	nUnique := 0
 	for _, v := range t.Indices() {
@@ -84,7 +129,7 @@ func getKeysNeedCheck(sctx sessionctx.Context, t table.Table, rows [][]types.Dat
 
 	var err error
 	for _, row := range rows {
-		toBeCheckRows, err = getKeysNeedCheckOneRow(sctx, t, row, nUnique, tblHandleCols, pkIdxInfo, toBeCheckRows)
+		toBeCheckRows, err = getKeysNeedCheckOneRow(sctx, t, row, nUnique, tblHandleCols, pkIdxInfo, toBeCheckRows, false)
 		if err != nil {
 			return nil, err
 		}
@@ -93,9 +138,9 @@ func getKeysNeedCheck(sctx sessionctx.Context, t table.Table, rows [][]types.Dat
 }
 
 func getKeysNeedCheckOneRow(ctx sessionctx.Context, t table.Table, row []types.Datum, nUnique int, handleCols []*table.Column,
-	pkIdxInfo *model.IndexInfo, result []toBeCheckedRow) ([]toBeCheckedRow, error) {
+	pkIdxInfo *model.IndexInfo, result []toBeCheckedRow, onlyGlobalIndex bool) ([]toBeCheckedRow, error) {
 	var err error
-	if p, ok := t.(table.PartitionedTable); ok {
+	if p, ok := t.(table.PartitionedTable); ok && !onlyGlobalIndex {
 		t, err = p.GetPartitionByRow(ctx.GetExprCtx().GetEvalCtx(), row)
 		if err != nil {
 			if terr, ok := errors.Cause(err).(*terror.Error); ok && (terr.Code() == errno.ErrNoPartitionForGivenValue || terr.Code() == errno.ErrRowDoesNotMatchGivenPartitionSet) {
@@ -113,13 +158,13 @@ func getKeysNeedCheckOneRow(ctx sessionctx.Context, t table.Table, row []types.D
 	uniqueKeys := make([]*keyValueWithDupInfo, 0, nUnique)
 	// Append record keys and errors.
 	var handle kv.Handle
-	if t.Meta().IsCommonHandle {
+	if t.Meta().IsCommonHandle && !onlyGlobalIndex {
 		var err error
 		handle, err = buildHandleFromDatumRow(ctx.GetSessionVars().StmtCtx, row, handleCols, pkIdxInfo)
 		if err != nil {
 			return nil, err
 		}
-	} else if len(handleCols) > 0 {
+	} else if len(handleCols) > 0 && !onlyGlobalIndex {
 		handle = kv.IntHandle(row[handleCols[0].Offset].GetInt64())
 	}
 	var handleKey *keyValueWithDupInfo
@@ -193,7 +238,10 @@ func getKeysNeedCheckOneRow(ctx sessionctx.Context, t table.Table, row []types.D
 		if !v.Meta().Unique {
 			continue
 		}
-		if t.Meta().IsCommonHandle && v.Meta().Primary {
+		if t.Meta().IsCommonHandle && v.Meta().Primary && !onlyGlobalIndex {
+			continue
+		}
+		if onlyGlobalIndex && !v.Meta().Global {
 			continue
 		}
 		colVals, err1 := v.FetchValues(row, nil)

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -163,6 +163,7 @@ func updateRecord(
 
 	// If handle changed, remove the old then add the new record, otherwise update the record.
 	if handleChanged {
+		// TODO: Anything to do for Global Index?
 		// For `UPDATE IGNORE`/`INSERT IGNORE ON DUPLICATE KEY UPDATE`
 		// we use the staging buffer so that we don't need to precheck the existence of handle or unique keys by sending
 		// extra kv requests, and the remove action will not take effect if there are conflicts.

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -231,6 +231,6 @@ func AssertLocationWithSessionVars(ctxLoc *time.Location, vars *variable.Session
 	stmtLocStr := vars.StmtCtx.TimeZone().String()
 	intest.Assert(ctxLocStr == varsLocStr && ctxLocStr == stmtLocStr,
 		"location mismatch, ctxLoc: %s, varsLoc: %s, stmtLoc: %s",
-		ctxLoc.String(), ctxLocStr, stmtLocStr,
+		ctxLocStr, varsLocStr, stmtLocStr,
 	)
 }

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3729,6 +3729,7 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 
 	// `REPLACE INTO` requires both INSERT + DELETE privilege
 	// `ON DUPLICATE KEY UPDATE` requires both INSERT + UPDATE privilege
+	// TODO: Anything to do for Global Index?
 	var extraPriv mysql.PrivilegeType
 	if insert.IsReplace {
 		extraPriv = mysql.DeletePriv
@@ -4021,6 +4022,7 @@ func (b *PlanBuilder) buildSelectPlanOfInsert(ctx context.Context, insert *ast.I
 	//   e.g. insert into a select x from b ON DUPLICATE KEY UPDATE  a.x=b.y; the `y` is not a column of select's output.
 	//        MySQL won't throw error and will execute this SQL successfully.
 	// To make compatible with this strange feature, we add the variable `actualColLen` and the following IF branch.
+	// TODO: Anything for Global Index?
 	if len(insert.OnDuplicate) > 0 {
 		// If the select has aggregation, it cannot see the columns not in the select field.
 		//   e.g. insert into a select x from b ON DUPLICATE KEY UPDATE  a.x=b.y; can be executed successfully.

--- a/pkg/store/driver/txn/error.go
+++ b/pkg/store/driver/txn/error.go
@@ -117,7 +117,7 @@ func ExtractKeyExistsErrFromIndex(key kv.Key, value []byte, tblInfo *model.Table
 	var idxInfo *model.IndexInfo
 	for _, index := range tblInfo.Indices {
 		if index.ID == indexID {
-			idxInfo = index
+			idxInfo = index // TODO: Add break?
 		}
 	}
 	if idxInfo == nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
