### PR TITLE
infoschema: use `ListTablesWithSpecialAttribute` instead of `SchemaTableInfos`

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -485,13 +485,9 @@ func (e *executor) ModifySchemaSetTiFlashReplica(sctx sessionctx.Context, stmt *
 		return errors.Trace(dbterror.ErrUnsupportedTiFlashOperationForSysOrMemTable)
 	}
 
-	schemas := is.ListTablesWithSpecialAttribute(infoschema.TiFlashAttribute)
-	var tbls []*model.TableInfo
-	for _, schema := range schemas {
-		if schema.DBName.L == dbInfo.Name.L {
-			tbls = schema.TableInfos
-			break
-		}
+	tbls, err := is.SchemaTableInfos(context.Background(), dbInfo.Name)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	total := len(tbls)
@@ -503,7 +499,7 @@ func (e *executor) ModifySchemaSetTiFlashReplica(sctx sessionctx.Context, stmt *
 	if total == 0 {
 		return infoschema.ErrEmptyDatabase.GenWithStack("Empty database '%v'", dbName.O)
 	}
-	err := checkTiFlashReplicaCount(sctx, tiflashReplica.Count)
+	err = checkTiFlashReplicaCount(sctx, tiflashReplica.Count)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -640,7 +640,7 @@ func (h FlashReplicaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	schemas := schema.ListTablesWithSpecialAttribute(infoschema.TiFlashAttribute)
 	for _, schema := range schemas {
 		for _, tbl := range schema.TableInfos {
-			replicaInfos = h.getTiFlashReplicaInfo(tbl, replicaInfos)
+			replicaInfos = appendTiFlashReplicaInfo(replicaInfos, tbl)
 		}
 	}
 
@@ -653,7 +653,7 @@ func (h FlashReplicaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	handler.WriteData(w, replicaInfos)
 }
 
-func (FlashReplicaHandler) getTiFlashReplicaInfo(tblInfo *model.TableInfo, replicaInfos []*TableFlashReplicaInfo) []*TableFlashReplicaInfo {
+func appendTiFlashReplicaInfo(replicaInfos []*TableFlashReplicaInfo, tblInfo *model.TableInfo) []*TableFlashReplicaInfo {
 	if tblInfo.TiFlashReplica == nil {
 		return replicaInfos
 	}
@@ -713,7 +713,7 @@ func (h FlashReplicaHandler) getDropOrTruncateTableTiflash(currentSchema infosch
 			return false, nil
 		}
 		uniqueIDMap[tblInfo.ID] = struct{}{}
-		replicaInfos = h.getTiFlashReplicaInfo(tblInfo, replicaInfos)
+		replicaInfos = appendTiFlashReplicaInfo(replicaInfos, tblInfo)
 		return false, nil
 	}
 	dom := domain.GetDomain(s)

--- a/pkg/server/handler/tikvhandler/tikv_handler.go
+++ b/pkg/server/handler/tikvhandler/tikv_handler.go
@@ -637,24 +637,19 @@ func (h FlashReplicaHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		return
 	}
 	replicaInfos := make([]*TableFlashReplicaInfo, 0)
-	allDBs := schema.AllSchemaNames()
-	for _, db := range allDBs {
-		tbls, err := schema.SchemaTableInfos(context.Background(), db)
-		if err != nil {
-			handler.WriteError(w, err)
-			return
-		}
-		for _, tbl := range tbls {
+	schemas := schema.ListTablesWithSpecialAttribute(infoschema.TiFlashAttribute)
+	for _, schema := range schemas {
+		for _, tbl := range schema.TableInfos {
 			replicaInfos = h.getTiFlashReplicaInfo(tbl, replicaInfos)
 		}
 	}
 
-	dropedOrTruncateReplicaInfos, err := h.getDropOrTruncateTableTiflash(schema)
+	droppedOrTruncateReplicaInfos, err := h.getDropOrTruncateTableTiflash(schema)
 	if err != nil {
 		handler.WriteError(w, err)
 		return
 	}
-	replicaInfos = append(replicaInfos, dropedOrTruncateReplicaInfos...)
+	replicaInfos = append(replicaInfos, droppedOrTruncateReplicaInfos...)
 	handler.WriteData(w, replicaInfos)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #55394

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

1. create a cluster with 3 tiflash nodes by `tiup playground --db.binpath bin/tidb-server --db 1 --pd 1 --kv 1 --tiflash 3`
2. create two tables with tiflash replica 1 and 3
```sql
TiDB root@127.0.0.1:(none)> use test;
You are now connected to database "test" as user "root"
Time: 0.000s
TiDB root@127.0.0.1:test> create table t1 (c int);
Query OK, 0 rows affected
Time: 0.021s
TiDB root@127.0.0.1:test> create table t2 (c int);
Query OK, 0 rows affected
Time: 0.026s
TiDB root@127.0.0.1:test> alter table t1 set tiflash replica 1;
Query OK, 0 rows affected
Time: 0.023s
TiDB root@127.0.0.1:test> alter table t2 set tiflash replica 3;
Query OK, 0 rows affected
Time: 0.028s
```
3. `curl http://127.0.0.1:10080/tiflash/replica-deprecated`
```
[
 {
  "id": 106,
  "replica_count": 3,
  "location_labels": [],
  "available": true,
  "high_priority": false
 },
 {
  "id": 104,
  "replica_count": 1,
  "location_labels": [],
  "available": true,
  "high_priority": false
 }
]%
```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
