### PR TITLE
privilege: optimize the processing of privilege cache

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1836,10 +1836,13 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 		defer util.Recover(metrics.LabelDomain, "loadPrivilegeInLoop", nil, false)
 
 		var count int
+		subWg := util.NewErrorGroupWithRecover()
+		subWg.SetLimit(100)
 		for {
 			ok := true
 			select {
 			case <-do.exit:
+				_ = subWg.Wait()
 				return
 			case _, ok = <-watchCh:
 			case <-time.After(duration):
@@ -1855,11 +1858,14 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 			}
 
 			count = 0
-			err := do.privHandle.Update(sctx)
-			metrics.LoadPrivilegeCounter.WithLabelValues(metrics.RetLabel(err)).Inc()
-			if err != nil {
-				logutil.BgLogger().Error("load privilege failed", zap.Error(err))
-			}
+			subWg.TryGo(func() error {
+				err := do.privHandle.Update(sctx)
+				metrics.LoadPrivilegeCounter.WithLabelValues(metrics.RetLabel(err)).Inc()
+				if err != nil {
+					logutil.BgLogger().Error("load privilege failed", zap.Error(err))
+				}
+				return err
+			})
 		}
 	}, "loadPrivilegeInLoop")
 	return nil

--- a/pkg/privilege/privileges/BUILD.bazel
+++ b/pkg/privilege/privileges/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/mathutil",
         "//pkg/util/sem",
         "//pkg/util/stringutil",
