### PR TITLE
expression: `StaticExprContext/EvalContext` support to load state from system variables

### DIFF
--- a/pkg/expression/contextstatic/BUILD.bazel
+++ b/pkg/expression/contextstatic/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":contextstatic"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 13,
     deps = [
         "//pkg/errctx",
         "//pkg/expression/context",

--- a/pkg/expression/contextstatic/evalctx_test.go
+++ b/pkg/expression/contextstatic/evalctx_test.go
@@ -16,6 +16,7 @@ package contextstatic
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -531,4 +532,163 @@ func TestMakeEvalContextStatic(t *testing.T) {
 	require.NotEqual(t, obj.GetOptionalPropSet(), staticObj.GetOptionalPropSet())
 	// Now, it didn't copy any optional properties.
 	require.Equal(t, context.OptionalEvalPropKeySet(0), staticObj.GetOptionalPropSet())
+}
+
+func TestEvalCtxLoadSystemVars(t *testing.T) {
+	vars := []struct {
+		name   string
+		val    string
+		field  string
+		assert func(ctx *StaticEvalContext, vars *variable.SessionVars)
+	}{
+		{
+			name:  "time_zone",
+			val:   "Europe/Berlin",
+			field: "$.typeCtx.loc",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				require.Equal(t, "Europe/Berlin", ctx.Location().String())
+				require.Equal(t, vars.Location().String(), ctx.Location().String())
+			},
+		},
+		{
+			name:  "sql_mode",
+			val:   "ALLOW_INVALID_DATES,ONLY_FULL_GROUP_BY",
+			field: "$.sqlMode",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				require.Equal(t, mysql.ModeAllowInvalidDates|mysql.ModeOnlyFullGroupBy, ctx.SQLMode())
+				require.Equal(t, vars.SQLMode, ctx.SQLMode())
+			},
+		},
+		{
+			name:  "timestamp",
+			val:   "1234567890.123456",
+			field: "$.currentTime",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				currentTime, err := ctx.CurrentTime()
+				require.NoError(t, err)
+				require.Equal(t, int64(1234567890123456), currentTime.UnixMicro())
+				require.Equal(t, vars.Location().String(), currentTime.Location().String())
+			},
+		},
+		{
+			name:  strings.ToUpper("max_allowed_packet"), // test for settings an upper case variable
+			val:   "524288",
+			field: "$.maxAllowedPacket",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				require.Equal(t, uint64(524288), ctx.GetMaxAllowedPacket())
+				require.Equal(t, vars.MaxAllowedPacket, ctx.GetMaxAllowedPacket())
+			},
+		},
+		{
+			name:  strings.ToUpper("tidb_redact_log"), // test for settings an upper case variable
+			val:   "on",
+			field: "$.enableRedactLog",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				require.Equal(t, "ON", ctx.GetTiDBRedactLog())
+				require.Equal(t, vars.EnableRedactLog, ctx.GetTiDBRedactLog())
+			},
+		},
+		{
+			name:  "default_week_format",
+			val:   "5",
+			field: "$.defaultWeekFormatMode",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				require.Equal(t, "5", ctx.GetDefaultWeekFormatMode())
+				mode, ok := vars.GetSystemVar(variable.DefaultWeekFormat)
+				require.True(t, ok)
+				require.Equal(t, mode, ctx.GetDefaultWeekFormatMode())
+			},
+		},
+		{
+			name:  "div_precision_increment",
+			val:   "12",
+			field: "$.divPrecisionIncrement",
+			assert: func(ctx *StaticEvalContext, vars *variable.SessionVars) {
+				require.Equal(t, 12, ctx.GetDivPrecisionIncrement())
+				require.Equal(t, vars.DivPrecisionIncrement, ctx.GetDivPrecisionIncrement())
+			},
+		},
+	}
+
+	// nonVarRelatedFields means the fields not related to any system variables.
+	// To make sure that all the variables which affect the context state are covered in the above test list,
+	// we need to test all inner fields except those in `nonVarRelatedFields` are changed after `LoadSystemVars`.
+	nonVarRelatedFields := []string{
+		"$.warnHandler",
+		"$.typeCtx.flags",
+		"$.typeCtx.warnHandler",
+		"$.errCtx",
+		"$.currentDB",
+		"$.requestVerificationFn",
+		"$.requestDynamicVerificationFn",
+		"$.paramList",
+		"$.props",
+	}
+
+	// varsRelatedFields means the fields related to
+	varsRelatedFields := make([]string, 0, len(vars))
+	varsMap := make(map[string]string)
+	sessionVars := variable.NewSessionVars(nil)
+	for _, sysVar := range vars {
+		varsMap[sysVar.name] = sysVar.val
+		if sysVar.field != "" {
+			varsRelatedFields = append(varsRelatedFields, sysVar.field)
+		}
+		require.NoError(t, sessionVars.SetSystemVar(sysVar.name, sysVar.val))
+	}
+
+	defaultEvalCtx := NewStaticEvalContext()
+	ctx, err := defaultEvalCtx.LoadSystemVars(varsMap)
+	require.NoError(t, err)
+	require.Greater(t, ctx.CtxID(), defaultEvalCtx.CtxID())
+
+	// Check all fields except these in `nonVarRelatedFields` are changed after `LoadSystemVars` to make sure
+	// all system variables related fields are covered in the test list.
+	deeptest.AssertRecursivelyNotEqual(
+		t,
+		defaultEvalCtx.staticEvalCtxState,
+		ctx.staticEvalCtxState,
+		deeptest.WithIgnorePath(nonVarRelatedFields),
+		deeptest.WithPointerComparePath([]string{"$.currentTime"}),
+	)
+
+	// We need to compare the new context again with an empty one to make sure those values are set from sys vars,
+	// not inherited from the empty go value.
+	deeptest.AssertRecursivelyNotEqual(
+		t,
+		staticEvalCtxState{},
+		ctx.staticEvalCtxState,
+		deeptest.WithIgnorePath(nonVarRelatedFields),
+		deeptest.WithPointerComparePath([]string{"$.currentTime"}),
+	)
+
+	// Check all system vars unrelated fields are not changed after `LoadSystemVars`.
+	deeptest.AssertDeepClonedEqual(
+		t,
+		defaultEvalCtx.staticEvalCtxState,
+		ctx.staticEvalCtxState,
+		deeptest.WithIgnorePath(append(
+			varsRelatedFields,
+			// Do not check warnHandler in `typeCtx` and `errCtx` because they should be changed to even if
+			// they are not related to any system variable.
+			"$.typeCtx.warnHandler",
+			"$.errCtx.warnHandler",
+		)),
+		// LoadSystemVars only does shallow copy for `EvalContext` so we just need to compare the pointers.
+		deeptest.WithPointerComparePath(nonVarRelatedFields),
+	)
+
+	for _, sysVar := range vars {
+		sysVar.assert(ctx, sessionVars)
+	}
+
+	// additional check about @@timestamp
+	// setting to `variable.DefTimestamp` should return the current timestamp
+	ctx, err = defaultEvalCtx.LoadSystemVars(map[string]string{
+		"timestamp": variable.DefTimestamp,
+	})
+	require.NoError(t, err)
+	tm, err := ctx.CurrentTime()
+	require.NoError(t, err)
+	require.InDelta(t, time.Now().Unix(), tm.Unix(), 5)
 }

