### PR TITLE
expression: fix incorrect copy of flag in truncate function

### DIFF
--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -1921,7 +1921,10 @@ func (c *truncateFunctionClass) getFunction(ctx BuildContext, args []Expression)
 		bf.tp.SetDecimalUnderLimit(calculateDecimal4RoundAndTruncate(ctx, args, argTp))
 		bf.tp.SetFlenUnderLimit(args[0].GetType(ctx.GetEvalCtx()).GetFlen() - args[0].GetType(ctx.GetEvalCtx()).GetDecimal() + bf.tp.GetDecimal())
 	}
-	bf.tp.AddFlag(args[0].GetType(ctx.GetEvalCtx()).GetFlag())
+	argFieldTp := args[0].GetType(ctx.GetEvalCtx())
+	if mysql.HasUnsignedFlag(argFieldTp.GetFlag()) {
+		bf.tp.AddFlag(mysql.UnsignedFlag)
+	}
 
 	var sig builtinFunc
 	switch argTp {

--- a/tests/integrationtest/r/expression/constant_fold.result
+++ b/tests/integrationtest/r/expression/constant_fold.result
@@ -24,3 +24,9 @@ utf8mb4_general_ci
 select collation(ifnull(concat(NULL),ifnull(concat(NULL),id))) from t1;
 collation(ifnull(concat(NULL),ifnull(concat(NULL),id)))
 utf8mb4_general_ci
+drop table if exists t1;
+create table t1 (c1 int);
+insert into t1 values (null);
+select truncate(1,c1), truncate(1,c1) is not NULL from t1;
+truncate(1,c1)	truncate(1,c1) is not NULL
+NULL	0

--- a/tests/integrationtest/t/expression/constant_fold.test
+++ b/tests/integrationtest/t/expression/constant_fold.test
@@ -11,3 +11,9 @@ select collation(ifnull(concat(NULL),ifnull(concat(id),'~'))) from t;
 select collation(ifnull(concat(id),ifnull(concat(id),'~'))) from t;
 select collation(ifnull(concat(NULL),id)) from t1;
 select collation(ifnull(concat(NULL),ifnull(concat(NULL),id))) from t1;
+
+# https://github.com/pingcap/tidb/issues/53546
+drop table if exists t1;
+create table t1 (c1 int);
+insert into t1 values (null);
+select truncate(1,c1), truncate(1,c1) is not NULL from t1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53546 

Problem Summary:
When `truncate([const], NULL)` is NULL, `truncate([const], NULL) is not NULL` evaluates to 1 unexpectedly.
In master, all the flags of `arg0` are copied to a truncate function.
If `arg0` is a constant, `NotNullFlag` is copied, leading to an unexpected constant fold.

### What changed and how does it work?
Only `UnsignedFlag` is copied, which is similar behavior to the round function.
`round([const], NULL)` is also NULL, but `round([const], NULL) is not NULL` returns 0 as expected, so it is used as the reference.

The root cause of this problem refers to https://github.com/pingcap/tidb/issues/53546#issuecomment-2478340107

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
