### PR TITLE
bootstrap: create sysvars for password validation during upgrade

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -116,5 +116,5 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(213), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(214), session.CurrentBootstrapVersion)
 }

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1309,6 +1309,7 @@ var (
 		upgradeToVer211,
 		upgradeToVer212,
 		upgradeToVer213,
+		upgradeToVer214,
 	}
 )
 
@@ -3148,7 +3149,7 @@ func upgradeToVer214(s sessiontypes.Session, ver int64) {
 	if ver >= version214 {
 		return
 	}
-	mustExecute(s, "DELETE FROM mysql.global_variables where VARIABLE_NAME like 'validate_password_%'")
+	mustExecute(s, `DELETE FROM mysql.global_variables WHERE variable_name LIKE 'validate\_password\_%'`)
 
 	initGlobalVariableIfNotExists(s, variable.ValidatePasswordCheckUserName, variable.On)
 	initGlobalVariableIfNotExists(s, variable.ValidatePasswordSpecialCharCount, "1")

--- a/pkg/session/bootstraptest/BUILD.bazel
+++ b/pkg/session/bootstraptest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/config",
         "//pkg/ddl",
@@ -21,6 +21,7 @@ go_test(
         "//pkg/session",  #keep
         "//pkg/session/types",
         "//pkg/sessionctx",
+        "//pkg/sessionctx/variable",
         "//pkg/testkit",  #keep
         "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testmain",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55838

Problem Summary:

https://github.com/pingcap/tidb/pull/38953 forgot to modify mysql.global_variables during upgrading

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
