### PR TITLE
*: Check sqlkiller status during split region process

### DIFF
--- a/pkg/distsql/BUILD.bazel
+++ b/pkg/distsql/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/memory",
         "//pkg/util/ranger",
+        "//pkg/util/sqlkiller",
         "//pkg/util/topsql/stmtstats",
         "//pkg/util/tracing",
         "//pkg/util/trxevents",

--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -323,7 +323,6 @@ func createSelectNormalByBenchmarkTest(batch, totalRows int, ctx sessionctx.Cont
 		SetKeepOrder(false).
 		SetFromSessionVars(DefaultDistSQLContext).
 		SetMemTracker(memory.NewTracker(-1, -1)).
-		SetSQLKiller(&ctx.GetSessionVars().SQLKiller).
 		Build()
 
 	// 4 int64 types.
@@ -393,7 +392,6 @@ func createSelectNormal(t *testing.T, batch, totalRows int, planIDs []int, sctx 
 		SetKeepOrder(false).
 		SetFromSessionVars(DefaultDistSQLContext).
 		SetMemTracker(memory.NewTracker(-1, -1)).
-		SetSQLKiller(&sctx.GetSessionVars().SQLKiller).
 		Build()
 	require.NoError(t, err)
 

--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -323,6 +323,7 @@ func createSelectNormalByBenchmarkTest(batch, totalRows int, ctx sessionctx.Cont
 		SetKeepOrder(false).
 		SetFromSessionVars(DefaultDistSQLContext).
 		SetMemTracker(memory.NewTracker(-1, -1)).
+		SetSQLKiller(&ctx.GetSessionVars().SQLKiller).
 		Build()
 
 	// 4 int64 types.
@@ -392,6 +393,7 @@ func createSelectNormal(t *testing.T, batch, totalRows int, planIDs []int, sctx 
 		SetKeepOrder(false).
 		SetFromSessionVars(DefaultDistSQLContext).
 		SetMemTracker(memory.NewTracker(-1, -1)).
+		SetSQLKiller(&sctx.GetSessionVars().SQLKiller).
 		Build()
 	require.NoError(t, err)
 

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -16,7 +16,6 @@ package distsql
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"math"
 	"sort"
 	"sync/atomic"
@@ -38,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/ranger"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/tikv/client-go/v2/tikvrpc"
 )

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -16,6 +16,7 @@ package distsql
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"math"
 	"sort"
 	"sync/atomic"
@@ -434,6 +435,12 @@ func (builder *RequestBuilder) SetClosestReplicaReadAdjuster(chkFn kv.CoprReques
 func (builder *RequestBuilder) SetConnIDAndConnAlias(connID uint64, connAlias string) *RequestBuilder {
 	builder.ConnID = connID
 	builder.ConnAlias = connAlias
+	return builder
+}
+
+// SetSQLKiller sets sqlkiller for the builder.
+func (builder *RequestBuilder) SetSQLKiller(killer *sqlkiller.SQLKiller) *RequestBuilder {
+	builder.SQLKiller = killer
 	return builder
 }
 

--- a/pkg/executor/analyze_col.go
+++ b/pkg/executor/analyze_col.go
@@ -124,6 +124,7 @@ func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.Range) (distsql.SelectRe
 		SetMemTracker(e.memTracker).
 		SetResourceGroupName(e.ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		SetExplicitRequestSourceType(e.ctx.GetSessionVars().ExplicitRequestSourceType).
+		SetSQLKiller(&e.ctx.GetSessionVars().SQLKiller).
 		Build()
 	if err != nil {
 		return nil, err

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -312,7 +312,8 @@ func (e *IndexReaderExecutor) buildKVReq(r []kv.KeyRange) (*kv.Request, error) {
 		SetFromInfoSchema(e.Ctx().GetInfoSchema()).
 		SetMemTracker(e.memTracker).
 		SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx().GetDistSQLCtx(), &builder.Request, e.netDataSize)).
-		SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
+		SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias).
+		SetSQLKiller(&e.Ctx().GetSessionVars().SQLKiller)
 	kvReq, err := builder.Build()
 	return kvReq, err
 }
@@ -721,7 +722,8 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 			SetFromInfoSchema(e.Ctx().GetInfoSchema()).
 			SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx().GetDistSQLCtx(), &builder.Request, e.idxNetDataSize/float64(len(kvRanges)))).
 			SetMemTracker(tracker).
-			SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
+			SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias).
+			SetSQLKiller(&e.Ctx().GetSessionVars().SQLKiller)
 
 		results := make([]distsql.SelectResult, 0, len(kvRanges))
 		for _, kvRange := range kvRanges {

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -389,7 +389,8 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					SetPaging(e.paging).
 					SetFromInfoSchema(e.Ctx().GetInfoSchema()).
 					SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx().GetDistSQLCtx(), &builder.Request, e.partialNetDataSizes[workID])).
-					SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias)
+					SetConnIDAndConnAlias(e.Ctx().GetSessionVars().ConnectionID, e.Ctx().GetSessionVars().SessionAlias).
+					SetSQLKiller(&e.Ctx().GetSessionVars().SQLKiller)
 
 				tps := worker.getRetTpsForIndexScan(e.handleCols)
 				results := make([]distsql.SelectResult, 0, len(keyRanges))

--- a/pkg/executor/table_reader.go
+++ b/pkg/executor/table_reader.go
@@ -442,6 +442,7 @@ func (e *TableReaderExecutor) buildKVReqSeparately(ctx context.Context, ranges [
 			SetAllowBatchCop(e.batchCop).
 			SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.dctx, &reqBuilder.Request, e.netDataSize)).
 			SetConnIDAndConnAlias(e.dctx.ConnectionID, e.dctx.SessionAlias).
