### PR TITLE
br: fix region split failure due to empty split key

### DIFF
--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -174,6 +174,9 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 func getEndKeys(ranges []rtree.RangeStats) [][]byte {
 	endKeys := make([][]byte, 0, len(ranges))
 	for _, rg := range ranges {
+		if len(rg.EndKey) == 0 {
+			continue
+		}
 		endKeys = append(endKeys, rg.EndKey)
 	}
 	return endKeys


### PR DESCRIPTION
### What problem does this PR solve?

when tikv region has empty endKey, the br split region will failed due to empty key

Issue Number: close https://github.com/pingcap/tidb/issues/56228



### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
