### PR TITLE
infoschema_v2: remove schemaTableInfos for foreign key

### DIFF
--- a/pkg/ddl/foreign_key.go
+++ b/pkg/ddl/foreign_key.go
@@ -589,15 +589,15 @@ func checkDatabaseHasForeignKeyReferred(ctx context.Context, is infoschema.InfoS
 	if !fkCheck {
 		return nil
 	}
-	tables, err := is.SchemaTableInfos(ctx, schema)
+	tableNameInfos, err := is.SchemaSimpleTableInfos(ctx, schema)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	tableNames := make([]ast.Ident, len(tables))
-	for i := range tables {
-		tableNames[i] = ast.Ident{Schema: schema, Name: tables[i].Name}
+	tableNames := make([]ast.Ident, len(tableNameInfos))
+	for i := range tableNameInfos {
+		tableNames[i] = ast.Ident{Schema: schema, Name: tableNameInfos[i].Name}
 	}
-	for _, tbl := range tables {
+	for _, tbl := range tableNameInfos {
 		if referredFK := checkTableHasForeignKeyReferred(is, schema.L, tbl.Name.L, tableNames, fkCheck); referredFK != nil {
 			return errors.Trace(dbterror.ErrForeignKeyCannotDropParent.GenWithStackByArgs(tbl.Name, referredFK.ChildFKName, referredFK.ChildTable))
 		}

--- a/tests/integrationtest/r/ddl/foreign_key.result
+++ b/tests/integrationtest/r/ddl/foreign_key.result
@@ -206,4 +206,21 @@ select * from t2;
 id	b
 2	2
 admin check table t1,t2;
+create database test_db_1;
+create database test_db_2;
+create database test_db_3;
+use test_db_1;
+create table t1 (id int primary key);
+use test_db_2;
+create table t2 (id int primary key, b int, foreign key (b) references test_db_1.t1(id));
+use test_db_3;
+create table t3 (id int primary key);
+drop table test_db_1.t1;
+Error 3730 (HY000): Cannot drop table 't1' referenced by a foreign key constraint 'fk_1' on table 't2'.
+drop database test_db_1;
+Error 3730 (HY000): Cannot drop table 't1' referenced by a foreign key constraint 'fk_1' on table 't2'.
+drop table test_db_3.t3;
+drop database test_db_3;
+drop database test_db_2;
+drop database test_db_1;
 set @@foreign_key_checks=default;

--- a/tests/integrationtest/t/ddl/foreign_key.test
+++ b/tests/integrationtest/t/ddl/foreign_key.test
@@ -213,4 +213,24 @@ select * from t1;
 select * from t2;
 admin check table t1,t2;
 
+# TestCheckFKDatabaseRefWithSchemaSimpleTableInfos
+create database test_db_1;
+create database test_db_2;
+create database test_db_3;
+use test_db_1;
+create table t1 (id int primary key);
+use test_db_2;
+create table t2 (id int primary key, b int, foreign key (b) references test_db_1.t1(id));
+use test_db_3;
+create table t3 (id int primary key);
+-- error 3730
+drop table test_db_1.t1;
+-- error 3730
+drop database test_db_1;
+drop table test_db_3.t3;
+drop database test_db_3;
+## clean up
+drop database test_db_2;
+drop database test_db_1;
+
 set @@foreign_key_checks=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55623 

Problem Summary:

### What changed and how does it work?
In this func, we only use the table's `Name`, we don't need the whole `TableInfo`, so replace `SchemaTableInfos()` by `SchemaSimpleTableInfos()` 
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Replace `SchemaTableInfos` by `SchemaSimpleTableInfos()` , avoid unnecessary load of all table infos
```
