### PR TITLE
ddl: fix 'create table like' for cached table

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1103,6 +1103,7 @@ func BuildTableInfoWithLike(ctx sessionctx.Context, ident ast.Ident, referTblInf
 	tblInfo.Name = ident.Name
 	tblInfo.AutoIncID = 0
 	tblInfo.ForeignKeys = nil
+	tblInfo.TableCacheStatusType = model.TableCacheStatusDisable
 	// Ignore TiFlash replicas for temporary tables.
 	if s.TemporaryKeyword != ast.TemporaryNone {
 		tblInfo.TiFlashReplica = nil

--- a/pkg/ddl/db_cache_test.go
+++ b/pkg/ddl/db_cache_test.go
@@ -93,6 +93,13 @@ func TestAlterTableCache(t *testing.T) {
 		"(id int not null primary key, code int not null, value int default null, unique key code(code))" +
 		"on commit delete rows")
 	tk.MustGetErrMsg("alter table tmp1 cache", dbterror.ErrOptOnTemporaryTable.GenWithStackByArgs("alter temporary table cache").Error())
+	// create table like
+	tk.MustExec("drop table t")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("alter table t cache")
+	tk.MustExec("create table t3 like t")
+	checkTableCacheStatus(t, tk, "test", "t", model.TableCacheStatusEnable)
+	checkTableCacheStatus(t, tk, "test", "t3", model.TableCacheStatusDisable)
 }
 
 func TestCacheTableSizeLimit(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56134

Problem Summary:

### What changed and how does it work?

Use 'create table like'  to copy a cached table, the new table should be a normal table.
This behavior is just like using migrate tools, treat cached tables as normal tables in those scenarios.
https://docs.pingcap.com/tidb/v8.3/cached-tables#compatibility-with-tidb-migration-tools 


### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
