### PR TITLE
br: fix duplicated table check would block incremental restore

### DIFF
--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -907,7 +907,7 @@ func runRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		if cfg.WithSysTable {
 			client.InitFullClusterRestore(cfg.ExplicitFilter)
 		}
-	} else if checkpointFirstRun && cfg.CheckRequirements {
+	} else if client.IsFull() && checkpointFirstRun && cfg.CheckRequirements {
 		if err := checkTableExistence(ctx, mgr, tables, g); err != nil {
 			schedulersRemovable = true
 			return errors.Trace(err)

--- a/tests/realtikvtest/brietest/brie_test.go
+++ b/tests/realtikvtest/brietest/brie_test.go
@@ -138,7 +138,7 @@ func TestExistedTables(t *testing.T) {
 	sqlTmp := strings.ReplaceAll(tmp, "'", "''")
 	executor.ResetGlobalBRIEQueueForTest()
 	tk.MustExec("use test;")
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		tableName := fmt.Sprintf("foo%d", i)
 		tk.MustExec(fmt.Sprintf("create table %s(pk int primary key auto_increment, v varchar(255));", tableName))
 		tk.MustExec(fmt.Sprintf("insert into %s(v) values %s;", tableName, strings.TrimSuffix(strings.Repeat("('hello, world'),", 100), ",")))
@@ -172,7 +172,54 @@ func TestExistedTables(t *testing.T) {
 	case <-done:
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
+		tableName := fmt.Sprintf("foo%d", i)
+		tk.MustExec(fmt.Sprintf("drop table %s;", tableName))
+	}
+}
+
+func TestExistedTablesOfIncremental(t *testing.T) {
+	tk := initTestKit(t)
+	tmp := makeTempDirForBackup(t)
+	sqlTmp := strings.ReplaceAll(tmp, "'", "''")
+	executor.ResetGlobalBRIEQueueForTest()
+	tk.MustExec("use test;")
+	for i := 0; i < 5; i++ {
+		tableName := fmt.Sprintf("foo%d", i)
+		tk.MustExec(fmt.Sprintf("create table %s(pk int primary key auto_increment, v varchar(255));", tableName))
+		tk.MustExec(fmt.Sprintf("insert into %s(v) values %s;", tableName, strings.TrimSuffix(strings.Repeat("('hello, world'),", 100), ",")))
+	}
+
+	// full backup
+	backupQuery := fmt.Sprintf("BACKUP DATABASE * TO 'local://%s/full'", sqlTmp)
+	res := tk.MustQuery(backupQuery)
+	backupTs := res.Rows()[0][2].(string)
+
+	// write incremental data
+	for i := 0; i < 5; i++ {
+		tableName := fmt.Sprintf("foo%d", i)
+		tk.MustExec(fmt.Sprintf("insert into %s(v) values %s;", tableName, strings.TrimSuffix(strings.Repeat("('hello, world'),", 100), ",")))
+	}
+
+	// incremental backup
+	IncrementalBackupQuery := fmt.Sprintf("BACKUP DATABASE * TO 'local://%s/incremental' last_backup=%s", sqlTmp, backupTs)
+	_ = tk.MustQuery(IncrementalBackupQuery)
+
+	// clean up tables
+	for i := 0; i < 5; i++ {
+		tableName := fmt.Sprintf("foo%d", i)
+		tk.MustExec(fmt.Sprintf("drop table %s;", tableName))
+	}
+
+	// restore full backup
+	restoreQuery := fmt.Sprintf("RESTORE DATABASE * FROM 'local://%s/full'", sqlTmp)
+	_ = tk.MustQuery(restoreQuery)
+
+	// restore incremental backup
+	restoreIncrementalQuery := fmt.Sprintf("RESTORE DATABASE * FROM 'local://%s/incremental'", sqlTmp)
+	_ = tk.MustQuery(restoreIncrementalQuery)
+
+	for i := 0; i < 5; i++ {
 		tableName := fmt.Sprintf("foo%d", i)
 		tk.MustExec(fmt.Sprintf("drop table %s;", tableName))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55562 

Problem Summary:

BR would report unexpected `BR:Restore:ErrTablesAlreadyExisted` when incremental restore.

### What changed and how does it work?

disable duplicated table check in incremental restore.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
