### PR TITLE
ddl: remove `mock.Context` from DDL reorg

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -133,6 +133,7 @@ go_library(
         "//pkg/store/driver/txn",
         "//pkg/store/helper",
         "//pkg/table",
+        "//pkg/table/context",
         "//pkg/table/tables",
         "//pkg/tablecodec",
         "//pkg/tidb-binlog/pump_client",

--- a/pkg/ddl/backfilling_test.go
+++ b/pkg/ddl/backfilling_test.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
@@ -27,6 +28,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/deeptest"
@@ -224,13 +227,25 @@ func assertStaticExprContextEqual(t *testing.T, sctx sessionctx.Context, exprCtx
 	)
 }
 
+// newMockReorgSessCtx creates a mock session context for reorg test.
+// In old implementations, DDL is using `mock.Context` to construct the contexts used in DDL reorg.
+// After refactoring, we just need it to do test the new implementation is compatible with the old one.
+func newMockReorgSessCtx(store kv.Storage) sessionctx.Context {
+	c := mock.NewContext()
+	c.Store = store
+	c.GetSessionVars().SetStatusFlag(mysql.ServerStatusAutocommit, false)
+	tz := *time.UTC
+	c.ResetSessionAndStmtTimeZone(&tz)
+	return c
+}
+
 // TestReorgExprContext is used in refactor stage to make sure the newReorgExprCtx() is
