### PR TITLE
planner: use intest.AssertFunc instead of intest.Assert when testing function

### DIFF
--- a/pkg/util/intest/assert_test.go
+++ b/pkg/util/intest/assert_test.go
@@ -15,6 +15,7 @@
 package intest_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -119,4 +120,71 @@ func doCheckAssert(t *testing.T, fn any, cond any, pass bool, msgAndArgs ...any)
 	default:
 		fail = "invalid input assert function"
 	}
+}
+
+func BenchmarkAssertWithSprintf(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.Assert(true, fmt.Sprintf("assert failed, %s", "test"))
+	}
+}
+
+func BenchmarkAssertWithNativeFormat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.Assert(true, "assert failed, %s", "test")
+	}
+}
+
+func BenchmarkAssertFunc(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.AssertFunc(func() bool { return returnTrue(i) }, "assert failed, %s", "test")
+	}
+}
+
+func BenchmarkAssertFuncWithWrapFunc(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.Assert(wrapReturn1(), "assert failed, %s", "test")
+	}
+}
+
+func BenchmarkAssertFuncWithComplexFunc(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.AssertFunc(func() bool { return returnTrue(fibo(i)) }, "assert failed, %s", "test")
+	}
+}
+
+func BenchmarkAssertFuncWithInterfaceParam(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.AssertFunc(func() bool { return checkNotNil(i) }, "assert failed, %s", "test")
+	}
+}
+
+func BenchmarkAssertWithFunc(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.Assert(returnTrue(i), "assert failed, %s", "test")
+	}
+}
+
+func BenchmarkAssertWithComplexFunc(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		intest.Assert(returnTrue(fibo(i)), "assert failed, %s", "test")
+	}
+}
+
+func wrapReturn1() bool {
+	return returnTrue(1)
+}
+
+func fibo(i int) int {
+	if i <= 1 {
+		return i
+	}
+	return fibo(i-1) + fibo(i-2)
+}
+
+func returnTrue(i int) bool {
+	return i >= 0
+}
+
+func checkNotNil(i any) bool {
+	return i != nil
 }

--- a/pkg/util/intest/assert_test.go
+++ b/pkg/util/intest/assert_test.go
@@ -15,7 +15,6 @@
 package intest_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -120,71 +119,4 @@ func doCheckAssert(t *testing.T, fn any, cond any, pass bool, msgAndArgs ...any)
 	default:
 		fail = "invalid input assert function"
 	}
-}
-
-func BenchmarkAssertWithSprintf(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.Assert(true, fmt.Sprintf("assert failed, %s", "test"))
-	}
-}
-
-func BenchmarkAssertWithNativeFormat(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.Assert(true, "assert failed, %s", "test")
-	}
-}
-
-func BenchmarkAssertFunc(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.AssertFunc(func() bool { return returnTrue(i) }, "assert failed, %s", "test")
-	}
-}
-
-func BenchmarkAssertFuncWithWrapFunc(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.Assert(wrapReturn1(), "assert failed, %s", "test")
-	}
-}
-
-func BenchmarkAssertFuncWithComplexFunc(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.AssertFunc(func() bool { return returnTrue(fibo(i)) }, "assert failed, %s", "test")
-	}
-}
-
-func BenchmarkAssertFuncWithInterfaceParam(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.AssertFunc(func() bool { return checkNotNil(i) }, "assert failed, %s", "test")
-	}
-}
-
-func BenchmarkAssertWithFunc(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.Assert(returnTrue(i), "assert failed, %s", "test")
-	}
-}
-
-func BenchmarkAssertWithComplexFunc(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		intest.Assert(returnTrue(fibo(i)), "assert failed, %s", "test")
-	}
-}
-
-func wrapReturn1() bool {
-	return returnTrue(1)
-}
-
-func fibo(i int) int {
-	if i <= 1 {
-		return i
-	}
-	return fibo(i-1) + fibo(i-2)
-}
-
-func returnTrue(i int) bool {
-	return i >= 0
-}
-
-func checkNotNil(i any) bool {
-	return i != nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

Golang will execute the `func` in `intest.AssertNoError(func())` when the build flag makes `AssertNoError` an empty function.

You can run the bench `BenchmarkAssertFuncWithComplexFunc` and `BenchmarkAssertWithComplexFunc` of the current golang complier.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
