### PR TITLE
infoschema: set the capacity of sieve to 0 for disabling infoschema v2

### DIFF
--- a/pkg/domain/domain_sysvars.go
+++ b/pkg/domain/domain_sysvars.go
@@ -128,8 +128,6 @@ func (do *Domain) changeSchemaCacheSize(ctx context.Context, size uint64) error 
 	if err != nil {
 		return err
 	}
-	if size > 0 {
-		do.infoCache.Data.SetCacheCapacity(size)
-	}
+	do.infoCache.Data.SetCacheCapacity(size)
 	return nil
 }

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -1019,9 +1019,7 @@ func NewBuilder(r autoid.Requirement, factory func() (pools.Resource, error), in
 		enableV2:     useV2,
 	}
 	schemaCacheSize := variable.SchemaCacheSize.Load()
-	if schemaCacheSize > 0 {
-		infoData.tableCache.SetCapacity(schemaCacheSize)
-	}
+	infoData.tableCache.SetCapacity(schemaCacheSize)
 	return builder
 }
 

--- a/pkg/infoschema/sieve.go
+++ b/pkg/infoschema/sieve.go
@@ -46,10 +46,11 @@ func (t *entry[K, V]) Size() uint64 {
 // See blog post https://cachemon.github.io/SIEVE-website/blog/2023/12/17/sieve-is-simpler-than-lru/
 // and also the academic paper "SIEVE is simpler than LRU"
 type Sieve[K comparable, V any] struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
-	mu       sync.Mutex
-	size     uint64
+	ctx    context.Context
+	cancel context.CancelFunc
+	mu     sync.Mutex
+	size   uint64
+	// capacity can be set to zero for indicating unlimited capacity.
 	capacity uint64
 	items    map[K]*entry[K, V]
 	ll       *list.List
@@ -97,6 +98,7 @@ func (s *Sieve[K, V]) SetStatusHook(hook sieveStatusHook) {
 	s.hook = hook
 }
 
+// SetCapacity sets the capacity of the cache.
 func (s *Sieve[K, V]) SetCapacity(capacity uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -108,7 +110,7 @@ func (s *Sieve[K, V]) SetCapacityAndWaitEvict(capacity uint64) {
 	s.SetCapacity(capacity)
 	for {
 		s.mu.Lock()
-		if s.size <= s.capacity {
+		if s.capacity == 0 || s.size <= s.capacity {
 			s.mu.Unlock()
 			break
 		}
@@ -119,6 +121,7 @@ func (s *Sieve[K, V]) SetCapacityAndWaitEvict(capacity uint64) {
 	}
 }
 
+// Capacity returns 0 means no capacity limit.
 func (s *Sieve[K, V]) Capacity() uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -135,7 +138,7 @@ func (s *Sieve[K, V]) Set(key K, value V) {
 		return
 	}
 
-	for i := 0; s.size > s.capacity && i < 10; i++ {
+	for i := 0; s.capacity > 0 && s.size > s.capacity && i < 10; i++ {
 		s.evict()
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55490

Problem Summary:

In the previous implementation, if the setting value is 0, we would not call `SetCapacity` for sieve, nor `onUpdateLimit`.

### What changed and how does it work?

always call `onUpdateLimit` for setting any capacity value

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Now `set @@tidb_schema_cache_size = 0` can update the metric

<img width="879" alt="image" src="https://github.com/user-attachments/assets/a312d655-d684-4eec-aa8a-5c5e64a3fbe1">

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
