### PR TITLE
br: redact ak/sk in logging

### DIFF
--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 32,
+    shard_count = 33,
     deps = [
         ":streamhelper",
         "//br/pkg/errors",

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -438,7 +438,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		if err != nil {
 			log.Warn("failed to upload service GC safepoint, skipping.", logutil.ShortError(err))
 		}
-		log.Info("added event", zap.Stringer("task", e.Info),
+		log.Info("added event", zap.Stringer("task", TaskInfoRedacted{e.Info}),
 			zap.Stringer("ranges", logutil.StringifyKeys(c.taskRange)), zap.Uint64("current-checkpoint", p))
 	case EventDel:
 		utils.LogBackupTaskCountDec()

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/redact"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
@@ -438,7 +439,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 		if err != nil {
 			log.Warn("failed to upload service GC safepoint, skipping.", logutil.ShortError(err))
 		}
-		log.Info("added event", zap.Stringer("task", TaskInfoRedacted{e.Info}),
+		log.Info("added event", zap.Stringer("task", redact.TaskInfoRedacted{Info: e.Info}),
 			zap.Stringer("ranges", logutil.StringifyKeys(c.taskRange)), zap.Uint64("current-checkpoint", p))
 	case EventDel:
 		utils.LogBackupTaskCountDec()

--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -22,13 +21,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/redact"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
-)
-
-var (
-	reAccessKey       = regexp.MustCompile(`access_key:\"[^\"]*\"`)
-	reSecretAccessKey = regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
-	reSharedKey       = regexp.MustCompile(`shared_key:\"[^\"]*\"`)
-	reCredentialsBlob = regexp.MustCompile(`credentials_blob:\"[^\"]*\"`)
 )
 
 type EventType int
@@ -70,24 +62,6 @@ func (t *TaskEvent) String() string {
 		return fmt.Sprintf("%s(%s, err = %s)", t.Type, t.Name, t.Err)
 	}
 	return fmt.Sprintf("%s(%s)", t.Type, t.Name)
-}
-
-type TaskInfoRedacted struct {
-	Info *backuppb.StreamBackupTaskInfo
-}
-
-func (t TaskInfoRedacted) redact(input string) string {
-	// Replace the matched fields with redacted versions
-	output := reAccessKey.ReplaceAllString(input, `access_key:"[REDACTED]"`)
-	output = reSecretAccessKey.ReplaceAllString(output, `secret_access_key:"[REDACTED]"`)
-	output = reSharedKey.ReplaceAllString(output, `SharedKey:"[REDACTED]"`)
-	output = reCredentialsBlob.ReplaceAllString(output, `CredentialsBlob:"[REDACTED]"`)
-
-	return output
-}
-
-func (t TaskInfoRedacted) String() string {
-	return t.redact(t.Info.String())
 }
 
 type AdvancerExt struct {

--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -62,6 +63,26 @@ func (t *TaskEvent) String() string {
 		return fmt.Sprintf("%s(%s, err = %s)", t.Type, t.Name, t.Err)
 	}
 	return fmt.Sprintf("%s(%s)", t.Type, t.Name)
+}
+
+type TaskInfoRedacted struct {
+	Info *backuppb.StreamBackupTaskInfo
+}
+
+func (t TaskInfoRedacted) redactSensitiveInfo(input string) string {
+	// Define regular expressions to match the fields
+	reAccessKey := regexp.MustCompile(`access_key:\"[^\"]*\"`)
+	reSecretAccessKey := regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
+
+	// Replace the matched fields with redacted versions
+	output := reAccessKey.ReplaceAllString(input, `access_key:"[REDACTED]"`)
+	output = reSecretAccessKey.ReplaceAllString(output, `secret_access_key:"[REDACTED]"`)
+
+	return output
+}
+
+func (t TaskInfoRedacted) String() string {
+	return t.redactSensitiveInfo(t.Info.String())
 }
 
 type AdvancerExt struct {

--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	reAccessKey        = regexp.MustCompile(`access_key:\"[^\"]*\"`)
-	reSecretAccessKey  = regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
-	reSharedKey        = regexp.MustCompile(`shared_key:\"[^\"]*\"`)
-	reCredentialsBlob  = regexp.MustCompile(`credentials_blob:\"[^\"]*\"`)
+	reAccessKey       = regexp.MustCompile(`access_key:\"[^\"]*\"`)
+	reSecretAccessKey = regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
+	reSharedKey       = regexp.MustCompile(`shared_key:\"[^\"]*\"`)
+	reCredentialsBlob = regexp.MustCompile(`credentials_blob:\"[^\"]*\"`)
 )
 
 type EventType int

--- a/br/pkg/streamhelper/advancer_cliext.go
+++ b/br/pkg/streamhelper/advancer_cliext.go
@@ -24,6 +24,13 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	reAccessKey        = regexp.MustCompile(`access_key:\"[^\"]*\"`)
+	reSecretAccessKey  = regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
+	reSharedKey        = regexp.MustCompile(`shared_key:\"[^\"]*\"`)
+	reCredentialsBlob  = regexp.MustCompile(`credentials_blob:\"[^\"]*\"`)
+)
+
 type EventType int
 
 const (
@@ -69,20 +76,18 @@ type TaskInfoRedacted struct {
 	Info *backuppb.StreamBackupTaskInfo
 }
 
-func (t TaskInfoRedacted) redactSensitiveInfo(input string) string {
-	// Define regular expressions to match the fields
-	reAccessKey := regexp.MustCompile(`access_key:\"[^\"]*\"`)
-	reSecretAccessKey := regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
-
+func (t TaskInfoRedacted) redact(input string) string {
 	// Replace the matched fields with redacted versions
 	output := reAccessKey.ReplaceAllString(input, `access_key:"[REDACTED]"`)
 	output = reSecretAccessKey.ReplaceAllString(output, `secret_access_key:"[REDACTED]"`)
+	output = reSharedKey.ReplaceAllString(output, `SharedKey:"[REDACTED]"`)
+	output = reCredentialsBlob.ReplaceAllString(output, `CredentialsBlob:"[REDACTED]"`)
 
 	return output
 }
 
 func (t TaskInfoRedacted) String() string {
-	return t.redactSensitiveInfo(t.Info.String())
+	return t.redact(t.Info.String())
 }
 
 type AdvancerExt struct {

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -830,10 +830,10 @@ func TestRedactBackend(t *testing.T) {
 	info.Storage = &backuppb.StorageBackend{
 		Backend: &backuppb.StorageBackend_S3{
 			S3: &backuppb.S3{
-				Endpoint: "http://",
-				Bucket:   "test",
-				Prefix:   "test",
-				AccessKey: "12abCD!@#[]{}?/\\",
+				Endpoint:        "http://",
+				Bucket:          "test",
+				Prefix:          "test",
+				AccessKey:       "12abCD!@#[]{}?/\\",
 				SecretAccessKey: "12abCD!@#[]{}?/\\",
 			},
 		},
@@ -845,9 +845,9 @@ func TestRedactBackend(t *testing.T) {
 	info.Storage = &backuppb.StorageBackend{
 		Backend: &backuppb.StorageBackend_Gcs{
 			Gcs: &backuppb.GCS{
-				Endpoint: "http://",
-				Bucket:   "test",
-				Prefix:   "test",
+				Endpoint:        "http://",
+				Bucket:          "test",
+				Prefix:          "test",
 				CredentialsBlob: "12abCD!@#[]{}?/\\",
 			},
 		},
@@ -858,9 +858,9 @@ func TestRedactBackend(t *testing.T) {
 	info.Storage = &backuppb.StorageBackend{
 		Backend: &backuppb.StorageBackend_AzureBlobStorage{
 			AzureBlobStorage: &backuppb.AzureBlobStorage{
-				Endpoint: "http://",
-				Bucket: "test",
-				Prefix:   "test",
+				Endpoint:  "http://",
+				Bucket:    "test",
+				Prefix:    "test",
 				SharedKey: "12abCD!@#[]{}?/\\",
 			},
 		},

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -839,7 +839,7 @@ func TestRedactBackend(t *testing.T) {
 		},
 	}
 
-	redacted := streamhelper.TaskInfoRedacted{info}
+	redacted := streamhelper.TaskInfoRedacted{Info: info}
 	require.Equal(t, "storage:<s3:<endpoint:\"http://\" bucket:\"test\" prefix:\"test\" access_key:\"[REDACTED]\" secret_access_key:\"[REDACTED]\" > > name:\"test\" ", redacted.String())
 
 	info.Storage = &backuppb.StorageBackend{
@@ -852,7 +852,7 @@ func TestRedactBackend(t *testing.T) {
 			},
 		},
 	}
-	redacted = streamhelper.TaskInfoRedacted{info}
+	redacted = streamhelper.TaskInfoRedacted{Info: info}
 	require.Equal(t, "storage:<gcs:<endpoint:\"http://\" bucket:\"test\" prefix:\"test\" CredentialsBlob:\"[REDACTED]\" > > name:\"test\" ", redacted.String())
 
 	info.Storage = &backuppb.StorageBackend{
@@ -865,6 +865,6 @@ func TestRedactBackend(t *testing.T) {
 			},
 		},
 	}
-	redacted = streamhelper.TaskInfoRedacted{info}
+	redacted = streamhelper.TaskInfoRedacted{Info: info}
 	require.Equal(t, "storage:<azure_blob_storage:<endpoint:\"http://\" bucket:\"test\" prefix:\"test\" SharedKey:\"[REDACTED]\" > > name:\"test\" ", redacted.String())
 }

--- a/pkg/util/redact/BUILD.bazel
+++ b/pkg/util/redact/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/util/intest",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_kvproto//pkg/brpb",
     ],
 )
 

--- a/pkg/util/redact/redact.go
+++ b/pkg/util/redact/redact.go
@@ -22,14 +22,23 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pingcap/errors"
+	backup "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 var (
 	_ fmt.Stringer = redactStringer{}
+
+	reAccessKey       = regexp.MustCompile(`access_key:\"[^\"]*\"`)
+	reSecretAccessKey = regexp.MustCompile(`secret_access_key:\"[^\"]*\"`)
+	reSharedKey       = regexp.MustCompile(`shared_key:\"[^\"]*\"`)
+	reCredentialsBlob = regexp.MustCompile(`credentials_blob:\"[^\"]*\"`)
+	reAccessSig       = regexp.MustCompile(`access_sig:\"[^\"]*\"`)
+	reEncryptKey      = regexp.MustCompile(`encryption_key:<.*?>`)
 )
 
 // String will redact the input string according to 'mode'. Check 'tidb_redact_log': https://github.com/pingcap/tidb/blob/acf9e3128693a5a13f31027f05f4de41edf8d7b2/pkg/sessionctx/variable/sysvar.go#L2154.
@@ -222,4 +231,24 @@ func WriteRedact(build *strings.Builder, v string, redact string) {
 		return
 	}
 	build.WriteString(v)
+}
+
+type TaskInfoRedacted struct {
+	Info *backup.StreamBackupTaskInfo
+}
+
+func (t TaskInfoRedacted) redact(input string) string {
+	// Replace the matched fields with redacted versions
+	output := reAccessKey.ReplaceAllString(input, `access_key:"[REDACTED]"`)
+	output = reSecretAccessKey.ReplaceAllString(output, `secret_access_key:"[REDACTED]"`)
+	output = reSharedKey.ReplaceAllString(output, `shared_key:"[REDACTED]"`)
+	output = reCredentialsBlob.ReplaceAllString(output, `CredentialsBlob:"[REDACTED]"`)
+	output = reAccessSig.ReplaceAllString(output, `access_sig:"[REDACTED]"`)
+	output = reEncryptKey.ReplaceAllString(output, `encryption_key:<[REDACTED]>`)
+
+	return output
+}
+
+func (t TaskInfoRedacted) String() string {
+	return t.redact(t.Info.String())
 }

--- a/pkg/util/redact/redact.go
+++ b/pkg/util/redact/redact.go
@@ -233,11 +233,12 @@ func WriteRedact(build *strings.Builder, v string, redact string) {
 	build.WriteString(v)
 }
 
+// TaskInfoRedacted is a wrapper of backup.StreamBackupTaskInfo to redact sensitive information
 type TaskInfoRedacted struct {
 	Info *backup.StreamBackupTaskInfo
 }
 
-func (t TaskInfoRedacted) redact(input string) string {
+func (TaskInfoRedacted) redact(input string) string {
 	// Replace the matched fields with redacted versions
 	output := reAccessKey.ReplaceAllString(input, `access_key:"[REDACTED]"`)
 	output = reSecretAccessKey.ReplaceAllString(output, `secret_access_key:"[REDACTED]"`)
@@ -249,6 +250,7 @@ func (t TaskInfoRedacted) redact(input string) string {
 	return output
 }
 
+// String returns the redacted string of the task info
 func (t TaskInfoRedacted) String() string {
 	return t.redact(t.Info.String())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55273 

Problem Summary:
log-backup: secrets may be directly logging to log when --send-credentials-to-tikv=false not set during starting log backup

### What changed and how does it work?

Added a wrap of the storage info and redact ak/sk, now the logging woud not print them directly.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

<img width="964" alt="截屏2024-08-23 17 40 01" src="https://github.com/user-attachments/assets/9be7cbe8-54dc-4ef9-a09c-e4d6281c0ff2">


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Added a wrap of the storage info and redact ak/sk, now the logging woud not print them directly.

```
