### PR TITLE
*: Change cpu usages related representation format

### DIFF
--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -147,8 +147,8 @@ func TestParseSlowLogFile(t *testing.T) {
 # Request_unit_read: 2.158
 # Request_unit_write: 2.123
 # Time_queued_by_rc: 0.05
-# Tidb_cpu_usage: 0.01
-# Tikv_cpu_usage: 0.021
+# Tidb_cpu_time: 0.01
+# Tikv_cpu_time: 0.021
 # Plan_digest: 60e9378c746d9a2be1c791047e008967cf252eb6de9167ad3aa6098fa2d523f4
 # Prev_stmt: update t set i = 1;
 use test;

--- a/pkg/infoschema/internal/testkit.go
+++ b/pkg/infoschema/internal/testkit.go
@@ -98,8 +98,8 @@ select * from t_slim;
 # Resource_group: rg1
 # Request_unit_read: 96.66703066666668
 # Request_unit_write: 3182.424414062492
-# Tidb_cpu_usage: 0.01
-# Tikv_cpu_usage: 0.021
+# Tidb_cpu_time: 0.01
+# Tikv_cpu_time: 0.021
 INSERT INTO ...;
 `)
 	require.NoError(t, f.Close())

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -858,8 +858,8 @@ var tableProcesslistCols = []columnInfo{
 	{name: "RESOURCE_GROUP", tp: mysql.TypeVarchar, size: resourcegroup.MaxGroupNameLength, flag: mysql.NotNullFlag, deflt: ""},
 	{name: "SESSION_ALIAS", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag, deflt: ""},
 	{name: "ROWS_AFFECTED", tp: mysql.TypeLonglong, size: 21, flag: mysql.UnsignedFlag},
-	{name: "TIDB_CPU", tp: mysql.TypeDouble, size: 22, flag: mysql.NotNullFlag, deflt: 0},
-	{name: "TIKV_CPU", tp: mysql.TypeDouble, size: 22, flag: mysql.NotNullFlag, deflt: 0},
+	{name: "TIDB_CPU", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag, deflt: 0},
+	{name: "TIKV_CPU", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag, deflt: 0},
 }
 
 var tableTiDBIndexesCols = []columnInfo{

--- a/pkg/infoschema/test/clustertablestest/tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/tables_test.go
@@ -170,8 +170,8 @@ func TestInfoSchemaFieldValue(t *testing.T) {
 			"  `RESOURCE_GROUP` varchar(32) NOT NULL DEFAULT '',\n" +
 			"  `SESSION_ALIAS` varchar(64) NOT NULL DEFAULT '',\n" +
 			"  `ROWS_AFFECTED` bigint(21) unsigned DEFAULT NULL,\n" +
-			"  `TIDB_CPU` double NOT NULL DEFAULT '0',\n" +
-			"  `TIKV_CPU` double NOT NULL DEFAULT '0'\n" +
+			"  `TIDB_CPU` bigint(21) NOT NULL DEFAULT '0',\n" +
+			"  `TIKV_CPU` bigint(21) NOT NULL DEFAULT '0'\n" +
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 	tk.MustQuery("show create table information_schema.cluster_log").Check(
 		testkit.Rows("" +

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -67,6 +67,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/tiflash"
 	"github.com/pingcap/tidb/pkg/util/tiflashcompute"
 	"github.com/pingcap/tidb/pkg/util/timeutil"
+	"github.com/pingcap/tipb/go-tipb"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/twmb/murmur3"

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -67,7 +67,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/tiflash"
 	"github.com/pingcap/tidb/pkg/util/tiflashcompute"
 	"github.com/pingcap/tidb/pkg/util/timeutil"
-	"github.com/pingcap/tipb/go-tipb"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/twmb/murmur3"
@@ -3325,9 +3324,9 @@ const (
 	// SlowLogWaitRUDuration is the total duration for kv requests to wait available request-units.
 	SlowLogWaitRUDuration = "Time_queued_by_rc"
 	// SlowLogTidbCPUUsageDuration is the total tidb cpu usages.
-	SlowLogTidbCPUUsageDuration = "Tidb_cpu_usage"
+	SlowLogTidbCPUUsageDuration = "Tidb_cpu_time"
 	// SlowLogTikvCPUUsageDuration is the total tikv cpu usages.
-	SlowLogTikvCPUUsageDuration = "Tikv_cpu_usage"
+	SlowLogTikvCPUUsageDuration = "Tikv_cpu_time"
 )
 
 // GenerateBinaryPlan decides whether we should record binary plan in slow log and stmt summary.

--- a/pkg/util/processinfo.go
+++ b/pkg/util/processinfo.go
@@ -155,7 +155,7 @@ func (pi *ProcessInfo) ToRow(tz *time.Location) []any {
 		cpuUsages = pi.SQLCPUUsage.GetCPUUsages()
 	}
 	return append(pi.ToRowForShow(true), pi.Digest, bytesConsumed, diskConsumed,
-		pi.txnStartTs(tz), pi.ResourceGroupName, pi.SessionAlias, affectedRows, cpuUsages.TidbCPUTime.Seconds(), cpuUsages.TikvCPUTime.Seconds())
+		pi.txnStartTs(tz), pi.ResourceGroupName, pi.SessionAlias, affectedRows, cpuUsages.TidbCPUTime.Nanoseconds(), cpuUsages.TikvCPUTime.Nanoseconds())
 }
 
 // ascServerStatus is a slice of all defined server status in ascending order.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55542

Problem Summary:
In #55455, we added tidb/tikv cpu usages into several system table. During document review process, we discussed the display details, and want to do some display changes: https://github.com/pingcap/docs-cn/pull/18527. Mainly two points:

1. Use nanoseconds instead of seconds to display processlist's tidb/tikv cpu time
2. Change the slow log field names from **tidb_cpu_usage** to **tidb_cpu_time**, **tikv_cpu_usage** to **tikv_cpu_time**

The display will look like this:
![img_v3_02em_5dc4075b-47c9-465a-882a-b19bd534694g](https://github.com/user-attachments/assets/68295a0d-1679-46c2-bdaa-50cb220199c5)


### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
