### PR TITLE
importinto: check column assignment expressions in `import into ...`

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -132,6 +132,8 @@ go_library(
         "//pkg/infoschema/context",
         "//pkg/keyspace",
         "//pkg/kv",
+        "//pkg/lightning/backend/encode",
+        "//pkg/lightning/backend/kv",
         "//pkg/lightning/log",
         "//pkg/lightning/mydump",
         "//pkg/meta",

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -15,10 +15,16 @@
 package executor_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/executor"
+	"github.com/pingcap/tidb/pkg/executor/importer"
+	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/sem"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSecurityEnhancedMode(t *testing.T) {
@@ -32,4 +38,63 @@ func TestSecurityEnhancedMode(t *testing.T) {
 	// When SEM is enabled these features are restricted to all users
 	// regardless of what privileges they have available.
 	tk.MustGetErrMsg("IMPORT INTO test.t FROM '/file.csv'", "[planner:8132]Feature 'IMPORT INTO from server disk' is not supported when security enhanced mode is enabled")
+}
+
+func TestImportIntoValidateColAssignmentsWithEncodeCtx(t *testing.T) {
+	cases := []struct {
+		exprs []string
+		error string
+	}{
+		{
+			exprs: []string{"'x'", "1+@1", "concat('hello', 'world')", "getvar('var1')"},
+		},
+		{
+			exprs: []string{"setvar('a', 'b')"},
+			error: "FUNCTION setvar is not supported in IMPORT INTO column assignment, index 0",
+		},
+		{
+			exprs: []string{"current_user()"},
+			error: "FUNCTION current_user is not supported in IMPORT INTO column assignment, index 0",
+		},
+		{
+			exprs: []string{"current_role()"},
+			error: "FUNCTION current_role is not supported in IMPORT INTO column assignment, index 0",
+		},
+		{
+			exprs: []string{"connection_id()"},
+			error: "FUNCTION connection_id is not supported in IMPORT INTO column assignment, index 0",
+		},
+		{
+			exprs: []string{"1", "tidb_is_ddl_owner()"},
+			error: "FUNCTION tidb_is_ddl_owner is not supported in IMPORT INTO column assignment, index 1",
+		},
+		{
+			exprs: []string{"sleep(1)"},
+			error: "FUNCTION sleep is not supported in IMPORT INTO column assignment, index 0",
+		},
+		{
+			exprs: []string{"LAST_INSERT_ID()"},
+			error: "FUNCTION last_insert_id is not supported in IMPORT INTO column assignment, index 0",
+		},
+	}
+
+	for _, c := range cases {
+		msg := strings.Join(c.exprs, ",")
+		assigns := make([]*ast.Assignment, 0, len(c.exprs))
+		for _, exprStr := range c.exprs {
+			stmt, err := parser.New().ParseOneStmt("select "+exprStr, "", "")
+			require.NoError(t, err, msg)
+			expr := stmt.(*ast.SelectStmt).Fields.Fields[0].Expr
+			assigns = append(assigns, &ast.Assignment{
+				Expr: expr,
+			})
+		}
+
+		err := executor.ValidateImportIntoColAssignmentsWithEncodeCtx(&importer.Plan{}, assigns)
+		if c.error == "" {
+			require.NoError(t, err, msg)
+		} else {
+			require.EqualError(t, err, c.error, msg)
+		}
+	}
 }

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1297,20 +1297,11 @@ func (e *LoadDataController) CreateColAssignExprs(planCtx planctx.PlanContext) (
 	_ []contextutil.SQLWarn,
 	retErr error,
 ) {
-	var (
-		i      int
-		assign *ast.Assignment
-	)
-	// TODO(lance6716): indeterministic function should also return error
-	defer tidbutil.Recover("load-data/import-into", "CreateColAssignExprs", func() {
-		retErr = errors.Errorf("can't use function at SET index %d", i)
-	}, false)
-
 	e.colAssignMu.Lock()
 	defer e.colAssignMu.Unlock()
 	res := make([]expression.Expression, 0, len(e.ColumnAssignments))
 	allWarnings := []contextutil.SQLWarn{}
-	for i, assign = range e.ColumnAssignments {
+	for _, assign := range e.ColumnAssignments {
 		newExpr, err := plannerutil.RewriteAstExprWithPlanCtx(planCtx, assign.Expr, nil, nil, false)
 		// col assign expr warnings is static, we should generate it for each row processed.
 		// so we save it and clear it here.
@@ -1332,21 +1323,11 @@ func (e *LoadDataController) CreateColAssignExprs(planCtx planctx.PlanContext) (
 //   - Aggregate functions
 //   - Other special functions used in some specified queries such as `GROUPING`, `VALUES` ...
 func (e *LoadDataController) CreateColAssignSimpleExprs(ctx expression.BuildContext) (_ []expression.Expression, _ []contextutil.SQLWarn, retErr error) {
-	var (
-		i      int
-		assign *ast.Assignment
-	)
-
-	// TODO(lance6716): indeterministic function should also return error
-	defer tidbutil.Recover("load-data/import-into", "CreateColAssignExprs", func() {
-		retErr = errors.Errorf("can't use function at SET index %d", i)
-	}, false)
-
 	e.colAssignMu.Lock()
 	defer e.colAssignMu.Unlock()
 	res := make([]expression.Expression, 0, len(e.ColumnAssignments))
 	var allWarnings []contextutil.SQLWarn
-	for i, assign = range e.ColumnAssignments {
+	for _, assign := range e.ColumnAssignments {
 		newExpr, err := expression.BuildSimpleExpr(ctx, assign.Expr)
 		// col assign expr warnings is static, we should generate it for each row processed.
 		// so we save it and clear it here.

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4327,6 +4327,93 @@ var (
 	ImportIntoDataSource = "data source"
 )
 
+// importIntoCollAssignmentChecker implements ast.Visitor interface.
+// It is used to check the column assignment expressions in IMPORT INTO statement.
+// Currently, the import into column assignment only supports some simple expressions.
+type importIntoCollAssignmentChecker struct {
+	idx        int
+	err        error
+	neededVars map[string]int
+}
+
+func newImportIntoCollAssignmentChecker() *importIntoCollAssignmentChecker {
+	return &importIntoCollAssignmentChecker{neededVars: make(map[string]int)}
+}
+
+// checkImportIntoColAssignments checks the column assignment expressions in IMPORT INTO statement.
+func checkImportIntoColAssignments(assignments []*ast.Assignment) (map[string]int, error) {
+	checker := newImportIntoCollAssignmentChecker()
+	for i, assign := range assignments {
+		checker.idx = i
+		assign.Expr.Accept(checker)
+		if checker.err != nil {
+			break
+		}
+	}
+	return checker.neededVars, checker.err
+}
+
+// Enter implements ast.Visitor interface.
+func (*importIntoCollAssignmentChecker) Enter(node ast.Node) (ast.Node, bool) {
+	return node, false
+}
+
+// Leave implements ast.Visitor interface.
+func (v *importIntoCollAssignmentChecker) Leave(node ast.Node) (ast.Node, bool) {
+	switch n := node.(type) {
+	case *ast.ColumnNameExpr:
+		v.err = errors.Errorf("COLUMN reference is not supported in IMPORT INTO column assignment, index %d", v.idx)
+		return n, false
+	case *ast.SubqueryExpr:
+		v.err = errors.Errorf("subquery is not supported in IMPORT INTO column assignment, index %d", v.idx)
+		return n, false
+	case *ast.VariableExpr:
+		if n.IsSystem {
+			v.err = errors.Errorf("system variable is not supported in IMPORT INTO column assignment, index %d", v.idx)
+			return n, false
+		}
+		if n.Value != nil {
+			v.err = errors.Errorf("setting a variable in IMPORT INTO column assignment is not supported, index %d", v.idx)
+			return n, false
+		}
+		v.neededVars[strings.ToLower(n.Name)] = v.idx
+	case *ast.DefaultExpr:
+		v.err = errors.Errorf("FUNCTION default is not supported in IMPORT INTO column assignment, index %d", v.idx)
+		return n, false
+	case *ast.WindowFuncExpr:
+		v.err = errors.Errorf("window FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.Name, v.idx)
+		return n, false
+	case *ast.AggregateFuncExpr:
+		v.err = errors.Errorf("aggregate FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.F, v.idx)
+		return n, false
+	case *ast.FuncCallExpr:
+		fnName := n.FnName.L
+		switch fnName {
+		case ast.Grouping:
+			v.err = errors.Errorf("FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.FnName.O, v.idx)
+			return n, false
+		case ast.GetVar:
+			if len(n.Args) > 0 {
+				val, ok := n.Args[0].(*driver.ValueExpr)
+				if !ok || val.Kind() != types.KindString {
+					v.err = errors.Errorf("the argument of getvar should be a constant string in IMPORT INTO column assignment, index %d", v.idx)
+					return n, false
+				}
+				v.neededVars[strings.ToLower(val.GetString())] = v.idx
+			}
+		default:
+			if !expression.IsFunctionSupported(fnName) {
+				v.err = errors.Errorf("FUNCTION %s is not supported in IMPORT INTO column assignment, index %d", n.FnName.O, v.idx)
+				return n, false
+			}
+		}
+	case *ast.ValuesExpr:
+		v.err = errors.Errorf("VALUES is not supported in IMPORT INTO column assignment, index %d", v.idx)
+		return n, false
+	}
+	return node, v.err == nil
+}
+
 func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStmt) (base.Plan, error) {
 	mockTablePlan := logicalop.LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
 	var (
@@ -4356,24 +4443,18 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 		}
 		options = append(options, &loadDataOpt)
 	}
-	// TODO(lance6716): check functions
-	neededVars := make(map[string]int)
-	for i, a := range ld.ColumnAssignments {
-		switch v := a.Expr.(type) {
-		case *ast.SubqueryExpr:
-			return nil, errors.Errorf(
-				"subquery is not supported in IMPORT INTO column assignment, index %d", i,
-			)
-		case *ast.VariableExpr:
-			neededVars[v.Name] = i
-		}
+
+	neededVars, err := checkImportIntoColAssignments(ld.ColumnAssignments)
+	if err != nil {
+		return nil, err
 	}
+
 	for _, v := range ld.ColumnsAndUserVars {
 		userVar := v.UserVar
 		if userVar == nil {
 			continue
 		}
-		delete(neededVars, userVar.Name)
+		delete(neededVars, strings.ToLower(userVar.Name))
 	}
 	if len(neededVars) > 0 {
 		valuesStr := make([]string, 0, len(neededVars))

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -753,3 +753,125 @@ func TestRequireInsertAndSelectPriv(t *testing.T) {
 	require.Equal(t, mysql.InsertPriv, pb.visitInfo[0].privilege)
 	require.Equal(t, mysql.SelectPriv, pb.visitInfo[1].privilege)
 }
+
+func TestImportIntoCollAssignmentChecker(t *testing.T) {
+	cases := []struct {
+		expr       string
+		error      string
+		neededVars []string
+	}{
+		{
+			expr:       "@a+1",
+			neededVars: []string{"a"},
+		},
+		{
+			expr:       "@b+@c+@1",
+			neededVars: []string{"b", "c", "1"},
+		},
+		{
+			expr: "instr(substr(concat_ws('','b','~~'), 6)) + sysdate()",
+		},
+		{
+			expr: "now() + interval 1 day",
+		},
+		{
+			expr: "sysdate() + interval 1 month",
+		},
+		{
+			expr: "cast('123' as unsigned)",
+		},
+		{
+			expr:       "getvar('c')",
+			neededVars: []string{"c"},
+		},
+		{
+			expr:  "a",
+			error: "COLUMN reference is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "a+2",
+			error: "COLUMN reference is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "(select 1)",
+			error: "subquery is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "exists(select 1)",
+			error: "subquery is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "1 in (select 1)",
+			error: "subquery is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "1 + (select 1)",
+			error: "subquery is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "@@sql_mode",
+			error: "system variable is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "@@global.sql_mode",
+			error: "system variable is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "@a:=1",
+			error: "setting a variable in IMPORT INTO column assignment is not supported",
+		},
+		{
+			expr:  "default(t.a)",
+			error: "FUNCTION default is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "ROW_NUMBER() OVER(PARTITION BY 1)",
+			error: "window FUNCTION ROW_NUMBER is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "COUNT(1)",
+			error: "aggregate FUNCTION COUNT is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "grouping(1)",
+			error: "FUNCTION grouping is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "getvar(concat('a', 'b'))",
+			error: "the argument of getvar should be a constant string in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "getvar(now())",
+			error: "the argument of getvar should be a constant string in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "noexist()",
+			error: "FUNCTION noexist is not supported in IMPORT INTO column assignment",
+		},
+		{
+			expr:  "values(a)",
+			error: "COLUMN reference is not supported in IMPORT INTO column assignment",
+		},
+	}
+
+	for i, c := range cases {
+		stmt, err := parser.New().ParseOneStmt("select "+c.expr, "", "")
+		require.NoError(t, err, c.expr)
+		expr := stmt.(*ast.SelectStmt).Fields.Fields[0].Expr
+
+		checker := newImportIntoCollAssignmentChecker()
+		checker.idx = i
+		expr.Accept(checker)
+		if c.error != "" {
+			require.EqualError(t, checker.err, fmt.Sprintf("%s, index %d", c.error, i), c.expr)
+		} else {
+			require.NoError(t, checker.err, c.expr)
+		}
+
+		expectedNeededVars := make(map[string]int)
+		for _, v := range c.neededVars {
+			expectedNeededVars[v] = i
+		}
+		require.Equal(t, expectedNeededVars, checker.neededVars, c.expr)
+	}
+}

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -855,23 +855,25 @@ func TestImportIntoCollAssignmentChecker(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		stmt, err := parser.New().ParseOneStmt("select "+c.expr, "", "")
-		require.NoError(t, err, c.expr)
-		expr := stmt.(*ast.SelectStmt).Fields.Fields[0].Expr
+		t.Run(fmt.Sprintf("case-%d-%s", i, c.expr), func(t *testing.T) {
+			stmt, err := parser.New().ParseOneStmt("select "+c.expr, "", "")
+			require.NoError(t, err, c.expr)
+			expr := stmt.(*ast.SelectStmt).Fields.Fields[0].Expr
 
-		checker := newImportIntoCollAssignmentChecker()
-		checker.idx = i
-		expr.Accept(checker)
-		if c.error != "" {
-			require.EqualError(t, checker.err, fmt.Sprintf("%s, index %d", c.error, i), c.expr)
-		} else {
-			require.NoError(t, checker.err, c.expr)
-		}
+			checker := newImportIntoCollAssignmentChecker()
+			checker.idx = i
+			expr.Accept(checker)
+			if c.error != "" {
+				require.EqualError(t, checker.err, fmt.Sprintf("%s, index %d", c.error, i), c.expr)
+			} else {
+				require.NoError(t, checker.err, c.expr)
+			}
 
-		expectedNeededVars := make(map[string]int)
-		for _, v := range c.neededVars {
-			expectedNeededVars[v] = i
-		}
-		require.Equal(t, expectedNeededVars, checker.neededVars, c.expr)
+			expectedNeededVars := make(map[string]int)
+			for _, v := range c.neededVars {
+				expectedNeededVars[v] = i
+			}
+			require.Equal(t, expectedNeededVars, checker.neededVars, c.expr)
+		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55497

### What changed and how does it work?

This PR does a complete check for column assignments in `IMPORT INTO ...`, it:

- Disallow subquery, column reference, system vars access... in planner pahse.
- Because import into is running across node, it uses a ctx that provides restricted fields. So we also check the `RequiredOptionalEvalProps`  of the expressions to match the context.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