+        "//pkg/util/syncutil",
         "@com_github_lestrrat_go_jwx_v2//jwk",
         "@com_github_lestrrat_go_jwx_v2//jws",
         "@com_github_lestrrat_go_jwx_v2//jwt",

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -1662,6 +1662,7 @@ func (h *Handle) mutexUpdate(ctx sessionctx.Context) error {
 	if h.lastUpdateTime.After(startTime) {
 		return nil
 	}
+	updateTime := time.Now()
 
 	var priv MySQLPrivilege
 	err := priv.LoadAll(ctx)
@@ -1670,6 +1671,6 @@ func (h *Handle) mutexUpdate(ctx sessionctx.Context) error {
 	}
 
 	h.priv.Store(&priv)
-	h.lastUpdateTime = time.Now()
+	h.lastUpdateTime = updateTime
 	return nil
 }

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -273,10 +273,9 @@ type MySQLPrivilege struct {
 	// This means that DB-records are organized in both a
 	// slice (p.DB) and a Map (p.DBMap).
 
-	// This helps in the case that there are a number of users with
-	// non-full privileges (i.e. user.db entries).
+	// User is only exported for test. Please use UserMap to access accounts
 	User          []UserRecord
-	UserMap       map[string][]UserRecord // Accelerate User searching
+	UserMap       map[string][]*UserRecord // Accelerate User searching
 	Global        map[string][]globalPrivRecord
 	Dynamic       map[string][]dynamicPrivRecord
 	DB            []dbRecord
@@ -427,15 +426,24 @@ func (p *MySQLPrivilege) LoadUserTable(ctx sessionctx.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	p.buildUserMap()
-	p.sortUserTable()
+	p.buildAndSortUserMap()
 	return nil
 }
 
-func (p *MySQLPrivilege) buildUserMap() {
-	userMap := make(map[string][]UserRecord, len(p.User))
+// See https://dev.mysql.com/doc/refman/8.0/en/connection-access.html
+// When multiple matches are possible, the server must determine which of them to use. It resolves this issue as follows:
+// 1. Whenever the server reads the user table into memory, it sorts the rows.
+// 2. When a client attempts to connect, the server looks through the rows in sorted order.
+// 3. The server uses the first row that matches the client host name and user name.
+// The server uses sorting rules that order rows with the most-specific Host values first.
+func (p *MySQLPrivilege) buildAndSortUserMap() {
+	userMap := make(map[string][]*UserRecord, len(p.User))
 	for _, record := range p.User {
-		userMap[record.User] = append(userMap[record.User], record)
+		userMap[record.User] = append(userMap[record.User], &record)
+	}
+	for userName, records := range userMap {
+		slices.SortFunc(records, compareUserRecord)
+		userMap[userName] = records
 	}
 	p.UserMap = userMap
 }
@@ -450,7 +458,7 @@ func compareBaseRecord(x, y *baseRecord) int {
 	return cmp.Compare(x.User, y.User)
 }
 
-func compareUserRecord(x, y UserRecord) int {
+func compareUserRecord(x, y *UserRecord) int {
 	return compareBaseRecord(&x.baseRecord, &y.baseRecord)
 }
 
@@ -501,20 +509,6 @@ func compareHost(x, y string) int {
 		return 1
 	}
 	return 0
-}
-
-// sortUserTable sorts p.User in the MySQLPrivilege struct.
-// See https://dev.mysql.com/doc/refman/8.0/en/connection-access.html
-// When multiple matches are possible, the server must determine which of them to use. It resolves this issue as follows:
-// 1. Whenever the server reads the user table into memory, it sorts the rows.
-// 2. When a client attempts to connect, the server looks through the rows in sorted order.
-// 3. The server uses the first row that matches the client host name and user name.
-// The server uses sorting rules that order rows with the most-specific Host values first.
-func (p MySQLPrivilege) sortUserTable() {
-	for userName, records := range p.UserMap {
-		slices.SortFunc(records, compareUserRecord)
-		p.UserMap[userName] = records
-	}
 }
 
 // LoadGlobalPrivTable loads the mysql.global_priv table from database.
@@ -981,10 +975,9 @@ func patternMatch(str string, patChars, patTypes []byte) bool {
 // matchIdentity finds an identity to match a user + host
 // using the correct rules according to MySQL.
 func (p *MySQLPrivilege) matchIdentity(user, host string, skipNameResolve bool) *UserRecord {
-	for i := 0; i < len(p.User); i++ {
-		record := &p.User[i]
+	for i, record := range p.UserMap[user] {
 		if record.match(user, host) {
-			return record
+			return p.UserMap[user][i]
 		}
 	}
 
@@ -1001,11 +994,13 @@ func (p *MySQLPrivilege) matchIdentity(user, host string, skipNameResolve bool) 
 			)
 			return nil
 		}
-		for _, addr := range addrs {
-			for i := 0; i < len(p.User); i++ {
-				record := &p.User[i]
-				if record.match(user, addr) {
-					return record
+		if records := p.UserMap[user]; len(records) > 0 {
+			for _, addr := range addrs {
+				for i := 0; i < len(records); i++ {
+					record := records[i]
+					if record.match(user, addr) {
+						return record
+					}
 				}
 			}
 		}
@@ -1013,12 +1008,14 @@ func (p *MySQLPrivilege) matchIdentity(user, host string, skipNameResolve bool) 
 	return nil
 }
 
-// matchResoureGroup finds an identity to match resource group.
-func (p *MySQLPrivilege) matchResoureGroup(resourceGroupName string) *UserRecord {
-	for i := 0; i < len(p.User); i++ {
-		record := &p.User[i]
-		if record.ResourceGroup == resourceGroupName {
-			return record
+// matchResourceGroup finds an identity to match resource group.
+func (p *MySQLPrivilege) matchResourceGroup(resourceGroupName string) *UserRecord {
+	for _, records := range p.UserMap {
+		for i := 0; i < len(records); i++ {
+			record := records[i]
+			if record.ResourceGroup == resourceGroupName {
+				return record
+			}
 		}
 	}
 	return nil
@@ -1031,9 +1028,8 @@ func (p *MySQLPrivilege) connectionVerification(user, host string) *UserRecord {
 	records, exists := p.UserMap[user]
 	if exists {
 		for i := 0; i < len(records); i++ {
-			record := &records[i]
-			if record.Host == host { // exact match
-				return record
+			if records[i].Host == host { // exact match
+				return records[i]
 			}
 		}
 	}
@@ -1058,9 +1054,8 @@ func (p *MySQLPrivilege) matchUser(user, host string) *UserRecord {
 	records, exists := p.UserMap[user]
 	if exists {
 		for i := 0; i < len(records); i++ {
-			record := &records[i]
-			if record.match(user, host) {
-				return record
+			if records[i].match(user, host) {
+				return records[i]
 			}
 		}
 	}
@@ -1274,15 +1269,17 @@ func (p *MySQLPrivilege) showGrants(ctx sessionctx.Context, user, host string, r
 		}
 	}
 	var g string
-	for _, record := range p.User {
-		if record.fullyMatch(user, host) {
-			hasGlobalGrant = true
-			currentPriv |= record.Privileges
-		} else {
-			for _, r := range allRoles {
-				if record.baseRecord.match(r.Username, r.Hostname) {
-					hasGlobalGrant = true
-					currentPriv |= record.Privileges
+	for _, records := range p.UserMap {
+		for _, record := range records {
+			if record.fullyMatch(user, host) {
+				hasGlobalGrant = true
+				currentPriv |= record.Privileges
+			} else {
+				for _, r := range allRoles {
+					if record.baseRecord.match(r.Username, r.Hostname) {
+						hasGlobalGrant = true
+						currentPriv |= record.Privileges
+					}
 				}
 			}
 		}
@@ -1560,9 +1557,11 @@ func (p *MySQLPrivilege) UserPrivilegesTable(activeRoles []*auth.RoleIdentity, u
 	// This is verified against MySQL.
 	showOtherUsers := p.RequestVerification(activeRoles, user, host, mysql.SystemDB, "", "", mysql.SelectPriv)
 	var rows [][]types.Datum
-	for _, u := range p.User {
-		if showOtherUsers || u.match(user, host) {
-			rows = appendUserPrivilegesTableRow(rows, u)
+	for _, records := range p.UserMap {
+		for _, u := range records {
+			if showOtherUsers || u.match(user, host) {
+				rows = appendUserPrivilegesTableRow(rows, u)
+			}
 		}
 	}
 	for _, dynamicPrivs := range p.Dynamic {
@@ -1585,7 +1584,7 @@ func appendDynamicPrivRecord(rows [][]types.Datum, user dynamicPrivRecord) [][]t
 	return append(rows, record)
 }
 
-func appendUserPrivilegesTableRow(rows [][]types.Datum, user UserRecord) [][]types.Datum {
+func appendUserPrivilegesTableRow(rows [][]types.Datum, user *UserRecord) [][]types.Datum {
 	var isGrantable string
 	if user.Privileges&mysql.GrantPriv > 0 {
 		isGrantable = "YES"

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -438,8 +438,8 @@ func (p *MySQLPrivilege) LoadUserTable(ctx sessionctx.Context) error {
 // The server uses sorting rules that order rows with the most-specific Host values first.
 func (p *MySQLPrivilege) buildAndSortUserMap() {
 	userMap := make(map[string][]*UserRecord, len(p.User))
-	for _, record := range p.User {
-		userMap[record.User] = append(userMap[record.User], &record)
+	for i, record := range p.User {
+		userMap[record.User] = append(userMap[record.User], &p.User[i])
 	}
 	for userName, records := range userMap {
 		slices.SortFunc(records, compareUserRecord)
@@ -997,9 +997,8 @@ func (p *MySQLPrivilege) matchIdentity(user, host string, skipNameResolve bool) 
 		if records := p.UserMap[user]; len(records) > 0 {
 			for _, addr := range addrs {
 				for i := 0; i < len(records); i++ {
-					record := records[i]
-					if record.match(user, addr) {
-						return record
+					if records[i].match(user, addr) {
+						return records[i]
 					}
 				}
 			}
@@ -1012,9 +1011,8 @@ func (p *MySQLPrivilege) matchIdentity(user, host string, skipNameResolve bool) 
 func (p *MySQLPrivilege) matchResourceGroup(resourceGroupName string) *UserRecord {
 	for _, records := range p.UserMap {
 		for i := 0; i < len(records); i++ {
-			record := records[i]
-			if record.ResourceGroup == resourceGroupName {
-				return record
+			if records[i].ResourceGroup == resourceGroupName {
+				return records[i]
 			}
 		}
 	}

--- a/pkg/privilege/privileges/cache_test.go
+++ b/pkg/privilege/privileges/cache_test.go
@@ -366,46 +366,6 @@ func TestFindAllUserEffectiveRoles(t *testing.T) {
 	require.Equal(t, "r_3", ret[1].Username)
 }
 
-func TestSortUserTable(t *testing.T) {
-	var p privileges.MySQLPrivilege
-	p.User = []privileges.UserRecord{
-		privileges.NewUserRecord(`%`, "root"),
-		privileges.NewUserRecord(`%`, "jeffrey"),
-		privileges.NewUserRecord("localhost", "root"),
-		privileges.NewUserRecord("localhost", ""),
-	}
-	p.SortUserTable()
-	result := []privileges.UserRecord{
-		privileges.NewUserRecord("localhost", "root"),
-		privileges.NewUserRecord("localhost", ""),
-		privileges.NewUserRecord(`%`, "jeffrey"),
-		privileges.NewUserRecord(`%`, "root"),
-	}
-	checkUserRecord(t, p.User, result)
-
-	p.User = []privileges.UserRecord{
-		privileges.NewUserRecord(`%`, "jeffrey"),
-		privileges.NewUserRecord("h1.example.net", ""),
-	}
-	p.SortUserTable()
-	result = []privileges.UserRecord{
-		privileges.NewUserRecord("h1.example.net", ""),
-		privileges.NewUserRecord(`%`, "jeffrey"),
-	}
-	checkUserRecord(t, p.User, result)
-
-	p.User = []privileges.UserRecord{
-		privileges.NewUserRecord(`192.168.%`, "xxx"),
-		privileges.NewUserRecord(`192.168.199.%`, "xxx"),
-	}
-	p.SortUserTable()
-	result = []privileges.UserRecord{
-		privileges.NewUserRecord(`192.168.199.%`, "xxx"),
-		privileges.NewUserRecord(`192.168.%`, "xxx"),
-	}
-	checkUserRecord(t, p.User, result)
-}
-
 func TestGlobalPrivValueRequireStr(t *testing.T) {
 	var (
 		none  = privileges.GlobalPrivValue{SSLType: privileges.SslTypeNone}
@@ -423,14 +383,6 @@ func TestGlobalPrivValueRequireStr(t *testing.T) {
 	require.Equal(t, "ISSUER 'i1' SUBJECT 's1'", spec2.RequireStr())
 	require.Equal(t, "ISSUER 'i1'", spec3.RequireStr())
 	require.Equal(t, "NONE", spec4.RequireStr())
-}
-
-func checkUserRecord(t *testing.T, x, y []privileges.UserRecord) {
-	require.Equal(t, len(x), len(y))
-	for i := 0; i < len(x); i++ {
-		require.Equal(t, x[i].User, y[i].User)
-		require.Equal(t, x[i].Host, y[i].Host)
-	}
 }
 
 func TestDBIsVisible(t *testing.T) {

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -1047,38 +1047,38 @@ type PasswordLocking struct {
 }
 
 // ParseJSON parses information about PasswordLocking.
-func (passwordLocking *PasswordLocking) ParseJSON(passwordLockingJSON types.BinaryJSON) error {
+func (pl *PasswordLocking) ParseJSON(passwordLockingJSON types.BinaryJSON) error {
 	var err error
 
-	passwordLocking.FailedLoginAttempts, err =
+	pl.FailedLoginAttempts, err =
 		extractInt64FromJSON(passwordLockingJSON, "$.Password_locking.failed_login_attempts")
 	if err != nil {
 		return err
 	}
-	passwordLocking.FailedLoginAttempts = min(passwordLocking.FailedLoginAttempts, math.MaxInt16)
-	passwordLocking.FailedLoginAttempts = mathutil.Max(passwordLocking.FailedLoginAttempts, 0)
+	pl.FailedLoginAttempts = min(pl.FailedLoginAttempts, math.MaxInt16)
+	pl.FailedLoginAttempts = mathutil.Max(pl.FailedLoginAttempts, 0)
 
-	passwordLocking.PasswordLockTimeDays, err =
+	pl.PasswordLockTimeDays, err =
 		extractInt64FromJSON(passwordLockingJSON, "$.Password_locking.password_lock_time_days")
 	if err != nil {
 		return err
 	}
-	passwordLocking.PasswordLockTimeDays = min(passwordLocking.PasswordLockTimeDays, math.MaxInt16)
-	passwordLocking.PasswordLockTimeDays = mathutil.Max(passwordLocking.PasswordLockTimeDays, -1)
+	pl.PasswordLockTimeDays = min(pl.PasswordLockTimeDays, math.MaxInt16)
+	pl.PasswordLockTimeDays = mathutil.Max(pl.PasswordLockTimeDays, -1)
 
-	passwordLocking.FailedLoginCount, err =
+	pl.FailedLoginCount, err =
 		extractInt64FromJSON(passwordLockingJSON, "$.Password_locking.failed_login_count")
 	if err != nil {
 		return err
 	}
 
-	passwordLocking.AutoLockedLastChanged, err =
+	pl.AutoLockedLastChanged, err =
 		extractTimeUnixFromJSON(passwordLockingJSON, "$.Password_locking.auto_locked_last_changed")
 	if err != nil {
 		return err
 	}
 
-	passwordLocking.AutoAccountLocked, err =
+	pl.AutoAccountLocked, err =
 		extractBoolFromJSON(passwordLockingJSON, "$.Password_locking.auto_account_locked")
 	if err != nil {
 		return err
@@ -1091,8 +1091,8 @@ func extractInt64FromJSON(json types.BinaryJSON, pathExpr string) (val int64, er
 	if err != nil {
 		return 0, err
 	}
-	if BJ, found := json.Extract([]types.JSONPathExpression{jsonPath}); found {
-		return BJ.GetInt64(), nil
+	if bj, found := json.Extract([]types.JSONPathExpression{jsonPath}); found {
+		return bj.GetInt64(), nil
 	}
 	return 0, nil
 }
@@ -1102,8 +1102,8 @@ func extractTimeUnixFromJSON(json types.BinaryJSON, pathExpr string) (int64, err
 	if err != nil {
 		return -1, err
 	}
-	if BJ, found := json.Extract([]types.JSONPathExpression{jsonPath}); found {
-		value, err := BJ.Unquote()
+	if bj, found := json.Extract([]types.JSONPathExpression{jsonPath}); found {
+		value, err := bj.Unquote()
 		if err != nil {
 			return -1, err
 		}
@@ -1121,8 +1121,8 @@ func extractBoolFromJSON(json types.BinaryJSON, pathExpr string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if BJ, found := json.Extract([]types.JSONPathExpression{jsonPath}); found {
-		value, err := BJ.Unquote()
+	if bj, found := json.Extract([]types.JSONPathExpression{jsonPath}); found {
+		value, err := bj.Unquote()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -390,7 +390,7 @@ func (p *UserPrivileges) MatchIdentity(user, host string, skipNameResolve bool) 
 // MatchUserResourceGroupName implements the Manager interface.
 func (p *UserPrivileges) MatchUserResourceGroupName(resourceGroupName string) (u string, success bool) {
 	mysqlPriv := p.Handle.Get()
-	record := mysqlPriv.matchResoureGroup(resourceGroupName)
+	record := mysqlPriv.matchResourceGroup(resourceGroupName)
 	if record != nil {
 		return record.User, true
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

This PR contains several optimizations for processing the privilege cache:

* Avoid to sort the whole users. Instead, sort only a small piece of users with the same user name. See `buildAndSortUserMap`
* Limit the number of reloading users within a period of time

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test (existing UT)
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
