### PR TITLE
planner: use code-gen to generate CloneForPlanCache method for SelectLock

### DIFF
--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1867,7 +1867,7 @@ func (p *PhysicalMergeJoin) Clone(newCtx base.PlanContext) (base.PhysicalPlan, e
 type PhysicalLock struct {
 	basePhysicalPlan
 
-	Lock *ast.SelectLockInfo
+	Lock *ast.SelectLockInfo `plan-cache-clone:"shallow"`
 
 	TblID2Handle       map[int64][]util.HandleCols
 	TblID2PhysTblIDCol map[int64]*expression.Column

--- a/pkg/planner/core/plan_cache_rebuild_test.go
+++ b/pkg/planner/core/plan_cache_rebuild_test.go
@@ -202,6 +202,12 @@ func TestPlanCacheClone(t *testing.T) {
 		`set @a=1, @b=2`, `execute st using @a`, `execute st using @b`)
 	testCachedPlanClone(t, tk1, tk2, `prepare st from 'update t1 set a=a+1 where a=?'`,
 		`set @a=1, @b=2`, `execute st using @a`, `execute st using @b`)
+
+	// Lock
+	testCachedPlanClone(t, tk1, tk2, `prepare st from 'select * from t where a<? for update'`,
+		`set @a1=1, @a2=2`, `execute st using @a1`, `execute st using @a2`)
+	testCachedPlanClone(t, tk1, tk2, `prepare st from 'select * from t where a=? for update'`,
+		`set @a1=1, @a2=2`, `execute st using @a1`, `execute st using @a2`)
 }
 
 func testCachedPlanClone(t *testing.T, tk1, tk2 *testkit.TestKit, prep, set, exec1, exec2 string) {

--- a/pkg/planner/core/plan_clone_generated.go
+++ b/pkg/planner/core/plan_clone_generated.go
@@ -481,3 +481,27 @@ func (op *Insert) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
 	}
 	return cloned, true
 }
+
+// CloneForPlanCache implements the base.Plan interface.
+func (op *PhysicalLock) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
+	cloned := new(PhysicalLock)
+	*cloned = *op
+	basePlan, baseOK := op.basePhysicalPlan.cloneForPlanCacheWithSelf(newCtx, cloned)
+	if !baseOK {
+		return nil, false
+	}
+	cloned.basePhysicalPlan = *basePlan
+	if op.TblID2Handle != nil {
+		cloned.TblID2Handle = make(map[int64][]util.HandleCols, len(op.TblID2Handle))
+		for k, v := range op.TblID2Handle {
+			cloned.TblID2Handle[k] = util.CloneHandleCols(newCtx.GetSessionVars().StmtCtx, v)
+		}
+	}
+	if op.TblID2PhysTblIDCol != nil {
+		cloned.TblID2PhysTblIDCol = make(map[int64]*expression.Column, len(op.TblID2PhysTblIDCol))
+		for k, v := range op.TblID2PhysTblIDCol {
+			cloned.TblID2PhysTblIDCol[k] = v.Clone().(*expression.Column)
+		}
+	}
+	return cloned, true
+}

--- a/pkg/planner/core/plan_clone_generated.go
+++ b/pkg/planner/core/plan_clone_generated.go
@@ -505,3 +505,19 @@ func (op *PhysicalLock) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, b
 	}
 	return cloned, true
 }
+
+// CloneForPlanCache implements the base.Plan interface.
+func (op *PhysicalUnionScan) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
+	cloned := new(PhysicalUnionScan)
+	*cloned = *op
+	basePlan, baseOK := op.basePhysicalPlan.cloneForPlanCacheWithSelf(newCtx, cloned)
+	if !baseOK {
+		return nil, false
+	}
+	cloned.basePhysicalPlan = *basePlan
+	cloned.Conditions = util.CloneExpressions(op.Conditions)
+	if op.HandleCols != nil {
+		cloned.HandleCols = op.HandleCols.Clone(newCtx.GetSessionVars().StmtCtx)
+	}
+	return cloned, true
+}

