### PR TITLE
planner/core: infoschema tables should show global temp tables

### DIFF
--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -322,7 +322,7 @@ func findNameAndAppendToTableMap(
 			return errors.Trace(err)
 		}
 		tblInfo := tbl.Meta()
-		if tblInfo.TempTableType != model.TempTableNone {
+		if tblInfo.TempTableType == model.TempTableLocal {
 			continue
 		}
 		tables[tblInfo.ID] = tblInfo
@@ -347,7 +347,7 @@ func findTablesByID(
 			continue
 		}
 		tblInfo := tbl.Meta()
-		if tblInfo.TempTableType != model.TempTableNone {
+		if tblInfo.TempTableType == model.TempTableLocal {
 			continue
 		}
 		if len(tableNames) > 0 {
@@ -408,7 +408,7 @@ func findTableAndSchemaByName(
 				return nil, nil, errors.Trace(err)
 			}
 			tblInfo := tbl.Meta()
-			if tblInfo.TempTableType != model.TempTableNone {
+			if tblInfo.TempTableType == model.TempTableLocal {
 				continue
 			}
 			tableMap[tblInfo.ID] = schemaAndTable{s, tblInfo}

--- a/tests/integrationtest/r/infoschema/infoschema.result
+++ b/tests/integrationtest/r/infoschema/infoschema.result
@@ -215,3 +215,14 @@ select count(1) from information_schema.statistics where table_name = 'temp_tabl
 count(1)
 0
 drop table temp_table;
+create global temporary table temp_table(a int, index idx(a)) on commit delete rows;
+select count(1) from information_schema.tables where table_schema = 'infoschema__infoschema';
+count(1)
+1
+select count(1) from information_schema.tables where table_name = 'temp_table';
+count(1)
+1
+select count(1) from information_schema.statistics where table_name = 'temp_table';
+count(1)
+1
+drop table temp_table;

--- a/tests/integrationtest/t/infoschema/infoschema.test
+++ b/tests/integrationtest/t/infoschema/infoschema.test
@@ -110,8 +110,13 @@ select * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE where table_schema = 'db1' ord
 drop database db1;
 drop database db2;
 
-# TestTemporaryTableShouldNotAppear
+# TestLocalTemporaryTableShouldNotAppear
 create temporary table temp_table (a int, index idx(a));
+select count(1) from information_schema.tables where table_schema = 'infoschema__infoschema';
+select count(1) from information_schema.tables where table_name = 'temp_table';
+select count(1) from information_schema.statistics where table_name = 'temp_table';
+drop table temp_table;
+create global temporary table temp_table(a int, index idx(a)) on commit delete rows;
 select count(1) from information_schema.tables where table_schema = 'infoschema__infoschema';
 select count(1) from information_schema.tables where table_name = 'temp_table';
 select count(1) from information_schema.statistics where table_name = 'temp_table';


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55375

Problem Summary:

### What changed and how does it work?

Memory tables from `information_schema` should show global temp tables.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
