### PR TITLE
distsql,util: Add executor open close time into its total consume time

### DIFF
--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -123,7 +123,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	stmtStats.RegisterStats(1, s1)
 	stmtStats.RegisterStats(1, &s2)
 	stats := stmtStats.GetRootStats(1)
-	expect := "time:1s(open:0s, execution:1s, close:0s), loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, backoff{RegionMiss: 2ms}"
+	expect := "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, backoff{RegionMiss: 2ms}"
 	require.Equal(t, expect, stats.String())
 	// Test for idempotence.
 	require.Equal(t, expect, stats.String())

--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -123,7 +123,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	stmtStats.RegisterStats(1, s1)
 	stmtStats.RegisterStats(1, &s2)
 	stats := stmtStats.GetRootStats(1)
-	expect := "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, backoff{RegionMiss: 2ms}"
+	expect := "time:1s(open:0s, execution:1s, close:0s), loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, backoff{RegionMiss: 2ms}"
 	require.Equal(t, expect, stats.String())
 	// Test for idempotence.
 	require.Equal(t, expect, stats.String())

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -430,6 +430,10 @@ func Open(ctx context.Context, e Executor) (err error) {
 			err = util.GetRecoverError(r)
 		}
 	}()
+	if e.RuntimeStats() != nil {
+		start := time.Now()
+		defer func() { e.RuntimeStats().RecordClose(time.Since(start)) }()
+	}
 	return e.Open(ctx)
 }
 
@@ -469,5 +473,9 @@ func Close(e Executor) (err error) {
 			err = util.GetRecoverError(r)
 		}
 	}()
+	if e.RuntimeStats() != nil {
+		start := time.Now()
+		defer func() { e.RuntimeStats().RecordClose(time.Since(start)) }()
+	}
 	return e.Close()
 }

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -432,7 +432,7 @@ func Open(ctx context.Context, e Executor) (err error) {
 	}()
 	if e.RuntimeStats() != nil {
 		start := time.Now()
-		defer func() { e.RuntimeStats().RecordClose(time.Since(start)) }()
+		defer func() { e.RuntimeStats().RecordOpen(time.Since(start)) }()
 	}
 	return e.Open(ctx)
 }

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -372,13 +372,10 @@ func TestVectorConstantExplain(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println(planTree)
 	fmt.Println("++++")
-	require.Equal(t, strings.Join([]string{
-		`	id                 	task     	estRows	operator info                                                                                                                      	actRows	execution info  	memory 	disk`,
-		`	Projection_3       	root     	10000  	vec_cosine_distance(test.t.c, cast([100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100...(len:401), vector))->Column#3	0      	time:0s, loops:0	0 Bytes	N/A`,
-		`	└─TableReader_5    	root     	10000  	data:TableFullScan_4                                                                                                               	0      	time:0s, loops:0	0 Bytes	N/A`,
-		`	  └─TableFullScan_4	cop[tikv]	10000  	table:t, keep order:false, stats:pseudo                                                                                            	0      	                	N/A    	N/A`,
-	}, "\n"), planTree)
-
+	// Don't check planTree directly, because it contains execution time info which is not fixed after open/close time is included
+	require.True(t, strings.Contains(planTree, `	Projection_3       	root     	10000  	vec_cosine_distance(test.t.c, cast([100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100...(len:401), vector))->Column#3`))
+	require.True(t, strings.Contains(planTree, `	└─TableReader_5    	root     	10000  	data:TableFullScan_4`))
+	require.True(t, strings.Contains(planTree, `	  └─TableFullScan_4	cop[tikv]	10000  	table:t, keep order:false, stats:pseudo`))
 	// No need to check result at all.
 	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs))
 }

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -17,7 +17,6 @@ package execdetails
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tipb/go-tipb"
 	"math"
 	"slices"
 	"sort"

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -17,6 +17,7 @@ package execdetails
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tipb/go-tipb"
 	"math"
 	"slices"
 	"sort"