+			SetSQLKiller(e.dctx.SQLKiller).
 			Build()
 		if err != nil {
 			return nil, err
@@ -484,6 +485,7 @@ func (e *TableReaderExecutor) buildKVReqForPartitionTableScan(ctx context.Contex
 		SetAllowBatchCop(e.batchCop).
 		SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.dctx, &reqBuilder.Request, e.netDataSize)).
 		SetConnIDAndConnAlias(e.dctx.ConnectionID, e.dctx.SessionAlias).
+		SetSQLKiller(e.dctx.SQLKiller).
 		Build()
 	if err != nil {
 		return nil, err
@@ -528,7 +530,8 @@ func (e *TableReaderExecutor) buildKVReq(ctx context.Context, ranges []*ranger.R
 		SetAllowBatchCop(e.batchCop).
 		SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.dctx, &reqBuilder.Request, e.netDataSize)).
 		SetPaging(e.paging).
-		SetConnIDAndConnAlias(e.dctx.ConnectionID, e.dctx.SessionAlias)
+		SetConnIDAndConnAlias(e.dctx.ConnectionID, e.dctx.SessionAlias).
+		SetSQLKiller(e.dctx.SQLKiller)
 	return reqBuilder.Build()
 }
 

--- a/pkg/executor/test/splittest/split_table_test.go
+++ b/pkg/executor/test/splittest/split_table_test.go
@@ -601,7 +601,7 @@ func BenchmarkLocateRegion(t *testing.B) {
 
 	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
-		_, err := cache.SplitKeyRangesByBuckets(bo, ranges)
+		_, err := cache.SplitKeyRangesByBuckets(bo, ranges, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/memory",
         "//pkg/util/set",
         "//pkg/util/size",
+        "//pkg/util/sqlkiller",
         "//pkg/util/tiflash",
         "//pkg/util/tiflashcompute",
         "//pkg/util/trxevents",

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"slices"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/domain/resourcegroup"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/util/memory"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/pingcap/tidb/pkg/util/tiflash"
 	"github.com/pingcap/tidb/pkg/util/trxevents"
 	tikvstore "github.com/tikv/client-go/v2/kv"

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"slices"
 	"time"
 
@@ -602,6 +603,8 @@ type Request struct {
 	ConnID uint64
 	// ConnAlias stores the session connection alias.
 	ConnAlias string
+	// SQLKiller is a flag to indicate that this query is killed.
+	SQLKiller *sqlkiller.SQLKiller
 }
 
 // CoprRequestAdjuster is used to check and adjust a copr request according to specific rules.

--- a/pkg/store/copr/BUILD.bazel
+++ b/pkg/store/copr/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/memory",
         "//pkg/util/paging",
         "//pkg/util/size",
+        "//pkg/util/sqlkiller",
         "//pkg/util/tiflash",
         "//pkg/util/tiflashcompute",
         "//pkg/util/tracing",

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/paging"
 	"github.com/pingcap/tidb/pkg/util/size"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 	"github.com/pingcap/tidb/pkg/util/trxevents"
 	"github.com/pingcap/tipb/go-tipb"
@@ -357,8 +358,12 @@ func buildCopTasks(bo *Backoffer, ranges *KeyRanges, opt *buildCopTaskOpt) ([]*c
 		}
 	})
 
+	var sqlkiller *sqlkiller.SQLKiller = nil
+	if req.MemTracker != nil {
+		sqlkiller = req.MemTracker.Killer
+	}
 	// TODO(youjiali1995): is there any request type that needn't be splitted by buckets?
-	locs, err := cache.SplitKeyRangesByBuckets(bo, ranges)
+	locs, err := cache.SplitKeyRangesByBuckets(bo, ranges, sqlkiller)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -52,7 +52,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/paging"
 	"github.com/pingcap/tidb/pkg/util/size"
-	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 	"github.com/pingcap/tidb/pkg/util/trxevents"
 	"github.com/pingcap/tipb/go-tipb"
@@ -358,12 +357,8 @@ func buildCopTasks(bo *Backoffer, ranges *KeyRanges, opt *buildCopTaskOpt) ([]*c
 		}
 	})
 
-	var sqlkiller *sqlkiller.SQLKiller = nil
-	if req.MemTracker != nil {
-		sqlkiller = req.MemTracker.Killer
-	}
 	// TODO(youjiali1995): is there any request type that needn't be splitted by buckets?
-	locs, err := cache.SplitKeyRangesByBuckets(bo, ranges, sqlkiller)
+	locs, err := cache.SplitKeyRangesByBuckets(bo, ranges, req.SQLKiller)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/store/copr/region_cache.go
+++ b/pkg/store/copr/region_cache.go
@@ -16,13 +16,12 @@ package copr
 
 import (
 	"bytes"
-	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"math"
 	"strconv"
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
@@ -30,6 +29,7 @@ import (
 	derr "github.com/pingcap/tidb/pkg/store/driver/error"
 	"github.com/pingcap/tidb/pkg/store/driver/options"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/tikv"
 	"go.uber.org/zap"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55957 

Problem Summary:
In 8.1 and earlier versions, during building cop tasks, tidb needs to split key ranges. Tidb may use rpc to connect pd to get latest region info one by one, and this will cost too much time if tidb needs to load many regions' info. Even worse, tidb won't check the sqlkiller signal during this process, so the query won't be killed until the spliting key ranges work is done.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that query won't be killed during building coprocessor tasks process.
```
