### PR TITLE
session: extend the length of action column to fix the truncation

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -624,7 +624,7 @@ const (
 		start_time TIMESTAMP NOT NULL,
 		repeats int default 1,
 		match_type varchar(12) NOT NULL,
-		action varchar(12) NOT NULL,
+		action varchar(64) NOT NULL,
 		sample_sql TEXT NOT NULL,
 		sql_digest varchar(64) NOT NULL,
 		plan_digest varchar(64) NOT NULL,
@@ -3131,6 +3131,8 @@ func upgradeToVer212(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries RENAME COLUMN `original_sql` TO `sample_sql`")
 	// modify column type of `plan_digest`.
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries MODIFY COLUMN `plan_digest` varchar(64) DEFAULT '';", infoschema.ErrColumnExists)
+	// modify column length of `action`.
+	doReentrantDDL(s, "ALTER TABLE mysql.tidb_runaway_queries MODIFY COLUMN `action` VARCHAR(64) NOT NULL;", infoschema.ErrColumnExists)
 }
 
 func upgradeToVer213(s sessiontypes.Session, ver int64) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56106.

### What changed and how does it work?

Extend the length of `VARCHAR` for the `action` column to fix the truncation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

Before:

<img width="986" alt="图片" src="https://github.com/user-attachments/assets/9de013e8-f8b0-4bd8-beb7-bad66da924f5">

After:

<img width="799" alt="图片" src="https://github.com/user-attachments/assets/e1f4e78c-61d8-4ca6-a2a1-29c47b34a4e7">

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
