### PR TITLE
owner: fix data race on ownerManager.campaignCancel

### DIFF
--- a/pkg/owner/BUILD.bazel
+++ b/pkg/owner/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     ],
     embed = [":owner"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/ddl",
         "//pkg/infoschema",

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -196,7 +196,9 @@ func (m *ownerManager) CampaignOwner(withTTL ...int) error {
 	}
 	m.sessionLease.Store(int64(session.Lease()))
 	m.wg.Add(1)
-	go m.campaignLoop(session)
+	var campaignContext context.Context
+	campaignContext, m.campaignCancel = context.WithCancel(m.ctx)
+	go m.campaignLoop(session, campaignContext)
 	return nil
 }
 
@@ -241,9 +243,7 @@ func (m *ownerManager) CampaignCancel() {
 	m.wg.Wait()
 }
 
-func (m *ownerManager) campaignLoop(etcdSession *concurrency.Session) {
-	var campaignContext context.Context
-	campaignContext, m.campaignCancel = context.WithCancel(m.ctx)
+func (m *ownerManager) campaignLoop(etcdSession *concurrency.Session, campaignContext context.Context) {
 	defer func() {
 		m.campaignCancel()
 		if r := recover(); r != nil {

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -198,7 +198,7 @@ func (m *ownerManager) CampaignOwner(withTTL ...int) error {
 	m.wg.Add(1)
 	var campaignContext context.Context
 	campaignContext, m.campaignCancel = context.WithCancel(m.ctx)
-	go m.campaignLoop(session, campaignContext)
+	go m.campaignLoop(campaignContext, session)
 	return nil
 }
 
@@ -243,7 +243,7 @@ func (m *ownerManager) CampaignCancel() {
 	m.wg.Wait()
 }
 
-func (m *ownerManager) campaignLoop(etcdSession *concurrency.Session, campaignContext context.Context) {
+func (m *ownerManager) campaignLoop(campaignContext context.Context, etcdSession *concurrency.Session) {
 	defer func() {
 		m.campaignCancel()
 		if r := recover(); r != nil {

--- a/pkg/owner/manager_test.go
+++ b/pkg/owner/manager_test.go
@@ -449,7 +449,7 @@ func TestImmediatelyCancel(t *testing.T) {
 	d := tInfo.ddl
 	defer tInfo.Close(t)
 	ownerManager := d.OwnerManager()
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		err := ownerManager.CampaignOwner()
 		require.NoError(t, err)
 		ownerManager.CampaignCancel()

--- a/pkg/owner/manager_test.go
+++ b/pkg/owner/manager_test.go
@@ -451,7 +451,6 @@ func TestImmediatelyCancel(t *testing.T) {
 	ownerManager := d.OwnerManager()
 	for i := 0; i < 100; i++ {
 		err := ownerManager.CampaignOwner()
-		//time.Sleep(100 * time.Millisecond)
 		require.NoError(t, err)
 		ownerManager.CampaignCancel()
 	}

--- a/pkg/owner/manager_test.go
+++ b/pkg/owner/manager_test.go
@@ -439,6 +439,25 @@ func deleteLeader(cli *clientv3.Client, prefixKey string) error {
 	return errors.Trace(err)
 }
 
+func TestImmediatelyCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration.NewClusterV3 will create file contains a colon which is not allowed on Windows")
+	}
+	integration.BeforeTestExternal(t)
+
+	tInfo := newTestInfo(t)
+	d := tInfo.ddl
+	defer tInfo.Close(t)
+	ownerManager := d.OwnerManager()
+	for i := 0; i < 100; i++ {
+		//fmt.Printf("TestImmediatelyCancleLoop %d\n", i)
+		err := ownerManager.CampaignOwner()
+		//time.Sleep(100 * time.Millisecond)
+		require.NoError(t, err)
+		ownerManager.CampaignCancel()
+	}
+}
+
 func TestAcquireDistributedLock(t *testing.T) {
 	const addrFmt = "http://127.0.0.1:%d"
 	cfg := embed.NewConfig()

--- a/pkg/owner/manager_test.go
+++ b/pkg/owner/manager_test.go
@@ -450,7 +450,6 @@ func TestImmediatelyCancel(t *testing.T) {
 	defer tInfo.Close(t)
 	ownerManager := d.OwnerManager()
 	for i := 0; i < 100; i++ {
-		//fmt.Printf("TestImmediatelyCancleLoop %d\n", i)
 		err := ownerManager.CampaignOwner()
 		//time.Sleep(100 * time.Millisecond)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56053

Problem Summary: **`m.campaignCancel`** is currently set in `campaignLoop` goroutine, which might happen after calling `campaignCancel()` that access **`m.campaignCancel`**, even though it is called after `CampaignOwner()`.

### What changed and how does it work?

Set **`m.campaignCancel`** in `CampaignOwner()` rather than in `campaignLoop` goroutine, to ensure a `campaignCancel()` called after `CampaignOwner()` can always access **`m.campaignCancel`** instead of nil.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
