### PR TITLE
ttl: fix the issue that TTL job may hang some time when shrink the delete worker count

### DIFF
--- a/pkg/ttl/ttlworker/del.go
+++ b/pkg/ttl/ttlworker/del.go
@@ -92,6 +92,12 @@ func (t *ttlDeleteTask) doDelete(ctx context.Context, rawSe session.Session) (re
 	tracer.EnterPhase(metrics.PhaseOther)
 
 	leftRows := t.rows
+	defer func() {
+		if len(leftRows) > 0 {
+			t.statistics.IncErrorRows(len(leftRows))
+		}
+	}()
+
 	se := newTableSession(rawSe, t.tbl, t.expire)
 	for len(leftRows) > 0 {
 		maxBatch := variable.TTLDeleteBatchSize.Load()
@@ -208,6 +214,18 @@ func (b *ttlDelRetryBuffer) DoRetry(do func(*ttlDeleteTask) [][]types.Datum) tim
 	return b.retryInterval
 }
 
+// Drain drains a retry buffer.
+func (b *ttlDelRetryBuffer) Drain() {
+	for ele := b.list.Front(); ele != nil; ele = ele.Next() {
+		if item, ok := ele.Value.(*ttlDelRetryItem); ok {
+			item.task.statistics.IncErrorRows(len(item.task.rows))
+		} else {
+			logutil.BgLogger().Error(fmt.Sprintf("invalid retry buffer item type: %T", ele))
+		}
+	}
+	b.list = list.New()
+}
+
 func (b *ttlDelRetryBuffer) recordRetryItem(task *ttlDeleteTask, retryRows [][]types.Datum, retryCnt int) bool {
 	if len(retryRows) == 0 {
 		return false
@@ -277,6 +295,8 @@ func (w *ttlDeleteWorker) loop() error {
 	timer := time.NewTimer(w.retryBuffer.retryInterval)
 	defer timer.Stop()
 
+	// drain retry buffer to make sure the statistics are correct
+	defer w.retryBuffer.Drain()
 	for w.Status() == workerStatusRunning {
 		tracer.EnterPhase(metrics.PhaseIdle)
 		select {

--- a/pkg/ttl/ttlworker/scan.go
+++ b/pkg/ttl/ttlworker/scan.go
@@ -82,12 +82,13 @@ type ttlScanTask struct {
 }
 
 type ttlScanTaskExecResult struct {
+	time time.Time
 	task *ttlScanTask
 	err  error
 }
 
 func (t *ttlScanTask) result(err error) *ttlScanTaskExecResult {
-	return &ttlScanTaskExecResult{task: t, err: err}
+	return &ttlScanTaskExecResult{time: time.Now(), task: t, err: err}
 }
 
 func (t *ttlScanTask) getDatumRows(rows []chunk.Row) [][]types.Datum {

--- a/pkg/ttl/ttlworker/task_manager.go
+++ b/pkg/ttl/ttlworker/task_manager.go
@@ -75,6 +75,10 @@ func updateTTLTaskHeartBeatSQL(jobID string, scanID int64, now time.Time, state 
 
 const countRunningTasks = "SELECT count(1) FROM mysql.tidb_ttl_task WHERE status = 'running'"
 
+// waitTaskProcessRowTimeout is the timeout for waiting the task to process all rows after a scan task finished.
+// If not all rows are processed after this timeout, the task will still be marked as finished.
+const waitTaskProcessRowsTimeout = 2 * time.Minute
+
 var errAlreadyScheduled = errors.New("task is already scheduled")
 var errTooManyRunningTasks = errors.New("there are too many running tasks")
 
@@ -460,7 +464,7 @@ func (m *taskManager) updateHeartBeat(ctx context.Context, se session.Session, n
 func (m *taskManager) checkFinishedTask(se session.Session, now time.Time) {
 	stillRunningTasks := make([]*runningScanTask, 0, len(m.runningTasks))
 	for _, task := range m.runningTasks {
-		if !task.finished() {
+		if !task.finished(logutil.Logger(m.ctx)) {
 			stillRunningTasks = append(stillRunningTasks, task)
 			continue
 		}
@@ -597,6 +601,33 @@ func (t *runningScanTask) Context() context.Context {
 	return t.ctx
 }
 
-func (t *runningScanTask) finished() bool {
-	return t.result != nil && t.statistics.TotalRows.Load() == t.statistics.ErrorRows.Load()+t.statistics.SuccessRows.Load()
+func (t *runningScanTask) finished(logger *zap.Logger) bool {
+	if t.result == nil {
+		// Scan task isn't finished
+		return false
+	}
+
+	logger = logger.With(
+		zap.String("jobID", t.JobID),
+		zap.Int64("scanID", t.ScanID),
+		zap.String("table", t.tbl.Name.O),
+	)
+
+	if t.statistics.TotalRows.Load() <= t.statistics.ErrorRows.Load()+t.statistics.SuccessRows.Load() {
+		// All rows are processed.
+		// We use `<=` instead of `==` to make the logic strong to make sure
+		// it also works when statistics are not accurate.
+		logger.Info("mark TTL task finished because all scanned rows are processed")
+		return true
+	}
+
+	if time.Since(t.result.time) > waitTaskProcessRowsTimeout {
+		// If the scan task is finished and not all rows are processed, we should wait a certain time to report the task.
+		// After a certain time, if the rows are still not processed, we need to mark the task finished anyway to make
+		// sure the TTL job does not hang.
+		logger.Info("mark TTL task finished because timeout for waiting all scanned rows processed after scan task done")
+		return true
+	}
+
+	return false
 }

--- a/pkg/ttl/ttlworker/task_manager.go
+++ b/pkg/ttl/ttlworker/task_manager.go
@@ -77,7 +77,7 @@ const countRunningTasks = "SELECT count(1) FROM mysql.tidb_ttl_task WHERE status
 
 // waitTaskProcessRowTimeout is the timeout for waiting the task to process all rows after a scan task finished.
 // If not all rows are processed after this timeout, the task will still be marked as finished.
-const waitTaskProcessRowsTimeout = 2 * time.Minute
+const waitTaskProcessRowsTimeout = 5 * time.Minute
 
 var errAlreadyScheduled = errors.New("task is already scheduled")
 var errTooManyRunningTasks = errors.New("there are too many running tasks")
@@ -613,11 +613,30 @@ func (t *runningScanTask) finished(logger *zap.Logger) bool {
 		zap.String("table", t.tbl.Name.O),
 	)
 
-	if t.statistics.TotalRows.Load() <= t.statistics.ErrorRows.Load()+t.statistics.SuccessRows.Load() {
+	totalRows := t.statistics.TotalRows.Load()
+	errRows := t.statistics.ErrorRows.Load()
+	successRows := t.statistics.SuccessRows.Load()
+	processedRows := successRows + errRows
+	if processedRows == totalRows {
 		// All rows are processed.
-		// We use `<=` instead of `==` to make the logic strong to make sure
-		// it also works when statistics are not accurate.
-		logger.Info("mark TTL task finished because all scanned rows are processed")
+		logger.Info(
+			"mark TTL task finished because all scanned rows are processed",
+			zap.Uint64("totalRows", totalRows),
+			zap.Uint64("successRows", successRows),
+			zap.Uint64("errorRows", errRows),
+		)
+		return true
+	}
+
+	if processedRows > totalRows {
+		// All rows are processed but processed rows are more than total rows.
+		// We still think it is finished.
+		logger.Warn(
+			"mark TTL task finished but processed rows are more than total rows",
+			zap.Uint64("totalRows", totalRows),
+			zap.Uint64("successRows", successRows),
+			zap.Uint64("errorRows", errRows),
+		)
 		return true
 	}
 
@@ -625,7 +644,12 @@ func (t *runningScanTask) finished(logger *zap.Logger) bool {
 		// If the scan task is finished and not all rows are processed, we should wait a certain time to report the task.
 		// After a certain time, if the rows are still not processed, we need to mark the task finished anyway to make
 		// sure the TTL job does not hang.
-		logger.Info("mark TTL task finished because timeout for waiting all scanned rows processed after scan task done")
+		logger.Info(
+			"mark TTL task finished because timeout for waiting all scanned rows processed after scan task done",
+			zap.Uint64("totalRows", totalRows),
+			zap.Uint64("successRows", successRows),
+			zap.Uint64("errorRows", errRows),
+		)
 		return true
 	}
 

--- a/pkg/ttl/ttlworker/task_manager_test.go
+++ b/pkg/ttl/ttlworker/task_manager_test.go
@@ -19,10 +19,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/ttl/cache"
 	"github.com/pingcap/tidb/pkg/ttl/session"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/tikv"
@@ -76,10 +78,7 @@ func (m *taskManager) MeetTTLRunningTasks(count int, taskStatus cache.TaskStatus
 
 // ReportTaskFinished is an exported version of reportTaskFinished
 func (t *runningScanTask) SetResult(err error) {
-	t.result = &ttlScanTaskExecResult{
-		task: t.ttlScanTask,
-		err:  err,
-	}
+	t.result = t.ttlScanTask.result(err)
 }
 
 func TestResizeWorkers(t *testing.T) {
@@ -141,13 +140,49 @@ func TestResizeWorkers(t *testing.T) {
 		},
 	})
 
-	scanWorker2.curTaskResult = &ttlScanTaskExecResult{task: &ttlScanTask{tbl: tbl, TTLTask: &cache.TTLTask{
+	task := &ttlScanTask{tbl: tbl, TTLTask: &cache.TTLTask{
 		JobID:  "test-job-id",
 		ScanID: 1,
-	}}}
+	}}
+	scanWorker2.curTaskResult = task.result(nil)
 	assert.NoError(t, m.resizeScanWorkers(1))
 	scanWorker2.checkWorkerStatus(workerStatusStopped, false, nil)
 	assert.NotNil(t, m.runningTasks[0].result)
+}
+
+func TestTaskFinishedCondition(t *testing.T) {
+	tbl := newMockTTLTbl(t, "t1")
+	task := runningScanTask{
+		ttlScanTask: &ttlScanTask{
+			tbl: tbl,
+			TTLTask: &cache.TTLTask{
+				JobID:  "test-job-id",
+				ScanID: 1,
+			},
+			statistics: &ttlStatistics{},
+		},
+	}
+	logger := logutil.BgLogger()
+	task.statistics.TotalRows.Store(10)
+
+	// result == nil means it is not finished
+	require.Nil(t, task.result)
+	require.False(t, task.finished(logger))
+
+	for _, resultErr := range []error{nil, errors.New("mockErr")} {
+		// result != nil but not are rows processed means it is not finished
+		task.result = task.ttlScanTask.result(resultErr)
+		require.InDelta(t, task.result.time.Unix(), time.Now().Unix(), 5)
+		require.False(t, task.finished(logger))
+		task.statistics.SuccessRows.Store(8)
+		task.statistics.ErrorRows.Store(1)
+		require.False(t, task.finished(logger))
+
+		// result != nil but time out means it is finished
+		task.result = task.ttlScanTask.result(resultErr)
+		task.result.time = time.Now().Add(-waitTaskProcessRowsTimeout - time.Second)
+		require.True(t, task.finished(logger))
+	}
 }
 
 type mockKVStore struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55561

### What changed and how does it work?

- fix some missed count for `ErrorRows`
- if a scan task is finished, it will wait for all rows to be processed. If it is not finished in a certain time, the task will go one to mark itself as finished.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
