### PR TITLE
ranger: should replace ast.Or with ast.LogicalOr 

### DIFF
--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -231,4 +231,14 @@ LIMIT 65122436;`).Check(testkit.Rows(
 		"  └─IndexReader_36 32.00 root  index:StreamAgg_15",
 		"    └─StreamAgg_15 32.00 cop[tikv]  group by:test.ta31c32a7.col_63, funcs:bit_xor(cast(test.ta31c32a7.col_63, bigint(22) BINARY))->Column#5",
 		"      └─IndexRangeScan_32 40.00 cop[tikv] table:ta31c32a7, index:idx_24(col_63) range:[NULL,NULL], [1531.4023068774668,1531.4023068774668], [1780.7418079754723,1780.7418079754723], [5904.959667345741,5904.959667345741], keep order:true, stats:pseudo"))
+	tk.MustExec(`CREATE TABLE tl75eff7ba (
+col_1 tinyint(1) DEFAULT '0',
+KEY idx_1 (col_1),
+UNIQUE KEY idx_2 (col_1),
+UNIQUE KEY idx_3 (col_1),
+KEY idx_4 (col_1) /*!80000 INVISIBLE */,
+UNIQUE KEY idx_5 (col_1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;`)
+	tk.MustExec(`INSERT INTO tl75eff7ba VALUES(1),(0);`)
+	tk.MustQuery(`SELECT tl75eff7ba.col_1 AS r0 FROM tl75eff7ba WHERE ISNULL(tl75eff7ba.col_1) OR tl75eff7ba.col_1 IN (0, 0, 1, 1) GROUP BY tl75eff7ba.col_1 HAVING ISNULL(tl75eff7ba.col_1) OR tl75eff7ba.col_1 IN (0, 1, 1, 0) LIMIT 58651509;`).Check(testkit.Rows("0", "1"))
 }

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -764,7 +764,7 @@ func points2EqOrInCond(ctx expression.BuildContext, points []*point, col *expres
 	if len(orArgs) == 1 {
 		return orArgs[0]
 	}
-	return expression.NewFunctionInternal(ctx, ast.Or, col.GetType(ctx.GetEvalCtx()), orArgs...)
+	return expression.NewFunctionInternal(ctx, ast.LogicOr, col.GetType(ctx.GetEvalCtx()), orArgs...)
 }
 
 // RangesToString print a list of Ranges into a string which can appear in an SQL as a condition.

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -257,6 +257,12 @@ func TestTableRange(t *testing.T) {
 			filterConds: "[]",
 			resultStr:   "[]",
 		},
+		{
+			exprStr:     "isnull(a) or a in (1, 2, 3)",
+			accessConds: "[or(isnull(test.t.a), in(test.t.a, 1, 2, 3))]",
+			filterConds: "[]",
+			resultStr:   "[[1,1] [2,2] [3,3]]",
+		},
 	}
 
 	ctx := context.Background()
@@ -2231,6 +2237,13 @@ create table t(
 			accessConds: "[isnull(test.t.a)]",
 			filterConds: "[]",
 			resultStr:   "[[NULL,NULL]]",
+		},
+		{
+			indexPos:    0,
+			exprStr:     "isnull(a) or a in (1,2,3,4)",
+			accessConds: "[]",
+			filterConds: "[or(isnull(test.t.a), or(or(eq(cast(test.t.a, double BINARY), 1), eq(cast(test.t.a, double BINARY), 2)), or(eq(cast(test.t.a, double BINARY), 3), eq(cast(test.t.a, double BINARY), 4))))]",
+			resultStr:   "[[NULL,+inf]]",
 		},
 		{
 			indexPos:    0,

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -2247,6 +2247,13 @@ create table t(
 		},
 		{
 			indexPos:    0,
+			exprStr:     "isnull(a) and a in (1,2,3,4)",
+			accessConds: "[isnull(test.t.a)]",
+			filterConds: "[or(or(eq(cast(test.t.a, double BINARY), 1), eq(cast(test.t.a, double BINARY), 2)), or(eq(cast(test.t.a, double BINARY), 3), eq(cast(test.t.a, double BINARY), 4)))]",
+			resultStr:   "[[NULL,NULL]]",
+		},
+		{
+			indexPos:    0,
 			exprStr:     "a is not null",
 			accessConds: "[not(isnull(test.t.a))]",
 			filterConds: "[]",

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -263,6 +263,12 @@ func TestTableRange(t *testing.T) {
 			filterConds: "[]",
 			resultStr:   "[[1,1] [2,2] [3,3]]",
 		},
+		{
+			exprStr:     "isnull(a) and a in (1, 2, 3)",
+			accessConds: "[isnull(test.t.a) in(test.t.a, 1, 2, 3)]",
+			filterConds: "[]",
+			resultStr:   "[]",
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55475

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
