### PR TITLE
*: fix affected rows metrics to make it compatiable with multi-queries

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1467,6 +1467,22 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 	a.Ctx.ReportUsageStats()
 }
 
+func (a *ExecStmt) recordAffectedRows2Metrics() {
+	sessVars := a.Ctx.GetSessionVars()
+	if affectedRows := sessVars.StmtCtx.AffectedRows(); affectedRows > 0 {
+		switch sessVars.StmtCtx.StmtType {
+		case "Insert":
+			metrics.AffectedRowsCounterInsert.Add(float64(affectedRows))
+		case "Replace":
+			metrics.AffectedRowsCounterReplace.Add(float64(affectedRows))
+		case "Delete":
+			metrics.AffectedRowsCounterDelete.Add(float64(affectedRows))
+		case "Update":
+			metrics.AffectedRowsCounterUpdate.Add(float64(affectedRows))
+		}
+	}
+}
+
 func (a *ExecStmt) recordLastQueryInfo(err error) {
 	sessVars := a.Ctx.GetSessionVars()
 	// Record diagnostic information for DML statements

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1421,6 +1421,7 @@ func (a *ExecStmt) FinishExecuteStmt(txnTS uint64, err error, hasMoreResults boo
 	}
 	a.updatePrevStmt()
 	a.recordLastQueryInfo(err)
+	a.recordAffectedRows2Metrics()
 	a.observePhaseDurations(sessVars.InRestrictedSQL, execDetail.CommitDetail)
 	executeDuration := sessVars.GetExecuteDuration()
 	if sessVars.InRestrictedSQL {

--- a/pkg/metrics/executor.go
+++ b/pkg/metrics/executor.go
@@ -39,6 +39,12 @@ var (
 
 	// MppCoordinatorLatency records latencies of mpp coordinator operations.
 	MppCoordinatorLatency *prometheus.HistogramVec
+
+	AffectedRowsCounter        *prometheus.CounterVec
+	AffectedRowsCounterInsert  prometheus.Counter
+	AffectedRowsCounterUpdate  prometheus.Counter
+	AffectedRowsCounterDelete  prometheus.Counter
+	AffectedRowsCounterReplace prometheus.Counter
 )
 
 // InitExecutorMetrics initializes excutor metrics.
@@ -101,4 +107,17 @@ func InitExecutorMetrics() {
 			Help:      "Bucketed histogram of processing time (ms) of mpp coordinator operations.",
 			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 28), // 1ms ~ 1.5days
 		}, []string{LblType})
+
+	AffectedRowsCounter = NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "executor",
+			Name:      "affected_rows",
+			Help:      "Counters of server affected rows.",
+		}, []string{LblSQLType})
+
+	AffectedRowsCounterInsert = AffectedRowsCounter.WithLabelValues("Insert")
+	AffectedRowsCounterUpdate = AffectedRowsCounter.WithLabelValues("Update")
+	AffectedRowsCounterDelete = AffectedRowsCounter.WithLabelValues("Delete")
+	AffectedRowsCounterReplace = AffectedRowsCounter.WithLabelValues("Replace")
 }

