### PR TITLE
executor: add heap object can move check for hash join v2

### DIFF
--- a/pkg/executor/join/BUILD.bazel
+++ b/pkg/executor/join/BUILD.bazel
@@ -79,7 +79,7 @@ go_test(
     ],
     embed = [":join"],
     flaky = True,
-    shard_count = 48,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -53,7 +53,7 @@ func IsHashJoinV2Enabled() bool {
 	// sizeOfUintptr should always equal to sizeOfUnsafePointer, because according to golang's doc,
 	// a Pointer can be converted to an uintptr. Add this check here in case in the future go runtime
 	// change this
-	return enableHashJoinV2.Load() && sizeOfUintptr >= sizeOfUnsafePointer
+	return !heapObjectsCanMove() && enableHashJoinV2.Load() && sizeOfUintptr >= sizeOfUnsafePointer
 }
 
 // SetEnableHashJoinV2 enable/disable hash join v2

--- a/pkg/executor/join/join_row_table_test.go
+++ b/pkg/executor/join/join_row_table_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHeapObjectCanMove(t *testing.T) {
+	require.Equal(t, false, heapObjectsCanMove())
+}
+
 func TestFixedOffsetInRowLayout(t *testing.T) {
 	require.Equal(t, 8, sizeOfNextPtr)
 	require.Equal(t, 8, sizeOfLengthField)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127

Problem Summary:
HashJoinV2 assumes that heap object can not be moved, this pr add runtime check to make sure of this.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