@@ -1305,7 +1306,7 @@ func (waitSummary *TiFlashWaitSummary) CanBeIgnored() bool {
 type BasicRuntimeStats struct {
 	// executor's Next() called times.
 	loop atomic.Int32
-	// executor consume time.
+	// executor consume time, including open, next, and close time.
 	consume atomic.Int64
 	// executor open time.
 	open atomic.Int64

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1307,6 +1307,10 @@ type BasicRuntimeStats struct {
 	loop atomic.Int32
 	// executor consume time.
 	consume atomic.Int64
+	// executor open time.
+	open atomic.Int64
+	// executor close time.
+	close atomic.Int64
 	// executor return row count.
 	rows atomic.Int64
 }
@@ -1321,6 +1325,8 @@ func (e *BasicRuntimeStats) Clone() RuntimeStats {
 	result := &BasicRuntimeStats{}
 	result.loop.Store(e.loop.Load())
 	result.consume.Store(e.consume.Load())
+	result.open.Store(e.open.Load())
+	result.close.Store(e.close.Load())
 	result.rows.Store(e.rows.Load())
 	return result
 }
@@ -1333,6 +1339,8 @@ func (e *BasicRuntimeStats) Merge(rs RuntimeStats) {
 	}
 	e.loop.Add(tmp.loop.Load())
 	e.consume.Add(tmp.consume.Load())
+	e.open.Add(tmp.open.Load())
+	e.close.Add(tmp.close.Load())
 	e.rows.Add(tmp.rows.Load())
 }
 
@@ -1388,6 +1396,18 @@ func (e *BasicRuntimeStats) Record(d time.Duration, rowNum int) {
 	e.rows.Add(int64(rowNum))
 }
 
+// RecordOpen records executor's open time.
+func (e *BasicRuntimeStats) RecordOpen(d time.Duration) {
+	e.consume.Add(int64(d))
+	e.open.Add(int64(d))
+}
+
+// RecordClose records executor's close time.
+func (e *BasicRuntimeStats) RecordClose(d time.Duration) {
+	e.consume.Add(int64(d))
+	e.close.Add(int64(d))
+}
+
 // SetRowNum sets the row num.
 func (e *BasicRuntimeStats) SetRowNum(rowNum int64) {
 	e.rows.Store(rowNum)
@@ -1399,9 +1419,19 @@ func (e *BasicRuntimeStats) String() string {
 		return ""
 	}
 	var str strings.Builder
+	totalTime := e.consume.Load()
+	openTime := e.open.Load()
+	closeTime := e.close.Load()
+	executionTime := totalTime - openTime - closeTime
 	str.WriteString("time:")
-	str.WriteString(FormatDuration(time.Duration(e.consume.Load())))
-	str.WriteString(", loops:")
+	str.WriteString(FormatDuration(time.Duration(totalTime)))
+	str.WriteString("(open:")
+	str.WriteString(FormatDuration(time.Duration(openTime)))
+	str.WriteString(", execution:")
+	str.WriteString(FormatDuration(time.Duration(executionTime)))
+	str.WriteString(", close:")
+	str.WriteString(FormatDuration(time.Duration(closeTime)))
+	str.WriteString("), loops:")
 	str.WriteString(strconv.FormatInt(int64(e.loop.Load()), 10))
 	return str.String()
 }

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1422,16 +1422,17 @@ func (e *BasicRuntimeStats) String() string {
 	totalTime := e.consume.Load()
 	openTime := e.open.Load()
 	closeTime := e.close.Load()
-	executionTime := totalTime - openTime - closeTime
 	str.WriteString("time:")
 	str.WriteString(FormatDuration(time.Duration(totalTime)))
-	str.WriteString("(open:")
-	str.WriteString(FormatDuration(time.Duration(openTime)))
-	str.WriteString(", execution:")
-	str.WriteString(FormatDuration(time.Duration(executionTime)))
-	str.WriteString(", close:")
-	str.WriteString(FormatDuration(time.Duration(closeTime)))
-	str.WriteString("), loops:")
+	if openTime >=  int64(time.Millisecond) {
+		str.WriteString(", open:")
+		str.WriteString(FormatDuration(time.Duration(openTime)))
+	}
+	if closeTime >=  int64(time.Millisecond) {
+		str.WriteString(", close:")
+		str.WriteString(FormatDuration(time.Duration(closeTime)))
+	}
+	str.WriteString(", loops:")
 	str.WriteString(strconv.FormatInt(int64(e.loop.Load()), 10))
 	return str.String()
 }

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1424,11 +1424,11 @@ func (e *BasicRuntimeStats) String() string {
 	closeTime := e.close.Load()
 	str.WriteString("time:")
 	str.WriteString(FormatDuration(time.Duration(totalTime)))
-	if openTime >=  int64(time.Millisecond) {
+	if openTime >= int64(time.Millisecond) {
 		str.WriteString(", open:")
 		str.WriteString(FormatDuration(time.Duration(openTime)))
 	}
-	if closeTime >=  int64(time.Millisecond) {
+	if closeTime >= int64(time.Millisecond) {
 		str.WriteString(", close:")
 		str.WriteString(FormatDuration(time.Duration(closeTime)))
 	}

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -474,7 +474,7 @@ func TestRootRuntimeStats(t *testing.T) {
 		Commit: commitDetail,
 	})
 	stats := stmtStats.GetRootStats(1)
-	expect := "time:3.11s(open:10ms, execution:3s, close:100ms), loops:2, worker:15, commit_txn: {prewrite:1s, get_commit_ts:1s, commit:1s, region_num:5, write_keys:3, write_byte:66, txn_retry:2}"
+	expect := "time:3.11s, open:10ms, close:100ms, loops:2, worker:15, commit_txn: {prewrite:1s, get_commit_ts:1s, commit:1s, region_num:5, write_keys:3, write_byte:66, txn_retry:2}"
 	require.Equal(t, expect, stats.String())
 }
 

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -454,8 +454,10 @@ func TestRootRuntimeStats(t *testing.T) {
 	stmtStats := NewRuntimeStatsColl(nil)
 	basic1 := stmtStats.GetBasicRuntimeStats(pid)
 	basic2 := stmtStats.GetBasicRuntimeStats(pid)
+	basic1.RecordOpen(time.Millisecond * 10)
 	basic1.Record(time.Second, 20)
 	basic2.Record(time.Second*2, 30)
+	basic2.RecordClose(time.Millisecond * 100)
 	concurrency := &RuntimeStatsWithConcurrencyInfo{}
 	concurrency.SetConcurrencyInfo(NewConcurrencyInfo("worker", 15))
 	commitDetail := &util.CommitDetails{
@@ -472,7 +474,7 @@ func TestRootRuntimeStats(t *testing.T) {
 		Commit: commitDetail,
 	})
 	stats := stmtStats.GetRootStats(1)
-	expect := "time:3s, loops:2, worker:15, commit_txn: {prewrite:1s, get_commit_ts:1s, commit:1s, region_num:5, write_keys:3, write_byte:66, txn_retry:2}"
+	expect := "time:3.11s(open:10ms, execution:3s, close:100ms), loops:2, worker:15, commit_txn: {prewrite:1s, get_commit_ts:1s, commit:1s, region_num:5, write_keys:3, write_byte:66, txn_retry:2}"
 	require.Equal(t, expect, stats.String())
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56233 ref #56232 

Problem Summary:
Some executors' open or close operation may take too much time, thus we'd probably record these time in execution summary. 
#55957 provides an example that table reader operator's open takes much time while not included.
#50377 provides an example that limit operator's close takes much time while not included. 
### What changed and how does it work?

**TPCH Q3 TiFlash**
```
+--------------------------------------------------------------------+------------+---------+--------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| id                                                                 | estRows    | actRows | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | operator info                                                                                                                                                                                                                                                                                                                                          | memory  | disk    |
+--------------------------------------------------------------------+------------+---------+--------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| Projection_14                                                      | 10.00      | 10      | root         |                | time:241.4ms, open:1.75ms, loops:2, RU:2571.659780, Concurrency:OFF                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | test.lineitem.l_orderkey, Column#34, test.orders.o_orderdate, test.orders.o_shippriority                                                                                                                                                                                                                                                               | 2.52 KB | N/A     |
| └─TopN_18                                                          | 10.00      | 10      | root         |                | time:241.4ms, open:1.75ms, loops:2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Column#34:desc, test.orders.o_orderdate, offset:0, count:10                                                                                                                                                                                                                                                                                            | 1.23 KB | 0 Bytes |
|   └─TableReader_92                                                 | 10.00      | 80      | root         |                | time:241.3ms, open:1.72ms, loops:3, cop_task: {num: 9, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | MppVersion: 2, data:ExchangeSender_91                                                                                                                                                                                                                                                                                                                  | 2.97 KB | N/A     |
|     └─ExchangeSender_91                                            | 10.00      | 80      | mpp[tiflash] |                | tiflash_task:{time:237.3ms, loops:8, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                              | N/A     | N/A     |
|       └─TopN_90                                                    | 10.00      | 80      | mpp[tiflash] |                | tiflash_task:{time:236.9ms, loops:8, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Column#34:desc, test.orders.o_orderdate, offset:0, count:10                                                                                                                                                                                                                                                                                            | N/A     | N/A     |
|         └─Projection_86                                            | 756.40     | 11479   | mpp[tiflash] |                | tiflash_task:{time:236.5ms, loops:8, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Column#34, test.orders.o_orderdate, test.orders.o_shippriority, test.lineitem.l_orderkey                                                                                                                                                                                                                                                               | N/A     | N/A     |
|           └─HashAgg_87                                             | 756.40     | 11479   | mpp[tiflash] |                | tiflash_task:{time:236.5ms, loops:8, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | group by:test.lineitem.l_orderkey, test.orders.o_orderdate, test.orders.o_shippriority, funcs:sum(Column#43)->Column#34, funcs:firstrow(test.orders.o_orderdate)->test.orders.o_orderdate, funcs:firstrow(test.orders.o_shippriority)->test.orders.o_shippriority, funcs:firstrow(test.lineitem.l_orderkey)->test.lineitem.l_orderkey, stream_count: 8 | N/A     | N/A     |
|             └─ExchangeReceiver_89                                  | 756.40     | 11479   | mpp[tiflash] |                | tiflash_task:{time:236ms, loops:8, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | stream_count: 8                                                                                                                                                                                                                                                                                                                                        | N/A     | N/A     |
|               └─ExchangeSender_88                                  | 756.40     | 11479   | mpp[tiflash] |                | tiflash_task:{time:233.6ms, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary], [name: test.orders.o_orderdate, collate: binary], [name: test.orders.o_shippriority, collate: binary], stream_count: 8                                                                                                                   | N/A     | N/A     |
|                 └─HashAgg_84                                       | 756.40     | 11479   | mpp[tiflash] |                | tiflash_task:{time:232.4ms, loops:1, threads:1}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | group by:Column#48, Column#49, Column#50, funcs:sum(Column#47)->Column#43                                                                                                                                                                                                                                                                              | N/A     | N/A     |
|                   └─Projection_93                                  | 756.40     | 30266   | mpp[tiflash] |                | tiflash_task:{time:226.3ms, loops:97, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount))->Column#47, test.lineitem.l_orderkey->Column#48, test.orders.o_orderdate->Column#49, test.orders.o_shippriority->Column#50                                                                                                                                                      | N/A     | N/A     |
|                     └─Projection_73                                | 756.40     | 30266   | mpp[tiflash] |                | tiflash_task:{time:224.2ms, loops:97, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | test.orders.o_orderdate, test.orders.o_shippriority, test.lineitem.l_orderkey, test.lineitem.l_extendedprice, test.lineitem.l_discount                                                                                                                                                                                                                 | N/A     | N/A     |
|                       └─HashJoin_72                                | 756.40     | 30266   | mpp[tiflash] |                | tiflash_task:{time:223.6ms, loops:97, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | inner join, equal:[eq(test.orders.o_orderkey, test.lineitem.l_orderkey)]                                                                                                                                                                                                                                                                               | N/A     | N/A     |
|                         ├─ExchangeReceiver_41(Build)               | 187.50     | 144399  | mpp[tiflash] |                | tiflash_task:{time:73.5ms, loops:14, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |                                                                                                                                                                                                                                                                                                                                                        | N/A     | N/A     |
|                         │ └─ExchangeSender_40                      | 187.50     | 144399  | mpp[tiflash] |                | tiflash_task:{time:73.8ms, loops:24, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | ExchangeType: Broadcast, Compression: FAST                                                                                                                                                                                                                                                                                                             | N/A     | N/A     |
|                         │   └─Projection_39                        | 187.50     | 144399  | mpp[tiflash] |                | tiflash_task:{time:73.5ms, loops:24, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | test.orders.o_orderkey, test.orders.o_orderdate, test.orders.o_shippriority                                                                                                                                                                                                                                                                            | N/A     | N/A     |
|                         │     └─HashJoin_32                        | 187.50     | 144399  | mpp[tiflash] |                | tiflash_task:{time:73.5ms, loops:24, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | inner join, equal:[eq(test.customer.c_custkey, test.orders.o_custkey)]                                                                                                                                                                                                                                                                                 | N/A     | N/A     |
|                         │       ├─ExchangeReceiver_36(Build)       | 150.00     | 29752   | mpp[tiflash] |                | tiflash_task:{time:15.6ms, loops:3, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |                                                                                                                                                                                                                                                                                                                                                        | N/A     | N/A     |
|                         │       │ └─ExchangeSender_35              | 150.00     | 29752   | mpp[tiflash] |                | tiflash_task:{time:15.4ms, loops:3, threads:8}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ExchangeType: Broadcast, Compression: FAST                                                                                                                                                                                                                                                                                                             | N/A     | N/A     |
|                         │       │   └─TableFullScan_33             | 150.00     | 29752   | mpp[tiflash] | table:customer | tiflash_task:{time:14.8ms, loops:3, threads:8}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, lm_skip_rows:0, local_regions:1, remote_regions:0, tot_learner_read:1ms, region_balance:{instance_num: 1, max/min: 1/1=1.000000}, delta_rows:0, delta_bytes:0, segments:1, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:0ms, tot_build_inputstream:1ms, min_local_stream:9ms, max_local_stream:10ms, dtfile:{data_scanned_rows:150000, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:150000, lm_filter_skipped_rows:0, tot_rs_index_check:0ms, tot_read:5ms}}              | pushed down filter:eq(test.customer.c_mktsegment, "AUTOMOBILE"), keep order:false, stats:partial[c_mktsegment:unInitialized]                                                                                                                                                                                                                           | N/A     | N/A     |
|                         │       └─TableFullScan_37(Probe)          | 521300.73  | 726007  | mpp[tiflash] | table:orders   | tiflash_task:{time:68.1ms, loops:24, threads:8}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, lm_skip_rows:0, local_regions:1, remote_regions:0, tot_learner_read:1ms, region_balance:{instance_num: 1, max/min: 1/1=1.000000}, delta_rows:0, delta_bytes:0, segments:3, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:0ms, tot_build_inputstream:3ms, min_local_stream:60ms, max_local_stream:63ms, dtfile:{data_scanned_rows:1500000, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:1500000, lm_filter_skipped_rows:0, tot_rs_index_check:1ms, tot_read:51ms}}         | pushed down filter:lt(test.orders.o_orderdate, 1995-03-13 00:00:00.000000), keep order:false, stats:partial[o_orderdate:unInitialized, ID 13:unInitialized]                                                                                                                                                                                            | N/A     | N/A     |
|                         └─TableFullScan_42(Probe)                  | 2148052.67 | 3246843 | mpp[tiflash] | table:lineitem | tiflash_task:{time:193.8ms, loops:97, threads:8}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, lm_skip_rows:0, local_regions:5, remote_regions:0, tot_learner_read:1ms, region_balance:{instance_num: 1, max/min: 5/5=1.000000}, delta_rows:0, delta_bytes:0, segments:11, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:11ms, tot_build_inputstream:31ms, min_local_stream:170ms, max_local_stream:189ms, dtfile:{data_scanned_rows:6001215, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:6001215, lm_filter_skipped_rows:0, tot_rs_index_check:16ms, tot_read:627ms}} | pushed down filter:gt(test.lineitem.l_shipdate, 1995-03-13 00:00:00.000000), keep order:false, stats:partial[l_shipdate:unInitialized, ID 28:unInitialized]                                                                                                                                                                                            | N/A     | N/A     |
+--------------------------------------------------------------------+------------+---------+--------------+----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
