### PR TITLE
tests: reduce some flaky timeout tests

### DIFF
--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -911,7 +911,8 @@ func TestMDLView(t *testing.T) {
 	}
 }
 
-func TestMDLViewPrivilege1(t *testing.T) {
+func TestMDLViewWithNoPrivilege(t *testing.T) {
+	// It's with TestMDLViewWithPrivilege. Split to two tests just because it runs too much time.
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
@@ -920,10 +921,9 @@ func TestMDLViewPrivilege1(t *testing.T) {
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "test", Hostname: "%"}, nil, nil, nil))
 	_, err := tk.Exec("select * from mysql.tidb_mdl_view;")
 	require.ErrorContains(t, err, "view lack rights")
-
 }
 
-func TestMDLViewPrivilege2(t *testing.T) {
+func TestMDLViewWithPrivilege(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	// grant all privileges to test user.

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -911,7 +911,7 @@ func TestMDLView(t *testing.T) {
 	}
 }
 
-func TestMDLViewPrivilege(t *testing.T) {
+func TestMDLViewPrivilege1(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
@@ -921,8 +921,14 @@ func TestMDLViewPrivilege(t *testing.T) {
 	_, err := tk.Exec("select * from mysql.tidb_mdl_view;")
 	require.ErrorContains(t, err, "view lack rights")
 
+}
+
+func TestMDLViewPrivilege2(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
 	// grant all privileges to test user.
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
+	tk.MustExec("create user 'test'@'%' identified by '';")
 	tk.MustExec("grant all privileges on *.* to 'test'@'%';")
 	tk.MustExec("flush privileges;")
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "test", Hostname: "%"}, nil, nil, nil))

--- a/pkg/planner/core/memtable_infoschema_extractor_test.go
+++ b/pkg/planner/core/memtable_infoschema_extractor_test.go
@@ -390,6 +390,12 @@ func TestMemtableInfoschemaExtractorPart1(t *testing.T) {
 			prepareData:  prepareDataViews,
 			cleanData:    cleanDataViews,
 		},
+	}
+	testMemtableInfoschemaExtractor(t, tcs)
+}
+
+func TestMemtableInfoschemaExtractorPart2(t *testing.T) {
+	tcs := []testCase{
 		{
 			memTableName: infoschema.TableKeyColumn,
 			prepareData:  prepareDataKeyColumnUsage,
@@ -409,7 +415,7 @@ func TestMemtableInfoschemaExtractorPart1(t *testing.T) {
 	testMemtableInfoschemaExtractor(t, tcs)
 }
 
-func TestMemtableInfoschemaExtractorPart2(t *testing.T) {
+func TestMemtableInfoschemaExtractorPart3(t *testing.T) {
 	tcs := []testCase{
 		{
 			memTableName: infoschema.TableStatistics,
@@ -426,6 +432,12 @@ func TestMemtableInfoschemaExtractorPart2(t *testing.T) {
 			prepareData:  prepareDataCheckConstraints,
 			cleanData:    cleanDataCheckConstraints,
 		},
+	}
+	testMemtableInfoschemaExtractor(t, tcs)
+}
+
+func TestMemtableInfoschemaExtractorPart4(t *testing.T) {
+	tcs := []testCase{
 		{
 			memTableName: infoschema.TableTiDBCheckConstraints,
 			prepareData:  prepareDataTidbCheckConstraints,

--- a/pkg/planner/core/plan_cost_ver1_test.go
+++ b/pkg/planner/core/plan_cost_ver1_test.go
@@ -103,7 +103,7 @@ func TestScanOnSmallTable(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec(`create table t (a int)`)
 	tk.MustExec("insert into t values (1), (2), (3), (4), (5)")
-	tk.MustExec("analyze table t")
+	tk.MustExec("analyze table t all columns")
 	tk.MustExec(`set @@tidb_cost_model_version=2`)
 
 	// Create virtual tiflash replica info.

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -454,11 +454,10 @@ func TestDebugRoutes(t *testing.T) {
 		"/debug/pprof/block?debug=1",
 		"/debug/pprof/threadcreate?debug=1",
 		"/debug/pprof/cmdline",
-		"/debug/pprof/profile",
+		"/debug/pprof/profile?seconds=5",
 		"/debug/pprof/mutex?debug=1",
 		"/debug/pprof/symbol",
 		"/debug/pprof/trace",
-		"/debug/pprof/profile",
 		"/debug/gogc",
 		// "/debug/zip", // this creates unexpected goroutines which will make goleak complain, so we skip it for now
 		"/debug/ballast-object-sz",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #41316 

Problem Summary:

### What changed and how does it work?

`TestMDLViewPrivilege` could run up to 85s+ in PingCAP's internal dev machine. Split it to two part

CPU profile is tested twice and without setting time in `TestDebugRoutes`. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
