### PR TITLE
server: wait for auto commit queries before shutdown

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1004,7 +1004,8 @@ func (s *Server) DrainClients(drainWait time.Duration, cancelWait time.Duration)
 	go func() {
 		defer close(allDone)
 		for _, conn := range conns {
-			if !conn.getCtx().GetSessionVars().InTxn() {
+			// Wait for the connections with explicit transaction or an executing auto-commit query.
+			if conn.getStatus() == connStatusReading && !conn.getCtx().GetSessionVars().InTxn() {
 				continue
 			}
 			select {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55464

Problem Summary:

Previously, TiDB will not wait for auto-commit queries. These queries are directly killed. It'd be better to wait for them to finish.

### What changed and how does it work?

Also checking the connection status when filtering the connection to wait.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Run a workload with heavy auto-commit traffic, and you'll see the connections are closed with little leaked lock.

### Release note

```release-note
None
```
