### PR TITLE
server: add hooks to wait for background commit goroutines

### DIFF
--- a/pkg/kv/option.go
+++ b/pkg/kv/option.go
@@ -114,6 +114,8 @@ const (
 	SizeLimits
 	// SessionID marks the connection id, for logging and tracing.
 	SessionID
+	// BackgroundGoroutineLifecycleHooks is the hooks to track the start and end of background goroutine
+	BackgroundGoroutineLifecycleHooks
 )
 
 // TxnSizeLimits is the argument type for `SizeLimits` option

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1021,6 +1021,17 @@ func (s *Server) DrainClients(drainWait time.Duration, cancelWait time.Duration)
 		for _, conn := range conns {
 			// Wait for the connections with explicit transaction or an executing auto-commit query.
 			if conn.getStatus() == connStatusReading && !conn.getCtx().GetSessionVars().InTxn() {
+				// The waitgroup is not protected by the `quitWaitingForConns`. However, the implementation
+				// of `client-go` will guarantee this `Wait` will return at least after killing the
+				// connections. We also wait for a similar `WaitGroup` on the store after killing the connections.
+				//
+				// Therefore, it'll not cause goroutine leak. Even if, it's not a big issue when the TiDB is
+				// going to shutdown.
+				//
+				// It should be waited for connections in all status, even if it's not in transactions and is reading
+				// from the client. Because it may run background commit goroutines at any time.
+				conn.getCtx().Session.GetCommitWaitGroup().Wait()
+
 				continue
 			}
 			select {
@@ -1028,6 +1039,11 @@ func (s *Server) DrainClients(drainWait time.Duration, cancelWait time.Duration)
 			case <-quitWaitingForConns:
 				return
 			}
+
+			// Wait for the commit wait group after waiting for the `conn.quit` channel to make sure the foreground
+			// process has finished to avoid the situation that after waiting for the wait group, the transaction starts
+			// a new background goroutine and increase the wait group.
+			conn.getCtx().Session.GetCommitWaitGroup().Wait()
 		}
 	}()
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -223,6 +223,9 @@ type session struct {
 	sandBoxMode bool
 
 	cursorTracker cursor.Tracker
+
+	// Used to wait for all async commit background jobs to finish.
+	commitWaitGroup sync.WaitGroup
 }
 
 var parserPool = &sync.Pool{New: func() any { return parser.New() }}
@@ -4603,4 +4606,9 @@ func GetDBNames(seVar *variable.SessionVars) []string {
 // GetCursorTracker returns the internal `cursor.Tracker`
 func (s *session) GetCursorTracker() cursor.Tracker {
 	return s.cursorTracker
+}
+
+// GetCommitWaitGroup returns the internal `sync.WaitGroup` for async commit and secondary key lock cleanup
+func (s *session) GetCommitWaitGroup() *sync.WaitGroup {
+	return &s.commitWaitGroup
 }

--- a/pkg/sessionctx/context.go
+++ b/pkg/sessionctx/context.go
@@ -16,6 +16,7 @@ package sessionctx
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -207,6 +208,8 @@ type Context interface {
 	NewStmtIndexUsageCollector() *indexusage.StmtIndexUsageCollector
 	// GetCursorTracker returns the cursor tracker of the session
 	GetCursorTracker() cursor.Tracker
+	// GetCommitWaitGroup returns the wait group for async commit and secondary lock cleanup background goroutines
+	GetCommitWaitGroup() *sync.WaitGroup
 }
 
 // TxnFuture is an interface where implementations have a kv.Transaction field and after

--- a/pkg/sessiontxn/isolation/BUILD.bazel
+++ b/pkg/sessiontxn/isolation/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "@com_github_tikv_client_go_v2//error",
         "@com_github_tikv_client_go_v2//kv",
         "@com_github_tikv_client_go_v2//oracle",
+        "@com_github_tikv_client_go_v2//txnkv/transaction",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/store/driver/txn/txn_driver.go
+++ b/pkg/store/driver/txn/txn_driver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/tikvrpc/interceptor"
 	"github.com/tikv/client-go/v2/txnkv"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 	"go.uber.org/zap"
 )
@@ -308,6 +309,8 @@ func (txn *tikvTxn) SetOption(opt int, val any) {
 		txn.KVTxn.GetUnionStore().SetEntrySizeLimit(limits.Entry, limits.Total)
 	case kv.SessionID:
 		txn.KVTxn.SetSessionID(val.(uint64))
+	case kv.BackgroundGoroutineLifecycleHooks:
+		txn.KVTxn.SetBackgroundGoroutineLifecycleHooks(val.(transaction.LifecycleHooks))
 	}
 }
 

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -18,6 +18,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -608,6 +609,11 @@ func (*Context) NewStmtIndexUsageCollector() *indexusage.StmtIndexUsageCollector
 
 // GetCursorTracker implements the sessionctx.Context interface
 func (*Context) GetCursorTracker() cursor.Tracker {
+	return nil
+}
+
+// GetCommitWaitGroup implements the sessionctx.Context interface
+func (*Context) GetCommitWaitGroup() *sync.WaitGroup {
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55607

Problem Summary:

TiDB will leak some lock if the transaction is not committed/rollbacked successfully. The graceful shutdown routine didn't wait for the background async-commit (and secondary key lock cleanup) goroutines to finish, so it'd be better to also wait for them to avoid leaking the locks.

### What changed and how does it work?

Use the hooks of the async-commit / secondary lock cleanup goroutines to track the lifecycle of them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

TODO

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that stopping TiDB may leak the transaction lock.
```
