### PR TITLE
*: replace maps.Copy which is for map clone with std maps.Clone

### DIFF
--- a/lightning/pkg/importer/BUILD.bazel
+++ b/lightning/pkg/importer/BUILD.bazel
@@ -95,7 +95,6 @@ go_library(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_multierr//:multierr",

--- a/lightning/pkg/importer/get_pre_info.go
+++ b/lightning/pkg/importer/get_pre_info.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	mysql_sql_driver "github.com/go-sql-driver/mysql"
@@ -52,7 +53,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/mock"
 	pdhttp "github.com/tikv/pd/client/http"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
 )
 
 // compressionRatio is the tikv/tiflash's compression ratio

--- a/pkg/distsql/BUILD.bazel
+++ b/pkg/distsql/BUILD.bazel
@@ -48,7 +48,6 @@ go_library(
         "@com_github_tikv_client_go_v2//tikvrpc/interceptor",
         "@com_github_tikv_client_go_v2//util",
         "@org_golang_google_grpc//metadata",
-        "@org_golang_x_exp//maps",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -19,6 +19,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -46,7 +47,6 @@ import (
 	"github.com/tikv/client-go/v2/tikv"
 	clientutil "github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
 )
 
 var (

--- a/pkg/domain/sysvar_cache.go
+++ b/pkg/domain/sysvar_cache.go
@@ -64,9 +64,7 @@ func (do *Domain) GetSessionCache() (map[string]string, error) {
 	do.sysVarCache.RLock()
 	defer do.sysVarCache.RUnlock()
 	// Perform a deep copy since this will be assigned directly to the session
-	newMap := make(map[string]string, len(do.sysVarCache.session))
-	maps.Copy(newMap, do.sysVarCache.session)
-	return newMap, nil
+	return maps.Clone(do.sysVarCache.session), nil
 }
 
 // GetGlobalVar gets an individual global var from the sysvar cache.

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -17,6 +17,7 @@ package statistics
 import (
 	"cmp"
 	"fmt"
+	stdmaps "maps"
 	"slices"
 	"strings"
 
@@ -169,10 +170,10 @@ func (m *ColAndIdxExistenceMap) IsEmpty() bool {
 // Clone deeply copies the map.
 func (m *ColAndIdxExistenceMap) Clone() *ColAndIdxExistenceMap {
 	mm := NewColAndIndexExistenceMap(len(m.colInfoMap), len(m.idxInfoMap))
-	mm.colInfoMap = maps.Clone(m.colInfoMap)
-	mm.colAnalyzed = maps.Clone(m.colAnalyzed)
-	mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
-	mm.idxInfoMap = maps.Clone(m.idxInfoMap)
+	mm.colInfoMap = stdmaps.Clone(m.colInfoMap)
+	mm.colAnalyzed = stdmaps.Clone(m.colAnalyzed)
+	mm.idxAnalyzed = stdmaps.Clone(m.idxAnalyzed)
+	mm.idxInfoMap = stdmaps.Clone(m.idxInfoMap)
 	return mm
 }
 

--- a/pkg/util/intset/BUILD.bazel
+++ b/pkg/util/intset/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
     shard_count = 5,
     deps = [
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_tools//container/intsets",
     ],
 )

--- a/pkg/util/intset/fast_int_set_test.go
+++ b/pkg/util/intset/fast_int_set_test.go
@@ -16,6 +16,7 @@ package intset
 
 import (
 	"fmt"
+	"maps"
 	"math/rand"
 	"reflect"
 	"runtime"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 	"golang.org/x/tools/container/intsets"
 )
 
@@ -95,8 +95,7 @@ func (is IntSet) Equals(target IntSet) bool {
 }
 
 func (is *IntSet) CopyFrom(target IntSet) {
-	*is = NewIntSetWithCap(len(target))
-	maps.Copy(*is, target)
+	*is = maps.Clone(target)
 }
 
 func (is IntSet) SortedArray() []int {
@@ -114,10 +113,6 @@ func (is IntSet) Insert(k int) {
 
 func NewIntSet() IntSet {
 	return make(map[int]struct{})
-}
-
-func NewIntSetWithCap(c int) IntSet {
-	return make(map[int]struct{}, c)
 }
 
 func TestFastIntSetBasic(t *testing.T) {

--- a/pkg/util/stmtsummary/BUILD.bazel
+++ b/pkg/util/stmtsummary/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/util/set",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_tikv_client_go_v2//util",
-        "@org_golang_x_exp//maps",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],

--- a/pkg/util/stmtsummary/statement_summary.go
+++ b/pkg/util/stmtsummary/statement_summary.go
@@ -19,6 +19,7 @@ import (
 	"cmp"
 	"container/list"
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -36,7 +37,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/tikv/client-go/v2/util"
 	atomic2 "go.uber.org/atomic"
-	"golang.org/x/exp/maps"
 )
 
 // stmtSummaryByDigestKey defines key for stmtSummaryByDigestMap.summaryMap.
@@ -421,9 +421,8 @@ func (ssMap *stmtSummaryByDigestMap) GetMoreThanCntBindableStmt(cnt int64) []*Bi
 							PlanHint:  ssElement.planHint,
 							Charset:   ssElement.charset,
 							Collation: ssElement.collation,
-							Users:     make(map[string]struct{}),
+							Users:     maps.Clone(ssElement.authUsers),
 						}
-						maps.Copy(stmt.Users, ssElement.authUsers)
 						// If it is SQL command prepare / execute, the ssElement.sampleSQL is `execute ...`, we should get the original select query.
 						// If it is binary protocol prepare / execute, ssbd.normalizedSQL should be same as ssElement.sampleSQL.
 						if ssElement.prepared {

--- a/pkg/util/stmtsummary/v2/stmtsummary.go
+++ b/pkg/util/stmtsummary/v2/stmtsummary.go
@@ -359,9 +359,8 @@ func (s *StmtSummary) GetMoreThanCntBindableStmt(cnt int64) []*stmtsummary.Binda
 						PlanHint:  record.PlanHint,
 						Charset:   record.Charset,
 						Collation: record.Collation,
-						Users:     make(map[string]struct{}),
+						Users:     maps.Clone(record.AuthUsers),
 					}
-					maps.Copy(stmt.Users, record.AuthUsers)
 
 					// If it is SQL command prepare / execute, the ssElement.sampleSQL
 					// is `execute ...`, we should get the original select query.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55527

Problem Summary:

### What changed and how does it work?
as title, some maps.Copy which are used to override old item are kept
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
