### PR TITLE
infoschema: add more tests for infoschema predicate

### DIFF
--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -493,7 +493,6 @@ func TestTablesTable(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
-	// prepare data
 	type tableMeta struct {
 		schema string
 		table  string
@@ -502,6 +501,8 @@ func TestTablesTable(t *testing.T) {
 	toString := func(tm *tableMeta) string {
 		return fmt.Sprintf("%s %s %s", tm.schema, tm.table, tm.id)
 	}
+
+	// prepare data
 	tableMetas := []*tableMeta{}
 	schemaNames := []string{"db1", "db2"}
 	tableNames := []string{"t1", "t2"}

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -489,6 +489,68 @@ func TestTiFlashSystemTableWithTiFlashV640(t *testing.T) {
 	tk.MustQuery("show warnings").Check(testkit.Rows())
 }
 
+func TestTablesTable(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	// prepare data
+	type tableMeta struct {
+		schema string
+		table  string
+		id     string
+	}
+	toString := func(tm *tableMeta) string {
+		return fmt.Sprintf("%s %s %s", tm.schema, tm.table, tm.id)
+	}
+	tableMetas := []*tableMeta{}
+	schemaNames := []string{"db1", "db2"}
+	tableNames := []string{"t1", "t2"}
+	tk.MustExec("create database db1")
+	tk.MustExec("create database db2")
+	for _, schemaName := range schemaNames {
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (a int)", schemaName, tableName))
+			res := tk.MustQuery(fmt.Sprintf("select tidb_table_id from information_schema.tables where table_schema = '%s' and table_name = '%s'", schemaName, tableName))
+			// [db1 t1 id0, db1 t2 id1, db2 t1 id2, db2 t2 id3]
+			tableMetas = append(tableMetas, &tableMeta{schema: schemaName, table: tableName, id: res.String()})
+		}
+	}
+
+	// Predicates are extracted in CNF, so we separate the test cases by the number of disjunctions in the predicate.
+
+	// predicate covers one disjunction
+	tk.MustQuery(`select table_schema, table_name, tidb_table_id from information_schema.tables
+		where table_schema = 'db1'`).Sort().Check(testkit.Rows(toString(tableMetas[0]), toString(tableMetas[1])))
+	tk.MustQuery(`select table_schema, table_name, tidb_table_id from information_schema.tables
+		where table_name = 't2'`).Sort().Check(testkit.Rows(toString(tableMetas[1]), toString(tableMetas[3])))
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where tidb_table_id = %s", tableMetas[2].id)).Check(
+		testkit.Rows(toString(tableMetas[2])))
+
+	// cover two disjunctions
+	tk.MustQuery(`select table_schema, table_name, tidb_table_id from information_schema.tables
+		where table_schema = 'db1' and table_name = 't2'`).Check(testkit.Rows(toString(tableMetas[1])))
+	tk.MustQuery(`select table_schema, table_name, tidb_table_id from information_schema.tables
+		where table_schema in ('db1', 'db2') and table_name = 't2'`).Sort().Check(testkit.Rows(toString(tableMetas[1]), toString(tableMetas[3])))
+	tk.MustQuery(`select table_schema, table_name, tidb_table_id from information_schema.tables
+		where (table_schema = 'db1' or table_schema = 'db2' ) and table_name = 't2'`).Sort().Check(testkit.Rows(toString(tableMetas[1]), toString(tableMetas[3])))
+	tk.MustQuery(`select table_schema, table_name, tidb_table_id from information_schema.tables
+		where (table_schema = 'db1' or table_schema = 'db2' ) and table_name = 't3'`).Check(testkit.Rows())
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_schema = 'db1' and tidb_table_id = %s", tableMetas[0].id)).Check(
+		testkit.Rows(toString(tableMetas[0])))
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_name = 't2' and tidb_table_id = %s", tableMetas[1].id)).Check(
+		testkit.Rows(toString(tableMetas[1])))
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_schema = 'db2' and tidb_table_id = %s", tableMetas[1].id)).Check(
+		testkit.Rows())
+
+	// cover three disjunctions
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_schema = 'db1' and table_name = 't1' and tidb_table_id = %s", tableMetas[0].id)).Check(
+		testkit.Rows(toString(tableMetas[0])))
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_schema = 'db1' and table_name = 't1' and tidb_table_id = %s", tableMetas[1].id)).Check(
+		testkit.Rows())
+	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_schema = 'db1' and table_name = 't1' and tidb_table_id in (%s,%s)", tableMetas[0].id, tableMetas[1].id)).Check(
+		testkit.Rows(toString(tableMetas[0])))
+}
+
 func TestColumnTable(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -231,6 +231,7 @@ go_test(
         "logical_plan_trace_test.go",
         "logical_plans_test.go",
         "main_test.go",
+        "memtable_infoschema_extractor_test.go",
         "optimizer_test.go",
         "partition_pruning_test.go",
         "physical_plan_test.go",

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -75,7 +75,10 @@ const (
 type InfoSchemaBaseExtractor struct {
 	extractHelper
 	// SkipRequest means the where clause always false, we don't need to request any component
-	SkipRequest   bool
+	SkipRequest bool
+	// ColPredicates records the columns that can be extracted from the predicates.
+	// For example, `select * from information_schema.SCHEMATA where schema_name='mysql' or schema_name='INFORMATION_SCHEMA'`
+	// {"schema_name": ["mysql", "INFORMATION_SCHEMA"]}
 	ColPredicates map[string]set.StringSet
 	// columns occurs in predicate will be extracted.
 	colNames []columnName

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -36,39 +36,41 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-// columnName is the type for column names used by tables information_schema.
-type columnName string
+// extractableCols records the column names used by tables in information_schema.
 type extractableCols struct {
-	schema      columnName
-	table       columnName
-	tableID     columnName
-	partitionID columnName
+	schema      string
+	table       string
+	tableID     string
+	partitionID string
 
-	partitionName columnName
-	indexName     columnName
-	columnName    columnName
-	constrName    columnName
-	constrSchema  columnName
+	partitionName string
+	indexName     string
+	columnName    string
+	constrName    string
+	constrSchema  string
 }
 
+//revive:disable:exported
 const (
-	_tableSchema      columnName = "table_schema"
-	_tableName        columnName = "table_name"
-	_tidbTableID      columnName = "tidb_table_id"
-	_partitionName    columnName = "partition_name"
-	_tidbPartitionID  columnName = "tidb_partition_id"
-	_indexName        columnName = "index_name"
-	_schemaName       columnName = "schema_name"
-	_constraintSchema columnName = "constraint_schema"
-	_constraintName   columnName = "constraint_name"
-	_tableID          columnName = "table_id"
-	_sequenceSchema   columnName = "sequence_schema"
-	_sequenceName     columnName = "sequence_name"
-	_columnName       columnName = "column_name"
+	TableSchema      = "table_schema"
+	TableName        = "table_name"
+	TidbTableID      = "tidb_table_id"
+	PartitionName    = "partition_name"
+	TidbPartitionID  = "tidb_partition_id"
+	IndexName        = "index_name"
+	SchemaName       = "schema_name"
+	ConstraintSchema = "constraint_schema"
+	ConstraintName   = "constraint_name"
+	TableID          = "table_id"
+	SequenceSchema   = "sequence_schema"
+	SequenceName     = "sequence_name"
+	ColumnName       = "column_name"
 )
 
+//revive:enable:exported
+
 const (
-	primaryKeyName string = "primary"
+	primaryKeyName = "primary"
 )
 
 // InfoSchemaBaseExtractor is used to extract infoSchema tables related predicates.
@@ -81,7 +83,7 @@ type InfoSchemaBaseExtractor struct {
 	// {"schema_name": ["mysql", "INFORMATION_SCHEMA"]}
 	ColPredicates map[string]set.StringSet
 	// columns occurs in predicate will be extracted.
-	colNames []columnName
+	colNames []string
 
 	extractableColumns extractableCols
 }
@@ -157,7 +159,6 @@ func (e *InfoSchemaBaseExtractor) Extract(
 	e.ColPredicates = make(map[string]set.StringSet)
 	remained = predicates
 	for _, colName := range e.colNames {
-		colName := string(colName)
 		remained, e.SkipRequest, resultSet = e.extractColWithLower(ctx, schema, names, remained, colName)
 		if e.SkipRequest {
 			break
@@ -203,13 +204,13 @@ func (e *InfoSchemaBaseExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 // Filter use the col predicates to filter records.
 // Return true if the underlying row does not match predicate,
 // then it should be filtered and not shown in the result.
-func (e *InfoSchemaBaseExtractor) filter(colName columnName, val string) bool {
+func (e *InfoSchemaBaseExtractor) filter(colName string, val string) bool {
 	if e.SkipRequest {
 		return true
 	}
-	predVals, ok := e.ColPredicates[string(colName)]
+	predVals, ok := e.ColPredicates[colName]
 	if ok && len(predVals) > 0 {
-		lower, ok := e.isLower[string(colName)]
+		lower, ok := e.isLower[colName]
 		if ok {
 			var valStr string
 			// only have varchar string type, safe to do that.
@@ -235,10 +236,10 @@ type InfoSchemaIndexesExtractor struct {
 func NewInfoSchemaIndexesExtractor() *InfoSchemaIndexesExtractor {
 	e := &InfoSchemaIndexesExtractor{}
 	e.extractableColumns = extractableCols{
-		schema: _tableSchema,
-		table:  _tableName,
+		schema: TableSchema,
+		table:  TableName,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName}
+	e.colNames = []string{TableSchema, TableName}
 	return e
 }
 
@@ -251,11 +252,11 @@ type InfoSchemaTablesExtractor struct {
 func NewInfoSchemaTablesExtractor() *InfoSchemaTablesExtractor {
 	e := &InfoSchemaTablesExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:  _tableSchema,
-		table:   _tableName,
-		tableID: _tidbTableID,
+		schema:  TableSchema,
+		table:   TableName,
+		tableID: TidbTableID,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _tidbTableID}
+	e.colNames = []string{TableSchema, TableName, TidbTableID}
 	return e
 }
 
@@ -268,10 +269,10 @@ type InfoSchemaViewsExtractor struct {
 func NewInfoSchemaViewsExtractor() *InfoSchemaViewsExtractor {
 	e := &InfoSchemaViewsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema: _tableSchema,
-		table:  _tableName,
+		schema: TableSchema,
+		table:  TableName,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName}
+	e.colNames = []string{TableSchema, TableName}
 	return e
 }
 
@@ -284,28 +285,28 @@ type InfoSchemaKeyColumnUsageExtractor struct {
 func NewInfoSchemaKeyColumnUsageExtractor() *InfoSchemaKeyColumnUsageExtractor {
 	e := &InfoSchemaKeyColumnUsageExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:       _tableSchema,
-		table:        _tableName,
-		constrName:   _constraintName,
-		constrSchema: _constraintSchema,
+		schema:       TableSchema,
+		table:        TableName,
+		constrName:   ConstraintName,
+		constrSchema: ConstraintSchema,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _constraintName, _constraintSchema}
+	e.colNames = []string{TableSchema, TableName, ConstraintName, ConstraintSchema}
 	return e
 }
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraint(name string) bool {
-	return !e.filter(_constraintName, name)
+	return !e.filter(ConstraintName, name)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasPrimaryKey() bool {
-	return !e.filter(_constraintName, primaryKeyName)
+	return !e.filter(ConstraintName, primaryKeyName)
 }
 
 // HasConstraintSchema returns true if constraint schema is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraintSchema(name string) bool {
-	return !e.filter(_constraintSchema, name)
+	return !e.filter(ConstraintSchema, name)
 }
 
 // InfoSchemaTableConstraintsExtractor is the predicate extractor for information_schema.constraints.
@@ -317,28 +318,28 @@ type InfoSchemaTableConstraintsExtractor struct {
 func NewInfoSchemaTableConstraintsExtractor() *InfoSchemaTableConstraintsExtractor {
 	e := &InfoSchemaTableConstraintsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:       _tableSchema,
-		table:        _tableName,
-		constrName:   _constraintName,
-		constrSchema: _constraintSchema,
+		schema:       TableSchema,
+		table:        TableName,
+		constrName:   ConstraintName,
+		constrSchema: ConstraintSchema,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _constraintName, _constraintSchema}
+	e.colNames = []string{TableSchema, TableName, ConstraintName, ConstraintSchema}
 	return e
 }
 
 // HasConstraintSchema returns true if constraint schema is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraintSchema(name string) bool {
-	return !e.filter(_constraintSchema, name)
+	return !e.filter(ConstraintSchema, name)
 }
 
 // HasConstraint returns true if constraint is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(_constraintName, name)
+	return !e.filter(ConstraintName, name)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasPrimaryKey() bool {
-	return !e.filter(_constraintName, primaryKeyName)
+	return !e.filter(ConstraintName, primaryKeyName)
 }
 
 // InfoSchemaPartitionsExtractor is the predicate extractor for information_schema.partitions.
@@ -350,18 +351,18 @@ type InfoSchemaPartitionsExtractor struct {
 func NewInfoSchemaPartitionsExtractor() *InfoSchemaPartitionsExtractor {
 	e := &InfoSchemaPartitionsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:        _tableSchema,
-		table:         _tableName,
-		partitionID:   _tidbPartitionID,
-		partitionName: _partitionName,
+		schema:        TableSchema,
+		table:         TableName,
+		partitionID:   TidbPartitionID,
+		partitionName: PartitionName,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _tidbPartitionID, _partitionName}
+	e.colNames = []string{TableSchema, TableName, TidbPartitionID, PartitionName}
 	return e
 }
 
 // HasPartition returns true if partition name is specified in predicates.
 func (e *InfoSchemaPartitionsExtractor) HasPartition(name string) bool {
-	return !e.filter(_partitionName, name)
+	return !e.filter(PartitionName, name)
 }
 
 // InfoSchemaStatisticsExtractor is the predicate extractor for  information_schema.statistics.
@@ -373,22 +374,22 @@ type InfoSchemaStatisticsExtractor struct {
 func NewInfoSchemaStatisticsExtractor() *InfoSchemaStatisticsExtractor {
 	e := &InfoSchemaStatisticsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:    _tableSchema,
-		table:     _tableName,
-		indexName: _indexName,
+		schema:    TableSchema,
+		table:     TableName,
+		indexName: IndexName,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _indexName}
+	e.colNames = []string{TableSchema, TableName, IndexName}
 	return e
 }
 
 // HasIndex returns true if index name is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasIndex(val string) bool {
-	return !e.filter(_indexName, val)
+	return !e.filter(IndexName, val)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasPrimaryKey() bool {
-	return !e.filter(_indexName, primaryKeyName)
+	return !e.filter(IndexName, primaryKeyName)
 }
 
 // InfoSchemaSchemataExtractor is the predicate extractor for information_schema.schemata.
@@ -400,9 +401,9 @@ type InfoSchemaSchemataExtractor struct {
 func NewInfoSchemaSchemataExtractor() *InfoSchemaSchemataExtractor {
 	e := &InfoSchemaSchemataExtractor{}
 	e.extractableColumns = extractableCols{
-		schema: _schemaName,
+		schema: SchemaName,
 	}
-	e.colNames = []columnName{_schemaName}
+	e.colNames = []string{SchemaName}
 	return e
 }
 
@@ -415,16 +416,16 @@ type InfoSchemaCheckConstraintsExtractor struct {
 func NewInfoSchemaCheckConstraintsExtractor() *InfoSchemaCheckConstraintsExtractor {
 	e := &InfoSchemaCheckConstraintsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:     _constraintSchema,
-		constrName: _constraintName,
+		schema:     ConstraintSchema,
+		constrName: ConstraintName,
 	}
-	e.colNames = []columnName{_constraintSchema, _constraintName}
+	e.colNames = []string{ConstraintSchema, ConstraintName}
 	return e
 }
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaCheckConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(_constraintName, name)
+	return !e.filter(ConstraintName, name)
 }
 
 // InfoSchemaTiDBCheckConstraintsExtractor is the predicate extractor for information_schema.tidb_check_constraints.
@@ -436,18 +437,18 @@ type InfoSchemaTiDBCheckConstraintsExtractor struct {
 func NewInfoSchemaTiDBCheckConstraintsExtractor() *InfoSchemaTiDBCheckConstraintsExtractor {
 	e := &InfoSchemaTiDBCheckConstraintsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:     _constraintSchema,
-		table:      _tableName,
-		tableID:    _tableID,
-		constrName: _constraintName,
+		schema:     ConstraintSchema,
+		table:      TableName,
+		tableID:    TableID,
+		constrName: ConstraintName,
 	}
-	e.colNames = []columnName{_constraintSchema, _tableName, _tableID, _constraintName}
+	e.colNames = []string{ConstraintSchema, TableName, TableID, ConstraintName}
 	return e
 }
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaTiDBCheckConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(_constraintName, name)
+	return !e.filter(ConstraintName, name)
 }
 
 // InfoSchemaReferConstExtractor is the predicate extractor for information_schema.referential_constraints.
@@ -459,17 +460,17 @@ type InfoSchemaReferConstExtractor struct {
 func NewInfoSchemaReferConstExtractor() *InfoSchemaReferConstExtractor {
 	e := &InfoSchemaReferConstExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:     _constraintSchema,
-		table:      _tableName,
-		constrName: _constraintName,
+		schema:     ConstraintSchema,
+		table:      TableName,
+		constrName: ConstraintName,
 	}
-	e.colNames = []columnName{_constraintSchema, _tableName, _constraintName}
+	e.colNames = []string{ConstraintSchema, TableName, ConstraintName}
 	return e
 }
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaReferConstExtractor) HasConstraint(name string) bool {
-	return !e.filter(_constraintName, name)
+	return !e.filter(ConstraintName, name)
 }
 
 // InfoSchemaSequenceExtractor is the predicate extractor for information_schema.sequences.
@@ -481,10 +482,10 @@ type InfoSchemaSequenceExtractor struct {
 func NewInfoSchemaSequenceExtractor() *InfoSchemaSequenceExtractor {
 	e := &InfoSchemaSequenceExtractor{}
 	e.extractableColumns = extractableCols{
-		schema: _sequenceSchema,
-		table:  _sequenceName,
+		schema: SequenceSchema,
+		table:  SequenceName,
 	}
-	e.colNames = []columnName{_sequenceSchema, _sequenceName}
+	e.colNames = []string{SequenceSchema, SequenceName}
 	return e
 }
 
@@ -653,8 +654,8 @@ func parseIDs(ids []model.CIStr) []int64 {
 }
 
 // getSchemaObjectNames gets the schema object names specified in predicate of given column name.
-func (e *InfoSchemaBaseExtractor) getSchemaObjectNames(colName columnName) []model.CIStr {
-	predVals, ok := e.ColPredicates[string(colName)]
+func (e *InfoSchemaBaseExtractor) getSchemaObjectNames(colName string) []model.CIStr {
+	predVals, ok := e.ColPredicates[colName]
 	if ok && len(predVals) > 0 {
 		tableNames := make([]model.CIStr, 0, len(predVals))
 		predVals.IterateWith(func(n string) {
@@ -711,7 +712,6 @@ func (e *InfoSchemaTableNameExtractor) Extract(
 	e.colsPredLower = make(map[string]set.StringSet, len(e.colNames))
 	var likePatterns []string
 	for _, colName := range e.colNames {
-		colName := string(colName)
 		remained, likePatterns = e.extractLikePatternCol(ctx, schema, names, remained, colName, true, false)
 		regexp := make([]collate.WildcardPattern, len(likePatterns))
 		predColLower := set.StringSet{}
@@ -733,7 +733,7 @@ func (e *InfoSchemaTableNameExtractor) Extract(
 }
 
 // getPredicates gets all names and regexps related to given column names.
-func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...columnName) (
+func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...string) (
 	set.StringSet, []collate.WildcardPattern, bool) {
 	filters := set.StringSet{}
 	regexp := []collate.WildcardPattern{}
@@ -741,10 +741,10 @@ func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...columnName) (
 
 	// Extract all filters and like patterns
 	for _, col := range colNames {
-		if rs, ok := e.colsRegexp[string(col)]; ok && len(rs) > 0 {
+		if rs, ok := e.colsRegexp[col]; ok && len(rs) > 0 {
 			regexp = append(regexp, rs...)
 		}
-		if f, ok := e.colsPredLower[string(col)]; ok && len(f) > 0 {
+		if f, ok := e.colsPredLower[col]; ok && len(f) > 0 {
 			if !hasPredicates {
 				filters = f
 				hasPredicates = true
@@ -761,7 +761,7 @@ func (e *InfoSchemaTableNameExtractor) getPredicates(colNames ...columnName) (
 // Add more columns if necessary.
 func (e *InfoSchemaTableNameExtractor) getSchemaNames() (
 	set.StringSet, []collate.WildcardPattern, bool) {
-	return e.getPredicates(_tableSchema, _schemaName, _constraintSchema)
+	return e.getPredicates(TableSchema, SchemaName, ConstraintSchema)
 }
 
 // ListSchemas lists related schemas from predicates.
@@ -801,7 +801,7 @@ ForLoop:
 	}
 
 	// TODO: add table_id here
-	tableNames := e.getSchemaObjectNames(_tableName)
+	tableNames := e.getSchemaObjectNames(TableName)
 	e.tableNames = tableNames
 	if len(tableNames) > 0 {
 		e.listTableFunc = e.listSchemaTablesByName
@@ -824,7 +824,7 @@ func (e *InfoSchemaTableNameExtractor) ListTables(
 		return nil, errors.Trace(err)
 	}
 
-	if regexp, ok := e.colsRegexp[string(_tableName)]; ok {
+	if regexp, ok := e.colsRegexp[TableName]; ok {
 		tbls := make([]*model.TableInfo, 0, len(allTbls))
 	ForLoop:
 		for _, tbl := range allTbls {
@@ -878,13 +878,13 @@ func (e *InfoSchemaTableNameExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 	r := new(bytes.Buffer)
 
 	for _, colName := range e.colNames {
-		if pred, ok := e.ColPredicates[string(colName)]; ok && len(pred) > 0 {
+		if pred, ok := e.ColPredicates[colName]; ok && len(pred) > 0 {
 			fmt.Fprintf(r, "%s:[%s], ", colName, extractStringFromStringSet(pred))
 		}
 	}
 
 	for _, colName := range e.colNames {
-		if patterns, ok := e.LikePatterns[string(colName)]; ok && len(patterns) > 0 {
+		if patterns, ok := e.LikePatterns[colName]; ok && len(patterns) > 0 {
 			fmt.Fprintf(r, "%s_pattern:[%s], ", colName, extractStringFromStringSlice(patterns))
 		}
 	}
@@ -906,11 +906,11 @@ type InfoSchemaColumnsExtractor struct {
 func NewInfoSchemaColumnsExtractor() *InfoSchemaColumnsExtractor {
 	e := &InfoSchemaColumnsExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:     _tableSchema,
-		table:      _tableName,
-		columnName: _columnName,
+		schema:     TableSchema,
+		table:      TableName,
+		columnName: ColumnName,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _columnName}
+	e.colNames = []string{TableSchema, TableName, ColumnName}
 	return e
 }
 
@@ -919,7 +919,7 @@ func NewInfoSchemaColumnsExtractor() *InfoSchemaColumnsExtractor {
 func (e *InfoSchemaTableNameExtractor) ListColumns(
 	tbl *model.TableInfo,
 ) ([]*model.ColumnInfo, []int) {
-	predCol, regexp, _ := e.getPredicates(_columnName)
+	predCol, regexp, _ := e.getPredicates(ColumnName)
 
 	columns := make([]*model.ColumnInfo, 0, len(predCol))
 	ordinalPos := make([]int, 0, len(predCol))
@@ -954,11 +954,11 @@ type InfoSchemaTiDBIndexUsageExtractor struct {
 func NewInfoSchemaTiDBIndexUsageExtractor() *InfoSchemaTiDBIndexUsageExtractor {
 	e := &InfoSchemaTiDBIndexUsageExtractor{}
 	e.extractableColumns = extractableCols{
-		schema:    _tableSchema,
-		table:     _tableName,
-		indexName: _indexName,
+		schema:    TableSchema,
+		table:     TableName,
+		indexName: IndexName,
 	}
-	e.colNames = []columnName{_tableSchema, _tableName, _indexName}
+	e.colNames = []string{TableSchema, TableName, IndexName}
 	return e
 }
 
@@ -967,7 +967,7 @@ func NewInfoSchemaTiDBIndexUsageExtractor() *InfoSchemaTiDBIndexUsageExtractor {
 func (e *InfoSchemaTiDBIndexUsageExtractor) ListIndexes(
 	tbl *model.TableInfo,
 ) []*model.IndexInfo {
-	predCol, regexp, _ := e.getPredicates(_indexName)
+	predCol, regexp, _ := e.getPredicates(IndexName)
 	if len(predCol) == 0 && len(regexp) == 0 {
 		return tbl.Indices
 	}

--- a/pkg/planner/core/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/memtable_infoschema_extractor_test.go
@@ -1,0 +1,198 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+type colPredicates struct {
+	// eg. table_schema
+	colName string
+	// eg. [db1, db2]
+	values []string
+	// for table_id, tidb_table_id etc.
+	isInteger bool
+}
+
+// input: ["a", "b", "c"]
+// output: [[], ["a"], ["b"], ["c"], ["a", "b"], ["a", "c"], ["b", "c"], ["a", "b", "c"]]
+func (cp colPredicates) generateCombinations(val []string) (res [][]string) {
+	switch l := len(val); l {
+	case 0:
+	case 1:
+		res = append(res, []string{})
+		if cp.isInteger {
+			res = append(res, []string{val[0]})
+		} else {
+			res = append(res, []string{fmt.Sprintf("'%s'", val[0])})
+		}
+	default:
+		tmp := cp.generateCombinations(val[:l-1])
+		for _, t := range tmp {
+			res = append(res, t)
+			if cp.isInteger {
+				t = append(t, val[l-1])
+			} else {
+				t = append(t, fmt.Sprintf("'%s'", val[l-1]))
+			}
+			res = append(res, t)
+		}
+	}
+	return
+}
+
+func (cp colPredicates) enumerateAll() (res []string) {
+	if len(cp.values) == 0 {
+		return
+	}
+
+	// EQ
+	if cp.isInteger {
+		for _, value := range cp.values {
+			res = append(res, fmt.Sprintf("%s = %s", cp.colName, value))
+		}
+	} else {
+		for _, value := range cp.values {
+			res = append(res, fmt.Sprintf("%s = '%s'", cp.colName, value))
+			res = append(res, fmt.Sprintf("lower(%s) = '%s'", cp.colName, value))
+		}
+	}
+
+	combs := cp.generateCombinations(cp.values)
+	for _, comb := range combs {
+		if len(comb) == 0 {
+			continue
+		}
+
+		// In
+		res = append(res, fmt.Sprintf("%s in (%s)", cp.colName, strings.Join(comb, ",")))
+		if !cp.isInteger {
+			res = append(res, fmt.Sprintf("lower(%s) in (%s)", cp.colName, strings.Join(comb, ",")))
+		}
+
+		// LogicOr
+		for i := range comb {
+			comb[i] = fmt.Sprintf("%s = %s", cp.colName, comb[i])
+		}
+		res = append(res, fmt.Sprintf("(%s)", strings.Join(comb, " or ")))
+	}
+	return
+}
+
+type testCase struct {
+	memTableName string
+	prepareData  func(t *testing.T, tk *testkit.TestKit) (names []colPredicates)
+	cleanData    func(t *testing.T, tk *testkit.TestKit)
+}
+
+func prepareDataTables(_ *testing.T, tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_tables1", "schema_tables2"}
+	tableNames := []string{"t1", "t2"}
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+	ids := []string{}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (a int)", schemaName, tableName))
+			tableID := tk.MustQuery(fmt.Sprintf("select tidb_table_id from information_schema.tables where table_schema = '%s' and table_name = '%s'", schemaName, tableName)).String()
+			ids = append(ids, tableID)
+		}
+	}
+	names = append(names, colPredicates{colName: core.TidbTableID, values: ids, isInteger: true})
+	return
+}
+
+func cleanDataTables(t *testing.T, tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_tables1")
+	tk.MustExec("drop database schema_tables2")
+}
+
+func prepareDataTiDBIndexes(_ *testing.T, tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_tidb_indexes1", "schema_tidb_indexes2", "schema_tidb_indexes3"}
+	tableNames := []string{"t1", "t2", "t3"}
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (a int, index i(a))", schemaName, tableName))
+		}
+	}
+	return
+}
+
+func cleanDataTiDBIndexes(t *testing.T, tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_tidb_indexes1")
+	tk.MustExec("drop database schema_tidb_indexes2")
+	tk.MustExec("drop database schema_tidb_indexes3")
+}
+
+func TestMemtableInfoschemaExtractor(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tcs := []testCase{
+		{
+			memTableName: infoschema.TableTiDBIndexes,
+			prepareData:  prepareDataTiDBIndexes,
+			cleanData:    cleanDataTiDBIndexes,
+		},
+		{
+			memTableName: infoschema.TableTables,
+			prepareData:  prepareDataTables,
+			cleanData:    cleanDataTables,
+		},
+
+		// TODO: add more infoschema tables
+	}
+
+	countSQL := 0
+	for _, tc := range tcs {
+		names := tc.prepareData(t, tk)
+		conditions := []string{}
+		for i := len(names) - 1; i >= 0; i-- {
+			all := names[i].enumerateAll()
+			if len(conditions) == 0 {
+				conditions = all
+			} else {
+				newConditions := []string{}
+				for _, a := range all {
+					for _, b := range conditions {
+						newConditions = append(newConditions, fmt.Sprintf("%s and %s", a, b))
+					}
+				}
+				conditions = newConditions
+			}
+		}
+
+		countSQL += len(conditions)
+		for _, c := range conditions {
+			sql := fmt.Sprintf("select * from information_schema.%s where %s", tc.memTableName, c)
+			tk.MustQuery(sql)
+		}
+
+		tc.cleanData(t, tk)
+	}
+	fmt.Printf("Total SQLs: %d\n", countSQL)
+}

--- a/pkg/planner/core/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/memtable_infoschema_extractor_test.go
@@ -100,11 +100,11 @@ func (cp colPredicates) enumerateAll() (res []string) {
 
 type testCase struct {
 	memTableName string
-	prepareData  func(t *testing.T, tk *testkit.TestKit) (names []colPredicates)
-	cleanData    func(t *testing.T, tk *testkit.TestKit)
+	prepareData  func(tk *testkit.TestKit) (names []colPredicates)
+	cleanData    func(tk *testkit.TestKit)
 }
 
-func prepareDataTables(_ *testing.T, tk *testkit.TestKit) (names []colPredicates) {
+func prepareDataTables(tk *testkit.TestKit) (names []colPredicates) {
 	schemaNames := []string{"schema_tables1", "schema_tables2"}
 	tableNames := []string{"t1", "t2"}
 	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
@@ -122,12 +122,12 @@ func prepareDataTables(_ *testing.T, tk *testkit.TestKit) (names []colPredicates
 	return
 }
 
-func cleanDataTables(t *testing.T, tk *testkit.TestKit) {
+func cleanDataTables(tk *testkit.TestKit) {
 	tk.MustExec("drop database schema_tables1")
 	tk.MustExec("drop database schema_tables2")
 }
 
-func prepareDataTiDBIndexes(_ *testing.T, tk *testkit.TestKit) (names []colPredicates) {
+func prepareDataTiDBIndexes(tk *testkit.TestKit) (names []colPredicates) {
 	schemaNames := []string{"schema_tidb_indexes1", "schema_tidb_indexes2", "schema_tidb_indexes3"}
 	tableNames := []string{"t1", "t2", "t3"}
 	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
@@ -142,16 +142,207 @@ func prepareDataTiDBIndexes(_ *testing.T, tk *testkit.TestKit) (names []colPredi
 	return
 }
 
-func cleanDataTiDBIndexes(t *testing.T, tk *testkit.TestKit) {
+func cleanDataTiDBIndexes(tk *testkit.TestKit) {
 	tk.MustExec("drop database schema_tidb_indexes1")
 	tk.MustExec("drop database schema_tidb_indexes2")
 	tk.MustExec("drop database schema_tidb_indexes3")
+}
+
+func prepareDataViews(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_views1", "schema_views2", "schema_views3"}
+	viewNames := []string{"v1", "v2", "v3"}
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: viewNames})
+
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		tk.MustExec(fmt.Sprintf("create table %s.t (c int)", schemaName))
+		for _, viewName := range viewNames {
+			tk.MustExec(fmt.Sprintf("create view %s.%s as select * from %s.t", schemaName, viewName, schemaName))
+		}
+	}
+	return
+}
+
+func cleanDataViews(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_views1")
+	tk.MustExec("drop database schema_views2")
+	tk.MustExec("drop database schema_views3")
+}
+
+func prepareDataKeyColumnUsage(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_key_column_usage1", "schema_key_column_usage2"}
+	tableNames := []string{"t1", "t2"}
+	constraintNames := []string{"c1", "c2"}
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+	names = append(names, colPredicates{colName: core.ConstraintSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.ConstraintName, values: constraintNames})
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (a int)", schemaName, tableName))
+			for _, constraintName := range constraintNames {
+				tk.MustExec(fmt.Sprintf("alter table %s.%s add constraint %s unique(a)", schemaName, tableName, constraintName))
+			}
+		}
+	}
+	return
+}
+
+func cleanDataKeyColumnUsage(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_key_column_usage1")
+	tk.MustExec("drop database schema_key_column_usage2")
+}
+
+func prepareDataPartitions(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_partition1", "schema_partition2"}
+	tableNames := []string{"t1", "t2"}
+	partitionNames := []string{"p1", "p2"}
+
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (a int) partition by list (a) (partition p1 values in (1, 2, 3), partition p2 default)", schemaName, tableName))
+		}
+	}
+
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+	names = append(names, colPredicates{colName: core.PartitionName, values: partitionNames})
+	return
+}
+
+func cleanDataPartitions(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_partition1")
+	tk.MustExec("drop database schema_partition2")
+}
+
+func prepareDataStatistics(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_statistics1", "schema_statistics2"}
+	tableNames := []string{"t1", "t2"}
+	indexNames := []string{"i1", "i2"}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (i1 int, i2 int, unique key(i1), unique key(i2))", schemaName, tableName))
+		}
+	}
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+	names = append(names, colPredicates{colName: core.IndexName, values: indexNames})
+	return
+}
+
+func cleanDataStatistics(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_statistics1")
+	tk.MustExec("drop database schema_statistics2")
+}
+
+func prepareDataSchemata(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_schemata1", "schema_schemata2", "schema_schemata3"}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+	}
+	names = append(names, colPredicates{colName: core.SchemaName, values: schemaNames})
+	return
+}
+
+func cleanDataSchemata(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_schemata1")
+	tk.MustExec("drop database schema_schemata2")
+	tk.MustExec("drop database schema_schemata3")
+}
+
+func prepareDataCheckConstraints(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_check_constraints1", "schema_check_constraints2", "schema_check_constraints3"}
+	constrainNames := []string{"c1", "c2", "c3"}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		tk.MustExec(fmt.Sprintf("create table %s.t (a int, constraint c1 check (a > 0), constraint c2 check (a = 0), constraint c3 check (a < 0))", schemaName))
+	}
+	names = append(names, colPredicates{colName: core.ConstraintSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.ConstraintName, values: constrainNames})
+	return
+}
+
+func cleanDataCheckConstraints(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_check_constraints1")
+	tk.MustExec("drop database schema_check_constraints2")
+	tk.MustExec("drop database schema_check_constraints3")
+}
+
+func prepareDataTidbCheckConstraints(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_tidb_check_constraints1", "schema_tidb_check_constraints2"}
+	tableNames := []string{"t1", "t2"}
+	constrainNames := []string{"t1_c", "t2_c"}
+	tableIDs := []string{}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (a int, constraint %s_c check (a != 0))", schemaName, tableName, tableName))
+			sql := fmt.Sprintf("select distinct table_id from information_schema.tidb_check_constraints where CONSTRAINT_SCHEMA = '%s' and TABLE_NAME = '%s'", schemaName, tableName)
+			id := tk.MustQuery(sql).String()
+			tableIDs = append(tableIDs, id)
+		}
+	}
+	names = append(names, colPredicates{colName: core.ConstraintSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+	names = append(names, colPredicates{colName: core.ConstraintName, values: constrainNames})
+	names = append(names, colPredicates{colName: core.TableID, values: tableIDs, isInteger: true})
+	return
+}
+
+func cleanDataTidbCheckConstraints(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_tidb_check_constraints1")
+	tk.MustExec("drop database schema_tidb_check_constraints2")
+}
+
+func prepareDataSequences(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_sequences1", "schema_sequences2"}
+	sequenceNames := []string{"s1", "s2"}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, sequenceName := range sequenceNames {
+			tk.MustExec(fmt.Sprintf("create sequence %s.%s", schemaName, sequenceName))
+		}
+	}
+	names = append(names, colPredicates{colName: core.SequenceSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.SequenceName, values: sequenceNames})
+	return
+}
+
+func cleanDataSequences(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_sequences1")
+	tk.MustExec("drop database schema_sequences2")
+}
+
+func prepareDataColumns(tk *testkit.TestKit) (names []colPredicates) {
+	schemaNames := []string{"schema_columns1", "schema_columns2"}
+	tableNames := []string{"t1", "t2"}
+	columnNames := []string{"c1", "c2"}
+	for _, schemaName := range schemaNames {
+		tk.MustExec(fmt.Sprintf("create database %s", schemaName))
+		for _, tableName := range tableNames {
+			tk.MustExec(fmt.Sprintf("create table %s.%s (c1 int, c2 int)", schemaName, tableName))
+		}
+	}
+	names = append(names, colPredicates{colName: core.TableSchema, values: schemaNames})
+	names = append(names, colPredicates{colName: core.TableName, values: tableNames})
+	names = append(names, colPredicates{colName: core.ColumnName, values: columnNames})
+	return
+}
+
+func cleanDataColumns(tk *testkit.TestKit) {
+	tk.MustExec("drop database schema_columns1")
+	tk.MustExec("drop database schema_columns2")
 }
 
 func TestMemtableInfoschemaExtractor(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
+	tk.MustExec("set global tidb_enable_check_constraint = true")
 	tcs := []testCase{
 		{
 			memTableName: infoschema.TableTiDBIndexes,
@@ -163,13 +354,61 @@ func TestMemtableInfoschemaExtractor(t *testing.T) {
 			prepareData:  prepareDataTables,
 			cleanData:    cleanDataTables,
 		},
-
-		// TODO: add more infoschema tables
+		{
+			memTableName: infoschema.TableViews,
+			prepareData:  prepareDataViews,
+			cleanData:    cleanDataViews,
+		},
+		{
+			memTableName: infoschema.TableKeyColumn,
+			prepareData:  prepareDataKeyColumnUsage,
+			cleanData:    cleanDataKeyColumnUsage,
+		},
+		{
+			memTableName: infoschema.TableConstraints,
+			prepareData:  prepareDataKeyColumnUsage,
+			cleanData:    cleanDataKeyColumnUsage,
+		},
+		{
+			memTableName: infoschema.TablePartitions,
+			prepareData:  prepareDataPartitions,
+			cleanData:    cleanDataPartitions,
+		},
+		{
+			memTableName: infoschema.TableStatistics,
+			prepareData:  prepareDataStatistics,
+			cleanData:    cleanDataStatistics,
+		},
+		{
+			memTableName: infoschema.TableSchemata,
+			prepareData:  prepareDataSchemata,
+			cleanData:    cleanDataSchemata,
+		},
+		{
+			memTableName: infoschema.TableCheckConstraints,
+			prepareData:  prepareDataCheckConstraints,
+			cleanData:    cleanDataCheckConstraints,
+		},
+		{
+			memTableName: infoschema.TableTiDBCheckConstraints,
+			prepareData:  prepareDataTidbCheckConstraints,
+			cleanData:    cleanDataTidbCheckConstraints,
+		},
+		{
+			memTableName: infoschema.TableSequences,
+			prepareData:  prepareDataSequences,
+			cleanData:    cleanDataSequences,
+		},
+		{
+			memTableName: infoschema.TableTiDBIndexUsage,
+			prepareData:  prepareDataStatistics,
+			cleanData:    cleanDataStatistics,
+		},
 	}
 
 	countSQL := 0
 	for _, tc := range tcs {
-		names := tc.prepareData(t, tk)
+		names := tc.prepareData(tk)
 		conditions := []string{}
 		for i := len(names) - 1; i >= 0; i-- {
 			all := names[i].enumerateAll()
@@ -192,7 +431,7 @@ func TestMemtableInfoschemaExtractor(t *testing.T) {
 			tk.MustQuery(sql)
 		}
 
-		tc.cleanData(t, tk)
+		tc.cleanData(tk)
 	}
 	fmt.Printf("Total SQLs: %d\n", countSQL)
 }

--- a/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/logical_mem_table_predicate_extractor_test.go
@@ -1835,6 +1835,27 @@ func TestInfoSchemaTableExtract(t *testing.T) {
 		colPredicates map[string]set.StringSet
 	}{
 		{
+			sql:         `select * from INFORMATION_SCHEMA.TABLES where table_schema='test';`,
+			skipRequest: false,
+			colPredicates: map[string]set.StringSet{
+				"table_schema": set.NewStringSet("test"),
+			},
+		},
+		{
+			sql:         `select * from INFORMATION_SCHEMA.TABLES where table_name='t';`,
+			skipRequest: false,
+			colPredicates: map[string]set.StringSet{
+				"table_name": set.NewStringSet("t"),
+			},
+		},
+		{
+			sql:         `select * from INFORMATION_SCHEMA.TABLES where tidb_table_id=111;`,
+			skipRequest: false,
+			colPredicates: map[string]set.StringSet{
+				"tidb_table_id": set.NewStringSet("111"),
+			},
+		},
+		{
 			sql:         `select * from INFORMATION_SCHEMA.TABLES where lower(table_name)='T';`,
 			skipRequest: false,
 			colPredicates: map[string]set.StringSet{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #50305

Problem Summary:

### What changed and how does it work?

In `pkg/planner/core/memtable_infoschema_extractor_test.go` we cover testing all combinations of predicates for each infoschema table. It takes tens of seconds to run `TestMemtableInfoschemaExtractor`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
