### PR TITLE
executor: fix data race in hash join v2

### DIFF
--- a/pkg/executor/join/BUILD.bazel
+++ b/pkg/executor/join/BUILD.bazel
@@ -80,7 +80,7 @@ go_test(
     ],
     embed = [":join"],
     flaky = True,
-    shard_count = 49,
+    shard_count = 50,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/join/base_join_probe.go
+++ b/pkg/executor/join/base_join_probe.go
@@ -356,9 +356,17 @@ func (j *baseJoinProbe) appendBuildRowToChunkInternal(chk *chunk.Chunk, usedCols
 		var currentColumn *chunk.Column
 		if ok {
 			currentColumn = chk.Column(indexInDstChk)
-			for index := range j.cachedBuildRows {
-				currentColumn.AppendNullBitmap(!meta.isColumnNull(*(*unsafe.Pointer)(unsafe.Pointer(&j.cachedBuildRows[index].buildRowStart)), columnIndex))
-				j.cachedBuildRows[index].buildRowOffset = chunk.AppendCellFromRawData(currentColumn, *(*unsafe.Pointer)(unsafe.Pointer(&j.cachedBuildRows[index].buildRowStart)), j.cachedBuildRows[index].buildRowOffset)
+			mayConcurrentWrite := meta.colOffsetInNullMap == 1 && columnIndex <= 31
+			if !mayConcurrentWrite {
+				for index := range j.cachedBuildRows {
+					currentColumn.AppendNullBitmap(!meta.isColumnNull(*(*unsafe.Pointer)(unsafe.Pointer(&j.cachedBuildRows[index].buildRowStart)), columnIndex))
+					j.cachedBuildRows[index].buildRowOffset = chunk.AppendCellFromRawData(currentColumn, *(*unsafe.Pointer)(unsafe.Pointer(&j.cachedBuildRows[index].buildRowStart)), j.cachedBuildRows[index].buildRowOffset)
+				}
+			} else {
+				for index := range j.cachedBuildRows {
+					currentColumn.AppendNullBitmap(!meta.isColumnNullThreadSafe(*(*unsafe.Pointer)(unsafe.Pointer(&j.cachedBuildRows[index].buildRowStart)), columnIndex))
+					j.cachedBuildRows[index].buildRowOffset = chunk.AppendCellFromRawData(currentColumn, *(*unsafe.Pointer)(unsafe.Pointer(&j.cachedBuildRows[index].buildRowStart)), j.cachedBuildRows[index].buildRowOffset)
+				}
 			}
 		} else {
 			// not used so don't need to insert into chk, but still need to advance rowData

--- a/pkg/executor/join/base_join_probe.go
+++ b/pkg/executor/join/base_join_probe.go
@@ -356,6 +356,8 @@ func (j *baseJoinProbe) appendBuildRowToChunkInternal(chk *chunk.Chunk, usedCols
 		var currentColumn *chunk.Column
 		if ok {
 			currentColumn = chk.Column(indexInDstChk)
+			// Other goroutine will use `atomic.StoreUint32` to write to the first 32 bit in nullmap when it need to set usedFlag
+			// so read from nullMap may meet concurrent write if meta.colOffsetInNullMap == 1 && (columnIndex + meta.colOffsetInNullMap <= 32)
 			mayConcurrentWrite := meta.colOffsetInNullMap == 1 && columnIndex <= 31
 			if !mayConcurrentWrite {
 				for index := range j.cachedBuildRows {

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -68,9 +68,9 @@ func init() {
 
 // initializeBitMasks encapsulates the bit-shifting logic to set the bitMaskInUint32 array based on endianness
 // The parameter isLittleEndian indicates the system's endianness
-// - If the system is little-endian, the bit mask for each byte starts from the most significant bit (bit 7) and decrements sequentially
-// - If the system is big-endian, the bit masks are set sequentially from the highest bit (bit 31) to the lowest bit (bit 0),
-//   ensuring that atomic operations can be performed correctly on different endian systems
+//   - If the system is little-endian, the bit mask for each byte starts from the most significant bit (bit 7) and decrements sequentially
+//   - If the system is big-endian, the bit masks are set sequentially from the highest bit (bit 31) to the lowest bit (bit 0),
+//     ensuring that atomic operations can be performed correctly on different endian systems
 func initializeBitMasks(isLittleEndian bool) {
 	for i := 0; i < 32; i++ {
 		if isLittleEndian {
@@ -82,6 +82,7 @@ func initializeBitMasks(isLittleEndian bool) {
 		}
 	}
 }
+
 //go:linkname heapObjectsCanMove runtime.heapObjectsCanMove
 func heapObjectsCanMove() bool
 

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -51,22 +51,21 @@ func init() {
 	// 0x70 0x00 0x00 0x00
 	// when interprete the 32 bit as uint32
 	// in big endian system, it is 0x70000000
-	// in small endian system, it is 0x00000070
+	// in little endian system, it is 0x00000070
 	// useFlagMask and bitMaskInUint32 is used to hide these difference in big endian/small endian system
 	// and init function is used to init usedFlagMask and bitMaskInUint32 based on endianness of current env
 	endiannessTest := uint32(1) << 7
 	low8Value := *(*uint8)(unsafe.Pointer(&endiannessTest))
 	if uint32(low8Value) == endiannessTest {
 		// Little-endian system: the lowest byte (at the lowest address) stores the least significant byte (LSB) of the integer
-		usedFlagMask = uint32(1) << 7
 		initializeBitMasks(true)
 	} else {
-		// Big-endian system: the highest byte (at the lowest address) stores the most significant byte (MSB) of the integer
-		usedFlagMask = uint32(1) << 31
+		// Big-endian system: the lowest byte (at the lowest address) stores the most significant byte (MSB) of the integer
 		initializeBitMasks(false)
 	}
-	}
+	usedFlagMask = bitMaskInUint32[0]
 }
+
 // initializeBitMasks encapsulates the bit-shifting logic to set the bitMaskInUint32 array based on endianness
 // The parameter isLittleEndian indicates the system's endianness
 // - If the system is little-endian, the bit mask for each byte starts from the most significant bit (bit 7) and decrements sequentially

--- a/pkg/executor/join/join_row_table.go
+++ b/pkg/executor/join/join_row_table.go
@@ -285,18 +285,18 @@ func (meta *TableMeta) isColumnNull(rowStart unsafe.Pointer, columnIndex int) bo
 }
 
 // for join that need to set UsedFlag during probe stage, read from nullMap is not thread safe for the first 32 bit of nullMap, atomic.LoadUint32 is used to avoid read-write conflict
-func (meta *TableMeta) isColumnNullThreadSafe(rowStart unsafe.Pointer, columnIndex int) bool {
+func (*TableMeta) isColumnNullThreadSafe(rowStart unsafe.Pointer, columnIndex int) bool {
 	return atomic.LoadUint32((*uint32)(unsafe.Add(rowStart, sizeOfNextPtr)))&bitMaskInUint32[columnIndex+1] != uint32(0)
 }
 
-func (meta *TableMeta) setUsedFlag(rowStart unsafe.Pointer) {
+func (*TableMeta) setUsedFlag(rowStart unsafe.Pointer) {
 	addr := (*uint32)(unsafe.Add(rowStart, sizeOfNextPtr))
 	value := atomic.LoadUint32(addr)
 	value |= usedFlagMask
 	atomic.StoreUint32(addr, value)
 }
 
-func (meta *TableMeta) isCurrentRowUsed(rowStart unsafe.Pointer) bool {
+func (*TableMeta) isCurrentRowUsed(rowStart unsafe.Pointer) bool {
 	return (*(*uint32)(unsafe.Add(rowStart, sizeOfNextPtr)) & usedFlagMask) == usedFlagMask
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55465

Problem Summary:
Add `TableMeta.isColumnNullThreadSafe` and use `TableMeta.isColumnNullThreadSafe` when there is potential data race during join probe.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
