### PR TITLE
executor: fix query hang when sorted column is constant

### DIFF
--- a/pkg/executor/sortexec/BUILD.bazel
+++ b/pkg/executor/sortexec/BUILD.bazel
@@ -42,7 +42,7 @@ go_test(
     timeout = "short",
     srcs = ["sort_test.go"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/config",
         "//pkg/sessionctx/variable",

--- a/pkg/executor/sortexec/parallel_sort_spill_test.go
+++ b/pkg/executor/sortexec/parallel_sort_spill_test.go
@@ -166,7 +166,7 @@ func TestIssue55344(t *testing.T) {
 	// Test correctness
 	tk.MustExec("drop table if exists t1;")
 	tk.MustExec("CREATE TABLE t1(c int);")
-	valueNum := 100
+	valueNum := 100 // TODO change to 1000
 	insertedValues := make([]int, 0, valueNum)
 	for i := 0; i < valueNum; i++ {
 		insertedValues = append(insertedValues, rand.Intn(10000))

--- a/pkg/executor/sortexec/parallel_sort_spill_test.go
+++ b/pkg/executor/sortexec/parallel_sort_spill_test.go
@@ -15,17 +15,12 @@
 package sortexec_test
 
 import (
-	"fmt"
-	"math/rand"
-	"sort"
 	"testing"
 
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/executor/internal/testutil"
 	"github.com/pingcap/tidb/pkg/executor/sortexec"
 	"github.com/pingcap/tidb/pkg/expression"
-	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
@@ -147,43 +142,4 @@ func TestParallelSortSpillDiskFailpoint(t *testing.T) {
 		failpointDataInMemoryThenSpillTest(t, ctx, nil, sortCase, dataSource)
 		failpointDataInMemoryThenSpillTest(t, ctx, exe, sortCase, dataSource)
 	}
-}
-
-func TestIssue55344(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("set @@tidb_max_chunk_size=32")
-	tk.MustExec("set @@tidb_init_chunk_size=1")
-	tk.MustExec("drop table if exists t0;")
-	tk.MustExec("CREATE TABLE t0(c0 BOOL);")
-	tk.MustExec("INSERT INTO mysql.opt_rule_blacklist VALUES('predicate_push_down'),('column_prune');")
-	tk.MustExec("ADMIN reload opt_rule_blacklist;")
-
-	// Should not be panic
-	tk.MustQuery("SELECT t0.c0 FROM t0 WHERE 0 ORDER BY -646041453 ASC;")
-
-	// Test correctness
-	tk.MustExec("drop table if exists t1;")
-	tk.MustExec("CREATE TABLE t1(c int);")
-	valueNum := 100 // TODO change to 1000
-	insertedValues := make([]int, 0, valueNum)
-	for i := 0; i < valueNum; i++ {
-		insertedValues = append(insertedValues, rand.Intn(10000))
-	}
-
-	insertSql := fmt.Sprintf("INSERT INTO t1 values (%d)", insertedValues[0])
-	for i := 1; i < valueNum; i++ {
-		insertSql = fmt.Sprintf("%s, (%d)", insertSql, insertSql[i])
-	}
-	insertSql += ";"
-
-	tk.MustExec(insertSql)
-	sort.Ints(insertedValues)
-
-	result := tk.MustQuery("select c from t1 order by c;")
-	log.Info(fmt.Sprintf("xzxdebug %s", result.String())) // TODO delete it
-
-	tk.MustExec("delete from mysql.opt_rule_blacklist where name='column_prune' or name='predicate_push_down';")
-	tk.MustExec("ADMIN reload opt_rule_blacklist;")
 }

--- a/pkg/executor/sortexec/parallel_sort_spill_test.go
+++ b/pkg/executor/sortexec/parallel_sort_spill_test.go
@@ -157,6 +157,6 @@ func TestIssue55344(t *testing.T) {
 	// Should not be panic
 	tk.MustQuery("SELECT t0.c0 FROM t0 WHERE 0 ORDER BY -646041453 ASC;")
 
-	tk.MustExec("delete from mysql.opt_rule_blacklist;")
+	tk.MustExec("delete from mysql.opt_rule_blacklist where name='column_prune' or name='predicate_push_down';")
 	tk.MustExec("ADMIN reload opt_rule_blacklist;")
 }

--- a/pkg/executor/sortexec/parallel_sort_spill_test.go
+++ b/pkg/executor/sortexec/parallel_sort_spill_test.go
@@ -156,4 +156,7 @@ func TestIssue55344(t *testing.T) {
 
 	// Should not be panic
 	tk.MustQuery("SELECT t0.c0 FROM t0 WHERE 0 ORDER BY -646041453 ASC;")
+
+	tk.MustExec("delete from mysql.opt_rule_blacklist;")
+	tk.MustExec("ADMIN reload opt_rule_blacklist;")
 }

--- a/pkg/executor/sortexec/parallel_sort_test.go
+++ b/pkg/executor/sortexec/parallel_sort_test.go
@@ -178,7 +178,7 @@ func TestIssue55344(t *testing.T) {
 	tk.MustExec(insertSql)
 	sort.Ints(insertedValues)
 
-	result := tk.MustQuery("select c from t1 order by c;")
+	result := tk.MustQuery("select c from t1 order by c, -646041453;")
 
 	sort.Ints(insertedValues)
 	expectValue := fmt.Sprintf("%d", insertedValues[0])

--- a/pkg/executor/sortexec/parallel_sort_test.go
+++ b/pkg/executor/sortexec/parallel_sort_test.go
@@ -169,13 +169,13 @@ func TestIssue55344(t *testing.T) {
 		insertedValues = append(insertedValues, rand.Intn(10000))
 	}
 
-	insertSql := fmt.Sprintf("INSERT INTO t1 values (%d)", insertedValues[0])
+	insertSQL := fmt.Sprintf("INSERT INTO t1 values (%d)", insertedValues[0])
 	for i := 1; i < valueNum; i++ {
-		insertSql = fmt.Sprintf("%s, (%d)", insertSql, insertedValues[i])
+		insertSQL = fmt.Sprintf("%s, (%d)", insertSQL, insertedValues[i])
 	}
-	insertSql += ";"
+	insertSQL += ";"
 
-	tk.MustExec(insertSql)
+	tk.MustExec(insertSQL)
 	sort.Ints(insertedValues)
 
 	expectValue := fmt.Sprintf("%d", insertedValues[0])

--- a/pkg/executor/sortexec/parallel_sort_test.go
+++ b/pkg/executor/sortexec/parallel_sort_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ngaut/log"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/executor/internal/testutil"
 	"github.com/pingcap/tidb/pkg/executor/sortexec"

--- a/pkg/executor/sortexec/parallel_sort_test.go
+++ b/pkg/executor/sortexec/parallel_sort_test.go
@@ -16,16 +16,20 @@ package sortexec_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
+	"sort"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/ngaut/log"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/executor/internal/testutil"
 	"github.com/pingcap/tidb/pkg/executor/sortexec"
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
@@ -141,4 +145,43 @@ func TestFailpoint(t *testing.T) {
 		failpointTest(t, ctx, nil, sortCase, dataSource)
 		failpointTest(t, ctx, exe, sortCase, dataSource)
 	}
+}
+
+func TestIssue55344(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_max_chunk_size=32")
+	tk.MustExec("set @@tidb_init_chunk_size=1")
+	tk.MustExec("drop table if exists t0;")
+	tk.MustExec("CREATE TABLE t0(c0 BOOL);")
+	tk.MustExec("INSERT INTO mysql.opt_rule_blacklist VALUES('predicate_push_down'),('column_prune');")
+	tk.MustExec("ADMIN reload opt_rule_blacklist;")
+
+	// Should not be panic
+	tk.MustQuery("SELECT t0.c0 FROM t0 WHERE 0 ORDER BY -646041453 ASC;")
+
+	// Test correctness
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("CREATE TABLE t1(c int);")
+	valueNum := 100 // TODO change to 1000
+	insertedValues := make([]int, 0, valueNum)
+	for i := 0; i < valueNum; i++ {
+		insertedValues = append(insertedValues, rand.Intn(10000))
+	}
+
+	insertSql := fmt.Sprintf("INSERT INTO t1 values (%d)", insertedValues[0])
+	for i := 1; i < valueNum; i++ {
+		insertSql = fmt.Sprintf("%s, (%d)", insertSql, insertSql[i])
+	}
+	insertSql += ";"
+
+	tk.MustExec(insertSql)
+	sort.Ints(insertedValues)
+
+	result := tk.MustQuery("select c from t1 order by c;")
+	log.Info(fmt.Sprintf("xzxdebug %s", result.String())) // TODO delete it
+
+	tk.MustExec("delete from mysql.opt_rule_blacklist where name='column_prune' or name='predicate_push_down';")
+	tk.MustExec("ADMIN reload opt_rule_blacklist;")
 }

--- a/pkg/executor/sortexec/parallel_sort_test.go
+++ b/pkg/executor/sortexec/parallel_sort_test.go
@@ -178,14 +178,18 @@ func TestIssue55344(t *testing.T) {
 	tk.MustExec(insertSql)
 	sort.Ints(insertedValues)
 
-	result := tk.MustQuery("select c from t1 order by c, -646041453;")
-
-	sort.Ints(insertedValues)
 	expectValue := fmt.Sprintf("%d", insertedValues[0])
 	for i := 1; i < valueNum; i++ {
 		expectValue = fmt.Sprintf("%s\n%d", expectValue, insertedValues[i])
 	}
 
+	result := tk.MustQuery("select c from t1 order by c, -646041453;")
+	require.Equal(t, expectValue, result.String())
+	result = tk.MustQuery("select c from t1 order by -646041453, c;")
+	require.Equal(t, expectValue, result.String())
+	result = tk.MustQuery("select c from t1 order by c, -646041453, c+1;")
+	require.Equal(t, expectValue, result.String())
+	result = tk.MustQuery("select c from t1 order by c+1, -646041453, c;")
 	require.Equal(t, expectValue, result.String())
 
 	tk.MustExec("delete from mysql.opt_rule_blacklist where name='column_prune' or name='predicate_push_down';")

--- a/pkg/executor/sortexec/sort.go
+++ b/pkg/executor/sortexec/sort.go
@@ -101,6 +101,7 @@ type SortExec struct {
 func (e *SortExec) closeChannels() {
 	close(e.Parallel.resultChannel)
 	close(e.Parallel.chunkChannel)
+	close(e.Parallel.closeSync)
 }
 
 // Close implements the Executor Close interface.

--- a/pkg/executor/sortexec/sort.go
+++ b/pkg/executor/sortexec/sort.go
@@ -795,6 +795,7 @@ func (e *SortExec) buildKeyColumns() error {
 		case *expression.Column:
 			e.keyColumns = append(e.keyColumns, col.Index)
 		case *expression.Constant:
+			// Ignore constant as constant can not affect the sorted result
 		default:
 			return errors.NewNoStackError("Get unexpected expression")
 		}

--- a/pkg/executor/sortexec/topn.go
+++ b/pkg/executor/sortexec/topn.go
@@ -268,7 +268,11 @@ func (e *TopNExec) loadChunksUntilTotalLimit(ctx context.Context) error {
 		return err
 	}
 
-	e.buildKeyColumns()
+	err = e.buildKeyColumns()
+	if err != nil {
+		return err
+	}
+
 	e.chkHeap.init(e, e.memTracker, e.Limit.Offset+e.Limit.Count, int(e.Limit.Offset), e.greaterRow, e.RetFieldTypes())
 	for uint64(e.chkHeap.rowChunks.Len()) < e.chkHeap.totalLimit {
 		srcChk := exec.TryNewCacheChunk(e.Children(0))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55344

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that parallel sort may be stuck when sorted column is constant
```
