### PR TITLE
tablecodec: optimize DecodeIndexHandle to avoid unnecessary allocation

### DIFF
--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -969,7 +969,7 @@ func DecodeIndexKV(key, value []byte, colsLen int, hdStatus HandleStatus, column
 func DecodeIndexHandle(key, value []byte, colsLen int) (kv.Handle, error) {
 	var err error
 	b := key[prefixLen+idLen:]
-	for i:=0; i<colsLen; i++ {
+	for i := 0; i < colsLen; i++ {
 		_, b, err = codec.CutOne(b)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -967,9 +967,13 @@ func DecodeIndexKV(key, value []byte, colsLen int, hdStatus HandleStatus, column
 
 // DecodeIndexHandle uses to decode the handle from index key/value.
 func DecodeIndexHandle(key, value []byte, colsLen int) (kv.Handle, error) {
-	_, b, err := CutIndexKeyNew(key, colsLen)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var err error
+	b := key[prefixLen+idLen:]
+	for i:=0; i<colsLen; i++ {
+		_, b, err = codec.CutOne(b)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	if len(b) > 0 {
 		return decodeHandleInIndexKey(b)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #43249

Problem Summary:

### What changed and how does it work?

CutIndexKeyNew decode the value, but discard the value. It cause unnecessary allocations.

```
_, b, err := CutIndexKeyNew(key, colsLen)
```

Before vs After:


![image](https://github.com/user-attachments/assets/d45640e5-b527-4947-a0fc-a5bdab5003c8)

![image](https://github.com/user-attachments/assets/2e04e1ff-92e1-49ca-a753-1de2c90d1f88)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

```
func BenchmarkUnionScanRead(b *testing.B) {
	store := testkit.CreateMockStore(b)

	tk := testkit.NewTestKit(b, store)
	tk.MustExec("use test")
	tk.MustExec(`create table t_us (
a int,
c1 varchar(10),
c2 varchar(30),
c3 varchar(1),
c4 varchar(12),
c5 varchar(10),
c6 datetime,
index k(a));`)
	tk.MustExec(`begin;`)
	for i := 0; i < 8000; i++ {
		tk.MustExec(fmt.Sprintf("insert into t_us values (%d, '54321', '1234', '1', '000000', '7518', '2014-05-08')", i))
	}

	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		// tk.MustQuery("select * from t_us where c1 = '12345'").Check(testkit.Rows())
		tk.MustQuery("select * from t_us use index(k) where c2 in ('12345') order by a ASC")
	}
	b.StopTimer()
	tk.MustExec("rollback")
}
```
```
go test -run XXX -bench BenchmarkUnionScanRead -cpuprofile cpu1.out -benchtime 45s
go tool pprof -http=:6060 cpu1.out
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
