### PR TITLE
planner: automatically explore enforced plans for DataSource if it has already found an unenforced plan

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1260,7 +1260,7 @@ func isPointGetConvertableSchema(ds *DataSource) bool {
 // See #46177 for more information.
 func exploreEnforcedPlan(ds *DataSource) bool {
 	// default value is false to keep it compatible with previous versions.
-	return fixcontrol.GetBoolWithDefault(ds.SCtx().GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix46177, false)
+	return fixcontrol.GetBoolWithDefault(ds.SCtx().GetSessionVars().GetOptimizerFixControlMap(), fixcontrol.Fix46177, true)
 }
 
 func findBestTask4DS(ds *DataSource, prop *property.PhysicalProperty, planCounter *base.PlanCounterTp, opt *optimizetrace.PhysicalOptimizeOp) (t base.Task, cntPlan int64, err error) {

--- a/tests/integrationtest/r/cte.result
+++ b/tests/integrationtest/r/cte.result
@@ -403,9 +403,9 @@ c1	c1
 // Sort should not exist, because tpk.c1 is pk. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_27	12500.00	root		inner join, left key:cte.tpk.c1, right key:cte.tpk.c1
-├─TableReader_24(Build)	10000.00	root		data:TableFullScan_23
-│ └─TableFullScan_23	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
+MergeJoin_33	12500.00	root		inner join, left key:cte.tpk.c1, right key:cte.tpk.c1
+├─TableReader_27(Build)	10000.00	root		data:TableFullScan_26
+│ └─TableFullScan_26	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
 └─TableReader_22(Probe)	10000.00	root		data:TableFullScan_21
   └─TableFullScan_21	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
 with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
@@ -507,7 +507,7 @@ c1	c1
 // Sort should not exist, because tpk is ordered. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_23	12487.50	root		inner join, left key:cte.t1.c1, right key:cte.tpk.c1
+MergeJoin_26	12487.50	root		inner join, left key:cte.t1.c1, right key:cte.tpk.c1
 ├─TableReader_21(Build)	10000.00	root		data:TableFullScan_20
 │ └─TableFullScan_20	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
 └─Sort_19(Probe)	9990.00	root		cte.t1.c1
@@ -564,12 +564,12 @@ insert into tpk1 values(1), (2), (3);
 explain with cte1 as (select c1 from tpk) select /*+ merge_join(dt1, dt2) */ * from tpk1 dt1 inner join cte1 dt2 inner join cte1 dt3 on dt1.c1 = dt2.c1 and dt2.c1 = dt3.c1;
 id	estRows	task	access object	operator info
 HashJoin_19	12500.00	root		inner join, equal:[eq(cte.tpk.c1, cte.tpk.c1)]
-├─Selection_28(Build)	8000.00	root		not(isnull(cte.tpk.c1))
-│ └─CTEFullScan_29	10000.00	root	CTE:cte1 AS dt3	data:CTE_0
+├─Selection_31(Build)	8000.00	root		not(isnull(cte.tpk.c1))
+│ └─CTEFullScan_32	10000.00	root	CTE:cte1 AS dt3	data:CTE_0
 └─MergeJoin_21(Probe)	10000.00	root		inner join, left key:cte.tpk1.c1, right key:cte.tpk.c1
-  ├─Sort_27(Build)	8000.00	root		cte.tpk.c1
-  │ └─Selection_25	8000.00	root		not(isnull(cte.tpk.c1))
-  │   └─CTEFullScan_26	10000.00	root	CTE:cte1 AS dt2	data:CTE_0
+  ├─Sort_30(Build)	8000.00	root		cte.tpk.c1
+  │ └─Selection_28	8000.00	root		not(isnull(cte.tpk.c1))
+  │   └─CTEFullScan_29	10000.00	root	CTE:cte1 AS dt2	data:CTE_0
   └─TableReader_23(Probe)	10000.00	root		data:TableFullScan_22
     └─TableFullScan_22	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
 CTE_0	10000.00	root		Non-Recursive CTE


### PR DESCRIPTION
…

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46177

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