--- a/pkg/expression/contextstatic/exprctx_test.go
+++ b/pkg/expression/contextstatic/exprctx_test.go
@@ -15,6 +15,7 @@
 package contextstatic
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -198,4 +199,179 @@ func TestMakeExprContextStatic(t *testing.T) {
 		}))
 
 	require.NotSame(t, obj.GetEvalCtx(), staticObj.GetEvalCtx())
+}
+
+func TestExprCtxLoadSystemVars(t *testing.T) {
+	vars := []struct {
+		name   string
+		val    string
+		field  string
+		assert func(ctx *StaticExprContext, vars *variable.SessionVars)
+	}{
+		{
+			name:  "character_set_connection",
+			val:   "gbk",
+			field: "$.charset",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				cs, _ := ctx.GetCharsetInfo()
+				require.Equal(t, "gbk", cs)
+				cs2, _ := vars.GetCharsetInfo()
+				require.Equal(t, cs2, cs)
+			},
+		},
+		{
+			name:  "collation_connection",
+			val:   "gbk_chinese_ci",
+			field: "$.collation",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				_, coll := ctx.GetCharsetInfo()
+				require.Equal(t, "gbk_chinese_ci", coll)
+				_, coll2 := vars.GetCharsetInfo()
+				require.Equal(t, coll2, coll)
+			},
+		},
+		{
+			name:  "default_collation_for_utf8mb4",
+			val:   "utf8mb4_general_ci",
+			field: "$.defaultCollationForUTF8MB4",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				require.Equal(t, "utf8mb4_general_ci", ctx.GetDefaultCollationForUTF8MB4())
+				require.Equal(t, vars.DefaultCollationForUTF8MB4, ctx.GetDefaultCollationForUTF8MB4())
+			},
+		},
+		{
+			name:  strings.ToUpper("tidb_sysdate_is_now"), // test for settings an upper case variable
+			val:   "1",
+			field: "$.sysDateIsNow",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				require.True(t, ctx.GetSysdateIsNow())
+				require.Equal(t, vars.SysdateIsNow, ctx.GetSysdateIsNow())
+			},
+		},
+		{
+			name:  "tidb_enable_noop_functions",
+			val:   "warn",
+			field: "$.noopFuncsMode",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				require.Equal(t, variable.WarnInt, ctx.GetNoopFuncsMode())
+				require.Equal(t, vars.NoopFuncsMode, ctx.GetNoopFuncsMode())
+			},
+		},
+		{
+			name:  "block_encryption_mode",
+			val:   "aes-256-cbc",
+			field: "$.blockEncryptionMode",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				require.Equal(t, "aes-256-cbc", ctx.GetBlockEncryptionMode())
+				blockMode, _ := vars.GetSystemVar(variable.BlockEncryptionMode)
+				require.Equal(t, blockMode, ctx.GetBlockEncryptionMode())
+			},
+		},
+		{
+			name:  "group_concat_max_len",
+			val:   "123456",
+			field: "$.groupConcatMaxLen",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				require.Equal(t, uint64(123456), ctx.GetGroupConcatMaxLen())
+				require.Equal(t, vars.GroupConcatMaxLen, ctx.GetGroupConcatMaxLen())
+			},
+		},
+		{
+			name:  "windowing_use_high_precision",
+			val:   "0",
+			field: "$.windowingUseHighPrecision",
+			assert: func(ctx *StaticExprContext, vars *variable.SessionVars) {
+				require.False(t, ctx.GetWindowingUseHighPrecision())
+				require.Equal(t, vars.WindowingUseHighPrecision, ctx.GetWindowingUseHighPrecision())
+			},
+		},
+	}
+
+	// nonVarRelatedFields means the fields not related to any system variables.
+	// To make sure that all the variables which affect the context state are covered in the above test list,
+	// we need to test all inner fields except those in `nonVarRelatedFields` are changed after `LoadSystemVars`.
+	nonVarRelatedFields := []string{
+		"$.rng",
+		"$.planCacheTracker",
+		"$.columnIDAllocator",
+		"$.connectionID",
+	}
+
+	// varsRelatedFields means the fields related to
+	varsRelatedFields := make([]string, 0, len(vars))
+	varsMap := make(map[string]string)
+	sessionVars := variable.NewSessionVars(nil)
+	for _, sysVar := range vars {
+		varsMap[sysVar.name] = sysVar.val
+		if sysVar.field != "" {
+			varsRelatedFields = append(varsRelatedFields, sysVar.field)
+		}
+		require.NoError(t, sessionVars.SetSystemVar(sysVar.name, sysVar.val))
+	}
+
+	defaultCtx := NewStaticExprContext()
+	ctx, err := defaultCtx.LoadSystemVars(varsMap)
+	require.NoError(t, err)
+
+	// Check all fields except these in `nonVarRelatedFields` are changed after `LoadSystemVars` to make sure
+	// all system variables related fields are covered in the test list.
+	deeptest.AssertRecursivelyNotEqual(
+		t,
+		defaultCtx.staticExprCtxState,
+		ctx.staticExprCtxState,
+		// ignore `evalCtx` because we'll test it standalone.
+		deeptest.WithIgnorePath(append(nonVarRelatedFields, "$.evalCtx")),
+	)
+
+	// We need to compare the new context again with an empty one to make sure those values are set from sys vars,
+	// not inherited from the empty go value.
+	deeptest.AssertRecursivelyNotEqual(
+		t,
+		staticExprCtxState{},
+		ctx.staticExprCtxState,
+		// ignore `windowingUseHighPrecision` because we set it to `false` in test case.
+		deeptest.WithIgnorePath(append(nonVarRelatedFields, "$.evalCtx", "$.windowingUseHighPrecision")),
+	)
+
+	// Check all system vars unrelated fields are not changed after `LoadSystemVars`.
+	deeptest.AssertDeepClonedEqual(
+		t,
+		defaultCtx.staticExprCtxState,
+		ctx.staticExprCtxState,
+		deeptest.WithIgnorePath(append(varsRelatedFields, "$.evalCtx")),
+		// LoadSystemVars only does shallow copy for `EvalContext` so we just need to compare the pointers.
+		deeptest.WithPointerComparePath(nonVarRelatedFields),
+	)
+
+	for _, sysVar := range vars {
+		sysVar.assert(ctx, sessionVars)
+	}
+
+	// additional tests for charset
+	// setting charset should also affect collation
+	ctx, err = defaultCtx.LoadSystemVars(map[string]string{
+		"character_set_connection": "ascii",
+	})
+	require.NoError(t, err)
+	cs, coll := ctx.GetCharsetInfo()
+	require.Equal(t, "ascii", cs)
+	require.Equal(t, "ascii_bin", coll)
+	// setting collation should also affect charset
+	ctx, err = defaultCtx.LoadSystemVars(map[string]string{
+		"collation_connection": "latin1_bin",
+	})
+	require.NoError(t, err)
+	cs, coll = ctx.GetCharsetInfo()
+	require.Equal(t, "latin1", cs)
+	require.Equal(t, "latin1_bin", coll)
+
+	// additional test for EvalContext
+	// LoadSystemVars should also affect EvalContext
+	ctx, err = defaultCtx.LoadSystemVars(map[string]string{
+		"div_precision_increment": "9",
+		"time_zone":               "Asia/Tokyo",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 9, ctx.GetEvalCtx().GetDivPrecisionIncrement())
+	require.Equal(t, "Asia/Tokyo", ctx.GetEvalCtx().Location().String())
 }

