### PR TITLE
expression: Truncate long strings in EXPLAIN

### DIFF
--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -156,8 +156,22 @@ func (c *Constant) StringWithCtx(ctx ParamValues, redact string) string {
 		return c.Value.StringWithCtx(ctx, redact)
 	}
 	if redact == perrors.RedactLogDisable {
+		if c.Value.Kind() == types.KindString || c.Value.Kind() == types.KindBytes {
+			str := c.Value.GetString()
+			if len(str) > 64 {
+				str = fmt.Sprintf("%s(len:%d)", str[:64], len(str))
+			}
+			return str
+		}
 		return fmt.Sprintf("%v", c.Value.GetValue())
 	} else if redact == perrors.RedactLogMarker {
+		if c.Value.Kind() == types.KindString || c.Value.Kind() == types.KindBytes {
+			str := c.Value.GetString()
+			if len(str) > 64 {
+				str = fmt.Sprintf("<%s(len:%d)>", str[:64], len(str))
+			}
+			return str
+		}
 		return fmt.Sprintf("‹%v›", c.Value.GetValue())
 	}
 	return "?"

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -152,6 +152,9 @@ func (c *Constant) StringWithCtx(ctx ParamValues, redact string) string {
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.StringWithCtx(ctx, redact)
 	}
+	if c.RetType.GetType() == mysql.TypeTiDBVectorFloat32 {
+		return c.Value.StringWithCtx(ctx, redact)
+	}
 	if redact == perrors.RedactLogDisable {
 		return fmt.Sprintf("%v", c.Value.GetValue())
 	} else if redact == perrors.RedactLogMarker {

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -152,7 +152,7 @@ func (c *Constant) StringWithCtx(ctx ParamValues, redact string) string {
 	} else if c.DeferredExpr != nil {
 		return c.DeferredExpr.StringWithCtx(ctx, redact)
 	}
-	if c.RetType.GetType() == mysql.TypeTiDBVectorFloat32 {
+	if c.Value.Kind() == types.KindVectorFloat32 {
 		return c.Value.StringWithCtx(ctx, redact)
 	}
 	if redact == perrors.RedactLogDisable {

--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 41,
+    shard_count = 42,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/types",
         "//pkg/util/codec",
         "//pkg/util/collate",
+        "//pkg/util/plancodec",
         "//pkg/util/sem",
         "//pkg/util/timeutil",
         "//pkg/util/versioninfo",

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -109,6 +109,23 @@ func TestVectorColumnInfo(t *testing.T) {
 	tk.MustGetErrMsg("create table t(embedding VECTOR(16384))", "vector cannot have more than 16383 dimensions")
 }
 
+func TestVectorConstantExplain(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE t(c VECTOR);")
+	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, '[1,2,3,4,5,6,7,8,9,10,11]') FROM t;`).Check(testkit.Rows(
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
+		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
+		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	))
+	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
+		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
+		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	))
+}
+
 func TestFixedVector(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -114,13 +114,21 @@ func TestVectorConstantExplain(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE t(c VECTOR);")
+	tk.MustExec("set session tidb_redact_log=off")
 	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, '[1,2,3,4,5,6,7,8,9,10,11]') FROM t;`).Check(testkit.Rows(
 		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
 		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
 		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
 	))
+	tk.MustExec("set session tidb_redact_log=on")
 	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
-		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, [1,2,3,4,5,(6 more)...])->Column#3",
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, ?)->Column#3",
+		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
+		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
+	))
+	tk.MustExec("set session tidb_redact_log=marker")
+	tk.MustQuery(`EXPLAIN SELECT VEC_COSINE_DISTANCE(c, VEC_FROM_TEXT('[1,2,3,4,5,6,7,8,9,10,11]')) FROM t;`).Check(testkit.Rows(
+		"Projection_3 10000.00 root  vec_cosine_distance(test.t.c, <[1,2,3,4,5,(6 more)...]>)->Column#3",
 		"└─TableReader_5 10000.00 root  data:TableFullScan_4",
 		"  └─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo",
 	))

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -927,7 +927,7 @@ func (d *Datum) compareMysqlTime(ctx Context, time Time) (int, error) {
 	}
 }
 
-func (d *Datum) compareVectorFloat32(ctx Context, vec VectorFloat32) (int, error) {
+func (d *Datum) compareVectorFloat32(_ Context, vec VectorFloat32) (int, error) {
 	switch d.k {
 	case KindNull, KindMinNotNull:
 		return -1, nil
@@ -2084,12 +2084,7 @@ func (d *Datum) ToString() (string, error) {
 
 // StringWithCtx implements Explainable interface.
 func (d *Datum) StringWithCtx(ctx ParamValues, redact string) string {
-	switch d.Kind() {
-	case KindVectorFloat32:
-		return d.GetVectorFloat32().StringWithCtx(ctx, redact)
-	default:
-		return fmt.Sprintf("%v", d.GetValue())
-	}
+	return d.GetVectorFloat32().StringWithCtx(ctx, redact)
 }
 
 // ToBytes gets the bytes representation of the datum.

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2082,6 +2082,16 @@ func (d *Datum) ToString() (string, error) {
 	}
 }
 
+// StringWithCtx implements Explainable interface.
+func (d *Datum) StringWithCtx(ctx ParamValues, redact string) string {
+	switch d.Kind() {
+	case KindVectorFloat32:
+		return d.GetVectorFloat32().StringWithCtx(ctx, redact)
+	default:
+		return fmt.Sprintf("%v", d.GetValue())
+	}
+}
+
 // ToBytes gets the bytes representation of the datum.
 func (d *Datum) ToBytes() ([]byte, error) {
 	switch d.k {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54245 

Problem Summary:
When used with prepared statement, there will be a CAST(String, Vector<Float32>) in the plan. Previously, we did not correctly truncate long strings. This result in very large slow log when there are vector queries.

### What changed and how does it work?
Truncate long strings, so that in vector query scenarios logs will not bloat too much.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
