### PR TITLE
planner: fix unique key get wrong row count when to query the NULL value | tidb-test=2eb0d03843bfec7539602dada4f96ea2ee982c0e

### DIFF
--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -257,7 +257,7 @@ func getIndexRowCountForStatsV2(sctx context.PlanContext, idx *statistics.Index,
 						}
 						continue
 					}
-					totalCount = float64(idx.NullCount)
+					totalCount = max(1, float64(idx.NullCount))
 					if debugTrace {
 						debugTraceEndEstimateRange(sctx, float64(idx.NullCount), debugTraceUniquePoint)
 					}

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -250,9 +250,16 @@ func getIndexRowCountForStatsV2(sctx context.PlanContext, idx *statistics.Index,
 			if fullLen {
 				// At most 1 in this case.
 				if idx.Info.Unique {
-					totalCount++
+					if !indexRange.IsOnlyNull() {
+						totalCount++
+						if debugTrace {
+							debugTraceEndEstimateRange(sctx, 1, debugTraceUniquePoint)
+						}
+						continue
+					}
+					totalCount = float64(idx.NullCount)
 					if debugTrace {
-						debugTraceEndEstimateRange(sctx, 1, debugTraceUniquePoint)
+						debugTraceEndEstimateRange(sctx, float64(idx.NullCount), debugTraceUniquePoint)
 					}
 					continue
 				}

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -220,4 +220,13 @@ func TestOrderedIndexWithIsNull(t *testing.T) {
 		"└─IndexReader_12 10.00 root  index:IndexRangeScan_11",
 		"  └─IndexRangeScan_11 10.00 cop[tikv] table:t1, index:b(b, c) range:[NULL,NULL], keep order:true, stats:pseudo",
 	))
+	// https://github.com/pingcap/tidb/issues/56116
+	tk.MustExec("create table t2(id bigint(20) DEFAULT NULL, UNIQUE KEY index_on_id (id))")
+	tk.MustExec("insert into t2 values (), (), ()")
+	tk.MustExec("analyze table t2")
+	tk.MustQuery("explain select count(*) from t2 where id is null;").Check(testkit.Rows(
+		"StreamAgg_17 1.00 root  funcs:count(Column#5)->Column#3",
+		"└─IndexReader_18 1.00 root  index:StreamAgg_9",
+		"  └─StreamAgg_9 1.00 cop[tikv]  funcs:count(1)->Column#5",
+		"    └─IndexRangeScan_16 3.00 cop[tikv] table:t2, index:index_on_id(id) range:[NULL,NULL], keep order:false"))
 }

--- a/pkg/util/ranger/types.go
+++ b/pkg/util/ranger/types.go
@@ -142,6 +142,18 @@ func (ran *Range) isPoint(tc types.Context, regardNullAsPoint bool) bool {
 	return !ran.LowExclude && !ran.HighExclude
 }
 
+// IsOnlyNull checks if the range has [NULL, NULL] or [NULL NULL, NULL NULL] range.
+func (ran *Range) IsOnlyNull() bool {
+	for i := range ran.LowVal {
+		a := ran.LowVal[i]
+		b := ran.HighVal[i]
+		if !(a.IsNull() && b.IsNull()) {
+			return false
+		}
+	}
+	return true
+}
+
 // IsPointNonNullable returns if the range is a point without NULL.
 func (ran *Range) IsPointNonNullable(tc types.Context) bool {
 	return ran.isPoint(tc, false)


### PR DESCRIPTION
…(#56117)

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/56116

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