--- a/pkg/util/deeptest/statictesthelper.go
+++ b/pkg/util/deeptest/statictesthelper.go
@@ -157,6 +157,9 @@ func (h *staticTestHelper) assertDeepClonedEqual(t require.TestingT, valA, valB 
 			h.assertDeepClonedEqual(t, valA.Elem(), valB.Elem(), path)
 		}
 	case reflect.Slice:
+		if valA.IsNil() && valB.IsNil() {
+			return
+		}
 		require.Equal(t, valA.Len(), valB.Len(), path+" should have the same length")
 
 		if h.shouldComparePointer(path) {
@@ -183,6 +186,9 @@ func (h *staticTestHelper) assertDeepClonedEqual(t require.TestingT, valA, valB 
 	case reflect.String:
 		require.Equal(t, valA.String(), valB.String(), path+" should be the same")
 	case reflect.Map:
+		if valA.IsNil() && valB.IsNil() {
+			return
+		}
 		require.Equal(t, valA.Len(), valB.Len(), path+" should have the same length")
 
 		if h.shouldComparePointer(path) {
@@ -199,6 +205,9 @@ func (h *staticTestHelper) assertDeepClonedEqual(t require.TestingT, valA, valB 
 		}
 		h.assertDeepClonedEqual(t, valA.Elem(), valB.Elem(), path)
 	case reflect.Func:
+		if valA.IsNil() && valB.IsNil() {
+			return
+		}
 		if h.shouldComparePointer(path) {
 			require.Equal(t, valA.Pointer(), valB.Pointer(), path+" should be the same")
 		} else {

--- a/pkg/util/deeptest/statictesthelper_test.go
+++ b/pkg/util/deeptest/statictesthelper_test.go
@@ -155,6 +155,7 @@ func TestAssertDeepClonedEqual(t *testing.T) {
 	AssertDeepClonedEqual(t, a, a, WithPointerComparePath([]string{"$"}))
 
 	// For slice
+	AssertDeepClonedEqual(t, []int(nil), []int(nil))
 	AssertDeepClonedEqual(t, []int{1, 2, 3}, []int{1, 2, 3})
 	shouldFail(t, func(t require.TestingT) {
 		AssertDeepClonedEqual(t, []int{1, 2, 3}, []int{1, 2, 4})
@@ -175,6 +176,7 @@ func TestAssertDeepClonedEqual(t *testing.T) {
 	})
 
 	// For map
+	AssertDeepClonedEqual(t, map[int]int(nil), map[int]int(nil))
 	AssertDeepClonedEqual(t, map[int]int{1: 2, 2: 3}, map[int]int{1: 2, 2: 3})
 	shouldFail(t, func(t require.TestingT) {
 		AssertDeepClonedEqual(t, map[int]int{1: 2, 2: 3}, map[int]int{1: 2, 3: 4})
@@ -196,6 +198,9 @@ func TestAssertDeepClonedEqual(t *testing.T) {
 	AssertDeepClonedEqual(t, a1, a1, WithPointerComparePath([]string{"$"}))
 
 	// For function
+	var nilFunc1 func()
+	var nilFunc2 func()
+	AssertDeepClonedEqual(t, nilFunc1, nilFunc2)
 	AssertDeepClonedEqual(t, TestAssertDeepClonedEqual, TestAssertDeepClonedEqual, WithPointerComparePath([]string{"$"}))
 	shouldFail(t, func(t require.TestingT) {
 		AssertDeepClonedEqual(t, func() {}, func() {})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55799

Problem Summary:

Sometimes we need to load state of `StaticExprContext/EvalContext` from system variables, just like in lightning:

https://github.com/pingcap/tidb/blob/df02db014ac68614909de4c728593d843a8c4d0f/pkg/lightning/backend/kv/session.go#L327-L357

### What changed and how does it work?

- This PR introduces a new method `LoadSystemVars` to `StaticExprContext` and `StaticEvalContext` to load state from system variables.
- Also do some modifies in `deeptest` to make it easier to use.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