--- a/pkg/metrics/executor.go
+++ b/pkg/metrics/executor.go
@@ -40,6 +40,7 @@ var (
 	// MppCoordinatorLatency records latencies of mpp coordinator operations.
 	MppCoordinatorLatency *prometheus.HistogramVec
 
+	// AffectedRowsCounter records the number of affected rows.
 	AffectedRowsCounter        *prometheus.CounterVec
 	AffectedRowsCounterInsert  prometheus.Counter
 	AffectedRowsCounterUpdate  prometheus.Counter

--- a/pkg/metrics/executor.go
+++ b/pkg/metrics/executor.go
@@ -41,10 +41,18 @@ var (
 	MppCoordinatorLatency *prometheus.HistogramVec
 
 	// AffectedRowsCounter records the number of affected rows.
-	AffectedRowsCounter        *prometheus.CounterVec
-	AffectedRowsCounterInsert  prometheus.Counter
-	AffectedRowsCounterUpdate  prometheus.Counter
-	AffectedRowsCounterDelete  prometheus.Counter
+	AffectedRowsCounter *prometheus.CounterVec
+
+	// AffectedRowsCounterInsert records the number of insert affected rows.
+	AffectedRowsCounterInsert prometheus.Counter
+
+	// AffectedRowsCounterUpdate records the number of update affected rows.
+	AffectedRowsCounterUpdate prometheus.Counter
+
+	// AffectedRowsCounterDelete records the number of delete affected rows.
+	AffectedRowsCounterDelete prometheus.Counter
+
+	// AffectedRowsCounterReplace records the number of replace affected rows.
 	AffectedRowsCounterReplace prometheus.Counter
 )
 

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -727,7 +727,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(tidb_server_affected_rows{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (sql_type)",
+              "expr": "sum(rate(tidb_executor_affected_rows{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (sql_type)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -737,7 +737,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(tidb_server_affected_rows{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m]))",
+              "expr": "sum(rate(tidb_executor_affected_rows{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "total",

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -32,7 +32,6 @@ var (
 	QueryRPCHistogram          *prometheus.HistogramVec
 	QueryProcessedKeyHistogram *prometheus.HistogramVec
 	QueryTotalCounter          *prometheus.CounterVec
-	AffectedRowsCounter        *prometheus.CounterVec
 	ConnGauge                  *prometheus.GaugeVec
 	DisconnectionCounter       *prometheus.CounterVec
 	PreparedStmtGauge          prometheus.Gauge
@@ -119,14 +118,6 @@ func InitServerMetrics() {
 			Name:      "query_total",
 			Help:      "Counter of queries.",
 		}, []string{LblType, LblResult, LblResourceGroup})
-
-	AffectedRowsCounter = NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "tidb",
-			Subsystem: "server",
-			Name:      "affected_rows",
-			Help:      "Counters of server affected rows.",
-		}, []string{LblSQLType})
 
 	ConnGauge = NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1258,17 +1258,6 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 		sqlType = stmtType
 	}
 
-	switch sqlType {
-	case "Insert":
-		server_metrics.AffectedRowsCounterInsert.Add(float64(affectedRows))
-	case "Replace":
-		server_metrics.AffectedRowsCounterReplace.Add(float64(affectedRows))
-	case "Delete":
-		server_metrics.AffectedRowsCounterDelete.Add(float64(affectedRows))
-	case "Update":
-		server_metrics.AffectedRowsCounterUpdate.Add(float64(affectedRows))
-	}
-
 	for _, dbName := range session.GetDBNames(vars) {
 		metrics.QueryDurationHistogram.WithLabelValues(sqlType, dbName, vars.StmtCtx.ResourceGroupName).Observe(cost.Seconds())
 		metrics.QueryRPCHistogram.WithLabelValues(sqlType, dbName).Observe(float64(vars.StmtCtx.GetExecDetails().RequestCount))

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -35,11 +35,6 @@ var (
 	ConnIdleDurationHistogramNotInTxn prometheus.Observer
 	ConnIdleDurationHistogramInTxn    prometheus.Observer
 
-	AffectedRowsCounterInsert  prometheus.Counter
-	AffectedRowsCounterUpdate  prometheus.Counter
-	AffectedRowsCounterDelete  prometheus.Counter
-	AffectedRowsCounterReplace prometheus.Counter
-
 	InPacketBytes  prometheus.Counter
 	OutPacketBytes prometheus.Counter
 )
@@ -120,11 +115,6 @@ func InitMetricsVars() {
 
 	ConnIdleDurationHistogramNotInTxn = metrics.ConnIdleDurationHistogram.WithLabelValues("0")
 	ConnIdleDurationHistogramInTxn = metrics.ConnIdleDurationHistogram.WithLabelValues("1")
-
-	AffectedRowsCounterInsert = metrics.AffectedRowsCounter.WithLabelValues("Insert")
-	AffectedRowsCounterUpdate = metrics.AffectedRowsCounter.WithLabelValues("Update")
-	AffectedRowsCounterDelete = metrics.AffectedRowsCounter.WithLabelValues("Delete")
-	AffectedRowsCounterReplace = metrics.AffectedRowsCounter.WithLabelValues("Replace")
 
 	InPacketBytes = metrics.PacketIOCounter.WithLabelValues("In")
 	OutPacketBytes = metrics.PacketIOCounter.WithLabelValues("Out")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55875

Problem Summary:

### What changed and how does it work?
Set it in executor.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. start a cluster
2. use multi-queries to insert data, e.g. insert; insert; insert;
3. compare QPS(insert) and Affected Rows(insert)

This PR:
<img width="1806" alt="image" src="https://github.com/user-attachments/assets/44890403-4eb3-415a-aac2-298839d4f134">

Master:
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/8d1c11c8-1aeb-4b8f-b0df-ef2b638cfdc4">

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
