### PR TITLE
table: make `AddRecordOpt`/`UpdateRecordOpt`/`CreateIdxOpt` immutable

### DIFF
--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -52,11 +52,11 @@ func TestOptions(t *testing.T) {
 	// NewAddRecordOpt with options
 	addOpt = NewAddRecordOpt(WithCtx(ctx), IsUpdate, WithReserveAutoIDHint(12))
 	require.Equal(t, AddRecordOpt{
-		commonMutateOpt: commonMutateOpt{Ctx: ctx},
-		IsUpdate:        true,
-		ReserveAutoID:   12,
+		commonMutateOpt: commonMutateOpt{ctx: ctx},
+		isUpdate:        true,
+		reserveAutoID:   12,
 	}, *addOpt)
-	require.Equal(t, CreateIdxOpt{commonMutateOpt: commonMutateOpt{Ctx: ctx}}, *(addOpt.GetCreateIdxOpt()))
+	require.Equal(t, CreateIdxOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *(addOpt.GetCreateIdxOpt()))
 	// NewUpdateRecordOpt without option
 	updateOpt := NewUpdateRecordOpt()
 	require.Equal(t, UpdateRecordOpt{}, *updateOpt)
@@ -64,17 +64,17 @@ func TestOptions(t *testing.T) {
 	require.Equal(t, CreateIdxOpt{}, *(updateOpt.GetCreateIdxOpt()))
 	// NewUpdateRecordOpt with options
 	updateOpt = NewUpdateRecordOpt(WithCtx(ctx))
-	require.Equal(t, UpdateRecordOpt{commonMutateOpt: commonMutateOpt{Ctx: ctx}}, *updateOpt)
-	require.Equal(t, AddRecordOpt{commonMutateOpt: commonMutateOpt{Ctx: ctx}}, *(updateOpt.GetAddRecordOpt()))
-	require.Equal(t, CreateIdxOpt{commonMutateOpt: commonMutateOpt{Ctx: ctx}}, *(updateOpt.GetCreateIdxOpt()))
+	require.Equal(t, UpdateRecordOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *updateOpt)
+	require.Equal(t, AddRecordOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *(updateOpt.GetAddRecordOpt()))
+	require.Equal(t, CreateIdxOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *(updateOpt.GetCreateIdxOpt()))
 	// NewCreateIdxOpt without option
 	createIdxOpt := NewCreateIdxOpt()
 	require.Equal(t, CreateIdxOpt{}, *createIdxOpt)
 	// NewCreateIdxOpt with options
 	createIdxOpt = NewCreateIdxOpt(WithCtx(ctx), WithIgnoreAssertion, FromBackfill)
 	require.Equal(t, CreateIdxOpt{
-		commonMutateOpt: commonMutateOpt{Ctx: ctx},
-		IgnoreAssertion: true,
-		FromBackFill:    true,
+		commonMutateOpt: commonMutateOpt{ctx: ctx},
+		ignoreAssertion: true,
+		fromBackFill:    true,
 	}, *createIdxOpt)
 }

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -168,7 +168,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 		txn.CacheTableInfo(c.phyTblID, c.tblInfo)
 	}
 	indexedValues := c.getIndexedValue(indexedValue)
-	ctx := opt.Ctx
+	ctx := opt.Ctx()
 	if ctx != nil {
 		var r tracing.Region
 		r, ctx = tracing.StartRegionEx(ctx, "index.Create")
@@ -178,7 +178,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 	}
 	vars := sctx.GetSessionVars()
 	writeBufs := sctx.GetMutateBuffers().GetWriteStmtBufs()
-	skipCheck := opt.DupKeyCheck == table.DupKeyCheckSkip
+	skipCheck := opt.DupKeyCheck() == table.DupKeyCheckSkip
 	evalCtx := sctx.GetExprCtx().GetEvalCtx()
 	loc, ec := evalCtx.Location(), evalCtx.ErrCtx()
 	for _, value := range indexedValues {
@@ -192,7 +192,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 			keyVer          byte
 			keyIsTempIdxKey bool
 		)
-		if !opt.FromBackFill {
+		if !opt.FromBackFill() {
 			key, tempKey, keyVer = GenTempIdxKeyByState(c.idxInfo, key)
 			if keyVer == TempIndexKeyTypeBackfill || keyVer == TempIndexKeyTypeDelete {
 				key, tempKey = tempKey, nil
@@ -246,7 +246,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 			return nil, err
 		}
 
-		ignoreAssertion := opt.IgnoreAssertion || c.idxInfo.State != model.StatePublic
+		ignoreAssertion := opt.IgnoreAssertion() || c.idxInfo.State != model.StatePublic
 
 		if !distinct || skipCheck || untouched {
 			val := idxVal
@@ -272,7 +272,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 				}
 			}
 			if !ignoreAssertion && !untouched {
-				if opt.DupKeyCheck == table.DupKeyCheckLazy && !txn.IsPessimistic() {
+				if opt.DupKeyCheck() == table.DupKeyCheckLazy && !txn.IsPessimistic() {
 					err = txn.SetAssertion(key, kv.SetAssertUnknown)
 				} else {
 					err = txn.SetAssertion(key, kv.SetAssertNotExist)
@@ -288,7 +288,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 		if c.tblInfo.TempTableType != model.TempTableNone {
 			// Always check key for temporary table because it does not write to TiKV
 			value, err = txn.Get(ctx, key)
-		} else if opt.DupKeyCheck == table.DupKeyCheckLazy && !keyIsTempIdxKey {
+		} else if opt.DupKeyCheck() == table.DupKeyCheckLazy && !keyIsTempIdxKey {
 			// For temp index keys, we can't get the temp value from memory buffer, even if the lazy check is enabled.
 			// Otherwise, it may cause the temp index value to be overwritten, leading to data inconsistency.
 			value, err = txn.GetMemBuffer().GetLocal(ctx, key)
@@ -308,7 +308,7 @@ func (c *index) create(sctx table.MutateContext, txn kv.Transaction, indexedValu
 		// The index key value is not found or deleted.
 		if err != nil || len(value) == 0 || (!tempIdxVal.IsEmpty() && tempIdxVal.Current().Delete) {
 			val := idxVal
-			lazyCheck := opt.DupKeyCheck == table.DupKeyCheckLazy && err != nil
+			lazyCheck := opt.DupKeyCheck() == table.DupKeyCheckLazy && err != nil
 			if keyIsTempIdxKey {
 				tempVal := tablecodec.TempIndexValueElem{Value: idxVal, KeyVer: keyVer, Distinct: true}
 				val = tempVal.Encode(value)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54397

Problem Summary:

We should to make `XXXOpt` in table immutable to avoid some potential bugs introduced by modifying its inner state and then shared with other operations. See issue: #55313

### What changed and how does it work?

- Make the fields in the opt objects private to avoid modification directly in other package.
- Make the method in the interfaces `AddRecordOption` / `UpdateRecordOption` / `CreateIdxOption` private to forbid outside package to use them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
