### PR TITLE
backup: reset timeout on store level

### DIFF
--- a/br/pkg/backup/store.go
+++ b/br/pkg/backup/store.go
@@ -60,6 +60,7 @@ func (r ResponseAndStore) GetStoreID() uint64 {
 
 // timeoutRecv cancel the context if `Refresh()` is not called within the specified time `timeout`.
 type timeoutRecv struct {
+	storeID   uint64
 	wg        sync.WaitGroup
 	parentCtx context.Context
 	cancel    context.CancelCauseFunc
@@ -97,15 +98,17 @@ func (trecv *timeoutRecv) loop(timeout time.Duration) {
 				return
 			}
 		case <-ticker.C:
-			log.Warn("receive a backup response timeout")
+			log.Warn("wait backup response timeout, cancel the backup",
+				zap.Duration("timeout", timeout), zap.Uint64("storeID", trecv.storeID))
 			trecv.cancel(errors.Errorf("receive a backup response timeout"))
 		}
 	}
 }
 
-func StartTimeoutRecv(ctx context.Context, timeout time.Duration) (context.Context, *timeoutRecv) {
+func StartTimeoutRecv(ctx context.Context, timeout time.Duration, storeID uint64) (context.Context, *timeoutRecv) {
 	cctx, cancel := context.WithCancelCause(ctx)
 	trecv := &timeoutRecv{
+		storeID:   storeID,
 		parentCtx: ctx,
 		cancel:    cancel,
 		refresh:   make(chan struct{}),
@@ -116,15 +119,12 @@ func StartTimeoutRecv(ctx context.Context, timeout time.Duration) (context.Conte
 }
 
 func doSendBackup(
-	pctx context.Context,
+	ctx context.Context,
 	client backuppb.BackupClient,
 	req backuppb.BackupRequest,
 	respFn func(*backuppb.BackupResponse) error,
 ) error {
-	// Backup might be stuck on GRPC `waitonHeader`, so start a timeout ticker to
-	// terminate the backup if it does not receive any new response for a long time.
-	ctx, timerecv := StartTimeoutRecv(pctx, TimeoutOneResponse)
-	defer timerecv.Stop()
+
 	failpoint.Inject("hint-backup-start", func(v failpoint.Value) {
 		logutil.CL(ctx).Info("failpoint hint-backup-start injected, " +
 			"process will notify the shell.")
@@ -169,7 +169,6 @@ func doSendBackup(
 
 	for {
 		resp, err := bCli.Recv()
-		timerecv.Refresh()
 		if err != nil {
 			if errors.Cause(err) == io.EOF { // nolint:errorlint
 				logutil.CL(ctx).Debug("backup streaming finish",
@@ -192,7 +191,7 @@ func doSendBackup(
 }
 
 func startBackup(
-	ctx context.Context,
+	pctx context.Context,
 	storeID uint64,
 	backupReq backuppb.BackupRequest,
 	backupCli backuppb.BackupClient,
@@ -201,14 +200,21 @@ func startBackup(
 ) error {
 	// this goroutine handle the response from a single store
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-pctx.Done():
+		return pctx.Err()
 	default:
-		logutil.CL(ctx).Info("try backup", zap.Uint64("storeID", storeID))
 		// Send backup request to the store.
 		// handle the backup response or internal error here.
 		// handle the store error(reboot or network partition) outside.
 		reqs := SplitBackupReqRanges(backupReq, concurrency)
+		logutil.CL(pctx).Info("start backup to corresponse store", zap.Uint64("storeID", storeID),
+			zap.Int("reqCount", len(reqs)), zap.Uint("concurrency", concurrency))
+
+		// Backup might be stuck on GRPC `waitonHeader`, so start a timeout ticker to
+		// terminate the backup if it does not receive any new response for a long time.
+		ctx, timerecv := StartTimeoutRecv(pctx, TimeoutOneResponse, storeID)
+		defer timerecv.Stop()
+
 		pool := tidbutil.NewWorkerPool(concurrency, "store_backup")
 		eg, ectx := errgroup.WithContext(ctx)
 		for i, req := range reqs {
@@ -218,8 +224,10 @@ func startBackup(
 				retry := -1
 				return utils.WithRetry(ectx, func() error {
 					retry += 1
-					logutil.CL(ectx).Info("backup to store", zap.Uint64("storeID", storeID),
-						zap.Int("retry", retry), zap.Int("reqIndex", reqIndex))
+					if retry > 1 {
+						logutil.CL(ectx).Info("retry backup to store", zap.Uint64("storeID", storeID),
+							zap.Int("retry", retry), zap.Int("reqIndex", reqIndex))
+					}
 					return doSendBackup(ectx, backupCli, bkReq, func(resp *backuppb.BackupResponse) error {
 						// Forward all responses (including error).
 						failpoint.Inject("backup-timeout-error", func(val failpoint.Value) {
@@ -262,6 +270,8 @@ func startBackup(
 							Resp:    resp,
 							StoreID: storeID,
 						}:
+							// reset timeout when receive a response
+							timerecv.Refresh()
 						}
 						return nil
 					})
@@ -325,7 +335,7 @@ func ObserveStoreChangesAsync(ctx context.Context, stateNotifier chan BackupRetr
 				// reset the state
 				sendAll = false
 				clear(newJoinStoresMap)
-				logutil.CL(ctx).Info("check store changes every tick")
+				logutil.CL(ctx).Info("check store changes every 30s")
 				err := watcher.Step(ctx)
 				if err != nil {
 					logutil.CL(ctx).Warn("failed to watch store changes, ignore it", zap.Error(err))

--- a/br/pkg/backup/store_test.go
+++ b/br/pkg/backup/store_test.go
@@ -92,7 +92,7 @@ func TestTimeoutRecvCancel(t *testing.T) {
 	ctx := context.Background()
 	cctx, cancel := context.WithCancel(ctx)
 
-	_, trecv := StartTimeoutRecv(cctx, time.Hour)
+	_, trecv := StartTimeoutRecv(cctx, time.Hour, 0)
 	cancel()
 	trecv.wg.Wait()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:  ref https://github.com/pingcap/tidb/issues/53480

Problem Summary:
The previous implementation will reset on grpc level. but actually, br could have multiple grpc connections to each store. we only need a timeout on a store level. this PR tried to fix it.
### What changed and how does it work?
Reset timeout when receive a backup response from a store.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
