### PR TITLE
executor: verify the existence of the resource group before switching

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -555,7 +555,12 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			return nil, err
 		}
 		if len(switchGroupName) > 0 {
-			stmtCtx.ResourceGroupName = switchGroupName
+			group, err := rm.ResourceGroupCtl.GetResourceGroup(switchGroupName)
+			if err != nil || group == nil {
+				logutil.BgLogger().Debug("invalid switch resource group", zap.String("switch-group-name", switchGroupName), zap.Error(err))
+			} else {
+				stmtCtx.ResourceGroupName = switchGroupName
+			}
 		}
 	}
 	ctx = a.observeStmtBeginForTopSQL(ctx)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54434.

### What changed and how does it work?

Before switching, verify the existence of the resource group. If the specified resource group does not exist, take no action.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test

Before:

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/aa732662-f211-493e-a02b-1afca93dbb83">

After:

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/7a25a012-a8a1-47db-88d5-6f8e49e5108f">

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
