### PR TITLE
planner: support using `with <opt>=<val>` to set options when running index advisor

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -5647,7 +5647,6 @@ func (b *executorBuilder) buildRecommendIndex(v *plannercore.RecommendIndexPlan)
 		Action:       v.Action,
 		SQL:          v.SQL,
 		AdviseID:     v.AdviseID,
-		Option:       v.Option,
-		Value:        v.Value,
+		Options:      v.Options,
 	}
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2731,8 +2731,7 @@ type RecommendIndexExec struct {
 	Action   string
 	SQL      string
 	AdviseID int64
-	Option   string
-	Value    ast.ValueExpr
+	Options  []ast.RecommendIndexOption
 	done     bool
 }
 
@@ -2745,7 +2744,7 @@ func (e *RecommendIndexExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	e.done = true
 
 	if e.Action == "set" {
-		return indexadvisor.SetOption(e.Ctx(), e.Option, e.Value)
+		return indexadvisor.SetOptions(e.Ctx(), e.Options...)
 	}
 	if e.Action == "show" {
 		return e.showOptions(req)
@@ -2755,12 +2754,11 @@ func (e *RecommendIndexExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		return fmt.Errorf("unsupported action: %s", e.Action)
 	}
 
-	opt := &indexadvisor.Option{}
+	var sqls []string
 	if e.SQL != "" {
-		opt.SpecifiedSQLs = []string{e.SQL}
+		sqls = strings.Split(e.SQL, ";")
 	}
-
-	results, err := indexadvisor.AdviseIndexes(ctx, e.Ctx(), opt)
+	results, err := indexadvisor.AdviseIndexes(ctx, e.Ctx(), sqls, e.Options)
 
 	for _, r := range results {
 		req.AppendString(0, r.Database)

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -2002,6 +2002,7 @@ func (n *StringOrUserVar) Accept(v Visitor) (node Node, ok bool) {
 	return v.Leave(n)
 }
 
+// RecommendIndexOption is the option for recommend index.
 type RecommendIndexOption struct {
 	Option string
 	Value  ValueExpr

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -2002,15 +2002,19 @@ func (n *StringOrUserVar) Accept(v Visitor) (node Node, ok bool) {
 	return v.Leave(n)
 }
 
+type RecommendIndexOption struct {
+	Option string
+	Value  ValueExpr
+}
+
 // RecommendIndexStmt is a statement to recommend index.
 type RecommendIndexStmt struct {
 	stmtNode
 
-	Action string
-	SQL    string
-	ID     int64
-	Option string
-	Value  ValueExpr
+	Action  string
+	SQL     string
+	ID      int64
+	Options []RecommendIndexOption
 }
 
 func (n *RecommendIndexStmt) Restore(ctx *format.RestoreCtx) error {
@@ -2022,6 +2026,19 @@ func (n *RecommendIndexStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WriteKeyWord(" FOR ")
 			ctx.WriteString(n.SQL)
 		}
+		if len(n.Options) > 0 {
+			ctx.WriteKeyWord(" WITH ")
+			for i, opt := range n.Options {
+				if i != 0 {
+					ctx.WritePlain(", ")
+				}
+				ctx.WriteKeyWord(opt.Option)
+				ctx.WritePlain(" = ")
+				if err := opt.Value.Restore(ctx); err != nil {
+					return errors.Annotatef(err, "An error occurred while restore RecommendIndexStmt.Options[%d]", i)
+				}
+			}
+		}
 	case "show":
 		ctx.WriteKeyWord(" SHOW")
 	case "apply":
@@ -2032,10 +2049,15 @@ func (n *RecommendIndexStmt) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord(fmt.Sprintf("%d", n.ID))
 	case "set":
 		ctx.WriteKeyWord(" SET ")
-		ctx.WriteKeyWord(n.Option)
-		ctx.WritePlain(" = ")
-		if err := n.Value.Restore(ctx); err != nil {
-			return errors.Annotate(err, "An error occurred while restore RecommendIndexStmt.Value")
+		for i, opt := range n.Options {
+			if i != 0 {
+				ctx.WritePlain(", ")
+			}
+			ctx.WriteKeyWord(opt.Option)
+			ctx.WritePlain(" = ")
+			if err := opt.Value.Restore(ctx); err != nil {
+				return errors.Annotatef(err, "An error occurred while restore RecommendIndexStmt.Options[%d]", i)
+			}
 		}
 	}
 	return nil

--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -880,7 +880,7 @@ var tokenMap = map[string]int{
 	"UTC_DATE":                 utcDate,
 	"UTC_TIME":                 utcTime,
 	"UTC_TIMESTAMP":            utcTimestamp,
-	"UTILIZATION_LIMIT":		utilizationLimit,
+	"UTILIZATION_LIMIT":        utilizationLimit,
 	"VALIDATION":               validation,
 	"VALUE":                    value,
 	"VALUES":                   values,

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -1278,6 +1278,9 @@ import (
 	OnUpdate                               "ON UPDATE clause"
 	OnDeleteUpdateOpt                      "optional ON DELETE and UPDATE clause"
 	OptGConcatSeparator                    "optional GROUP_CONCAT SEPARATOR"
+	RecommendIndexOptionListOpt            "Optional recommend index option list"
+	RecommendIndexOptionList               "Recommend index option list"
+	RecommendIndexOption                   "Recommend index option"
 	ReferOpt                               "reference option"
 	ReorganizePartitionRuleOpt             "optional reorganize partition partition list and definitions"
 	RequireList                            "require list for tls options"
@@ -1977,7 +1980,6 @@ DirectResourceGroupBackgroundOption:
 	{
 		$$ = &ast.ResourceGroupBackgroundOption{Type: ast.BackgroundUtilizationLimit, UintValue: $3.(uint64)}
 	}
-
 
 PlacementOptionList:
 	DirectPlacementOption
@@ -14148,19 +14150,21 @@ SetBindingStmt:
 	}
 
 RecommendIndexStmt:
-	"RECOMMEND" "INDEX" "RUN" "FOR" stringLit
+	"RECOMMEND" "INDEX" "RUN" "FOR" stringLit RecommendIndexOptionListOpt
 	{
 		x := &ast.RecommendIndexStmt{
-			Action: "run",
-			SQL:    $5,
+			Action:  "run",
+			SQL:     $5,
+			Options: $6.([]ast.RecommendIndexOption),
 		}
 
 		$$ = x
 	}
-|	"RECOMMEND" "INDEX" "RUN"
+|	"RECOMMEND" "INDEX" "RUN" RecommendIndexOptionListOpt
 	{
 		x := &ast.RecommendIndexStmt{
-			Action: "run",
+			Action:  "run",
+			Options: $4.([]ast.RecommendIndexOption),
 		}
 
 		$$ = x
@@ -14191,15 +14195,42 @@ RecommendIndexStmt:
 
 		$$ = x
 	}
-|	"RECOMMEND" "INDEX" "SET" Identifier "=" Literal
+|	"RECOMMEND" "INDEX" "SET" RecommendIndexOptionList
 	{
 		x := &ast.RecommendIndexStmt{
-			Action: "set",
-			Option: $4,
-			Value:  ast.NewValueExpr($6, parser.charset, parser.collation),
+			Action:  "set",
+			Options: $4.([]ast.RecommendIndexOption),
 		}
 
 		$$ = x
+	}
+
+RecommendIndexOptionListOpt:
+	{
+		$$ = []ast.RecommendIndexOption{}
+	}
+|	"WITH" RecommendIndexOptionList
+	{
+		$$ = $2.([]ast.RecommendIndexOption)
+	}
+
+RecommendIndexOptionList:
+	RecommendIndexOption
+	{
+		$$ = []ast.RecommendIndexOption{$1.(ast.RecommendIndexOption)}
+	}
+|	RecommendIndexOptionList ',' RecommendIndexOption
+	{
+		$$ = append($1.([]ast.RecommendIndexOption), $3.(ast.RecommendIndexOption))
+	}
+
+RecommendIndexOption:
+	Identifier "=" Literal
+	{
+		$$ = ast.RecommendIndexOption{
+			Option: $1,
+			Value:  ast.NewValueExpr($3, parser.charset, parser.collation),
+		}
 	}
 
 /*************************************************************************************

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -466,12 +466,20 @@ func RunErrMsgTest(t *testing.T, table []testErrMsgCase) {
 func TestRecommendIndex(t *testing.T) {
 	table := []testCase{
 		{"recommend index run", true, "RECOMMEND INDEX RUN"},
+		{"recommend index run with A = 1", true, "RECOMMEND INDEX RUN WITH A = 1"},
+		{"recommend index run with A = 1, B = 2", true, "RECOMMEND INDEX RUN WITH A = 1, B = 2"},
 		{"recommend index run for 'select * from t where a=1'", true,
 			"RECOMMEND INDEX RUN FOR 'select * from t where a=1'"},
+		{"recommend index run for 'select * from t where a=1' with A = 1", true,
+			"RECOMMEND INDEX RUN FOR 'select * from t where a=1' WITH A = 1"},
+		{"recommend index run for 'select * from t where a=1' with A = 1, B = 2", true,
+			"RECOMMEND INDEX RUN FOR 'select * from t where a=1' WITH A = 1, B = 2"},
 		{"recommend index show", true, "RECOMMEND INDEX SHOW"},
 		{"recommend index apply 1", true, "RECOMMEND INDEX APPLY 1"},
 		{"recommend index ignore 1", true, "RECOMMEND INDEX IGNORE 1"},
 		{"recommend index set A = 1", true, "RECOMMEND INDEX SET A = 1"},
+		{"recommend index set A = 1, B = 2", true, "RECOMMEND INDEX SET A = 1, B = 2"},
+		{"recommend index set A = 1, B = 2, C = 3", true, "RECOMMEND INDEX SET A = 1, B = 2, C = 3"},
 	}
 	RunTest(t, table, false)
 }

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -246,8 +246,7 @@ type RecommendIndexPlan struct {
 	Action   string
 	SQL      string
 	AdviseID int64
-	Option   string
-	Value    ast.ValueExpr
+	Options  []ast.RecommendIndexOption
 }
 
 // SQLBindOpType repreents the SQL bind type

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5801,8 +5801,7 @@ func (*PlanBuilder) buildRecommendIndex(v *ast.RecommendIndexStmt) (base.Plan, e
 		Action:   v.Action,
 		SQL:      v.SQL,
 		AdviseID: v.ID,
-		Option:   v.Option,
-		Value:    v.Value,
+		Options:  v.Options,
 	}
 
 	switch v.Action {
@@ -5817,8 +5816,7 @@ func (*PlanBuilder) buildRecommendIndex(v *ast.RecommendIndexStmt) (base.Plan, e
 		schema.Append(buildColumnWithName("", "top_impacted_query", mysql.TypeBlob, -1))
 		p.setSchemaAndNames(schema.col2Schema(), schema.names)
 	case "set":
-		p.Option = strings.TrimSpace(p.Option)
-		if p.Option == "" {
+		if len(p.Options) == 0 {
 			return nil, fmt.Errorf("option is empty")
 		}
 	case "show":

--- a/pkg/planner/indexadvisor/BUILD.bazel
+++ b/pkg/planner/indexadvisor/BUILD.bazel
@@ -50,7 +50,7 @@ go_test(
         "utils_test.go",
     ],
     flaky = True,
-    shard_count = 39,
+    shard_count = 41,
     deps = [
         ":indexadvisor",
         "//pkg/parser/mysql",

--- a/pkg/planner/indexadvisor/indexadvisor.go
+++ b/pkg/planner/indexadvisor/indexadvisor.go
@@ -19,12 +19,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"math"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	s "github.com/pingcap/tidb/pkg/util/set"

--- a/pkg/planner/indexadvisor/indexadvisor.go
+++ b/pkg/planner/indexadvisor/indexadvisor.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"math"
 	"sort"
 	"strings"
@@ -44,23 +45,30 @@ type Option struct {
 	SpecifiedSQLs []string
 }
 
-// AdviseIndexes is the only entry point for the index advisor.
+// AdviseIndexes is the entry point for the index advisor.
 func AdviseIndexes(ctx context.Context, sctx sessionctx.Context,
+	userSQLs []string, userOptions []ast.RecommendIndexOption) ([]*Recommendation, error) {
+	advisorLogger().Info("fill index advisor option")
+	option := &Option{SpecifiedSQLs: userSQLs}
+	if err := fillOption(sctx, option, userOptions); err != nil {
+		advisorLogger().Error("fill index advisor option failed", zap.Error(err))
+		return nil, err
+	}
+
+	return adviseIndexesWithOption(ctx, sctx, option)
+}
+
+func adviseIndexesWithOption(ctx context.Context, sctx sessionctx.Context,
 	option *Option) (results []*Recommendation, err error) {
 	if ctx == nil || sctx == nil || option == nil {
 		return nil, errors.New("nil input")
 	}
 
-	advisorLogger().Info("fill index advisor option")
-	if err := fillOption(sctx, option); err != nil {
-		advisorLogger().Error("fill index advisor option failed", zap.Error(err))
-		return nil, err
-	}
 	advisorLogger().Info("index advisor option filled and start", zap.Any("option", option))
 	defer func() {
 		if r := recover(); r != nil {
-			advisorLogger().Error("panic in AdviseIndexes", zap.Any("recover", r))
-			err = fmt.Errorf("panic in AdviseIndexes: %v", r)
+			advisorLogger().Error("panic in AdviseIndexesWithOption", zap.Any("recover", r))
+			err = fmt.Errorf("panic in AdviseIndexesWithOption: %v", r)
 		}
 	}()
 

--- a/pkg/planner/indexadvisor/indexadvisor_tpch_test.go
+++ b/pkg/planner/indexadvisor/indexadvisor_tpch_test.go
@@ -769,7 +769,7 @@ func TestIndexAdvisorTPCH1(t *testing.T) {
 	querySet.Add(indexadvisor.Query{SchemaName: "test", Text: tpchQ7, Frequency: 1})
 
 	ctx := context.WithValue(context.Background(), indexadvisor.TestKey("query_set"), querySet)
-	r, err := indexadvisor.AdviseIndexes(ctx, tk.Session(), option(""))
+	r, err := indexadvisor.AdviseIndexes(ctx, tk.Session(), nil, nil)
 	require.NoError(t, err) // no error and can get some recommendations
 	require.True(t, len(r) > 0)
 }
@@ -796,7 +796,7 @@ func TestIndexAdvisorTPCH2(t *testing.T) {
 	querySet.Add(indexadvisor.Query{SchemaName: "test", Text: tpchQ22, Frequency: 1})
 
 	ctx := context.WithValue(context.Background(), indexadvisor.TestKey("query_set"), querySet)
-	r, err := indexadvisor.AdviseIndexes(ctx, tk.Session(), option(""))
+	r, err := indexadvisor.AdviseIndexes(ctx, tk.Session(), nil, nil)
 	require.NoError(t, err) // no error and can get some recommendations
 	require.True(t, len(r) > 0)
 }

--- a/pkg/planner/indexadvisor/options_test.go
+++ b/pkg/planner/indexadvisor/options_test.go
@@ -16,6 +16,8 @@ package indexadvisor_test
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/planner/indexadvisor"
@@ -48,11 +50,11 @@ func TestOptionMaxNumIndex(t *testing.T) {
 	querySet.Add(indexadvisor.Query{SchemaName: "test", Text: "select * from t where b=1", Frequency: 1})
 	querySet.Add(indexadvisor.Query{SchemaName: "test", Text: "select * from t where c=1", Frequency: 1})
 	ctx := context.WithValue(context.Background(), indexadvisor.TestKey("query_set"), querySet)
-	check(ctx, t, tk, "test.t.a,test.t.b,test.t.c", new(indexadvisor.Option)) // 3 indexes
+	check(ctx, t, tk, "test.t.a,test.t.b,test.t.c", "") // 3 indexes
 	tk.MustExec(`recommend index set max_num_index=2`)
-	check(ctx, t, tk, "test.t.a,test.t.b", new(indexadvisor.Option)) // 2 indexes
+	check(ctx, t, tk, "test.t.a,test.t.b", "") // 2 indexes
 	tk.MustExec(`recommend index set max_num_index=1`)
-	check(ctx, t, tk, "test.t.a", new(indexadvisor.Option)) // 1 index
+	check(ctx, t, tk, "test.t.a", "") // 1 index
 }
 
 func TestOptionMaxIndexColumns(t *testing.T) {
@@ -74,20 +76,17 @@ func TestOptionMaxIndexColumns(t *testing.T) {
 
 	tk.MustExec(`use test`)
 	tk.MustExec(`create table t (a int, b int, c int, d int)`)
-	opt := func(sql string) *indexadvisor.Option {
-		return &indexadvisor.Option{SpecifiedSQLs: []string{sql}}
-	}
-	check(nil, t, tk, "test.t.a_b", opt("select b from t where a=1"))
-	check(nil, t, tk, "test.t.a_b_c", opt("select b, c from t where a=1"))
-	check(nil, t, tk, "test.t.a_d_b", opt("select b from t where a=1 and d=1"))
+	check(nil, t, tk, "test.t.a_b", "select b from t where a=1")
+	check(nil, t, tk, "test.t.a_b_c", "select b, c from t where a=1")
+	check(nil, t, tk, "test.t.a_d_b", "select b from t where a=1 and d=1")
 	tk.MustExec(`recommend index set max_index_columns=2`)
-	check(nil, t, tk, "test.t.a_b", opt("select b from t where a=1"))
-	check(nil, t, tk, "test.t.a", opt("select b, c from t where a=1"))
-	check(nil, t, tk, "test.t.a_d", opt("select b from t where a=1 and d=1"))
+	check(nil, t, tk, "test.t.a_b", "select b from t where a=1")
+	check(nil, t, tk, "test.t.a", "select b, c from t where a=1")
+	check(nil, t, tk, "test.t.a_d", "select b from t where a=1 and d=1")
 	tk.MustExec(`recommend index set max_index_columns=1`)
-	check(nil, t, tk, "test.t.a", opt("select b from t where a=1"))
-	check(nil, t, tk, "test.t.a", opt("select b, c from t where a=1"))
-	check(nil, t, tk, "test.t.a", opt("select b from t where a=1 and d=1"))
+	check(nil, t, tk, "test.t.a", "select b from t where a=1")
+	check(nil, t, tk, "test.t.a", "select b, c from t where a=1")
+	check(nil, t, tk, "test.t.a", "select b from t where a=1 and d=1")
 }
 
 func TestOptionMaxNumQuery(t *testing.T) {
@@ -139,6 +138,73 @@ func TestOptionTimeout(t *testing.T) {
 	tk.MustExec(`recommend index set timeout='1m'`)
 	rows = tk.MustQuery(`recommend index run for 'select a from t where a=1'`).Rows()
 	require.Equal(t, 1, len(rows))
+}
+
+func TestOptionsMultiple(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustQuery(`recommend index show`).Sort().
+		Check(testkit.Rows("max_index_columns 3 The maximum number of columns in an index.",
+			"max_num_index 5 The maximum number of indexes to recommend for a table.",
+			"max_num_query 1000 The maximum number of queries to recommend indexes.",
+			"timeout 30s The timeout of index advisor."))
+
+	tk.MustExec(`recommend index set max_num_query=111, max_index_columns=11, timeout='11m'`)
+	tk.MustQuery(`recommend index show`).Sort().
+		Check(testkit.Rows("max_index_columns 11 The maximum number of columns in an index.",
+			"max_num_index 5 The maximum number of indexes to recommend for a table.",
+			"max_num_query 111 The maximum number of queries to recommend indexes.",
+			"timeout 11m The timeout of index advisor."))
+
+	tk.MustExec(`recommend index set max_num_query=222, max_index_columns=22, timeout='22m'`)
+	tk.MustQuery(`recommend index show`).Sort().
+		Check(testkit.Rows("max_index_columns 22 The maximum number of columns in an index.",
+			"max_num_index 5 The maximum number of indexes to recommend for a table.",
+			"max_num_query 222 The maximum number of queries to recommend indexes.",
+			"timeout 22m The timeout of index advisor."))
+
+	tk.MustExecToErr(`recommend index set max_num_query=333, max_index_columns=33, timeout='-33m'`)
+	tk.MustQuery(`recommend index show`).Sort().
+		Check(testkit.Rows("max_index_columns 33 The maximum number of columns in an index.",
+			"max_num_index 5 The maximum number of indexes to recommend for a table.",
+			"max_num_query 333 The maximum number of queries to recommend indexes.",
+			"timeout 22m The timeout of index advisor.")) // unchanged
+}
+
+func TestOptionWithRun(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t (a int, b int, c int, d int)`)
+
+	check := func(sql, expected string) {
+		rs := tk.MustQuery(sql).Rows()
+		indexes := make([]string, 0, len(rs))
+		for _, r := range rs {
+			indexes = append(indexes, r[2].(string))
+		}
+		sort.Strings(indexes)
+		require.Equal(t, expected, strings.Join(indexes, ","))
+	}
+
+	check(`recommend index run for 'select * from t where a=1 and b=1 and c=1'`, "idx_a_b_c")
+	check(`recommend index run for 'select * from t where a=1 and b=1 and c=1' with max_index_columns=2`,
+		"idx_a_b")
+	check(`recommend index run for 'select * from t where a=1 and b=1 and c=1' with max_index_columns=1`,
+		"idx_a")
+	check(`recommend index run for 'select a from t where a=1; select b from t where b=1'`,
+		"idx_a,idx_b")
+	check(`recommend index run for 'select a from t where a=1; select b from t where b=1' with max_num_index=1`,
+		"idx_a_b")
+	check(`recommend index run for 'select a from t where a=1; select b from t where b=1'
+                with max_num_index=1, max_index_columns=1`,
+		"idx_a")
+
+	tk.MustQueryToErr(`recommend index run for 'select a from t' with timeout='0s'`)
+	tk.MustQueryToErr(`recommend index run for 'select a from t' with timeout='-0s'`)
+	tk.MustQueryToErr(`recommend index run for 'select a from t' with timeout='xxx'`)
+	tk.MustQueryToErr(`recommend index run for 'select a from t' with xxx=0`)
 }
 
 func TestOptionShow(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #12303

Problem Summary: planner: support using `with <opt>=<val>` to set options when running index advisor

### What changed and how does it work?

planner: support using `with <opt>=<val>` to set options when running index advisor.
For example: `recommend index with max_num_index=5`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
