### PR TITLE
ddl: support session level tidb_ddl_reorg_worker_cnt and batch_size

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -337,7 +337,6 @@ go_test(
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
-        "@com_github_pingcap_parser//model:go_default_library",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",

--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -337,6 +337,7 @@ go_test(
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_pingcap_parser//model:go_default_library",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -683,7 +683,7 @@ func (dc *ddlCtx) runAddIndexInLocalIngestMode(
 
 	//nolint: forcetypeassert
 	discovery := dc.store.(tikv.Storage).GetRegionCache().PDClient().GetServiceDiscovery()
-	importConc := ingest.IngestConcurrency(job.ReorgMeta.Concurrency)
+	importConc := ingest.ResolveConcurrency(job.ReorgMeta.Concurrency)
 	bcCtx, err := ingest.LitBackCtxMgr.Register(
 		ctx, job.ID, hasUnique, dc.etcdCli, discovery, job.ReorgMeta.ResourceGroupName, importConc)
 	if err != nil {
@@ -733,7 +733,7 @@ func (dc *ddlCtx) runAddIndexInLocalIngestMode(
 		return errors.Trace(err)
 	}
 
-	concurrency := ingest.IngestConcurrency(job.ReorgMeta.Concurrency)
+	concurrency := ingest.ResolveConcurrency(job.ReorgMeta.Concurrency)
 	pipe, err := NewAddIndexIngestPipeline(
 		opCtx,
 		dc.store,

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/tikv/client-go/v2/tikv"
@@ -153,7 +154,7 @@ func (s *backfillDistExecutor) getBackendCtx() (ingest.BackendCtx, error) {
 		ddlObj.etcdCli,
 		discovery,
 		job.ReorgMeta.ResourceGroupName,
-		ingest.ResolveConcurrency(job.ReorgMeta.Concurrency),
+		job.ReorgMeta.GetConcurrencyOrDefault(int(variable.GetDDLReorgWorkerCounter())),
 	)
 }
 

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -147,7 +147,14 @@ func (s *backfillDistExecutor) getBackendCtx() (ingest.BackendCtx, error) {
 	ddlObj := s.d
 	discovery := ddlObj.store.(tikv.Storage).GetRegionCache().PDClient().GetServiceDiscovery()
 
-	return ingest.LitBackCtxMgr.Register(s.BaseTaskExecutor.Ctx(), job.ID, hasUnique, ddlObj.etcdCli, discovery, job.ReorgMeta.ResourceGroupName)
+	return ingest.LitBackCtxMgr.Register(
+		s.BaseTaskExecutor.Ctx(),
+		job.ID, hasUnique,
+		ddlObj.etcdCli,
+		discovery,
+		job.ReorgMeta.ResourceGroupName,
+		ingest.IngestConcurrency(job.ReorgMeta.Concurrency),
+	)
 }
 
 func hasUniqueIndex(job *model.Job) (bool, error) {

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -153,7 +153,7 @@ func (s *backfillDistExecutor) getBackendCtx() (ingest.BackendCtx, error) {
 		ddlObj.etcdCli,
 		discovery,
 		job.ReorgMeta.ResourceGroupName,
-		ingest.IngestConcurrency(job.ReorgMeta.Concurrency),
+		ingest.ResolveConcurrency(job.ReorgMeta.Concurrency),
 	)
 }
 

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -85,10 +85,7 @@ func newTxnBackfillScheduler(ctx context.Context, info *reorgInfo, sessPool *ses
 	if err != nil {
 		return nil, err
 	}
-	workerCnt := info.ReorgMeta.Concurrency
-	if workerCnt == 0 {
-		workerCnt = int(variable.GetDDLReorgWorkerCounter())
-	}
+	workerCnt := info.ReorgMeta.GetConcurrencyOrDefault(int(variable.GetDDLReorgWorkerCounter()))
 	return &txnBackfillScheduler{
 		ctx:          ctx,
 		reorgInfo:    info,
@@ -235,10 +232,7 @@ func restoreSessCtx(sessCtx sessionctx.Context) func(sessCtx sessionctx.Context)
 }
 
 func (b *txnBackfillScheduler) expectedWorkerSize() (size int) {
-	workerCnt := b.reorgInfo.ReorgMeta.Concurrency
-	if workerCnt == 0 {
-		workerCnt = int(variable.GetDDLReorgWorkerCounter())
-	}
+	workerCnt := b.reorgInfo.ReorgMeta.GetConcurrencyOrDefault(int(variable.GetDDLReorgWorkerCounter()))
 	return min(workerCnt, maxBackfillWorkerSize)
 }
 

--- a/pkg/ddl/cancel_test.go
+++ b/pkg/ddl/cancel_test.go
@@ -242,8 +242,8 @@ func TestCancel(t *testing.T) {
 
 	// Change some configurations.
 	ddl.ReorgWaitTimeout = 10 * time.Millisecond
-	tk.MustExec("set @@global.tidb_ddl_reorg_batch_size = 8")
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1")
+	tk.MustExec("set @@tidb_ddl_reorg_batch_size = 8")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1")
 	tk = testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockBackfillSlow", "return"))

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4755,6 +4755,12 @@ func newReorgMetaFromVariables(job *model.Job, sctx sessionctx.Context) (*model.
 	reorgMeta.IsDistReorg = variable.EnableDistTask.Load()
 	reorgMeta.IsFastReorg = variable.EnableFastReorg.Load()
 	reorgMeta.TargetScope = variable.ServiceScope.Load()
+	if sv, ok := sctx.GetSessionVars().GetSystemVar(variable.TiDBDDLReorgWorkerCount); ok {
+		reorgMeta.Concurrency = variable.TidbOptInt(sv, 0)
+	}
+	if sv, ok := sctx.GetSessionVars().GetSystemVar(variable.TiDBDDLReorgBatchSize); ok {
+		reorgMeta.BatchSize = variable.TidbOptInt(sv, 0)
+	}
 
 	if reorgMeta.IsDistReorg && !reorgMeta.IsFastReorg {
 		return nil, dbterror.ErrUnsupportedDistTask
@@ -4770,6 +4776,17 @@ func newReorgMetaFromVariables(job *model.Job, sctx sessionctx.Context) (*model.
 			LastReorgMetaFastReorgDisabled = true
 		})
 	}
+
+	logutil.DDLLogger().Info("initialize reorg meta",
+		zap.String("jobSchema", job.SchemaName),
+		zap.String("jobTable", job.TableName),
+		zap.Stringer("jobType", job.Type),
+		zap.Bool("enableDistTask", reorgMeta.IsDistReorg),
+		zap.Bool("enableFastReorg", reorgMeta.IsFastReorg),
+		zap.String("targetScope", reorgMeta.TargetScope),
+		zap.Int("concurrency", reorgMeta.Concurrency),
+		zap.Int("batchSize", reorgMeta.BatchSize),
+	)
 	return reorgMeta, nil
 }
 

--- a/pkg/ddl/export_test.go
+++ b/pkg/ddl/export_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/ngaut/pools"
-	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/copr"
 	"github.com/pingcap/tidb/pkg/ddl/session"

--- a/pkg/ddl/export_test.go
+++ b/pkg/ddl/export_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ngaut/pools"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/copr"
 	"github.com/pingcap/tidb/pkg/ddl/session"
@@ -47,7 +48,7 @@ func FetchChunk4Test(copCtx copr.CopContext, tbl table.PhysicalTable, startKey, 
 	}
 	opCtx := ddl.NewLocalOperatorCtx(context.Background(), 1)
 	src := testutil.NewOperatorTestSource(ddl.TableScanTask{1, startKey, endKey})
-	scanOp := ddl.NewTableScanOperator(opCtx, sessPool, copCtx, srcChkPool, 1, nil)
+	scanOp := ddl.NewTableScanOperator(opCtx, sessPool, copCtx, srcChkPool, 1, nil, 0)
 	sink := testutil.NewOperatorTestSink[ddl.IndexRecordChunk]()
 
 	operator.Compose[ddl.TableScanTask](src, scanOp)

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1954,7 +1954,7 @@ func checkDuplicateForUniqueIndex(ctx context.Context, t table.Table, reorgInfo 
 		if indexInfo.Unique {
 			ctx := tidblogutil.WithCategory(ctx, "ddl-ingest")
 			if bc == nil {
-				bc, err = ingest.LitBackCtxMgr.Register(ctx, reorgInfo.ID, indexInfo.Unique, nil, discovery, reorgInfo.ReorgMeta.ResourceGroupName)
+				bc, err = ingest.LitBackCtxMgr.Register(ctx, reorgInfo.ID, indexInfo.Unique, nil, discovery, reorgInfo.ReorgMeta.ResourceGroupName, 1)
 				if err != nil {
 					return err
 				}
@@ -2029,7 +2029,7 @@ func (w *worker) executeDistTask(t table.Table, reorgInfo *reorgInfo) error {
 		})
 	} else {
 		job := reorgInfo.Job
-		workerCntLimit := int(variable.GetDDLReorgWorkerCounter())
+		workerCntLimit := ingest.IngestConcurrency(job.ReorgMeta.Concurrency)
 		cpuCount, err := handle.GetCPUCountOfNode(ctx)
 		if err != nil {
 			return err

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2029,7 +2029,7 @@ func (w *worker) executeDistTask(t table.Table, reorgInfo *reorgInfo) error {
 		})
 	} else {
 		job := reorgInfo.Job
-		workerCntLimit := ingest.ResolveConcurrency(job.ReorgMeta.Concurrency)
+		workerCntLimit := job.ReorgMeta.GetConcurrencyOrDefault(int(variable.GetDDLReorgWorkerCounter()))
 		cpuCount, err := handle.GetCPUCountOfNode(ctx)
 		if err != nil {
 			return err

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2029,7 +2029,7 @@ func (w *worker) executeDistTask(t table.Table, reorgInfo *reorgInfo) error {
 		})
 	} else {
 		job := reorgInfo.Job
-		workerCntLimit := ingest.IngestConcurrency(job.ReorgMeta.Concurrency)
+		workerCntLimit := ingest.ResolveConcurrency(job.ReorgMeta.Concurrency)
 		cpuCount, err := handle.GetCPUCountOfNode(ctx)
 		if err != nil {
 			return err

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -28,7 +28,6 @@ import (
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
-	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
@@ -40,20 +39,6 @@ import (
 	"github.com/pingcap/tipb/go-tipb"
 	kvutil "github.com/tikv/client-go/v2/util"
 )
-
-// copReadBatchSize is the batch size of coprocessor read.
-// It multiplies the tidb_ddl_reorg_batch_size by 10 to avoid
-// sending too many cop requests for the same handle range.
-func copReadBatchSize() int {
-	return 10 * int(variable.GetDDLReorgBatchSize())
-}
-
-// copReadChunkPoolSize is the size of chunk pool, which
-// represents the max concurrent ongoing coprocessor requests.
-// It multiplies the tidb_ddl_reorg_worker_cnt by 10.
-func copReadChunkPoolSize() int {
-	return 10 * int(variable.GetDDLReorgWorkerCounter())
-}
 
 func wrapInBeginRollback(se *sess.Session, f func(startTS uint64) error) error {
 	err := se.Begin(context.Background())

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -1047,7 +1047,7 @@ func TestAddIndexUniqueFailOnDuplicate(t *testing.T) {
 	tk.MustExec("create table t (a bigint primary key clustered, b int);")
 	// The subtask execution order is not guaranteed in distributed reorg. We need to disable it first.
 	tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1;")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1;")
 	for i := 1; i <= 12; i++ {
 		tk.MustExec("insert into t values (?, ?)", i, i)
 	}

--- a/pkg/ddl/ingest/backend_mgr.go
+++ b/pkg/ddl/ingest/backend_mgr.go
@@ -49,6 +49,7 @@ type BackendCtxMgr interface {
 		etcdClient *clientv3.Client,
 		pdSvcDiscovery pd.ServiceDiscovery,
 		resourceGroupName string,
+		importConc int,
 	) (BackendCtx, error)
 	Unregister(jobID int64)
 	// EncodeJobSortPath encodes the job ID to the local disk sort path.
@@ -114,6 +115,7 @@ func (m *litBackendCtxMgr) Register(
 	etcdClient *clientv3.Client,
 	pdSvcDiscovery pd.ServiceDiscovery,
 	resourceGroupName string,
+	concurrency int,
 ) (BackendCtx, error) {
 	bc, exist := m.Load(jobID)
 	if exist {
@@ -131,7 +133,7 @@ func (m *litBackendCtxMgr) Register(
 		logutil.Logger(ctx).Error(LitErrCreateDirFail, zap.Error(err))
 		return nil, err
 	}
-	cfg, err := genConfig(ctx, sortPath, m.memRoot, hasUnique, resourceGroupName)
+	cfg, err := genConfig(ctx, sortPath, m.memRoot, hasUnique, resourceGroupName, concurrency)
 	if err != nil {
 		logutil.Logger(ctx).Warn(LitWarnConfigError, zap.Int64("job ID", jobID), zap.Error(err))
 		return nil, err

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -91,8 +91,8 @@ func genConfig(
 	return c, nil
 }
 
-// IngestConcurrency is the concurrency used during ingest.
-func IngestConcurrency(hintConc int) int {
+// ResolveConcurrency gets the concurrency used for ingest mode of adding index.
+func ResolveConcurrency(hintConc int) int {
 	if hintConc > 0 {
 		return hintConc
 	}
@@ -113,7 +113,7 @@ func CopReadBatchSize(hintSize int) int {
 // represents the max concurrent ongoing coprocessor requests.
 // It multiplies the tidb_ddl_reorg_worker_cnt by 10.
 func CopReadChunkPoolSize(hintConc int) int {
-	return IngestConcurrency(hintConc) * 10
+	return ResolveConcurrency(hintConc) * 10
 }
 
 // NewDDLTLS creates a common.TLS from the tidb config for DDL.

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -91,14 +91,6 @@ func genConfig(
 	return c, nil
 }
 
-// ResolveConcurrency gets the concurrency used for ingest mode of adding index.
-func ResolveConcurrency(hintConc int) int {
-	if hintConc > 0 {
-		return hintConc
-	}
-	return int(variable.GetDDLReorgWorkerCounter())
-}
-
 // CopReadBatchSize is the batch size of coprocessor read.
 // It multiplies the tidb_ddl_reorg_batch_size by 10 to avoid
 // sending too many cop requests for the same handle range.
@@ -113,7 +105,10 @@ func CopReadBatchSize(hintSize int) int {
 // represents the max concurrent ongoing coprocessor requests.
 // It multiplies the tidb_ddl_reorg_worker_cnt by 10.
 func CopReadChunkPoolSize(hintConc int) int {
-	return ResolveConcurrency(hintConc) * 10
+	if hintConc > 0 {
+		return 10 * hintConc
+	}
+	return 10 * int(variable.GetDDLReorgWorkerCounter())
 }
 
 // NewDDLTLS creates a common.TLS from the tidb config for DDL.

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -48,16 +48,16 @@ func genConfig(
 	memRoot MemRoot,
 	unique bool,
 	resourceGroup string,
+	concurrency int,
 ) (*litConfig, error) {
 	tidbCfg := tidb.GetGlobalConfig()
 	cfg := lightning.NewConfig()
 	cfg.TikvImporter.Backend = lightning.BackendLocal
 	// Each backend will build a single dir in lightning dir.
 	cfg.TikvImporter.SortedKVDir = jobSortPath
+	cfg.TikvImporter.RangeConcurrency = concurrency
 	if ImporterRangeConcurrencyForTest != nil {
 		cfg.TikvImporter.RangeConcurrency = int(ImporterRangeConcurrencyForTest.Load())
-	} else {
-		cfg.TikvImporter.RangeConcurrency = int(variable.GetDDLReorgWorkerCounter())
 	}
 	err := cfg.AdjustForDDL()
 	if err != nil {
@@ -89,6 +89,31 @@ func genConfig(
 	}
 
 	return c, nil
+}
+
+// IngestConcurrency is the concurrency used during ingest.
+func IngestConcurrency(hintConc int) int {
+	if hintConc > 0 {
+		return hintConc
+	}
+	return int(variable.GetDDLReorgWorkerCounter())
+}
+
+// CopReadBatchSize is the batch size of coprocessor read.
+// It multiplies the tidb_ddl_reorg_batch_size by 10 to avoid
+// sending too many cop requests for the same handle range.
+func CopReadBatchSize(hintSize int) int {
+	if hintSize > 0 {
+		return hintSize
+	}
+	return 10 * int(variable.GetDDLReorgBatchSize())
+}
+
+// CopReadChunkPoolSize is the size of chunk pool, which
+// represents the max concurrent ongoing coprocessor requests.
+// It multiplies the tidb_ddl_reorg_worker_cnt by 10.
+func CopReadChunkPoolSize(hintConc int) int {
+	return IngestConcurrency(hintConc) * 10
 }
 
 // NewDDLTLS creates a common.TLS from the tidb config for DDL.

--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -87,7 +87,7 @@ func TestIngestError(t *testing.T) {
 	tk.MustExec("set global tidb_enable_dist_task = 0")
 	defer ingesttestutil.InjectMockBackendMgr(t, store)()
 
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1;")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1;")
 	tk.MustExec("create table t (a int primary key, b int);")
 	for i := 0; i < 4; i++ {
 		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d);", i*10000, i*10000))

--- a/pkg/ddl/ingest/mock.go
+++ b/pkg/ddl/ingest/mock.go
@@ -56,7 +56,8 @@ func (m *MockBackendCtxMgr) CheckMoreTasksAvailable() (bool, error) {
 }
 
 // Register implements BackendCtxMgr.Register interface.
-func (m *MockBackendCtxMgr) Register(ctx context.Context, jobID int64, unique bool, etcdClient *clientv3.Client, pdSvcDiscovery pd.ServiceDiscovery, resourceGroupName string) (BackendCtx, error) {
+func (m *MockBackendCtxMgr) Register(ctx context.Context, jobID int64, unique bool, etcdClient *clientv3.Client,
+	pdSvcDiscovery pd.ServiceDiscovery, resourceGroupName string, importConc int) (BackendCtx, error) {
 	logutil.DDLIngestLogger().Info("mock backend mgr register", zap.Int64("jobID", jobID))
 	if mockCtx, ok := m.runningJobs[jobID]; ok {
 		return mockCtx, nil

--- a/pkg/ddl/tests/adminpause/global.go
+++ b/pkg/ddl/tests/adminpause/global.go
@@ -35,8 +35,8 @@ func prepareDomain(t *testing.T) (*domain.Domain, *testkit.TestKit, *testkit.Tes
 	adminCommandKit := testkit.NewTestKit(t, store)
 
 	ddlctrl.ReorgWaitTimeout = 10 * time.Millisecond
-	stmtKit.MustExec("set @@global.tidb_ddl_reorg_batch_size = 2")
-	stmtKit.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1")
+	stmtKit.MustExec("set @@tidb_ddl_reorg_batch_size = 2")
+	stmtKit.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1")
 	stmtKit = testkit.NewTestKit(t, store)
 	stmtKit.MustExec("use test")
 

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2073,7 +2073,7 @@ func TestAdminCheckGlobalIndexDuringDDL(t *testing.T) {
 	}
 
 	batchSize := 32
-	tk.MustExec(fmt.Sprintf("set global tidb_ddl_reorg_batch_size = %d", batchSize))
+	tk.MustExec(fmt.Sprintf("set @@tidb_ddl_reorg_batch_size = %d", batchSize))
 
 	var enableFastCheck = []bool{false, true}
 	for _, enabled := range enableFastCheck {

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -813,6 +813,11 @@ func TestSetDDLReorgWorkerCnt(t *testing.T) {
 	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 257")
 	tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_ddl_reorg_worker_cnt value: '257'"))
 	tk.MustQuery("select @@global.tidb_ddl_reorg_worker_cnt").Check(testkit.Rows("256"))
+
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 10;")
+	tk.MustQuery("select @@tidb_ddl_reorg_worker_cnt;").Check(testkit.Rows("10"))
+	tk.MustQuery("select @@global.tidb_ddl_reorg_worker_cnt;").Check(testkit.Rows("256"))
+	require.Equal(t, int32(256), variable.GetDDLReorgWorkerCounter())
 }
 
 func TestSetDDLReorgBatchSize(t *testing.T) {
@@ -850,6 +855,10 @@ func TestSetDDLReorgBatchSize(t *testing.T) {
 	tk.MustExec("set @@global.tidb_ddl_reorg_batch_size = 1000")
 	res = tk.MustQuery("select @@global.tidb_ddl_reorg_batch_size")
 	res.Check(testkit.Rows("1000"))
+
+	tk.MustExec("set @@tidb_ddl_reorg_batch_size = 256;")
+	tk.MustQuery("select @@tidb_ddl_reorg_batch_size").Check(testkit.Rows("256"))
+	tk.MustQuery("select @@global.tidb_ddl_reorg_batch_size").Check(testkit.Rows("1000"))
 }
 
 func TestSetDDLErrorCountLimit(t *testing.T) {

--- a/pkg/parser/model/reorg.go
+++ b/pkg/parser/model/reorg.go
@@ -30,12 +30,30 @@ type DDLReorgMeta struct {
 	ReorgTp           ReorgType                        `json:"reorg_tp"`
 	IsFastReorg       bool                             `json:"is_fast_reorg"`
 	IsDistReorg       bool                             `json:"is_dist_reorg"`
-	Concurrency       int                              `json:"concurrency"`
-	BatchSize         int                              `json:"batch_size"`
 	UseCloudStorage   bool                             `json:"use_cloud_storage"`
 	ResourceGroupName string                           `json:"resource_group_name"`
 	Version           int64                            `json:"version"`
 	TargetScope       string                           `json:"target_scope"`
+	// These two variables are set when corresponding session variables are set explicitly. When they are set,
+	// user cannot change it by setting the global one. Otherwise, they can be adjusted dynamically through global var.
+	Concurrency int `json:"concurrency"`
+	BatchSize   int `json:"batch_size"`
+}
+
+// GetConcurrencyOrDefault gets the concurrency from DDLReorgMeta or returns the default value.
+func (dm *DDLReorgMeta) GetConcurrencyOrDefault(defaultVal int) int {
+	if dm == nil || dm.Concurrency == 0 {
+		return defaultVal
+	}
+	return dm.Concurrency
+}
+
+// GetBatchSizeOrDefault gets the batch size from DDLReorgMeta or returns the default value.
+func (dm *DDLReorgMeta) GetBatchSizeOrDefault(defaultVal int) int {
+	if dm == nil || dm.BatchSize == 0 {
+		return defaultVal
+	}
+	return dm.BatchSize
 }
 
 const (

--- a/pkg/parser/model/reorg.go
+++ b/pkg/parser/model/reorg.go
@@ -30,6 +30,8 @@ type DDLReorgMeta struct {
 	ReorgTp           ReorgType                        `json:"reorg_tp"`
 	IsFastReorg       bool                             `json:"is_fast_reorg"`
 	IsDistReorg       bool                             `json:"is_dist_reorg"`
+	Concurrency       int                              `json:"concurrency"`
+	BatchSize         int                              `json:"batch_size"`
 	UseCloudStorage   bool                             `json:"use_cloud_storage"`
 	ResourceGroupName string                           `json:"resource_group_name"`
 	Version           int64                            `json:"version"`

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -758,11 +758,11 @@ var defaultSysVars = []*SysVar{
 		SetDDLFlashbackConcurrency(int32(tidbOptPositiveInt32(val, DefTiDBDDLFlashbackConcurrency)))
 		return nil
 	}},
-	{Scope: ScopeGlobal, Name: TiDBDDLReorgWorkerCount, Value: strconv.Itoa(DefTiDBDDLReorgWorkerCount), Type: TypeUnsigned, MinValue: 1, MaxValue: MaxConfigurableConcurrency, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgWorkerCount, Value: strconv.Itoa(DefTiDBDDLReorgWorkerCount), Type: TypeUnsigned, MinValue: 1, MaxValue: MaxConfigurableConcurrency, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLReorgWorkerCounter(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgWorkerCount)))
 		return nil
 	}},
-	{Scope: ScopeGlobal, Name: TiDBDDLReorgBatchSize, Value: strconv.Itoa(DefTiDBDDLReorgBatchSize), Type: TypeUnsigned, MinValue: int64(MinDDLReorgBatchSize), MaxValue: uint64(MaxDDLReorgBatchSize), SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgBatchSize, Value: strconv.Itoa(DefTiDBDDLReorgBatchSize), Type: TypeUnsigned, MinValue: int64(MinDDLReorgBatchSize), MaxValue: uint64(MaxDDLReorgBatchSize), SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLReorgBatchSize(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgBatchSize)))
 		return nil
 	}},

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -758,11 +758,11 @@ var defaultSysVars = []*SysVar{
 		SetDDLFlashbackConcurrency(int32(tidbOptPositiveInt32(val, DefTiDBDDLFlashbackConcurrency)))
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgWorkerCount, Value: strconv.Itoa(DefTiDBDDLReorgWorkerCount), Type: TypeUnsigned, MinValue: 1, MaxValue: MaxConfigurableConcurrency, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgWorkerCount, skipInit: true, Value: strconv.Itoa(DefTiDBDDLReorgWorkerCount), Type: TypeUnsigned, MinValue: 1, MaxValue: MaxConfigurableConcurrency, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLReorgWorkerCounter(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgWorkerCount)))
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgBatchSize, Value: strconv.Itoa(DefTiDBDDLReorgBatchSize), Type: TypeUnsigned, MinValue: int64(MinDDLReorgBatchSize), MaxValue: uint64(MaxDDLReorgBatchSize), SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgBatchSize, skipInit: true, Value: strconv.Itoa(DefTiDBDDLReorgBatchSize), Type: TypeUnsigned, MinValue: int64(MinDDLReorgBatchSize), MaxValue: uint64(MaxDDLReorgBatchSize), SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLReorgBatchSize(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgBatchSize)))
 		return nil
 	}},

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -758,11 +758,11 @@ var defaultSysVars = []*SysVar{
 		SetDDLFlashbackConcurrency(int32(tidbOptPositiveInt32(val, DefTiDBDDLFlashbackConcurrency)))
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgWorkerCount, skipInit: true, Value: strconv.Itoa(DefTiDBDDLReorgWorkerCount), Type: TypeUnsigned, MinValue: 1, MaxValue: MaxConfigurableConcurrency, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgWorkerCount, Value: strconv.Itoa(DefTiDBDDLReorgWorkerCount), Type: TypeUnsigned, MinValue: 1, MaxValue: MaxConfigurableConcurrency, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLReorgWorkerCounter(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgWorkerCount)))
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgBatchSize, skipInit: true, Value: strconv.Itoa(DefTiDBDDLReorgBatchSize), Type: TypeUnsigned, MinValue: int64(MinDDLReorgBatchSize), MaxValue: uint64(MaxDDLReorgBatchSize), SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDDLReorgBatchSize, Value: strconv.Itoa(DefTiDBDDLReorgBatchSize), Type: TypeUnsigned, MinValue: int64(MinDDLReorgBatchSize), MaxValue: uint64(MaxDDLReorgBatchSize), SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLReorgBatchSize(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgBatchSize)))
 		return nil
 	}},

--- a/pkg/sessionctx/variable/varsutil_test.go
+++ b/pkg/sessionctx/variable/varsutil_test.go
@@ -251,9 +251,6 @@ func TestVarsutil(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, v.OptimizerEnableNewOnlyFullGroupByCheck)
 
-	err = v.SetSystemVar(TiDBDDLReorgWorkerCount, "4") // wrong scope global only
-	require.True(t, terror.ErrorEqual(err, errGlobalVariable))
-
 	err = v.SetSystemVar(TiDBRetryLimit, "3")
 	require.NoError(t, err)
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), TiDBRetryLimit)

--- a/tests/realtikvtest/addindextest1/disttask_test.go
+++ b/tests/realtikvtest/addindextest1/disttask_test.go
@@ -62,6 +62,7 @@ func TestAddIndexDistBasic(t *testing.T) {
 
 	bak := variable.GetDDLReorgWorkerCounter()
 	tk.MustExec("set global tidb_ddl_reorg_worker_cnt = 111")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 111")
 	require.Equal(t, int32(111), variable.GetDDLReorgWorkerCounter())
 	tk.MustExec("create table t(a bigint auto_random primary key) partition by hash(a) partitions 20;")
 	tk.MustExec("insert into t values (), (), (), (), (), ()")
@@ -80,6 +81,7 @@ func TestAddIndexDistBasic(t *testing.T) {
 	require.Equal(t, 1, task.Concurrency)
 
 	tk.MustExec(fmt.Sprintf("set global tidb_ddl_reorg_worker_cnt = %d", bak))
+	tk.MustExec(fmt.Sprintf("set @@tidb_ddl_reorg_worker_cnt = %d", bak))
 	require.Equal(t, bak, variable.GetDDLReorgWorkerCounter())
 
 	tk.MustExec("create table t1(a bigint auto_random primary key);")

--- a/tests/realtikvtest/addindextest3/functional_test.go
+++ b/tests/realtikvtest/addindextest3/functional_test.go
@@ -83,7 +83,7 @@ func TestDDLTestEstimateTableRowSize(t *testing.T) {
 func TestBackendCtxConcurrentUnregister(t *testing.T) {
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	discovery := store.(tikv.Storage).GetRegionCache().PDClient().GetServiceDiscovery()
-	bCtx, err := ingest.LitBackCtxMgr.Register(context.Background(), 1, false, nil, discovery, "test")
+	bCtx, err := ingest.LitBackCtxMgr.Register(context.Background(), 1, false, nil, discovery, "test", 1)
 	require.NoError(t, err)
 	idxIDs := []int64{1, 2, 3, 4, 5, 6, 7}
 	uniques := make([]bool, 0, len(idxIDs))

--- a/tests/realtikvtest/addindextest3/ingest_test.go
+++ b/tests/realtikvtest/addindextest3/ingest_test.go
@@ -398,7 +398,7 @@ func TestAddIndexRemoteDuplicateCheck(t *testing.T) {
 	tk.MustExec("use addindexlit;")
 	tk.MustExec(`set global tidb_ddl_enable_fast_reorg=on;`)
 	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt=1;")
-	tk.MustExec("set @@global tidb_enable_dist_task = 0;")
+	tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
 
 	tk.MustExec("create table t(id int primary key, b int, k int);")
 	tk.MustQuery("split table t by (30000);").Check(testkit.Rows("1 1"))

--- a/tests/realtikvtest/addindextest3/ingest_test.go
+++ b/tests/realtikvtest/addindextest3/ingest_test.go
@@ -398,7 +398,7 @@ func TestAddIndexRemoteDuplicateCheck(t *testing.T) {
 	tk.MustExec("use addindexlit;")
 	tk.MustExec(`set global tidb_ddl_enable_fast_reorg=on;`)
 	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt=1;")
-	tk.MustExec("set @@tidb_enable_dist_task = 0;")
+	tk.MustExec("set @@global tidb_enable_dist_task = 0;")
 
 	tk.MustExec("create table t(id int primary key, b int, k int);")
 	tk.MustQuery("split table t by (30000);").Check(testkit.Rows("1 1"))

--- a/tests/realtikvtest/addindextest3/ingest_test.go
+++ b/tests/realtikvtest/addindextest3/ingest_test.go
@@ -191,7 +191,7 @@ func TestAddIndexIngestAdjustBackfillWorker(t *testing.T) {
 	tk.MustExec("create database addindexlit;")
 	tk.MustExec("use addindexlit;")
 	tk.MustExec(`set global tidb_ddl_enable_fast_reorg=on;`)
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 1;")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1;")
 	tk.MustExec("create table t (a int primary key);")
 	var sb strings.Builder
 	sb.WriteString("insert into t values ")
@@ -219,7 +219,7 @@ func TestAddIndexIngestAdjustBackfillWorker(t *testing.T) {
 			running = false
 		case wg := <-ddl.TestCheckWorkerNumCh:
 			offset = (offset + 1) % 3
-			tk.MustExec(fmt.Sprintf("set @@global.tidb_ddl_reorg_worker_cnt=%d", cnt[offset]))
+			tk.MustExec(fmt.Sprintf("set @@tidb_ddl_reorg_worker_cnt=%d", cnt[offset]))
 			atomic.StoreInt32(&ddl.TestCheckWorkerNumber, int32(cnt[offset]/2+2))
 			wg.Done()
 		}
@@ -231,7 +231,6 @@ func TestAddIndexIngestAdjustBackfillWorker(t *testing.T) {
 	require.Len(t, rows, 1)
 	jobTp := rows[0][3].(string)
 	require.True(t, strings.Contains(jobTp, "ingest"), jobTp)
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 4;")
 }
 
 func TestAddIndexIngestAdjustBackfillWorkerCountFail(t *testing.T) {
@@ -244,7 +243,7 @@ func TestAddIndexIngestAdjustBackfillWorkerCountFail(t *testing.T) {
 
 	ingest.ImporterRangeConcurrencyForTest = &atomic.Int32{}
 	ingest.ImporterRangeConcurrencyForTest.Store(2)
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 20;")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 20;")
 
 	tk.MustExec("create table t (a int primary key);")
 	var sb strings.Builder
@@ -262,7 +261,6 @@ func TestAddIndexIngestAdjustBackfillWorkerCountFail(t *testing.T) {
 	require.Len(t, rows, 1)
 	jobTp := rows[0][3].(string)
 	require.True(t, strings.Contains(jobTp, "ingest"), jobTp)
-	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 4;")
 	ingest.ImporterRangeConcurrencyForTest = nil
 }
 
@@ -399,8 +397,8 @@ func TestAddIndexRemoteDuplicateCheck(t *testing.T) {
 	tk.MustExec("create database addindexlit;")
 	tk.MustExec("use addindexlit;")
 	tk.MustExec(`set global tidb_ddl_enable_fast_reorg=on;`)
-	tk.MustExec("set global tidb_ddl_reorg_worker_cnt=1;")
-	tk.MustExec("set global tidb_enable_dist_task = 0;")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt=1;")
+	tk.MustExec("set @@tidb_enable_dist_task = 0;")
 
 	tk.MustExec("create table t(id int primary key, b int, k int);")
 	tk.MustQuery("split table t by (30000);").Check(testkit.Rows("1 1"))
@@ -410,8 +408,6 @@ func TestAddIndexRemoteDuplicateCheck(t *testing.T) {
 	ingest.ForceSyncFlagForTest = true
 	tk.MustGetErrMsg("alter table t add unique index idx(b);", "[kv:1062]Duplicate entry '1' for key 't.idx'")
 	ingest.ForceSyncFlagForTest = false
-
-	tk.MustExec("set global tidb_ddl_reorg_worker_cnt=4;")
 }
 
 func TestAddIndexBackfillLostUpdate(t *testing.T) {

--- a/tests/realtikvtest/addindextest3/operator_test.go
+++ b/tests/realtikvtest/addindextest3/operator_test.go
@@ -95,7 +95,7 @@ func TestBackfillOperators(t *testing.T) {
 		ctx := context.Background()
 		opCtx := ddl.NewDistTaskOperatorCtx(ctx, 1, 1)
 		src := testutil.NewOperatorTestSource(opTasks...)
-		scanOp := ddl.NewTableScanOperator(opCtx, sessPool, copCtx, srcChkPool, 3, nil)
+		scanOp := ddl.NewTableScanOperator(opCtx, sessPool, copCtx, srcChkPool, 3, nil, 0)
 		sink := testutil.NewOperatorTestSink[ddl.IndexRecordChunk]()
 
 		operator.Compose[ddl.TableScanTask](src, scanOp)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55335

Problem Summary: see https://github.com/pingcap/tidb/issues/55335

### What changed and how does it work?

- Add session scope support for system variables `tidb_ddl_reorg_worker_cnt` and `tidb_ddl_reorg_batch_size`.
- For session scope variables, the value cannot be changed during DDL job execution.
- For global scope variables, the they only provide the default values of session variables.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
    Execute following SQLs on root user:
    ```
    create user 'aa'@'%' identified by '';
    create database aa;
    grant create, alter, insert on aa.* to 'aa'@'%';
    ```
    Switch to user 'aa'@'%':
    ```
    mysql> use aa;
    Database changed
    mysql> show tables;
    Empty set (0.00 sec)

    mysql> create table t (a int, b int);
    Query OK, 0 rows affected (0.07 sec)

    mysql> insert into t values (1, 1);
    Query OK, 1 row affected (0.03 sec)

    mysql> select @@global.tidb_ddl_reorg_worker_cnt;
    +------------------------------------+
    | @@global.tidb_ddl_reorg_worker_cnt |
    +------------------------------------+
    |                                  4 |
    +------------------------------------+
    1 row in set (0.00 sec)

    mysql> set  @@global.tidb_ddl_reorg_worker_cnt = 8;
    ERROR 1227 (42000): Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
    mysql> set @@tidb_ddl_reorg_worker_cnt = 8;
    Query OK, 0 rows affected (0.00 sec)

    mysql> alter table t add index idx(a);
    Query OK, 0 rows affected (2.20 sec)
    ```
    Check TiDB log:
    ```
    [INFO] [executor.go:4780] ["initialize reorg meta"] [category=ddl] [jobSchema=aa] [jobTable=t] [jobType="add index"] [enableDistTask=true] [enableFastReorg=true] [targetScope=] [concurrency=8] [batchSize=256]
    ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
