### PR TITLE
expression: fix expression return wrong current time when using `StaticEvalContext`

### DIFF
--- a/pkg/expression/BUILD.bazel
+++ b/pkg/expression/BUILD.bazel
@@ -122,6 +122,7 @@ go_library(
         "//pkg/util/size",
         "//pkg/util/sqlexec",
         "//pkg/util/stringutil",
+        "//pkg/util/timeutil",
         "//pkg/util/vitess",
         "//pkg/util/zeropool",
         "@com_github_gogo_protobuf//proto",

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -2524,7 +2524,7 @@ func evalNowWithFsp(ctx EvalContext, fsp int) (types.Time, bool, error) {
 		return types.ZeroTime, true, err
 	}
 
-	err = result.ConvertTimeZone(time.Local, location(ctx))
+	err = result.ConvertTimeZone(nowTs.Location(), location(ctx))
 	if err != nil {
 		return types.ZeroTime, true, err
 	}

--- a/tests/integrationtest/r/ddl/db_change.result
+++ b/tests/integrationtest/r/ddl/db_change.result
@@ -33,3 +33,21 @@ alter table t rename column b to b2;
 Error 3837 (HY000): Column 'b' has an expression index dependency and cannot be dropped or renamed
 alter table t drop column b;
 Error 3837 (HY000): Column 'b' has an expression index dependency and cannot be dropped or renamed
+drop table if exists t;
+create table t(a int, b int, c int);
+insert into t values(NULL, NULL, NULL);
+alter table t modify column a timestamp not null;
+select floor((unix_timestamp() - unix_timestamp(a)) / 2) from t;
+floor((unix_timestamp() - unix_timestamp(a)) / 2)
+0
+set @@time_zone='UTC';
+alter table t modify column b timestamp not null;
+select floor((unix_timestamp() - unix_timestamp(b)) / 2) from t;
+floor((unix_timestamp() - unix_timestamp(b)) / 2)
+0
+set @@time_zone='Asia/Tokyo';
+alter table t modify column c timestamp not null;
+select floor((unix_timestamp() - unix_timestamp(c)) / 2) from t;
+floor((unix_timestamp() - unix_timestamp(c)) / 2)
+0
+set @@time_zone='SYSTEM'

--- a/tests/integrationtest/t/ddl/db_change.test
+++ b/tests/integrationtest/t/ddl/db_change.test
@@ -31,3 +31,18 @@ alter table t rename column b to b2;
 -- error 3837
 alter table t drop column b;
 
+# The generated current time should be correct after DDL reorging in different timezones.
+# see issue: https://github.com/pingcap/tidb/issues/56051
+drop table if exists t;
+create table t(a int, b int, c int);
+insert into t values(NULL, NULL, NULL);
+alter table t modify column a timestamp not null;
+# the timestamp diff should be less than 2s
+select floor((unix_timestamp() - unix_timestamp(a)) / 2) from t;
+set @@time_zone='UTC';
+alter table t modify column b timestamp not null;
+select floor((unix_timestamp() - unix_timestamp(b)) / 2) from t;
+set @@time_zone='Asia/Tokyo';
+alter table t modify column c timestamp not null;
+select floor((unix_timestamp() - unix_timestamp(c)) / 2) from t;
+set @@time_zone='SYSTEM'


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56051, close #56054

### What changed and how does it work?

Fix all strong assumptions of the location of the return value of `getStmtTimestamp`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
