### PR TITLE
importinto: protect panic from encode loop

### DIFF
--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -80,7 +80,6 @@ go_library(
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
         "@io_etcd_go_etcd_client_v3//:client",
-        "@org_golang_x_sync//errgroup",
         "@org_uber_go_multierr//:multierr",
         "@org_uber_go_zap//:zap",
     ],

--- a/pkg/executor/importer/chunk_process.go
+++ b/pkg/executor/importer/chunk_process.go
@@ -33,10 +33,10 @@ import (
 	verify "github.com/pingcap/tidb/pkg/lightning/verification"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/syncutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 // constants, make it a variable for test
@@ -337,7 +337,7 @@ func (p *baseChunkProcessor) Process(ctx context.Context) (err error) {
 		}
 	}()
 
-	group, gCtx := errgroup.WithContext(ctx)
+	group, gCtx := util.NewErrorGroupWithRecoverWithCtx(ctx)
 	group.Go(func() error {
 		return p.deliver.deliverLoop(gCtx)
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55970 

Problem Summary:

### What changed and how does it work?
use wrapped error group
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

manually revert https://github.com/pingcap/tidb/pull/55983 , and import into a global temp table, now we can capture panic
```
mysql> create global temporary table temp (a varchar(100), b varchar(100), c varchar(100)) on commit delete rows;
Query OK, 0 rows affected (0.06 sec)

mysql> import into temp from '/Users/jujiajia/playground/lightning/single-file/test.t.1.csv';
ERROR 1105 (HY000): runtime error: invalid memory address or nil pointer dereference
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
