### PR TITLE
planner: fix CTE hang or wrong result when multiple Apply is used

### DIFF
--- a/tests/integrationtest/r/cte.result
+++ b/tests/integrationtest/r/cte.result
@@ -788,3 +788,142 @@ with cte1 as (select 1), cte2 as (select 2) select * from cte1 union (with cte2 
 1
 1
 3
+drop table if exists tt, tt1, tt2, tt3, tt4, tt5;
+create table tt(c1 int, c2 int);
+create table tt1(c1 int, c2 int);
+create table tt2(c1 int, c2 int);
+create table tt3(c1 int, c2 int);
+create table tt4(c1 int, c2 int);
+create table tt5(c1 int, c2 int);
+insert into tt values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt1 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt2 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt3 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt4 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt5 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+explain with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1)) select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) order by 1;
+id	estRows	task	access object	operator info
+Sort_31	10000.00	root		cte1.tt2.c1
+└─Apply_35	10000.00	root		CARTESIAN semi join
+  ├─TableReader_37(Build)	10000.00	root		data:TableFullScan_36
+  │ └─TableFullScan_36	10000.00	cop[tikv]	table:tt2	keep order:false, stats:pseudo
+  └─Selection_38(Probe)	64008000.00	root		eq(cte1.tt.c1, cte1.tt2.c1)
+    └─CTEFullScan_39	80010000.00	root	CTE:cte1	data:CTE_0
+CTE_0	8001.00	root		Recursive CTE
+├─TableReader_23(Seed Part)	10000.00	root		data:TableFullScan_22
+│ └─TableFullScan_22	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+└─Apply_26(Recursive Part)	10000.00	root		CARTESIAN semi join
+  ├─CTETable_27(Build)	10000.00	root		Scan on CTE_0
+  └─TableReader_30(Probe)	100000.00	root		data:Selection_29
+    └─Selection_29	100000.00	cop[tikv]		eq(cte1.tt1.c2, cte1.tt.c1)
+      └─TableFullScan_28	100000000.00	cop[tikv]	table:tt1	keep order:false, stats:pseudo
+with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1)) select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) order by 1;
+c1
+1
+2
+3
+4
+5
+6
+explain with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1))
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+id	estRows	task	access object	operator info
+Sort_58	32000.00	root		Column#28
+└─HashAgg_60	32000.00	root		group by:Column#28, funcs:firstrow(Column#28)->Column#28
+  └─Union_61	40000.00	root		
+    ├─Apply_64	10000.00	root		CARTESIAN semi join
+    │ ├─TableReader_66(Build)	10000.00	root		data:TableFullScan_65
+    │ │ └─TableFullScan_65	10000.00	cop[tikv]	table:tt2	keep order:false, stats:pseudo
+    │ └─Selection_67(Probe)	64008000.00	root		eq(cte1.tt.c1, cte1.tt2.c1)
+    │   └─CTEFullScan_68	80010000.00	root	CTE:cte1	data:CTE_0
+    ├─Apply_71	10000.00	root		CARTESIAN semi join
+    │ ├─TableReader_73(Build)	10000.00	root		data:TableFullScan_72
+    │ │ └─TableFullScan_72	10000.00	cop[tikv]	table:tt3	keep order:false, stats:pseudo
+    │ └─Selection_74(Probe)	64008000.00	root		eq(cte1.tt.c1, cte1.tt3.c1)
+    │   └─CTEFullScan_75	80010000.00	root	CTE:cte1	data:CTE_0
+    ├─Apply_78	10000.00	root		CARTESIAN semi join
+    │ ├─TableReader_80(Build)	10000.00	root		data:TableFullScan_79
+    │ │ └─TableFullScan_79	10000.00	cop[tikv]	table:tt4	keep order:false, stats:pseudo
+    │ └─Selection_81(Probe)	64008000.00	root		eq(cte1.tt.c1, cte1.tt4.c1)
+    │   └─CTEFullScan_82	80010000.00	root	CTE:cte1	data:CTE_0
+    └─Apply_85	10000.00	root		CARTESIAN semi join
+      ├─TableReader_87(Build)	10000.00	root		data:TableFullScan_86
+      │ └─TableFullScan_86	10000.00	cop[tikv]	table:tt5	keep order:false, stats:pseudo
+      └─Selection_88(Probe)	64008000.00	root		eq(cte1.tt.c1, cte1.tt5.c1)
+        └─CTEFullScan_89	80010000.00	root	CTE:cte1	data:CTE_0
+CTE_0	8001.00	root		Recursive CTE
+├─TableReader_50(Seed Part)	10000.00	root		data:TableFullScan_49
+│ └─TableFullScan_49	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+└─Apply_53(Recursive Part)	10000.00	root		CARTESIAN semi join
+  ├─CTETable_54(Build)	10000.00	root		Scan on CTE_0
+  └─TableReader_57(Probe)	100000.00	root		data:Selection_56
+    └─Selection_56	100000.00	cop[tikv]		eq(cte1.tt1.c2, cte1.tt.c1)
+      └─TableFullScan_55	100000000.00	cop[tikv]	table:tt1	keep order:false, stats:pseudo
+with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1))
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+c1
+1
+2
+3
+4
+5
+6
+explain with cte1 as (with recursive cte2 as (select c1 from tt union all select c1 from cte2 where exists(select /*+ no_decorrelate() */ c1 from tt1 where tt1.c1 = cte2.c1) limit 300)
+select c1 from tt union select c1 from cte2 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte2.c1))
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+id	estRows	task	access object	operator info
+Sort_85	32000.00	root		Column#36
+└─HashAgg_87	32000.00	root		group by:Column#36, funcs:firstrow(Column#36)->Column#36
+  └─Union_88	40000.00	root		
+    ├─Apply_91	10000.00	root		CARTESIAN semi join
+    │ ├─TableReader_93(Build)	10000.00	root		data:TableFullScan_92
+    │ │ └─TableFullScan_92	10000.00	cop[tikv]	table:tt2	keep order:false, stats:pseudo
+    │ └─Selection_94(Probe)	128008000.00	root		eq(Column#23, cte1.tt2.c1)
+    │   └─CTEFullScan_95	160010000.00	root	CTE:cte1	data:CTE_0
+    ├─Apply_98	10000.00	root		CARTESIAN semi join
+    │ ├─TableReader_100(Build)	10000.00	root		data:TableFullScan_99
+    │ │ └─TableFullScan_99	10000.00	cop[tikv]	table:tt3	keep order:false, stats:pseudo
+    │ └─Selection_101(Probe)	128008000.00	root		eq(Column#27, cte1.tt3.c1)
+    │   └─CTEFullScan_102	160010000.00	root	CTE:cte1	data:CTE_0
+    ├─Apply_105	10000.00	root		CARTESIAN semi join
+    │ ├─TableReader_107(Build)	10000.00	root		data:TableFullScan_106
+    │ │ └─TableFullScan_106	10000.00	cop[tikv]	table:tt4	keep order:false, stats:pseudo
+    │ └─Selection_108(Probe)	128008000.00	root		eq(Column#31, cte1.tt4.c1)
+    │   └─CTEFullScan_109	160010000.00	root	CTE:cte1	data:CTE_0
+    └─Apply_112	10000.00	root		CARTESIAN semi join
+      ├─TableReader_114(Build)	10000.00	root		data:TableFullScan_113
+      │ └─TableFullScan_113	10000.00	cop[tikv]	table:tt5	keep order:false, stats:pseudo
+      └─Selection_115(Probe)	128008000.00	root		eq(Column#35, cte1.tt5.c1)
+        └─CTEFullScan_116	160010000.00	root	CTE:cte1	data:CTE_0
+CTE_0	16001.00	root		Non-Recursive CTE
+└─HashAgg_73(Seed Part)	16001.00	root		group by:Column#19, funcs:firstrow(Column#19)->Column#19
+  └─Union_74	30000.00	root		
+    ├─TableReader_77	10000.00	root		data:TableFullScan_76
+    │ └─TableFullScan_76	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+    └─Apply_80	20000.00	root		CARTESIAN semi join
+      ├─CTEFullScan_81(Build)	20000.00	root	CTE:cte2	data:CTE_1
+      └─TableReader_84(Probe)	200000.00	root		data:Selection_83
+        └─Selection_83	200000.00	cop[tikv]		eq(cte1.tt1.c2, cte1.tt.c1)
+          └─TableFullScan_82	200000000.00	cop[tikv]	table:tt1	keep order:false, stats:pseudo
+CTE_1	20000.00	root		Recursive CTE, limit(offset:0, count:300)
+├─TableReader_65(Seed Part)	10000.00	root		data:TableFullScan_64
+│ └─TableFullScan_64	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+└─Apply_68(Recursive Part)	10000.00	root		CARTESIAN semi join
+  ├─CTETable_69(Build)	10000.00	root		Scan on CTE_1
+  └─TableReader_72(Probe)	100000.00	root		data:Selection_71
+    └─Selection_71	100000.00	cop[tikv]		eq(cte1.tt1.c1, cte1.tt.c1)
+      └─TableFullScan_70	100000000.00	cop[tikv]	table:tt1	keep order:false, stats:pseudo
+with cte1 as (with recursive cte2 as (select c1 from tt union all select c1 from cte2 where exists(select /*+ no_decorrelate() */ c1 from tt1 where tt1.c1 = cte2.c1) limit 300)
+select c1 from tt union select c1 from cte2 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte2.c1))
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+c1
+1
+2
+3
+4
+5
+6

--- a/tests/integrationtest/r/cte.result
+++ b/tests/integrationtest/r/cte.result
@@ -927,7 +927,6 @@ c1
 4
 5
 6
-use test;
 drop table if exists table_a, table_b, table_c, table_d, table_e;
 CREATE TABLE `table_a` (
 `col_1` varchar(40) DEFAULT NULL,
@@ -1077,7 +1076,7 @@ VALUES
 ('20230628', 'CFETS_MID', 'Mid', 'USD/CNY', 'USD', 'CNY',
 7.0, 'Source A', 'Unit A', 'Region A', '2023-06-28 15:00:00', '20230627',
 6.9, 'user_001', CURRENT_TIMESTAMP, 'Exchange rate on 2023-06-28');
-desc analyze WITH date_table AS (
+desc WITH date_table AS (
 SELECT
 d.col_1 AS date,
 (SELECT MAX(col_1)
@@ -1143,66 +1142,66 @@ UNION ALL
 SELECT col_4
 FROM product_detail
 ) a;
-id	estRows	actRows	task	access object	execution info	operator info	memory	disk
-Union_212	199600.20	2	root		time:4.81ms, loops:3, RU:4.285513		N/A	N/A
-├─Projection_213	99800.10	1	root		time:4.37ms, loops:2, Concurrency:5	test.table_c.col_4->Column#418	2.03 KB	N/A
-│ └─CTEFullScan_214	99800.10	1	root	CTE:product_detail	time:4.26ms, loops:2	data:CTE_4	564 Bytes	0 Bytes
-└─Projection_215	99800.10	1	root		time:4.34ms, loops:2, Concurrency:5	test.table_c.col_4->Column#418	2.03 KB	N/A
-  └─CTEFullScan_216	99800.10	1	root	CTE:product_detail	time:4.22ms, loops:2	data:CTE_4	N/A	N/A
-CTE_4	99800.10	1	root		time:4.26ms, loops:2	Non-Recursive CTE	564 Bytes	0 Bytes
-└─Projection_174(Seed Part)	99800.10	1	root		time:4.16ms, loops:2, Concurrency:5	test.table_c.col_4, 3集合->Column#413	2.01 KB	N/A
-  └─HashJoin_190	99800.10	1	root		time:4ms, loops:2, build_hash_table:{total:414.3µs, fetch:384.5µs, build:29.8µs}, probe:{concurrency:1, total:3.86ms, max:3.86ms, probe:14.8µs, fetch and wait:3.85ms}	left outer join, equal:[eq(test.table_c.col_4, test.table_c.col_4) eq(Column#390, test.table_c.col_1)]	2.46 KB	0 Bytes
-    ├─TableReader_206(Build)	9980.01	1	root		time:346.1µs, loops:2, cop_task: {num: 1, max: 301µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 5.89µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:273.5µs}}	data:Selection_205	253 Bytes	N/A
-    │ └─Selection_205	9980.01	1	cop[tikv]		tikv_task:{time:231.3µs, loops:0}	not(isnull(test.table_c.col_1)), not(isnull(test.table_c.col_4))	N/A	N/A
-    │   └─TableFullScan_204	10000.00	1	cop[tikv]	table:a	tikv_task:{time:231.3µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-    └─HashJoin_192(Probe)	80000.00	1	root		time:3.84ms, loops:2, build_hash_table:{total:3.69ms, fetch:3.67ms, build:23.2µs}, probe:{concurrency:1, total:3.71ms, max:3.71ms, probe:15.8µs, fetch and wait:3.7ms}	CARTESIAN left outer join	1.98 KB	0 Bytes
-      ├─CTEFullScan_202(Build)	10.00	1	root	CTE:date_table AS dt	time:3.61ms, loops:2	data:CTE_0	1.45 KB	0 Bytes
-      └─HashAgg_198(Probe)	8000.00	1	root		time:263µs, loops:2, partial_worker:{wall_time:228.298µs, concurrency:5, task_num:1, tot_wait:713.525µs, tot_exec:35.626µs, tot_time:793.331µs, max:172.611µs, p95:172.611µs}, final_worker:{wall_time:247.925µs, concurrency:5, task_num:5, tot_wait:118.267µs, tot_exec:351ns, tot_time:1.093619ms, max:231.735µs, p95:231.735µs}	group by:test.table_c.col_3, test.table_c.col_4, funcs:firstrow(test.table_c.col_4)->test.table_c.col_4	7.73 KB	0 Bytes
-        └─TableReader_199	8000.00	1	root		time:106.2µs, loops:2, cop_task: {num: 1, max: 253.9µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 10.7µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:219.7µs}}	data:HashAgg_194	256 Bytes	N/A
-          └─HashAgg_194	8000.00	1	cop[tikv]		tikv_task:{time:166.7µs, loops:0}	group by:test.table_c.col_3, test.table_c.col_4, 	N/A	N/A
-            └─TableFullScan_197	10000.00	1	cop[tikv]	table:t	tikv_task:{time:166.7µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-CTE_0	10.00	1	root		time:3.61ms, loops:2	Non-Recursive CTE	1.45 KB	0 Bytes
-└─Apply_97(Seed Part)	10.00	1	root		time:3.54ms, loops:2, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
-  ├─Apply_99(Build)	10.00	1	root		time:2.76ms, loops:3, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
-  │ ├─Apply_101(Build)	10.00	1	root		time:1.98ms, loops:4, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
-  │ │ ├─Apply_103(Build)	10.00	1	root		time:1.14ms, loops:5, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
-  │ │ │ ├─TableReader_106(Build)	10.00	1	root		time:166.6µs, loops:6, cop_task: {num: 1, max: 541.3µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 6.63µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:514.7µs}}	data:Selection_105	236 Bytes	N/A
-  │ │ │ │ └─Selection_105	10.00	1	cop[tikv]		tikv_task:{time:469.9µs, loops:0}	eq(test.table_d.col_1, 20240628)	N/A	N/A
-  │ │ │ │   └─TableFullScan_104	10000.00	1	cop[tikv]	table:d	tikv_task:{time:469.9µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-  │ │ │ └─StreamAgg_108(Probe)	10.00	1	root		time:508.6µs, loops:2	funcs:max(test.table_c.col_1)->Column#159	169 Bytes	N/A
-  │ │ │   └─TopN_111	10.00	0	root		time:499.2µs, loops:1	test.table_c.col_1:desc, offset:0, count:1	0 Bytes	0 Bytes
-  │ │ │     └─HashJoin_116	63936.00	0	root		time:466.5µs, loops:2, build_hash_table:{total:333.6µs, fetch:304.5µs, build:29.1µs}, probe:{concurrency:1, total:331.8µs, max:331.8µs, probe:11.2µs, fetch and wait:320.6µs}	semi join, equal:[eq(Column#423, Column#424)]	1.35 KB	0 Bytes
-  │ │ │       ├─Projection_121(Build)	80000.00	1	root		time:272.4µs, loops:2, Concurrency:5	cast(test.table_d.col_1, double BINARY)->Column#424	2.24 KB	N/A
-  │ │ │       │ └─TableReader_124	80000.00	1	root		time:139.4µs, loops:2, cop_task: {num: 1, max: 215.8µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 8.89µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:194.4µs}}	data:Selection_123	261 Bytes	N/A
-  │ │ │       │   └─Selection_123	80000.00	1	cop[tikv]		tikv_task:{time:158.7µs, loops:0}	eq(cast(test.table_d.col_2, double BINARY), 1)	N/A	N/A
-  │ │ │       │     └─TableFullScan_122	100000.00	1	cop[tikv]	table:d	tikv_task:{time:158.7µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-  │ │ │       └─Projection_117(Probe)	79920.00	1	root		time:306.3µs, loops:2, Concurrency:5	test.table_c.col_1, cast(test.table_c.col_1, double BINARY)->Column#423	1.97 KB	N/A
-  │ │ │         └─Selection_118	79920.00	1	root		time:185µs, loops:2	le(test.table_c.col_1, concat(cast(year(cast(date_sub(test.table_d.col_1, 1, "YEAR"), datetime(6) BINARY)), var_string(20)), "1231"))	137 Bytes	N/A
-  │ │ │           └─IndexReader_120	99900.00	1	root		time:63.9µs, loops:3, cop_task: {num: 1, max: 171.6µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 12.5µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:143.4µs}}	index:IndexFullScan_119	210 Bytes	N/A
-  │ │ │             └─IndexFullScan_119	99900.00	1	cop[tikv]	table:a, index:index_col_1_3(col_1, col_3)	tikv_task:{time:99.9µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-  │ │ └─StreamAgg_126(Probe)	10.00	1	root		time:476.7µs, loops:2	funcs:max(test.table_a.col_1)->Column#208	169 Bytes	N/A
-  │ │   └─TopN_129	10.00	0	root		time:467.9µs, loops:1	test.table_a.col_1:desc, offset:0, count:1	0 Bytes	0 Bytes
-  │ │     └─HashJoin_134	63936.00	0	root		time:433.8µs, loops:2, build_hash_table:{total:340.7µs, fetch:315.4µs, build:25.3µs}, probe:{concurrency:1, total:354.2µs, max:354.2µs, probe:11.1µs, fetch and wait:343.1µs}	semi join, equal:[eq(Column#429, Column#430)]	1.35 KB	0 Bytes
-  │ │       ├─Projection_139(Build)	80000.00	1	root		time:287.1µs, loops:2, Concurrency:5	cast(test.table_d.col_1, double BINARY)->Column#430	2.29 KB	N/A
-  │ │       │ └─TableReader_142	80000.00	1	root		time:161.9µs, loops:2, cop_task: {num: 1, max: 249.6µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 5.59µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:228µs}}	data:Selection_141	261 Bytes	N/A
-  │ │       │   └─Selection_141	80000.00	1	cop[tikv]		tikv_task:{time:187µs, loops:0}	eq(cast(test.table_d.col_2, double BINARY), 1)	N/A	N/A
-  │ │       │     └─TableFullScan_140	100000.00	1	cop[tikv]	table:d	tikv_task:{time:187µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-  │ │       └─Projection_135(Probe)	79920.00	1	root		time:302.2µs, loops:2, Concurrency:5	test.table_a.col_1, cast(test.table_a.col_1, double BINARY)->Column#429	1.97 KB	N/A
-  │ │         └─Selection_136	79920.00	1	root		time:175.4µs, loops:2	le(test.table_a.col_1, concat(cast(year(cast(date_sub(test.table_d.col_1, 1, "YEAR"), datetime(6) BINARY)), var_string(20)), "1231"))	137 Bytes	N/A
-  │ │           └─IndexReader_138	99900.00	1	root		time:78.4µs, loops:3, cop_task: {num: 1, max: 146.8µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 9.28µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:123µs}}	index:IndexFullScan_137	210 Bytes	N/A
-  │ │             └─IndexFullScan_137	99900.00	1	cop[tikv]	table:a, index:index_col_1(col_1)	tikv_task:{time:87µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
-  │ └─StreamAgg_144(Probe)	10.00	1	root		time:543.2µs, loops:2	funcs:max(test.table_c.col_1)->Column#230	184 Bytes	N/A
-  │   └─Limit_148	10.00	1	root		time:514.8µs, loops:2	offset:0, count:1	N/A	N/A
-  │     └─IndexReader_157	10.00	1	root		time:506.3µs, loops:1, cop_task: {num: 1, max: 373.7µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 13.8µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:338.4µs}}	index:Limit_156	226 Bytes	N/A
-  │       └─Limit_156	10.00	1	cop[tikv]		tikv_task:{time:277.8µs, loops:0}	offset:0, count:1	N/A	N/A
-  │         └─Selection_155	10.00	1	cop[tikv]		tikv_task:{time:277.8µs, loops:0}	le(cast(test.table_c.col_1, double BINARY), cast(test.table_d.col_1, double BINARY))	N/A	N/A
-  │           └─IndexFullScan_154	12.50	1	cop[tikv]	table:table_c, index:index_col_1_3(col_1, col_3)	tikv_task:{time:277.8µs, loops:0}	keep order:true, desc, stats:pseudo	N/A	N/A
-  └─StreamAgg_159(Probe)	10.00	1	root		time:573.9µs, loops:2	funcs:max(test.table_a.col_1)->Column#254	184 Bytes	N/A
-    └─Limit_163	10.00	1	root		time:553.7µs, loops:2	offset:0, count:1	N/A	N/A
-      └─IndexReader_172	10.00	1	root		time:547.7µs, loops:1, cop_task: {num: 1, max: 360µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 13.8µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:323µs}}	index:Limit_171	226 Bytes	N/A
-        └─Limit_171	10.00	1	cop[tikv]		tikv_task:{time:264.1µs, loops:0}	offset:0, count:1	N/A	N/A
-          └─Selection_170	10.00	1	cop[tikv]		tikv_task:{time:264.1µs, loops:0}	le(cast(test.table_a.col_1, double BINARY), cast(test.table_d.col_1, double BINARY))	N/A	N/A
-            └─IndexFullScan_169	12.50	1	cop[tikv]	table:table_a, index:index_col_1(col_1)	tikv_task:{time:264.1µs, loops:0}	keep order:true, desc, stats:pseudo	N/A	N/A
+id	estRows	task	access object	operator info
+Union_212	199600.20	root		
+├─Projection_213	99800.10	root		cte1.table_c.col_4->Column#418
+│ └─CTEFullScan_214	99800.10	root	CTE:product_detail	data:CTE_4
+└─Projection_215	99800.10	root		cte1.table_c.col_4->Column#418
+  └─CTEFullScan_216	99800.10	root	CTE:product_detail	data:CTE_4
+CTE_4	99800.10	root		Non-Recursive CTE
+└─Projection_174(Seed Part)	99800.10	root		cte1.table_c.col_4, 3集合->Column#413
+  └─HashJoin_190	99800.10	root		left outer join, equal:[eq(cte1.table_c.col_4, cte1.table_c.col_4) eq(Column#390, cte1.table_c.col_1)]
+    ├─TableReader_206(Build)	9980.01	root		data:Selection_205
+    │ └─Selection_205	9980.01	cop[tikv]		not(isnull(cte1.table_c.col_1)), not(isnull(cte1.table_c.col_4))
+    │   └─TableFullScan_204	10000.00	cop[tikv]	table:a	keep order:false, stats:pseudo
+    └─HashJoin_192(Probe)	80000.00	root		CARTESIAN left outer join
+      ├─CTEFullScan_202(Build)	10.00	root	CTE:date_table AS dt	data:CTE_0
+      └─HashAgg_198(Probe)	8000.00	root		group by:cte1.table_c.col_3, cte1.table_c.col_4, funcs:firstrow(cte1.table_c.col_4)->cte1.table_c.col_4
+        └─TableReader_199	8000.00	root		data:HashAgg_194
+          └─HashAgg_194	8000.00	cop[tikv]		group by:cte1.table_c.col_3, cte1.table_c.col_4, 
+            └─TableFullScan_197	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+CTE_0	10.00	root		Non-Recursive CTE
+└─Apply_97(Seed Part)	10.00	root		CARTESIAN left outer join
+  ├─Apply_99(Build)	10.00	root		CARTESIAN left outer join
+  │ ├─Apply_101(Build)	10.00	root		CARTESIAN left outer join
+  │ │ ├─Apply_103(Build)	10.00	root		CARTESIAN left outer join
+  │ │ │ ├─TableReader_106(Build)	10.00	root		data:Selection_105
+  │ │ │ │ └─Selection_105	10.00	cop[tikv]		eq(cte1.table_d.col_1, 20240628)
+  │ │ │ │   └─TableFullScan_104	10000.00	cop[tikv]	table:d	keep order:false, stats:pseudo
+  │ │ │ └─StreamAgg_108(Probe)	10.00	root		funcs:max(cte1.table_c.col_1)->Column#159
+  │ │ │   └─TopN_111	10.00	root		cte1.table_c.col_1:desc, offset:0, count:1
+  │ │ │     └─HashJoin_116	63936.00	root		semi join, equal:[eq(Column#423, Column#424)]
+  │ │ │       ├─Projection_121(Build)	80000.00	root		cast(cte1.table_d.col_1, double BINARY)->Column#424
+  │ │ │       │ └─TableReader_124	80000.00	root		data:Selection_123
+  │ │ │       │   └─Selection_123	80000.00	cop[tikv]		eq(cast(cte1.table_d.col_2, double BINARY), 1)
+  │ │ │       │     └─TableFullScan_122	100000.00	cop[tikv]	table:d	keep order:false, stats:pseudo
+  │ │ │       └─Projection_117(Probe)	79920.00	root		cte1.table_c.col_1, cast(cte1.table_c.col_1, double BINARY)->Column#423
+  │ │ │         └─Selection_118	79920.00	root		le(cte1.table_c.col_1, concat(cast(year(cast(date_sub(cte1.table_d.col_1, 1, "YEAR"), datetime(6) BINARY)), var_string(20)), "1231"))
+  │ │ │           └─IndexReader_120	99900.00	root		index:IndexFullScan_119
+  │ │ │             └─IndexFullScan_119	99900.00	cop[tikv]	table:a, index:index_col_1_3(col_1, col_3)	keep order:false, stats:pseudo
+  │ │ └─StreamAgg_126(Probe)	10.00	root		funcs:max(cte1.table_a.col_1)->Column#208
+  │ │   └─TopN_129	10.00	root		cte1.table_a.col_1:desc, offset:0, count:1
+  │ │     └─HashJoin_134	63936.00	root		semi join, equal:[eq(Column#429, Column#430)]
+  │ │       ├─Projection_139(Build)	80000.00	root		cast(cte1.table_d.col_1, double BINARY)->Column#430
+  │ │       │ └─TableReader_142	80000.00	root		data:Selection_141
+  │ │       │   └─Selection_141	80000.00	cop[tikv]		eq(cast(cte1.table_d.col_2, double BINARY), 1)
+  │ │       │     └─TableFullScan_140	100000.00	cop[tikv]	table:d	keep order:false, stats:pseudo
+  │ │       └─Projection_135(Probe)	79920.00	root		cte1.table_a.col_1, cast(cte1.table_a.col_1, double BINARY)->Column#429
+  │ │         └─Selection_136	79920.00	root		le(cte1.table_a.col_1, concat(cast(year(cast(date_sub(cte1.table_d.col_1, 1, "YEAR"), datetime(6) BINARY)), var_string(20)), "1231"))
+  │ │           └─IndexReader_138	99900.00	root		index:IndexFullScan_137
+  │ │             └─IndexFullScan_137	99900.00	cop[tikv]	table:a, index:index_col_1(col_1)	keep order:false, stats:pseudo
+  │ └─StreamAgg_144(Probe)	10.00	root		funcs:max(cte1.table_c.col_1)->Column#230
+  │   └─Limit_148	10.00	root		offset:0, count:1
+  │     └─IndexReader_157	10.00	root		index:Limit_156
+  │       └─Limit_156	10.00	cop[tikv]		offset:0, count:1
+  │         └─Selection_155	10.00	cop[tikv]		le(cast(cte1.table_c.col_1, double BINARY), cast(cte1.table_d.col_1, double BINARY))
+  │           └─IndexFullScan_154	12.50	cop[tikv]	table:table_c, index:index_col_1_3(col_1, col_3)	keep order:true, desc, stats:pseudo
+  └─StreamAgg_159(Probe)	10.00	root		funcs:max(cte1.table_a.col_1)->Column#254
+    └─Limit_163	10.00	root		offset:0, count:1
+      └─IndexReader_172	10.00	root		index:Limit_171
+        └─Limit_171	10.00	cop[tikv]		offset:0, count:1
+          └─Selection_170	10.00	cop[tikv]		le(cast(cte1.table_a.col_1, double BINARY), cast(cte1.table_d.col_1, double BINARY))
+            └─IndexFullScan_169	12.50	cop[tikv]	table:table_a, index:index_col_1(col_1)	keep order:true, desc, stats:pseudo
 WITH date_table AS (
 SELECT
 d.col_1 AS date,

--- a/tests/integrationtest/r/cte.result
+++ b/tests/integrationtest/r/cte.result
@@ -927,3 +927,348 @@ c1
 4
 5
 6
+use test;
+drop table if exists table_a, table_b, table_c, table_d, table_e;
+CREATE TABLE `table_a` (
+`col_1` varchar(40) DEFAULT NULL,
+`col_2` varchar(40) DEFAULT NULL,
+`col_3` varchar(500) DEFAULT NULL,
+`col_4` varchar(500) DEFAULT NULL,
+`col_5` varchar(500) DEFAULT NULL,
+`col_6` varchar(500) DEFAULT NULL,
+`col_7` decimal(38,6) DEFAULT NULL,
+`col_8` decimal(38,6) DEFAULT NULL,
+`col_9` decimal(38,6) DEFAULT NULL,
+`col_10` decimal(38,6) DEFAULT NULL,
+`col_11` decimal(38,6) DEFAULT NULL,
+`col_12` decimal(38,6) DEFAULT NULL,
+`col_13` decimal(38,6) DEFAULT NULL,
+`col_14` decimal(38,6) DEFAULT NULL,
+`col_15` decimal(38,6) DEFAULT NULL,
+`col_16` decimal(38,6) DEFAULT NULL,
+`col_17` decimal(38,6) DEFAULT NULL,
+`col_18` decimal(38,6) DEFAULT NULL,
+`col_19` varchar(40) DEFAULT NULL,
+`col_20` varchar(100) DEFAULT NULL,
+`col_21` varchar(100) DEFAULT NULL,
+`created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+KEY `index_col_1` (`col_1`),
+KEY `index_col_2_3` (`col_2`,`col_3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `table_b` (
+`col_1` varchar(8) NOT NULL,
+`col_2` varchar(100) NOT NULL,
+`col_3` varchar(200) DEFAULT NULL,
+`col_4` varchar(10) NOT NULL,
+`col_5` decimal(38,6) DEFAULT NULL,
+`col_6` decimal(38,6) DEFAULT NULL,
+`col_7` decimal(38,6) DEFAULT NULL,
+`col_8` decimal(38,6) DEFAULT NULL,
+`created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+KEY `index_col_1_2` (`col_1`,`col_2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `table_c` (
+`col_1` varchar(50) DEFAULT NULL,
+`col_2` varchar(50) DEFAULT NULL,
+`col_3` varchar(30) DEFAULT NULL,
+`col_4` varchar(100) DEFAULT NULL,
+`col_5` varchar(50) DEFAULT NULL,
+`col_6` varchar(100) DEFAULT NULL,
+`col_7` decimal(38,6) DEFAULT NULL,
+`col_8` decimal(38,6) DEFAULT NULL,
+`col_9` decimal(38,6) DEFAULT NULL,
+`col_10` decimal(38,6) DEFAULT NULL,
+`col_11` decimal(38,6) DEFAULT NULL,
+`col_12` decimal(38,6) DEFAULT NULL,
+`col_13` decimal(38,6) DEFAULT NULL,
+`col_14` decimal(38,6) DEFAULT NULL,
+`col_15` decimal(38,6) DEFAULT NULL,
+`col_16` decimal(38,6) DEFAULT NULL,
+`col_17` varchar(50) DEFAULT NULL,
+`col_18` varchar(50) DEFAULT NULL,
+`col_19` varchar(50) DEFAULT NULL,
+`created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+KEY `index_col_1_3` (`col_1`,`col_3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `table_d` (
+`col_1` decimal(10,0) DEFAULT NULL,
+`col_2` varchar(1) DEFAULT NULL,
+`col_3` date NOT NULL,
+`col_4` varchar(13) DEFAULT NULL,
+`col_5` varchar(6) DEFAULT NULL,
+`col_6` varchar(255) DEFAULT NULL,
+`col_7` decimal(10,0) DEFAULT NULL,
+`col_8` varchar(12) DEFAULT NULL,
+`col_9` decimal(10,0) DEFAULT NULL,
+`col_10` varchar(17) DEFAULT NULL,
+`col_11` decimal(10,0) DEFAULT NULL,
+`col_12` varchar(7) DEFAULT NULL,
+`col_13` date DEFAULT NULL,
+`col_14` date DEFAULT NULL,
+`col_15` date DEFAULT NULL,
+`col_16` date DEFAULT NULL,
+`col_17` date DEFAULT NULL,
+`col_18` date DEFAULT NULL,
+`col_19` date DEFAULT NULL,
+`col_20` varchar(1) DEFAULT NULL,
+`col_21` varchar(1) DEFAULT NULL,
+`col_22` decimal(1,0) DEFAULT NULL,
+`col_23` varchar(1) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE `table_e` (
+`col_1` varchar(8) NOT NULL,
+`col_2` varchar(100) NOT NULL,
+`col_3` varchar(100) DEFAULT NULL,
+`col_4` varchar(100) NOT NULL,
+`col_5` varchar(100) DEFAULT NULL,
+`col_6` varchar(100) DEFAULT NULL,
+`col_7` decimal(38,12) DEFAULT NULL,
+`col_8` varchar(100) DEFAULT NULL,
+`col_9` varchar(100) DEFAULT NULL,
+`col_10` varchar(100) DEFAULT NULL,
+`col_11` varchar(100) DEFAULT NULL,
+`col_12` varchar(8) DEFAULT NULL,
+`col_13` decimal(38,12) DEFAULT NULL,
+`col_14` varchar(100) DEFAULT NULL,
+`created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+`col_15` varchar(500) DEFAULT NULL,
+PRIMARY KEY (`col_2`, `col_1`, `col_4`),
+KEY `index_col_5_6` (`col_5`, `col_6`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+INSERT INTO `table_a`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+`col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`,
+`col_14`, `col_15`, `col_16`, `col_17`, `col_18`, `col_19`,
+`col_20`, `col_21`, `created_at`)
+VALUES
+('20230628', '20230628', 'Portfolio A', 'Product B', 'Direct', 'USD',
+200000, 150000, 50000, 100000,
+50000, 10000, 5000, 1.2, 0.1,
+0.15, 0.08, 0.02, '2023-06-28',
+'2023-06-28', '2025-06-28', CURRENT_TIMESTAMP);
+INSERT INTO `table_b`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`, `col_8`, `created_at`)
+VALUES
+('20240628', 'DR201800093', 'Product A', '申购', 1000, 100000, 95000, 1.1, CURRENT_TIMESTAMP);
+INSERT INTO `table_c`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+`col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`,
+`col_14`, `col_15`, `col_16`, `col_17`, `col_18`, `col_19`, `created_at`)
+VALUES
+('20230628', 'Dept A', 'DR201800093', 'Product A', '孵化', 'Strategy 1',
+100000, 100000, 120000, 100, 1.2,
+0.2, 0.15, 0.1, 0.05, 0.08,
+'2023-06-28', '2025-06-28', '2Y', CURRENT_TIMESTAMP);
+INSERT INTO `table_d`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+`col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`, `col_14`,
+`col_15`, `col_16`, `col_17`, `col_18`, `col_19`, `col_20`, `col_21`,
+`col_22`, `col_23`)
+VALUES
+('20240628', '1', '2024-06-28', 'Friday', '28', 'End of Month', 202406,
+'June', 20242, 'Q2', 2024, '2024', '2024-06-27', '2024-05-28',
+'2024-03-28', '2023-06-28', '2024-06-27', '2024-06-27', '2024-06-27',
+'1', '1', '1', '1');
+INSERT INTO `table_e`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+`col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`, `col_14`,
+`created_at`, `col_15`)
+VALUES
+('20230628', 'CFETS_MID', 'Mid', 'USD/CNY', 'USD', 'CNY',
+7.0, 'Source A', 'Unit A', 'Region A', '2023-06-28 15:00:00', '20230627',
+6.9, 'user_001', CURRENT_TIMESTAMP, 'Exchange rate on 2023-06-28');
+desc analyze WITH date_table AS (
+SELECT
+d.col_1 AS date,
+(SELECT MAX(col_1)
+FROM table_c a
+WHERE col_1 <=
+CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+'1231')
+AND EXISTS (SELECT 1
+FROM table_d d
+WHERE a.col_1 = d.col_1
+AND d.col_2 = 1)) AS date1,
+(SELECT MAX(col_1)
+FROM table_a a
+WHERE col_1 <= CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+'1231')
+AND EXISTS (SELECT 1
+FROM table_d d
+WHERE a.col_1 = d.col_1
+AND d.col_2 = 1)) AS date2,
+(SELECT MAX(col_1)
+FROM table_c
+WHERE col_1 <= d.col_1) AS date3,
+(SELECT MAX(col_1)
+FROM table_a
+WHERE col_1 <= d.col_1) AS date4
+FROM table_d d
+WHERE d.col_1 = '20240628'
+),
+rm_am_champs_ex_risk_portfolio_seed_money_1 AS (
+SELECT b.col_2
+FROM table_a b
+LEFT JOIN table_e rb
+ON rb.col_1 = b.col_19
+AND b.col_6 = rb.col_3
+WHERE b.col_2 = (SELECT date4 FROM date_table)
+),
+rm_am_champs_ex_risk_portfolio_seed_money_2 AS (
+SELECT b.col_2
+FROM table_a b
+LEFT JOIN table_e rb
+ON rb.col_1 = b.col_19
+AND b.col_6 = rb.col_3
+),
+product_base AS (
+SELECT DISTINCT t.col_3, col_4, 'ML' AS is_do
+FROM table_c t
+),
+product_detail AS (
+SELECT t.col_4,
+"3集合" AS nature_investment
+FROM product_base t
+LEFT JOIN date_table dt
+ON 1 = 1
+LEFT JOIN table_c a
+ON t.col_4 = a.col_4
+AND a.col_1 = dt.date3
+)
+SELECT col_4
+FROM (
+SELECT col_4
+FROM product_detail
+UNION ALL
+SELECT col_4
+FROM product_detail
+) a;
+id	estRows	actRows	task	access object	execution info	operator info	memory	disk
+Union_212	199600.20	2	root		time:4.81ms, loops:3, RU:4.285513		N/A	N/A
+├─Projection_213	99800.10	1	root		time:4.37ms, loops:2, Concurrency:5	test.table_c.col_4->Column#418	2.03 KB	N/A
+│ └─CTEFullScan_214	99800.10	1	root	CTE:product_detail	time:4.26ms, loops:2	data:CTE_4	564 Bytes	0 Bytes
+└─Projection_215	99800.10	1	root		time:4.34ms, loops:2, Concurrency:5	test.table_c.col_4->Column#418	2.03 KB	N/A
+  └─CTEFullScan_216	99800.10	1	root	CTE:product_detail	time:4.22ms, loops:2	data:CTE_4	N/A	N/A
+CTE_4	99800.10	1	root		time:4.26ms, loops:2	Non-Recursive CTE	564 Bytes	0 Bytes
+└─Projection_174(Seed Part)	99800.10	1	root		time:4.16ms, loops:2, Concurrency:5	test.table_c.col_4, 3集合->Column#413	2.01 KB	N/A
+  └─HashJoin_190	99800.10	1	root		time:4ms, loops:2, build_hash_table:{total:414.3µs, fetch:384.5µs, build:29.8µs}, probe:{concurrency:1, total:3.86ms, max:3.86ms, probe:14.8µs, fetch and wait:3.85ms}	left outer join, equal:[eq(test.table_c.col_4, test.table_c.col_4) eq(Column#390, test.table_c.col_1)]	2.46 KB	0 Bytes
+    ├─TableReader_206(Build)	9980.01	1	root		time:346.1µs, loops:2, cop_task: {num: 1, max: 301µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 5.89µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:273.5µs}}	data:Selection_205	253 Bytes	N/A
+    │ └─Selection_205	9980.01	1	cop[tikv]		tikv_task:{time:231.3µs, loops:0}	not(isnull(test.table_c.col_1)), not(isnull(test.table_c.col_4))	N/A	N/A
+    │   └─TableFullScan_204	10000.00	1	cop[tikv]	table:a	tikv_task:{time:231.3µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+    └─HashJoin_192(Probe)	80000.00	1	root		time:3.84ms, loops:2, build_hash_table:{total:3.69ms, fetch:3.67ms, build:23.2µs}, probe:{concurrency:1, total:3.71ms, max:3.71ms, probe:15.8µs, fetch and wait:3.7ms}	CARTESIAN left outer join	1.98 KB	0 Bytes
+      ├─CTEFullScan_202(Build)	10.00	1	root	CTE:date_table AS dt	time:3.61ms, loops:2	data:CTE_0	1.45 KB	0 Bytes
+      └─HashAgg_198(Probe)	8000.00	1	root		time:263µs, loops:2, partial_worker:{wall_time:228.298µs, concurrency:5, task_num:1, tot_wait:713.525µs, tot_exec:35.626µs, tot_time:793.331µs, max:172.611µs, p95:172.611µs}, final_worker:{wall_time:247.925µs, concurrency:5, task_num:5, tot_wait:118.267µs, tot_exec:351ns, tot_time:1.093619ms, max:231.735µs, p95:231.735µs}	group by:test.table_c.col_3, test.table_c.col_4, funcs:firstrow(test.table_c.col_4)->test.table_c.col_4	7.73 KB	0 Bytes
+        └─TableReader_199	8000.00	1	root		time:106.2µs, loops:2, cop_task: {num: 1, max: 253.9µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 10.7µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:219.7µs}}	data:HashAgg_194	256 Bytes	N/A
+          └─HashAgg_194	8000.00	1	cop[tikv]		tikv_task:{time:166.7µs, loops:0}	group by:test.table_c.col_3, test.table_c.col_4, 	N/A	N/A
+            └─TableFullScan_197	10000.00	1	cop[tikv]	table:t	tikv_task:{time:166.7µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+CTE_0	10.00	1	root		time:3.61ms, loops:2	Non-Recursive CTE	1.45 KB	0 Bytes
+└─Apply_97(Seed Part)	10.00	1	root		time:3.54ms, loops:2, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
+  ├─Apply_99(Build)	10.00	1	root		time:2.76ms, loops:3, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
+  │ ├─Apply_101(Build)	10.00	1	root		time:1.98ms, loops:4, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
+  │ │ ├─Apply_103(Build)	10.00	1	root		time:1.14ms, loops:5, concurrency:OFF, cache:ON, cacheHitRatio:0.000%	CARTESIAN left outer join	8 Bytes	N/A
+  │ │ │ ├─TableReader_106(Build)	10.00	1	root		time:166.6µs, loops:6, cop_task: {num: 1, max: 541.3µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 6.63µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:514.7µs}}	data:Selection_105	236 Bytes	N/A
+  │ │ │ │ └─Selection_105	10.00	1	cop[tikv]		tikv_task:{time:469.9µs, loops:0}	eq(test.table_d.col_1, 20240628)	N/A	N/A
+  │ │ │ │   └─TableFullScan_104	10000.00	1	cop[tikv]	table:d	tikv_task:{time:469.9µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+  │ │ │ └─StreamAgg_108(Probe)	10.00	1	root		time:508.6µs, loops:2	funcs:max(test.table_c.col_1)->Column#159	169 Bytes	N/A
+  │ │ │   └─TopN_111	10.00	0	root		time:499.2µs, loops:1	test.table_c.col_1:desc, offset:0, count:1	0 Bytes	0 Bytes
+  │ │ │     └─HashJoin_116	63936.00	0	root		time:466.5µs, loops:2, build_hash_table:{total:333.6µs, fetch:304.5µs, build:29.1µs}, probe:{concurrency:1, total:331.8µs, max:331.8µs, probe:11.2µs, fetch and wait:320.6µs}	semi join, equal:[eq(Column#423, Column#424)]	1.35 KB	0 Bytes
+  │ │ │       ├─Projection_121(Build)	80000.00	1	root		time:272.4µs, loops:2, Concurrency:5	cast(test.table_d.col_1, double BINARY)->Column#424	2.24 KB	N/A
+  │ │ │       │ └─TableReader_124	80000.00	1	root		time:139.4µs, loops:2, cop_task: {num: 1, max: 215.8µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 8.89µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:194.4µs}}	data:Selection_123	261 Bytes	N/A
+  │ │ │       │   └─Selection_123	80000.00	1	cop[tikv]		tikv_task:{time:158.7µs, loops:0}	eq(cast(test.table_d.col_2, double BINARY), 1)	N/A	N/A
+  │ │ │       │     └─TableFullScan_122	100000.00	1	cop[tikv]	table:d	tikv_task:{time:158.7µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+  │ │ │       └─Projection_117(Probe)	79920.00	1	root		time:306.3µs, loops:2, Concurrency:5	test.table_c.col_1, cast(test.table_c.col_1, double BINARY)->Column#423	1.97 KB	N/A
+  │ │ │         └─Selection_118	79920.00	1	root		time:185µs, loops:2	le(test.table_c.col_1, concat(cast(year(cast(date_sub(test.table_d.col_1, 1, "YEAR"), datetime(6) BINARY)), var_string(20)), "1231"))	137 Bytes	N/A
+  │ │ │           └─IndexReader_120	99900.00	1	root		time:63.9µs, loops:3, cop_task: {num: 1, max: 171.6µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 12.5µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:143.4µs}}	index:IndexFullScan_119	210 Bytes	N/A
+  │ │ │             └─IndexFullScan_119	99900.00	1	cop[tikv]	table:a, index:index_col_1_3(col_1, col_3)	tikv_task:{time:99.9µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+  │ │ └─StreamAgg_126(Probe)	10.00	1	root		time:476.7µs, loops:2	funcs:max(test.table_a.col_1)->Column#208	169 Bytes	N/A
+  │ │   └─TopN_129	10.00	0	root		time:467.9µs, loops:1	test.table_a.col_1:desc, offset:0, count:1	0 Bytes	0 Bytes
+  │ │     └─HashJoin_134	63936.00	0	root		time:433.8µs, loops:2, build_hash_table:{total:340.7µs, fetch:315.4µs, build:25.3µs}, probe:{concurrency:1, total:354.2µs, max:354.2µs, probe:11.1µs, fetch and wait:343.1µs}	semi join, equal:[eq(Column#429, Column#430)]	1.35 KB	0 Bytes
+  │ │       ├─Projection_139(Build)	80000.00	1	root		time:287.1µs, loops:2, Concurrency:5	cast(test.table_d.col_1, double BINARY)->Column#430	2.29 KB	N/A
+  │ │       │ └─TableReader_142	80000.00	1	root		time:161.9µs, loops:2, cop_task: {num: 1, max: 249.6µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 5.59µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:228µs}}	data:Selection_141	261 Bytes	N/A
+  │ │       │   └─Selection_141	80000.00	1	cop[tikv]		tikv_task:{time:187µs, loops:0}	eq(cast(test.table_d.col_2, double BINARY), 1)	N/A	N/A
+  │ │       │     └─TableFullScan_140	100000.00	1	cop[tikv]	table:d	tikv_task:{time:187µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+  │ │       └─Projection_135(Probe)	79920.00	1	root		time:302.2µs, loops:2, Concurrency:5	test.table_a.col_1, cast(test.table_a.col_1, double BINARY)->Column#429	1.97 KB	N/A
+  │ │         └─Selection_136	79920.00	1	root		time:175.4µs, loops:2	le(test.table_a.col_1, concat(cast(year(cast(date_sub(test.table_d.col_1, 1, "YEAR"), datetime(6) BINARY)), var_string(20)), "1231"))	137 Bytes	N/A
+  │ │           └─IndexReader_138	99900.00	1	root		time:78.4µs, loops:3, cop_task: {num: 1, max: 146.8µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 9.28µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:123µs}}	index:IndexFullScan_137	210 Bytes	N/A
+  │ │             └─IndexFullScan_137	99900.00	1	cop[tikv]	table:a, index:index_col_1(col_1)	tikv_task:{time:87µs, loops:0}	keep order:false, stats:pseudo	N/A	N/A
+  │ └─StreamAgg_144(Probe)	10.00	1	root		time:543.2µs, loops:2	funcs:max(test.table_c.col_1)->Column#230	184 Bytes	N/A
+  │   └─Limit_148	10.00	1	root		time:514.8µs, loops:2	offset:0, count:1	N/A	N/A
+  │     └─IndexReader_157	10.00	1	root		time:506.3µs, loops:1, cop_task: {num: 1, max: 373.7µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 13.8µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:338.4µs}}	index:Limit_156	226 Bytes	N/A
+  │       └─Limit_156	10.00	1	cop[tikv]		tikv_task:{time:277.8µs, loops:0}	offset:0, count:1	N/A	N/A
+  │         └─Selection_155	10.00	1	cop[tikv]		tikv_task:{time:277.8µs, loops:0}	le(cast(test.table_c.col_1, double BINARY), cast(test.table_d.col_1, double BINARY))	N/A	N/A
+  │           └─IndexFullScan_154	12.50	1	cop[tikv]	table:table_c, index:index_col_1_3(col_1, col_3)	tikv_task:{time:277.8µs, loops:0}	keep order:true, desc, stats:pseudo	N/A	N/A
+  └─StreamAgg_159(Probe)	10.00	1	root		time:573.9µs, loops:2	funcs:max(test.table_a.col_1)->Column#254	184 Bytes	N/A
+    └─Limit_163	10.00	1	root		time:553.7µs, loops:2	offset:0, count:1	N/A	N/A
+      └─IndexReader_172	10.00	1	root		time:547.7µs, loops:1, cop_task: {num: 1, max: 360µs, proc_keys: 0, copr_cache_hit_ratio: 0.00, build_task_duration: 13.8µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:323µs}}	index:Limit_171	226 Bytes	N/A
+        └─Limit_171	10.00	1	cop[tikv]		tikv_task:{time:264.1µs, loops:0}	offset:0, count:1	N/A	N/A
+          └─Selection_170	10.00	1	cop[tikv]		tikv_task:{time:264.1µs, loops:0}	le(cast(test.table_a.col_1, double BINARY), cast(test.table_d.col_1, double BINARY))	N/A	N/A
+            └─IndexFullScan_169	12.50	1	cop[tikv]	table:table_a, index:index_col_1(col_1)	tikv_task:{time:264.1µs, loops:0}	keep order:true, desc, stats:pseudo	N/A	N/A
+WITH date_table AS (
+SELECT
+d.col_1 AS date,
+(SELECT MAX(col_1)
+FROM table_c a
+WHERE col_1 <=
+CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+'1231')
+AND EXISTS (SELECT 1
+FROM table_d d
+WHERE a.col_1 = d.col_1
+AND d.col_2 = 1)) AS date1,
+(SELECT MAX(col_1)
+FROM table_a a
+WHERE col_1 <= CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+'1231')
+AND EXISTS (SELECT 1
+FROM table_d d
+WHERE a.col_1 = d.col_1
+AND d.col_2 = 1)) AS date2,
+(SELECT MAX(col_1)
+FROM table_c
+WHERE col_1 <= d.col_1) AS date3,
+(SELECT MAX(col_1)
+FROM table_a
+WHERE col_1 <= d.col_1) AS date4
+FROM table_d d
+WHERE d.col_1 = '20240628'
+),
+rm_am_champs_ex_risk_portfolio_seed_money_1 AS (
+SELECT b.col_2
+FROM table_a b
+LEFT JOIN table_e rb
+ON rb.col_1 = b.col_19
+AND b.col_6 = rb.col_3
+WHERE b.col_2 = (SELECT date4 FROM date_table)
+),
+rm_am_champs_ex_risk_portfolio_seed_money_2 AS (
+SELECT b.col_2
+FROM table_a b
+LEFT JOIN table_e rb
+ON rb.col_1 = b.col_19
+AND b.col_6 = rb.col_3
+),
+product_base AS (
+SELECT DISTINCT t.col_3, col_4, 'ML' AS is_do
+FROM table_c t
+),
+product_detail AS (
+SELECT t.col_4,
+"3集合" AS nature_investment
+FROM product_base t
+LEFT JOIN date_table dt
+ON 1 = 1
+LEFT JOIN table_c a
+ON t.col_4 = a.col_4
+AND a.col_1 = dt.date3
+)
+SELECT col_4
+FROM (
+SELECT col_4
+FROM product_detail
+UNION ALL
+SELECT col_4
+FROM product_detail
+) a;
+col_4
+Product A
+Product A

--- a/tests/integrationtest/t/cte.test
+++ b/tests/integrationtest/t/cte.test
@@ -376,3 +376,308 @@ with cte1 as (with recursive cte2 as (select c1 from tt union all select c1 from
 select c1 from tt union select c1 from cte2 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte2.c1)) 
 select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
 select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+
+## sub case-4: simplified user query
+use test;
+drop table if exists table_a, table_b, table_c, table_d, table_e;
+CREATE TABLE `table_a` (
+  `col_1` varchar(40) DEFAULT NULL,
+  `col_2` varchar(40) DEFAULT NULL,
+  `col_3` varchar(500) DEFAULT NULL,
+  `col_4` varchar(500) DEFAULT NULL,
+  `col_5` varchar(500) DEFAULT NULL,
+  `col_6` varchar(500) DEFAULT NULL,
+  `col_7` decimal(38,6) DEFAULT NULL,
+  `col_8` decimal(38,6) DEFAULT NULL,
+  `col_9` decimal(38,6) DEFAULT NULL,
+  `col_10` decimal(38,6) DEFAULT NULL,
+  `col_11` decimal(38,6) DEFAULT NULL,
+  `col_12` decimal(38,6) DEFAULT NULL,
+  `col_13` decimal(38,6) DEFAULT NULL,
+  `col_14` decimal(38,6) DEFAULT NULL,
+  `col_15` decimal(38,6) DEFAULT NULL,
+  `col_16` decimal(38,6) DEFAULT NULL,
+  `col_17` decimal(38,6) DEFAULT NULL,
+  `col_18` decimal(38,6) DEFAULT NULL,
+  `col_19` varchar(40) DEFAULT NULL,
+  `col_20` varchar(100) DEFAULT NULL,
+  `col_21` varchar(100) DEFAULT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  KEY `index_col_1` (`col_1`),
+  KEY `index_col_2_3` (`col_2`,`col_3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+
+CREATE TABLE `table_b` (
+  `col_1` varchar(8) NOT NULL,
+  `col_2` varchar(100) NOT NULL,
+  `col_3` varchar(200) DEFAULT NULL,
+  `col_4` varchar(10) NOT NULL,
+  `col_5` decimal(38,6) DEFAULT NULL,
+  `col_6` decimal(38,6) DEFAULT NULL,
+  `col_7` decimal(38,6) DEFAULT NULL,
+  `col_8` decimal(38,6) DEFAULT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  KEY `index_col_1_2` (`col_1`,`col_2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE `table_c` (
+  `col_1` varchar(50) DEFAULT NULL,
+  `col_2` varchar(50) DEFAULT NULL,
+  `col_3` varchar(30) DEFAULT NULL,
+  `col_4` varchar(100) DEFAULT NULL,
+  `col_5` varchar(50) DEFAULT NULL,
+  `col_6` varchar(100) DEFAULT NULL,
+  `col_7` decimal(38,6) DEFAULT NULL,
+  `col_8` decimal(38,6) DEFAULT NULL,
+  `col_9` decimal(38,6) DEFAULT NULL,
+  `col_10` decimal(38,6) DEFAULT NULL,
+  `col_11` decimal(38,6) DEFAULT NULL,
+  `col_12` decimal(38,6) DEFAULT NULL,
+  `col_13` decimal(38,6) DEFAULT NULL,
+  `col_14` decimal(38,6) DEFAULT NULL,
+  `col_15` decimal(38,6) DEFAULT NULL,
+  `col_16` decimal(38,6) DEFAULT NULL,
+  `col_17` varchar(50) DEFAULT NULL,
+  `col_18` varchar(50) DEFAULT NULL,
+  `col_19` varchar(50) DEFAULT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  KEY `index_col_1_3` (`col_1`,`col_3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE `table_d` (
+  `col_1` decimal(10,0) DEFAULT NULL,
+  `col_2` varchar(1) DEFAULT NULL,
+  `col_3` date NOT NULL,
+  `col_4` varchar(13) DEFAULT NULL,
+  `col_5` varchar(6) DEFAULT NULL,
+  `col_6` varchar(255) DEFAULT NULL,
+  `col_7` decimal(10,0) DEFAULT NULL,
+  `col_8` varchar(12) DEFAULT NULL,
+  `col_9` decimal(10,0) DEFAULT NULL,
+  `col_10` varchar(17) DEFAULT NULL,
+  `col_11` decimal(10,0) DEFAULT NULL,
+  `col_12` varchar(7) DEFAULT NULL,
+  `col_13` date DEFAULT NULL,
+  `col_14` date DEFAULT NULL,
+  `col_15` date DEFAULT NULL,
+  `col_16` date DEFAULT NULL,
+  `col_17` date DEFAULT NULL,
+  `col_18` date DEFAULT NULL,
+  `col_19` date DEFAULT NULL,
+  `col_20` varchar(1) DEFAULT NULL,
+  `col_21` varchar(1) DEFAULT NULL,
+  `col_22` decimal(1,0) DEFAULT NULL,
+  `col_23` varchar(1) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE `table_e` (
+  `col_1` varchar(8) NOT NULL,
+  `col_2` varchar(100) NOT NULL,
+  `col_3` varchar(100) DEFAULT NULL,
+  `col_4` varchar(100) NOT NULL,
+  `col_5` varchar(100) DEFAULT NULL,
+  `col_6` varchar(100) DEFAULT NULL,
+  `col_7` decimal(38,12) DEFAULT NULL,
+  `col_8` varchar(100) DEFAULT NULL,
+  `col_9` varchar(100) DEFAULT NULL,
+  `col_10` varchar(100) DEFAULT NULL,
+  `col_11` varchar(100) DEFAULT NULL,
+  `col_12` varchar(8) DEFAULT NULL,
+  `col_13` decimal(38,12) DEFAULT NULL,
+  `col_14` varchar(100) DEFAULT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  `col_15` varchar(500) DEFAULT NULL,
+  PRIMARY KEY (`col_2`, `col_1`, `col_4`),
+  KEY `index_col_5_6` (`col_5`, `col_6`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+INSERT INTO `table_a`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+ `col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`,
+ `col_14`, `col_15`, `col_16`, `col_17`, `col_18`, `col_19`,
+ `col_20`, `col_21`, `created_at`)
+VALUES
+('20230628', '20230628', 'Portfolio A', 'Product B', 'Direct', 'USD',
+ 200000, 150000, 50000, 100000,
+ 50000, 10000, 5000, 1.2, 0.1,
+ 0.15, 0.08, 0.02, '2023-06-28',
+ '2023-06-28', '2025-06-28', CURRENT_TIMESTAMP);
+
+ INSERT INTO `table_b`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`, `col_8`, `created_at`)
+VALUES
+('20240628', 'DR201800093', 'Product A', '申购', 1000, 100000, 95000, 1.1, CURRENT_TIMESTAMP);
+
+INSERT INTO `table_c`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+ `col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`,
+ `col_14`, `col_15`, `col_16`, `col_17`, `col_18`, `col_19`, `created_at`)
+VALUES
+('20230628', 'Dept A', 'DR201800093', 'Product A', '孵化', 'Strategy 1',
+ 100000, 100000, 120000, 100, 1.2,
+ 0.2, 0.15, 0.1, 0.05, 0.08,
+ '2023-06-28', '2025-06-28', '2Y', CURRENT_TIMESTAMP);
+
+INSERT INTO `table_d`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+ `col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`, `col_14`,
+ `col_15`, `col_16`, `col_17`, `col_18`, `col_19`, `col_20`, `col_21`,
+ `col_22`, `col_23`)
+VALUES
+('20240628', '1', '2024-06-28', 'Friday', '28', 'End of Month', 202406,
+ 'June', 20242, 'Q2', 2024, '2024', '2024-06-27', '2024-05-28',
+ '2024-03-28', '2023-06-28', '2024-06-27', '2024-06-27', '2024-06-27',
+ '1', '1', '1', '1');
+
+ INSERT INTO `table_e`
+(`col_1`, `col_2`, `col_3`, `col_4`, `col_5`, `col_6`, `col_7`,
+ `col_8`, `col_9`, `col_10`, `col_11`, `col_12`, `col_13`, `col_14`,
+ `created_at`, `col_15`)
+VALUES
+('20230628', 'CFETS_MID', 'Mid', 'USD/CNY', 'USD', 'CNY',
+ 7.0, 'Source A', 'Unit A', 'Region A', '2023-06-28 15:00:00', '20230627',
+ 6.9, 'user_001', CURRENT_TIMESTAMP, 'Exchange rate on 2023-06-28');
+
+desc analyze WITH date_table AS (
+  SELECT
+        d.col_1 AS date,
+        (SELECT MAX(col_1)
+            FROM table_c a
+           WHERE col_1 <=
+                 CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+                        '1231')
+             AND EXISTS (SELECT 1
+                    FROM table_d d
+                   WHERE a.col_1 = d.col_1
+                     AND d.col_2 = 1)) AS date1,
+        (SELECT MAX(col_1)
+            FROM table_a a
+           WHERE col_1 <= CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+                                '1231')
+             AND EXISTS (SELECT 1
+                    FROM table_d d
+                   WHERE a.col_1 = d.col_1
+                     AND d.col_2 = 1)) AS date2,
+        (SELECT MAX(col_1)
+            FROM table_c
+           WHERE col_1 <= d.col_1) AS date3,
+        (SELECT MAX(col_1)
+            FROM table_a
+           WHERE col_1 <= d.col_1) AS date4
+    FROM table_d d
+   WHERE d.col_1 = '20240628'
+),
+rm_am_champs_ex_risk_portfolio_seed_money_1 AS (
+  SELECT b.col_2
+    FROM table_a b
+    LEFT JOIN table_e rb
+      ON rb.col_1 = b.col_19
+     AND b.col_6 = rb.col_3
+   WHERE b.col_2 = (SELECT date4 FROM date_table)
+),
+
+rm_am_champs_ex_risk_portfolio_seed_money_2 AS (
+  SELECT b.col_2
+  FROM table_a b
+  LEFT JOIN table_e rb
+      ON rb.col_1 = b.col_19
+     AND b.col_6 = rb.col_3
+),
+
+product_base AS (
+  SELECT DISTINCT t.col_3, col_4, 'ML' AS is_do
+    FROM table_c t
+),
+
+product_detail AS (
+  SELECT t.col_4,
+        "3集合" AS nature_investment
+    FROM product_base t
+    LEFT JOIN date_table dt
+      ON 1 = 1
+    LEFT JOIN table_c a
+      ON t.col_4 = a.col_4
+     AND a.col_1 = dt.date3
+)
+
+SELECT col_4
+  FROM (
+        SELECT col_4
+          FROM product_detail
+        UNION ALL
+        SELECT col_4
+          FROM product_detail
+) a;
+
+WITH date_table AS (
+  SELECT
+        d.col_1 AS date,
+        (SELECT MAX(col_1)
+            FROM table_c a
+           WHERE col_1 <=
+                 CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+                        '1231')
+             AND EXISTS (SELECT 1
+                    FROM table_d d
+                   WHERE a.col_1 = d.col_1
+                     AND d.col_2 = 1)) AS date1,
+        (SELECT MAX(col_1)
+            FROM table_a a
+           WHERE col_1 <= CONCAT(YEAR(DATE_SUB(d.col_1, INTERVAL 1 YEAR)),
+                                '1231')
+             AND EXISTS (SELECT 1
+                    FROM table_d d
+                   WHERE a.col_1 = d.col_1
+                     AND d.col_2 = 1)) AS date2,
+        (SELECT MAX(col_1)
+            FROM table_c
+           WHERE col_1 <= d.col_1) AS date3,
+        (SELECT MAX(col_1)
+            FROM table_a
+           WHERE col_1 <= d.col_1) AS date4
+    FROM table_d d
+   WHERE d.col_1 = '20240628'
+),
+rm_am_champs_ex_risk_portfolio_seed_money_1 AS (
+  SELECT b.col_2
+    FROM table_a b
+    LEFT JOIN table_e rb
+      ON rb.col_1 = b.col_19
+     AND b.col_6 = rb.col_3
+   WHERE b.col_2 = (SELECT date4 FROM date_table)
+),
+
+rm_am_champs_ex_risk_portfolio_seed_money_2 AS (
+  SELECT b.col_2
+  FROM table_a b
+  LEFT JOIN table_e rb
+      ON rb.col_1 = b.col_19
+     AND b.col_6 = rb.col_3
+),
+
+product_base AS (
+  SELECT DISTINCT t.col_3, col_4, 'ML' AS is_do
+    FROM table_c t
+),
+
+product_detail AS (
+  SELECT t.col_4,
+        "3集合" AS nature_investment
+    FROM product_base t
+    LEFT JOIN date_table dt
+      ON 1 = 1
+    LEFT JOIN table_c a
+      ON t.col_4 = a.col_4
+     AND a.col_1 = dt.date3
+)
+
+SELECT col_4
+  FROM (
+        SELECT col_4
+          FROM product_detail
+        UNION ALL
+        SELECT col_4
+          FROM product_detail
+) a;
+

--- a/tests/integrationtest/t/cte.test
+++ b/tests/integrationtest/t/cte.test
@@ -378,7 +378,6 @@ select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 wher
 select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
 
 ## sub case-4: simplified user query
-use test;
 drop table if exists table_a, table_b, table_c, table_d, table_e;
 CREATE TABLE `table_a` (
   `col_1` varchar(40) DEFAULT NULL,
@@ -539,7 +538,7 @@ VALUES
  7.0, 'Source A', 'Unit A', 'Region A', '2023-06-28 15:00:00', '20230627',
  6.9, 'user_001', CURRENT_TIMESTAMP, 'Exchange rate on 2023-06-28');
 
-desc analyze WITH date_table AS (
+desc WITH date_table AS (
   SELECT
         d.col_1 AS date,
         (SELECT MAX(col_1)

--- a/tests/integrationtest/t/cte.test
+++ b/tests/integrationtest/t/cte.test
@@ -336,3 +336,43 @@ INSERT INTO `t_dnmxh` VALUES (104,571000,NULL),(104,572000,44.37),(104,573000,59
 WITH cte_0 AS (select distinct ref_0.wkey as c0, ref_0.pkey as c1, ref_0.c_xhsndb as c2 from t_dnmxh as ref_0 where (1 <= ( select ref_1.pkey not in ( select ref_5.wkey as c0 from t_dnmxh as ref_5 where (ref_5.wkey < ( select ref_6.pkey as c0 from t_cqmg3b as ref_6 where 88 between 96 and 76)) ) as c0 from (t_cqmg3b as ref_1 left outer join t_dnmxh as ref_2 on (ref_1.wkey = ref_2.wkey )) where ref_0.c_xhsndb is NULL union select 33 <= 91 as c0 from t_cqmg3b as ref_8 ))), cte_1 AS (select ref_9.wkey as c0, ref_9.pkey as c1, ref_9.c_anpf_c as c2, ref_9.c_b_fp_c as c3, ref_9.c_ndccfb as c4, ref_9.c_8rswc as c5 from t_cqmg3b as ref_9) select count(1) from cte_0 as ref_10 where case when 56 < 50 then case when 100 in ( select distinct ref_11.c4 as c0 from cte_1 as ref_11 where (ref_11.c4 > ( select ref_13.pkey as c0 from t_dnmxh as ref_13 where (ref_13.wkey > ( select distinct ref_11.c1 as c0 from cte_0 as ref_14)) )) or (1 = 1)) then null else null end else '7mxv6' end not like 'ki4%vc';
 #case
 with cte1 as (select 1), cte2 as (select 2) select * from cte1 union (with cte2 as (select 3) select * from cte2 union all select * from cte2) order by 1;
+
+# case: test CTE with complicated Apply and other operators
+drop table if exists tt, tt1, tt2, tt3, tt4, tt5;
+create table tt(c1 int, c2 int);
+create table tt1(c1 int, c2 int);
+create table tt2(c1 int, c2 int);
+create table tt3(c1 int, c2 int);
+create table tt4(c1 int, c2 int);
+create table tt5(c1 int, c2 int);
+insert into tt values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt1 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt2 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt3 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt4 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+insert into tt5 values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);
+
+## sub case-1: CTE with Apply
+explain with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1)) select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) order by 1;
+
+with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1)) select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) order by 1;
+
+## sub case-2: CTE with Apply and Union
+explain with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1)) 
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+
+with recursive cte1 as (select c1 from tt union select c1 from cte1 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte1.c1)) 
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+
+## sub case-3: nested CTE with Apply and union
+explain with cte1 as (with recursive cte2 as (select c1 from tt union all select c1 from cte2 where exists(select /*+ no_decorrelate() */ c1 from tt1 where tt1.c1 = cte2.c1) limit 300)
+select c1 from tt union select c1 from cte2 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte2.c1)) 
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;
+
+with cte1 as (with recursive cte2 as (select c1 from tt union all select c1 from cte2 where exists(select /*+ no_decorrelate() */ c1 from tt1 where tt1.c1 = cte2.c1) limit 300)
+select c1 from tt union select c1 from cte2 where exists (select /*+ no_decorrelate() */ c1 from tt1 where tt1.c2 = cte2.c1)) 
+select c1 from tt2 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt2.c1) union select c1 from tt3 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt3.c1) union
+select c1 from tt4 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt4.c1) union select c1 from tt5 where exists (select /*+ no_decorrelate() */ * from cte1 where cte1.c1 = tt5.c1) order by 1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55551

Problem Summary:
`ExtractOuterApplyCorrelatedCols` is used to find all correlated columns which is inside CTE definition and its corresponding Apply is outside of CTE definition. Check the following diagram, `ExtractOuterApplyCorrelatedCols` should **NOT** return `cor_col_3`, because `cor_col_3`'s corresponding Apply is `Apply_3`, which is inside CTE definition.

Why need `ExtractOuterApplyCorrelatedCols`: For those CTE whose result of `ExtractOuterApplyCorrelatedCols(CTE_definition)` is not empty, we need to re-compute the definition of CTE.
```
// For Plan-2, the result of ExtractOuterApplyCorrelatedCols(CTE-2) will not return cor_col_3.
// Because Apply_3 is inside CTE-2.
// Plan-2:
//
//	Apply_2
//	 |_ outerSide
//	 |_ Selection(cor_col_2)
//	     |_CTEExec(CTE-2)
//	CTE-2
//	 |_ Apply_3
//	     |_ outerSide
//	     |_ innerSide(cor_col_3)
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
