### PR TITLE
*: remove call of SchemaTableInfos for CheckPlacementPolicy

### DIFF
--- a/pkg/ddl/placement_policy.go
+++ b/pkg/ddl/placement_policy.go
@@ -375,7 +375,6 @@ func CheckPlacementPolicyNotInUseFromInfoSchema(is infoschema.InfoSchema, policy
 			if err := checkPlacementPolicyNotUsedByTable(tblInfo, policy); err != nil {
 				return err
 			}
-
 		}
 	}
 
@@ -415,7 +414,10 @@ func getPlacementPolicyDependedObjectsIDs(t *meta.Meta, policy *model.PolicyInfo
 		if dbInfo.PlacementPolicyRef != nil && dbInfo.PlacementPolicyRef.ID == policy.ID {
 			dbIDs = append(dbIDs, dbInfo.ID)
 		}
-		tables, err := t.ListTables(dbInfo.ID)
+		tables, err := meta.GetTableInfoWithAttributes(
+			t, dbInfo.ID,
+			`"partition":null"`,
+			`"policy_ref_info":null`)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/ddl/placement_policy.go
+++ b/pkg/ddl/placement_policy.go
@@ -367,17 +367,18 @@ func CheckPlacementPolicyNotInUseFromInfoSchema(is infoschema.InfoSchema, policy
 		if ref := dbInfo.PlacementPolicyRef; ref != nil && ref.ID == policy.ID {
 			return dbterror.ErrPlacementPolicyInUse.GenWithStackByArgs(policy.Name)
 		}
+	}
 
-		tblInfos, err := is.SchemaTableInfos(context.Background(), dbInfo.Name)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		for _, tblInfo := range tblInfos {
+	schemaTables := is.ListTablesWithSpecialAttribute(infoschema.AllPlacementPolicyAttribute)
+	for _, schemaTable := range schemaTables {
+		for _, tblInfo := range schemaTable.TableInfos {
 			if err := checkPlacementPolicyNotUsedByTable(tblInfo, policy); err != nil {
 				return err
 			}
+
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -1406,6 +1406,22 @@ var PlacementPolicyAttribute specialAttributeFilter = func(t *model.TableInfo) b
 	return false
 }
 
+// AllPlacementPolicyAttribute is the Placement Policy attribute filter used by ListTablesWithSpecialAttribute.
+// Different from PlacementPolicyAttribute, Partition.Enable flag will be ignored.
+var AllPlacementPolicyAttribute specialAttributeFilter = func(t *model.TableInfo) bool {
+	if t.PlacementPolicyRef != nil {
+		return true
+	}
+	if t.Partition != nil {
+		for _, def := range t.Partition.Definitions {
+			if def.PlacementPolicyRef != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // TableLockAttribute is the Table Lock attribute filter used by ListTablesWithSpecialAttribute.
 var TableLockAttribute specialAttributeFilter = func(t *model.TableInfo) bool {
 	return t.Lock != nil

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1027,9 +1027,10 @@ var checkAttributesInOrder = []string{
 // If the byte representation contains all the given attributes,
 // then it does not need to be loaded and this function will return false.
 // Otherwise, it will return true, indicating that the table info should be loaded.
-func isTableInfoMustLoad(json []byte, attrs ...string) bool {
+// Since attributes are checked in sequence, it's important to choose the order carefully.
+func isTableInfoMustLoad(json []byte, filterAttrs ...string) bool {
 	idx := 0
-	for _, substr := range attrs {
+	for _, substr := range filterAttrs {
 		idx = bytes.Index(json, hack.Slice(substr))
 		if idx == -1 {
 			return true
@@ -1103,8 +1104,8 @@ func GetAllNameToIDAndTheMustLoadedTableInfo(m *Meta, dbID int64) (map[string]in
 }
 
 // GetTableInfoWithAttributes retrieves all the table infos for a given db.
-// The provided attrs are used to filter out any table that is not needed.
-func GetTableInfoWithAttributes(m *Meta, dbID int64, attrs ...string) ([]*model.TableInfo, error) {
+// The filterAttrs are used to filter out any table that is not needed.
+func GetTableInfoWithAttributes(m *Meta, dbID int64, filterAttrs ...string) ([]*model.TableInfo, error) {
 	dbKey := m.dbKey(dbID)
 	if err := m.checkDBExists(dbKey); err != nil {
 		return nil, errors.Trace(err)
@@ -1116,7 +1117,7 @@ func GetTableInfoWithAttributes(m *Meta, dbID int64, attrs ...string) ([]*model.
 			return nil
 		}
 
-		if isTableInfoMustLoad(value, attrs...) {
+		if isTableInfoMustLoad(value, filterAttrs...) {
 			tbInfo := &model.TableInfo{}
 			err := json.Unmarshal(value, tbInfo)
 			if err != nil {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1023,12 +1023,11 @@ var checkAttributesInOrder = []string{
 	`"ttl_info":null`,
 }
 
-// IsTableInfoMustLoad checks whether the table info needs to be loaded.
+// isTableInfoMustLoad checks whether the table info needs to be loaded.
 // If the byte representation contains all the given attributes,
 // then it does not need to be loaded and this function will return false.
 // Otherwise, it will return true, indicating that the table info should be loaded.
-// Exported for testing.
-func IsTableInfoMustLoad(json []byte, attrs ...string) bool {
+func isTableInfoMustLoad(json []byte, attrs ...string) bool {
 	idx := 0
 	for _, substr := range attrs {
 		idx = bytes.Index(json, hack.Slice(substr))
@@ -1038,6 +1037,12 @@ func IsTableInfoMustLoad(json []byte, attrs ...string) bool {
 		json = json[idx:]
 	}
 	return false
+}
+
+// IsTableInfoMustLoad checks whether the table info needs to be loaded.
+// Exported for testing.
+func IsTableInfoMustLoad(json []byte) bool {
+	return isTableInfoMustLoad(json, checkAttributesInOrder...)
 }
 
 // NameExtractRegexp is exported for testing.
@@ -1082,7 +1087,7 @@ func GetAllNameToIDAndTheMustLoadedTableInfo(m *Meta, dbID int64) (map[string]in
 
 		key := Unescape(nameLMatch[1])
 		res[strings.Clone(key)] = int64(id)
-		if IsTableInfoMustLoad(value, checkAttributesInOrder...) {
+		if isTableInfoMustLoad(value, checkAttributesInOrder...) {
 			tbInfo := &model.TableInfo{}
 			err = json.Unmarshal(value, tbInfo)
 			if err != nil {
@@ -1111,7 +1116,7 @@ func GetTableInfoWithAttributes(m *Meta, dbID int64, attrs ...string) ([]*model.
 			return nil
 		}
 
-		if IsTableInfoMustLoad(value, attrs...) {
+		if isTableInfoMustLoad(value, attrs...) {
 			tbInfo := &model.TableInfo{}
 			err := json.Unmarshal(value, tbInfo)
 			if err != nil {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1023,12 +1023,12 @@ var checkAttributesInOrder = []string{
 	`"ttl_info":null`,
 }
 
-// IsTableMustLoad checks whether the table info needs to be loaded.
+// IsTableInfoMustLoad checks whether the table info needs to be loaded.
 // If the byte representation contains all the given attributes,
 // then it does not need to be loaded and this function will return false.
 // Otherwise, it will return true, indicating that the table info should be loaded.
 // Exported for testing.
-func IsTableMustLoad(json []byte, attrs ...string) bool {
+func IsTableInfoMustLoad(json []byte, attrs ...string) bool {
 	idx := 0
 	for _, substr := range attrs {
 		idx = bytes.Index(json, hack.Slice(substr))
@@ -1082,7 +1082,7 @@ func GetAllNameToIDAndTheMustLoadedTableInfo(m *Meta, dbID int64) (map[string]in
 
 		key := Unescape(nameLMatch[1])
 		res[strings.Clone(key)] = int64(id)
-		if IsTableMustLoad(value, checkAttributesInOrder...) {
+		if IsTableInfoMustLoad(value, checkAttributesInOrder...) {
 			tbInfo := &model.TableInfo{}
 			err = json.Unmarshal(value, tbInfo)
 			if err != nil {
@@ -1111,7 +1111,7 @@ func GetTableInfoWithAttributes(m *Meta, dbID int64, attrs ...string) ([]*model.
 			return nil
 		}
 
-		if IsTableMustLoad(value, attrs...) {
+		if IsTableInfoMustLoad(value, attrs...) {
 			tbInfo := &model.TableInfo{}
 			err := json.Unmarshal(value, tbInfo)
 			if err != nil {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1046,7 +1046,7 @@ const NameExtractRegexp = `"O":"([^"\\]*(?:\\.[^"\\]*)*)",`
 // Unescape is exported for testing.
 func Unescape(s string) string {
 	s = strings.ReplaceAll(s, `\"`, `"`)
-	//s = strings.ReplaceAll(s, `\\`, `\`)
+	s = strings.ReplaceAll(s, `\\`, `\`)
 	return s
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55394

Problem Summary:

### What changed and how does it work?

Replace`SchemaTableInfos` with `ListTablesWithSpecialAttribute` to get table infos.

Currently, `CheckPlacementPolicyNotInUseFromInfoSchema` will fetch table infos from meta, which makes it no different from `CheckPlacementPolicyNotInUseFromMeta`.

https://github.com/pingcap/tidb/blob/87244edabf0ebae9870411cb83d91a9add4a797e/pkg/ddl/placement_policy.go#L347-L362

Additionally, a new function `GetTableInfoWithAttributes` is added to meta module to retrieve tables with special attributes under certain db.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test using the following SQLs:

```mysql
mysql> use test
Database changed

mysql> CREATE PLACEMENT POLICY p1 PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-west-1" FOLLOWERS=4;
Query OK, 0 rows affected (0.02 sec)

mysql> CREATE PLACEMENT POLICY p3 FOLLOWERS=4;
Query OK, 0 rows affected (0.02 sec)

mysql> CREATE TABLE t1 (a INT) PLACEMENT POLICY=p3;
Query OK, 0 rows affected (0.03 sec)

mysql> drop placement policy p1;
Query OK, 0 rows affected (0.05 sec)

mysql> drop placement policy p3;
ERROR 8241 (HY000): Placement policy 'p3' is still in use
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
