### PR TITLE
planner: move `rule_constant_propagation` to rule pkg. (#55231)

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -67,7 +67,6 @@ go_library(
         "rule_aggregation_skew_rewrite.go",
         "rule_collect_plan_stats.go",
         "rule_column_pruning.go",
-        "rule_constant_propagation.go",
         "rule_decorrelate.go",
         "rule_derive_topn_from_window.go",
         "rule_eliminate_projection.go",

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -110,7 +110,7 @@ var optRuleList = []base.LogicalOptRule{
 	&SkewDistinctAggRewriter{},
 	&ProjectionEliminator{},
 	&MaxMinEliminator{},
-	&ConstantPropagationSolver{},
+	&rule.ConstantPropagationSolver{},
 	&ConvertOuterToInnerJoin{},
 	&PPDSolver{},
 	&OuterJoinEliminator{},

--- a/pkg/planner/core/rule/BUILD.bazel
+++ b/pkg/planner/core/rule/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "rule",
     srcs = [
         "rule_build_key_info.go",
+        "rule_constant_propagation.go",
         "rule_init.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/planner/core/rule",

--- a/pkg/planner/core/rule/rule_constant_propagation.go
+++ b/pkg/planner/core/rule/rule_constant_propagation.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package rule
 
 import (
 	"context"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55231

Problem Summary:

### What changed and how does it work?
move rule_constant_propagation from core to rule pkg

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > - [x] I ran locally, and executed a sql with pagination.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
