### PR TITLE
table: Add `GetExchangePartitionDMLSupport` and remove `GetDomainInfoSchema` in `MutateContext`

### DIFF
--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -694,7 +694,7 @@ func (e *InsertValues) fillRow(ctx context.Context, row []types.Datum, hasValue 
 	// Handle exchange partition
 	tbl := e.Table.Meta()
 	if tbl.ExchangePartitionInfo != nil && tbl.GetPartitionInfo() == nil {
-		if err := checkRowForExchangePartition(e.Ctx().GetTableCtx(), row, tbl); err != nil {
+		if err := checkRowForExchangePartition(e.Ctx(), row, tbl); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -83,7 +83,7 @@ func updateRecord(
 	// Handle exchange partition
 	tbl := t.Meta()
 	if tbl.ExchangePartitionInfo != nil && tbl.GetPartitionInfo() == nil {
-		if err := checkRowForExchangePartition(sctx.GetTableCtx(), newData, tbl); err != nil {
+		if err := checkRowForExchangePartition(sctx, newData, tbl); err != nil {
 			return false, err
 		}
 	}
@@ -332,7 +332,7 @@ func resetErrDataTooLong(colName string, rowIdx int, _ error) error {
 
 // checkRowForExchangePartition is only used for ExchangePartition by non-partitionTable during write only state.
 // It check if rowData inserted or updated violate partition definition or checkConstraints of partitionTable.
-func checkRowForExchangePartition(sctx table.MutateContext, row []types.Datum, tbl *model.TableInfo) error {
+func checkRowForExchangePartition(sctx sessionctx.Context, row []types.Datum, tbl *model.TableInfo) error {
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 	pt, tableFound := is.TableByID(context.Background(), tbl.ExchangePartitionInfo.ExchangePartitionTableID)
 	if !tableFound {

--- a/pkg/table/context/table.go
+++ b/pkg/table/context/table.go
@@ -103,13 +103,18 @@ type TemporaryTableSupport interface {
 	AddTemporaryTableToTxn(tblInfo *model.TableInfo) (TemporaryTableHandler, bool)
 }
 
+// ExchangePartitionDMLSupport is used for DML operations when the table exchanging a partition.
+type ExchangePartitionDMLSupport interface {
+	// GetInfoSchemaToCheckExchangeConstraint is used by DML to get the exchanged table to check
+	// constraints when exchanging partition.
+	GetInfoSchemaToCheckExchangeConstraint() infoschema.MetaOnlyInfoSchema
+}
+
 // MutateContext is used to when mutating a table.
 type MutateContext interface {
 	AllocatorContext
 	// GetExprCtx returns the context to build or evaluate expressions
 	GetExprCtx() exprctx.ExprContext
-	// GetDomainInfoSchema returns the latest information schema in domain
-	GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema
 	// ConnectionID returns the id of the current connection.
 	// If the current environment is not in a query from the client, the return value is 0.
 	ConnectionID() uint64
@@ -141,6 +146,9 @@ type MutateContext interface {
 	// GetTemporaryTableSupport returns a `TemporaryTableSupport` if the context supports it.
 	// If the context does not support temporary table, the second return value will be false.
 	GetTemporaryTableSupport() (TemporaryTableSupport, bool)
+	// GetExchangePartitionDMLSupport returns a `ExchangePartitionDMLSupport` if the context supports it.
+	// ExchangePartitionDMLSupport is used by DMLs when the table is exchanging a partition.
+	GetExchangePartitionDMLSupport() (ExchangePartitionDMLSupport, bool)
 }
 
 // AllocatorContext is used to provide context for method `table.Allocators`.

--- a/pkg/table/contextimpl/BUILD.bazel
+++ b/pkg/table/contextimpl/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/expression/context",
+        "//pkg/infoschema/context",
         "//pkg/meta/autoid",
         "//pkg/parser/model",
         "//pkg/sessionctx",

--- a/pkg/table/contextimpl/table.go
+++ b/pkg/table/contextimpl/table.go
@@ -17,6 +17,7 @@ package contextimpl
 import (
 	"github.com/pingcap/failpoint"
 	exprctx "github.com/pingcap/tidb/pkg/expression/context"
+	infoschema "github.com/pingcap/tidb/pkg/infoschema/context"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -177,6 +178,16 @@ func (ctx *TableContextImpl) GetTemporaryTableSupport() (context.TemporaryTableS
 	if ctx.vars().TxnCtx == nil {
 		return nil, false
 	}
+	return ctx, true
+}
+
+// GetInfoSchemaToCheckExchangeConstraint implements the ExchangePartitionDMLSupport interface.
+func (ctx *TableContextImpl) GetInfoSchemaToCheckExchangeConstraint() infoschema.MetaOnlyInfoSchema {
+	return ctx.Context.GetDomainInfoSchema()
+}
+
+// GetExchangePartitionDMLSupport implements the MutateContext interface.
+func (ctx *TableContextImpl) GetExchangePartitionDMLSupport() (context.ExchangePartitionDMLSupport, bool) {
 	return ctx, true
 }
 

--- a/pkg/table/contextimpl/table_test.go
+++ b/pkg/table/contextimpl/table_test.go
@@ -169,4 +169,7 @@ func TestMutateContextImplFields(t *testing.T) {
 	require.Equal(t, int64(333), tmpTblHandler.GetDirtySize())
 	tmpTblHandler.UpdateTxnDeltaSize(-1)
 	require.Equal(t, int64(332), tmpTblHandler.GetDirtySize())
+	exchange, ok := ctx.GetExchangePartitionDMLSupport()
+	require.True(t, ok)
+	require.Same(t, ctx.GetDomainInfoSchema(), exchange.GetInfoSchemaToCheckExchangeConstraint())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53388

Problem Summary:

`MutateContext.GetDomainInfoSchema()` is only used by DML when a DDL exchanging partition is in progress. It is not required in other cases, such as lighting or DDL reorg (adding index). We can make `GetDomainInfoSchema` "optional" so  to make easier to construct `MutateContext` for the scenes who does not need it.

### What changed and how does it work?

- Remove `GetDomainInfoSchema` in `MutateContext`
- Add a new interface `ExchangePartitionDMLSupport` to provide information schema optionally:

```go
// ExchangePartitionDMLSupport is used for DML operations when the table exchanging a partition.
type ExchangePartitionDMLSupport interface {
	// GetInfoSchemaToCheckExchangeConstraint is used by DML to get the exchanged table to check
	// constraints when exchanging partition.
	GetInfoSchemaToCheckExchangeConstraint() infoschema.MetaOnlyInfoSchema
}

type MutateContext interface {
	// ...
	// GetExchangePartitionDMLSupport returns a `ExchangePartitionDMLSupport` if the context supports it.
	// ExchangePartitionDMLSupport is used by DMLs when the table is exchanging a partition.
	GetExchangePartitionDMLSupport() (ExchangePartitionDMLSupport, bool)
}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
