### PR TITLE
test: fix data conflict in `TestCursorWillBlockMinStartTS`

### DIFF
--- a/pkg/executor/staticrecordset/BUILD.bazel
+++ b/pkg/executor/staticrecordset/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     flaky = True,
     shard_count = 7,
     deps = [
+        "//pkg/parser/mysql",
         "//pkg/session/cursor",
         "//pkg/testkit",
         "//pkg/util/sqlexec",

--- a/pkg/executor/staticrecordset/integration_test.go
+++ b/pkg/executor/staticrecordset/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/session/cursor"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -30,6 +31,8 @@ import (
 func TestStaticRecordSet(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
@@ -61,6 +64,8 @@ func TestStaticRecordSet(t *testing.T) {
 func TestStaticRecordSetWithTxn(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
@@ -101,6 +106,8 @@ func TestStaticRecordSetExceedGCTime(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
+
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
 	tk.MustExec("insert into t values (1), (2), (3)")
@@ -136,6 +143,8 @@ func TestDetachError(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
+
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
 	tk.MustExec("insert into t values (1), (2), (3)")
@@ -154,6 +163,8 @@ func TestDetachError(t *testing.T) {
 func TestCursorWillBeClosed(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
@@ -179,6 +190,8 @@ func TestCursorWillBeClosed(t *testing.T) {
 func TestCursorWillBlockMinStartTS(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
@@ -216,6 +229,8 @@ func TestCursorWillBlockMinStartTS(t *testing.T) {
 func TestFinishStmtError(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+
+	tk.Session().GetSessionVars().SetStatusFlag(mysql.ServerStatusCursorExists, true)
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2378,6 +2378,10 @@ func (rs *execStmtResult) Close() error {
 }
 
 func (rs *execStmtResult) TryDetach() (sqlexec.RecordSet, bool, error) {
+	// If `TryDetach` is called, the connection must have set `mysql.ServerStatusCursorExists`, or
+	// the `StatementContext` will be re-used and cause data race.
+	intest.Assert(rs.se.GetSessionVars().HasStatusFlag(mysql.ServerStatusCursorExists))
+
 	if !rs.sql.IsReadOnly(rs.se.GetSessionVars()) {
 		return nil, false, nil
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55227

Problem Summary:

There was a data conflict in the test, because the `MemTracker` is pre-allocated in the cache of `StatementContext`. If the `StatementContext` is re-used, the mem tracker will be cleaned..

### What changed and how does it work?

Add a `ServerStatusCursorExists` flag. It makes sure the `StatementContext` will not be re-used.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
