### PR TITLE
server: remove call of SchemaTableInfos for ServeHTTP

### DIFF
--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -637,15 +637,10 @@ func (h FlashReplicaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		return
 	}
 	replicaInfos := make([]*TableFlashReplicaInfo, 0)
-	allDBs := schema.AllSchemaNames()
-	for _, db := range allDBs {
-		tbls, err := schema.SchemaTableInfos(context.Background(), db)
-		if err != nil {
-			handler.WriteError(w, err)
-			return
-		}
-		for _, tbl := range tbls {
-			replicaInfos = h.getTiFlashReplicaInfo(tbl, replicaInfos)
+	schemaTables := schema.ListTablesWithSpecialAttribute(infoschema.TiFlashAttribute)
+	for _, schemaTable := range schemaTables {
+		for _, tblInfo := range schemaTable.TableInfos {
+			replicaInfos = h.getTiFlashReplicaInfo(tblInfo, replicaInfos)
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55394

Problem Summary:

### What changed and how does it work?

Replace`SchemaTableInfos` with `ListTablesWithSpecialAttribute` to get table infos.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
