### PR TITLE
planner: improve the performance of FindFieldName

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -188,6 +188,7 @@ go_test(
         "main_test.go",
         "scalar_function_test.go",
         "schema_test.go",
+        "simple_rewriter_test.go",
         "typeinfer_test.go",
         "util_test.go",
     ],

--- a/pkg/expression/simple_rewriter.go
+++ b/pkg/expression/simple_rewriter.go
@@ -76,36 +76,13 @@ func FindFieldName(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
 		// Check database and table name match
 		if (dbName == "" || dbName == name.DBName.L) &&
 			(tblName == "" || tblName == name.TblName.L) {
-			if idx != -1 {
-				// Handle redundant case
-				if names[idx].Redundant || name.Redundant {
-					if !name.Redundant {
-						idx = i
-					}
-					hasRedundant = true
-					continue
-				}
+			if idx != -1 && !hasRedundant && !name.Redundant {
 				return -1, errNonUniq.GenWithStackByArgs(astCol.String(), "field list")
 			}
-			idx = i
-			if name.Redundant {
-				hasRedundant = true
-			}
-		}
-	}
-
-	// If we only found redundant matches, ensure we return the last one
-	if hasRedundant && idx == -1 {
-		for i := len(names) - 1; i >= 0; i-- {
-			name := names[i]
-			if name.NotExplicitUsable || name.ColName.L != colName {
-				continue
-			}
-			if (dbName == "" || dbName == name.DBName.L) &&
-				(tblName == "" || tblName == name.TblName.L) {
+			if idx == -1 || !name.Redundant {
 				idx = i
-				break
 			}
+			hasRedundant = hasRedundant || name.Redundant
 		}
 	}
 

--- a/pkg/expression/simple_rewriter.go
+++ b/pkg/expression/simple_rewriter.go
@@ -63,16 +63,27 @@ func ParseSimpleExpr(ctx BuildContext, exprStr string, opts ...BuildOption) (Exp
 
 // FindFieldName finds the column name from NameSlice.
 func FindFieldName(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
-	dbName, tblName, colName := astCol.Schema, astCol.Table, astCol.Name
+	dbName, tblName, colName := astCol.Schema.L, astCol.Table.L, astCol.Name.L
 	idx := -1
+	var redundantIdx int
+	hasRedundant := false
+
 	for i, name := range names {
-		if !name.NotExplicitUsable && (dbName.L == "" || dbName.L == name.DBName.L) &&
-			(tblName.L == "" || tblName.L == name.TblName.L) &&
-			(colName.L == name.ColName.L) {
+		// Early continue if not usable or column name doesn't match
+		if name.NotExplicitUsable || name.ColName.L != colName {
+			continue
+		}
+
+		// Check database and table name match
+		if (dbName == "" || dbName == name.DBName.L) &&
+			(tblName == "" || tblName == name.TblName.L) {
+
 			if idx != -1 {
+				// Handle redundant case
 				if names[idx].Redundant || name.Redundant {
 					if !name.Redundant {
-						idx = i
+						redundantIdx = i
+						hasRedundant = true
 					}
 					continue
 				}
@@ -81,6 +92,12 @@ func FindFieldName(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
 			idx = i
 		}
 	}
+
+	// If we found a non-redundant match after a redundant one, use it
+	if hasRedundant && idx == -1 {
+		idx = redundantIdx
+	}
+
 	return idx, nil
 }
 

--- a/pkg/expression/simple_rewriter.go
+++ b/pkg/expression/simple_rewriter.go
@@ -76,7 +76,6 @@ func FindFieldName(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
 		// Check database and table name match
 		if (dbName == "" || dbName == name.DBName.L) &&
 			(tblName == "" || tblName == name.TblName.L) {
-
 			if idx != -1 {
 				// Handle redundant case
 				if names[idx].Redundant || name.Redundant {

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -124,6 +124,26 @@ func TestFindFieldName(t *testing.T) {
 			astCol:   &ast.ColumnName{Schema: model.NewCIStr(""), Table: model.NewCIStr(""), Name: model.NewCIStr("col")},
 			expected: 1,
 		},
+		{
+			name: "Non-unique match with a redundant",
+			names: types.NameSlice{
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col")},
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col")},
+			},
+			astCol: &ast.ColumnName{Schema: model.NewCIStr("db"), Table: model.NewCIStr("tbl"), Name: model.NewCIStr("col")},
+			err:    errNonUniq.GenWithStackByArgs("db.tbl.col", "field list"),
+		},
+		{
+			name: "Match with multiple redundant",
+			names: types.NameSlice{
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
+			},
+			astCol:   &ast.ColumnName{Schema: model.NewCIStr("db"), Table: model.NewCIStr("tbl"), Name: model.NewCIStr("col")},
+			expected: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -89,6 +89,22 @@ func TestFindFieldName(t *testing.T) {
 			expected: 0,
 		},
 		{
+			name: "Match with empty schema, non-empty table",
+			names: types.NameSlice{
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col")},
+			},
+			astCol:   &ast.ColumnName{Schema: model.NewCIStr(""), Table: model.NewCIStr("tbl"), Name: model.NewCIStr("col")},
+			expected: 0,
+		},
+		{
+			name: "Match with non-empty schema, empty table",
+			names: types.NameSlice{
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col")},
+			},
+			astCol:   &ast.ColumnName{Schema: model.NewCIStr("db"), Table: model.NewCIStr(""), Name: model.NewCIStr("col")},
+			expected: 0,
+		},
+		{
 			name: "No match",
 			names: types.NameSlice{
 				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col1")},

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression
 
 import (

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -86,10 +86,11 @@ func TestFindFieldName(t *testing.T) {
 			name: "Match with redundant field",
 			names: types.NameSlice{
 				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
 				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col")},
 			},
 			astCol:   &ast.ColumnName{Schema: model.NewCIStr("db"), Table: model.NewCIStr("tbl"), Name: model.NewCIStr("col")},
-			expected: 1,
+			expected: 2,
 		},
 		{
 			name: "Non-unique match",
@@ -99,6 +100,15 @@ func TestFindFieldName(t *testing.T) {
 			},
 			astCol: &ast.ColumnName{Schema: model.NewCIStr("db"), Table: model.NewCIStr("tbl"), Name: model.NewCIStr("col")},
 			err:    errNonUniq.GenWithStackByArgs("db.tbl.col", "field list"),
+		},
+		{
+			name: "Match with empty schema and table and redundant",
+			names: types.NameSlice{
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col"), Redundant: true},
+				{DBName: model.NewCIStr("db"), TblName: model.NewCIStr("tbl"), ColName: model.NewCIStr("col")},
+			},
+			astCol:   &ast.ColumnName{Schema: model.NewCIStr(""), Table: model.NewCIStr(""), Name: model.NewCIStr("col")},
+			expected: 1,
 		},
 	}
 

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -162,7 +162,7 @@ func TestFindFieldName(t *testing.T) {
 
 // go test -bench=^BenchmarkFindFieldName$ -run=^$ -tags intest github.com/pingcap/tidb/pkg/expression
 func BenchmarkFindFieldName(b *testing.B) {
-	sizes := []int{10, 100, 1000, 10000}
+	sizes := []int{10, 100, 200, 1000, 10000}
 
 	for _, size := range sizes {
 		names, astCol := generateTestData(size)

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -59,7 +59,7 @@ func generateTestData(size int) (types.NameSlice, *ast.ColumnName) {
 	astCol := &ast.ColumnName{
 		Schema: model.NewCIStr("db"),
 		Table:  model.NewCIStr("tbl"),
-		Name:   model.NewCIStr("colZ"), // This will be at the end of the slice
+		Name:   model.NewCIStr("colZ"),
 	}
 	return names, astCol
 }

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -1,0 +1,71 @@
+package expression
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/types"
+)
+
+// Original function for comparison
+func FindFieldNameOriginal(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
+	dbName, tblName, colName := astCol.Schema, astCol.Table, astCol.Name
+	idx := -1
+	for i, name := range names {
+		if !name.NotExplicitUsable && (dbName.L == "" || dbName.L == name.DBName.L) &&
+			(tblName.L == "" || tblName.L == name.TblName.L) &&
+			(colName.L == name.ColName.L) {
+			if idx != -1 {
+				if names[idx].Redundant || name.Redundant {
+					if !name.Redundant {
+						idx = i
+					}
+					continue
+				}
+				return -1, errNonUniq.GenWithStackByArgs(astCol.String(), "field list")
+			}
+			idx = i
+		}
+	}
+	return idx, nil
+}
+
+func generateTestData(size int) (types.NameSlice, *ast.ColumnName) {
+	names := make(types.NameSlice, size)
+	for i := 0; i < size; i++ {
+		names[i] = &types.FieldName{
+			DBName:  model.NewCIStr("db"),
+			TblName: model.NewCIStr("tbl"),
+			ColName: model.NewCIStr("col" + string(rune('A'+i))),
+		}
+	}
+	astCol := &ast.ColumnName{
+		Schema: model.NewCIStr("db"),
+		Table:  model.NewCIStr("tbl"),
+		Name:   model.NewCIStr("colZ"), // This will be at the end of the slice
+	}
+	return names, astCol
+}
+
+// go test -bench=^BenchmarkFindFieldName$ -run=^$ -tags intest github.com/pingcap/tidb/pkg/expression
+func BenchmarkFindFieldName(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000}
+
+	for _, size := range sizes {
+		names, astCol := generateTestData(size)
+
+		b.Run("Original-"+fmt.Sprint(size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				FindFieldNameOriginal(names, astCol)
+			}
+		})
+
+		b.Run("Optimized-"+fmt.Sprint(size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				FindFieldName(names, astCol)
+			}
+		})
+	}
+}

--- a/pkg/expression/simple_rewriter_test.go
+++ b/pkg/expression/simple_rewriter_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Original function for comparison
-func FindFieldNameOriginal(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
+func findFieldNameOriginal(names types.NameSlice, astCol *ast.ColumnName) (int, error) {
 	dbName, tblName, colName := astCol.Schema, astCol.Table, astCol.Name
 	idx := -1
 	for i, name := range names {
@@ -130,8 +130,8 @@ func TestFindFieldName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			// Test FindFieldNameOriginal
-			idxOriginal, errOriginal := FindFieldNameOriginal(tt.names, tt.astCol)
+			// Test findFieldNameOriginal
+			idxOriginal, errOriginal := findFieldNameOriginal(tt.names, tt.astCol)
 			if tt.err != nil {
 				require.Error(errOriginal)
 				require.Equal(tt.err.Error(), errOriginal.Error())
@@ -169,7 +169,7 @@ func BenchmarkFindFieldName(b *testing.B) {
 
 		b.Run("Original-"+fmt.Sprint(size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				FindFieldNameOriginal(names, astCol)
+				findFieldNameOriginal(names, astCol)
 			}
 		})
 

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -907,6 +907,9 @@ func (b *PlanBuilder) coalesceCommonColumns(p *logicalop.LogicalJoin, leftPlan, 
 }
 
 func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, where ast.ExprNode, aggMapper map[*ast.AggregateFuncExpr]int) (base.LogicalPlan, error) {
+	if strings.Contains(ToString(p), "t1") {
+		logutil.Logger(ctx).Info("buildSelection", zap.String("p", ToString(p)), zap.String("where", where.Text()))
+	}
 	b.optFlag |= flagPredicatePushDown
 	b.optFlag |= flagDeriveTopNFromWindow
 	b.optFlag |= flagPredicateSimplification

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -907,9 +907,6 @@ func (b *PlanBuilder) coalesceCommonColumns(p *logicalop.LogicalJoin, leftPlan, 
 }
 
 func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, where ast.ExprNode, aggMapper map[*ast.AggregateFuncExpr]int) (base.LogicalPlan, error) {
-	if strings.Contains(ToString(p), "t1") {
-		logutil.Logger(ctx).Info("buildSelection", zap.String("p", ToString(p)), zap.String("where", where.Text()))
-	}
 	b.optFlag |= flagPredicatePushDown
 	b.optFlag |= flagDeriveTopNFromWindow
 	b.optFlag |= flagPredicateSimplification


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/52112

Problem Summary:
This function becomes sluggish with numerous columns. So, I tried to improve it in this pull request.

### What changed and how does it work?

1. Early continue: We check NotExplicitUsable and ColName first, as these are likely to eliminate many candidates quickly.
2. Avoid repeated access: We precompute dbName.L, tblName.L, and colName.L at the beginning.


Benchmark result:

```console
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -tags intest -bench ^BenchmarkFindFieldName$ github.com/pingcap/tidb/pkg/expression

goos: darwin
goarch: arm64
pkg: github.com/pingcap/tidb/pkg/expression
BenchmarkFindFieldName/Original-10-8         	10015628	       120.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkFindFieldName/Optimized-10-8        	37335829	        31.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkFindFieldName/Original-100-8        	  559112	      2155 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Optimized-100-8       	  693345	      1720 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Original-200-8        	  540812	      2150 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Optimized-200-8       	  713084	      1725 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Original-1000-8       	  558850	      2159 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Optimized-1000-8      	  712002	      1795 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Original-10000-8      	  558022	      2184 ns/op	     736 B/op	      10 allocs/op
BenchmarkFindFieldName/Optimized-10000-8     	  682408	      1725 ns/op	     736 B/op	      10 allocs/op
PASS
ok  	github.com/pingcap/tidb/pkg/expression	14.262s
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
