### PR TITLE
*: Fix possibly invalid vector default values

### DIFF
--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -766,6 +766,17 @@ func getFuncCallDefaultValue(col *table.Column, option *ast.ColumnOption, expr *
 		col.DefaultIsExpr = true
 		return str, false, nil
 
+	case ast.VecFromText:
+		if err := expression.VerifyArgsWrapper(expr.FnName.L, len(expr.Args)); err != nil {
+			return nil, false, errors.Trace(err)
+		}
+		str, err := restoreFuncCall(expr)
+		if err != nil {
+			return nil, false, errors.Trace(err)
+		}
+		col.DefaultIsExpr = true
+		return str, false, nil
+
 	default:
 		return nil, false, dbterror.ErrDefValGeneratedNamedFunctionIsNotAllowed.GenWithStackByArgs(col.Name.String(), expr.FnName.String())
 	}
@@ -1174,6 +1185,12 @@ func checkColumnValueConstraint(col *table.Column, collation string) error {
 // In NO_ZERO_DATE SQL mode, TIMESTAMP/DATE/DATETIME type can't have zero date like '0000-00-00' or '0000-00-00 00:00:00'.
 func checkColumnDefaultValue(ctx exprctx.BuildContext, col *table.Column, value any) (bool, any, error) {
 	hasDefaultValue := true
+
+	if value != nil && col.GetType() == mysql.TypeTiDBVectorFloat32 {
+		// In any SQL mode we don't allow VECTOR column to have a default value.
+		// Note that expression default is still supported.
+		return hasDefaultValue, value, errors.Errorf("VECTOR column '%-.192s' can't have a default value", col.Name.O)
+	}
 	if value != nil && (col.GetType() == mysql.TypeJSON ||
 		col.GetType() == mysql.TypeTinyBlob || col.GetType() == mysql.TypeMediumBlob ||
 		col.GetType() == mysql.TypeLongBlob || col.GetType() == mysql.TypeBlob) {

--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -1189,7 +1189,7 @@ func checkColumnDefaultValue(ctx exprctx.BuildContext, col *table.Column, value 
 	if value != nil && col.GetType() == mysql.TypeTiDBVectorFloat32 {
 		// In any SQL mode we don't allow VECTOR column to have a default value.
 		// Note that expression default is still supported.
-		return hasDefaultValue, value, errors.Errorf("VECTOR column '%-.192s' can't have a default value", col.Name.O)
+		return hasDefaultValue, value, errors.Errorf("VECTOR column '%-.192s' can't have a literal default. Use expression default instead: ((VEC_FROM_TEXT('...')))", col.Name.O)
 	}
 	if value != nil && (col.GetType() == mysql.TypeJSON ||
 		col.GetType() == mysql.TypeTinyBlob || col.GetType() == mysql.TypeMediumBlob ||

--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 43,
+    shard_count = 44,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -126,7 +126,7 @@ func TestVectorDefaultValue(t *testing.T) {
 	// ============================
 	// NULLABLE, DEFAULT
 
-	tk.MustGetErrMsg("create table t(embedding VECTOR DEFAULT '[1,2,3]')", `VECTOR column 'embedding' can't have a default value`)
+	tk.MustGetErrMsg("create table t(embedding VECTOR DEFAULT '[1,2,3]')", `VECTOR column 'embedding' can't have a literal default. Use expression default instead: ((VEC_FROM_TEXT('...')))`)
 	tk.MustExec("create table t(embedding VECTOR DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
 	tk.MustExec("insert into t values ()")
 	tk.MustExec("insert into t values ('[4]')")

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -60,6 +60,215 @@ import (
 	"github.com/tikv/client-go/v2/oracle"
 )
 
+func TestVectorDefaultValue(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// ============================
+	// NULLABLE, NO DEFAULT, Non-Strict Mode
+
+	tk.MustExec("set @@session.sql_mode=''")
+	tk.MustExec("create table t(embedding VECTOR)")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+		"<nil> <nil>",
+		"<nil> <nil>",
+	))
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(embedding VECTOR(3))")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExecToErr("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"<nil> <nil>",
+		"<nil> <nil>",
+	))
+	tk.MustExec("drop table t")
+
+	// ============================
+	// NULLABLE, NO DEFAULT, Strict Mode
+
+	tk.MustExec("set @@session.sql_mode='STRICT_ALL_TABLES'")
+	tk.MustExec("create table t(embedding VECTOR)")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+		"<nil> <nil>",
+		"<nil> <nil>",
+	))
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(embedding VECTOR(3))")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExecToErr("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"<nil> <nil>",
+		"<nil> <nil>",
+	))
+	tk.MustExec("drop table t")
+
+	// ============================
+	// NULLABLE, DEFAULT
+
+	tk.MustGetErrMsg("create table t(embedding VECTOR DEFAULT '[1,2,3]')", `VECTOR column 'embedding' can't have a default value`)
+	tk.MustExec("create table t(embedding VECTOR DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
+	tk.MustExec("insert into t values ()")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustExec("insert into t values (DEFAULT(embedding))")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+		"[1,2,3] 3",
+		"<nil> <nil>",
+		"[1,2,3] 3",
+	))
+	tk.MustExec("drop table t")
+
+	// Allow. Error happens when inserting.
+	tk.MustExec("create table t(embedding VECTOR(5) DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
+	tk.MustGetErrMsg("insert into t values ()", "vector has 3 dimensions, does not fit VECTOR(5)")
+	tk.MustGetErrMsg("insert into t values (DEFAULT)", "vector has 3 dimensions, does not fit VECTOR(5)")
+	tk.MustExec("insert into t values ('[1,2,3,4,5]')")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows("[1,2,3,4,5] 5", "<nil> <nil>"))
+	tk.MustExec("drop table t")
+
+	// Allow. Error happens when inserting.
+	tk.MustExec("create table t(embedding VECTOR(5) DEFAULT (UUID()))")
+	tk.MustContainErrMsg("insert into t values ()", "Invalid vector text: ")
+	tk.MustExec("insert into t values ('[1,2,3,4,5]')")
+	tk.MustExec("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows("[1,2,3,4,5] 5", "<nil> <nil>"))
+	tk.MustExec("drop table t")
+
+	// ============================
+	// NOT NULL, NO DEFAULT, Non-Strict Mode
+
+	tk.MustExec("set @@session.sql_mode=''")
+	tk.MustExec("create table t(embedding VECTOR NOT NULL)")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+		"[] 0",
+	))
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(embedding VECTOR(3) NOT NULL)")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExecToErr("insert into t values ('[4]')")
+	tk.MustExecToErr("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+	))
+	tk.MustExec("drop table t")
+
+	// ============================
+	// NOT NULL, NO DEFAULT, Strict Mode
+
+	tk.MustExec("set @@session.sql_mode='STRICT_ALL_TABLES'")
+	tk.MustExec("create table t(embedding VECTOR NOT NULL)")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExecToErr("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+	))
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(embedding VECTOR(3) NOT NULL)")
+	tk.MustExec("insert into t values ('[1,2,3]')")
+	tk.MustExecToErr("insert into t values ('[4]')")
+	tk.MustExecToErr("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+	))
+	tk.MustExec("drop table t")
+
+	// ============================
+	// NOT NULL, DEFAULT, Non-Strict Mode
+
+	tk.MustExec("set @@session.sql_mode=''")
+	tk.MustExec("create table t(embedding VECTOR NOT NULL DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
+	tk.MustExec("insert into t values ()")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustExec("insert into t values (DEFAULT(embedding))")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+		"[1,2,3] 3",
+		"[1,2,3] 3",
+	))
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(embedding VECTOR(1) NOT NULL DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
+	tk.MustExecToErr("insert into t values ()")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExecToErr("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustExecToErr("insert into t values (DEFAULT(embedding))")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[4] 1",
+	))
+	tk.MustExec("drop table t")
+
+	// ============================
+	// NOT NULL, DEFAULT, Strict Mode
+
+	tk.MustExec("set @@session.sql_mode='STRICT_ALL_TABLES'")
+	tk.MustExec("create table t(embedding VECTOR NOT NULL DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
+	tk.MustExec("insert into t values ()")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExec("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustExec("insert into t values (DEFAULT(embedding))")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[1,2,3] 3",
+		"[4] 1",
+		"[1,2,3] 3",
+		"[1,2,3] 3",
+	))
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(embedding VECTOR(1) NOT NULL DEFAULT (VEC_FROM_TEXT('[1,2,3]')))")
+	tk.MustExecToErr("insert into t values ()")
+	tk.MustExec("insert into t values ('[4]')")
+	tk.MustExecToErr("insert into t values (DEFAULT)")
+	tk.MustExecToErr("insert into t values (NULL)")
+	tk.MustExecToErr("insert into t values (DEFAULT(embedding))")
+	tk.MustQuery("select *, vec_dims(embedding) from t").Check(testkit.Rows(
+		"[4] 1",
+	))
+	tk.MustExec("drop table t")
+}
+
 func TestVectorColumnInfo(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -493,6 +493,11 @@ func CheckOnce(cols []*Column) error {
 // Otherwise, it will return a ErrColumnCantNull when error.
 func (c *Column) CheckNotNull(data *types.Datum, rowCntInLoadData uint64) error {
 	if (mysql.HasNotNullFlag(c.GetFlag()) || mysql.HasPreventNullInsertFlag(c.GetFlag())) && data.IsNull() {
+		if c.FieldType.EvalType().IsVectorKind() {
+			// Vector(N) is a special case because it does not have zero values as a fallback.
+			// So we always reject NULLs in NotNull context even if SQL mode is not strict.
+			return errors.Errorf("VECTOR column '%s' cannot be null", c.Name)
+		}
 		if rowCntInLoadData > 0 {
 			return ErrWarnNullToNotnull.GenWithStackByArgs(c.Name, rowCntInLoadData)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/54245

Problem Summary:

In non-strict mode, 0-sized vector may be wrongly inserted into a Non-Zero-Sized vector column:

```sql
set @session.sql_mode='';
create table x(e vector(3) not null comment 'hnsw(distance=l2)');
insert into x values();
```

### What changed and how does it work?

Forbid such values in any SQL modes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
