### PR TITLE
*: add extractor for cluster_tidb_index_usage

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -221,8 +221,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableTiDBIndexUsage:
 			err = e.setDataFromIndexUsage(ctx, sctx)
 		case infoschema.ClusterTableTiDBIndexUsage:
-			dbs := getAllSchemas()
-			err = e.setDataFromClusterIndexUsage(ctx, sctx, dbs)
+			err = e.setDataFromClusterIndexUsage(ctx, sctx)
 		}
 		if err != nil {
 			return nil, err
@@ -3687,65 +3686,6 @@ func (e *memtableRetriever) setDataFromKeywords() error {
 	return nil
 }
 
-func (e *memtableRetriever) setDataForClusterIndexUsage(ctx context.Context, sctx sessionctx.Context, schemas []model.CIStr) error {
-	dom := domain.GetDomain(sctx)
-	rows := make([][]types.Datum, 0, 100)
-	checker := privilege.GetPrivilegeManager(sctx)
-	extractor, ok := e.extractor.(*plannercore.InfoSchemaIndexUsageExtractor)
-	if ok && extractor.SkipRequest {
-		return nil
-	}
-
-	for _, schema := range schemas {
-		if ok && extractor.Filter("table_schema", schema.L) {
-			continue
-		}
-		tables, err := dom.InfoSchema().SchemaTableInfos(ctx, schema)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		for _, tbl := range tables {
-			if ok && extractor.Filter("table_name", tbl.Name.L) {
-				continue
-			}
-			allowed := checker == nil || checker.RequestVerification(
-				sctx.GetSessionVars().ActiveRoles,
-				schema.L, tbl.Name.L, "", mysql.AllPrivMask)
-			if !allowed {
-				continue
-			}
-
-			for _, idx := range tbl.Indices {
-				if ok && extractor.Filter("index_name", idx.Name.L) {
-					continue
-				}
-				row := make([]types.Datum, 0, 14)
-				usage := dom.StatsHandle().GetIndexUsage(tbl.ID, idx.ID)
-				row = append(row, types.NewStringDatum(schema.O))
-				row = append(row, types.NewStringDatum(tbl.Name.O))
-				row = append(row, types.NewStringDatum(idx.Name.O))
-				row = append(row, types.NewIntDatum(int64(usage.QueryTotal)))
-				row = append(row, types.NewIntDatum(int64(usage.KvReqTotal)))
-				row = append(row, types.NewIntDatum(int64(usage.RowAccessTotal)))
-				for _, percentage := range usage.PercentageAccess {
-					row = append(row, types.NewIntDatum(int64(percentage)))
-				}
-				lastUsedAt := types.Datum{}
-				lastUsedAt.SetNull()
-				if !usage.LastUsedAt.IsZero() {
-					t := types.NewTime(types.FromGoTime(usage.LastUsedAt), mysql.TypeTimestamp, 0)
-					lastUsedAt = types.NewTimeDatum(t)
-				}
-				row = append(row, lastUsedAt)
-				rows = append(rows, row)
-			}
-		}
-	}
-
-	e.rows = rows
-	return nil
-}
-
 func (e *memtableRetriever) setDataFromIndexUsage(ctx context.Context, sctx sessionctx.Context) error {
 	dom := domain.GetDomain(sctx)
 	rows := make([][]types.Datum, 0, 100)
@@ -3801,9 +3741,8 @@ func (e *memtableRetriever) setDataFromIndexUsage(ctx context.Context, sctx sess
 	return nil
 }
 
-// Currently, ClusterIndexUsage will not be be pushed down, so just use the previous logic
-func (e *memtableRetriever) setDataFromClusterIndexUsage(ctx context.Context, sctx sessionctx.Context, schemas []model.CIStr) error {
-	err := e.setDataForClusterIndexUsage(ctx, sctx, schemas)
+func (e *memtableRetriever) setDataFromClusterIndexUsage(ctx context.Context, sctx sessionctx.Context) error {
+	err := e.setDataFromIndexUsage(ctx, sctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3691,7 +3691,7 @@ func (e *memtableRetriever) setDataForClusterIndexUsage(ctx context.Context, sct
 	dom := domain.GetDomain(sctx)
 	rows := make([][]types.Datum, 0, 100)
 	checker := privilege.GetPrivilegeManager(sctx)
-	extractor, ok := e.extractor.(*plannercore.InfoSchemaBaseExtractor)
+	extractor, ok := e.extractor.(*plannercore.InfoSchemaIndexUsageExtractor)
 	if ok && extractor.SkipRequest {
 		return nil
 	}

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -108,8 +108,9 @@ func init() {
 	}
 }
 
-// isClusterTableByName used to check whether the table is a cluster memory table.
-func isClusterTableByName(dbName, tableName string) bool {
+// IsClusterTableByName used to check whether the table is a cluster memory table.
+// Export for PhysicalTableScan.ExplainID
+func IsClusterTableByName(dbName, tableName string) bool {
 	dbName = strings.ToUpper(dbName)
 	switch dbName {
 	case util.InformationSchemaName.O, util.PerformanceSchemaName.O:

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -2359,7 +2359,7 @@ func createInfoSchemaTable(_ autoid.Allocators, _ func() (pools.Resource, error)
 		columns[i] = table.ToColumn(col)
 	}
 	tp := table.VirtualTable
-	if isClusterTableByName(util.InformationSchemaName.O, meta.Name.O) {
+	if IsClusterTableByName(util.InformationSchemaName.O, meta.Name.O) {
 		tp = table.ClusterTable
 	}
 	return &infoschemaTable{meta: meta, cols: columns, tp: tp}, nil

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -23,6 +23,7 @@ import (
 	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
+	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -166,7 +167,9 @@ func (p *PhysicalTableScan) ExplainID() fmt.Stringer {
 
 // TP overrides the TP in order to match different range.
 func (p *PhysicalTableScan) TP() string {
-	if p.isChildOfIndexLookUp {
+	if infoschema.IsClusterTableByName(p.DBName.O, p.Table.Name.O) {
+		return plancodec.TypeMemTableScan
+	} else if p.isChildOfIndexLookUp {
 		return plancodec.TypeTableRowIDScan
 	} else if p.isFullScan() {
 		return plancodec.TypeTableFullScan

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -189,6 +189,10 @@ func (p *PhysicalTableScan) ExplainNormalizedInfo() string {
 
 // OperatorInfo implements dataAccesser interface.
 func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
+	if infoschema.IsClusterTableByName(p.DBName.O, p.Table.Name.O) {
+		return ""
+	}
+
 	ectx := p.SCtx().GetExprCtx().GetEvalCtx()
 	redact := p.SCtx().GetSessionVars().EnableRedactLog
 	var buffer strings.Builder

--- a/pkg/planner/core/pb_to_plan.go
+++ b/pkg/planner/core/pb_to_plan.go
@@ -131,6 +131,10 @@ func (b *PBPlanBuilder) pbToTableScan(e *tipb.Executor) (base.PhysicalPlan, erro
 		p.Extractor = extractor
 	case infoschema.ClusterTableStatementsSummary, infoschema.ClusterTableStatementsSummaryHistory:
 		p.Extractor = &StatementsSummaryExtractor{}
+	case infoschema.ClusterTableTiDBIndexUsage:
+		ex := &InfoSchemaIndexUsageExtractor{}
+		ex.initExtractableColNames(infoschema.TableTiDBIndexUsage)
+		p.Extractor = ex
 	}
 	return p, nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50305

### What changed and how does it work?

`InfoSchemaIndexUsageExtractor` is added for cluster_tidb_index usage memtable.

Besides, the explain output of cluster memory table is changed to make it consistent with other memtable.

```
mysql> explain select * from information_schema.CLUSTER_TIDB_INDEX_USAGE where table_schema = "test";    
+------------------------+----------+-----------+--------------------------------+----------------------------------------------------------------------+
| id                     | estRows  | task      | access object                  | operator info                                                        |
+------------------------+----------+-----------+--------------------------------+----------------------------------------------------------------------+
| TableReader_7          | 10.00    | root      |                                | data:Selection_6                                                     |
| └─Selection_6          | 10.00    | cop[tidb] |                                | eq(information_schema.cluster_tidb_index_usage.table_schema, "test") |
|   └─MemTableScan_5     | 10000.00 | cop[tidb] | table:CLUSTER_TIDB_INDEX_USAGE |                                                                      |
+------------------------+----------+-----------+--------------------------------+----------------------------------------------------------------------+
```

Before:

```
mysql> explain select * from information_schema.CLUSTER_TIDB_INDEX_USAGE where table_schema = "test";                                                                                 
+-------------------------+----------+-----------+--------------------------------+----------------------------------------------------------------------+                            
| id                      | estRows  | task      | access object                  | operator info                                                        |                            
+-------------------------+----------+-----------+--------------------------------+----------------------------------------------------------------------+                            
| TableReader_7           | 10.00    | root      |                                | data:Selection_6                                                     |                            
| └─Selection_6           | 10.00    | cop[tidb] |                                | eq(information_schema.cluster_tidb_index_usage.table_schema, "test") |                            
|   └─TableFullScan_5     | 10000.00 | cop[tidb] | table:CLUSTER_TIDB_INDEX_USAGE | keep order:false, stats:pseudo                                       |                            
+-------------------------+----------+-----------+--------------------------------+----------------------------------------------------------------------+                            
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