-// compatible with newReorgSessCtx(nil).GetExprCtx() to make it safe to replace `mock.Context` usage.
+// compatible with newMockReorgSessCtx(nil).GetExprCtx() to make it safe to replace `mock.Context` usage.
 // After refactor, the TestReorgExprContext can be removed.
 func TestReorgExprContext(t *testing.T) {
 	// test default expr context
 	store := &mockStorage{client: &mock.Client{}}
-	sctx := newReorgSessCtx(store)
+	sctx := newMockReorgSessCtx(store)
 	defaultCtx := newReorgExprCtx()
 	// should use an empty static warn handler by default
 	evalCtx := defaultCtx.GetStaticEvalCtx()
@@ -255,7 +270,7 @@ func TestReorgExprContext(t *testing.T) {
 			ResourceGroupName: "rg2",
 		},
 	} {
-		sctx = newReorgSessCtx(store)
+		sctx = newMockReorgSessCtx(store)
 		require.NoError(t, initSessCtx(sctx, &reorg))
 		ctx, err := newReorgExprCtxWithReorgMeta(&reorg, sctx.GetSessionVars().StmtCtx.WarnHandler)
 		require.NoError(t, err)
@@ -276,6 +291,68 @@ func TestReorgExprContext(t *testing.T) {
 		require.NotEqual(t, defaultTypeCtx.Flags(), tc.Flags())
 		require.NotEqual(t, defaultErrCtx.LevelMap(), ec.LevelMap())
 	}
+}
+
+func TestReorgTableMutateContext(t *testing.T) {
+	originalRowFmt := variable.GetDDLReorgRowFormat()
+	defer variable.SetDDLReorgRowFormat(originalRowFmt)
+
+	exprCtx := contextstatic.NewStaticExprContext()
+
+	assertTblCtxMatchSessionCtx := func(ctx table.MutateContext, sctx sessionctx.Context) {
+		sctxTblCtx := sctx.GetTableCtx()
+		require.Equal(t, uint64(0), ctx.ConnectionID())
+		require.Equal(t, sctxTblCtx.ConnectionID(), ctx.ConnectionID())
+
+		require.False(t, ctx.InRestrictedSQL())
+		require.Equal(t, sctxTblCtx.InRestrictedSQL(), ctx.InRestrictedSQL())
+
+		require.Equal(t, variable.AssertionLevelOff, ctx.TxnAssertionLevel())
+		require.Equal(t, sctxTblCtx.TxnAssertionLevel(), ctx.TxnAssertionLevel())
+
+		require.Equal(t, variable.GetDDLReorgRowFormat() != variable.DefTiDBRowFormatV1, ctx.GetRowEncodingConfig().IsRowLevelChecksumEnabled)
+		require.Equal(t, variable.GetDDLReorgRowFormat() != variable.DefTiDBRowFormatV1, ctx.GetRowEncodingConfig().RowEncoder.Enable)
+		require.Equal(t, sctxTblCtx.GetRowEncodingConfig(), ctx.GetRowEncodingConfig())
+
+		require.NotNil(t, ctx.GetMutateBuffers())
+		require.Equal(t, sctxTblCtx.GetMutateBuffers(), ctx.GetMutateBuffers())
+
+		require.Equal(t, variable.DefTiDBShardAllocateStep, ctx.GetRowIDShardGenerator().GetShardStep())
+		sctx.GetSessionVars().TxnCtx.StartTS = 123 // make sure GetRowIDShardGenerator() pass assert
+		require.Equal(t, sctxTblCtx.GetRowIDShardGenerator().GetShardStep(), ctx.GetRowIDShardGenerator().GetShardStep())
+		require.GreaterOrEqual(t, ctx.GetRowIDShardGenerator().GetCurrentShard(1), int64(0))
+
+		alloc1, ok := sctxTblCtx.GetReservedRowIDAlloc()
+		require.True(t, ok)
+		alloc2, ok := ctx.GetReservedRowIDAlloc()
+		require.True(t, ok)
+		require.Equal(t, alloc1, alloc2)
+		require.True(t, alloc2.Exhausted())
+
+		binlog, ok := ctx.GetBinlogSupport()
+		require.False(t, ok)
+		require.Nil(t, binlog)
+		statistics, ok := ctx.GetStatisticsSupport()
+		require.False(t, ok)
+		require.Nil(t, statistics)
+		cached, ok := ctx.GetCachedTableSupport()
+		require.False(t, ok)
+		require.Nil(t, cached)
+		temp, ok := ctx.GetTemporaryTableSupport()
+		require.False(t, ok)
+		require.Nil(t, temp)
+		dml, ok := ctx.GetExchangePartitionDMLSupport()
+		require.False(t, ok)
+		require.Nil(t, dml)
+	}
+
+	// test when the row format is v1
+	variable.SetDDLReorgRowFormat(variable.DefTiDBRowFormatV1)
+	sctx := newMockReorgSessCtx(&mockStorage{client: &mock.Client{}})
+	require.NoError(t, initSessCtx(sctx, &model.DDLReorgMeta{}))
+	ctx := newReorgTableMutateContext(exprCtx)
+	require.Same(t, exprCtx, ctx.GetExprCtx())
+	assertTblCtxMatchSessionCtx(ctx, sctx)
 }
 
 type mockStorage struct {
@@ -313,13 +390,13 @@ func assertDistSQLCtxEqual(t *testing.T, expected *distsqlctx.DistSQLContext, ac
 }
 
 // TestReorgExprContext is used in refactor stage to make sure the newDefaultReorgDistSQLCtx() is
-// compatible with newReorgSessCtx(nil).GetDistSQLCtx() to make it safe to replace `mock.Context` usage.
+// compatible with newMockReorgSessCtx(nil).GetDistSQLCtx() to make it safe to replace `mock.Context` usage.
 // After refactor, the TestReorgExprContext can be removed.
 func TestReorgDistSQLCtx(t *testing.T) {
 	store := &mockStorage{client: &mock.Client{}}
 
 	// test default dist sql context
-	expected := newReorgSessCtx(store).GetDistSQLCtx()
+	expected := newMockReorgSessCtx(store).GetDistSQLCtx()
 	defaultCtx := newDefaultReorgDistSQLCtx(store.client, expected.WarnHandler)
 	assertDistSQLCtxEqual(t, expected, defaultCtx)
 
@@ -339,7 +416,7 @@ func TestReorgDistSQLCtx(t *testing.T) {
 			ResourceGroupName: "rg2",
 		},
 	} {
-		sctx := newReorgSessCtx(store)
+		sctx := newMockReorgSessCtx(store)
 		require.NoError(t, initSessCtx(sctx, &reorg))
 		expected = sctx.GetDistSQLCtx()
 		ctx, err := newReorgDistSQLCtxWithReorgMeta(store.client, &reorg, expected.WarnHandler)

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -606,17 +606,10 @@ type updateColumnWorker struct {
 }
 
 func newUpdateColumnWorker(id int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*updateColumnWorker, error) {
-	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, "update_col_rate", false)
+	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, "update_col_rate", false, true)
 	if err != nil {
 		return nil, err
 	}
-
-	sessCtx := bCtx.sessCtx
-	sessCtx.GetSessionVars().StmtCtx.SetTypeFlags(
-		sessCtx.GetSessionVars().StmtCtx.TypeFlags().
-			WithIgnoreZeroDateErr(!reorgInfo.ReorgMeta.SQLMode.HasStrictMode()))
-	bCtx.exprCtx = bCtx.sessCtx.GetExprCtx()
-	bCtx.tblCtx = bCtx.sessCtx.GetTableCtx()
 
 	if !bytes.Equal(reorgInfo.currElement.TypeKey, meta.ColumnElementKey) {
 		logutil.DDLLogger().Error("Element type for updateColumnWorker incorrect", zap.String("jobQuery", reorgInfo.Query),

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2397,7 +2397,7 @@ type cleanUpIndexWorker struct {
 }
 
 func newCleanUpIndexWorker(id int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*cleanUpIndexWorker, error) {
-	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, "cleanup_idx_rate", false)
+	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, "cleanup_idx_rate", false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -3600,7 +3600,7 @@ type reorgPartitionWorker struct {
 }
 
 func newReorgPartitionWorker(i int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*reorgPartitionWorker, error) {
-	bCtx, err := newBackfillCtx(i, reorgInfo, reorgInfo.SchemaName, t, jc, "reorg_partition_rate", false)
+	bCtx, err := newBackfillCtx(i, reorgInfo, reorgInfo.SchemaName, t, jc, "reorg_partition_rate", false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -246,6 +246,8 @@ func newReorgTableMutateContext(exprCtx exprctx.ExprContext) table.MutateContext
 		exprCtx:        exprCtx,
 		encodingConfig: encodingConfig,
 		mutateBuffers:  tbctx.NewMutateBuffers(&variable.WriteStmtBufs{}),
+		// Though currently, `RowIDShardGenerator` is not required in DDL reorg,
+		// we still provide a valid one to keep the context complete and to avoid panic if it is used in the future.
 		shardID: variable.NewRowIDShardGenerator(
 			rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404
 			variable.DefTiDBShardAllocateStep,

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,17 +33,21 @@ import (
 	"github.com/pingcap/tidb/pkg/distsql"
 	distsqlctx "github.com/pingcap/tidb/pkg/distsql/context"
 	"github.com/pingcap/tidb/pkg/errctx"
+	exprctx "github.com/pingcap/tidb/pkg/expression/context"
 	"github.com/pingcap/tidb/pkg/expression/contextstatic"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
+	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/table"
+	tbctx "github.com/pingcap/tidb/pkg/table/context"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
@@ -53,6 +58,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/ranger"
+	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tidb/pkg/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	atomicutil "go.uber.org/atomic"
@@ -121,6 +127,132 @@ func newReorgExprCtxWithReorgMeta(reorgMeta *model.DDLReorgMeta, warnHandler con
 	return ctx.Apply(contextstatic.WithEvalCtx(evalCtx)), nil
 }
 
+// reorgTableMutateContext implements table.MutateContext for reorganization.
+type reorgTableMutateContext struct {
+	exprCtx            exprctx.ExprContext
+	encodingConfig     tbctx.RowEncodingConfig
+	mutateBuffers      *tbctx.MutateBuffers
+	shardID            *variable.RowIDShardGenerator
+	reservedRowIDAlloc stmtctx.ReservedRowIDAlloc
+}
+
+// AlternativeAllocators implements table.MutateContext.AlternativeAllocators.
+func (*reorgTableMutateContext) AlternativeAllocators(*model.TableInfo) (autoid.Allocators, bool) {
+	// No alternative allocators for all tables because temporary tables
+	// are not supported (temporary tables do not have any data in TiKV) in reorganization.
+	return autoid.Allocators{}, false
+}
+
+// GetExprCtx implements table.MutateContext.GetExprCtx.
+func (ctx *reorgTableMutateContext) GetExprCtx() exprctx.ExprContext {
+	return ctx.exprCtx
+}
+
+// ConnectionID implements table.MutateContext.ConnectionID.
+func (*reorgTableMutateContext) ConnectionID() uint64 {
+	return 0
+}
+
+// InRestrictedSQL implements table.MutateContext.InRestrictedSQL.
+func (*reorgTableMutateContext) InRestrictedSQL() bool {
+	return false
+}
+
+// TxnAssertionLevel implements table.MutateContext.TxnAssertionLevel.
+func (*reorgTableMutateContext) TxnAssertionLevel() variable.AssertionLevel {
+	// Because only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method,
+	// we can just return `AssertionLevelOff`.
+	return variable.AssertionLevelOff
+}
+
+// EnableMutationChecker implements table.MutateContext.EnableMutationChecker.
+func (*reorgTableMutateContext) EnableMutationChecker() bool {
+	// Because only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method,
+	// we can just return false.
+	return false
+}
+
+// GetRowEncodingConfig implements table.MutateContext.GetRowEncodingConfig.
+func (ctx *reorgTableMutateContext) GetRowEncodingConfig() tbctx.RowEncodingConfig {
+	return ctx.encodingConfig
+}
+
+// GetMutateBuffers implements table.MutateContext.GetMutateBuffers.
+func (ctx *reorgTableMutateContext) GetMutateBuffers() *tbctx.MutateBuffers {
+	return ctx.mutateBuffers
+}
+
+// GetRowIDShardGenerator implements table.MutateContext.GetRowIDShardGenerator.
+func (ctx *reorgTableMutateContext) GetRowIDShardGenerator() *variable.RowIDShardGenerator {
+	return ctx.shardID
+}
+
+// GetReservedRowIDAlloc implements table.MutateContext.GetReservedRowIDAlloc.
+func (ctx *reorgTableMutateContext) GetReservedRowIDAlloc() (*stmtctx.ReservedRowIDAlloc, bool) {
+	return &ctx.reservedRowIDAlloc, true
+}
+
+// GetBinlogSupport implements table.MutateContext.GetBinlogSupport.
+func (*reorgTableMutateContext) GetBinlogSupport() (tbctx.BinlogSupport, bool) {
+	// We can just return `(nil, false)` because:
+	// - Only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method.
+	// - Data change in DDL reorganization should not write binlog.
+	return nil, false
+}
+
+// GetStatisticsSupport implements table.MutateContext.GetStatisticsSupport.
+func (*reorgTableMutateContext) GetStatisticsSupport() (tbctx.StatisticsSupport, bool) {
+	// We can just return `(nil, false)` because:
+	// - Only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method.
+	// - DDL reorg do need to collect statistics in this way.
+	return nil, false
+}
+
+// GetCachedTableSupport implements table.MutateContext.GetCachedTableSupport.
+func (*reorgTableMutateContext) GetCachedTableSupport() (tbctx.CachedTableSupport, bool) {
+	// We can just return `(nil, false)` because:
+	// - Only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method.
+	// - It is not allowed to execute DDL on a cached table.
+	return nil, false
+}
+
+// GetTemporaryTableSupport implements table.MutateContext.GetTemporaryTableSupport.
+func (*reorgTableMutateContext) GetTemporaryTableSupport() (tbctx.TemporaryTableSupport, bool) {
+	// We can just return `(nil, false)` because:
+	// - Only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method.
+	// - Temporary tables do not have any data in TiKV.
+	return nil, false
+}
+
+// GetExchangePartitionDMLSupport implements table.MutateContext.GetExchangePartitionDMLSupport.
+func (*reorgTableMutateContext) GetExchangePartitionDMLSupport() (tbctx.ExchangePartitionDMLSupport, bool) {
+	// We can just return `(nil, false)` because:
+	// - Only `index.Create` and `index.Delete` are invoked in reorganization which does not use this method.
+	return nil, false
+}
+
+// newReorgTableMutateContext creates a new table.MutateContext for reorganization.
+func newReorgTableMutateContext(exprCtx exprctx.ExprContext) table.MutateContext {
+	rowEncoder := &rowcodec.Encoder{
+		Enable: variable.GetDDLReorgRowFormat() != variable.DefTiDBRowFormatV1,
+	}
+
+	encodingConfig := tbctx.RowEncodingConfig{
+		IsRowLevelChecksumEnabled: rowEncoder.Enable,
+		RowEncoder:                rowEncoder,
+	}
+
+	return &reorgTableMutateContext{
+		exprCtx:        exprCtx,
+		encodingConfig: encodingConfig,
+		mutateBuffers:  tbctx.NewMutateBuffers(&variable.WriteStmtBufs{}),
+		shardID: variable.NewRowIDShardGenerator(
+			rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404
+			variable.DefTiDBShardAllocateStep,
+		),
+	}
+}
+
 func reorgTypeFlagsWithSQLMode(mode mysql.SQLMode) types.Flags {
 	return types.StrictFlags.
 		WithTruncateAsWarning(!mode.HasStrictMode()).
@@ -146,17 +278,6 @@ func reorgTimeZoneWithTzLoc(tzLoc *model.TimeZoneLocation) (*time.Location, erro
 		return timeutil.SystemLocation(), nil
 	}
 	return tzLoc.GetLocation()
-}
-
-func newReorgSessCtx(store kv.Storage) sessionctx.Context {
-	c := mock.NewContext()
-	c.Store = store
-	c.GetSessionVars().SetStatusFlag(mysql.ServerStatusAutocommit, false)
-
-	tz := *time.UTC
-	c.GetSessionVars().TimeZone = &tz
-	c.GetSessionVars().StmtCtx.SetTimeZone(&tz)
-	return c
 }
 
 // ReorgWaitTimeout is the timeout that wait ddl in write reorganization stage.

--- a/pkg/table/context/BUILD.bazel
+++ b/pkg/table/context/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/tablecodec",
         "//pkg/types",
         "//pkg/util/chunk",
+        "//pkg/util/intest",
         "//pkg/util/rowcodec",
         "//pkg/util/tableutil",
         "@com_github_pingcap_tipb//go-binlog",

--- a/pkg/table/context/buffers.go
+++ b/pkg/table/context/buffers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 )
 
@@ -156,6 +157,7 @@ type MutateBuffers struct {
 
 // NewMutateBuffers creates a new `MutateBuffers`.
 func NewMutateBuffers(stmtBufs *variable.WriteStmtBufs) *MutateBuffers {
+	intest.AssertNotNil(stmtBufs)
 	return &MutateBuffers{
 		stmtBufs: stmtBufs,
 		encodeRow: &EncodeRowBuffer{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53388

### What changed and how does it work?

This PR:

- Introduces `reorgTableMutateContext` as the `table.MutateContext` to provide context for DDL reorg
- remove `newReorgSessCtx` from production code.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
