### PR TITLE
runaway: change `QUERY WATCH` time type to UTC

### DIFF
--- a/pkg/executor/internal/querywatch/query_watch.go
+++ b/pkg/executor/internal/querywatch/query_watch.go
@@ -122,7 +122,7 @@ func fromQueryWatchOptionList(ctx context.Context, sctx, newSctx sessionctx.Cont
 	optionList []*ast.QueryWatchOption) (*runaway.QuarantineRecord, error) {
 	record := &runaway.QuarantineRecord{
 		Source:    runaway.ManualSource,
-		StartTime: time.Now(),
+		StartTime: time.Now().UTC(),
 		EndTime:   runaway.NullTime,
 	}
 	for _, op := range optionList {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

#### before 
When using `QUERY WATCH ADD RESOURCE GROUP default SQL TEXT EXACT TO 'select * from sbtest.sbtest1';` will add local time
```
mysql> SELECT * FROM INFORMATION_SCHEMA.RUNAWAY_WATCHES ORDER BY id\G
*************************** 1. row ***************************
                 ID: 1
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-09-11 07:38:09
           END_TIME: 2024-09-11 07:48:09
              WATCH: Exact
         WATCH_TEXT: select sleep(2) from t
             SOURCE: 127.0.0.1:4000
             ACTION: Kill
*************************** 2. row ***************************
                 ID: 2
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-09-11 15:38:20
           END_TIME: UNLIMITED
              WATCH: Exact
         WATCH_TEXT: select * from sbtest.sbtest1
             SOURCE: manual
             ACTION: Kill
2 rows in set (0.00 sec)
```

#### After

```bash

mysql> SELECT * FROM INFORMATION_SCHEMA.RUNAWAY_WATCHES ORDER BY id\G
*************************** 1. row ***************************
                 ID: 1
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-09-11 07:41:55
           END_TIME: 2024-09-11 07:51:55
              WATCH: Exact
         WATCH_TEXT: select sleep(2) from t
             SOURCE: 127.0.0.1:4000
             ACTION: Kill
*************************** 2. row ***************************
                 ID: 2
RESOURCE_GROUP_NAME: default
         START_TIME: 2024-09-11 07:42:02
           END_TIME: UNLIMITED
              WATCH: Exact
         WATCH_TEXT: select * from sbtest.sbtest1
             SOURCE: manual
             ACTION: Kill
```

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54770

Problem Summary:

### What changed and how does it work?



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
