### PR TITLE
vector: shorten explain output for vector constants

### DIFF
--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -152,6 +152,9 @@ func (c *Constant) StringWithCtx(ctx ParamValues, redact string) string {
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.StringWithCtx(ctx, redact)
 	}
+	if c.RetType.GetType() == mysql.TypeTiDBVectorFloat32 {
+		return c.Value.StringWithCtx(ctx, redact)
+	}
 	if redact == perrors.RedactLogDisable {
 		return fmt.Sprintf("%v", c.Value.GetValue())
 	} else if redact == perrors.RedactLogMarker {

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -152,13 +152,10 @@ func (c *Constant) StringWithCtx(ctx ParamValues, redact string) string {
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.StringWithCtx(ctx, redact)
 	}
-	if c.Value.Kind() == types.KindVectorFloat32 {
-		return c.Value.StringWithCtx(ctx, redact)
-	}
 	if redact == perrors.RedactLogDisable {
-		return fmt.Sprintf("%v", c.Value.GetValue())
+		return fmt.Sprintf("%v", c.Value.StringTruncate())
 	} else if redact == perrors.RedactLogMarker {
-		return fmt.Sprintf("‹%v›", c.Value.GetValue())
+		return fmt.Sprintf("‹%v›", c.Value.StringTruncate())
 	}
 	return "?"
 }

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -152,7 +152,7 @@ func (c *Constant) StringWithCtx(ctx ParamValues, redact string) string {
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.StringWithCtx(ctx, redact)
 	}
-	if c.RetType.GetType() == mysql.TypeTiDBVectorFloat32 {
+	if c.Value.Kind() == types.KindVectorFloat32 {
 		return c.Value.StringWithCtx(ctx, redact)
 	}
 	if redact == perrors.RedactLogDisable {

--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 41,
+    shard_count = 42,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -109,6 +109,23 @@ func TestVectorColumnInfo(t *testing.T) {
 	tk.MustGetErrMsg("create table t(embedding VECTOR(16384))", "vector cannot have more than 16383 dimensions")
 }
 
+func TestVectorConstantExplain(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE t(c VECTOR);")
+	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, '[1,2,3,4,5,6,7,8,9,10,11]') FROM t;`).Check(testkit.Rows(
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
+		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
+		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	))
+	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
+		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
+		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	))
+}
+
 func TestFixedVector(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -128,7 +128,7 @@ func TestVectorConstantExplain(t *testing.T) {
 	))
 	tk.MustExec("set session tidb_redact_log=marker")
 	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
-		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, <[1,2,3,4,5,(6 more)...]>)->Column#3",
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, ‹[1,2,3,4,5,(6 more)...]›)->Column#3",
 		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
 		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
 	))

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -114,13 +114,21 @@ func TestVectorConstantExplain(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE t(c VECTOR);")
+	tk.MustExec("set session tidb_redact_log=off")
 	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, '[1,2,3,4,5,6,7,8,9,10,11]') FROM t;`).Check(testkit.Rows(
 		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
 		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
 		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
 	))
+	tk.MustExec("set session tidb_redact_log=on")
 	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
-		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, ?)->Column#3",
+		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
+		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	))
+	tk.MustExec("set session tidb_redact_log=marker")
+	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, <[1,2,3,4,5,(6 more)...]>)->Column#3",
 		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
 		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
 	))

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -927,7 +927,7 @@ func (d *Datum) compareMysqlTime(ctx Context, time Time) (int, error) {
 	}
 }
 
