### PR TITLE
*: fix data race in the EnableAnalyzeSnapshot

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -413,11 +413,12 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	wg := util.NewWaitGroupPool(e.gp)
 	saveResultsCh := make(chan *statistics.AnalyzeResults, saveStatsConcurrency)
 	errCh := make(chan error, saveStatsConcurrency)
+	enableAnalyzeSnapshot := e.Ctx().GetSessionVars().EnableAnalyzeSnapshot
 	for i := 0; i < saveStatsConcurrency; i++ {
 		worker := newAnalyzeSaveStatsWorker(saveResultsCh, errCh, &e.Ctx().GetSessionVars().SQLKiller)
 		ctx1 := kv.WithInternalSourceType(context.Background(), kv.InternalTxnStats)
 		wg.Run(func() {
-			worker.run(ctx1, statsHandle, e.Ctx().GetSessionVars().EnableAnalyzeSnapshot)
+			worker.run(ctx1, statsHandle, enableAnalyzeSnapshot)
 		})
 	}
 	tableIDs := map[int64]struct{}{}

--- a/pkg/executor/test/analyzetest/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
+    race = "on",
     shard_count = 49,
     deps = [
         "//pkg/config",

--- a/pkg/executor/test/analyzetest/memorycontrol/BUILD.bazel
+++ b/pkg/executor/test/analyzetest/memorycontrol/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "memory_control_test.go",
     ],
     flaky = True,
+    race = "on",
     shard_count = 5,
     deps = [
         "//pkg/config",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55469

Problem Summary:

### What changed and how does it work?

```EnableAnalyzeSnapshot``` should not be used with different goroutines. 


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

enable race for analyze test.

- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
