### PR TITLE
planner: consider path is global index path or not in `skylinePruning` function

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -737,7 +737,7 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 	// (1): the set of columns that occurred in the access condition,
 	// (2): does it require a double scan,
 	// (3): whether or not it matches the physical property,
-	// (4): it's a global index path or not.
+	// (4): it's a global index path or not, it only works when two indexes contains same columns.
 	// If `x` is not worse than `y` at all factors,
 	// and there exists one factor that `x` is better than `y`, then `x` is better than `y`.
 	accessResult, comparable1 := util.CompareCol2Len(lhs.accessCondsColMap, rhs.accessCondsColMap)

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -700,6 +700,13 @@ func compareIndexBack(lhs, rhs *candidatePath) (int, bool) {
 	return result, true
 }
 
+func compareGlobalIndex(lhs, rhs *candidatePath) int {
+	if lhs.path.IsTablePath() || rhs.path.IsTablePath() {
+		return 0
+	}
+	return compareBool(lhs.path.Index.Global, rhs.path.Index.Global)
+}
+
 // compareCandidates is the core of skyline pruning, which is used to decide which candidate path is better.
 // The return value is 1 if lhs is better, -1 if rhs is better, 0 if they are equivalent or not comparable.
 func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, lhs, rhs *candidatePath) int {
@@ -728,7 +735,8 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 	// Below compares the two candidate paths on three dimensions:
 	// (1): the set of columns that occurred in the access condition,
 	// (2): does it require a double scan,
-	// (3): whether or not it matches the physical property.
+	// (3): whether or not it matches the physical property,
+	// (4): it's a global index path or not.
 	// If `x` is not worse than `y` at all factors,
 	// and there exists one factor that `x` is better than `y`, then `x` is better than `y`.
 	accessResult, comparable1 := util.CompareCol2Len(lhs.accessCondsColMap, rhs.accessCondsColMap)
@@ -739,12 +747,12 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 	if !comparable2 {
 		return 0
 	}
-	matchResult := compareBool(lhs.isMatchProp, rhs.isMatchProp)
-	sum := accessResult + scanResult + matchResult
-	if accessResult >= 0 && scanResult >= 0 && matchResult >= 0 && sum > 0 {
+	matchResult, globalResult := compareBool(lhs.isMatchProp, rhs.isMatchProp), compareGlobalIndex(lhs, rhs)
+	sum := accessResult + scanResult + matchResult + globalResult
+	if accessResult >= 0 && scanResult >= 0 && matchResult >= 0 && globalResult >= 0 && sum > 0 {
 		return 1
 	}
-	if accessResult <= 0 && scanResult <= 0 && matchResult <= 0 && sum < 0 {
+	if accessResult <= 0 && scanResult <= 0 && matchResult <= 0 && globalResult <= 0 && sum < 0 {
 		return -1
 	}
 	return 0

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -932,7 +932,19 @@ func matchPropForIndexMergeAlternatives(ds *DataSource, path *util.AccessPath, p
 				if len(tmpOneItemAlternatives[b].IndexFilters) > 0 {
 					rhsCountAfter = tmpOneItemAlternatives[b].CountAfterIndex
 				}
-				return cmp.Compare(lhsCountAfter, rhsCountAfter)
+				res := cmp.Compare(lhsCountAfter, rhsCountAfter)
+				// If CountAfterAccess is same, any path is global index should be the first one.
+				if res == 0 {
+					var lIsGlobalIndex, rIsGlobalIndex int
+					if !tmpOneItemAlternatives[a].IsTablePath() && tmpOneItemAlternatives[a].Index.Global {
+						lIsGlobalIndex = 1
+					}
+					if !tmpOneItemAlternatives[b].IsTablePath() && tmpOneItemAlternatives[b].Index.Global {
+						rIsGlobalIndex = 1
+					}
+					return -cmp.Compare(lIsGlobalIndex, rIsGlobalIndex)
+				}
+				return res
 			})
 		}
 		allMatchIdxes = append(allMatchIdxes, idxWrapper{matchIdxes, pathIdx})

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -737,7 +737,7 @@ func compareCandidates(sctx base.PlanContext, prop *property.PhysicalProperty, l
 	// (1): the set of columns that occurred in the access condition,
 	// (2): does it require a double scan,
 	// (3): whether or not it matches the physical property,
-	// (4): it's a global index path or not, it only works when two indexes contains same columns.
+	// (4): it's a global index path or not.
 	// If `x` is not worse than `y` at all factors,
 	// and there exists one factor that `x` is better than `y`, then `x` is better than `y`.
 	accessResult, comparable1 := util.CompareCol2Len(lhs.accessCondsColMap, rhs.accessCondsColMap)

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -1957,8 +1957,10 @@ func pathsName(paths []*candidatePath) string {
 }
 
 func TestSkylinePruning(t *testing.T) {
-	failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune"))
+	}()
 
 	tests := []struct {
 		sql    string

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -2036,7 +2036,11 @@ func TestSkylinePruning(t *testing.T) {
 		},
 		{
 			sql:    "select * from pt2_global_index where b = 1 and c = 1 and d = 1",
-			result: "b_c_global", // will prune `c_d_e`
+			result: "b_c_global", // will prune `b_c` and `c_d_e`
+		},
+		{
+			sql:    "select * from pt2_global_index where c = 1 and d = 1 and e = 1",
+			result: "c_d_e", // will prune `b_c` and `b_c_global`
 		},
 	}
 	s := createPlannerSuite()

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -2031,15 +2031,15 @@ func TestSkylinePruning(t *testing.T) {
 			result: "PRIMARY_KEY,[g,b_global]",
 		},
 		{
-			sql:    "select * from pt2_global_index where b = 1 and c = 1",
+			sql:    "select * from pt2_global_index where b > 1 and c > 1",
 			result: "b_c_global", // will prune `b_c`
 		},
 		{
-			sql:    "select * from pt2_global_index where b = 1 and c = 1 and d = 1",
-			result: "b_c_global", // will prune `b_c` and `c_d_e`
+			sql:    "select * from pt2_global_index where b > 1 and c > 1 and d > 1",
+			result: "PRIMARY_KEY,c_d_e,b_c_global", // will prune `b_c` and keep `c_d_e`
 		},
 		{
-			sql:    "select * from pt2_global_index where c = 1 and d = 1 and e = 1",
+			sql:    "select * from pt2_global_index where c > 1 and d > 1 and e > 1",
 			result: "c_d_e", // will prune `b_c` and `b_c_global`
 		},
 	}

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -2018,15 +2018,23 @@ func TestSkylinePruning(t *testing.T) {
 		},
 		{
 			sql:    "select * from pt2_global_index where b > 1 order by b",
-			result: "b_global",
+			result: "b_global,b_c_global",
 		},
 		{
 			sql:    "select b from pt2_global_index where b > 1 order by b",
-			result: "b_global",
+			result: "b_global,b_c_global",
 		},
 		{
 			sql:    "select * from pt2_global_index where b > 1 or g = 5",
 			result: "PRIMARY_KEY,[g,b_global]",
+		},
+		{
+			sql:    "select * from pt2_global_index where b = 1 and c = 1",
+			result: "b_c_global", // will prune `b_c`
+		},
+		{
+			sql:    "select * from pt2_global_index where b = 1 and c = 1 and d = 1",
+			result: "b_c_global", // will prune `c_d_e`
 		},
 	}
 	s := createPlannerSuite()

