### PR TITLE
copr: Support VECTOR for RowFormatv1

### DIFF
--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -151,19 +151,11 @@ func PeekBytesAsVectorFloat32(b []byte) (n int, err error) {
 // ZeroCopyDeserializeVectorFloat32 deserializes the byte slice into a vector, without memory copy.
 // Note: b must not be mutated, because this function does zero copy.
 func ZeroCopyDeserializeVectorFloat32(b []byte) (VectorFloat32, []byte, error) {
-	if len(b) < 4 {
-		return ZeroVectorFloat32, b, errors.Errorf("bad VectorFloat32 value header (len=%d)", len(b))
+	len, err := PeekBytesAsVectorFloat32(b)
+	if err != nil {
+		return ZeroVectorFloat32, b, err
 	}
-
-	elements := binary.LittleEndian.Uint32(b)
-	totalDataSize := elements*4 + 4
-	if len(b) < int(totalDataSize) {
-		return ZeroVectorFloat32, b, errors.Errorf("bad VectorFloat32 value (len=%d, expected=%d)", len(b), totalDataSize)
-	}
-
-	data := b[:totalDataSize]
-	remaining := b[totalDataSize:]
-	return VectorFloat32{data: data}, remaining, nil
+	return VectorFloat32{data: b[:len]}, b[len:], nil
 }
 
 // ParseVectorFloat32 parses a string into a vector.

--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -148,6 +148,24 @@ func PeekBytesAsVectorFloat32(b []byte) (n int, err error) {
 	return int(totalDataSize), nil
 }
 
+// ZeroCopyDeserializeVectorFloat32 deserializes the byte slice into a vector, without memory copy.
+// Note: b must not be mutated, because this function does zero copy.
+func ZeroCopyDeserializeVectorFloat32(b []byte) (VectorFloat32, []byte, error) {
+	if len(b) < 4 {
+		return ZeroVectorFloat32, b, errors.Errorf("bad VectorFloat32 value header (len=%d)", len(b))
+	}
+
+	elements := binary.LittleEndian.Uint32(b)
+	totalDataSize := elements*4 + 4
+	if len(b) < int(totalDataSize) {
+		return ZeroVectorFloat32, b, errors.Errorf("bad VectorFloat32 value (len=%d, expected=%d)", len(b), totalDataSize)
+	}
+
+	data := b[:totalDataSize]
+	remaining := b[totalDataSize:]
+	return VectorFloat32{data: data}, remaining, nil
+}
+
 // ParseVectorFloat32 parses a string into a vector.
 func ParseVectorFloat32(s string) (VectorFloat32, error) {
 	var values []float32

--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -148,16 +148,6 @@ func PeekBytesAsVectorFloat32(b []byte) (n int, err error) {
 	return int(totalDataSize), nil
 }
 
-// ZeroCopyDeserializeVectorFloat32 deserializes the byte slice into a vector, without memory copy.
-// Note: b must not be mutated, because this function does zero copy.
-func ZeroCopyDeserializeVectorFloat32(b []byte) (VectorFloat32, []byte, error) {
-	len, err := PeekBytesAsVectorFloat32(b)
-	if err != nil {
-		return ZeroVectorFloat32, b, err
-	}
-	return VectorFloat32{data: b[:len]}, b[len:], nil
-}
-
 // ParseVectorFloat32 parses a string into a vector.
 func ParseVectorFloat32(s string) (VectorFloat32, error) {
 	var values []float32

--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -151,11 +151,11 @@ func PeekBytesAsVectorFloat32(b []byte) (n int, err error) {
 // ZeroCopyDeserializeVectorFloat32 deserializes the byte slice into a vector, without memory copy.
 // Note: b must not be mutated, because this function does zero copy.
 func ZeroCopyDeserializeVectorFloat32(b []byte) (VectorFloat32, []byte, error) {
-	len, err := PeekBytesAsVectorFloat32(b)
+	length, err := PeekBytesAsVectorFloat32(b)
 	if err != nil {
 		return ZeroVectorFloat32, b, err
 	}
-	return VectorFloat32{data: b[:len]}, b[len:], nil
+	return VectorFloat32{data: b[:length]}, b[length:], nil
 }
 
 // ParseVectorFloat32 parses a string into a vector.

--- a/pkg/types/vector_test.go
+++ b/pkg/types/vector_test.go
@@ -131,3 +131,28 @@ func TestVectorCompare(t *testing.T) {
 	require.Equal(t, -1, v1.Compare(v2))
 	require.Equal(t, 1, v2.Compare(v1))
 }
+
+func TestVectorSerialize(t *testing.T) {
+	v1, err := types.ParseVectorFloat32(`[1.1, 2.2, 3.3]`)
+	require.NoError(t, err)
+
+	serialized := v1.SerializeTo(nil)
+	serialized = append(serialized, 0x01, 0x02, 0x03, 0x04)
+
+	v2, remaining, err := types.ZeroCopyDeserializeVectorFloat32(serialized)
+	require.NoError(t, err)
+	require.Len(t, remaining, 4)
+	require.Equal(t, []byte{
+		0x01, 0x02, 0x03, 0x04,
+	}, remaining)
+
+	require.Equal(t, "[1.1,2.2,3.3]", v2.String())
+
+	v3, remaining, err := types.ZeroCopyDeserializeVectorFloat32([]byte{0xF1, 0xFC})
+	require.Error(t, err)
+	require.Len(t, remaining, 2)
+	require.Equal(t, []byte{
+		0xF1, 0xFC,
+	}, remaining)
+	require.True(t, v3.IsZeroValue())
+}

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -1206,6 +1206,8 @@ func peek(b []byte) (length int, err error) {
 		l, err = peekUvarint(b)
 	case jsonFlag:
 		l, err = types.PeekBytesAsJSON(b)
+	case vectorFloat32Flag:
+		l, err = types.PeekBytesAsVectorFloat32(b)
 	default:
 		return 0, errors.Errorf("invalid encoded key flag %v", flag)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54245 

Problem Summary:

### What changed and how does it work?
When CSV data is loaded via LOAD DATA statement, it turns out that row is encoded using Format v1:
```
LOAD DATA LOCAL INFILE '/Users/breezewish/Downloads/backup_llama_index_rag_test/test.llama_index_rag_test.0000000010000.csv' INTO TABLE `llama_index_rag_test` FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES;
```
And it causes problems:
```mysql
mysql> select * from llama_index_rag_test limit 10;
ERROR 1105 (HY000): invalid data type: unsupported data type `20`
```
This PR make it work.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
