### PR TITLE
ddl/domain: disallow set schema lease to 0

### DIFF
--- a/br/pkg/mock/mock_cluster.go
+++ b/br/pkg/mock/mock_cluster.go
@@ -72,7 +72,6 @@ func NewCluster() (*Cluster, error) {
 	}
 	cluster.Storage = storage
 
-	session.SetSchemaLease(0)
 	session.DisableStats4Test()
 	dom, err := session.BootstrapSession(storage)
 	if err != nil {

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -750,6 +750,13 @@ func setGlobalVars() {
 	util.SetGOGC(cfg.Performance.GOGC)
 
 	ddlLeaseDuration := parseDuration(cfg.Lease)
+	if ddlLeaseDuration <= 0 {
+		// previous version allow set schema lease to 0, and mainly used on
+		// uni-store and for test, to be compatible we set it to default value here.
+		log.Warn("schema lease is invalid, use default value",
+			zap.String("lease", ddlLeaseDuration.String()))
+		ddlLeaseDuration = config.DefSchemaLease
+	}
 	session.SetSchemaLease(ddlLeaseDuration)
 	statsLeaseDuration := parseDuration(cfg.Performance.StatsLease)
 	session.SetStatsLease(statsLeaseDuration)

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -749,15 +749,15 @@ func setGlobalVars() {
 
 	util.SetGOGC(cfg.Performance.GOGC)
 
-	ddlLeaseDuration := parseDuration(cfg.Lease)
-	if ddlLeaseDuration <= 0 {
+	schemaLeaseDuration := parseDuration(cfg.Lease)
+	if schemaLeaseDuration <= 0 {
 		// previous version allow set schema lease to 0, and mainly used on
 		// uni-store and for test, to be compatible we set it to default value here.
 		log.Warn("schema lease is invalid, use default value",
-			zap.String("lease", ddlLeaseDuration.String()))
-		ddlLeaseDuration = config.DefSchemaLease
+			zap.String("lease", schemaLeaseDuration.String()))
+		schemaLeaseDuration = config.DefSchemaLease
 	}
-	session.SetSchemaLease(ddlLeaseDuration)
+	session.SetSchemaLease(schemaLeaseDuration)
 	statsLeaseDuration := parseDuration(cfg.Performance.StatsLease)
 	session.SetStatsLease(statsLeaseDuration)
 	planReplayerGCLease := parseDuration(cfg.Performance.PlanReplayerGCLease)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,7 +98,8 @@ const (
 	// EnvVarKeyspaceName is the system env name for keyspace name.
 	EnvVarKeyspaceName = "KEYSPACE_NAME"
 	// MaxTokenLimit is the max token limit value.
-	MaxTokenLimit = 1024 * 1024
+	MaxTokenLimit  = 1024 * 1024
+	DefSchemaLease = 45 * time.Second
 )
 
 // Valid config maps
@@ -912,7 +913,7 @@ var defaultConf = Config{
 	Path:                         "/tmp/tidb",
 	RunDDL:                       true,
 	SplitTable:                   true,
-	Lease:                        "45s",
+	Lease:                        DefSchemaLease.String(),
 	TokenLimit:                   1000,
 	OOMUseTmpStorage:             true,
 	TempDir:                      DefTempDir,

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -613,7 +613,7 @@ func TestSnapshotVersion(t *testing.T) {
 
 	dd := dom.DDL()
 	ddl.DisableTiFlashPoll(dd)
-	require.Equal(t, dbTestLease, dd.GetLease())
+	require.Equal(t, dbTestLease, dom.GetSchemaLease())
 
 	snapTS := oracle.GoTimeToTS(time.Now())
 	tk.MustExec("create database test2")
@@ -673,7 +673,7 @@ func TestSchemaValidator(t *testing.T) {
 
 	dd := dom.DDL()
 	ddl.DisableTiFlashPoll(dd)
-	require.Equal(t, dbTestLease, dd.GetLease())
+	require.Equal(t, dbTestLease, dom.GetSchemaLease())
 
 	tk.MustExec("create table test.t(a int)")
 

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -164,8 +164,6 @@ type DDL interface {
 	// Start campaigns the owner and starts workers.
 	// ctxPool is used for the worker's delRangeManager and creates sessions.
 	Start(ctxPool *pools.ResourcePool) error
-	// GetLease returns current schema lease time.
-	GetLease() time.Duration
 	// Stats returns the DDL statistics.
 	Stats(vars *variable.SessionVars) (map[string]any, error)
 	// GetScope gets the status variables scope.
@@ -573,14 +571,6 @@ func (d *ddl) RegisterStatsHandle(h *handle.Handle) {
 // give up notify and log it.
 func asyncNotifyEvent(d *ddlCtx, e *statsutil.DDLEvent) {
 	if d.ddlEventCh != nil {
-		if d.lease == 0 {
-			// If lease is 0, it's always used in test.
-			select {
-			case d.ddlEventCh <- e:
-			default:
-			}
-			return
-		}
 		for i := 0; i < 10; i++ {
 			select {
 			case d.ddlEventCh <- e:
@@ -853,12 +843,6 @@ func (d *ddl) close() {
 	logutil.DDLLogger().Info("DDL closed", zap.String("ID", d.uuid), zap.Duration("take time", time.Since(startTime)))
 }
 
-// GetLease implements DDL.GetLease interface.
-func (d *ddl) GetLease() time.Duration {
-	lease := d.lease
-	return lease
-}
-
 // SchemaSyncer implements DDL.SchemaSyncer interface.
 func (d *ddl) SchemaSyncer() syncer.SchemaSyncer {
 	return d.schemaSyncer
@@ -1021,9 +1005,19 @@ type RecoverSchemaInfo struct {
 // This provides a safe window for async commit and 1PC to commit with an old schema.
 func delayForAsyncCommit() {
 	if variable.EnableMDL.Load() {
-		// If metadata lock is enabled. The transaction of DDL must begin after prewrite of the async commit transaction,
-		// then the commit ts of DDL must be greater than the async commit transaction. In this case, the corresponding schema of the async commit transaction
-		// is correct. But if metadata lock is disabled, we can't ensure that the corresponding schema of the async commit transaction isn't change.
+		// If metadata lock is enabled. The transaction of DDL must begin after
+		// pre-write of the async commit transaction, then the commit ts of DDL
+		// must be greater than the async commit transaction. In this case, the
+		// corresponding schema of the async commit transaction is correct.
+		// suppose we're adding index:
+		// - schema state -> StateWriteOnly with version V
+		// - some txn T started using async commit and version V,
+		//   and T do pre-write before or after V+1
+		// - schema state -> StateWriteReorganization with version V+1
+		// - T commit finish, with TS
+		// - 'wait schema synced' finish
+		// - schema state -> Done with version V+2, commit-ts of this
+		//   transaction must > TS, so it's safe for T to commit.
 		return
 	}
 	cfg := config.GetGlobalConfig().TiKVClient.AsyncCommit

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1054,7 +1054,7 @@ func runReorgJobAndHandleErr(
 	if err != nil {
 		return false, ver, errors.Trace(err)
 	}
-	err = w.runReorgJob(reorgInfo, tbl.Meta(), d.lease, func() (addIndexErr error) {
+	err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (addIndexErr error) {
 		defer util.Recover(metrics.LabelDDL, "onCreateIndex",
 			func() {
 				addIndexErr = dbterror.ErrCancelledDDLJob.GenWithStack("add table `%v` index `%v` panic", tbl.Meta().Name, allIndexInfos[0].Name)

--- a/pkg/ddl/job_worker_test.go
+++ b/pkg/ddl/job_worker_test.go
@@ -38,7 +38,7 @@ func TestCheckOwner(t *testing.T) {
 
 	time.Sleep(testLease)
 	require.Equal(t, dom.DDL().OwnerManager().IsOwner(), true)
-	require.Equal(t, dom.DDL().GetLease(), testLease)
+	require.Equal(t, dom.GetSchemaLease(), testLease)
 }
 
 func TestInvalidDDLJob(t *testing.T) {

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2233,7 +2233,7 @@ func (w *worker) onDropTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (
 				// and then run the reorg next time.
 				return ver, errors.Trace(err)
 			}
-			err = w.runReorgJob(reorgInfo, tbl.Meta(), d.lease, func() (dropIndexErr error) {
+			err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (dropIndexErr error) {
 				defer tidbutil.Recover(metrics.LabelDDL, "onDropTablePartition",
 					func() {
 						dropIndexErr = dbterror.ErrCancelledDDLJob.GenWithStack("drop partition panic")
@@ -2431,7 +2431,7 @@ func (w *worker) onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 				// and then run the reorg next time.
 				return ver, errors.Trace(err)
 			}
-			err = w.runReorgJob(reorgInfo, tbl.Meta(), d.lease, func() (dropIndexErr error) {
+			err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (dropIndexErr error) {
 				defer tidbutil.Recover(metrics.LabelDDL, "onDropTablePartition",
 					func() {
 						dropIndexErr = dbterror.ErrCancelledDDLJob.GenWithStack("drop partition panic")
@@ -2702,9 +2702,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 	// partition to be exchange with.
 	// So we need to rollback that change, instead of just cancelling.
 
-	if d.lease > 0 {
-		delayForAsyncCommit()
-	}
+	delayForAsyncCommit()
 
 	if defID != partDef.ID {
 		// Should never happen, should have been updated above, in previous state!
@@ -3451,7 +3449,7 @@ func doPartitionReorgWork(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job, tb
 		return false, ver, errors.Trace(err)
 	}
 	reorgInfo, err := getReorgInfoFromPartitions(d.jobContext(job.ID, job.ReorgMeta), d, rh, job, dbInfo, partTbl, physTblIDs, elements)
-	err = w.runReorgJob(reorgInfo, tbl.Meta(), d.lease, func() (reorgErr error) {
+	err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (reorgErr error) {
 		defer tidbutil.Recover(metrics.LabelDDL, "doPartitionReorgWork",
 			func() {
 				reorgErr = dbterror.ErrCancelledDDLJob.GenWithStack("reorganize partition for table `%v` panic", tbl.Meta().Name)

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -142,7 +142,7 @@ func newReorgSessCtx(store kv.Storage) sessionctx.Context {
 
 // ReorgWaitTimeout is the timeout that wait ddl in write reorganization stage.
 // make it a var for testing.
-var ReorgWaitTimeout = 10 * time.Second
+var ReorgWaitTimeout = 5 * time.Second
 
 func (rc *reorgCtx) notifyJobState(state model.JobState) {
 	atomic.StoreInt32((*int32)(&rc.jobState), int32(state))

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -140,10 +140,9 @@ func newReorgSessCtx(store kv.Storage) sessionctx.Context {
 	return c
 }
 
-const defaultWaitReorgTimeout = 10 * time.Second
-
 // ReorgWaitTimeout is the timeout that wait ddl in write reorganization stage.
-var ReorgWaitTimeout = 5 * time.Second
+// make it a var for testing.
+var ReorgWaitTimeout = 10 * time.Second
 
 func (rc *reorgCtx) notifyJobState(state model.JobState) {
 	atomic.StoreInt32((*int32)(&rc.jobState), int32(state))
@@ -226,7 +225,6 @@ func (rc *reorgCtx) getRowCount() int64 {
 func (w *worker) runReorgJob(
 	reorgInfo *reorgInfo,
 	tblInfo *model.TableInfo,
-	lease time.Duration,
 	reorgFn func() error,
 ) error {
 	job := reorgInfo.Job
@@ -268,16 +266,7 @@ func (w *worker) runReorgJob(
 		}()
 	}
 
-	waitTimeout := defaultWaitReorgTimeout
-	// if lease is 0, we are using a local storage,
-	// and we can wait the reorganization to be done here.
-	// if lease > 0, we don't need to wait here because
-	// we should update some job's progress context and try checking again,
-	// so we use a very little timeout here.
-	if lease > 0 {
-		waitTimeout = ReorgWaitTimeout
-	}
-
+	waitTimeout := ReorgWaitTimeout
 	// wait reorganization job done or timeout
 	select {
 	case res := <-rc.doneCh:
@@ -744,9 +733,7 @@ func getReorgInfo(ctx *JobContext, d *ddlCtx, rh *reorgHandler, job *model.Job, 
 		})
 
 		info.first = true
-		if d.lease > 0 { // Only delay when it's not in test.
-			delayForAsyncCommit()
-		}
+		delayForAsyncCommit()
 		ver, err := getValidCurrentVersion(d.store)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -837,9 +824,7 @@ func getReorgInfoFromPartitions(ctx *JobContext, d *ddlCtx, rh *reorgHandler, jo
 	)
 	if job.SnapshotVer == 0 {
 		info.first = true
-		if d.lease > 0 { // Only delay when it's not in test.
-			delayForAsyncCommit()
-		}
+		delayForAsyncCommit()
 		ver, err := getValidCurrentVersion(d.store)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/pkg/ddl/restart_test.go
+++ b/pkg/ddl/restart_test.go
@@ -46,7 +46,7 @@ func restartWorkers(t *testing.T, store kv.Storage, d *domain.Domain) {
 	newDDL, newDDLExecutor := ddl.NewDDL(context.Background(),
 		ddl.WithStore(d.Store()),
 		ddl.WithInfoCache(d.InfoCache()),
-		ddl.WithLease(d.DDL().GetLease()),
+		ddl.WithLease(d.GetSchemaLease()),
 		ddl.WithSchemaLoader(d),
 	)
 	d.SetDDL(newDDL, newDDLExecutor)
@@ -92,7 +92,7 @@ func testRunInterruptedJob(t *testing.T, store kv.Storage, d *domain.Domain, job
 	done := make(chan error, 1)
 	go runInterruptedJob(t, store, d.DDLExecutor(), job, done)
 
-	ticker := time.NewTicker(d.DDL().GetLease())
+	ticker := time.NewTicker(d.GetSchemaLease())
 	defer ticker.Stop()
 	for {
 		select {
@@ -140,7 +140,7 @@ func TestStat(t *testing.T) {
 	done := make(chan error, 1)
 	go runInterruptedJob(t, store, dom.DDLExecutor(), job, done)
 
-	ticker := time.NewTicker(dom.DDL().GetLease() * 1)
+	ticker := time.NewTicker(dom.GetSchemaLease() * 1)
 	defer ticker.Stop()
 	ver := getDDLSchemaVer(t, dom.DDL())
 LOOP:

--- a/pkg/ddl/schematracker/checker.go
+++ b/pkg/ddl/schematracker/checker.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/ngaut/pools"
 	"github.com/pingcap/tidb/pkg/ddl"
@@ -488,11 +487,6 @@ func (*Checker) CreatePlacementPolicyWithInfo(_ sessionctx.Context, _ *model.Pol
 // Start implements the DDL interface.
 func (d *Checker) Start(ctxPool *pools.ResourcePool) error {
 	return d.realDDL.Start(ctxPool)
-}
-
-// GetLease implements the DDL interface.
-func (d *Checker) GetLease() time.Duration {
-	return d.realDDL.GetLease()
 }
 
 // Stats implements the DDL interface.

--- a/pkg/ddl/tests/indexmerge/merge_test.go
+++ b/pkg/ddl/tests/indexmerge/merge_test.go
@@ -74,7 +74,7 @@ func TestAddIndexMergeProcess(t *testing.T) {
 }
 
 func TestAddPrimaryKeyMergeProcess(t *testing.T) {
-	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, 0)
+	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, time.Second)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk2 := testkit.NewTestKit(t, store)

--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -96,7 +96,6 @@ func createTiFlashContext(t *testing.T) (*tiflashContext, func()) {
 	)
 
 	require.NoError(t, err)
-	session.SetSchemaLease(0)
 	session.DisableStats4Test()
 	s.dom, err = session.BootstrapSession(s.store)
 	infosync.SetMockTiFlash(s.tiflash)

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -148,6 +148,7 @@ type Domain struct {
 	globalCfgSyncer *globalconfigsync.GlobalConfigSyncer
 	m               syncutil.Mutex
 	SchemaValidator SchemaValidator
+	schemaLease     time.Duration
 	sysSessionPool  util.SessionPool
 	exit            chan struct{}
 	// `etcdClient` must be used when keyspace is not set, or when the logic to each etcd path needs to be separated by keyspace.
@@ -773,7 +774,7 @@ func (do *Domain) Reload() error {
 
 	// lease renew, so it must be executed despite it is cache or not
 	do.SchemaValidator.Update(version, oldSchemaVersion, is.SchemaMetaVersion(), changes)
-	lease := do.DDL().GetLease()
+	lease := do.GetSchemaLease()
 	sub := time.Since(startTime)
 	// Reload interval is lease / 2, if load schema time elapses more than this interval,
 	// some query maybe responded by ErrInfoSchemaExpired error.
@@ -1034,11 +1035,11 @@ func (do *Domain) mdlCheckLoop() {
 	}
 }
 
-func (do *Domain) loadSchemaInLoop(ctx context.Context, lease time.Duration) {
+func (do *Domain) loadSchemaInLoop(ctx context.Context) {
 	defer util.Recover(metrics.LabelDomain, "loadSchemaInLoop", nil, true)
 	// Lease renewal can run at any frequency.
 	// Use lease/2 here as recommend by paper.
-	ticker := time.NewTicker(lease / 2)
+	ticker := time.NewTicker(do.schemaLease / 2)
 	defer func() {
 		ticker.Stop()
 		logutil.BgLogger().Info("loadSchemaInLoop exited.")
@@ -1219,7 +1220,8 @@ func (do *Domain) Close() {
 const resourceIdleTimeout = 3 * time.Minute // resources in the ResourcePool will be recycled after idleTimeout
 
 // NewDomain creates a new domain. Should not create multiple domains for the same store.
-func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duration, dumpFileGcLease time.Duration, factory pools.Factory) *Domain {
+func NewDomain(store kv.Storage, schemaLease time.Duration, statsLease time.Duration, dumpFileGcLease time.Duration, factory pools.Factory) *Domain {
+	intest.Assert(schemaLease > 0, "schema lease should be a positive duration")
 	capacity := 200 // capacity of the sysSessionPool size
 	do := &Domain{
 		store: store,
@@ -1238,6 +1240,7 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 			},
 		),
 		statsLease:        statsLease,
+		schemaLease:       schemaLease,
 		slowQuery:         newTopNSlowQueries(config.GetGlobalConfig().InMemSlowQueryTopNNum, time.Hour*24*7, config.GetGlobalConfig().InMemSlowQueryRecentNum),
 		dumpFileGcChecker: &dumpFileGcChecker{gcLease: dumpFileGcLease, paths: []string{replayer.GetPlanReplayerDirName(), GetOptimizerTraceDirName(), GetExtractTaskDirName()}},
 		mdlCheckTableInfo: &mdlCheckTableInfo{
@@ -1251,7 +1254,7 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 	do.infoCache = infoschema.NewCache(do, int(variable.SchemaVersionCacheLimit.Load()))
 	do.stopAutoAnalyze.Store(false)
 	do.wg = util.NewWaitGroupEnhancedWrapper("domain", do.exit, config.GetGlobalConfig().TiDBEnableExitCheck)
-	do.SchemaValidator = NewSchemaValidator(ddlLease, do)
+	do.SchemaValidator = NewSchemaValidator(schemaLease, do)
 	do.expensiveQueryHandle = expensivequery.NewExpensiveQueryHandle(do.exit)
 	do.memoryUsageAlarmHandle = memoryusagealarm.NewMemoryUsageAlarmHandle(do.exit)
 	do.serverMemoryLimitHandle = servermemorylimit.NewServerMemoryLimitHandle(do.exit)
@@ -1291,16 +1294,9 @@ func newEtcdCli(addrs []string, ebd kv.EtcdBackend) (*clientv3.Client, error) {
 // Init initializes a domain. after return, session can be used to do DMLs but not
 // DDLs which can be used after domain Start.
 func (do *Domain) Init(
-	ddlLease time.Duration,
 	sysExecutorFactory func(*Domain) (pools.Resource, error),
 	ddlInjector func(ddl.DDL, ddl.Executor, *infoschema.InfoCache) *schematracker.Checker,
 ) error {
-	// TODO there are many place set ddlLease to 0, remove them completely, we want
-	//  UT and even local uni-store to run similar code path as normal.
-	if ddlLease == 0 {
-		ddlLease = time.Second
-	}
-
 	do.sysExecutorFactory = sysExecutorFactory
 	perfschema.Init()
 	if ebd, ok := do.store.(kv.EtcdBackend); ok {
@@ -1342,7 +1338,7 @@ func (do *Domain) Init(
 		ddl.WithStore(do.store),
 		ddl.WithAutoIDClient(do.autoidClient),
 		ddl.WithInfoCache(do.infoCache),
-		ddl.WithLease(ddlLease),
+		ddl.WithLease(do.schemaLease),
 		ddl.WithSchemaLoader(do),
 	)
 
@@ -1414,7 +1410,7 @@ func (do *Domain) Init(
 	sub := time.Since(startReloadTime)
 	// The reload(in step 2) operation takes more than ddlLease and a new reload operation was not performed,
 	// the next query will respond by ErrInfoSchemaExpired error. So we do a new reload to update schemaValidator.latestSchemaExpire.
-	if sub > (ddlLease / 2) {
+	if sub > (do.schemaLease / 2) {
 		logutil.BgLogger().Warn("loading schema and starting ddl take a long time, we do a new reload", zap.Duration("take time", sub))
 		err = do.Reload()
 		if err != nil {
@@ -1453,7 +1449,7 @@ func (do *Domain) Start() error {
 
 	// Local store needs to get the change information for every DDL state in each session.
 	do.wg.Run(func() {
-		do.loadSchemaInLoop(do.ctx, do.ddl.GetLease())
+		do.loadSchemaInLoop(do.ctx)
 	}, "loadSchemaInLoop")
 	do.wg.Run(do.mdlCheckLoop, "mdlCheckLoop")
 	do.wg.Run(do.topNSlowQueryLoop, "topNSlowQueryLoop")
@@ -1478,6 +1474,11 @@ func (do *Domain) Start() error {
 	}
 
 	return nil
+}
+
+// GetSchemaLease return the schema lease.
+func (do *Domain) GetSchemaLease() time.Duration {
+	return do.schemaLease
 }
 
 // InitInfo4Test init infosync for distributed execution test.
@@ -2571,7 +2572,7 @@ func (do *Domain) updateStatsWorker(_ sessionctx.Context, owner owner.Manager) {
 			if !owner.IsOwner() {
 				continue
 			}
-			err := statsHandle.GCStats(do.InfoSchema(), do.DDL().GetLease())
+			err := statsHandle.GCStats(do.InfoSchema(), do.GetSchemaLease())
 			if err != nil {
 				logutil.BgLogger().Debug("GC stats failed", zap.Error(err))
 			}

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -93,7 +93,7 @@ func TestInfo(t *testing.T) {
 	ddl.DisableTiFlashPoll(dom.ddl)
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/domain/MockReplaceDDL", `return(true)`))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/NoDDLDispatchLoop", `return(true)`))
-	require.NoError(t, dom.Init(ddlLease, sysMockFactory, nil))
+	require.NoError(t, dom.Init(sysMockFactory, nil))
 	require.NoError(t, dom.Start())
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/NoDDLDispatchLoop"))
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/domain/MockReplaceDDL"))

--- a/pkg/domain/schema_validator.go
+++ b/pkg/domain/schema_validator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
@@ -78,6 +79,7 @@ type schemaValidator struct {
 
 // NewSchemaValidator returns a SchemaValidator structure.
 func NewSchemaValidator(lease time.Duration, do *Domain) SchemaValidator {
+	intest.Assert(lease > 0, "lease should be greater than 0")
 	return &schemaValidator{
 		isStarted:        true,
 		lease:            lease,
@@ -236,9 +238,6 @@ func (s *schemaValidator) Check(txnTS uint64, schemaVer int64, relatedPhysicalTa
 		logutil.BgLogger().Info("the schema version is too old, TiDB and PD maybe unhealthy after the transaction started",
 			zap.Int64("schemaVer", schemaVer))
 		return nil, ResultFail
-	}
-	if s.lease == 0 {
-		return nil, ResultSucc
 	}
 
 	// Schema changed, result decided by whether related tables change.

--- a/pkg/executor/analyze_test.go
+++ b/pkg/executor/analyze_test.go
@@ -63,7 +63,6 @@ func TestAnalyzeIndexExtractTopN(t *testing.T) {
 	}()
 	var dom *domain.Domain
 	session.DisableStats4Test()
-	session.SetSchemaLease(0)
 	dom, err = session.BootstrapSession(store)
 	require.NoError(t, err)
 	defer dom.Close()

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -39,7 +39,6 @@ func TestAuditLogNormal(t *testing.T) {
 	conn := server.CreateMockConn(t, sv)
 	defer conn.Close()
 	session.DisableStats4Test()
-	session.SetSchemaLease(0)
 
 	type normalTest struct {
 		sql      string

--- a/pkg/privilege/privileges/main_test.go
+++ b/pkg/privilege/privileges/main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 	}
 	testsetup.SetupForCommonTest()
 
-	session.SetSchemaLease(0)
 	session.DisableStats4Test()
 
 	goleak.VerifyTestMain(m, opts...)

--- a/pkg/server/handler/extractorhandler/main_test.go
+++ b/pkg/server/handler/extractorhandler/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/handler/optimizor/main_test.go
+++ b/pkg/server/handler/optimizor/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/handler/tests/main_test.go
+++ b/pkg/server/handler/tests/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/main_test.go
+++ b/pkg/server/main_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/pingcap/tidb/pkg/testkit/testmain"
@@ -42,10 +41,6 @@ func TestMain(m *testing.M) {
 	// This is used to detect which codes are not tracked by TopSQL.
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/tests/BUILD.bazel
+++ b/pkg/server/tests/BUILD.bazel
@@ -16,7 +16,6 @@ go_test(
         "//pkg/server",
         "//pkg/server/internal/util",
         "//pkg/server/tests/servertestkit",
-        "//pkg/session",
         "//pkg/store/mockstore/unistore",
         "//pkg/testkit",
         "//pkg/testkit/testsetup",

--- a/pkg/server/tests/commontest/main_test.go
+++ b/pkg/server/tests/commontest/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/tests/cursor/BUILD.bazel
+++ b/pkg/server/tests/cursor/BUILD.bazel
@@ -15,7 +15,6 @@ go_test(
         "//pkg/parser/mysql",
         "//pkg/server",
         "//pkg/server/tests/servertestkit",
-        "//pkg/session",
         "//pkg/store/mockstore/unistore",
         "//pkg/testkit",
         "//pkg/testkit/testsetup",

--- a/pkg/server/tests/cursor/main_test.go
+++ b/pkg/server/tests/cursor/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/tests/main_test.go
+++ b/pkg/server/tests/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/server/tests/tls/BUILD.bazel
+++ b/pkg/server/tests/tls/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
         "//pkg/server/internal/testutil",
         "//pkg/server/internal/util",
         "//pkg/server/tests/servertestkit",
-        "//pkg/session",
         "//pkg/sessionctx/variable",
         "//pkg/store/mockstore/unistore",
         "//pkg/testkit/testsetup",

--- a/pkg/server/tests/tls/main_test.go
+++ b/pkg/server/tests/tls/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/server"
-	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit/testsetup"
 	topsqlstate "github.com/pingcap/tidb/pkg/util/topsql/state"
@@ -37,10 +36,6 @@ func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	topsqlstate.EnableTopSQL()
 	unistore.CheckResourceTagForTopSQLInGoTest = true
-
-	// AsyncCommit will make DDL wait 2.5s before changing to the next state.
-	// Set schema lease to avoid it from making CI slow.
-	session.SetSchemaLease(0)
 
 	tikv.EnableFailpoints()
 

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1422,6 +1422,8 @@ func upgrade(s sessiontypes.Session) {
 		logutil.BgLogger().Fatal("[upgrade] init metadata lock failed", zap.Error(err))
 	}
 
+	// when upgrade from v6.4.0 or earlier, enables metadata lock automatically,
+	// but during upgrade we disable it.
 	if isNull {
 		upgradeToVer99Before(s)
 	}

--- a/pkg/session/test/session_test.go
+++ b/pkg/session/test/session_test.go
@@ -152,7 +152,7 @@ func TestLoadSchemaFailed(t *testing.T) {
 	}()
 	require.Error(t, domain.GetDomain(tk.Session()).Reload())
 
-	lease := domain.GetDomain(tk.Session()).DDL().GetLease()
+	lease := domain.GetDomain(tk.Session()).GetSchemaLease()
 	time.Sleep(lease * 2)
 
 	// Make sure executing insert statement is failed when server is invalid.

--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -94,7 +94,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 		if injector, ok := store.(schematracker.StorageDDLInjector); ok {
 			ddlInjector = injector.Injector
 		}
-		err1 = d.Init(ddlLease, sysFactory, ddlInjector)
+		err1 = d.Init(sysFactory, ddlInjector)
 		if err1 != nil {
 			// If we don't clean it, there are some dirty data when retrying the function of Init.
 			d.Close()
@@ -128,12 +128,11 @@ var (
 	storeBootstrapped     = make(map[string]bool)
 	storeBootstrappedLock sync.Mutex
 
-	// schemaLease is the time for re-updating remote schema.
-	// In online DDL, we must wait 2 * SchemaLease time to guarantee
-	// all servers get the neweset schema.
-	// Default schema lease time is 1 second, you can change it with a proper time,
-	// but you must know that too little may cause badly performance degradation.
-	// For production, you should set a big schema lease, like 300s+.
+	// schemaLease is lease of info schema, we use this to check whether info schema
+	// is valid in SchemaChecker. we also use half of it as info schema reload interval.
+	// Default info schema lease 45s which is init at main, we set it to 1 second
+	// here for tests. you can change it with a proper time, but you must know that
+	// too little may cause badly performance degradation.
 	schemaLease = int64(1 * time.Second)
 
 	// statsLease is the time for reload stats table.

--- a/pkg/store/gcworker/BUILD.bazel
+++ b/pkg/store/gcworker/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     race = "on",
     shard_count = 25,
     deps = [
+        "//pkg/config",
         "//pkg/ddl/placement",
         "//pkg/ddl/util",
         "//pkg/domain",

--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -169,7 +170,7 @@ func createGCWorkerSuiteWithStoreType(t *testing.T, storeType mockstore.StoreTyp
 	require.NoError(t, err)
 	store.GetOracle().Close()
 	store.(tikv.Storage).SetOracle(s.oracle)
-	dom := bootstrap(t, store, 0)
+	dom := bootstrap(t, store, config.DefSchemaLease)
 	s.store, s.dom = store, dom
 
 	s.tikvStore = s.store.(tikv.Storage)

--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -142,10 +142,10 @@ type mockGCWorkerSuite struct {
 }
 
 func createGCWorkerSuite(t *testing.T) (s *mockGCWorkerSuite) {
-	return createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore)
+	return createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, config.DefSchemaLease)
 }
 
-func createGCWorkerSuiteWithStoreType(t *testing.T, storeType mockstore.StoreType) (s *mockGCWorkerSuite) {
+func createGCWorkerSuiteWithStoreType(t *testing.T, storeType mockstore.StoreType, schemaLease time.Duration) (s *mockGCWorkerSuite) {
 	s = new(mockGCWorkerSuite)
 	hijackClient := func(client tikv.Client) tikv.Client {
 		s.client = &mockGCWorkerClient{Client: client}
@@ -170,7 +170,7 @@ func createGCWorkerSuiteWithStoreType(t *testing.T, storeType mockstore.StoreTyp
 	require.NoError(t, err)
 	store.GetOracle().Close()
 	store.(tikv.Storage).SetOracle(s.oracle)
-	dom := bootstrap(t, store, config.DefSchemaLease)
+	dom := bootstrap(t, store, schemaLease)
 	s.store, s.dom = store, dom
 
 	s.tikvStore = s.store.(tikv.Storage)
@@ -339,7 +339,10 @@ func TestMinStartTS(t *testing.T) {
 }
 
 func TestPrepareGC(t *testing.T) {
-	s := createGCWorkerSuite(t)
+	// as we are adjusting the base TS, we need a larger schema lease to avoid
+	// the info schema outdated error. as we keep adding offset to time oracle,
+	// so we need set a very large lease.
+	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, 220*time.Minute)
 
 	now, err := s.gcWorker.getOracleTime()
 	require.NoError(t, err)
@@ -936,7 +939,9 @@ Loop:
 }
 
 func TestLeaderTick(t *testing.T) {
-	s := createGCWorkerSuite(t)
+	// as we are adjusting the base TS, we need a larger schema lease to avoid
+	// the info schema outdated error.
+	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, time.Hour)
 
 	gcSafePointCacheInterval = 0
 
@@ -1127,7 +1132,7 @@ func TestResolveLockRangeMeetRegionEnlargeCausedByRegionMerge(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/copr/DisablePaging"))
 	}()
-	s := createGCWorkerSuiteWithStoreType(t, mockstore.MockTiKV)
+	s := createGCWorkerSuiteWithStoreType(t, mockstore.MockTiKV, config.DefSchemaLease)
 
 	var (
 		firstAccess    = true
@@ -1452,7 +1457,7 @@ func TestGCLabelRules(t *testing.T) {
 }
 
 func TestGCWithPendingTxn(t *testing.T) {
-	s := createGCWorkerSuite(t)
+	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, 30*time.Minute)
 
 	ctx := gcContext()
 	gcSafePointCacheInterval = 0
@@ -1503,7 +1508,9 @@ func TestGCWithPendingTxn(t *testing.T) {
 }
 
 func TestGCWithPendingTxn2(t *testing.T) {
-	s := createGCWorkerSuite(t)
+	// as we are adjusting the base TS, we need a larger schema lease to avoid
+	// the info schema outdated error.
+	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, 10*time.Minute)
 
 	ctx := gcContext()
 	gcSafePointCacheInterval = 0
@@ -1573,7 +1580,9 @@ func TestGCWithPendingTxn2(t *testing.T) {
 }
 
 func TestSkipGCAndOnlyResolveLock(t *testing.T) {
-	s := createGCWorkerSuite(t)
+	// as we are adjusting the base TS, we need a larger schema lease to avoid
+	// the info schema outdated error.
+	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, 10*time.Minute)
 
 	ctx := gcContext()
 	gcSafePointCacheInterval = 0

--- a/pkg/store/mockstore/mockcopr/executor_test.go
+++ b/pkg/store/mockstore/mockcopr/executor_test.go
@@ -58,7 +58,6 @@ func TestResolvedLargeTxnLocks(t *testing.T) {
 		require.NoError(t, store.Close())
 	}()
 
-	session.SetSchemaLease(0)
 	session.DisableStats4Test()
 	dom, err := session.BootstrapSession(store)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54436

Problem Summary:

### What changed and how does it work?
- disallow set schema lease to 0. set it to 0 in config is still allowwed, but will adjust it to default
- after we have MDL we can avoid the wait in DDL used for async commit and 1PC, see https://github.com/pingcap/tidb/issues/39196, so no need to depends on ddlLease=0
- move GetLease to domain, most part of ddl don't depends on the lease now
- add some comments
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test, only fix existing case, doesn't add new one
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

run tidb with unistore and lease=0s, run some statement, should work


make ut this pr: run all tasks takes 7m18.029994491s
make ut master: run all tasks takes 7m5.36566918s

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
