### PR TITLE
planner: refactor infoschema predicate extractors

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -1743,27 +1743,25 @@ func (e *memtableRetriever) setDataForMetricTables() {
 
 func keyColumnUsageInTable(schema model.CIStr, table *model.TableInfo, ex *plannercore.InfoSchemaKeyColumnUsageExtractor) [][]types.Datum {
 	var rows [][]types.Datum
-	if table.PKIsHandle {
-		if ex.HasPrimaryKey() {
-			for _, col := range table.Columns {
-				if mysql.HasPriKeyFlag(col.GetFlag()) {
-					record := types.MakeDatums(
-						infoschema.CatalogVal,        // CONSTRAINT_CATALOG
-						schema.O,                     // CONSTRAINT_SCHEMA
-						infoschema.PrimaryConstraint, // CONSTRAINT_NAME
-						infoschema.CatalogVal,        // TABLE_CATALOG
-						schema.O,                     // TABLE_SCHEMA
-						table.Name.O,                 // TABLE_NAME
-						col.Name.O,                   // COLUMN_NAME
-						1,                            // ORDINAL_POSITION
-						1,                            // POSITION_IN_UNIQUE_CONSTRAINT
-						nil,                          // REFERENCED_TABLE_SCHEMA
-						nil,                          // REFERENCED_TABLE_NAME
-						nil,                          // REFERENCED_COLUMN_NAME
-					)
-					rows = append(rows, record)
-					break
-				}
+	if table.PKIsHandle && ex.HasPrimaryKey() {
+		for _, col := range table.Columns {
+			if mysql.HasPriKeyFlag(col.GetFlag()) {
+				record := types.MakeDatums(
+					infoschema.CatalogVal,        // CONSTRAINT_CATALOG
+					schema.O,                     // CONSTRAINT_SCHEMA
+					infoschema.PrimaryConstraint, // CONSTRAINT_NAME
+					infoschema.CatalogVal,        // TABLE_CATALOG
+					schema.O,                     // TABLE_SCHEMA
+					table.Name.O,                 // TABLE_NAME
+					col.Name.O,                   // COLUMN_NAME
+					1,                            // ORDINAL_POSITION
+					1,                            // POSITION_IN_UNIQUE_CONSTRAINT
+					nil,                          // REFERENCED_TABLE_SCHEMA
+					nil,                          // REFERENCED_TABLE_NAME
+					nil,                          // REFERENCED_COLUMN_NAME
+				)
+				rows = append(rows, record)
+				break
 			}
 		}
 	}

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -115,14 +115,6 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		is := sctx.GetInfoSchema().(infoschema.InfoSchema)
 		e.is = is
 
-		var getAllSchemas = func() []model.CIStr {
-			dbs := is.AllSchemaNames()
-			slices.SortFunc(dbs, func(a, b model.CIStr) int {
-				return strings.Compare(a.L, b.L)
-			})
-			return dbs
-		}
-
 		var err error
 		switch e.table.Name.O {
 		case infoschema.TableSchemata:
@@ -176,8 +168,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableTiDBServersInfo:
 			err = e.setDataForServersInfo(sctx)
 		case infoschema.TableTiFlashReplica:
-			dbs := getAllSchemas()
-			err = e.dataForTableTiFlashReplica(ctx, sctx, dbs)
+			err = e.dataForTableTiFlashReplica(ctx, sctx)
 		case infoschema.TableTiKVStoreStatus:
 			err = e.dataForTiKVStoreStatus(ctx, sctx)
 		case infoschema.TableClientErrorsSummaryGlobal,
@@ -415,35 +406,38 @@ func (e *memtableRetriever) setDataForStatistics(ctx context.Context, sctx sessi
 	return nil
 }
 
-func (e *memtableRetriever) setDataForStatisticsInTable(schema model.CIStr, table *model.TableInfo, extractor *plannercore.InfoSchemaStatisticsExtractor) {
+func (e *memtableRetriever) setDataForStatisticsInTable(
+	schema model.CIStr,
+	table *model.TableInfo,
+	ex *plannercore.InfoSchemaStatisticsExtractor,
+) {
 	var rows [][]types.Datum
-	if table.PKIsHandle {
-		if !extractor.Filter("index_name", "primary") {
-			for _, col := range table.Columns {
-				if mysql.HasPriKeyFlag(col.GetFlag()) {
-					record := types.MakeDatums(
-						infoschema.CatalogVal, // TABLE_CATALOG
-						schema.O,              // TABLE_SCHEMA
-						table.Name.O,          // TABLE_NAME
-						"0",                   // NON_UNIQUE
-						schema.O,              // INDEX_SCHEMA
-						"PRIMARY",             // INDEX_NAME
-						1,                     // SEQ_IN_INDEX
-						col.Name.O,            // COLUMN_NAME
-						"A",                   // COLLATION
-						0,                     // CARDINALITY
-						nil,                   // SUB_PART
-						nil,                   // PACKED
-						"",                    // NULLABLE
-						"BTREE",               // INDEX_TYPE
-						"",                    // COMMENT
-						"",                    // INDEX_COMMENT
-						"YES",                 // IS_VISIBLE
-						nil,                   // Expression
-					)
-					rows = append(rows, record)
-				}
+	if table.PKIsHandle && ex.HasPrimaryKey() {
+		for _, col := range table.Columns {
+			if mysql.HasPriKeyFlag(col.GetFlag()) {
+				record := types.MakeDatums(
+					infoschema.CatalogVal, // TABLE_CATALOG
+					schema.O,              // TABLE_SCHEMA
+					table.Name.O,          // TABLE_NAME
+					"0",                   // NON_UNIQUE
+					schema.O,              // INDEX_SCHEMA
+					"PRIMARY",             // INDEX_NAME
+					1,                     // SEQ_IN_INDEX
+					col.Name.O,            // COLUMN_NAME
+					"A",                   // COLLATION
+					0,                     // CARDINALITY
+					nil,                   // SUB_PART
+					nil,                   // PACKED
+					"",                    // NULLABLE
+					"BTREE",               // INDEX_TYPE
+					"",                    // COMMENT
+					"",                    // INDEX_COMMENT
+					"YES",                 // IS_VISIBLE
+					nil,                   // Expression
+				)
+				rows = append(rows, record)
 			}
+
 		}
 	}
 	nameToCol := make(map[string]*model.ColumnInfo, len(table.Columns))
@@ -451,7 +445,7 @@ func (e *memtableRetriever) setDataForStatisticsInTable(schema model.CIStr, tabl
 		nameToCol[c.Name.L] = c
 	}
 	for _, index := range table.Indices {
-		if extractor.Filter("index_name", index.Name.L) {
+		if !ex.HasIndex(index.Name.L) {
 			continue
 		}
 		nonUnique := "1"
@@ -528,7 +522,7 @@ func (e *memtableRetriever) setDataFromReferConst(ctx context.Context, sctx sess
 			continue
 		}
 		for _, fk := range table.ForeignKeys {
-			if ok && ex.Filter("constraint_name", fk.Name.L) {
+			if ok && !ex.HasConstraint(fk.Name.L) {
 				continue
 			}
 			updateRule, deleteRule := "NO ACTION", "NO ACTION"
@@ -753,7 +747,7 @@ func (e *memtableRetriever) setDataFromCheckConstraints(ctx context.Context, sct
 					if constraint.State != model.StatePublic {
 						continue
 					}
-					if ok && ex.Filter("constraint_name", constraint.Name.L) {
+					if ok && !ex.HasConstraint(constraint.Name.L) {
 						continue
 					}
 					record := types.MakeDatums(
@@ -797,7 +791,7 @@ func (e *memtableRetriever) setDataFromTiDBCheckConstraints(ctx context.Context,
 				if constraint.State != model.StatePublic {
 					continue
 				}
-				if ok && ex.Filter("constraint_name", constraint.Name.L) {
+				if ok && !ex.HasConstraint(constraint.Name.L) {
 					continue
 				}
 				record := types.MakeDatums(
@@ -1152,7 +1146,7 @@ func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sess
 			rows = append(rows, record)
 		} else {
 			for i, pi := range table.GetPartitionInfo().Definitions {
-				if ex.Filter("partition_name", pi.Name.L) {
+				if !ex.HasPartition(pi.Name.L) {
 					continue
 				}
 				rowCount = cache.TableRowStatsCache.GetTableRows(pi.ID)
@@ -1676,7 +1670,7 @@ func (e *memtableRetriever) setDataFromKeyColumnUsage(ctx context.Context, sctx 
 		if checker != nil && !checker.RequestVerification(sctx.GetSessionVars().ActiveRoles, schema.L, table.Name.L, "", mysql.AllPrivMask) {
 			continue
 		}
-		if ex.Filter("constraint_schema", schema.O) {
+		if !ex.HasConstraintSchema(schema.L) {
 			continue
 		}
 		rs := keyColumnUsageInTable(schema, table, ex)
@@ -1748,10 +1742,10 @@ func (e *memtableRetriever) setDataForMetricTables() {
 	e.rows = rows
 }
 
-func keyColumnUsageInTable(schema model.CIStr, table *model.TableInfo, extractor *plannercore.InfoSchemaKeyColumnUsageExtractor) [][]types.Datum {
+func keyColumnUsageInTable(schema model.CIStr, table *model.TableInfo, ex *plannercore.InfoSchemaKeyColumnUsageExtractor) [][]types.Datum {
 	var rows [][]types.Datum
 	if table.PKIsHandle {
-		if extractor == nil || !extractor.Filter("constraint_name", lowerPrimaryKeyName) {
+		if ex.HasPrimaryKey() {
 			for _, col := range table.Columns {
 				if mysql.HasPriKeyFlag(col.GetFlag()) {
 					record := types.MakeDatums(
@@ -1792,7 +1786,7 @@ func keyColumnUsageInTable(schema model.CIStr, table *model.TableInfo, extractor
 			continue
 		}
 
-		if extractor != nil && extractor.Filter("constraint_name", filterIdxName) {
+		if !ex.HasConstraint(filterIdxName) {
 			continue
 		}
 
@@ -1819,7 +1813,7 @@ func keyColumnUsageInTable(schema model.CIStr, table *model.TableInfo, extractor
 		}
 	}
 	for _, fk := range table.ForeignKeys {
-		if extractor != nil && extractor.Filter("constraint_name", fk.Name.L) {
+		if !ex.HasConstraint(fk.Name.L) {
 			continue
 		}
 
@@ -2077,7 +2071,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 	rows := make([][]types.Datum, 0, len(tables))
 	for i, tbl := range tables {
 		schema := schemas[i]
-		if ex.Filter("constraint_schema", schema.L) {
+		if !ex.HasConstraintSchema(schema.L) {
 			continue
 		}
 		if checker != nil && !checker.RequestVerification(sctx.GetSessionVars().ActiveRoles, schema.L, tbl.Name.L, "", mysql.AllPrivMask) {
@@ -2085,7 +2079,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 		}
 
 		if tbl.PKIsHandle {
-			if !ex.Filter("constraint_name", lowerPrimaryKeyName) {
+			if ex.HasPrimaryKey() {
 				record := types.MakeDatums(
 					infoschema.CatalogVal,     // CONSTRAINT_CATALOG
 					schema.O,                  // CONSTRAINT_SCHEMA
@@ -2113,7 +2107,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 				// The index has no constriant.
 				continue
 			}
-			if ex.Filter("constraint_name", filterName) {
+			if !ex.HasConstraint(filterName) {
 				continue
 			}
 			record := types.MakeDatums(
@@ -2128,7 +2122,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 		}
 		//  TiDB includes foreign key information for compatibility but foreign keys are not yet enforced.
 		for _, fk := range tbl.ForeignKeys {
-			if ex.Filter("constraint_name", fk.Name.L) {
+			if !ex.HasConstraint(fk.Name.L) {
 				continue
 			}
 			record := types.MakeDatums(
@@ -2571,7 +2565,7 @@ func (e *memtableRetriever) setDataFromSequences(ctx context.Context, sctx sessi
 }
 
 // dataForTableTiFlashReplica constructs data for table tiflash replica info.
-func (e *memtableRetriever) dataForTableTiFlashReplica(_ context.Context, sctx sessionctx.Context, _ []model.CIStr) error {
+func (e *memtableRetriever) dataForTableTiFlashReplica(_ context.Context, sctx sessionctx.Context) error {
 	var (
 		checker       = privilege.GetPrivilegeManager(sctx)
 		rows          [][]types.Datum
@@ -3677,7 +3671,7 @@ func (e *memtableRetriever) setDataFromIndexUsage(ctx context.Context, sctx sess
 	dom := domain.GetDomain(sctx)
 	rows := make([][]types.Datum, 0, 100)
 	checker := privilege.GetPrivilegeManager(sctx)
-	extractor, ok := e.extractor.(*plannercore.InfoSchemaIndexUsageExtractor)
+	extractor, ok := e.extractor.(*plannercore.InfoSchemaTiDBIndexUsageExtractor)
 	if !ok {
 		return errors.Errorf("wrong extractor type: %T, expected InfoSchemaIndexUsageExtractor", e.extractor)
 	}

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -437,7 +437,6 @@ func (e *memtableRetriever) setDataForStatisticsInTable(
 				)
 				rows = append(rows, record)
 			}
-
 		}
 	}
 	nameToCol := make(map[string]*model.ColumnInfo, len(table.Columns))

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4814,61 +4814,33 @@ func (b *PlanBuilder) buildMemTable(_ context.Context, dbName model.CIStr, table
 		case infoschema.TableTiKVRegionPeers:
 			p.Extractor = &TikvRegionPeersExtractor{}
 		case infoschema.TableColumns:
-			ex := &InfoSchemaColumnsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaColumnsExtractor()
 		case infoschema.TableTables:
-			ex := &InfoSchemaTablesExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaTablesExtractor()
 		case infoschema.TablePartitions:
-			ex := &InfoSchemaPartitionsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaPartitionsExtractor()
 		case infoschema.TableStatistics:
-			ex := &InfoSchemaStatisticsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaStatisticsExtractor()
 		case infoschema.TableSchemata:
-			ex := &InfoSchemaSchemataExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaSchemataExtractor()
 		case infoschema.TableSequences:
-			ex := &InfoSchemaSequenceExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaSequenceExtractor()
 		case infoschema.TableTiDBIndexUsage:
-			ex := &InfoSchemaIndexUsageExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaTiDBIndexUsageExtractor()
 		case infoschema.TableCheckConstraints:
-			ex := &InfoSchemaCheckConstraintsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaCheckConstraintsExtractor()
 		case infoschema.TableTiDBCheckConstraints:
-			ex := &InfoSchemaTiDBCheckConstraintsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaTiDBCheckConstraintsExtractor()
 		case infoschema.TableReferConst:
-			ex := &InfoSchemaReferConstExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaReferConstExtractor()
 		case infoschema.TableTiDBIndexes:
-			ex := &InfoSchemaIndexesExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaIndexesExtractor()
 		case infoschema.TableViews:
-			ex := &InfoSchemaViewsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaViewsExtractor()
 		case infoschema.TableKeyColumn:
-			ex := &InfoSchemaKeyColumnUsageExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaKeyColumnUsageExtractor()
 		case infoschema.TableConstraints:
-			ex := &InfoSchemaTableConstraintsExtractor{}
-			ex.initExtractableColNames(upTbl)
-			p.Extractor = ex
+			p.Extractor = NewInfoSchemaTableConstraintsExtractor()
 		case infoschema.TableTiKVRegionStatus:
 			p.Extractor = &TiKVRegionStatusExtractor{tablesID: make([]int64, 0)}
 		}

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -36,109 +36,38 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+type extractableCols struct {
+	schema      columnName
+	table       columnName
+	tableID     columnName
+	partitionID columnName
+
+	partitionName columnName
+	indexName     columnName
+	columnName    columnName
+	constrName    columnName
+	constrSchema  columnName
+}
+
 const (
-	_tableSchema      = "table_schema"
-	_tableName        = "table_name"
-	_tidbTableID      = "tidb_table_id"
-	_partitionName    = "partition_name"
-	_tidbPartitionID  = "tidb_partition_id"
-	_indexName        = "index_name"
-	_schemaName       = "schema_name"
-	_constraintSchema = "constraint_schema"
-	_constraintName   = "constraint_name"
-	_tableID          = "table_id"
-	_sequenceSchema   = "sequence_schema"
-	_sequenceName     = "sequence_name"
-	_columnName       = "column_name"
+	_tableSchema      columnName = "table_schema"
+	_tableName        columnName = "table_name"
+	_tidbTableID      columnName = "tidb_table_id"
+	_partitionName    columnName = "partition_name"
+	_tidbPartitionID  columnName = "tidb_partition_id"
+	_indexName        columnName = "index_name"
+	_schemaName       columnName = "schema_name"
+	_constraintSchema columnName = "constraint_schema"
+	_constraintName   columnName = "constraint_name"
+	_tableID          columnName = "table_id"
+	_sequenceSchema   columnName = "sequence_schema"
+	_sequenceName     columnName = "sequence_name"
+	_columnName       columnName = "column_name"
 )
 
-var extractableColumns = map[string][]string{
-	// See infoschema.tablesCols for full columns.
-	// Used by InfoSchemaTablesExtractor and setDataFromTables.
-	infoschema.TableTables: {
-		_tableSchema, _tableName, _tidbTableID,
-	},
-	// See infoschema.partitionsCols for full columns.
-	// Used by InfoSchemaPartitionsExtractor and setDataFromPartitions.
-	infoschema.TablePartitions: {
-		_tableSchema, _tableName, _tidbPartitionID,
-		_partitionName,
-	},
-	// See infoschema.statisticsCols for full columns.
-	// Used by InfoSchemaStatisticsExtractor and setDataForStatistics.
-	infoschema.TableStatistics: {
-		_tableSchema, _tableName,
-		_indexName,
-	},
-	// See infoschema.columns for full columns.
-	// Used by InfoSchemaColumnsExtractor and setDataFromColumns.
-	infoschema.TableColumns: {
-		_tableSchema, _tableName,
-		_columnName,
-	},
-	// See infoschema.tidb_index_usage for full columns.
-	// Used by InfoSchemaIndexesExtractor and setDataFromIndexUsage.
-	infoschema.TableTiDBIndexUsage: {
-		_tableSchema, _tableName,
-		_indexName,
-	},
-	// See infoschema.schemataCols for full columns.
-	// Used by InfoSchemaSchemataExtractor and setDataFromSchemata.
-	infoschema.TableSchemata: {
-		_schemaName,
-	},
-	// See infoschema.tableTiDBIndexesCols for full columns.
-	// Used by InfoSchemaIndexesExtractor and setDataFromIndexes.
-	infoschema.TableTiDBIndexes: {
-		_tableSchema,
-		_tableName,
-	},
-	// See infoschema.tableViewsCols for full columns.
-	// Used by InfoSchemaViewsExtractor and setDataFromViews.
-	infoschema.TableViews: {
-		_tableSchema,
-		_tableName,
-	},
-	// See infoschema.keyColumnUsageCols for full columns.
-	// Used by InfoSchemaViewsExtractor and setDataFromKeyColumn
-	infoschema.TableKeyColumn: {
-		_tableSchema,
-		_constraintSchema,
-		_tableName,
-		_constraintName,
-	},
-	// See infoschema.tableConstraintsCols for full columns.
-	// Used by InfoSchemaTableConstraintsExtractor and setDataFromTableConstraints.
-	infoschema.TableConstraints: {
-		_tableSchema,
-		_constraintSchema,
-		_tableName,
-		_constraintName,
-	},
-	// See infoschema.tableCheckConstraintsCols for full columns.
-	// Used by InfoSchemaCheckConstraintsExtractor and setDataFromCheckConstraints.
-	infoschema.TableCheckConstraints: {
-		_constraintSchema,
-		_constraintName,
-	},
-	// See infoschema.tableTiDBCheckConstraintsCols for full columns.
-	// Used by InfoSchemaTiDBCheckConstraintsExtractor and setDataFromTiDBCheckConstraints.
-	infoschema.TableTiDBCheckConstraints: {
-		_constraintSchema, _tableName, _tableID,
-		_constraintName,
-	},
-	// See infoschema.referConstCols for full columns.
-	// Used by InfoSchemaReferConstExtractor and setDataFromReferConst.
-	infoschema.TableReferConst: {
-		_constraintSchema, _tableName,
-		_constraintName,
-	},
-	// See infoschema.tableSequencesCols for full columns.
-	// Used by InfoSchemaSequenceExtractor and setDataFromSequences.
-	infoschema.TableSequences: {
-		_sequenceSchema, _sequenceName,
-	},
-}
+const (
+	primaryKeyName string = "primary"
+)
 
 // InfoSchemaBaseExtractor is used to extract infoSchema tables related predicates.
 type InfoSchemaBaseExtractor struct {
@@ -147,33 +76,61 @@ type InfoSchemaBaseExtractor struct {
 	SkipRequest   bool
 	ColPredicates map[string]set.StringSet
 	// columns occurs in predicate will be extracted.
-	colNames []string
+	colNames []columnName
+
+	extractableColumns extractableCols
 }
 
-func (e *InfoSchemaBaseExtractor) initExtractableColNames(systableName string) {
-	cols, ok := extractableColumns[systableName]
-	if ok {
-		e.colNames = cols
-	} else {
-		// TODO: remove this after all system tables are supported.
-		e.colNames = []string{
-			"table_schema",
-			"constraint_schema",
-			"table_name",
-			"constraint_name",
-			"sequence_schema",
-			"sequence_name",
-			"partition_name",
-			"schema_name",
-			"index_name",
-			"tidb_table_id",
+func (e *InfoSchemaBaseExtractor) ListSchemas(is infoschema.InfoSchema) []model.CIStr {
+	ec := e.extractableColumns
+	schemas := e.getSchemaObjectNames(ec.schema)
+	if len(schemas) == 0 {
+		ret := is.AllSchemaNames()
+		slices.SortFunc(ret, func(a, b model.CIStr) int {
+			return strings.Compare(a.L, b.L)
+		})
+		return ret
+	}
+	ret := schemas[:0]
+	for _, s := range schemas {
+		if n, ok := is.SchemaByName(s); ok {
+			ret = append(ret, n.Name)
 		}
 	}
+	return ret
 }
 
-// SetExtractColNames sets the columns that need to be extracted.
-func (e *InfoSchemaBaseExtractor) SetExtractColNames(colNames ...string) {
-	e.colNames = colNames
+func (e *InfoSchemaBaseExtractor) ListSchemasAndTables(
+	ctx context.Context,
+	is infoschema.InfoSchema,
+) ([]model.CIStr, []*model.TableInfo, error) {
+	ec := e.extractableColumns
+	schemas := e.ListSchemas(is)
+	var tableNames []model.CIStr
+	if ec.table != "" {
+		tableNames = e.getSchemaObjectNames(ec.table)
+	}
+	var tableIDs []model.CIStr
+	if ec.tableID != "" {
+		tableIDs = e.getSchemaObjectNames(ec.tableID)
+		if len(tableIDs) > 0 {
+			tableMap := make(map[int64]*model.TableInfo, len(tableIDs))
+			findTablesByID(is, tableIDs, tableNames, tableMap)
+			return findSchemasForTables(ctx, is, schemas, maps.Values(tableMap))
+		}
+	}
+	if ec.partitionID != "" {
+		partIDs := e.getSchemaObjectNames(ec.partitionID)
+		if len(partIDs) > 0 {
+			tableMap := make(map[int64]*model.TableInfo, len(partIDs))
+			findTablesByPartID(is, partIDs, tableNames, tableMap)
+			return findSchemasForTables(ctx, is, schemas, maps.Values(tableMap))
+		}
+	}
+	if len(tableNames) > 0 {
+		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+	}
+	return listTablesForEachSchema(ctx, is, schemas)
 }
 
 // Extract implements the MemTablePredicateExtractor Extract interface
@@ -187,6 +144,7 @@ func (e *InfoSchemaBaseExtractor) Extract(
 	e.ColPredicates = make(map[string]set.StringSet)
 	remained = predicates
 	for _, colName := range e.colNames {
+		colName := string(colName)
 		remained, e.SkipRequest, resultSet = e.extractColWithLower(ctx, schema, names, remained, colName)
 		if e.SkipRequest {
 			break
@@ -232,13 +190,13 @@ func (e *InfoSchemaBaseExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 // Filter use the col predicates to filter records.
 // Return true if the underlying row does not match predicate,
 // then it should be filtered and not shown in the result.
-func (e *InfoSchemaBaseExtractor) Filter(colName string, val string) bool {
+func (e *InfoSchemaBaseExtractor) filter(colName columnName, val string) bool {
 	if e.SkipRequest {
 		return true
 	}
-	predVals, ok := e.ColPredicates[colName]
+	predVals, ok := e.ColPredicates[string(colName)]
 	if ok && len(predVals) > 0 {
-		lower, ok := e.isLower[colName]
+		lower, ok := e.isLower[string(colName)]
 		if ok {
 			var valStr string
 			// only have varchar string type, safe to do that.
@@ -255,23 +213,27 @@ func (e *InfoSchemaBaseExtractor) Filter(colName string, val string) bool {
 	return false
 }
 
+// columnName is the type for column names used by tables information_schema.
+type columnName string
+
+type ColumnExtractor interface {
+	extratableColumns() extractableCols
+}
+
 // InfoSchemaIndexesExtractor is the predicate extractor for information_schema.tidb_indexes.
 type InfoSchemaIndexesExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaIndexesExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+// NewInfoSchemaIndexesExtractor creates a new InfoSchemaIndexesExtractor.
+func NewInfoSchemaIndexesExtractor() *InfoSchemaIndexesExtractor {
+	e := &InfoSchemaIndexesExtractor{}
+	e.extractableColumns = extractableCols{
+		schema: _tableSchema,
+		table:  _tableName,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName}
+	return e
 }
 
 // InfoSchemaTablesExtractor is the predicate extractor for information_schema.tables.
@@ -279,26 +241,16 @@ type InfoSchemaTablesExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaTablesExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-
-	tableIDs := e.getSchemaObjectNames(_tidbTableID)
-	tableNames := e.getSchemaObjectNames(_tableName)
-
-	if len(tableIDs) > 0 {
-		tableMap := make(map[int64]*model.TableInfo, len(tableIDs))
-		findTablesByID(is, tableIDs, tableNames, tableMap)
-		return findSchemasForTables(ctx, is, schemas, maps.Values(tableMap))
+// NewInfoSchemaTablesExtractor creates a new InfoSchemaTablesExtractor.
+func NewInfoSchemaTablesExtractor() *InfoSchemaTablesExtractor {
+	e := &InfoSchemaTablesExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:  _tableSchema,
+		table:   _tableName,
+		tableID: _tidbTableID,
 	}
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
-	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName, _tidbTableID}
+	return e
 }
 
 // InfoSchemaViewsExtractor is the predicate extractor for information_schema.views.
@@ -306,18 +258,15 @@ type InfoSchemaViewsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaViewsExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+// NewInfoSchemaViewsExtractor creates a new InfoSchemaViewsExtractor.
+func NewInfoSchemaViewsExtractor() *InfoSchemaViewsExtractor {
+	e := &InfoSchemaViewsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema: _tableSchema,
+		table:  _tableName,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName}
+	return e
 }
 
 // InfoSchemaKeyColumnUsageExtractor is the predicate extractor for information_schema.key_column_usage.
@@ -325,18 +274,32 @@ type InfoSchemaKeyColumnUsageExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaKeyColumnUsageExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+// NewInfoSchemaKeyColumnUsageExtractor creates a new InfoSchemaKeyColumnUsageExtractor.
+func NewInfoSchemaKeyColumnUsageExtractor() *InfoSchemaKeyColumnUsageExtractor {
+	e := &InfoSchemaKeyColumnUsageExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:       _tableSchema,
+		table:        _tableName,
+		constrName:   _constraintName,
+		constrSchema: _constraintSchema,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName, _constraintName, _constraintSchema}
+	return e
+}
+
+// HasConstraint returns true if constraint name is specified in predicates.
+func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraint(name string) bool {
+	return !e.filter(_constraintName, name)
+}
+
+// HasPrimaryKey returns true if primary key is specified in predicates.
+func (e *InfoSchemaKeyColumnUsageExtractor) HasPrimaryKey() bool {
+	return !e.filter(_constraintName, primaryKeyName)
+}
+
+// HasConstraintSchema returns true if constraint schema is specified in predicates.
+func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraintSchema(name string) bool {
+	return !e.filter(_constraintSchema, name)
 }
 
 // InfoSchemaTableConstraintsExtractor is the predicate extractor for information_schema.constraints.
@@ -344,18 +307,32 @@ type InfoSchemaTableConstraintsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaTableConstraintsExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+// NewInfoSchemaTableConstraintsExtractor creates a new InfoSchemaTableConstraintsExtractor.
+func NewInfoSchemaTableConstraintsExtractor() *InfoSchemaTableConstraintsExtractor {
+	e := &InfoSchemaTableConstraintsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:       _tableSchema,
+		table:        _tableName,
+		constrName:   _constraintName,
+		constrSchema: _constraintSchema,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName, _constraintName, _constraintSchema}
+	return e
+}
+
+// HasConstraintSchema returns true if constraint schema is specified in predicates.
+func (e *InfoSchemaTableConstraintsExtractor) HasConstraintSchema(name string) bool {
+	return !e.filter(_constraintSchema, name)
+}
+
+// HasConstraintSchema returns true if constraint schema is specified in predicates.
+func (e *InfoSchemaTableConstraintsExtractor) HasConstraint(name string) bool {
+	return !e.filter(_constraintName, name)
+}
+
+// HasPrimaryKey returns true if primary key is specified in predicates.
+func (e *InfoSchemaTableConstraintsExtractor) HasPrimaryKey() bool {
+	return !e.filter(_constraintName, primaryKeyName)
 }
 
 // InfoSchemaPartitionsExtractor is the predicate extractor for information_schema.partitions.
@@ -363,26 +340,21 @@ type InfoSchemaPartitionsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaPartitionsExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-
-	partIDs := e.getSchemaObjectNames(_tidbPartitionID)
-	tableNames := e.getSchemaObjectNames(_tableName)
-
-	if len(partIDs) > 0 {
-		tableMap := make(map[int64]*model.TableInfo, len(partIDs))
-		findTablesByPartID(is, partIDs, tableNames, tableMap)
-		return findSchemasForTables(ctx, is, schemas, maps.Values(tableMap))
+func NewInfoSchemaPartitionsExtractor() *InfoSchemaPartitionsExtractor {
+	e := &InfoSchemaPartitionsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:        _tableSchema,
+		table:         _tableName,
+		partitionID:   _tidbPartitionID,
+		partitionName: _partitionName,
 	}
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
-	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName, _tidbPartitionID, _partitionName}
+	return e
+}
+
+// HasPartition returns true if partition name is specified in predicates.
+func (e *InfoSchemaPartitionsExtractor) HasPartition(name string) bool {
+	return !e.filter(_partitionName, name)
 }
 
 // InfoSchemaStatisticsExtractor is the predicate extractor for  information_schema.statistics.
@@ -390,38 +362,24 @@ type InfoSchemaStatisticsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
-func (e *InfoSchemaStatisticsExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _tableSchema)
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+// NewInfoSchemaStatisticsExtractor creates a new InfoSchemaStatisticsExtractor.
+func NewInfoSchemaStatisticsExtractor() *InfoSchemaStatisticsExtractor {
+	e := &InfoSchemaStatisticsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:    _tableSchema,
+		table:     _tableName,
+		indexName: _indexName,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_tableSchema, _tableName, _indexName}
+	return e
 }
 
-// ListTables lists related tables from predicate.
-// If no table is found in predicate, it return all tables.
-func (e *InfoSchemaStatisticsExtractor) ListTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-	schema model.CIStr,
-) ([]*model.TableInfo, error) {
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) == 0 {
-		return is.SchemaTableInfos(ctx, schema)
-	}
+func (e *InfoSchemaStatisticsExtractor) HasIndex(val string) bool {
+	return e.filter(_indexName, val)
+}
 
-	tables := make(map[int64]*model.TableInfo, 8)
-	err := findNameAndAppendToTableMap(ctx, is, schema, tableNames, tables)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return maps.Values(tables), nil
+func (e *InfoSchemaStatisticsExtractor) HasPrimaryKey() bool {
+	return !e.filter(_indexName, primaryKeyName)
 }
 
 // InfoSchemaSchemataExtractor is the predicate extractor for information_schema.schemata.
@@ -429,10 +387,14 @@ type InfoSchemaSchemataExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemas lists related schemas from predicate.
-// If no schema found in predicate, it return all schemas.
-func (e *InfoSchemaSchemataExtractor) ListSchemas(is infoschema.InfoSchema) []model.CIStr {
-	return e.listSchemas(is, _schemaName)
+// NewInfoSchemaSchemataExtractor creates a new InfoSchemaSchemataExtractor.
+func NewInfoSchemaSchemataExtractor() *InfoSchemaSchemataExtractor {
+	e := &InfoSchemaSchemataExtractor{}
+	e.extractableColumns = extractableCols{
+		schema: _schemaName,
+	}
+	e.colNames = []columnName{_schemaName}
+	return e
 }
 
 // InfoSchemaCheckConstraintsExtractor is the predicate extractor for information_schema.check_constraints.
@@ -440,9 +402,20 @@ type InfoSchemaCheckConstraintsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemas lists related schemas from predicate.
-func (e *InfoSchemaCheckConstraintsExtractor) ListSchemas(is infoschema.InfoSchema) []model.CIStr {
-	return e.listSchemas(is, _constraintSchema)
+// NewInfoSchemaCheckConstraintsExtractor creates a new InfoSchemaCheckConstraintsExtractor.
+func NewInfoSchemaCheckConstraintsExtractor() *InfoSchemaCheckConstraintsExtractor {
+	e := &InfoSchemaCheckConstraintsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:     _constraintSchema,
+		constrName: _constraintName,
+	}
+	e.colNames = []columnName{_constraintSchema, _constraintName}
+	return e
+}
+
+// HasConstraint returns true if constraint name is specified in predicates.
+func (e *InfoSchemaCheckConstraintsExtractor) HasConstraint(name string) bool {
+	return !e.filter(_constraintName, name)
 }
 
 // InfoSchemaTiDBCheckConstraintsExtractor is the predicate extractor for information_schema.tidb_check_constraints.
@@ -450,25 +423,22 @@ type InfoSchemaTiDBCheckConstraintsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-func (e *InfoSchemaTiDBCheckConstraintsExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _constraintSchema)
-
-	tableIDs := e.getSchemaObjectNames(_tableID)
-	tableNames := e.getSchemaObjectNames(_tableName)
-
-	if len(tableIDs) > 0 {
-		tableMap := make(map[int64]*model.TableInfo, len(tableIDs))
-		findTablesByID(is, tableIDs, tableNames, tableMap)
-		return findSchemasForTables(ctx, is, schemas, maps.Values(tableMap))
+// NewInfoSchemaTiDBCheckConstraintsExtractor creates a new InfoSchemaTiDBCheckConstraintsExtractor.
+func NewInfoSchemaTiDBCheckConstraintsExtractor() *InfoSchemaTiDBCheckConstraintsExtractor {
+	e := &InfoSchemaTiDBCheckConstraintsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:     _constraintSchema,
+		table:      _tableName,
+		tableID:    _tableID,
+		constrName: _constraintName,
 	}
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
-	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_constraintSchema, _tableName, _tableID, _constraintName}
+	return e
+}
+
+// HasConstraint returns true if constraint name is specified in predicates.
+func (e *InfoSchemaTiDBCheckConstraintsExtractor) HasConstraint(name string) bool {
+	return !e.filter(_constraintName, name)
 }
 
 // InfoSchemaReferConstExtractor is the predicate extractor for information_schema.referential_constraints.
@@ -476,17 +446,21 @@ type InfoSchemaReferConstExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-func (e *InfoSchemaReferConstExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _constraintSchema)
-	tableNames := e.getSchemaObjectNames(_tableName)
-	if len(tableNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, tableNames)
+// NewInfoSchemaReferConstExtractor creates a new InfoSchemaReferConstExtractor.
+func NewInfoSchemaReferConstExtractor() *InfoSchemaReferConstExtractor {
+	e := &InfoSchemaReferConstExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:     _constraintSchema,
+		table:      _tableName,
+		constrName: _constraintName,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
+	e.colNames = []columnName{_constraintSchema, _tableName, _constraintName}
+	return e
+}
+
+// HasConstraint returns true if constraint name is specified in predicates.
+func (e *InfoSchemaReferConstExtractor) HasConstraint(name string) bool {
+	return !e.filter(_constraintName, name)
 }
 
 // InfoSchemaSequenceExtractor is the predicate extractor for information_schema.sequences.
@@ -494,59 +468,15 @@ type InfoSchemaSequenceExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
-// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
-func (e *InfoSchemaSequenceExtractor) ListSchemasAndTables(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-) ([]model.CIStr, []*model.TableInfo, error) {
-	schemas := e.listSchemas(is, _sequenceSchema)
-	seqNames := e.getSchemaObjectNames(_sequenceName)
-	if len(seqNames) > 0 {
-		return findTableAndSchemaByName(ctx, is, schemas, seqNames)
+// NewInfoSchemaSequenceExtractor creates a new InfoSchemaSequenceExtractor.
+func NewInfoSchemaSequenceExtractor() *InfoSchemaSequenceExtractor {
+	e := &InfoSchemaSequenceExtractor{}
+	e.extractableColumns = extractableCols{
+		schema: _sequenceSchema,
+		table:  _sequenceName,
 	}
-	return listTablesForEachSchema(ctx, is, schemas)
-}
-
-func (e *InfoSchemaBaseExtractor) listSchemas(is infoschema.InfoSchema, schemaCol string) []model.CIStr {
-	schemas := e.getSchemaObjectNames(schemaCol)
-	if len(schemas) == 0 {
-		ret := is.AllSchemaNames()
-		slices.SortFunc(ret, func(a, b model.CIStr) int {
-			return strings.Compare(a.L, b.L)
-		})
-		return ret
-	}
-	ret := schemas[:0]
-	for _, s := range schemas {
-		if n, ok := is.SchemaByName(s); ok {
-			ret = append(ret, n.Name)
-		}
-	}
-	return ret
-}
-
-func findNameAndAppendToTableMap(
-	ctx context.Context,
-	is infoschema.InfoSchema,
-	schema model.CIStr,
-	tableNames []model.CIStr,
-	tables map[int64]*model.TableInfo,
-) error {
-	for _, n := range tableNames {
-		tbl, err := is.TableByName(ctx, schema, n)
-		if err != nil {
-			if terror.ErrorEqual(err, infoschema.ErrTableNotExists) {
-				continue
-			}
-			return errors.Trace(err)
-		}
-		tblInfo := tbl.Meta()
-		if tblInfo.TempTableType == model.TempTableLocal {
-			continue
-		}
-		tables[tblInfo.ID] = tblInfo
-	}
-	return nil
+	e.colNames = []columnName{_sequenceSchema, _sequenceName}
+	return e
 }
 
 // findTablesByID finds tables by table IDs and append them to table map.
@@ -713,8 +643,8 @@ func parseIDs(ids []model.CIStr) []int64 {
 }
 
 // getSchemaObjectNames gets the schema object names specified in predicate of given column name.
-func (e *InfoSchemaBaseExtractor) getSchemaObjectNames(colName string) []model.CIStr {
-	predVals, ok := e.ColPredicates[colName]
+func (e *InfoSchemaBaseExtractor) getSchemaObjectNames(colName columnName) []model.CIStr {
+	predVals, ok := e.ColPredicates[string(colName)]
 	if ok && len(predVals) > 0 {
 		tableNames := make([]model.CIStr, 0, len(predVals))
 		predVals.IterateWith(func(n string) {
@@ -733,7 +663,7 @@ func (e *InfoSchemaBaseExtractor) getSchemaObjectNames(colName string) []model.C
 // But for other columns, Subclass **must** reimplement `Filter` method to use like operators for filtering.
 // Currently, table_id is not taken into consideration.
 type InfoSchemaTableNameExtractor struct {
-	InfoSchemaSchemataExtractor
+	InfoSchemaBaseExtractor
 
 	listTableFunc func(
 		ctx context.Context,
@@ -771,6 +701,7 @@ func (e *InfoSchemaTableNameExtractor) Extract(
 	e.colsPredLower = make(map[string]set.StringSet, len(e.colNames))
 	var likePatterns []string
 	for _, colName := range e.colNames {
+		colName := string(colName)
 		remained, likePatterns = e.extractLikePatternCol(ctx, schema, names, remained, colName, true, false)
 		regexp := make([]collate.WildcardPattern, len(likePatterns))
 		predColLower := set.StringSet{}
@@ -792,7 +723,7 @@ func (e *InfoSchemaTableNameExtractor) Extract(
 }
 
 // getPredicates gets all names and regexps related to given column names.
-func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...string) (
+func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...columnName) (
 	set.StringSet, []collate.WildcardPattern, bool) {
 	filters := set.StringSet{}
 	regexp := []collate.WildcardPattern{}
@@ -800,10 +731,10 @@ func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...string) (
 
 	// Extract all filters and like patterns
 	for _, col := range colNames {
-		if rs, ok := e.colsRegexp[col]; ok && len(rs) > 0 {
+		if rs, ok := e.colsRegexp[string(col)]; ok && len(rs) > 0 {
 			regexp = append(regexp, rs...)
 		}
-		if f, ok := e.colsPredLower[col]; ok && len(f) > 0 {
+		if f, ok := e.colsPredLower[string(col)]; ok && len(f) > 0 {
 			if !hasPredicates {
 				filters = f
 				hasPredicates = true
@@ -883,7 +814,7 @@ func (e *InfoSchemaTableNameExtractor) ListTables(
 		return nil, errors.Trace(err)
 	}
 
-	if regexp, ok := e.colsRegexp[_tableName]; ok {
+	if regexp, ok := e.colsRegexp[string(_tableName)]; ok {
 		tbls := make([]*model.TableInfo, 0, len(allTbls))
 	ForLoop:
 		for _, tbl := range allTbls {
@@ -937,13 +868,13 @@ func (e *InfoSchemaTableNameExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 	r := new(bytes.Buffer)
 
 	for _, colName := range e.colNames {
-		if pred, ok := e.ColPredicates[colName]; ok && len(pred) > 0 {
+		if pred, ok := e.ColPredicates[string(colName)]; ok && len(pred) > 0 {
 			fmt.Fprintf(r, "%s:[%s], ", colName, extractStringFromStringSet(pred))
 		}
 	}
 
 	for _, colName := range e.colNames {
-		if patterns, ok := e.LikePatterns[colName]; ok && len(patterns) > 0 {
+		if patterns, ok := e.LikePatterns[string(colName)]; ok && len(patterns) > 0 {
 			fmt.Fprintf(r, "%s_pattern:[%s], ", colName, extractStringFromStringSlice(patterns))
 		}
 	}
@@ -959,6 +890,18 @@ func (e *InfoSchemaTableNameExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 // InfoSchemaColumnsExtractor is the predicate extractor for information_schema.columns.
 type InfoSchemaColumnsExtractor struct {
 	InfoSchemaTableNameExtractor
+}
+
+// NewInfoSchemaColumnsExtractor creates a new InfoSchemaColumnsExtractor.
+func NewInfoSchemaColumnsExtractor() *InfoSchemaColumnsExtractor {
+	e := &InfoSchemaColumnsExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:     _tableSchema,
+		table:      _tableName,
+		columnName: _columnName,
+	}
+	e.colNames = []columnName{_tableSchema, _tableName, _columnName}
+	return e
 }
 
 // ListColumns lists unhidden columns and corresponding ordinal positions for given table from predicates.
@@ -992,14 +935,26 @@ ForLoop:
 	return columns, ordinalPos
 }
 
-// InfoSchemaIndexUsageExtractor is the predicate extractor for information_schema.tidb_index_usage.
-type InfoSchemaIndexUsageExtractor struct {
+// InfoSchemaTiDBIndexUsageExtractor is the predicate extractor for information_schema.tidb_index_usage.
+type InfoSchemaTiDBIndexUsageExtractor struct {
 	InfoSchemaTableNameExtractor
+}
+
+// NewInfoSchemaTiDBIndexUsageExtractor creates a new InfoSchemaTiDBIndexUsageExtractor.
+func NewInfoSchemaTiDBIndexUsageExtractor() *InfoSchemaTiDBIndexUsageExtractor {
+	e := &InfoSchemaTiDBIndexUsageExtractor{}
+	e.extractableColumns = extractableCols{
+		schema:    _tableSchema,
+		table:     _tableName,
+		indexName: _indexName,
+	}
+	e.colNames = []columnName{_tableSchema, _tableName, _indexName}
+	return e
 }
 
 // ListIndexes lists related indexes for given table from predicate.
 // If no index found in predicate, it return all indexes.
-func (e *InfoSchemaIndexUsageExtractor) ListIndexes(
+func (e *InfoSchemaTiDBIndexUsageExtractor) ListIndexes(
 	tbl *model.TableInfo,
 ) []*model.IndexInfo {
 	predCol, regexp, _ := e.getPredicates(_indexName)

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -83,6 +83,11 @@ type InfoSchemaBaseExtractor struct {
 	extractableColumns extractableCols
 }
 
+// GetBase is only used for test.
+func (e *InfoSchemaBaseExtractor) GetBase() *InfoSchemaBaseExtractor {
+	return e
+}
+
 // ListSchemas lists related schemas from predicate.
 func (e *InfoSchemaBaseExtractor) ListSchemas(is infoschema.InfoSchema) []model.CIStr {
 	ec := e.extractableColumns

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -36,6 +36,8 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// columnName is the type for column names used by tables information_schema.
+type columnName string
 type extractableCols struct {
 	schema      columnName
 	table       columnName
@@ -81,6 +83,7 @@ type InfoSchemaBaseExtractor struct {
 	extractableColumns extractableCols
 }
 
+// ListSchemas lists related schemas from predicate.
 func (e *InfoSchemaBaseExtractor) ListSchemas(is infoschema.InfoSchema) []model.CIStr {
 	ec := e.extractableColumns
 	schemas := e.getSchemaObjectNames(ec.schema)
@@ -100,6 +103,8 @@ func (e *InfoSchemaBaseExtractor) ListSchemas(is infoschema.InfoSchema) []model.
 	return ret
 }
 
+// ListSchemasAndTables lists related tables and their corresponding schemas from predicate.
+// If there is no error, returning schema slice and table slice are guaranteed to have the same length.
 func (e *InfoSchemaBaseExtractor) ListSchemasAndTables(
 	ctx context.Context,
 	is infoschema.InfoSchema,
@@ -211,13 +216,6 @@ func (e *InfoSchemaBaseExtractor) filter(colName columnName, val string) bool {
 	}
 	// No need to filter records since no predicate for the column exists.
 	return false
-}
-
-// columnName is the type for column names used by tables information_schema.
-type columnName string
-
-type ColumnExtractor interface {
-	extratableColumns() extractableCols
 }
 
 // InfoSchemaIndexesExtractor is the predicate extractor for information_schema.tidb_indexes.
@@ -340,6 +338,7 @@ type InfoSchemaPartitionsExtractor struct {
 	InfoSchemaBaseExtractor
 }
 
+// NewInfoSchemaPartitionsExtractor creates a new InfoSchemaPartitionsExtractor.
 func NewInfoSchemaPartitionsExtractor() *InfoSchemaPartitionsExtractor {
 	e := &InfoSchemaPartitionsExtractor{}
 	e.extractableColumns = extractableCols{
@@ -374,10 +373,12 @@ func NewInfoSchemaStatisticsExtractor() *InfoSchemaStatisticsExtractor {
 	return e
 }
 
+// HasIndex returns true if index name is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasIndex(val string) bool {
 	return e.filter(_indexName, val)
 }
 
+// HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasPrimaryKey() bool {
 	return !e.filter(_indexName, primaryKeyName)
 }

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -375,7 +375,7 @@ func NewInfoSchemaStatisticsExtractor() *InfoSchemaStatisticsExtractor {
 
 // HasIndex returns true if index name is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasIndex(val string) bool {
-	return e.filter(_indexName, val)
+	return !e.filter(_indexName, val)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -323,7 +323,7 @@ func (e *InfoSchemaTableConstraintsExtractor) HasConstraintSchema(name string) b
 	return !e.filter(_constraintSchema, name)
 }
 
-// HasConstraintSchema returns true if constraint schema is specified in predicates.
+// HasConstraint returns true if constraint is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraint(name string) bool {
 	return !e.filter(_constraintName, name)
 }

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -2052,7 +2052,7 @@ func TestInfoSchemaTableExtract(t *testing.T) {
 			base = &ex.InfoSchemaBaseExtractor
 		case *plannercore.InfoSchemaIndexesExtractor:
 			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaIndexUsageExtractor:
+		case *plannercore.InfoSchemaTiDBIndexUsageExtractor:
 			base = &ex.InfoSchemaBaseExtractor
 		case *plannercore.InfoSchemaViewsExtractor:
 			base = &ex.InfoSchemaBaseExtractor

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -2038,42 +2038,11 @@ func TestInfoSchemaTableExtract(t *testing.T) {
 	for _, ca := range cases {
 		logicalMemTable := getLogicalMemTable(t, dom, se, parser, ca.sql)
 		require.NotNil(t, logicalMemTable.Extractor)
-		var base *plannercore.InfoSchemaBaseExtractor
-		switch ex := logicalMemTable.Extractor.(type) {
-		case *plannercore.InfoSchemaBaseExtractor:
-			base = ex
-		case *plannercore.InfoSchemaTablesExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaPartitionsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaStatisticsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaSchemataExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaIndexesExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaTiDBIndexUsageExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaViewsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaKeyColumnUsageExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaTableConstraintsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaSequenceExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaCheckConstraintsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaReferConstExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaTiDBCheckConstraintsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		case *plannercore.InfoSchemaColumnsExtractor:
-			base = &ex.InfoSchemaBaseExtractor
-		default:
-			require.Failf(t, "unexpected extractor type", "%T", ex)
-		}
-		require.Equal(t, ca.skipRequest, base.SkipRequest, "SQL: %v", ca.sql)
-		require.Equal(t, ca.colPredicates, base.ColPredicates, "SQL: %v", ca.sql)
+		ex, ok := logicalMemTable.Extractor.(interface {
+			GetBase() *plannercore.InfoSchemaBaseExtractor
+		})
+		require.True(t, ok)
+		require.Equal(t, ca.skipRequest, ex.GetBase().SkipRequest, "SQL: %v", ca.sql)
+		require.Equal(t, ca.colPredicates, ex.GetBase().ColPredicates, "SQL: %v", ca.sql)
 	}
 }

--- a/pkg/planner/core/pb_to_plan.go
+++ b/pkg/planner/core/pb_to_plan.go
@@ -132,9 +132,7 @@ func (b *PBPlanBuilder) pbToTableScan(e *tipb.Executor) (base.PhysicalPlan, erro
 	case infoschema.ClusterTableStatementsSummary, infoschema.ClusterTableStatementsSummaryHistory:
 		p.Extractor = &StatementsSummaryExtractor{}
 	case infoschema.ClusterTableTiDBIndexUsage:
-		ex := &InfoSchemaIndexUsageExtractor{}
-		ex.initExtractableColNames(infoschema.TableTiDBIndexUsage)
-		p.Extractor = ex
+		p.Extractor = NewInfoSchemaTiDBIndexUsageExtractor()
 	}
 	return p, nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50305

Problem Summary:

Previously, we have a few usages like `ex.Filter("partition_name", pi.Name.L)` which is easy to misuse.

### What changed and how does it work?

- Add `HasXXX` method for each extractors, remove `Filter`s.
- Extract similar code `ListSchemasAndTables` to `InfoSchemaBaseExtractor`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
