### PR TITLE
planner: use logical cores as default fine grained stream count

### DIFF
--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"runtime"
 	"slices"
 	"strconv"
 	"time"
@@ -68,6 +67,8 @@ var AllowCartesianProduct = atomic.NewBool(true)
 
 // IsReadOnly check whether the ast.Node is a read only statement.
 var IsReadOnly func(node ast.Node, vars *variable.SessionVars) bool
+
+const initialMaxCores uint64 = 10000
 
 var optRuleList = []base.LogicalOptRule{
 	&GcSubstituter{},
@@ -622,9 +623,7 @@ func (h *fineGrainedShuffleHelper) updateTarget(t shuffleTarget, p *physicalop.B
 	h.plans = append(h.plans, p)
 }
 
-// calculateTiFlashStreamCountUsingMinLogicalCores uses minimal logical cpu cores among tiflash servers, and divide by 2
-// return false, 0 if any err happens
-func calculateTiFlashStreamCountUsingMinLogicalCores(ctx context.Context, sctx base.PlanContext, serversInfo []infoschema.ServerInfo) (bool, uint64) {
+func getTiFlashServerMinLogicalCores(ctx context.Context, sctx base.PlanContext, serversInfo []infoschema.ServerInfo) (bool, uint64) {
 	failpoint.Inject("mockTiFlashStreamCountUsingMinLogicalCores", func(val failpoint.Value) {
 		intVal, err := strconv.Atoi(val.(string))
 		if err == nil {
@@ -637,7 +636,6 @@ func calculateTiFlashStreamCountUsingMinLogicalCores(ctx context.Context, sctx b
 	if err != nil {
 		return false, 0
 	}
-	var initialMaxCores uint64 = 10000
 	var minLogicalCores = initialMaxCores // set to a large enough value here
 	for _, row := range rows {
 		if row[4].GetString() == "cpu-logical-cores" {
@@ -648,14 +646,19 @@ func calculateTiFlashStreamCountUsingMinLogicalCores(ctx context.Context, sctx b
 		}
 	}
 	// No need to check len(serersInfo) == serverCount here, since missing some servers' info won't affect the correctness
-	if minLogicalCores > 1 && minLogicalCores != initialMaxCores {
-		if runtime.GOARCH == "amd64" {
-			// In most x86-64 platforms, `Thread(s) per core` is 2
-			return true, minLogicalCores / 2
-		}
-		// ARM cpus don't implement Hyper-threading.
+	return true, minLogicalCores
+}
+
+// calculateTiFlashStreamCountUsingMinLogicalCores uses minimal logical cpu cores among tiflash servers
+// return false, 0 if any err happens
+func calculateTiFlashStreamCountUsingMinLogicalCores(ctx context.Context, sctx base.PlanContext, serversInfo []infoschema.ServerInfo) (bool, uint64) {
+	valid, minLogicalCores := getTiFlashServerMinLogicalCores(ctx, sctx, serversInfo)
+	if !valid {
+		return false, 0
+	}
+	if minLogicalCores != initialMaxCores {
+		// use logical core number as the stream count, the same as TiFlash's default max_threads: https://github.com/pingcap/tiflash/blob/v7.5.0/dbms/src/Interpreters/SettingsCommon.h#L166
 		return true, minLogicalCores
-		// Other platforms are too rare to consider
 	}
 
 	return false, 0

--- a/pkg/planner/core/optimizer_test.go
+++ b/pkg/planner/core/optimizer_test.go
@@ -306,7 +306,7 @@ func TestHandleFineGrainedShuffle(t *testing.T) {
 	require.NoError(t, failpoint.Enable(fpName, fpExpr))
 	defer func() { require.NoError(t, failpoint.Disable(fpName)) }()
 	fpName2 := "github.com/pingcap/tidb/pkg/planner/core/mockTiFlashStreamCountUsingMinLogicalCores"
-	require.NoError(t, failpoint.Enable(fpName2, `return("8")`))
+	require.NoError(t, failpoint.Enable(fpName2, `return("16")`))
 	sctx.GetSessionVars().TiFlashFineGrainedShuffleStreamCount = 0
 
 	col0 := &expression.Column{
@@ -331,7 +331,7 @@ func TestHandleFineGrainedShuffle(t *testing.T) {
 	recv.SetChildren([]base.PhysicalPlan{hashSender}...)
 	hashSender.SetChildren([]base.PhysicalPlan{tableScan}...)
 	tableScan.Schema().Columns = append(tableScan.Schema().Columns, col0)
-	start(hashAgg, 8, 3, 0)
+	start(hashAgg, 16, 3, 0)
 
 	// Join(x) <- ExchangeReceiver <- ExchangeSender
 	//                   <- ExchangeReceiver <- ExchangeSender
@@ -359,9 +359,9 @@ func TestHandleFineGrainedShuffle(t *testing.T) {
 	hashSender1.HashCols = partitionCols
 	tableScan1.Schema().Columns = append(tableScan1.Schema().Columns, col0)
 	handleFineGrainedShuffle(nil, sctx.GetPlanCtx(), tableReader)
-	require.Equal(t, uint64(8), hashJoin.TiFlashFineGrainedShuffleStreamCount)
-	require.Equal(t, uint64(8), recv1.TiFlashFineGrainedShuffleStreamCount)
-	require.Equal(t, uint64(8), hashSender1.TiFlashFineGrainedShuffleStreamCount)
+	require.Equal(t, uint64(16), hashJoin.TiFlashFineGrainedShuffleStreamCount)
+	require.Equal(t, uint64(16), recv1.TiFlashFineGrainedShuffleStreamCount)
+	require.Equal(t, uint64(16), hashSender1.TiFlashFineGrainedShuffleStreamCount)
 	require.Equal(t, uint64(0), recv.TiFlashFineGrainedShuffleStreamCount)
 	require.Equal(t, uint64(0), hashSender.TiFlashFineGrainedShuffleStreamCount)
 	clear(plans)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55543

Problem Summary:
As the issue described.
### What changed and how does it work?
Use logical cores as default fine grained stream count
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
