### PR TITLE
executor: fix incorrect result when hash agg spill is triggered

### DIFF
--- a/pkg/executor/aggfuncs/aggfuncs.go
+++ b/pkg/executor/aggfuncs/aggfuncs.go
@@ -71,6 +71,7 @@ var (
 	_ AggFunc = (*maxMin4Float64)(nil)
 	_ AggFunc = (*maxMin4Decimal)(nil)
 	_ AggFunc = (*maxMin4String)(nil)
+	_ AggFunc = (*maxMin4Time)(nil)
 	_ AggFunc = (*maxMin4Duration)(nil)
 	_ AggFunc = (*maxMin4JSON)(nil)
 	_ AggFunc = (*maxMin4Enum)(nil)

--- a/pkg/executor/aggfuncs/func_count.go
+++ b/pkg/executor/aggfuncs/func_count.go
@@ -58,8 +58,8 @@ func (e *baseCount) DeserializePartialResult(src *chunk.Chunk) ([]PartialResult,
 
 func (e *baseCount) deserializeForSpill(helper *deserializeHelper) (PartialResult, int64) {
 	pr, memDelta := e.AllocPartialResult()
-	result := *(*partialResult4Count)(pr)
-	success := helper.deserializePartialResult4Count(&result)
+	result := (*partialResult4Count)(pr)
+	success := helper.deserializePartialResult4Count(result)
 	if !success {
 		return nil, 0
 	}

--- a/pkg/executor/aggfuncs/func_max_min.go
+++ b/pkg/executor/aggfuncs/func_max_min.go
@@ -1287,6 +1287,26 @@ func (e *maxMin4Time) MergePartialResult(_ AggFuncUpdateContext, src, dst Partia
 	return 0, nil
 }
 
+func (e *maxMin4Time) SerializePartialResult(partialResult PartialResult, chk *chunk.Chunk, spillHelper *SerializeHelper) {
+	pr := (*partialResult4MaxMinTime)(partialResult)
+	resBuf := spillHelper.serializePartialResult4MaxMinTime(*pr)
+	chk.AppendBytes(e.ordinal, resBuf)
+}
+
+func (e *maxMin4Time) DeserializePartialResult(src *chunk.Chunk) ([]PartialResult, int64) {
+	return deserializePartialResultCommon(src, e.ordinal, e.deserializeForSpill)
+}
+
+func (e *maxMin4Time) deserializeForSpill(helper *deserializeHelper) (PartialResult, int64) {
+	pr, memDelta := e.AllocPartialResult()
+	result := (*partialResult4MaxMinTime)(pr)
+	success := helper.deserializePartialResult4MaxMinTime(result)
+	if !success {
+		return nil, 0
+	}
+	return pr, memDelta
+}
+
 type maxMin4TimeSliding struct {
 	maxMin4Time
 	windowInfo

--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -398,7 +398,7 @@ func (e *HashAggExec) initForParallelExec(ctx sessionctx.Context) error {
 		spillChunkFieldTypes[i] = types.NewFieldType(mysql.TypeVarString)
 	}
 	spillChunkFieldTypes[baseRetTypeNum] = types.NewFieldType(mysql.TypeString)
-	e.spillHelper = newSpillHelper(e.memTracker, e.FinalAggFuncs, func() *chunk.Chunk {
+	e.spillHelper = newSpillHelper(e.memTracker, e.PartialAggFuncs, e.FinalAggFuncs, func() *chunk.Chunk {
 		return chunk.New(spillChunkFieldTypes, e.InitCap(), e.MaxChunkSize())
 	}, spillChunkFieldTypes)
 

--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -398,7 +398,7 @@ func (e *HashAggExec) initForParallelExec(ctx sessionctx.Context) error {
 		spillChunkFieldTypes[i] = types.NewFieldType(mysql.TypeVarString)
 	}
 	spillChunkFieldTypes[baseRetTypeNum] = types.NewFieldType(mysql.TypeString)
-	e.spillHelper = newSpillHelper(e.memTracker, e.PartialAggFuncs, func() *chunk.Chunk {
+	e.spillHelper = newSpillHelper(e.memTracker, e.FinalAggFuncs, func() *chunk.Chunk {
 		return chunk.New(spillChunkFieldTypes, e.InitCap(), e.MaxChunkSize())
 	}, spillChunkFieldTypes)
 

--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -397,10 +397,15 @@ func (e *HashAggExec) initForParallelExec(ctx sessionctx.Context) error {
 	for i := 0; i < baseRetTypeNum; i++ {
 		spillChunkFieldTypes[i] = types.NewFieldType(mysql.TypeVarString)
 	}
+
+	var err error
 	spillChunkFieldTypes[baseRetTypeNum] = types.NewFieldType(mysql.TypeString)
-	e.spillHelper = newSpillHelper(e.memTracker, e.PartialAggFuncs, e.FinalAggFuncs, func() *chunk.Chunk {
+	e.spillHelper, err = newSpillHelper(e.memTracker, e.PartialAggFuncs, e.FinalAggFuncs, func() *chunk.Chunk {
 		return chunk.New(spillChunkFieldTypes, e.InitCap(), e.MaxChunkSize())
 	}, spillChunkFieldTypes)
+	if err != nil {
+		return err
+	}
 
 	if isTrackerEnabled && isParallelHashAggSpillEnabled {
 		if e.diskTracker != nil {

--- a/pkg/executor/aggregate/agg_spill.go
+++ b/pkg/executor/aggregate/agg_spill.go
@@ -79,10 +79,10 @@ func newSpillHelper(
 	finalWorkerAggFuncs []aggfuncs.AggFunc,
 	getNewSpillChunkFunc func() *chunk.Chunk,
 	spillChunkFieldTypes []*types.FieldType) (*parallelHashAggSpillHelper, error) {
-		if len(aggFuncsForRestoring) != len(finalWorkerAggFuncs) {
-			return nil, errors.NewNoStackError("len(aggFuncsForRestoring) != len(finalWorkerAggFuncs)")
-		}
-		
+	if len(aggFuncsForRestoring) != len(finalWorkerAggFuncs) {
+		return nil, errors.NewNoStackError("len(aggFuncsForRestoring) != len(finalWorkerAggFuncs)")
+	}
+
 	mu := new(sync.Mutex)
 	helper := &parallelHashAggSpillHelper{
 		lock: struct {

--- a/pkg/executor/aggregate/agg_spill.go
+++ b/pkg/executor/aggregate/agg_spill.go
@@ -66,6 +66,8 @@ type parallelHashAggSpillHelper struct {
 	// They only be used for restoring data that are spilled to disk in partial stage.
 	aggFuncsForRestoring []aggfuncs.AggFunc
 
+	finalWorkerAggFuncs []aggfuncs.AggFunc
+
 	getNewSpillChunkFunc func() *chunk.Chunk
 	spillChunkFieldTypes []*types.FieldType
 }
@@ -73,6 +75,7 @@ type parallelHashAggSpillHelper struct {
 func newSpillHelper(
 	tracker *memory.Tracker,
 	aggFuncsForRestoring []aggfuncs.AggFunc,
+	finalWorkerAggFuncs []aggfuncs.AggFunc,
 	getNewSpillChunkFunc func() *chunk.Chunk,
 	spillChunkFieldTypes []*types.FieldType) *parallelHashAggSpillHelper {
 	mu := new(sync.Mutex)
@@ -97,6 +100,7 @@ func newSpillHelper(
 		memTracker:           tracker,
 		hasError:             atomic.Bool{},
 		aggFuncsForRestoring: aggFuncsForRestoring,
+		finalWorkerAggFuncs:  finalWorkerAggFuncs,
 		getNewSpillChunkFunc: getNewSpillChunkFunc,
 		spillChunkFieldTypes: spillChunkFieldTypes,
 	}
@@ -239,7 +243,7 @@ type processRowContext struct {
 	chunk                  *chunk.Chunk
 	rowPos                 int
 	keyColPos              int
-	aggFuncNum             int
+	aggRestoreFuncNum      int
 	restoreadData          *aggfuncs.AggPartialResultMapper
 	partialResultsRestored [][]aggfuncs.PartialResult
 	bInMap                 *int
@@ -247,15 +251,15 @@ type processRowContext struct {
 
 func (p *parallelHashAggSpillHelper) restoreFromOneSpillFile(ctx sessionctx.Context, restoreadData *aggfuncs.AggPartialResultMapper, diskIO *chunk.DataInDiskByChunks, bInMap *int) (totalMemDelta int64, totalExpandMem int64, err error) {
 	chunkNum := diskIO.NumChunks()
-	aggFuncNum := len(p.aggFuncsForRestoring)
+	aggRestoreFuncNum := len(p.aggFuncsForRestoring)
 	processRowContext := &processRowContext{
 		ctx:                    ctx,
 		chunk:                  nil, // Will be set in the loop
 		rowPos:                 0,   // Will be set in the loop
-		keyColPos:              aggFuncNum,
-		aggFuncNum:             aggFuncNum,
+		keyColPos:              aggRestoreFuncNum,
+		aggRestoreFuncNum:      aggRestoreFuncNum,
 		restoreadData:          restoreadData,
-		partialResultsRestored: make([][]aggfuncs.PartialResult, aggFuncNum),
+		partialResultsRestored: make([][]aggfuncs.PartialResult, aggRestoreFuncNum),
 		bInMap:                 bInMap,
 	}
 	for i := 0; i < chunkNum; i++ {
@@ -293,8 +297,8 @@ func (p *parallelHashAggSpillHelper) processRow(context *processRowContext) (tot
 	if ok {
 		exprCtx := context.ctx.GetExprCtx()
 		// The key has appeared before, merge results.
-		for aggPos := 0; aggPos < context.aggFuncNum; aggPos++ {
-			memDelta, err := p.aggFuncsForRestoring[aggPos].MergePartialResult(exprCtx.GetEvalCtx(), context.partialResultsRestored[aggPos][context.rowPos], prs[aggPos])
+		for aggPos := 0; aggPos < len(p.finalWorkerAggFuncs); aggPos++ {
+			memDelta, err := p.finalWorkerAggFuncs[aggPos].MergePartialResult(exprCtx.GetEvalCtx(), context.partialResultsRestored[aggPos][context.rowPos], prs[aggPos])
 			if err != nil {
 				return totalMemDelta, 0, err
 			}
@@ -309,10 +313,10 @@ func (p *parallelHashAggSpillHelper) processRow(context *processRowContext) (tot
 			(*context.bInMap)++
 		}
 
-		results := make([]aggfuncs.PartialResult, context.aggFuncNum)
+		results := make([]aggfuncs.PartialResult, context.aggRestoreFuncNum)
 		(*context.restoreadData)[key] = results
 
-		for aggPos := 0; aggPos < context.aggFuncNum; aggPos++ {
+		for aggPos := 0; aggPos < context.aggRestoreFuncNum; aggPos++ {
 			results[aggPos] = context.partialResultsRestored[aggPos][context.rowPos]
 		}
 	}

--- a/pkg/executor/aggregate/agg_spill_test.go
+++ b/pkg/executor/aggregate/agg_spill_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"strconv"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -45,49 +45,6 @@ import (
 // Chunk schema in this test file: | column0: string | column1: float64 |
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-type resultsContainer struct {
-	rows []chunk.Row
-}
-
-func (r *resultsContainer) add(chk *chunk.Chunk) {
-	iter := chunk.NewIterator4Chunk(chk.CopyConstruct())
-	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		r.rows = append(r.rows, row)
-	}
-}
-
-func (r *resultsContainer) check(expectRes map[string]float64) bool {
-	if len(r.rows) != len(expectRes) {
-		return false
-	}
-
-	cols := getColumns()
-	retFields := []*types.FieldType{cols[0].RetType, cols[1].RetType}
-	for _, row := range r.rows {
-		key := ""
-		for i, field := range retFields {
-			d := row.GetDatum(i, field)
-			resStr, err := d.ToString()
-			if err != nil {
-				panic("Fail to convert to string")
-			}
-
-			if i == 0 {
-				key = resStr
-			} else {
-				expectVal, ok := expectRes[key]
-				if !ok {
-					return false
-				}
-				if resStr != strconv.Itoa(int(expectVal)) {
-					return false
-				}
-			}
-		}
-	}
-	return true
-}
 
 func getRandString() string {
 	b := make([]byte, 5)
@@ -146,24 +103,77 @@ func buildMockDataSource(opt testutil.MockDataSourceParameters, col0Data []strin
 	return mockDatasource
 }
 
-func generateResult(col0 []string) map[string]float64 {
-	result := make(map[string]float64, 0)
-	length := len(col0)
+func generateCMPFunc(fieldTypes []*types.FieldType) func(chunk.Row, chunk.Row) int {
+	cmpFuncs := make([]chunk.CompareFunc, 0, len(fieldTypes))
+	for _, colType := range fieldTypes {
+		cmpFuncs = append(cmpFuncs, chunk.GetCompareFunc(colType))
+	}
 
-	for i := 0; i < length; i++ {
-		_, ok := result[col0[i]]
-		if ok {
-			result[col0[i]]++
-		} else {
-			result[col0[i]] = 1
+	cmp := func(rowI, rowJ chunk.Row) int {
+		for i, cmpFunc := range cmpFuncs {
+			cmp := cmpFunc(rowI, i, rowJ, i)
+			if cmp != 0 {
+				return cmp
+			}
+		}
+		return 0
+	}
+
+	return cmp
+}
+
+func sortRows(rows []chunk.Row, fieldTypes []*types.FieldType) []chunk.Row {
+	cmp := generateCMPFunc(fieldTypes)
+
+	sort.Slice(rows, func(i, j int) bool {
+		return cmp(rows[i], rows[j]) < 0
+	})
+	return rows
+}
+
+func generateResult(t *testing.T, ctx *mock.Context, dataSource *testutil.MockDataSource) []chunk.Row {
+	aggExec := buildHashAggExecutor(t, ctx, dataSource)
+	dataSource.PrepareChunks()
+	tmpCtx := context.Background()
+	resultRows := make([]chunk.Row, 0)
+	aggExec.Open(tmpCtx)
+	for {
+		chk := exec.NewFirstChunk(aggExec)
+		err := aggExec.Next(tmpCtx, chk)
+		require.Equal(t, nil, err)
+		if chk.NumRows() == 0 {
+			break
+		}
+
+		rowNum := chk.NumRows()
+		for i := 0; i < rowNum; i++ {
+			resultRows = append(resultRows, chk.GetRow(i))
 		}
 	}
-	return result
+	aggExec.Close()
+
+	require.False(t, aggExec.IsSpillTriggeredForTest())
+	return sortRows(resultRows, getRetTypes())
+}
+
+func getRetTypes() []*types.FieldType {
+	return []*types.FieldType{
+		types.NewFieldType(mysql.TypeVarString),
+		types.NewFieldType(mysql.TypeDouble),
+		types.NewFieldType(mysql.TypeDouble),
+		types.NewFieldType(mysql.TypeDouble),
+		// types.NewFieldType(mysql.TypeDouble),
+		types.NewFieldType(mysql.TypeDouble),
+	}
 }
 
 func getColumns() []*expression.Column {
 	return []*expression.Column{
 		{Index: 0, RetType: types.NewFieldType(mysql.TypeVarString)},
+		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
+		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
+		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
+		// {Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
 		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
 	}
 }
@@ -191,17 +201,45 @@ func buildHashAggExecutor(t *testing.T, ctx sessionctx.Context, child exec.Execu
 	schema := expression.NewSchema(childCols...)
 	groupItems := []expression.Expression{childCols[0]}
 
-	aggFirstRow, err := aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncFirstRow, []expression.Expression{childCols[0]}, false)
+	var err error
+	var aggFirstRow *aggregation.AggFuncDesc
+	var aggSum *aggregation.AggFuncDesc
+	var aggCount *aggregation.AggFuncDesc
+	// var aggAvg *aggregation.AggFuncDesc
+	var aggMin *aggregation.AggFuncDesc
+	var aggMax *aggregation.AggFuncDesc
+	aggFirstRow, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncFirstRow, []expression.Expression{childCols[0]}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	aggFunc, err := aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncSum, []expression.Expression{childCols[1]}, false)
+	aggSum, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncSum, []expression.Expression{childCols[1]}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	aggFuncs := []*aggregation.AggFuncDesc{aggFirstRow, aggFunc}
+	aggCount, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncCount, []expression.Expression{childCols[1]}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// aggAvg, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncAvg, []expression.Expression{childCols[1]}, false)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+
+	aggMin, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncMin, []expression.Expression{childCols[1]}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aggMax, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncMax, []expression.Expression{childCols[1]}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aggFuncs := []*aggregation.AggFuncDesc{aggFirstRow, aggSum, aggCount, aggMin, aggMax}
+	// aggFuncs := []*aggregation.AggFuncDesc{aggFirstRow, aggSum, aggCount, aggAvg, aggMin, aggMax}
 
 	aggExec := &aggregate.HashAggExec{
 		BaseExecutor:     exec.NewBaseExecutor(ctx, schema, 0, child),
@@ -237,30 +275,49 @@ func initCtx(ctx *mock.Context, newRootExceedAction *testutil.MockActionOnExceed
 	ctx.GetSessionVars().MemTracker.SetActionOnExceed(newRootExceedAction)
 }
 
-// select t0, sum(t1) from t group by t0;
-func executeCorrecResultTest(t *testing.T, ctx *mock.Context, aggExec *aggregate.HashAggExec, dataSource *testutil.MockDataSource, result map[string]float64) {
+func checkResult(expectResult []chunk.Row, actualResult []chunk.Row, retTypes []*types.FieldType) bool {
+	if len(expectResult) != len(actualResult) {
+		return false
+	}
+
+	rowNum := len(expectResult)
+	for i := 0; i < rowNum; i++ {
+		if expectResult[i].ToString(retTypes) != actualResult[i].ToString(retTypes) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func executeCorrecResultTest(t *testing.T, ctx *mock.Context, aggExec *aggregate.HashAggExec, dataSource *testutil.MockDataSource, expectResult []chunk.Row) {
 	if aggExec == nil {
 		aggExec = buildHashAggExecutor(t, ctx, dataSource)
 	}
 	dataSource.PrepareChunks()
 	tmpCtx := context.Background()
-	chk := exec.NewFirstChunk(aggExec)
-	resContainer := resultsContainer{}
+	resultRows := make([]chunk.Row, 0)
 	aggExec.Open(tmpCtx)
-
+	
 	for {
+		chk := exec.NewFirstChunk(aggExec)
 		err := aggExec.Next(tmpCtx, chk)
 		require.Equal(t, nil, err)
 		if chk.NumRows() == 0 {
 			break
 		}
-		resContainer.add(chk)
-		chk.Reset()
+
+		rowNum := chk.NumRows()
+		for i := 0; i < rowNum; i++ {
+			resultRows = append(resultRows, chk.GetRow(i))
+		}
 	}
 	aggExec.Close()
 
 	require.True(t, aggExec.IsSpillTriggeredForTest())
-	require.True(t, resContainer.check(result))
+	retTypes := getRetTypes()
+	resultRows = sortRows(resultRows, retTypes)
+	require.True(t, checkResult(expectResult, resultRows, retTypes))
 }
 
 func fallBackActionTest(t *testing.T) {
@@ -283,15 +340,12 @@ func fallBackActionTest(t *testing.T) {
 	dataSource.PrepareChunks()
 	tmpCtx := context.Background()
 	chk := exec.NewFirstChunk(aggExec)
-	resContainer := resultsContainer{}
 	aggExec.Open(tmpCtx)
-
 	for {
 		aggExec.Next(tmpCtx, chk)
 		if chk.NumRows() == 0 {
 			break
 		}
-		resContainer.add(chk)
 		chk.Reset()
 	}
 	aggExec.Close()
@@ -340,21 +394,23 @@ func randomFailTest(t *testing.T, ctx *mock.Context, aggExec *aggregate.HashAggE
 	})
 }
 
+// sql: select col0, sum(col1), count(col1), avg(col1), min(col1), max(col1) from t group by t.col0;
 func TestGetCorrectResult(t *testing.T) {
 	newRootExceedAction := new(testutil.MockActionOnExceed)
-	hardLimitBytesNum := int64(6000000)
 
 	ctx := mock.NewContext()
-	initCtx(ctx, newRootExceedAction, hardLimitBytesNum, 256)
+	initCtx(ctx, newRootExceedAction, -1, 1024)
 
 	rowNum := 100000
 	ndv := 50000
-	col1, col2 := generateData(rowNum, ndv)
-	result := generateResult(col1)
+	col0, col1 := generateData(rowNum, ndv)
 	opt := getMockDataSourceParameters(ctx)
-	dataSource := buildMockDataSource(opt, col1, col2)
+	dataSource := buildMockDataSource(opt, col0, col1)
+	result := generateResult(t, ctx, dataSource)
 
-	failpoint.Enable("github.com/pingcap/tidb/pkg/executor/aggregate/slowSomePartialWorkers", `return(true)`)
+	err := failpoint.Enable("github.com/pingcap/tidb/pkg/executor/aggregate/slowSomePartialWorkers", `return(true)`)
+	require.NoError(t, err)
+	defer require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/aggregate/slowSomePartialWorkers"))
 
 	finished := atomic.Bool{}
 	wg := sync.WaitGroup{}
@@ -372,6 +428,9 @@ func TestGetCorrectResult(t *testing.T) {
 		wg.Done()
 	}()
 
+	hardLimitBytesNum := int64(6000000)
+	initCtx(ctx, newRootExceedAction, hardLimitBytesNum, 256)
+
 	aggExec := buildHashAggExecutor(t, ctx, dataSource)
 	for i := 0; i < 5; i++ {
 		executeCorrecResultTest(t, ctx, nil, dataSource, result)
@@ -380,7 +439,6 @@ func TestGetCorrectResult(t *testing.T) {
 
 	finished.Store(true)
 	wg.Wait()
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/aggregate/slowSomePartialWorkers"))
 }
 
 func TestFallBackAction(t *testing.T) {

--- a/pkg/executor/aggregate/agg_spill_test.go
+++ b/pkg/executor/aggregate/agg_spill_test.go
@@ -65,9 +65,9 @@ func generateData(rowNum int, ndv int) ([]string, []float64) {
 
 	// Generate data
 	for i := 0; i < rowNum; i++ {
-		key := keys[i%ndv]
+		key := keys[rand.Intn(ndv)]
 		col0Data = append(col0Data, key)
-		col1Data = append(col1Data, 1) // Always 1
+		col1Data = append(col1Data, float64(rand.Intn(10000000)))
 	}
 
 	// Shuffle data
@@ -160,7 +160,7 @@ func getRetTypes() []*types.FieldType {
 	return []*types.FieldType{
 		types.NewFieldType(mysql.TypeVarString),
 		types.NewFieldType(mysql.TypeDouble),
-		types.NewFieldType(mysql.TypeDouble),
+		types.NewFieldType(mysql.TypeLonglong),
 		types.NewFieldType(mysql.TypeDouble),
 		types.NewFieldType(mysql.TypeDouble),
 	}
@@ -236,6 +236,7 @@ func buildHashAggExecutor(t *testing.T, ctx sessionctx.Context, child exec.Execu
 		BaseExecutor:     exec.NewBaseExecutor(ctx, schema, 0, child),
 		Sc:               ctx.GetSessionVars().StmtCtx,
 		PartialAggFuncs:  make([]aggfuncs.AggFunc, 0, len(aggFuncs)),
+		FinalAggFuncs:    make([]aggfuncs.AggFunc, 0, len(aggFuncs)),
 		GroupByItems:     groupItems,
 		IsUnparallelExec: false,
 	}
@@ -289,7 +290,6 @@ func executeCorrecResultTest(t *testing.T, ctx *mock.Context, aggExec *aggregate
 	tmpCtx := context.Background()
 	resultRows := make([]chunk.Row, 0)
 	aggExec.Open(tmpCtx)
-	
 	for {
 		chk := exec.NewFirstChunk(aggExec)
 		err := aggExec.Next(tmpCtx, chk)
@@ -423,7 +423,7 @@ func TestGetCorrectResult(t *testing.T) {
 	initCtx(ctx, newRootExceedAction, hardLimitBytesNum, 256)
 
 	aggExec := buildHashAggExecutor(t, ctx, dataSource)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 1; i++ {
 		executeCorrecResultTest(t, ctx, nil, dataSource, result)
 		executeCorrecResultTest(t, ctx, aggExec, dataSource, result)
 	}

--- a/pkg/executor/aggregate/agg_spill_test.go
+++ b/pkg/executor/aggregate/agg_spill_test.go
@@ -162,7 +162,6 @@ func getRetTypes() []*types.FieldType {
 		types.NewFieldType(mysql.TypeDouble),
 		types.NewFieldType(mysql.TypeDouble),
 		types.NewFieldType(mysql.TypeDouble),
-		// types.NewFieldType(mysql.TypeDouble),
 		types.NewFieldType(mysql.TypeDouble),
 	}
 }
@@ -173,7 +172,6 @@ func getColumns() []*expression.Column {
 		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
 		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
 		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
-		// {Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
 		{Index: 1, RetType: types.NewFieldType(mysql.TypeDouble)},
 	}
 }
@@ -205,7 +203,6 @@ func buildHashAggExecutor(t *testing.T, ctx sessionctx.Context, child exec.Execu
 	var aggFirstRow *aggregation.AggFuncDesc
 	var aggSum *aggregation.AggFuncDesc
 	var aggCount *aggregation.AggFuncDesc
-	// var aggAvg *aggregation.AggFuncDesc
 	var aggMin *aggregation.AggFuncDesc
 	var aggMax *aggregation.AggFuncDesc
 	aggFirstRow, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncFirstRow, []expression.Expression{childCols[0]}, false)
@@ -223,11 +220,6 @@ func buildHashAggExecutor(t *testing.T, ctx sessionctx.Context, child exec.Execu
 		t.Fatal(err)
 	}
 
-	// aggAvg, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncAvg, []expression.Expression{childCols[1]}, false)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-
 	aggMin, err = aggregation.NewAggFuncDesc(ctx.GetExprCtx(), ast.AggFuncMin, []expression.Expression{childCols[1]}, false)
 	if err != nil {
 		t.Fatal(err)
@@ -239,7 +231,6 @@ func buildHashAggExecutor(t *testing.T, ctx sessionctx.Context, child exec.Execu
 	}
 
 	aggFuncs := []*aggregation.AggFuncDesc{aggFirstRow, aggSum, aggCount, aggMin, aggMax}
-	// aggFuncs := []*aggregation.AggFuncDesc{aggFirstRow, aggSum, aggCount, aggAvg, aggMin, aggMax}
 
 	aggExec := &aggregate.HashAggExec{
 		BaseExecutor:     exec.NewBaseExecutor(ctx, schema, 0, child),
@@ -394,7 +385,7 @@ func randomFailTest(t *testing.T, ctx *mock.Context, aggExec *aggregate.HashAggE
 	})
 }
 
-// sql: select col0, sum(col1), count(col1), avg(col1), min(col1), max(col1) from t group by t.col0;
+// sql: select col0, sum(col1), count(col1), min(col1), max(col1) from t group by t.col0;
 func TestGetCorrectResult(t *testing.T) {
 	newRootExceedAction := new(testutil.MockActionOnExceed)
 

--- a/pkg/executor/aggregate/agg_spill_test.go
+++ b/pkg/executor/aggregate/agg_spill_test.go
@@ -423,7 +423,7 @@ func TestGetCorrectResult(t *testing.T) {
 	initCtx(ctx, newRootExceedAction, hardLimitBytesNum, 256)
 
 	aggExec := buildHashAggExecutor(t, ctx, dataSource)
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 5; i++ {
 		executeCorrecResultTest(t, ctx, nil, dataSource, result)
 		executeCorrecResultTest(t, ctx, aggExec, dataSource, result)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55290

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that getting incorrect result when hash agg spill is triggered
```
