### PR TITLE
expression: Support 2 argument version of MID()

### DIFF
--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -734,7 +734,7 @@ var funcs = map[string]functionClass{
 	ast.Lower:           &lowerFunctionClass{baseFunctionClass{ast.Lower, 1, 1}},
 	ast.Lpad:            &lpadFunctionClass{baseFunctionClass{ast.Lpad, 3, 3}},
 	ast.LTrim:           &lTrimFunctionClass{baseFunctionClass{ast.LTrim, 1, 1}},
-	ast.Mid:             &substringFunctionClass{baseFunctionClass{ast.Mid, 3, 3}},
+	ast.Mid:             &substringFunctionClass{baseFunctionClass{ast.Mid, 2, 3}},
 	ast.MakeSet:         &makeSetFunctionClass{baseFunctionClass{ast.MakeSet, 2, -1}},
 	ast.Oct:             &octFunctionClass{baseFunctionClass{ast.Oct, 1, 1}},
 	ast.OctetLength:     &lengthFunctionClass{baseFunctionClass{ast.OctetLength, 1, 1}},

--- a/tests/integrationtest/r/expression/builtin.result
+++ b/tests/integrationtest/r/expression/builtin.result
@@ -3333,3 +3333,9 @@ B1
 D5
 FF
 drop table t, t2, t3;
+SELECT MID('abc',2,1);
+MID('abc',2,1)
+b
+SELECT MID('abc',2);
+MID('abc',2)
+bc

--- a/tests/integrationtest/t/expression/builtin.test
+++ b/tests/integrationtest/t/expression/builtin.test
@@ -1578,3 +1578,7 @@ insert into t3 (col1, col2) values (2306.9705216860984, x'31'), (6779.2396154715
 select hex(r) as r0 from (select ELT(2, col1, col2) as r from t3 group by ELT(2, col1, col2)) as t order by r0;
 select hex(r) as r0 from (select distinct ELT(2, col1, col2) as r from t3) as t order by r0;
 drop table t, t2, t3;
+
+# Issue $52420
+SELECT MID('abc',2,1);
+SELECT MID('abc',2);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52420 

Problem Summary:

Based on https://github.com/pingcap/tidb/issues/52420#issuecomment-2268270133

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The two argument version of `MID()` is now supported to improve MySQL compatibility.
```
