### PR TITLE
ddl: alloc global id together with job id

### DIFF
--- a/pkg/ddl/db_table_test.go
+++ b/pkg/ddl/db_table_test.go
@@ -555,6 +555,12 @@ func TestLockTables(t *testing.T) {
 	// Test lock 1 table.
 	tk.MustExec("lock tables t1 write")
 	checkTableLock(t, tk, "test", "t1", model.TableLockWrite)
+	// still locked after truncate.
+	tk.MustExec("truncate table t1")
+	checkTableLock(t, tk, "test", "t1", model.TableLockWrite)
+	// should unlock the new table id.
+	tk.MustExec("unlock tables")
+	checkTableLock(t, tk, "test", "t1", model.TableLockNone)
 	tk.MustExec("lock tables t1 read")
 	checkTableLock(t, tk, "test", "t1", model.TableLockRead)
 	tk.MustExec("lock tables t1 write")

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -651,7 +651,6 @@ func newDDL(ctx context.Context, options ...Option) (*ddl, *executor) {
 
 	ddlJobDoneChMap := generic.NewSyncMap[int64, chan struct{}](10)
 	limitJobCh := make(chan *JobWrapper, batchAddingJobs)
-	var globalIDLock sync.Mutex
 
 	submitter := &JobSubmitter{
 		ctx:               d.ctx,
@@ -663,7 +662,6 @@ func newDDL(ctx context.Context, options ...Option) (*ddl, *executor) {
 
 		limitJobCh:     limitJobCh,
 		ddlJobNotifyCh: make(chan struct{}, 100),
-		globalIDLock:   &globalIDLock,
 	}
 	d.jobSubmitter = submitter
 
@@ -676,7 +674,6 @@ func newDDL(ctx context.Context, options ...Option) (*ddl, *executor) {
 		limitJobCh:      limitJobCh,
 		lease:           d.lease,
 		ddlJobDoneChMap: &ddlJobDoneChMap,
-		globalIDLock:    &globalIDLock,
 	}
 	d.executor = e
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -185,9 +184,6 @@ type executor struct {
 	// ddlJobDoneChMap is used to notify the session that the DDL job is finished.
 	// jobID -> chan struct{}
 	ddlJobDoneChMap *generic.SyncMap[int64, chan struct{}]
-	// globalIDLock locks global id to reduce write conflict.
-	// TODO after we move all id allocation into job submitter we can remove it.
-	globalIDLock *sync.Mutex
 }
 
 var _ Executor = (*executor)(nil)
@@ -2806,7 +2802,7 @@ func (e *executor) TruncateTablePartition(ctx sessionctx.Context, ident ast.Iden
 		BinlogInfo:  &model.HistoryInfo{},
 		// the second item is the new partition IDs, we add a placeholder here,
 		// job submitter will fill it.
-		Args:           []any{pids, nil},
+		Args:           []any{pids, []int64{}},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		SQLMode:        ctx.GetSessionVars().SQLMode,
 	}
@@ -4175,10 +4171,11 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if tb.Meta().IsView() || tb.Meta().IsSequence() {
-		return infoschema.ErrTableNotExists.GenWithStackByArgs(schema.Name.O, tb.Meta().Name.O)
+	tblInfo := tb.Meta()
+	if tblInfo.IsView() || tblInfo.IsSequence() {
+		return infoschema.ErrTableNotExists.GenWithStackByArgs(schema.Name.O, tblInfo.Name.O)
 	}
-	if tb.Meta().TableCacheStatusType != model.TableCacheStatusDisable {
+	if tblInfo.TableCacheStatusType != model.TableCacheStatusDisable {
 		return dbterror.ErrOptOnCacheTable.GenWithStackByArgs("Truncate Table")
 	}
 	fkCheck := ctx.GetSessionVars().ForeignKeyChecks
@@ -4188,47 +4185,30 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 		return errors.Trace(dbterror.ErrTruncateIllegalForeignKey.GenWithStackByArgs(msg))
 	}
 
-	ids := 1
+	var partCount int
 	if tb.Meta().Partition != nil {
-		ids += len(tb.Meta().Partition.Definitions)
+		partCount = len(tb.Meta().Partition.Definitions)
 	}
-	genIDs, err := e.genGlobalIDs(ids)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	newTableID := genIDs[0]
 	job := &model.Job{
-		SchemaID:       schema.ID,
-		TableID:        tb.Meta().ID,
-		SchemaName:     schema.Name.L,
-		TableName:      tb.Meta().Name.L,
-		Type:           model.ActionTruncateTable,
-		BinlogInfo:     &model.HistoryInfo{},
-		Args:           []any{newTableID, fkCheck, genIDs[1:]},
+		SchemaID:   schema.ID,
+		TableID:    tblInfo.ID,
+		SchemaName: schema.Name.L,
+		TableName:  tblInfo.Name.L,
+		Type:       model.ActionTruncateTable,
+		BinlogInfo: &model.HistoryInfo{},
+		// Args[0] is the new table ID, args[2] is the ids for table partitions, we
+		// add a placeholder here, they will be filled by job submitter.
+		// the last param is not required for execution, we need it to calculate
+		// number of new IDs to generate.
+		Args:           []any{int64(0), fkCheck, []int64{}, partCount},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		SQLMode:        ctx.GetSessionVars().SQLMode,
 	}
-	if ok, _ := ctx.CheckTableLocked(tb.Meta().ID); ok && config.TableLockEnabled() {
-		// AddTableLock here to avoid this ddl job was executed successfully but the session was been kill before return.
-		// The session will release all table locks it holds, if we don't add the new locking table id here,
-		// the session may forget to release the new locked table id when this ddl job was executed successfully
-		// but the session was killed before return.
-		ctx.AddTableLock([]model.TableLockTpInfo{{SchemaID: schema.ID, TableID: newTableID, Tp: tb.Meta().Lock.Tp}})
-	}
 	err = e.DoDDLJob(ctx, job)
 	if err != nil {
-		if config.TableLockEnabled() {
-			ctx.ReleaseTableLockByTableIDs([]int64{newTableID})
-		}
 		return errors.Trace(err)
 	}
 
-	if !config.TableLockEnabled() {
-		return nil
-	}
-	if ok, _ := ctx.CheckTableLocked(tb.Meta().ID); ok {
-		ctx.ReleaseTableLockByTableIDs([]int64{tb.Meta().ID})
-	}
 	return nil
 }
 
@@ -6239,22 +6219,6 @@ func (e *executor) AlterCheckConstraint(ctx sessionctx.Context, ti ast.Ident, co
 	return errors.Trace(err)
 }
 
-func (e *executor) genGlobalIDs(count int) ([]int64, error) {
-	var ret []int64
-	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
-	// lock to reduce conflict
-	e.globalIDLock.Lock()
-	defer e.globalIDLock.Unlock()
-	err := kv.RunInNewTxn(ctx, e.store, true, func(_ context.Context, txn kv.Transaction) error {
-		m := meta.NewMeta(txn)
-		var err error
-		ret, err = m.GenGlobalIDs(count)
-		return err
-	})
-
-	return ret, err
-}
-
 func (e *executor) genPlacementPolicyID() (int64, error) {
 	var ret int64
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL)
@@ -6279,7 +6243,7 @@ func (e *executor) DoDDLJob(ctx sessionctx.Context, job *model.Job) error {
 // DoDDLJobWrapper submit DDL job and wait it finishes.
 // When fast create is enabled, we might merge multiple jobs into one, so do not
 // depend on job.ID, use JobID from jobSubmitResult.
-func (e *executor) DoDDLJobWrapper(ctx sessionctx.Context, jobW *JobWrapper) error {
+func (e *executor) DoDDLJobWrapper(ctx sessionctx.Context, jobW *JobWrapper) (resErr error) {
 	job := jobW.Job
 	job.TraceInfo = &model.TraceInfo{
 		ConnectionID: ctx.GetSessionVars().ConnectionID,
@@ -6325,6 +6289,20 @@ func (e *executor) DoDDLJobWrapper(ctx sessionctx.Context, jobW *JobWrapper) err
 		logutil.DDLLogger().Info("DDL job submitted", zap.Int64("job_id", jobID), zap.String("query", job.Query), zap.String("merged", "true"))
 	} else {
 		logutil.DDLLogger().Info("DDL job submitted", zap.Stringer("job", job), zap.String("query", job.Query))
+	}
+
+	// lock tables works on table ID, for some DDLs which changes table ID, we need
+	// make sure the session still tracks it.
+	// we need add it here to avoid this ddl job was executed successfully but the
+	// session was killed before return. The session will release all table locks
+	// it holds, if we don't add the new locking table id here, the session may forget
+	// to release the new locked table id when this ddl job was executed successfully
+	// but the session was killed before return.
+	if config.TableLockEnabled() {
+		HandleLockTablesOnSuccessSubmit(ctx, jobW)
+		defer func() {
+			HandleLockTablesOnFinish(ctx, jobW, resErr)
+		}()
 	}
 
 	var historyJob *model.Job
@@ -6439,6 +6417,34 @@ func (e *executor) DoDDLJobWrapper(ctx sessionctx.Context, jobW *JobWrapper) err
 			return errors.Trace(historyJob.Error)
 		}
 		panic("When the state is JobStateRollbackDone or JobStateCancelled, historyJob.Error should never be nil")
+	}
+}
+
+// HandleLockTablesOnSuccessSubmit handles the table lock for the job which is submitted
+// successfully. exported for testing purpose.
+func HandleLockTablesOnSuccessSubmit(ctx sessionctx.Context, jobW *JobWrapper) {
+	switch jobW.Type {
+	case model.ActionTruncateTable:
+		if ok, lockTp := ctx.CheckTableLocked(jobW.TableID); ok {
+			newTableID := jobW.Args[0].(int64)
+			ctx.AddTableLock([]model.TableLockTpInfo{{SchemaID: jobW.SchemaID, TableID: newTableID, Tp: lockTp}})
+		}
+	}
+}
+
+// HandleLockTablesOnFinish handles the table lock for the job which is finished.
+// exported for testing purpose.
+func HandleLockTablesOnFinish(ctx sessionctx.Context, jobW *JobWrapper, ddlErr error) {
+	switch jobW.Type {
+	case model.ActionTruncateTable:
+		if ddlErr != nil {
+			newTableID := jobW.Args[0].(int64)
+			ctx.ReleaseTableLockByTableIDs([]int64{newTableID})
+			return
+		}
+		if ok, _ := ctx.CheckTableLocked(jobW.TableID); ok {
+			ctx.ReleaseTableLockByTableIDs([]int64{jobW.TableID})
+		}
 	}
 }
 

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4186,8 +4186,8 @@ func (e *executor) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	}
 
 	var partCount int
-	if tb.Meta().Partition != nil {
-		partCount = len(tb.Meta().Partition.Definitions)
+	if tblInfo.Partition != nil {
+		partCount = len(tblInfo.Partition.Definitions)
 	}
 	job := &model.Job{
 		SchemaID:   schema.ID,
@@ -6423,8 +6423,7 @@ func (e *executor) DoDDLJobWrapper(ctx sessionctx.Context, jobW *JobWrapper) (re
 // HandleLockTablesOnSuccessSubmit handles the table lock for the job which is submitted
 // successfully. exported for testing purpose.
 func HandleLockTablesOnSuccessSubmit(ctx sessionctx.Context, jobW *JobWrapper) {
-	switch jobW.Type {
-	case model.ActionTruncateTable:
+	if jobW.Type == model.ActionTruncateTable {
 		if ok, lockTp := ctx.CheckTableLocked(jobW.TableID); ok {
 			newTableID := jobW.Args[0].(int64)
 			ctx.AddTableLock([]model.TableLockTpInfo{{SchemaID: jobW.SchemaID, TableID: newTableID, Tp: lockTp}})
@@ -6435,8 +6434,7 @@ func HandleLockTablesOnSuccessSubmit(ctx sessionctx.Context, jobW *JobWrapper) {
 // HandleLockTablesOnFinish handles the table lock for the job which is finished.
 // exported for testing purpose.
 func HandleLockTablesOnFinish(ctx sessionctx.Context, jobW *JobWrapper, ddlErr error) {
-	switch jobW.Type {
-	case model.ActionTruncateTable:
+	if jobW.Type == model.ActionTruncateTable {
 		if ddlErr != nil {
 			newTableID := jobW.Args[0].(int64)
 			ctx.ReleaseTableLockByTableIDs([]int64{newTableID})

--- a/pkg/ddl/job_submitter.go
+++ b/pkg/ddl/job_submitter.go
@@ -495,7 +495,7 @@ func getRequiredGIDCount(jobWs []*JobWrapper) int {
 		case model.ActionAlterTablePartitioning:
 			pInfo := jobW.Args[1].(*model.PartitionInfo)
 			// A new table ID would be needed for
-			// the global index, which cannot be the same as the current table id,
+			// the global table, which cannot be the same as the current table id,
 			// since this table id will be removed in the final state when removing
 			// all the data with this table id.
 			count += 1 + len(pInfo.Definitions)

--- a/pkg/ddl/job_submitter.go
+++ b/pkg/ddl/job_submitter.go
@@ -49,9 +49,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// JobSubmitter collects the DDL jobs and submits them to job tables in batch.
-// when fast-create is enabled, it will merge the create-table jobs to a single
-// batch create-table job.
+// JobSubmitter collects the DDL jobs and submits them to job tables in batch, it's
+// also responsible allocating IDs for the jobs. when fast-create is enabled, it
+// will merge the create-table jobs to a single batch create-table job.
 // export for testing.
 type JobSubmitter struct {
 	ctx               context.Context
@@ -446,17 +446,42 @@ func (s *JobSubmitter) GenGIDAndInsertJobsWithRetry(ctx context.Context, ddlSe *
 	})
 }
 
+type gidAllocator struct {
+	idx int
+	ids []int64
+}
+
+func (a *gidAllocator) next() int64 {
+	id := a.ids[a.idx]
+	a.idx++
+	return id
+}
+
+func (a *gidAllocator) assignIDsForTable(info *model.TableInfo) {
+	info.ID = a.next()
+	if partitionInfo := info.GetPartitionInfo(); partitionInfo != nil {
+		a.assignIDsForPartitionInfo(partitionInfo)
+	}
+}
+
+func (a *gidAllocator) assignIDsForPartitionInfo(partitionInfo *model.PartitionInfo) {
+	for i := range partitionInfo.Definitions {
+		partitionInfo.Definitions[i].ID = a.next()
+	}
+}
+
+func idCountForTable(info *model.TableInfo) int {
+	c := 1
+	if partitionInfo := info.GetPartitionInfo(); partitionInfo != nil {
+		c += len(partitionInfo.Definitions)
+	}
+	return c
+}
+
 // getRequiredGIDCount returns the count of required global IDs for the jobs. it's calculated
 // as: the count of jobs + the count of IDs for the jobs which do NOT have pre-allocated ID.
 func getRequiredGIDCount(jobWs []*JobWrapper) int {
 	count := len(jobWs)
-	idCountForTable := func(info *model.TableInfo) int {
-		c := 1
-		if partitionInfo := info.GetPartitionInfo(); partitionInfo != nil {
-			c += len(partitionInfo.Definitions)
-		}
-		return c
-	}
 	for _, jobW := range jobWs {
 		if jobW.IDAllocated {
 			continue
@@ -470,8 +495,23 @@ func getRequiredGIDCount(jobWs []*JobWrapper) int {
 			for _, info := range infos {
 				count += idCountForTable(info)
 			}
-		case model.ActionCreateSchema:
+		case model.ActionCreateSchema, model.ActionCreateResourceGroup:
 			count++
+		case model.ActionAlterTablePartitioning:
+			pInfo := jobW.Args[1].(*model.PartitionInfo)
+			// A new table ID would be needed for
+			// the global index, which cannot be the same as the current table id,
+			// since this table id will be removed in the final state when removing
+			// all the data with this table id.
+			count += 1 + len(pInfo.Definitions)
+		case model.ActionTruncateTablePartition:
+			count += len(jobW.Args[0].([]int64))
+		case model.ActionAddTablePartition:
+			pInfo := jobW.Args[0].(*model.PartitionInfo)
+			count += len(pInfo.Definitions)
+		case model.ActionReorganizePartition, model.ActionRemovePartitioning:
+			pInfo := jobW.Args[1].(*model.PartitionInfo)
+			count += len(pInfo.Definitions)
 		}
 		// TODO support other type of jobs
 	}
@@ -481,44 +521,68 @@ func getRequiredGIDCount(jobWs []*JobWrapper) int {
 // assignGIDsForJobs should be used with getRequiredGIDCount, and len(ids) must equal
 // what getRequiredGIDCount returns.
 func assignGIDsForJobs(jobWs []*JobWrapper, ids []int64) {
-	idx := 0
-
-	assignIDsForTable := func(info *model.TableInfo) {
-		info.ID = ids[idx]
-		idx++
-		if partitionInfo := info.GetPartitionInfo(); partitionInfo != nil {
-			for i := range partitionInfo.Definitions {
-				partitionInfo.Definitions[i].ID = ids[idx]
-				idx++
-			}
-		}
-	}
+	alloc := &gidAllocator{ids: ids}
 	for _, jobW := range jobWs {
 		switch jobW.Type {
 		case model.ActionCreateView, model.ActionCreateSequence, model.ActionCreateTable:
 			info := jobW.Args[0].(*model.TableInfo)
 			if !jobW.IDAllocated {
-				assignIDsForTable(info)
+				alloc.assignIDsForTable(info)
 			}
 			jobW.TableID = info.ID
 		case model.ActionCreateTables:
 			if !jobW.IDAllocated {
 				infos := jobW.Args[0].([]*model.TableInfo)
 				for _, info := range infos {
-					assignIDsForTable(info)
+					alloc.assignIDsForTable(info)
 				}
 			}
 		case model.ActionCreateSchema:
 			dbInfo := jobW.Args[0].(*model.DBInfo)
 			if !jobW.IDAllocated {
-				dbInfo.ID = ids[idx]
-				idx++
+				dbInfo.ID = alloc.next()
 			}
 			jobW.SchemaID = dbInfo.ID
+		case model.ActionCreateResourceGroup:
+			if !jobW.IDAllocated {
+				rgInfo := jobW.Args[0].(*model.ResourceGroupInfo)
+				rgInfo.ID = alloc.next()
+			}
+		case model.ActionAlterTablePartitioning:
+			if !jobW.IDAllocated {
+				pInfo := jobW.Args[1].(*model.PartitionInfo)
+				alloc.assignIDsForPartitionInfo(pInfo)
+				pInfo.NewTableID = alloc.next()
+			}
+		case model.ActionTruncateTablePartition:
+			if !jobW.IDAllocated {
+				newIDs := make([]int64, 0, len(jobW.Args[0].([]int64)))
+				for i := range newIDs {
+					newIDs[i] = alloc.next()
+				}
+				jobW.Args[1] = newIDs
+			}
+		case model.ActionAddTablePartition:
+			if !jobW.IDAllocated {
+				pInfo := jobW.Args[0].(*model.PartitionInfo)
+				alloc.assignIDsForPartitionInfo(pInfo)
+			}
+		case model.ActionReorganizePartition:
+			if !jobW.IDAllocated {
+				pInfo := jobW.Args[1].(*model.PartitionInfo)
+				alloc.assignIDsForPartitionInfo(pInfo)
+			}
+		case model.ActionRemovePartitioning:
+			// a special partition is pInfo in this case, and we will use the ID
+			// of the partition as the new table ID.
+			pInfo := jobW.Args[1].(*model.PartitionInfo)
+			if !jobW.IDAllocated {
+				alloc.assignIDsForPartitionInfo(pInfo)
+			}
+			pInfo.NewTableID = pInfo.Definitions[0].ID
 		}
 		// TODO support other type of jobs
-		jobW.ID = ids[idx]
-		idx++
+		jobW.ID = alloc.next()
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54436

Problem Summary:

### What changed and how does it work?
- in https://github.com/pingcap/tidb/pull/54669 we have combine table/db id together with job id, in this pr we unify all global id allocation with job id, after that we don't need globalIDLock to reduce potential write conflict.
- move table lock handling in TruncateTable into DoDDLWrapper

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
