### PR TITLE
expression: Add `GetUserVarsReader` to `EvalContext`

### DIFF
--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -1025,7 +1025,6 @@ func (c *getStringVarFunctionClass) getFunction(ctx BuildContext, args []Express
 
 type builtinGetStringVarSig struct {
 	baseBuiltinFunc
-	contextopt.SessionVarsPropReader
 }
 
 func (b *builtinGetStringVarSig) Clone() builtinFunc {
@@ -1034,21 +1033,13 @@ func (b *builtinGetStringVarSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinGetStringVarSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
-}
-
 func (b *builtinGetStringVarSig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return "", true, err
-	}
 	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", isNull, err
 	}
 	varName = strings.ToLower(varName)
-	if v, ok := sessionVars.GetUserVarVal(varName); ok {
+	if v, ok := ctx.GetUserVarsReader().GetUserVarVal(varName); ok {
 		// We cannot use v.GetString() here, because the datum may be in KindMysqlTime, which
 		// stores the data in datum.x.
 		// This seems controversial with https://dev.mysql.com/doc/refman/8.0/en/user-variables.html:
@@ -1085,7 +1076,6 @@ func (c *getIntVarFunctionClass) getFunction(ctx BuildContext, args []Expression
 
 type builtinGetIntVarSig struct {
 	baseBuiltinFunc
-	contextopt.SessionVarsPropReader
 }
 
 func (b *builtinGetIntVarSig) Clone() builtinFunc {
@@ -1094,21 +1084,13 @@ func (b *builtinGetIntVarSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinGetIntVarSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
-}
-
 func (b *builtinGetIntVarSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return 0, true, err
-	}
 	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	varName = strings.ToLower(varName)
-	if v, ok := sessionVars.GetUserVarVal(varName); ok {
+	if v, ok := ctx.GetUserVarsReader().GetUserVarVal(varName); ok {
 		return v.GetInt64(), false, nil
 	}
 	return 0, true, nil
@@ -1133,7 +1115,6 @@ func (c *getRealVarFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 type builtinGetRealVarSig struct {
 	baseBuiltinFunc
-	contextopt.SessionVarsPropReader
 }
 
 func (b *builtinGetRealVarSig) Clone() builtinFunc {
@@ -1142,21 +1123,13 @@ func (b *builtinGetRealVarSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinGetRealVarSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
-}
-
 func (b *builtinGetRealVarSig) evalReal(ctx EvalContext, row chunk.Row) (float64, bool, error) {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return 0, true, err
-	}
 	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
 	varName = strings.ToLower(varName)
-	if v, ok := sessionVars.GetUserVarVal(varName); ok {
+	if v, ok := ctx.GetUserVarsReader().GetUserVarVal(varName); ok {
 		d, err := v.ToFloat64(typeCtx(ctx))
 		if err != nil {
 			return 0, false, err
@@ -1185,7 +1158,6 @@ func (c *getDecimalVarFunctionClass) getFunction(ctx BuildContext, args []Expres
 
 type builtinGetDecimalVarSig struct {
 	baseBuiltinFunc
-	contextopt.SessionVarsPropReader
 }
 
 func (b *builtinGetDecimalVarSig) Clone() builtinFunc {
@@ -1194,21 +1166,13 @@ func (b *builtinGetDecimalVarSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinGetDecimalVarSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
-}
-
 func (b *builtinGetDecimalVarSig) evalDecimal(ctx EvalContext, row chunk.Row) (*types.MyDecimal, bool, error) {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return nil, true, err
-	}
 	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, err
 	}
 	varName = strings.ToLower(varName)
-	if v, ok := sessionVars.GetUserVarVal(varName); ok {
+	if v, ok := ctx.GetUserVarsReader().GetUserVarVal(varName); ok {
 		d, err := v.ToDecimal(typeCtx(ctx))
 		if err != nil {
 			return nil, false, err
@@ -1245,7 +1209,6 @@ func (c *getTimeVarFunctionClass) getFunction(ctx BuildContext, args []Expressio
 
 type builtinGetTimeVarSig struct {
 	baseBuiltinFunc
-	contextopt.SessionVarsPropReader
 }
 
 func (b *builtinGetTimeVarSig) Clone() builtinFunc {
@@ -1254,21 +1217,13 @@ func (b *builtinGetTimeVarSig) Clone() builtinFunc {
 	return newSig
 }
 
-func (b *builtinGetTimeVarSig) RequiredOptionalEvalProps() OptionalEvalPropKeySet {
-	return b.SessionVarsPropReader.RequiredOptionalEvalProps()
-}
-
 func (b *builtinGetTimeVarSig) evalTime(ctx EvalContext, row chunk.Row) (types.Time, bool, error) {
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return types.ZeroTime, true, err
-	}
 	varName, isNull, err := b.args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.ZeroTime, isNull, err
 	}
 	varName = strings.ToLower(varName)
-	if v, ok := sessionVars.GetUserVarVal(varName); ok {
+	if v, ok := ctx.GetUserVarsReader().GetUserVarVal(varName); ok {
 		return v.GetMysqlTime(), false, nil
 	}
 	return types.ZeroTime, true, nil

--- a/pkg/expression/builtin_other_vec.go
+++ b/pkg/expression/builtin_other_vec.go
@@ -345,17 +345,14 @@ func (b *builtinGetStringVarSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 		return err
 	}
 	result.ReserveString(n)
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return err
-	}
+	userVars := ctx.GetUserVarsReader()
 	for i := 0; i < n; i++ {
 		if buf0.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.GetUserVarVal(varName); ok {
+		if v, ok := userVars.GetUserVarVal(varName); ok {
 			res, err := v.ToString()
 			if err != nil {
 				return err
@@ -385,16 +382,13 @@ func (b *builtinGetIntVarSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf0)
 	i64s := result.Int64s()
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return err
-	}
+	userVars := ctx.GetUserVarsReader()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.GetUserVarVal(varName); ok {
+		if v, ok := userVars.GetUserVarVal(varName); ok {
 			i64s[i] = v.GetInt64()
 			continue
 		}
@@ -422,16 +416,13 @@ func (b *builtinGetRealVarSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 	result.ResizeFloat64(n, false)
 	result.MergeNulls(buf0)
 	f64s := result.Float64s()
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return err
-	}
+	userVars := ctx.GetUserVarsReader()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.GetUserVarVal(varName); ok {
+		if v, ok := userVars.GetUserVarVal(varName); ok {
 			d, err := v.ToFloat64(typeCtx(ctx))
 			if err != nil {
 				return err
@@ -463,16 +454,13 @@ func (b *builtinGetDecimalVarSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	result.ResizeDecimal(n, false)
 	result.MergeNulls(buf0)
 	decs := result.Decimals()
-	sessionVars, err := b.GetSessionVars(ctx)
-	if err != nil {
-		return err
-	}
+	userVars := ctx.GetUserVarsReader()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.GetUserVarVal(varName); ok {
+		if v, ok := userVars.GetUserVarVal(varName); ok {
 			d, err := v.ToDecimal(typeCtx(ctx))
 			if err != nil {
 				return err

--- a/pkg/expression/context/context.go
+++ b/pkg/expression/context/context.go
@@ -86,6 +86,8 @@ type EvalContext interface {
 	GetDefaultWeekFormatMode() string
 	// GetDivPrecisionIncrement returns the specified value of DivPrecisionIncrement.
 	GetDivPrecisionIncrement() int
+	// GetUserVarsReader returns the `UserVarsReader` to read user vars.
+	GetUserVarsReader() variable.UserVarsReader
 	// RequestVerification verifies user privilege
 	RequestVerification(db, table, column string, priv mysql.PrivilegeType) bool
 	// RequestDynamicVerification verifies user privilege for a DYNAMIC privilege.

--- a/pkg/expression/contextsession/sessionctx.go
+++ b/pkg/expression/contextsession/sessionctx.go
@@ -298,6 +298,11 @@ func (ctx *SessionEvalContext) GetParamValue(idx int) (types.Datum, error) {
 	return params[idx], nil
 }
 
+// GetUserVarsReader returns the user variables.
+func (ctx *SessionEvalContext) GetUserVarsReader() variable.UserVarsReader {
+	return ctx.sctx.GetSessionVars().UserVars
+}
+
 // IntoStatic turns the SessionEvalContext into a StaticEvalContext.
 func (ctx *SessionEvalContext) IntoStatic() *contextstatic.StaticEvalContext {
 	return contextstatic.MakeEvalContextStatic(ctx)

--- a/pkg/expression/contextsession/sessionctx_test.go
+++ b/pkg/expression/contextsession/sessionctx_test.go
@@ -71,6 +71,7 @@ func TestSessionEvalContextBasic(t *testing.T) {
 	require.Equal(t, "0", impl.GetDefaultWeekFormatMode())
 	require.NoError(t, ctx.GetSessionVars().SetSystemVar("default_week_format", "5"))
 	require.Equal(t, "5", impl.GetDefaultWeekFormatMode())
+	require.Same(t, vars.UserVars, impl.GetUserVarsReader())
 
 	// handle warnings
 	require.Equal(t, 0, impl.WarningCount())

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -687,33 +687,87 @@ func validateReadConsistencyLevel(val string) error {
 	}
 }
 
+// UserVarsReader is used to read user defined variables.
+type UserVarsReader interface {
+	// GetUserVarVal get user defined variables' value
+	GetUserVarVal(name string) (types.Datum, bool)
+	// GetUserVarType get user defined variables' type
+	GetUserVarType(name string) (*types.FieldType, bool)
+	// Clone clones the user vars
+	Clone() UserVarsReader
+}
+
+// UserVars should implement UserVarsReader interface.
+var _ UserVarsReader = &UserVars{}
+
+// UserVars is used to provide user variable operations.
+type UserVars struct {
+	// lock is for user defined variables. values and types is read/write protected.
+	lock sync.RWMutex
+	// values stores the Datum for user variables
+	values map[string]types.Datum
+	// types stores the FieldType for user variables, it cannot be inferred from values when values have not been set yet.
+	types map[string]*types.FieldType
+}
+
+// NewUserVars creates a new user UserVars object
+func NewUserVars() *UserVars {
+	return &UserVars{
+		values: make(map[string]types.Datum),
+		types:  make(map[string]*types.FieldType),
+	}
+}
+
+// Clone clones the user vars
+func (s *UserVars) Clone() UserVarsReader {
+	cloned := NewUserVars()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	for name, userVar := range s.values {
+		cloned.values[name] = *userVar.Clone()
+	}
+	for name, userVarType := range s.types {
+		cloned.types[name] = userVarType.Clone()
+	}
+	return cloned
+}
+
 // SetUserVarVal set user defined variables' value
-func (s *SessionVars) SetUserVarVal(name string, dt types.Datum) {
-	s.userVars.lock.Lock()
-	defer s.userVars.lock.Unlock()
-	s.userVars.values[name] = dt
+func (s *UserVars) SetUserVarVal(name string, dt types.Datum) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.values[name] = dt
+}
+
+// UnsetUserVar unset an user defined variable by name.
+func (s *UserVars) UnsetUserVar(varName string) {
+	varName = strings.ToLower(varName)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.values, varName)
+	delete(s.types, varName)
 }
 
 // GetUserVarVal get user defined variables' value
-func (s *SessionVars) GetUserVarVal(name string) (types.Datum, bool) {
-	s.userVars.lock.RLock()
-	defer s.userVars.lock.RUnlock()
-	dt, ok := s.userVars.values[name]
+func (s *UserVars) GetUserVarVal(name string) (types.Datum, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	dt, ok := s.values[name]
 	return dt, ok
 }
 
 // SetUserVarType set user defined variables' type
-func (s *SessionVars) SetUserVarType(name string, ft *types.FieldType) {
-	s.userVars.lock.Lock()
-	defer s.userVars.lock.Unlock()
-	s.userVars.types[name] = ft
+func (s *UserVars) SetUserVarType(name string, ft *types.FieldType) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.types[name] = ft
 }
 
 // GetUserVarType get user defined variables' type
-func (s *SessionVars) GetUserVarType(name string) (*types.FieldType, bool) {
-	s.userVars.lock.RLock()
-	defer s.userVars.lock.RUnlock()
-	ft, ok := s.userVars.types[name]
+func (s *UserVars) GetUserVarType(name string) (*types.FieldType, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	ft, ok := s.types[name]
 	return ft, ok
 }
 
@@ -740,14 +794,7 @@ type SessionVars struct {
 	DMLBatchSize        int
 	RetryLimit          int64
 	DisableTxnAutoRetry bool
-	userVars            struct {
-		// lock is for user defined variables. values and types is read/write protected.
-		lock sync.RWMutex
-		// values stores the Datum for user variables
-		values map[string]types.Datum
-		// types stores the FieldType for user variables, it cannot be inferred from values when values have not been set yet.
-		types map[string]*types.FieldType
-	}
+	*UserVars
 	// systems variables, don't modify it directly, use GetSystemVar/SetSystemVar method.
 	systems map[string]string
 	// SysWarningCount is the system variable "warning_count", because it is on the hot path, so we extract it from the systems
@@ -2067,14 +2114,7 @@ func (connInfo *ConnectionInfo) IsSecureTransport() bool {
 // NewSessionVars creates a session vars object.
 func NewSessionVars(hctx HookContext) *SessionVars {
 	vars := &SessionVars{
-		userVars: struct {
-			lock   sync.RWMutex
-			values map[string]types.Datum
-			types  map[string]*types.FieldType
-		}{
-			values: make(map[string]types.Datum),
-			types:  make(map[string]*types.FieldType),
-		},
+		UserVars:                      NewUserVars(),
 		systems:                       make(map[string]string),
 		PreparedStmts:                 make(map[uint32]any),
 		PreparedStmtNameToID:          make(map[string]uint32),
@@ -2389,15 +2429,6 @@ func (s *SessionVars) SetStringUserVar(name string, strVal string, collation str
 		_, collation = s.GetCharsetInfo()
 		s.SetUserVarVal(name, types.NewCollationStringDatum(stringutil.Copy(strVal), collation))
 	}
-}
-
-// UnsetUserVar unset an user defined variable by name.
-func (s *SessionVars) UnsetUserVar(varName string) {
-	varName = strings.ToLower(varName)
-	s.userVars.lock.Lock()
-	defer s.userVars.lock.Unlock()
-	delete(s.userVars.values, varName)
-	delete(s.userVars.types, varName)
 }
 
 // SetLastInsertID saves the last insert id to the session context.
@@ -2787,16 +2818,16 @@ func (s *SessionVars) GetTemporaryTable(tblInfo *model.TableInfo) tableutil.Temp
 // EncodeSessionStates saves session states into SessionStates.
 func (s *SessionVars) EncodeSessionStates(_ context.Context, sessionStates *sessionstates.SessionStates) (err error) {
 	// Encode user-defined variables.
-	s.userVars.lock.RLock()
-	sessionStates.UserVars = make(map[string]*types.Datum, len(s.userVars.values))
-	sessionStates.UserVarTypes = make(map[string]*ptypes.FieldType, len(s.userVars.types))
-	for name, userVar := range s.userVars.values {
+	s.UserVars.lock.RLock()
+	sessionStates.UserVars = make(map[string]*types.Datum, len(s.UserVars.values))
+	sessionStates.UserVarTypes = make(map[string]*ptypes.FieldType, len(s.UserVars.types))
+	for name, userVar := range s.UserVars.values {
 		sessionStates.UserVars[name] = userVar.Clone()
 	}
-	for name, userVarType := range s.userVars.types {
+	for name, userVarType := range s.UserVars.types {
 		sessionStates.UserVarTypes[name] = userVarType.Clone()
 	}
-	s.userVars.lock.RUnlock()
+	s.UserVars.lock.RUnlock()
 
 	// Encode other session contexts.
 	sessionStates.PreparedStmtID = s.preparedStmtID

--- a/pkg/sessionctx/variable/session_test.go
+++ b/pkg/sessionctx/variable/session_test.go
@@ -627,3 +627,27 @@ func TestRowIDShardGenerator(t *testing.T) {
 	g.SetShardStep(5)
 	require.NotEqual(t, shard, g.GetCurrentShard(1))
 }
+
+func TestUserVars(t *testing.T) {
+	vars := variable.NewUserVars()
+	vars.SetUserVarVal("a", types.NewIntDatum(1))
+	vars.SetUserVarVal("b", types.NewStringDatum("v2"))
+	dt, ok := vars.GetUserVarVal("a")
+	require.True(t, ok)
+	require.Equal(t, types.NewIntDatum(1), dt)
+
+	vars.SetUserVarType("a", types.NewFieldType(mysql.TypeLonglong))
+	tp, ok := vars.GetUserVarType("a")
+	require.True(t, ok)
+	require.Equal(t, types.NewFieldType(mysql.TypeLonglong), tp)
+
+	vars.UnsetUserVar("a")
+	_, ok = vars.GetUserVarVal("a")
+	require.False(t, ok)
+	_, ok = vars.GetUserVarType("a")
+	require.False(t, ok)
+
+	dt, ok = vars.GetUserVarVal("b")
+	require.True(t, ok)
+	require.Equal(t, types.NewStringDatum("v2"), dt)
+}

--- a/pkg/testkit/BUILD.bazel
+++ b/pkg/testkit/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/kv",
         "//pkg/parser/ast",
         "//pkg/parser/auth",
+        "//pkg/parser/mysql",
         "//pkg/parser/terror",
         "//pkg/planner/core",
         "//pkg/planner/core/resolve",

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/session"
@@ -406,6 +407,8 @@ func (tk *TestKit) Exec(sql string, args ...any) (sqlexec.RecordSet, error) {
 // ExecWithContext executes a sql statement using the prepared stmt API
 func (tk *TestKit) ExecWithContext(ctx context.Context, sql string, args ...any) (rs sqlexec.RecordSet, err error) {
 	defer tk.Session().GetSessionVars().ClearAlloc(&tk.alloc, err != nil)
+
+	cursorExists := tk.Session().GetSessionVars().HasStatusFlag(mysql.ServerStatusCursorExists)
 	if len(args) == 0 {
 		sc := tk.session.GetSessionVars().StmtCtx
 		prevWarns := sc.GetWarnings()
@@ -419,7 +422,11 @@ func (tk *TestKit) ExecWithContext(ctx context.Context, sql string, args ...any)
 		}
 		warns := sc.GetWarnings()
 		parserWarns := warns[len(prevWarns):]
-		tk.Session().GetSessionVars().SetAlloc(tk.alloc)
+		if !cursorExists {
+			// When the cursor exists, do not use alloc pool to disable chunk reuses because multiple statements may
+			// exist in a session at the same time.
+			tk.Session().GetSessionVars().SetAlloc(tk.alloc)
+		}
 		var rs0 sqlexec.RecordSet
 		for i, stmt := range stmts {
 			var rs sqlexec.RecordSet
@@ -459,7 +466,11 @@ func (tk *TestKit) ExecWithContext(ctx context.Context, sql string, args ...any)
 		return nil, errors.Trace(err)
 	}
 	params := expression.Args2Expressions4Test(args...)
-	tk.Session().GetSessionVars().SetAlloc(tk.alloc)
+	if !cursorExists {
+		// When the cursor exists, do not use alloc pool to disable chunk reuses because multiple statements may
+		// exist in a session at the same time.
+		tk.Session().GetSessionVars().SetAlloc(tk.alloc)
+	}
 	rs, err = tk.session.ExecutePreparedStmt(ctx, stmtID, params)
 	if err != nil {
 		return rs, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55865

### What changed and how does it work?

This PR adds new method `GetUserVarsReader` to `EvalContext` so that the user vars can be read directly from the context. It has some benefits:

1. `BuildSimpleExpr` can now build expressions like `@a+1` without adding optional property `SessionVars` to the inner context.
2. We can evaluate an expression like `@a+1` or `get_var("a")` without requiring an additional property `SessionVars` in `EvalContext`.
3. Lazy cursor fetch can now support SQL with user vars.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
