### PR TITLE
WIP: statistics:  add the analysis worker

### DIFF
--- a/pkg/planner/core/main_test.go
+++ b/pkg/planner/core/main_test.go
@@ -50,6 +50,7 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 		goleak.IgnoreTopFunction("github.com/tikv/client-go/v2/txnkv/transaction.keepAlive"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/refresher.(*worker).run"),
 	}
 
 	callback := func(i int) int {

--- a/pkg/statistics/handle/autoanalyze/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/statistics/handle/util",
         "//pkg/types",
         "//pkg/util",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "//pkg/util/sqlescape",
         "//pkg/util/timeutil",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -61,6 +61,7 @@ func NewStatsAnalyze(
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sysproctrack.Tracker,
 ) statstypes.StatsAnalyze {
+	// TODO: only create the refresher when auto-analyze and priority queue are enabled.
 	r := refresher.NewRefresher(statsHandle, sysProcTracker)
 	return &statsAnalyze{
 		statsHandle:    statsHandle,

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job.go
@@ -138,6 +138,12 @@ func (j *DynamicPartitionedTableAnalysisJob) SetWeight(weight float64) {
 	j.Weight = weight
 }
 
+// GetTableID gets the table ID of the job.
+// Because it is partitioned table, so we need to use the global table ID.
+func (j *DynamicPartitionedTableAnalysisJob) GetTableID() int64 {
+	return j.GlobalTableID
+}
+
 // GetWeight gets the weight of the job.
 func (j *DynamicPartitionedTableAnalysisJob) GetWeight() float64 {
 	return j.Weight

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
@@ -72,6 +72,9 @@ type AnalysisJob interface {
 	// GetIndicators gets the indicators of the job.
 	GetIndicators() Indicators
 
+	// GetTableID gets the table ID of the job.
+	GetTableID() int64
+
 	fmt.Stringer
 }
 

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
@@ -121,6 +121,11 @@ func (j *NonPartitionedTableAnalysisJob) GetIndicators() Indicators {
 	return j.Indicators
 }
 
+// GetTableID gets the table ID of the job.
+func (j *NonPartitionedTableAnalysisJob) GetTableID() int64 {
+	return j.TableID
+}
+
 // String implements fmt.Stringer interface.
 func (j *NonPartitionedTableAnalysisJob) String() string {
 	return fmt.Sprintf(

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
@@ -98,6 +98,11 @@ func (j *StaticPartitionedTableAnalysisJob) GetIndicators() Indicators {
 	return j.Indicators
 }
 
+// GetTableID gets the table ID of the job.
+func (j *StaticPartitionedTableAnalysisJob) GetTableID() int64 {
+	return j.StaticPartitionID
+}
+
 // HasNewlyAddedIndex implements AnalysisJob.
 func (j *StaticPartitionedTableAnalysisJob) HasNewlyAddedIndex() bool {
 	return len(j.Indexes) > 0

--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "refresher",
-    srcs = ["refresher.go"],
+    srcs = [
+        "refresher.go",
+        "worker.go",
+    ],
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/refresher",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -144,6 +144,8 @@ func (r *Refresher) AnalyzeHighestPriorityTables() bool {
 	return false
 }
 
+// WaitAutoAnalyzeFinishedForTest waits for the auto analyze job to be finished.
+// Only used in the test.
 func (r *Refresher) WaitAutoAnalyzeFinishedForTest() {
 	r.worker.WaitAutoAnalyzeFinishedForTest()
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -144,6 +144,10 @@ func (r *Refresher) AnalyzeHighestPriorityTables() bool {
 	return false
 }
 
+func (r *Refresher) WaitAutoAnalyzeFinishedForTest() {
+	r.worker.WaitAutoAnalyzeFinishedForTest()
+}
+
 // GetRunningJobs returns the currently running jobs.
 func (r *Refresher) GetRunningJobs() map[int64]struct{} {
 	return r.worker.GetRunningJobs()

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -1,0 +1,136 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package refresher
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pingcap/tidb/pkg/sessionctx/sysproctrack"
+	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/priorityqueue"
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
+	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
+	"go.uber.org/zap"
+)
+
+type worker struct {
+	statsHandle    statstypes.StatsHandle
+	sysProcTracker sysproctrack.Tracker
+	wg             sync.WaitGroup
+	jobChan        chan priorityqueue.AnalysisJob
+	ctx            context.Context
+	cancel         context.CancelFunc
+	runningJobs    map[int64]struct{}
+	runningJobsMu  sync.Mutex
+	maxConcurrency int
+}
+
+func newWorker(statsHandle statstypes.StatsHandle, sysProcTracker sysproctrack.Tracker, maxConcurrency int) *worker {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &worker{
+		statsHandle:    statsHandle,
+		sysProcTracker: sysProcTracker,
+		jobChan:        make(chan priorityqueue.AnalysisJob, maxConcurrency),
+		ctx:            ctx,
+		cancel:         cancel,
+		runningJobs:    make(map[int64]struct{}),
+		maxConcurrency: maxConcurrency,
+	}
+	w.wg.Add(1)
+	go w.run()
+	return w
+}
+
+// UpdateConcurrency updates the maximum concurrency for the worker
+func (w *worker) UpdateConcurrency(newConcurrency int) {
+	w.runningJobsMu.Lock()
+	defer w.runningJobsMu.Unlock()
+
+	if newConcurrency == w.maxConcurrency {
+		return
+	}
+
+	// Create a new job channel with the updated capacity
+	newJobChan := make(chan priorityqueue.AnalysisJob, newConcurrency)
+
+	// Move existing jobs to the new channel
+	close(w.jobChan)
+	for job := range w.jobChan {
+		newJobChan <- job
+	}
+
+	w.jobChan = newJobChan
+	w.maxConcurrency = newConcurrency
+}
+
+func (w *worker) run() {
+	defer w.wg.Done()
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case job := <-w.jobChan:
+			w.runningJobsMu.Lock()
+			w.runningJobs[job.GetTableID()] = struct{}{}
+			w.runningJobsMu.Unlock()
+
+			if err := job.Analyze(w.statsHandle, w.sysProcTracker); err != nil {
+				statslogutil.StatsLogger().Error(
+					"Auto analyze job execution failed",
+					zap.Stringer("job", job),
+					zap.Error(err),
+				)
+			}
+
+			w.runningJobsMu.Lock()
+			delete(w.runningJobs, job.GetTableID())
+			w.runningJobsMu.Unlock()
+		}
+	}
+}
+
+func (w *worker) SubmitJob(job priorityqueue.AnalysisJob) bool {
+	w.runningJobsMu.Lock()
+	defer w.runningJobsMu.Unlock()
+
+	if len(w.runningJobs) >= w.maxConcurrency {
+		statslogutil.StatsLogger().Warn("Worker at maximum capacity, job discarded", zap.Stringer("job", job))
+		return false
+	}
+
+	select {
+	case w.jobChan <- job:
+		return true
+	default:
+		statslogutil.StatsLogger().Warn("Worker job channel is full, job discarded", zap.Stringer("job", job))
+		return false
+	}
+}
+
+func (w *worker) GetRunningJobs() map[int64]struct{} {
+	w.runningJobsMu.Lock()
+	defer w.runningJobsMu.Unlock()
+	runningJobs := make(map[int64]struct{}, len(w.runningJobs))
+	for id := range w.runningJobs {
+		runningJobs[id] = struct{}{}
+	}
+	return runningJobs
+}
+
+func (w *worker) Stop() {
+	w.cancel()
+	close(w.jobChan)
+	w.wg.Wait()
+}

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -134,5 +134,6 @@ func (w *worker) GetRunningJobs() map[int64]struct{} {
 func (w *worker) Stop() {
 	w.cancel()
 	close(w.jobChan)
+	// TODO: Check if we need to kill the running jobs.
 	w.wg.Wait()
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -139,8 +139,11 @@ func (w *worker) Stop() {
 func (w *worker) WaitAutoAnalyzeFinishedForTest() {
 	for {
 		time.Sleep(time.Millisecond * 100)
+		w.mu.Lock()
 		if len(w.runningJobs) == 0 {
+			w.mu.Unlock()
 			return
 		}
+		w.mu.Unlock()
 	}
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -17,6 +17,7 @@ package refresher
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/sessionctx/sysproctrack"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/priorityqueue"
@@ -132,4 +133,14 @@ func (w *worker) Stop() {
 	w.cancel()
 	close(w.jobChan)
 	w.wg.Wait()
+}
+
+// TODO: remove this after we have a better way to wait for the auto analyze job to be finished.
+func (w *worker) WaitAutoAnalyzeFinishedForTest() {
+	for {
+		time.Sleep(time.Millisecond * 100)
+		if len(w.runningJobs) == 0 {
+			return
+		}
+	}
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -25,6 +25,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// worker manages the execution of analysis jobs.
+// Fields are ordered to represent the mutex protection clearly.
+//
+//nolint:fieldalignment
 type worker struct {
 	statsHandle    statstypes.StatsHandle
 	sysProcTracker sysproctrack.Tracker
@@ -32,7 +36,9 @@ type worker struct {
 	jobChan        chan priorityqueue.AnalysisJob
 	ctx            context.Context
 	cancel         context.CancelFunc
-	mu             sync.Mutex
+
+	mu sync.Mutex
+	// mu is used to protect the following fields.
 	runningJobs    map[int64]struct{}
 	maxConcurrency int
 	currentJobs    int

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -67,6 +67,8 @@ func (w *worker) UpdateConcurrency(newConcurrency int) {
 
 	// Move existing jobs to the new channel
 	close(w.jobChan)
+
+	// TODO: consider the case that the concurrency is reduced.
 	for job := range w.jobChan {
 		newJobChan <- job
 	}

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -213,4 +213,5 @@ func (h *Handle) Close() {
 	h.Pool.Close()
 	h.StatsCache.Close()
 	h.StatsUsage.Close()
+	h.StatsAnalyze.Close()
 }

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -156,6 +156,9 @@ type StatsAnalyze interface {
 
 	// CheckAnalyzeVersion checks whether all the statistics versions of this table's columns and indexes are the same.
 	CheckAnalyzeVersion(tblInfo *model.TableInfo, physicalIDs []int64, version *int) bool
+
+	// Close closes the auto-analyze worker.
+	Close()
 }
 
 // StatsCache is used to manage all table statistics in memory.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/55618

Problem Summary:

This is a POC PR for https://github.com/pingcap/tidb/issues/55618.

In this PR we introduced started tracking the current running tables within the refresher.
We also started always running N analysis jobs in TiDB instead of blocking the whole process in the HandleAutoAnalyze.

### What changed and how does it work?
- An analysis worker was added for the statistics refresher.
- The analysis jobs are always spawned whenever possible.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test(TBD)
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
