### PR TITLE
store/driver: set `MaxCallRecvMsgSize` to `MaxInt32` for pd client

### DIFF
--- a/pkg/store/driver/tikv_driver.go
+++ b/pkg/store/driver/tikv_driver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 	"sync"
@@ -159,6 +160,9 @@ func (d TiKVDriver) OpenWithOptions(path string, options ...Option) (resStore kv
 		KeyPath:  d.security.ClusterSSLKey,
 	},
 		pd.WithGRPCDialOptions(
+			// keep the same with etcd, see
+			// https://github.com/etcd-io/etcd/blob/5704c6148d798ea444db26a966394406d8c10526/server/etcdserver/api/v3rpc/grpc.go#L34
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time:    time.Duration(d.tikvConfig.GrpcKeepAliveTime) * time.Second,
 				Timeout: time.Duration(d.tikvConfig.GrpcKeepAliveTimeout) * time.Second,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55872.

Problem Summary:

### What changed and how does it work?

The original pd client uses the default `MaxCallRecvMsgSize` which is 4MB.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

1. `tiup playground nightly --kv 3 --pd 1 --db 1 --tiflash 0 --host 10.2.8.101`
2. `mysql -h 10.2.8.101 -P 43099 -u root -D test --comments -e "create table t(id bigint primary key)"`
3. execute the following command and wait for it to finish
```
for i in {1..100}
do
    mysql -h 10.2.8.101 -P 43099 -u root -D test --comments -e "SPLIT TABLE t BETWEEN ($(($i))000000) AND ($(( $i + 1 ))000000) REGIONS 1000" > /dev/null &
done
```
4. call the API
```
curl http://10.2.8.101:33613/tables/test/t/regions
{
 "name": "t",
 "id": 110,
 "record_regions": [
  {
   "region_id": 1358901,
   "leader": {
    "id": 1358902,
    "store_id": 1
   },
   "peers": [
    {
     "id": 1358902,
     "store_id": 1
    },
    {
     "id": 1358903,
     "store_id": 4
    },
    {
     "id": 1358904,
     "store_id": 5
    }
   ],
   "region_epoch": {
    "conf_ver": 5,
    "version": 3057
   }
  },
  {
   "region_id": 1358905,
   "leader": {
    "id": 1358906,
    "store_id": 1
   },
   "peers": [
    {
     "id": 1358906,
     "store_id": 1
    },
    {
     "id": 1358907,
     "store_id": 4
    },
    {
     "id": 1358908,
     "store_id": 5
    }
   ],
   "region_epoch": {
    "conf_ver": 5,
    "version": 3057
   }
  },
...
```

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