--- a/pkg/planner/core/mock.go
+++ b/pkg/planner/core/mock.go
@@ -619,11 +619,9 @@ func MockGlobalIndexHashPartitionTable() *model.TableInfo {
 				},
 			},
 			State: model.StatePublic,
-			Unique: true,
-			Global: true,
 		},
 		{
-			Name: pmodel.NewCIStr("b_1"),
+			Name: pmodel.NewCIStr("b_global"),
 			Columns: []*model.IndexColumn{
 				{
 					Name:   pmodel.NewCIStr("b"),
@@ -632,6 +630,8 @@ func MockGlobalIndexHashPartitionTable() *model.TableInfo {
 				},
 			},
 			State:  model.StatePublic,
+			Unique: true,
+			Global: true,
 		},
 	}...)
 	return tableInfo

--- a/pkg/planner/core/mock.go
+++ b/pkg/planner/core/mock.go
@@ -607,7 +607,7 @@ func MockGlobalIndexHashPartitionTable() *model.TableInfo {
 	}
 	tableInfo.Columns = cols
 	tableInfo.Partition = partition
-	// add a global index `b` and noraml index `b_1`
+	// add a global index `b_global` and `b_c_global` and noraml index `b` and `b_c`
 	tableInfo.Indices = append(tableInfo.Indices, []*model.IndexInfo{
 		{
 			Name: pmodel.NewCIStr("b"),
@@ -627,6 +627,40 @@ func MockGlobalIndexHashPartitionTable() *model.TableInfo {
 					Name:   pmodel.NewCIStr("b"),
 					Length: types.UnspecifiedLength,
 					Offset: 1,
+				},
+			},
+			State:  model.StatePublic,
+			Unique: true,
+			Global: true,
+		},
+		{
+			Name: pmodel.NewCIStr("b_c"),
+			Columns: []*model.IndexColumn{
+				{
+					Name:   pmodel.NewCIStr("b"),
+					Length: types.UnspecifiedLength,
+					Offset: 1,
+				},
+				{
+					Name:   pmodel.NewCIStr("c"),
+					Length: types.UnspecifiedLength,
+					Offset: 2,
+				},
+			},
+			State: model.StatePublic,
+		},
+		{
+			Name: pmodel.NewCIStr("b_c_global"),
+			Columns: []*model.IndexColumn{
+				{
+					Name:   pmodel.NewCIStr("b"),
+					Length: types.UnspecifiedLength,
+					Offset: 1,
+				},
+				{
+					Name:   pmodel.NewCIStr("c"),
+					Length: types.UnspecifiedLength,
+					Offset: 2,
 				},
 			},
 			State:  model.StatePublic,

--- a/pkg/planner/core/mock.go
+++ b/pkg/planner/core/mock.go
@@ -607,7 +607,7 @@ func MockGlobalIndexHashPartitionTable() *model.TableInfo {
 	}
 	tableInfo.Columns = cols
 	tableInfo.Partition = partition
-	// add a global index `b_global` and `b_c_global` and noraml index `b` and `b_c`
+	// add a global index `b_global` and `b_c_global` and normal index `b` and `b_c`
 	tableInfo.Indices = append(tableInfo.Indices, []*model.IndexInfo{
 		{
 			Name: pmodel.NewCIStr("b"),

--- a/pkg/planner/core/mock.go
+++ b/pkg/planner/core/mock.go
@@ -574,6 +574,69 @@ func MockListPartitionTable() *model.TableInfo {
 	return tableInfo
 }
 
+// MockGlobalIndexHashPartitionTable mocks a hash partition table with global index for test
+func MockGlobalIndexHashPartitionTable() *model.TableInfo {
+	definitions := []model.PartitionDefinition{
+		{
+			ID:   51,
+			Name: pmodel.NewCIStr("p1"),
+		},
+		{
+			ID:   52,
+			Name: pmodel.NewCIStr("p2"),
+		},
+	}
+	tableInfo := MockSignedTable()
+	tableInfo.Name = pmodel.NewCIStr("pt2_global_index")
+	cols := make([]*model.ColumnInfo, 0, len(tableInfo.Columns))
+	cols = append(cols, tableInfo.Columns...)
+	last := tableInfo.Columns[len(tableInfo.Columns)-1]
+	cols = append(cols, &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    last.Offset + 1,
+		Name:      pmodel.NewCIStr("ptn"),
+		FieldType: newLongType(),
+		ID:        last.ID + 1,
+	})
+	partition := &model.PartitionInfo{
+		Type:        pmodel.PartitionTypeHash,
+		Expr:        "ptn",
+		Enable:      true,
+		Definitions: definitions,
+		Num:         2,
+	}
+	tableInfo.Columns = cols
+	tableInfo.Partition = partition
+	// add a global index `b` and noraml index `b_1`
+	tableInfo.Indices = append(tableInfo.Indices, []*model.IndexInfo{
+		{
+			Name: pmodel.NewCIStr("b"),
+			Columns: []*model.IndexColumn{
+				{
+					Name:   pmodel.NewCIStr("b"),
+					Length: types.UnspecifiedLength,
+					Offset: 1,
+				},
+			},
+			State: model.StatePublic,
+			Unique: true,
+			Global: true,
+		},
+		{
+			Name: pmodel.NewCIStr("b_1"),
+			Columns: []*model.IndexColumn{
+				{
+					Name:   pmodel.NewCIStr("b"),
+					Length: types.UnspecifiedLength,
+					Offset: 1,
+				},
+			},
+			State:  model.StatePublic,
+		},
+	}...)
+	return tableInfo
+}
+
 // MockStateNoneColumnTable is only used for plan related tests.
 func MockStateNoneColumnTable() *model.TableInfo {
 	// column: a, b


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #52061

Problem Summary: Because we didn't consider `mergeSort` cost for many executors and it's not easy to fix it right now, see [comments](https://github.com/pingcap/tidb/issues/52061#issuecomment-2362859572). So we decided to consider a path is global index or not in `skylinePruning` function.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
