### PR TITLE
server, client-go: sleep before restarting and replace client-go with a patched version (DNM)

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -328,8 +328,11 @@ func main() {
 
 	exited := make(chan struct{})
 	signal.SetupSignalHandler(func() {
+		logutil.BgLogger().Info("got signal to exit")
 		svr.Close()
+		logutil.BgLogger().Info("after closing the server")
 		cleanup(svr, storage, dom)
+		logutil.BgLogger().Info("after cleanup")
 		cpuprofile.StopCPUProfiler()
 		resourcemanager.InstanceResourceManager.Stop()
 		executor.Stop()

--- a/go.mod
+++ b/go.mod
@@ -329,6 +329,9 @@ replace (
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
 	github.com/pingcap/tidb/pkg/parser => ./pkg/parser
 
+	// For debug
+	github.com/tikv/client-go/v2 => github.com/YangKeao/client-go/v2 v2.0.1-0.20240815134705-0f240d6c1040
+
 	// TODO: `sourcegraph.com/sourcegraph/appdash` has been archived, and the original host has been removed.
 	// Please remove these dependencies.
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
+github.com/YangKeao/client-go/v2 v2.0.1-0.20240815134705-0f240d6c1040 h1:EF73XT1OStYrvu9qyjltEJPfx2Y1e3cdRm8kWcBHwQE=
+github.com/YangKeao/client-go/v2 v2.0.1-0.20240815134705-0f240d6c1040/go.mod h1:4HDOAx8OXAJPtqhCZ03IhChXgaFs4B3+vSrPWmiPxjg=
 github.com/YangKeao/go-mysql-driver v0.0.0-20240627104025-dd5589458cfa h1:mx7rQczQb38AWgiFJsuwvygvOnktsz/mknqUJNByB1Q=
 github.com/YangKeao/go-mysql-driver v0.0.0-20240627104025-dd5589458cfa/go.mod h1:qn/VrHolklFxsKZNciiayiHO5qi+2v1TN5jEKDkPC2g=
 github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117 h1:+OqGGFc2YHFd82aSHmjlILVt1t4JWJjrNIfV8cVEPow=
@@ -852,8 +854,6 @@ github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
-github.com/tikv/client-go/v2 v2.0.8-0.20240813045544-4c6b2171b262 h1:BgN8ALPyjYR+6LoHmeUoiPog6CXp1BwC9KcYUMpAnPw=
-github.com/tikv/client-go/v2 v2.0.8-0.20240813045544-4c6b2171b262/go.mod h1:4HDOAx8OXAJPtqhCZ03IhChXgaFs4B3+vSrPWmiPxjg=
 github.com/tikv/pd/client v0.0.0-20240805092608-838ee7983b78 h1:PtW+yTvs9eGTMblulaCHmJ5OtifuE4SJXCACCtkd6ko=
 github.com/tikv/pd/client v0.0.0-20240805092608-838ee7983b78/go.mod h1:TxrJRY949Vl14Lmarx6hTNP/HEDYzn4dP0KmjdzQ59w=
 github.com/timakin/bodyclose v0.0.0-20240125160201-f835fa56326a h1:A6uKudFIfAEpoPdaal3aSqGxBzLyU8TqyXImLwo6dIo=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1029,6 +1029,18 @@ func (s *Server) DrainClients(drainWait time.Duration, cancelWait time.Duration)
 	case <-time.After(cancelWait):
 		logger.Warn("some sessions do not quit in cancel wait time")
 	}
+
+	// Set the duration to wait in seconds
+	waitTime := 15
+
+	logutil.BgLogger().Info(fmt.Sprintf("Waiting for %d seconds...", waitTime))
+
+	for i := waitTime; i > 0; i-- {
+		logger.Info(fmt.Sprintf("Remaining time: %d seconds", i))
+		time.Sleep(time.Second)
+	}
+
+	logutil.BgLogger().Info("Time's up!")
 }
 
 // ServerID implements SessionManager interface.


### PR DESCRIPTION
### What problem does this PR solve?

It tries to avoid leaking stale lock after restarting TiDB.

Issue Number: None

This PR is only used to do experiments. It's not a good solution. If it's proved to be effective, we'll consider to have a better solution.

### What changed and how does it work?

1. Add extra waiting time before closing the TiDB (similar to https://github.com/pingcap/tidb/pull/52895).
2. Use a patched client-go https://github.com/tikv/client-go/pull/1424

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
