### PR TITLE
expression: remove `SessionVarsPropReader` in `builtinGetParamStringSig`

### DIFF
--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -1616,7 +1616,6 @@ func (c *getParamFunctionClass) getFunction(ctx BuildContext, args []Expression)
 
 type builtinGetParamStringSig struct {
 	baseBuiltinFunc
-	contextopt.SessionVarsPropReader
 }
 
 func (b *builtinGetParamStringSig) Clone() builtinFunc {
@@ -1625,20 +1624,16 @@ func (b *builtinGetParamStringSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinGetParamStringSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
-}
-
 func (b *builtinGetParamStringSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return "", true, err
-	}
 	idx, isNull, err := b.args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	v := sessionVars.PlanCacheParams.GetParamValue(int(idx))
+
+	v, err := ctx.GetParamValue(int(idx))
+	if err != nil {
+		return "", true, err
+	}
 
 	str, err := v.ToString()
 	if err != nil {

--- a/pkg/expression/builtin_other_vec.go
+++ b/pkg/expression/builtin_other_vec.go
@@ -126,10 +126,6 @@ func (b *builtinGetParamStringSig) vectorized() bool {
 }
 
 func (b *builtinGetParamStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return err
-	}
 	n := input.NumRows()
 	idx, err := b.bufAllocator.get()
 	if err != nil {
@@ -147,7 +143,11 @@ func (b *builtinGetParamStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 			continue
 		}
 		idxI := idxIs[i]
-		v := sessionVars.PlanCacheParams.GetParamValue(int(idxI))
+		v, err := ctx.GetParamValue(int(idxI))
+		if err != nil {
+			return err
+		}
+
 		str, err := v.ToString()
 		if err != nil {
 			result.AppendNull()

--- a/pkg/expression/context/param.go
+++ b/pkg/expression/context/param.go
@@ -34,6 +34,6 @@ var EmptyParamValues ParamValues = &emptyParamValues{}
 type emptyParamValues struct{}
 
 // GetParamValue always returns the `ErrParamIndexExceedParamCounts` for any index
-func (e *emptyParamValues) GetParamValue(idx int) (types.Datum, error) {
+func (e *emptyParamValues) GetParamValue(_ int) (types.Datum, error) {
 	return types.Datum{}, ErrParamIndexExceedParamCounts
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55471

Problem Summary:

After EvalContext implemented `ParamValues` in https://github.com/pingcap/tidb/pull/53534, builtinGetParamStringSig do not need to read SessionVarsPropReader to get param values. So it' time to delete SessionVarsPropReader in it.

### What changed and how does it work?

remove `SessionVarsPropReader` in `builtinGetParamStringSig`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