--- a/pkg/planner/core/plan_clone_generator.go
+++ b/pkg/planner/core/plan_clone_generator.go
@@ -39,7 +39,7 @@ func genPlanCloneForPlanCacheCode() ([]byte, error) {
 		PointGetPlan{}, BatchPointGetPlan{}, PhysicalLimit{},
 		PhysicalIndexJoin{}, PhysicalIndexHashJoin{},
 		PhysicalIndexLookUpReader{}, PhysicalIndexMergeReader{},
-		Update{}, Delete{}, Insert{}}
+		Update{}, Delete{}, Insert{}, PhysicalLock{}}
 	c := new(codeGen)
 	c.write(codeGenPrefix)
 	for _, s := range structures {
@@ -145,6 +145,18 @@ func genPlanCloneForPlanCache(x any) ([]byte, error) {
 			c.write("}")
 		case "ranger.MutableRanges":
 			c.write("cloned.%v = op.%v.CloneForPlanCache()", f.Name, f.Name)
+		case "map[int64][]util.HandleCols":
+			c.write("if op.%v != nil {", f.Name)
+			c.write("cloned.%v = make(map[int64][]util.HandleCols, len(op.%v))", f.Name, f.Name)
+			c.write("for k, v := range op.%v {", f.Name)
+			c.write("cloned.%v[k] = util.CloneHandleCols(newCtx.GetSessionVars().StmtCtx, v)", f.Name)
+			c.write("}}")
+		case "map[int64]*expression.Column":
+			c.write("if op.%v != nil {", f.Name)
+			c.write("cloned.%v = make(map[int64]*expression.Column, len(op.%v))", f.Name, f.Name)
+			c.write("for k, v := range op.%v {", f.Name)
+			c.write("cloned.%v[k] = v.Clone().(*expression.Column)", f.Name)
+			c.write("}}")
 		default:
 			return nil, fmt.Errorf("can't generate Clone method for type %v in %v", f.Type.String(), vType.String())
 		}

--- a/pkg/planner/core/plan_clone_generator.go
+++ b/pkg/planner/core/plan_clone_generator.go
@@ -39,7 +39,7 @@ func genPlanCloneForPlanCacheCode() ([]byte, error) {
 		PointGetPlan{}, BatchPointGetPlan{}, PhysicalLimit{},
 		PhysicalIndexJoin{}, PhysicalIndexHashJoin{},
 		PhysicalIndexLookUpReader{}, PhysicalIndexMergeReader{},
-		Update{}, Delete{}, Insert{}, PhysicalLock{}}
+		Update{}, Delete{}, Insert{}, PhysicalLock{}, PhysicalUnionScan{}}
 	c := new(codeGen)
 	c.write(codeGenPrefix)
 	for _, s := range structures {

--- a/pkg/planner/util/misc.go
+++ b/pkg/planner/util/misc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/planner/property"
+	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 )
@@ -101,6 +102,18 @@ func CloneAssignments(assignments []*expression.Assignment) []*expression.Assign
 	cloned := make([]*expression.Assignment, 0, len(assignments))
 	for _, a := range assignments {
 		cloned = append(cloned, a.Clone())
+	}
+	return cloned
+}
+
+// CloneHandleCols uses HandleCols.Clone to clone a slice of HandleCols.
+func CloneHandleCols(newCtx *stmtctx.StatementContext, handles []HandleCols) []HandleCols {
+	if handles == nil {
+		return nil
+	}
+	cloned := make([]HandleCols, 0, len(handles))
+	for _, h := range handles {
+		cloned = append(cloned, h.Clone(newCtx))
 	}
 	return cloned
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54057

Problem Summary: planner: use code-gen to generate CloneForPlanCache method for SelectLock

### What changed and how does it work?

planner: use code-gen to generate CloneForPlanCache method for SelectLock

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