-func (d *Datum) compareVectorFloat32(ctx Context, vec VectorFloat32) (int, error) {
+func (d *Datum) compareVectorFloat32(_ Context, vec VectorFloat32) (int, error) {
 	switch d.k {
 	case KindNull, KindMinNotNull:
 		return -1, nil
@@ -2084,12 +2084,7 @@ func (d *Datum) ToString() (string, error) {
 
 // StringWithCtx implements Explainable interface.
 func (d *Datum) StringWithCtx(ctx ParamValues, redact string) string {
-	switch d.Kind() {
-	case KindVectorFloat32:
-		return d.GetVectorFloat32().StringWithCtx(ctx, redact)
-	default:
-		return fmt.Sprintf("%v", d.GetValue())
-	}
+	return d.GetVectorFloat32().StringWithCtx(ctx, redact)
 }
 
 // ToBytes gets the bytes representation of the datum.

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2082,6 +2082,16 @@ func (d *Datum) ToString() (string, error) {
 	}
 }
 
+// StringWithCtx implements Explainable interface.
+func (d *Datum) StringWithCtx(ctx ParamValues, redact string) string {
+	switch d.Kind() {
+	case KindVectorFloat32:
+		return d.GetVectorFloat32().StringWithCtx(ctx, redact)
+	default:
+		return fmt.Sprintf("%v", d.GetValue())
+	}
+}
+
 // ToBytes gets the bytes representation of the datum.
 func (d *Datum) ToBytes() ([]byte, error) {
 	switch d.k {

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2082,9 +2082,14 @@ func (d *Datum) ToString() (string, error) {
 	}
 }
 
-// StringWithCtx implements Explainable interface.
-func (d *Datum) StringWithCtx(ctx ParamValues, redact string) string {
-	return d.GetVectorFloat32().StringWithCtx(ctx, redact)
+// StringTruncate truncate long string.
+func (d *Datum) StringTruncate() string {
+	switch d.k {
+	case KindVectorFloat32:
+		return d.GetVectorFloat32().StringTruncate()
+	default:
+		return fmt.Sprintf("%v", d.GetValue())
+	}
 }
 
 // ToBytes gets the bytes representation of the datum.

--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -26,12 +26,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/types"
 )
 
-// ParamValues is a readonly interface to return param
-type ParamValues interface {
-	// GetParamValue returns the value of the parameter by index.
-	GetParamValue(idx int) (Datum, error)
-}
-
 func init() {
 	var buf [4]byte
 	binary.NativeEndian.PutUint32(buf[:], 0x2)
@@ -100,14 +94,8 @@ func (v VectorFloat32) Elements() []float32 {
 	return unsafe.Slice((*float32)(unsafe.Pointer(&v.data[4])), l)
 }
 
-// StringWithCtx implements Explainable interface.
-// In EXPLAIN context, we truncate the elements to avoid too long output.
-func (v VectorFloat32) StringWithCtx(ctx ParamValues, redact string) string {
-	return v.StringWithRedact(ctx, redact)
-}
-
-// StringWithRedact parse vector into string with redact mode.
-func (v VectorFloat32) StringWithRedact(ctx ParamValues, redact string) string {
+// StringTruncate truncate vector to a readable format.
+func (v VectorFloat32) StringTruncate() string {
 	const (
 		maxDisplayElements = 5
 	)
@@ -121,33 +109,18 @@ func (v VectorFloat32) StringWithRedact(ctx ParamValues, redact string) string {
 	}
 
 	buf := make([]byte, 0, 2+v.Len()*2)
-	if redact == errors.RedactLogDisable {
-		buf = append(buf, '[')
-		for i, v := range elements {
-			if i > 0 {
-				buf = append(buf, ","...)
-			}
-			buf = strconv.AppendFloat(buf, float64(v), 'g', 2, 32)
+	buf = append(buf, '[')
+	for i, v := range elements {
+		if i > 0 {
+			buf = append(buf, ","...)
 		}
-		if truncatedElements > 0 {
-			buf = append(buf, fmt.Sprintf(",(%d more)...", truncatedElements)...)
-		}
-		buf = append(buf, ']')
-	} else if redact == errors.RedactLogMarker {
-		buf = append(buf, '<', '[')
-		for i, v := range elements {
-			if i > 0 {
-				buf = append(buf, ","...)
-			}
-			buf = strconv.AppendFloat(buf, float64(v), 'g', 2, 32)
-		}
-		if truncatedElements > 0 {
-			buf = append(buf, fmt.Sprintf(",(%d more)...", truncatedElements)...)
-		}
-		buf = append(buf, ']', '>')
-	} else {
-		buf = append(buf, '?')
+		buf = strconv.AppendFloat(buf, float64(v), 'g', 2, 32)
 	}
+	if truncatedElements > 0 {
+		buf = append(buf, fmt.Sprintf(",(%d more)...", truncatedElements)...)
+	}
+	buf = append(buf, ']')
+
 	// buf is not used elsewhere, so it's safe to just cast to String
 	return unsafe.String(unsafe.SliceData(buf), len(buf))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54245 

Problem Summary:

### What changed and how does it work?
It is very likely that user passes a vector with very high dimension (e.g. dimension of 1000). Previously we output all values when such SQL is explained, which makes the explain hard to read.

This PR shortens the output and truncates the vector to display only first several elements.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
