### PR TITLE
sessionctx: fix a deadlock when set `tidb_restricted_read_only = true`

### DIFF
--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -823,10 +823,11 @@ var defaultSysVars = []*SysVar{
 		on := TiDBOptOn(val)
 		// For user initiated SET GLOBAL, also change the value of TiDBSuperReadOnly
 		if on && s.StmtCtx.StmtType == "Set" {
-			err := s.GlobalVarsAccessor.SetGlobalSysVar(context.Background(), TiDBSuperReadOnly, "ON")
+			err := s.GlobalVarsAccessor.SetGlobalSysVarOnly(context.Background(), TiDBSuperReadOnly, "ON", false)
 			if err != nil {
 				return err
 			}
+			VarTiDBSuperReadOnly.Store(on)
 		}
 		RestrictedReadOnly.Store(on)
 		return nil

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -827,7 +827,10 @@ var defaultSysVars = []*SysVar{
 			if err != nil {
 				return err
 			}
-			GetSysVar(TiDBSuperReadOnly).SetGlobal(context.Background(), s, "ON")
+			err = GetSysVar(TiDBSuperReadOnly).SetGlobal(context.Background(), s, "ON")
+			if err != nil {
+				return err
+			}
 		}
 		RestrictedReadOnly.Store(on)
 		return nil

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -827,7 +827,7 @@ var defaultSysVars = []*SysVar{
 			if err != nil {
 				return err
 			}
-			VarTiDBSuperReadOnly.Store(on)
+			GetSysVar(TiDBSuperReadOnly).SetGlobal(context.Background(), s, "ON")
 		}
 		RestrictedReadOnly.Store(on)
 		return nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55373, close #53822, 

Problem Summary: follow https://github.com/pingcap/tidb/pull/40283

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

run shell below, reach more than 10000
```shell
count=0
while true; do
mysql -h 127.0.0.1 -P 4000 -u root -e "set global tidb_restricted_read_only = 1;set global tidb_restricted_read_only = 0;";
count=$((count+1))
echo "$count"
done
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
