### PR TITLE
statistics: add the SetIndicators API

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
@@ -46,7 +46,7 @@ go_test(
         "static_partitioned_table_analysis_job_test.go",
     ],
     flaky = True,
-    shard_count = 28,
+    shard_count = 29,
     deps = [
         ":priorityqueue",
         "//pkg/meta/model",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/calculatoranalysis/calculator_analysis_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/calculatoranalysis/calculator_analysis_test.go
@@ -272,6 +272,10 @@ func (j *TestJob) GetIndicators() priorityqueue.Indicators {
 	}
 }
 
+func (j *TestJob) SetIndicators(indicators priorityqueue.Indicators) {
+	panic("unimplemented")
+}
+
 func (j *TestJob) HasNewlyAddedIndex() bool {
 	return false
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job.go
@@ -110,6 +110,11 @@ func (j *DynamicPartitionedTableAnalysisJob) GetIndicators() Indicators {
 	return j.Indicators
 }
 
+// SetIndicators sets the indicators of the table.
+func (j *DynamicPartitionedTableAnalysisJob) SetIndicators(indicators Indicators) {
+	j.Indicators = indicators
+}
+
 // HasNewlyAddedIndex checks whether the job has newly added index.
 func (j *DynamicPartitionedTableAnalysisJob) HasNewlyAddedIndex() bool {
 	return len(j.PartitionIndexes) > 0

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
@@ -71,6 +71,9 @@ type AnalysisJob interface {
 	// GetIndicators gets the indicators of the job.
 	GetIndicators() Indicators
 
+	// SetIndicators sets the indicators of the job.
+	SetIndicators(indicators Indicators)
+
 	// GetTableID gets the table ID of the job.
 	GetTableID() int64
 
@@ -155,4 +158,10 @@ func isValidToAnalyze(
 	}
 
 	return true, ""
+}
+
+// IsDynamicPartitionedTableAnalysisJob checks whether the job is a dynamic partitioned table analysis job.
+func IsDynamicPartitionedTableAnalysisJob(job AnalysisJob) bool {
+	_, ok := job.(*DynamicPartitionedTableAnalysisJob)
+	return ok
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job_test.go
@@ -128,3 +128,34 @@ func TestStringer(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDynamicPartitionedTableAnalysisJob(t *testing.T) {
+	type args struct {
+		job priorityqueue.AnalysisJob
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "non-partitioned table",
+			args: args{
+				job: &priorityqueue.NonPartitionedTableAnalysisJob{},
+			},
+			want: false,
+		},
+		{
+			name: "dynamic partitioned table",
+			args: args{
+				job: &priorityqueue.DynamicPartitionedTableAnalysisJob{},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, priorityqueue.IsDynamicPartitionedTableAnalysisJob(tt.args.job))
+		})
+	}
+}

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
@@ -126,6 +126,11 @@ func (j *NonPartitionedTableAnalysisJob) GetIndicators() Indicators {
 	return j.Indicators
 }
 
+// SetIndicators sets the indicators of the table.
+func (j *NonPartitionedTableAnalysisJob) SetIndicators(indicators Indicators) {
+	j.Indicators = indicators
+}
+
 // String implements fmt.Stringer interface.
 func (j *NonPartitionedTableAnalysisJob) String() string {
 	return fmt.Sprintf(

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
@@ -104,6 +104,11 @@ func (j *StaticPartitionedTableAnalysisJob) GetIndicators() Indicators {
 	return j.Indicators
 }
 
+// SetIndicators implements AnalysisJob.
+func (j *StaticPartitionedTableAnalysisJob) SetIndicators(indicators Indicators) {
+	j.Indicators = indicators
+}
+
 // HasNewlyAddedIndex implements AnalysisJob.
 func (j *StaticPartitionedTableAnalysisJob) HasNewlyAddedIndex() bool {
 	return len(j.Indexes) > 0

--- a/pkg/statistics/handle/autoanalyze/refresher/worker_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker_test.go
@@ -59,6 +59,9 @@ func (m *mockAnalysisJob) HasNewlyAddedIndex() bool {
 func (m *mockAnalysisJob) GetIndicators() priorityqueue.Indicators {
 	panic("not implemented")
 }
+func (m *mockAnalysisJob) SetIndicators(indicators priorityqueue.Indicators) {
+	panic("not implemented")
+}
 
 func TestWorker(t *testing.T) {
 	_, dom := testkit.CreateMockStoreAndDomain(t)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55906

Problem Summary:

### What changed and how does it work?

1. Added the SetIndicators API to update the indicators of jobs.
2. Added a util function `IsDynamicPartitionedTableAnalysisJob` to check if the job is a dynamic partitioned table analysis job.

Check https://github.com/pingcap/tidb/pull/55889/files#r1772550852 to see how we use it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
