### PR TITLE
ddl: fix unexpected duplicate entry error when adding unique index

### DIFF
--- a/pkg/ddl/index_merge_tmp.go
+++ b/pkg/ddl/index_merge_tmp.go
@@ -49,44 +49,55 @@ func (w *mergeIndexWorker) batchCheckTemporaryUniqueKey(
 	}
 
 	for i, key := range w.originIdxKeys {
-		if val, found := batchVals[string(key)]; found {
+		keyStr := string(key)
+		if val, found := batchVals[keyStr]; found {
 			// Found a value in the original index key.
-			err := checkTempIndexKey(txn, idxRecords[i], val, w.table)
+			matchDeleted, err := checkTempIndexKey(txn, idxRecords[i], val, w.table)
 			if err != nil {
 				if kv.ErrKeyExists.Equal(err) {
 					return driver.ExtractKeyExistsErrFromIndex(key, val, w.table.Meta(), w.currentIndex.ID)
 				}
 				return errors.Trace(err)
 			}
+			if matchDeleted {
+				// Delete from batchVals to prevent false-positive duplicate detection.
+				delete(batchVals, keyStr)
+			}
 		} else if idxRecords[i].distinct {
 			// The keys in w.batchCheckKeys also maybe duplicate,
 			// so we need to backfill the not found key into `batchVals` map.
-			batchVals[string(key)] = idxRecords[i].vals
+			batchVals[keyStr] = idxRecords[i].vals
 		}
+
 	}
 	return nil
 }
 
-func checkTempIndexKey(txn kv.Transaction, tmpRec *temporaryIndexRecord, originIdxVal []byte, tblInfo table.Table) error {
+// checkTempIndexKey determines whether there is a duplicated index key entry according to value of temp index.
+// For non-delete temp record, if the index values mismatch, it is duplicated.
+// For delete temp record, we decode the handle from the origin index value and temp index value.
+//   - if the handles matche, we can delete the index key.
+//   - otherwise, we further check if the row exists in the table.
+func checkTempIndexKey(txn kv.Transaction, tmpRec *temporaryIndexRecord, originIdxVal []byte, tblInfo table.Table) (matchDelete bool, err error) {
 	if !tmpRec.delete {
 		if tmpRec.distinct && !bytes.Equal(originIdxVal, tmpRec.vals) {
-			return kv.ErrKeyExists
+			return false, kv.ErrKeyExists
 		}
 		// The key has been found in the original index, skip merging it.
 		tmpRec.skip = true
-		return nil
+		return false, nil
 	}
 	// Delete operation.
 	distinct := tablecodec.IndexKVIsUnique(originIdxVal)
 	if !distinct {
 		// For non-distinct key, it is consist of a null value and the handle.
 		// Same as the non-unique indexes, replay the delete operation on non-distinct keys.
-		return nil
+		return false, nil
 	}
 	// For distinct index key values, prevent deleting an unexpected index KV in original index.
 	hdInVal, err := tablecodec.DecodeHandleInIndexValue(originIdxVal)
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	if !tmpRec.handle.Equal(hdInVal) {
 		// The inequality means multiple modifications happened in the same key.
@@ -97,16 +108,16 @@ func checkTempIndexKey(txn kv.Transaction, tmpRec *temporaryIndexRecord, originI
 			if kv.IsErrNotFound(err) {
 				// The row is deleted, so we can merge the delete operation to the origin index.
 				tmpRec.skip = false
-				return nil
+				return false, nil
 			}
 			// Unexpected errors.
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		// Don't delete the index key if the row exists.
 		tmpRec.skip = true
-		return nil
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
 // temporaryIndexRecord is the record information of an index.

--- a/pkg/ddl/index_merge_tmp.go
+++ b/pkg/ddl/index_merge_tmp.go
@@ -68,7 +68,6 @@ func (w *mergeIndexWorker) batchCheckTemporaryUniqueKey(
 			// so we need to backfill the not found key into `batchVals` map.
 			batchVals[keyStr] = idxRecords[i].vals
 		}
-
 	}
 	return nil
 }

--- a/pkg/ddl/tests/indexmerge/BUILD.bazel
+++ b/pkg/ddl/tests/indexmerge/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/config",
         "//pkg/ddl",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56161

Problem Summary: when merge-temp-index workers check duplicate index keys, they use `BatchGet()` to get index KV from the origin index and record them as a map. However, this map is not updated while handling temp index records, there may be a false-positive detection.

For example, we have `{key_1 -> handle_1, key_2 -> handle_2}`. If there is a temp index record like `key_1 -> handle_3`, then there is a duplicate key. 

In this issue, we have two temp index records:

```
key_1 -> handle_1(deleted)
key_1 -> handle_2
```

The first record passes the check because a delete operation cannot cause a duplicate key. The second record fails the check because `handle_2 != handle_1`, even if `handle_1` is deleted in the previous operation.

### What changed and how does it work?

Maintain the map while handling, and remove the delete keys if necessary.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
