### PR TITLE
infoschema: fix snapshot read bug for information_schema.tables

### DIFF
--- a/pkg/infoschema/test/infoschemav2test/BUILD.bazel
+++ b/pkg/infoschema/test/infoschemav2test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "v2_test.go",
     ],
     flaky = True,
-    shard_count = 10,
+    shard_count = 11,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",

--- a/pkg/infoschema/test/infoschemav2test/v2_test.go
+++ b/pkg/infoschema/test/infoschemav2test/v2_test.go
@@ -504,3 +504,32 @@ func TestSchemaSimpleTableInfos(t *testing.T) {
 	require.Equal(t, tblInfos[0].Name.L, "t2")
 	require.Equal(t, tblInfos[1].Name.L, "t1")
 }
+
+func TestSnapshotInfoschemaReader(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	// For mocktikv, safe point is not initialized, we manually insert it for snapshot to use.
+	safePointName := "tikv_gc_safe_point"
+	safePointValue := "20160102-15:04:05 -0700"
+	safePointComment := "All versions after safe point can be accessed. (DO NOT EDIT)"
+	updateSafePoint := fmt.Sprintf(`INSERT INTO mysql.tidb VALUES ('%[1]s', '%[2]s', '%[3]s')
+	ON DUPLICATE KEY
+	UPDATE variable_value = '%[2]s', comment = '%[3]s'`, safePointName, safePointValue, safePointComment)
+	tk.MustExec(updateSafePoint)
+
+	tk.MustExec("create database issue55827")
+	tk.MustExec("use issue55827")
+
+	time1 := time.Now()
+	timeStr := time1.Format("2006-1-2 15:04:05.000")
+
+	tk.MustExec("create table t (id int primary key);")
+	tk.MustQuery("select count(*) from INFORMATION_SCHEMA.TABLES where table_schema = 'issue55827'").Check(testkit.Rows("1"))
+	tk.MustQuery("select count(tidb_table_id) from INFORMATION_SCHEMA.TABLES where table_schema = 'issue55827'").Check(testkit.Rows("1"))
+
+	// For issue 55827
+	sql := fmt.Sprintf("select count(*) from INFORMATION_SCHEMA.TABLES as of timestamp '%s' where table_schema = 'issue55827'", timeStr)
+	tk.MustQuery(sql).Check(testkit.Rows("0"))
+	sql = fmt.Sprintf("select * from INFORMATION_SCHEMA.TABLES as of timestamp '%s' where table_schema = 'issue55827'", timeStr)
+	tk.MustQuery(sql).Check(testkit.Rows())
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55827

Problem Summary:

### What changed and how does it work?

Fix a bug introduced by https://github.com/pingcap/tidb/pull/55574
That PR does not consider the snapshot read, its `IterateAllTableItems` funcation is always reading the latest infoschema.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
