### PR TITLE
ddl: fix panic in TablePartitionArgs v2

### DIFF
--- a/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
+++ b/pkg/ddl/tests/tiflash/ddl_tiflash_test.go
@@ -1430,12 +1430,11 @@ func TestTiFlashReorgPartition(t *testing.T) {
 				// Add the tiflash stores as peers for the new regions, to fullfil the check
 				// in checkPartitionReplica
 				pdCli := s.store.(tikv.Storage).GetRegionCache().PDClient()
-				var dummy []pmodel.CIStr
-				partInfo := &model.PartitionInfo{}
-				_ = job.DecodeArgs(&dummy, &partInfo)
+				args, err := model.GetTablePartitionArgs(job)
+				require.NoError(t, err)
 				ctx := context.Background()
 				stores, _ := pdCli.GetAllStores(ctx)
-				for _, pDef := range partInfo.Definitions {
+				for _, pDef := range args.PartInfo.Definitions {
 					startKey, endKey := tablecodec.GetTableHandleKeyRange(pDef.ID)
 					regions, _ := pdCli.BatchScanRegions(ctx, []pd.KeyRange{{StartKey: startKey, EndKey: endKey}}, -1)
 					for i := range regions {

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -434,7 +434,16 @@ func GetTablePartitionArgs(job *Job) (*TablePartitionArgs, error) {
 		}
 		return args, nil
 	}
-	return getOrDecodeArgsV2[*TablePartitionArgs](job)
+	args, err := getOrDecodeArgsV2[*TablePartitionArgs](job)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// when it's ActionDropTablePartition job, or roll-backing a ActionAddTablePartition
+	// job, our execution part expect a non-nil PartInfo.
+	if args.PartInfo == nil {
+		args.PartInfo = &PartitionInfo{}
+	}
+	return args, nil
 }
 
 // GetFinishedTablePartitionArgs gets the table partition args after the job is finished.

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -256,10 +256,20 @@ func TestTablePartitionArgs(t *testing.T) {
 				}
 				if j2.Type != ActionDropTablePartition {
 					require.Equal(t, inArgs.PartInfo, args.PartInfo)
+				} else {
+					require.EqualValues(t, &PartitionInfo{}, args.PartInfo)
 				}
 			}
 		}
 	}
+
+	// for ActionDropTablePartition in V2, check PartInfo is not nil
+	j2 := &Job{}
+	require.NoError(t, j2.Decode(getJobBytes(t, &TablePartitionArgs{PartNames: []string{"a", "b"}},
+		JobVersion2, ActionDropTablePartition)))
+	args, err := GetTablePartitionArgs(j2)
+	require.NoError(t, err)
+	require.EqualValues(t, &PartitionInfo{}, args.PartInfo)
 
 	for _, ver := range []JobVersion{JobVersion1, JobVersion2} {
 		j := &Job{
@@ -297,6 +307,7 @@ func TestTablePartitionArgs(t *testing.T) {
 		args, err := GetTablePartitionArgs(j2)
 		require.NoError(t, err)
 		require.EqualValues(t, partNames, args.PartNames)
+		require.EqualValues(t, &PartitionInfo{}, args.PartInfo)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53930 

Problem Summary:

### What changed and how does it work?
introduced in https://github.com/pingcap/tidb/pull/56163, we need to make sure that PartInfo is not nil for DropPartition and roll-backing AddPartition, for v1 we have make sure it already, but forget v2
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

run TestAddPartitionReplicaBiggerThanTiFlashStores with v1/v2, make sure it pass

run TestTiFlashReorgPartition with v2, pass

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
