### PR TITLE
executor: remove `EnablePointGetCache` session var

### DIFF
--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -637,17 +637,6 @@ func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) ([]byte, error) 
 		// fallthrough to snapshot get.
 	}
 
-	lock := e.tblInfo.Lock
-	if lock != nil && (lock.Tp == model.TableLockRead || lock.Tp == model.TableLockReadOnly) {
-		if e.Ctx().GetSessionVars().EnablePointGetCache {
-			cacheDB := e.Ctx().GetStore().GetMemCache()
-			val, err = cacheDB.UnionGet(ctx, e.tblInfo.ID, e.snapshot, key)
-			if err != nil {
-				return nil, err
-			}
-			return val, nil
-		}
-	}
 	// if not read lock or table was unlock then snapshot get
 	return e.snapshot.Get(ctx, key)
 }

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -17,11 +17,9 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/session"
@@ -99,133 +97,6 @@ func TestReturnValues(t *testing.T) {
 func mustExecDDL(tk *testkit.TestKit, t *testing.T, sql string, dom *domain.Domain) {
 	tk.MustExec(sql)
 	require.NoError(t, dom.Reload())
-}
-
-func TestMemCacheReadLock(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableTableLock = true
-	})
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.Session().GetSessionVars().EnablePointGetCache = true
-	defer func() {
-		tk.Session().GetSessionVars().EnablePointGetCache = false
-		tk.MustExec("drop table if exists point")
-	}()
-
-	tk.MustExec("drop table if exists point")
-	tk.MustExec("create table point (id int primary key, c int, d varchar(10), unique c_d (c, d))")
-	tk.MustExec("insert point values (1, 1, 'a')")
-	tk.MustExec("insert point values (2, 2, 'b')")
-
-	// Simply check the cached results.
-	mustExecDDL(tk, t, "lock tables point read", dom)
-	tk.MustQuery("select id from point where id = 1").Check(testkit.Rows("1"))
-	tk.MustQuery("select id from point where id = 1").Check(testkit.Rows("1"))
-	mustExecDDL(tk, t, "unlock tables", dom)
-
-	cases := []struct {
-		sql string
-		r1  bool
-		r2  bool
-	}{
-		{"explain analyze select * from point where id = 1", false, false},
-		{"explain analyze select * from point where id in (1, 2)", false, false},
-
-		// Cases for not exist keys.
-		{"explain analyze select * from point where id = 3", true, true},
-		{"explain analyze select * from point where id in (1, 3)", true, true},
-		{"explain analyze select * from point where id in (3, 4)", true, true},
-	}
-
-	for _, ca := range cases {
-		mustExecDDL(tk, t, "lock tables point read", dom)
-
-		rows := tk.MustQuery(ca.sql).Rows()
-		require.Lenf(t, rows, 1, "%v", ca.sql)
-		explain := fmt.Sprintf("%v", rows[0])
-		require.Regexp(t, ".*num_rpc.*", explain)
-
-		rows = tk.MustQuery(ca.sql).Rows()
-		require.Len(t, rows, 1)
-		explain = fmt.Sprintf("%v", rows[0])
-		ok := strings.Contains(explain, "num_rpc")
-		require.Equalf(t, ok, ca.r1, "%v", ca.sql)
-		mustExecDDL(tk, t, "unlock tables", dom)
-
-		rows = tk.MustQuery(ca.sql).Rows()
-		require.Len(t, rows, 1)
-		explain = fmt.Sprintf("%v", rows[0])
-		require.Regexp(t, ".*num_rpc.*", explain)
-
-		// Test cache release after unlocking tables.
-		mustExecDDL(tk, t, "lock tables point read", dom)
-		rows = tk.MustQuery(ca.sql).Rows()
-		require.Len(t, rows, 1)
-		explain = fmt.Sprintf("%v", rows[0])
-		require.Regexp(t, ".*num_rpc.*", explain)
-
-		rows = tk.MustQuery(ca.sql).Rows()
-		require.Len(t, rows, 1)
-		explain = fmt.Sprintf("%v", rows[0])
-		ok = strings.Contains(explain, "num_rpc")
-		require.Equal(t, ok, ca.r2, "%v", ca.sql)
-
-		mustExecDDL(tk, t, "unlock tables", dom)
-		mustExecDDL(tk, t, "lock tables point read", dom)
-
-		rows = tk.MustQuery(ca.sql).Rows()
-		require.Len(t, rows, 1)
-		explain = fmt.Sprintf("%v", rows[0])
-		require.Regexp(t, ".*num_rpc.*", explain)
-
-		mustExecDDL(tk, t, "unlock tables", dom)
-	}
-}
-
-func TestPartitionMemCacheReadLock(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableTableLock = true
-	})
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.Session().GetSessionVars().EnablePointGetCache = true
-	defer func() {
-		tk.Session().GetSessionVars().EnablePointGetCache = false
-		tk.MustExec("drop table if exists point")
-	}()
-
-	tk.MustExec("drop table if exists point")
-	tk.MustExec("create table point (id int unique key, c int, d varchar(10)) partition by hash (id) partitions 4")
-	tk.MustExec("insert point values (1, 1, 'a')")
-	tk.MustExec("insert point values (2, 2, 'b')")
-
-	// Confirm _tidb_rowid will not be duplicated.
-	tk.MustQuery("select distinct(_tidb_rowid) from point order by _tidb_rowid").Check(testkit.Rows("1", "2"))
-
-	mustExecDDL(tk, t, "lock tables point read", dom)
-
-	tk.MustQuery("select _tidb_rowid from point where id = 1").Check(testkit.Rows("1"))
-	mustExecDDL(tk, t, "unlock tables", dom)
-
-	tk.MustQuery("select _tidb_rowid from point where id = 1").Check(testkit.Rows("1"))
-	tk.MustExec("update point set id = -id")
-
-	// Test cache release after unlocking tables.
-	mustExecDDL(tk, t, "lock tables point read", dom)
-	tk.MustQuery("select _tidb_rowid from point where id = 1").Check(testkit.Rows())
-
-	tk.MustQuery("select _tidb_rowid from point where id = -1").Check(testkit.Rows("1"))
-	tk.MustQuery("select _tidb_rowid from point where id = -1").Check(testkit.Rows("1"))
-	tk.MustQuery("select _tidb_rowid from point where id = -2").Check(testkit.Rows("2"))
-
-	mustExecDDL(tk, t, "unlock tables", dom)
 }
 
 func TestPointGetLockExistKey(t *testing.T) {

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1080,9 +1080,6 @@ type SessionVars struct {
 	// EnableAutoIncrementInGenerated is used to control whether to allow auto incremented columns in generated columns.
 	EnableAutoIncrementInGenerated bool
 
-	// EnablePointGetCache is used to cache value for point get for read only scenario.
-	EnablePointGetCache bool
-
 	// PlacementMode the placement mode we use
 	//   strict: Check placement settings strictly in ddl operations
 	//   ignore: Ignore all placement settings in ddl operations


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55696

Problem Summary:

These codes are not modified for a very long time, and there is no option to enable this session var. Therefore, I think maybe it's safe to remove it :thinking:.

### What changed and how does it work?

Simply remove the codes related to `EnablePointGetCache`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > This PR doesn't change the existing logic. The existing tests about normal point get should cover it.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
