### PR TITLE
*: add ctx parameter to infoschema TableByID

### DIFF
--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1577,7 +1577,7 @@ func (rc *LogClient) FailpointDoChecksumForLogRestore(
 		reidRules[downstreamID] = upstreamID
 	}
 	for upstreamID, downstreamID := range idrules {
-		newTable, ok := infoSchema.TableByID(downstreamID)
+		newTable, ok := infoSchema.TableByID(ctx, downstreamID)
 		if !ok {
 			// a dropped table
 			continue

--- a/br/pkg/restore/tiflashrec/tiflash_recorder.go
+++ b/br/pkg/restore/tiflashrec/tiflash_recorder.go
@@ -16,6 +16,7 @@ package tiflashrec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/pingcap/log"
@@ -90,7 +91,7 @@ func (r *TiFlashRecorder) Rewrite(oldID int64, newID int64) {
 func (r *TiFlashRecorder) GenerateResetAlterTableDDLs(info infoschema.InfoSchema) []string {
 	items := make([]string, 0, len(r.items))
 	r.Iterate(func(id int64, replica model.TiFlashReplicaInfo) {
-		table, ok := info.TableByID(id)
+		table, ok := info.TableByID(context.Background(), id)
 		if !ok {
 			log.Warn("Table do not exist, skipping", zap.Int64("id", id))
 			return
@@ -130,7 +131,7 @@ func (r *TiFlashRecorder) GenerateResetAlterTableDDLs(info infoschema.InfoSchema
 func (r *TiFlashRecorder) GenerateAlterTableDDLs(info infoschema.InfoSchema) []string {
 	items := make([]string, 0, len(r.items))
 	r.Iterate(func(id int64, replica model.TiFlashReplicaInfo) {
-		table, ok := info.TableByID(id)
+		table, ok := info.TableByID(context.Background(), id)
 		if !ok {
 			log.Warn("Table do not exist, skipping", zap.Int64("id", id))
 			return

--- a/pkg/ddl/column_change_test.go
+++ b/pkg/ddl/column_change_test.go
@@ -60,7 +60,7 @@ func TestColumnAdd(t *testing.T) {
 	var jobID int64
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *model.Job) {
 		jobID = job.ID
-		tbl, exist := dom.InfoSchema().TableByID(job.TableID)
+		tbl, exist := dom.InfoSchema().TableByID(context.Background(), job.TableID)
 		require.True(t, exist)
 		switch job.SchemaState {
 		case model.StateDeleteOnly:
@@ -110,7 +110,7 @@ func TestColumnAdd(t *testing.T) {
 	first = true
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *model.Job) {
 		jobID = job.ID
-		tbl, exist := dom.InfoSchema().TableByID(job.TableID)
+		tbl, exist := dom.InfoSchema().TableByID(context.Background(), job.TableID)
 		require.True(t, exist)
 		switch job.SchemaState {
 		case model.StateWriteOnly:

--- a/pkg/ddl/column_test.go
+++ b/pkg/ddl/column_test.go
@@ -51,7 +51,7 @@ func testCreateColumn(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context,
 	id := int64(idi)
 	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
-	tblInfo, exist := dom.InfoSchema().TableByID(tblID)
+	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
 	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
 	return id
@@ -74,7 +74,7 @@ func testCreateColumns(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context
 	id := int64(idi)
 	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
-	tblInfo, exist := dom.InfoSchema().TableByID(tblID)
+	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
 	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
 	return id
@@ -93,7 +93,7 @@ func testDropColumnInternal(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Co
 	id := int64(idi)
 	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
-	tblInfo, exist := dom.InfoSchema().TableByID(tblID)
+	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
 	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
 	return id
@@ -124,7 +124,7 @@ func testCreateIndex(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context, 
 	id := int64(idi)
 	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
-	tblInfo, exist := dom.InfoSchema().TableByID(tblID)
+	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
 	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
 	return id
@@ -149,7 +149,7 @@ func testDropColumns(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context, 
 	id := int64(idi)
 	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
-	tblInfo, exist := dom.InfoSchema().TableByID(tblID)
+	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
 	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
 	return id
@@ -888,7 +888,7 @@ func TestDropColumns(t *testing.T) {
 
 func testGetTable(t *testing.T, dom *domain.Domain, tableID int64) table.Table {
 	require.NoError(t, dom.Reload())
-	tbl, exist := dom.InfoSchema().TableByID(tableID)
+	tbl, exist := dom.InfoSchema().TableByID(context.Background(), tableID)
 	require.True(t, exist)
 	return tbl
 }

--- a/pkg/ddl/db_table_test.go
+++ b/pkg/ddl/db_table_test.go
@@ -748,7 +748,7 @@ func TestAddColumn2(t *testing.T) {
 	var writeOnlyTable table.Table
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobRunBefore", func(job *model.Job) {
 		if job.SchemaState == model.StateWriteOnly {
-			writeOnlyTable, _ = dom.InfoSchema().TableByID(job.TableID)
+			writeOnlyTable, _ = dom.InfoSchema().TableByID(context.Background(), job.TableID)
 		}
 	})
 	done := make(chan error, 1)

--- a/pkg/ddl/ddl_tiflash_api.go
+++ b/pkg/ddl/ddl_tiflash_api.go
@@ -370,7 +370,7 @@ func PollAvailableTableProgress(schemas infoschema.InfoSchema, _ sessionctx.Cont
 			}
 		} else {
 			var ok bool
-			table, ok = schemas.TableByID(availableTableID.ID)
+			table, ok = schemas.TableByID(context.Background(), availableTableID.ID)
 			if !ok {
 				logutil.DDLLogger().Info("get table id failed, may be dropped or truncated",
 					zap.Int64("tableID", availableTableID.ID),
@@ -461,7 +461,7 @@ func (d *ddl) refreshTiFlashTicker(ctx sessionctx.Context, pollTiFlashContext *T
 	failpoint.Inject("waitForAddPartition", func(val failpoint.Value) {
 		for _, phyTable := range tableList {
 			is := d.infoCache.GetLatest()
-			_, ok := is.TableByID(phyTable.ID)
+			_, ok := is.TableByID(d.ctx, phyTable.ID)
 			if !ok {
 				tb, _, _ := is.FindTableByPartitionID(phyTable.ID)
 				if tb == nil {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -3887,7 +3887,7 @@ func (e *executor) AlterTableDropStatistics(ctx sessionctx.Context, ident ast.Id
 // UpdateTableReplicaInfo updates the table flash replica infos.
 func (e *executor) UpdateTableReplicaInfo(ctx sessionctx.Context, physicalID int64, available bool) error {
 	is := e.infoCache.GetLatest()
-	tb, ok := is.TableByID(physicalID)
+	tb, ok := is.TableByID(e.ctx, physicalID)
 	if !ok {
 		tb, _, _ = is.FindTableByPartitionID(physicalID)
 		if tb == nil {
@@ -4303,7 +4303,7 @@ func (e *executor) renameTable(ctx sessionctx.Context, oldIdent, newIdent ast.Id
 		return nil
 	}
 
-	if tbl, ok := is.TableByID(tableID); ok {
+	if tbl, ok := is.TableByID(e.ctx, tableID); ok {
 		if tbl.Meta().TableCacheStatusType != model.TableCacheStatusDisable {
 			return errors.Trace(dbterror.ErrOptOnCacheTable.GenWithStackByArgs("Rename Table"))
 		}
@@ -4351,7 +4351,7 @@ func (e *executor) renameTables(ctx sessionctx.Context, oldIdents, newIdents []a
 			return err
 		}
 
-		if t, ok := is.TableByID(tableID); ok {
+		if t, ok := is.TableByID(e.ctx, tableID); ok {
 			if t.Meta().TableCacheStatusType != model.TableCacheStatusDisable {
 				return errors.Trace(dbterror.ErrOptOnCacheTable.GenWithStackByArgs("Rename Tables"))
 			}
@@ -5291,7 +5291,7 @@ func (e *executor) UnlockTables(ctx sessionctx.Context, unlockTables []model.Tab
 		if !ok {
 			continue
 		}
-		tbl, ok := is.TableByID(t.TableID)
+		tbl, ok := is.TableByID(e.ctx, t.TableID)
 		if !ok {
 			continue
 		}

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -63,7 +63,7 @@ func TestIndexChange(t *testing.T) {
 		ctx1 := testNewContext(store)
 		prevState = job.SchemaState
 		require.NoError(t, dom.Reload())
-		tbl, exist := dom.InfoSchema().TableByID(job.TableID)
+		tbl, exist := dom.InfoSchema().TableByID(context.Background(), job.TableID)
 		require.True(t, exist)
 		switch job.SchemaState {
 		case model.StateDeleteOnly:
@@ -105,7 +105,7 @@ func TestIndexChange(t *testing.T) {
 		prevState = job.SchemaState
 		var err error
 		require.NoError(t, dom.Reload())
-		tbl, exist := dom.InfoSchema().TableByID(job.TableID)
+		tbl, exist := dom.InfoSchema().TableByID(context.Background(), job.TableID)
 		require.True(t, exist)
 		ctx1 := testNewContext(store)
 		switch job.SchemaState {

--- a/pkg/ddl/tests/fk/foreign_key_test.go
+++ b/pkg/ddl/tests/fk/foreign_key_test.go
@@ -960,7 +960,7 @@ func getTableInfo(t *testing.T, dom *domain.Domain, db, tb string) *model.TableI
 	is := dom.InfoSchema()
 	tbl, err := is.TableByName(context.Background(), model.NewCIStr(db), model.NewCIStr(tb))
 	require.NoError(t, err)
-	_, exist := is.TableByID(tbl.Meta().ID)
+	_, exist := is.TableByID(context.Background(), tbl.Meta().ID)
 	require.True(t, exist)
 	return tbl.Meta()
 }

--- a/pkg/domain/historical_stats.go
+++ b/pkg/domain/historical_stats.go
@@ -15,6 +15,8 @@
 package domain
 
 import (
+	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	domain_metrics "github.com/pingcap/tidb/pkg/domain/metrics"
@@ -64,7 +66,7 @@ func (w *HistoricalStatsWorker) DumpHistoricalStats(tableID int64, statsHandle *
 	is := GetDomain(sctx).InfoSchema()
 	isPartition := false
 	var tblInfo *model.TableInfo
-	tbl, existed := is.TableByID(tableID)
+	tbl, existed := is.TableByID(context.Background(), tableID)
 	if !existed {
 		tbl, db, p := is.FindTableByPartitionID(tableID)
 		if !(tbl != nil && db != nil && p != nil) {

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -243,7 +243,7 @@ func filterAndCollectTasks(tasks []*analyzeTask, statsHandle *handle.Handle, is 
 						skippedTables = append(skippedTables, fmt.Sprintf("%s.%s partition (%s)", schema.Name, tbl.Meta().Name.O, def.Name.O))
 					}
 				} else {
-					tbl, ok := is.TableByID(physicalTableID)
+					tbl, ok := is.TableByID(context.Background(), physicalTableID)
 					if !ok {
 						logutil.BgLogger().Warn("Unknown table ID in analyze task", zap.Int64("tid", physicalTableID))
 					} else {

--- a/pkg/executor/analyze_global_stats.go
+++ b/pkg/executor/analyze_global_stats.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/tidb/pkg/domain"
@@ -93,7 +94,7 @@ func (e *AnalyzeExec) handleGlobalStats(statsHandle *handle.Handle, globalStatsM
 func (e *AnalyzeExec) newAnalyzeHandleGlobalStatsJob(key globalStatsKey) *statistics.AnalyzeJob {
 	dom := domain.GetDomain(e.Ctx())
 	is := dom.InfoSchema()
-	table, ok := is.TableByID(key.tableID)
+	table, ok := is.TableByID(context.Background(), key.tableID)
 	if !ok {
 		return nil
 	}

--- a/pkg/executor/ddl.go
+++ b/pkg/executor/ddl.go
@@ -408,7 +408,7 @@ func (e *DDLExec) executeRecoverTable(s *ast.RecoverTableStmt) error {
 		return err
 	}
 	// Check the table ID was not exists.
-	tbl, ok := dom.InfoSchema().TableByID(tblInfo.ID)
+	tbl, ok := dom.InfoSchema().TableByID(context.Background(), tblInfo.ID)
 	if ok {
 		return infoschema.ErrTableExists.GenWithStack("Table '%-.192s' already been recover to '%-.192s', can't be recover repeatedly", s.Table.Name.O, tbl.Meta().Name.O)
 	}
@@ -463,7 +463,7 @@ func (e *DDLExec) getRecoverTableByJobID(s *ast.RecoverTableStmt, dom *domain.Do
 		return nil, nil, err
 	}
 	// Get table meta from snapshot infoSchema.
-	table, ok := snapInfo.TableByID(job.TableID)
+	table, ok := snapInfo.TableByID(ctx, job.TableID)
 	if !ok {
 		return nil, nil, infoschema.ErrTableNotExists.GenWithStackByArgs(
 			fmt.Sprintf("(Schema ID %d)", job.SchemaID),
@@ -563,7 +563,7 @@ func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {
 	}
 	// Check the table ID was not exists.
 	is := domain.GetDomain(e.Ctx()).InfoSchema()
-	tbl, ok := is.TableByID(tblInfo.ID)
+	tbl, ok := is.TableByID(context.Background(), tblInfo.ID)
 	if ok {
 		return infoschema.ErrTableExists.GenWithStack("Table '%-.192s' already been flashback to '%-.192s', can't be flashback repeatedly", s.Table.Name.O, tbl.Meta().Name.O)
 	}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -825,7 +825,7 @@ func getSchemaName(is infoschema.InfoSchema, id int64) string {
 
 func getTableName(is infoschema.InfoSchema, id int64) string {
 	var tableName string
-	table, ok := is.TableByID(id)
+	table, ok := is.TableByID(context.Background(), id)
 	if ok {
 		tableName = table.Meta().Name.O
 		return tableName

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -256,7 +256,7 @@ func getAutoIncrementID(
 	sctx sessionctx.Context,
 	tblInfo *model.TableInfo,
 ) int64 {
-	tbl, ok := is.TableByID(tblInfo.ID)
+	tbl, ok := is.TableByID(context.Background(), tblInfo.ID)
 	if !ok {
 		return 0
 	}
@@ -1970,7 +1970,7 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 }
 
 func (e *memtableRetriever) getRegionsInfoForTable(ctx context.Context, h *helper.Helper, is infoschema.InfoSchema, tableID int64) (*pd.RegionsInfo, error) {
-	tbl, _ := is.TableByID(tableID)
+	tbl, _ := is.TableByID(ctx, tableID)
 	if tbl == nil {
 		return nil, infoschema.ErrTableExists.GenWithStackByArgs(tableID)
 	}

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -659,7 +659,7 @@ func (e *PointGetExecutor) verifyTxnScope() error {
 
 	var partName string
 	is := e.Ctx().GetInfoSchema().(infoschema.InfoSchema)
-	tblInfo, _ := is.TableByID((e.tblInfo.ID))
+	tblInfo, _ := is.TableByID(context.Background(), e.tblInfo.ID)
 	tblName := tblInfo.Meta().Name.String()
 	tblID := GetPhysID(tblInfo.Meta(), e.partitionDefIdx)
 	if tblID != tblInfo.Meta().ID {

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1956,7 +1956,7 @@ func (e *ShowExec) getTable() (table.Table, error) {
 	if e.Table == nil {
 		return nil, errors.New("table not found")
 	}
-	tb, ok := e.is.TableByID(e.Table.TableInfo.ID)
+	tb, ok := e.is.TableByID(context.Background(), e.Table.TableInfo.ID)
 	if !ok {
 		return nil, errors.Errorf("table %s not found", e.Table.Name)
 	}

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -332,7 +332,7 @@ func resetErrDataTooLong(colName string, rowIdx int, _ error) error {
 // It check if rowData inserted or updated violate partition definition or checkConstraints of partitionTable.
 func checkRowForExchangePartition(sctx table.MutateContext, row []types.Datum, tbl *model.TableInfo) error {
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-	pt, tableFound := is.TableByID(tbl.ExchangePartitionInfo.ExchangePartitionTableID)
+	pt, tableFound := is.TableByID(context.Background(), tbl.ExchangePartitionInfo.ExchangePartitionTableID)
 	if !tableFound {
 		return errors.Errorf("exchange partition process table by id failed")
 	}

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -705,7 +705,7 @@ func applyCreateTable(b *Builder, m *meta.Meta, dbInfo *model.DBInfo, tableID in
 		b.addTemporaryTable(tableID)
 	}
 
-	newTbl, ok := b.infoSchema.TableByID(tableID)
+	newTbl, ok := b.infoSchema.TableByID(context.Background(), tableID)
 	if ok {
 		dbInfo.Deprecated.Tables = append(dbInfo.Deprecated.Tables, newTbl.Meta())
 	}

--- a/pkg/infoschema/bundle_builder.go
+++ b/pkg/infoschema/bundle_builder.go
@@ -15,6 +15,8 @@
 package infoschema
 
 import (
+	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -114,7 +116,7 @@ func (b *bundleInfoBuilder) completeUpdateTables(is *infoSchema) {
 
 func (b *bundleInfoBuilder) updateTableBundles(infoSchemaInterface InfoSchema, tableID int64) {
 	is := infoSchemaInterface.base()
-	tbl, ok := infoSchemaInterface.TableByID(tableID)
+	tbl, ok := infoSchemaInterface.TableByID(context.Background(), tableID)
 	if !ok {
 		b.deleteBundle(is, tableID)
 		return

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -294,7 +294,7 @@ func SchemaByTable(is InfoSchema, tableInfo *model.TableInfo) (val *model.DBInfo
 	return is.SchemaByID(tableInfo.DBID)
 }
 
-func (is *infoSchema) TableByID(id int64) (val table.Table, ok bool) {
+func (is *infoSchema) TableByID(_ stdctx.Context, id int64) (val table.Table, ok bool) {
 	if !tableIDIsValid(id) {
 		return nil, false
 	}
@@ -309,7 +309,7 @@ func (is *infoSchema) TableByID(id int64) (val table.Table, ok bool) {
 
 // TableInfoByID implements InfoSchema.TableInfoByID
 func (is *infoSchema) TableInfoByID(id int64) (*model.TableInfo, bool) {
-	tbl, ok := is.TableByID(id)
+	tbl, ok := is.TableByID(stdctx.Background(), id)
 	return getTableInfo(tbl), ok
 }
 
@@ -810,7 +810,7 @@ func (ts *SessionExtendedInfoSchema) TableInfoByName(schema, table model.CIStr) 
 
 // TableInfoByID implements InfoSchema.TableInfoByID
 func (ts *SessionExtendedInfoSchema) TableInfoByID(id int64) (*model.TableInfo, bool) {
-	tbl, ok := ts.TableByID(id)
+	tbl, ok := ts.TableByID(stdctx.Background(), id)
 	return getTableInfo(tbl), ok
 }
 
@@ -823,7 +823,7 @@ func (ts *SessionExtendedInfoSchema) FindTableInfoByPartitionID(
 }
 
 // TableByID implements InfoSchema.TableByID
-func (ts *SessionExtendedInfoSchema) TableByID(id int64) (table.Table, bool) {
+func (ts *SessionExtendedInfoSchema) TableByID(ctx stdctx.Context, id int64) (table.Table, bool) {
 	if !tableIDIsValid(id) {
 		return nil, false
 	}
@@ -840,7 +840,7 @@ func (ts *SessionExtendedInfoSchema) TableByID(id int64) (table.Table, bool) {
 		}
 	}
 
-	return ts.InfoSchema.TableByID(id)
+	return ts.InfoSchema.TableByID(ctx, id)
 }
 
 // SchemaByID implements InfoSchema.SchemaByID, it returns a stale DBInfo even if it's dropped.
@@ -892,7 +892,7 @@ func (ts *SessionExtendedInfoSchema) DetachTemporaryTableInfoSchema() *SessionEx
 // If the id is a partition id, the corresponding table.Table and PartitionDefinition will be returned.
 // If the id is not found in the InfoSchema, nil will be returned for both return values.
 func FindTableByTblOrPartID(is InfoSchema, id int64) (table.Table, *model.PartitionDefinition) {
-	tbl, ok := is.TableByID(id)
+	tbl, ok := is.TableByID(stdctx.Background(), id)
 	if ok {
 		return tbl, nil
 	}

--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -77,7 +77,7 @@ func TestV2Basic(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, dbInfo, getDBInfo)
 
-	getTableInfo, ok = is.TableByID(tblInfo.ID)
+	getTableInfo, ok = is.TableByID(context.Background(), tblInfo.ID)
 	require.True(t, ok)
 	require.NotNil(t, getTableInfo)
 
@@ -86,7 +86,7 @@ func TestV2Basic(t *testing.T) {
 	require.Same(t, gotTblInfo, getTableInfo.Meta())
 
 	// negative id should always be seen as not exists
-	getTableInfo, ok = is.TableByID(-1)
+	getTableInfo, ok = is.TableByID(context.Background(), -1)
 	require.False(t, ok)
 	require.Nil(t, getTableInfo)
 	gotTblInfo, ok = is.TableInfoByID(-1)

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -28,7 +28,7 @@ import (
 type InfoSchema interface {
 	context.MetaOnlyInfoSchema
 	TableByName(ctx stdctx.Context, schema, table model.CIStr) (table.Table, error)
-	TableByID(id int64) (table.Table, bool)
+	TableByID(ctx stdctx.Context, id int64) (table.Table, bool)
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
 	ListTablesWithSpecialAttribute(filter specialAttributeFilter) []tableInfoResult
 	base() *infoSchema

--- a/pkg/infoschema/test/clustertablestest/tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/tables_test.go
@@ -613,7 +613,7 @@ func TestReloadDropDatabase(t *testing.T) {
 	is = domain.GetDomain(tk.Session()).InfoSchema()
 	_, err = is.TableByName(context.Background(), model.NewCIStr("test_dbs"), model.NewCIStr("t2"))
 	require.True(t, terror.ErrorEqual(infoschema.ErrTableNotExists, err))
-	_, ok := is.TableByID(t2.Meta().ID)
+	_, ok := is.TableByID(context.Background(), t2.Meta().ID)
 	require.False(t, ok)
 }
 

--- a/pkg/planner/core/access_object.go
+++ b/pkg/planner/core/access_object.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -380,7 +381,7 @@ func getDynamicAccessPartition(sctx base.PlanContext, tblInfo *model.TableInfo, 
 	if ok {
 		res.Database = db.Name.O
 	}
-	tmp, ok := is.TableByID(tblInfo.ID)
+	tmp, ok := is.TableByID(context.Background(), tblInfo.ID)
 	if !ok {
 		res.err = "partition table not found:" + strconv.FormatInt(tblInfo.ID, 10)
 		return res

--- a/pkg/planner/core/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/collect_column_stats_usage_test.go
@@ -31,7 +31,7 @@ import (
 func getColumnName(t *testing.T, is infoschema.InfoSchema, tblColID model.TableItemID, comment string) string {
 	var tblInfo *model.TableInfo
 	var prefix string
-	if tbl, ok := is.TableByID(tblColID.TableID); ok {
+	if tbl, ok := is.TableByID(context.Background(), tblColID.TableID); ok {
 		tblInfo = tbl.Meta()
 		prefix = tblInfo.Name.L + "."
 	} else {

--- a/pkg/planner/core/fragment.go
+++ b/pkg/planner/core/fragment.go
@@ -551,7 +551,7 @@ func (e *mppTaskGenerator) constructMPPTasksImpl(ctx context.Context, ts *Physic
 	if ts.Table.GetPartitionInfo() != nil {
 		tiFlashStaticPrune = !e.ctx.GetSessionVars().StmtCtx.UseDynamicPartitionPrune()
 
-		tmp, _ := e.is.TableByID(ts.Table.ID)
+		tmp, _ := e.is.TableByID(ctx, ts.Table.ID)
 		tbl := tmp.(table.PartitionedTable)
 		if !tiFlashStaticPrune {
 			var partitions []table.PhysicalTable

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5436,7 +5436,7 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 	}
 	tblID2table := make(map[int64]table.Table, len(tblID2Handle))
 	for id := range tblID2Handle {
-		tblID2table[id], _ = b.is.TableByID(id)
+		tblID2table[id], _ = b.is.TableByID(ctx, id)
 	}
 	updt.TblColPosInfos, err = buildColumns2Handle(updt.OutputNames(), tblID2Handle, tblID2table, true)
 	if err != nil {
@@ -5581,7 +5581,7 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 		}
 
 		tableInfo := tn.TableInfo
-		tableVal, found := b.is.TableByID(tableInfo.ID)
+		tableVal, found := b.is.TableByID(ctx, tableInfo.ID)
 		if !found {
 			return nil, nil, false, infoschema.ErrTableNotExists.FastGenByArgs(tn.DBInfo.Name.O, tableInfo.Name.O)
 		}
@@ -5896,7 +5896,7 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, ds *ast.DeleteStmt) (base
 	}
 	tblID2table := make(map[int64]table.Table, len(tblID2Handle))
 	for id := range tblID2Handle {
-		tblID2table[id], _ = b.is.TableByID(id)
+		tblID2table[id], _ = b.is.TableByID(ctx, id)
 	}
 	del.TblColPosInfos, err = buildColumns2Handle(del.names, tblID2Handle, tblID2table, false)
 	if err != nil {

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -342,7 +342,7 @@ func findTablesByID(
 		tblNameMap[n.L] = struct{}{}
 	}
 	for _, tid := range parseIDs(tableIDs) {
-		tbl, ok := is.TableByID(tid)
+		tbl, ok := is.TableByID(context.Background(), tid)
 		if !ok {
 			continue
 		}

--- a/pkg/planner/core/pb_to_plan.go
+++ b/pkg/planner/core/pb_to_plan.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -94,7 +95,7 @@ func (b *PBPlanBuilder) pbToPhysicalPlan(e *tipb.Executor, subPlan base.Physical
 
 func (b *PBPlanBuilder) pbToTableScan(e *tipb.Executor) (base.PhysicalPlan, error) {
 	tblScan := e.TblScan
-	tbl, ok := b.is.TableByID(tblScan.TableId)
+	tbl, ok := b.is.TableByID(context.Background(), tblScan.TableId)
 	if !ok {
 		return nil, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %d does not exist.", tblScan.TableId)
 	}

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -106,7 +106,7 @@ func planCachePreprocess(ctx context.Context, sctx sessionctx.Context, isNonPrep
 	// step 3: add metadata lock and check each table's schema version
 	schemaNotMatch := false
 	for i := 0; i < len(stmt.dbName); i++ {
-		tbl, ok := is.TableByID(stmt.tbls[i].Meta().ID)
+		tbl, ok := is.TableByID(ctx, stmt.tbls[i].Meta().ID)
 		if !ok {
 			tblByName, err := is.TableByName(context.Background(), stmt.dbName[i], stmt.tbls[i].Meta().Name)
 			if err != nil {

--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -186,7 +186,7 @@ func GeneratePlanCacheStmtWithAST(ctx context.Context, sctx sessionctx.Context, 
 	tbls := make([]table.Table, 0, len(vars.StmtCtx.MDLRelatedTableIDs))
 	relateVersion := make(map[int64]uint64, len(vars.StmtCtx.MDLRelatedTableIDs))
 	for id := range vars.StmtCtx.MDLRelatedTableIDs {
-		tbl, ok := is.TableByID(id)
+		tbl, ok := is.TableByID(ctx, id)
 		if !ok {
 			logutil.BgLogger().Error("table not found in info schema", zap.Int64("tableID", id))
 			return nil, nil, 0, errors.New("table not found in info schema")

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1038,7 +1038,7 @@ func getLatestIndexInfo(ctx base.PlanContext, id int64, startVer int64) (map[int
 	}
 	latestIndexes := make(map[int64]*model.IndexInfo)
 
-	latestTbl, latestTblExist := is.TableByID(id)
+	latestTbl, latestTblExist := is.TableByID(context.Background(), id)
 	if latestTblExist {
 		latestTblInfo := latestTbl.Meta()
 		for _, index := range latestTblInfo.Indices {
@@ -1717,7 +1717,7 @@ func (b *PlanBuilder) buildPhysicalIndexLookUpReaders(ctx context.Context, dbNam
 func (b *PlanBuilder) buildAdminCheckTable(ctx context.Context, as *ast.AdminStmt) (*CheckTable, error) {
 	tblName := as.Tables[0]
 	tableInfo := as.Tables[0].TableInfo
-	tbl, ok := b.is.TableByID(tableInfo.ID)
+	tbl, ok := b.is.TableByID(ctx, tableInfo.ID)
 	if !ok {
 		return nil, infoschema.ErrTableNotExists.FastGenByArgs(tblName.DBInfo.Name.O, tableInfo.Name.O)
 	}
@@ -3690,7 +3690,7 @@ func (b *PlanBuilder) buildInsert(ctx context.Context, insert *ast.InsertStmt) (
 	if err != nil {
 		return nil, err
 	}
-	tableInPlan, ok := b.is.TableByID(tableInfo.ID)
+	tableInPlan, ok := b.is.TableByID(ctx, tableInfo.ID)
 	if !ok {
 		return nil, errors.Errorf("Can't get table %s", tableInfo.Name.O)
 	}
@@ -4174,7 +4174,7 @@ func (b *PlanBuilder) buildLoadData(ctx context.Context, ld *ast.LoadDataStmt) (
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.DeletePriv, p.Table.Schema.O, p.Table.Name.O, "", deleteErr)
 	}
 	tableInfo := p.Table.TableInfo
-	tableInPlan, ok := b.is.TableByID(tableInfo.ID)
+	tableInPlan, ok := b.is.TableByID(ctx, tableInfo.ID)
 	if !ok {
 		db := b.ctx.GetSessionVars().CurrentDB
 		return nil, infoschema.ErrTableNotExists.FastGenByArgs(db, tableInfo.Name.O)
@@ -4269,7 +4269,7 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 	// tidb_read_staleness can be used to do stale read too, it's allowed as long as
 	// TableInfo.ID matches with the latest schema.
 	latestIS := b.ctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-	tableInPlan, ok := latestIS.TableByID(tableInfo.ID)
+	tableInPlan, ok := latestIS.TableByID(ctx, tableInfo.ID)
 	if !ok {
 		// adaptor.handleNoDelayExecutor has a similar check, but we want to give
 		// a more specific error message here.

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	math2 "math"
 	"strconv"
 	"strings"
@@ -368,7 +369,7 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) bool {
 		return false
 	}
 	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
-	tbl, ok := is.TableByID(p.TblInfo.ID)
+	tbl, ok := is.TableByID(context.Background(), p.TblInfo.ID)
 	if tbl == nil || !ok {
 		// Can this happen?
 		intest.Assert(false)
@@ -666,7 +667,7 @@ func isInExplicitPartitions(pi *model.PartitionInfo, idx int, names []model.CISt
 // Map each index value to Partition ID
 func (p *BatchPointGetPlan) getPartitionIdxs(sctx sessionctx.Context) []int {
 	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
-	tbl, ok := is.TableByID(p.TblInfo.ID)
+	tbl, ok := is.TableByID(context.Background(), p.TblInfo.ID)
 	intest.Assert(ok)
 	pTbl, ok := tbl.(table.PartitionedTable)
 	intest.Assert(ok)
@@ -760,7 +761,7 @@ func (p *BatchPointGetPlan) PrunePartitionsAndValues(sctx sessionctx.Context) ([
 		}
 		if pi != nil {
 			is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
-			tbl, ok := is.TableByID(p.TblInfo.ID)
+			tbl, ok := is.TableByID(context.Background(), p.TblInfo.ID)
 			intest.Assert(ok)
 			pTbl, ok := tbl.(table.PartitionedTable)
 			intest.Assert(ok)
@@ -978,7 +979,7 @@ func newBatchPointGetPlan(
 		// Only keeping it for now to limit impact of
 		// enable plan cache for partitioned tables PR.
 		is := ctx.GetInfoSchema().(infoschema.InfoSchema)
-		table, ok := is.TableByID(tbl.ID)
+		table, ok := is.TableByID(context.Background(), tbl.ID)
 		if !ok {
 			return nil
 		}
@@ -1954,7 +1955,7 @@ func buildPointUpdatePlan(ctx base.PlanContext, pointPlan base.PhysicalPlan, dbN
 	}.Init(ctx)
 	updatePlan.names = pointPlan.OutputNames()
 	is := ctx.GetInfoSchema().(infoschema.InfoSchema)
-	t, _ := is.TableByID(tbl.ID)
+	t, _ := is.TableByID(context.Background(), tbl.ID)
 	updatePlan.tblID2Table = map[int64]table.Table{
 		tbl.ID: t,
 	}
@@ -2070,7 +2071,7 @@ func buildPointDeletePlan(ctx base.PlanContext, pointPlan base.PhysicalPlan, dbN
 	}.Init(ctx)
 	var err error
 	is := ctx.GetInfoSchema().(infoschema.InfoSchema)
-	t, _ := is.TableByID(tbl.ID)
+	t, _ := is.TableByID(context.Background(), tbl.ID)
 	if t != nil {
 		tblID2Table := map[int64]table.Table{tbl.ID: t}
 		err = delPlan.buildOnDeleteFKTriggers(ctx, is, tblID2Table)
@@ -2136,7 +2137,7 @@ func getHashOrKeyPartitionColumnName(ctx base.PlanContext, tbl *model.TableInfo)
 		return nil
 	}
 	is := ctx.GetInfoSchema().(infoschema.InfoSchema)
-	table, ok := is.TableByID(tbl.ID)
+	table, ok := is.TableByID(context.Background(), tbl.ID)
 	if !ok {
 		return nil
 	}

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -304,7 +304,7 @@ func recordSingleTableRuntimeStats(sctx base.PlanContext, tblID int64) (stats *s
 	dom := domain.GetDomain(sctx)
 	statsHandle := dom.StatsHandle()
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-	tbl, ok := is.TableByID(tblID)
+	tbl, ok := is.TableByID(context.Background(), tblID)
 	if !ok {
 		return nil, false, nil
 	}

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -711,7 +711,7 @@ func (h FlashReplicaHandler) getDropOrTruncateTableTiflash(currentSchema infosch
 	uniqueIDMap := make(map[int64]struct{})
 	handleJobAndTableInfo := func(_ *model.Job, tblInfo *model.TableInfo) (bool, error) {
 		// Avoid duplicate table ID info.
-		if _, ok := currentSchema.TableByID(tblInfo.ID); ok {
+		if _, ok := currentSchema.TableByID(context.Background(), tblInfo.ID); ok {
 			return false, nil
 		}
 		if _, ok := uniqueIDMap[tblInfo.ID]; ok {
@@ -1067,7 +1067,7 @@ func getTableByIDStr(schema infoschema.InfoSchema, tableID string) (*model.Table
 	if tid < 0 {
 		return nil, infoschema.ErrTableNotExists.GenWithStack("Table which ID = %s does not exist.", tableID)
 	}
-	if data, ok := schema.TableByID(int64(tid)); ok {
+	if data, ok := schema.TableByID(context.Background(), int64(tid)); ok {
 		return data.Meta(), nil
 	}
 	// The tid maybe a partition ID of the partition-table.
@@ -1860,7 +1860,7 @@ func (h DBTableHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	dbTblInfo := DBTableInfo{
 		SchemaVersion: schema.SchemaMetaVersion(),
 	}
-	tbl, ok := schema.TableByID(int64(physicalID))
+	tbl, ok := schema.TableByID(context.Background(), int64(physicalID))
 	if ok {
 		dbTblInfo.TableInfo = tbl.Meta()
 		dbInfo, ok := infoschema.SchemaByTable(schema, dbTblInfo.TableInfo)

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -3380,7 +3380,7 @@ func rebuildAllPartitionValueMapAndSorted(s *session) {
 			if pi == nil || pi.Type != model.PartitionTypeList {
 				continue
 			}
-			tbl, ok := is.TableByID(t.ID)
+			tbl, ok := is.TableByID(s.currentCtx, t.ID)
 			intest.Assert(ok, "table not found in infoschema")
 			pe := tbl.(partitionExpr).PartitionExpr()
 			for _, cp := range pe.ColPrunes {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -619,7 +619,7 @@ func (s *session) handleAssertionFailure(ctx context.Context, err error) error {
 	if infoSchema, ok := s.sessionVars.TxnCtx.InfoSchema.(infoschema.InfoSchema); ok &&
 		infoSchema != nil && (tablecodec.IsRecordKey(key) || tablecodec.IsIndexKey(key)) {
 		tableOrPartitionID := tablecodec.DecodeTableID(key)
-		tbl, ok := infoSchema.TableByID(tableOrPartitionID)
+		tbl, ok := infoSchema.TableByID(ctx, tableOrPartitionID)
 		if !ok {
 			tbl, _, _ = infoSchema.FindTableByPartitionID(tableOrPartitionID)
 		}
@@ -885,7 +885,7 @@ func addTableNameInTableIDField(tableIDField any, is infoschema.InfoSchema) (enh
 		return "", false
 	}
 	var tableName string
-	tbl, ok := is.TableByID(tableID)
+	tbl, ok := is.TableByID(context.Background(), tableID)
 	if !ok {
 		tableName = "unknown"
 	} else {
@@ -4152,7 +4152,7 @@ func (s *session) checkPlacementPolicyBeforeCommit() error {
 				tableName = tblInfo.Meta().Name.String()
 				partitionName = partInfo.Name.String()
 			} else {
-				tblInfo, _ := is.TableByID(physicalTableID)
+				tblInfo, _ := is.TableByID(s.currentCtx, physicalTableID)
 				tableName = tblInfo.Meta().Name.String()
 			}
 			bundle, ok := is.PlacementBundleByPhysicalTableID(physicalTableID)

--- a/pkg/statistics/handle/storage/gc.go
+++ b/pkg/statistics/handle/storage/gc.go
@@ -76,9 +76,12 @@ func (gc *statsGCImpl) DeleteTableStatsFromKV(statsIDs []int64) (err error) {
 // GCStats will garbage collect the useless stats' info.
 // For dropped tables, we will first update their version
 // so that other tidb could know that table is deleted.
-func GCStats(sctx sessionctx.Context,
+func GCStats(
+	sctx sessionctx.Context,
 	statsHandle types.StatsHandle,
-	is infoschema.InfoSchema, ddlLease time.Duration) (err error) {
+	is infoschema.InfoSchema,
+	ddlLease time.Duration,
+) (err error) {
 	// To make sure that all the deleted tables' schema and stats info have been acknowledged to all tidb,
 	// we only garbage collect version before 10 lease.
 	lease := max(statsHandle.Lease(), ddlLease)
@@ -109,7 +112,7 @@ func GCStats(sctx sessionctx.Context,
 		if err := gcTableStats(sctx, statsHandle, is, row.GetInt64(0)); err != nil {
 			return errors.Trace(err)
 		}
-		_, existed := is.TableByID(row.GetInt64(0))
+		_, existed := is.TableByID(context.Background(), row.GetInt64(0))
 		if !existed {
 			if err := gcHistoryStatsFromKV(sctx, row.GetInt64(0)); err != nil {
 				return errors.Trace(err)

--- a/pkg/statistics/handle/usage/index_usage.go
+++ b/pkg/statistics/handle/usage/index_usage.go
@@ -15,6 +15,8 @@
 package usage
 
 import (
+	"context"
+
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -33,7 +35,7 @@ func (u *statsUsageImpl) GCIndexUsage() error {
 	return util.CallWithSCtx(u.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		schema := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 		u.idxUsageCollector.GCIndexUsage(func(id int64) (*model.TableInfo, bool) {
-			tbl, ok := schema.TableByID(id)
+			tbl, ok := schema.TableByID(context.Background(), id)
 			if !ok {
 				return nil, false
 			}

--- a/pkg/statistics/handle/usage/predicatecolumn/predicate_column.go
+++ b/pkg/statistics/handle/usage/predicatecolumn/predicate_column.go
@@ -15,6 +15,7 @@
 package predicatecolumn
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -109,7 +110,7 @@ func GetPredicateColumns(sctx sessionctx.Context, tableID int64) ([]int64, error
 // cleanupDroppedColumnStatsUsage deletes the column stats usage information whose column is dropped.
 func cleanupDroppedColumnStatsUsage(sctx sessionctx.Context, tableID int64) error {
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-	table, ok := is.TableByID(tableID)
+	table, ok := is.TableByID(context.Background(), tableID)
 	if !ok {
 		// Usually, it should not happen.
 		// But if it happens, we can safely do nothing.

--- a/pkg/statistics/handle/util/table_info.go
+++ b/pkg/statistics/handle/util/table_info.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	"sync"
 
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -53,9 +54,9 @@ func (c *tableInfoGetterImpl) TableInfoByID(is infoschema.InfoSchema, physicalID
 		c.pid2tid = buildPartitionID2TableID(is)
 	}
 	if id, ok := c.pid2tid[physicalID]; ok {
-		return is.TableByID(id)
+		return is.TableByID(context.Background(), id)
 	}
-	return is.TableByID(physicalID)
+	return is.TableByID(context.Background(), physicalID)
 }
 
 func buildPartitionID2TableID(is infoschema.InfoSchema) map[int64]int64 {

--- a/pkg/table/temptable/interceptor.go
+++ b/pkg/table/temptable/interceptor.go
@@ -183,7 +183,7 @@ func (i *TemporaryTableSnapshotInterceptor) iterTable(tblID int64, snap kv.Snaps
 }
 
 func (i *TemporaryTableSnapshotInterceptor) temporaryTableInfoByID(tblID int64) (*model.TableInfo, bool) {
-	if tbl, ok := i.is.TableByID(tblID); ok {
+	if tbl, ok := i.is.TableByID(context.Background(), tblID); ok {
 		tblInfo := tbl.Meta()
 		if tblInfo.TempTableType != model.TempTableNone {
 			return tblInfo, true

--- a/pkg/table/temptable/interceptor_test.go
+++ b/pkg/table/temptable/interceptor_test.go
@@ -265,13 +265,13 @@ func TestGetSessionTemporaryTableKey(t *testing.T) {
 		AddTable(model.TempTableGlobal, 3).
 		AddTable(model.TempTableLocal, 5)
 
-	normalTb, ok := is.TableByID(1)
+	normalTb, ok := is.TableByID(context.Background(), 1)
 	require.True(t, ok)
 	require.Equal(t, model.TempTableNone, normalTb.Meta().TempTableType)
-	globalTb, ok := is.TableByID(3)
+	globalTb, ok := is.TableByID(context.Background(), 3)
 	require.True(t, ok)
 	require.Equal(t, model.TempTableGlobal, globalTb.Meta().TempTableType)
-	localTb, ok := is.TableByID(5)
+	localTb, ok := is.TableByID(context.Background(), 5)
 	require.True(t, ok)
 	require.Equal(t, model.TempTableLocal, localTb.Meta().TempTableType)
 
@@ -1283,7 +1283,7 @@ func TestIterTable(t *testing.T) {
 		}
 		require.Equal(t, c.result, result, i)
 
-		tbl, ok := is.TableByID(c.tblID)
+		tbl, ok := is.TableByID(context.Background(), c.tblID)
 		if !ok || tbl.Meta().TempTableType == model.TempTableNone {
 			require.Equal(t, 0, len(retriever.GetInvokes()), i)
 			require.Equal(t, 1, len(snap.GetInvokes()), i)

--- a/pkg/table/temptable/main_test.go
+++ b/pkg/table/temptable/main_test.go
@@ -67,7 +67,7 @@ func (is *mockedInfoSchema) AddTable(tempType model.TempTableType, id ...int64) 
 	return is
 }
 
-func (is *mockedInfoSchema) TableByID(tblID int64) (table.Table, bool) {
+func (is *mockedInfoSchema) TableByID(_ context.Context, tblID int64) (table.Table, bool) {
 	tempType, ok := is.tables[tblID]
 	if !ok {
 		return nil, false

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -1160,7 +1160,7 @@ func (a *managerJobAdapter) CanSubmitJob(tableID, physicalID int64) bool {
 	defer se.Close()
 
 	is := se.GetDomainInfoSchema().(infoschema.InfoSchema)
-	tbl, ok := is.TableByID(tableID)
+	tbl, ok := is.TableByID(context.Background(), tableID)
 	if !ok {
 		return false
 	}

--- a/pkg/util/keydecoder/keydecoder.go
+++ b/pkg/util/keydecoder/keydecoder.go
@@ -15,6 +15,7 @@
 package keydecoder
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/errors"
@@ -81,7 +82,7 @@ func DecodeKey(key []byte, is infoschema.InfoSchema) (DecodedKey, error) {
 	}
 	result.TableID = tableOrPartitionID
 
-	table, tableFound := is.TableByID(tableOrPartitionID)
+	table, tableFound := is.TableByID(context.Background(), tableOrPartitionID)
 
 	// The schema may have changed since when the key is get.
 	// Then we just omit the table name and show the table ID only.

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -297,7 +297,7 @@ func TestIngestUseGivenTS(t *testing.T) {
 	var idxInfo *model.IndexInfo
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *model.Job) {
 		if idxInfo == nil {
-			tbl, _ := dom.InfoSchema().TableByID(job.TableID)
+			tbl, _ := dom.InfoSchema().TableByID(context.Background(), job.TableID)
 			tblInfo = tbl.Meta()
 			if len(tblInfo.Indices) == 0 {
 				return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959

Problem Summary:

### What changed and how does it work?

In infoschema v1, all schema meta are in-memory, so TableByName are fast enough.
In infoschema v2, there may be cache miss and loading from remote network, that could be slower.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
