### PR TITLE
session: fix wrong etcd mutex key

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1447,6 +1447,7 @@ func forceToLeader(ctx context.Context, s sessiontypes.Session) error {
 	for !dom.DDL().OwnerManager().IsOwner() {
 		ownerID, err := dom.DDL().OwnerManager().GetOwnerID(ctx)
 		if err != nil && (errors.ErrorEqual(err, concurrency.ErrElectionNoLeader) || strings.Contains(err.Error(), "no owner")) {
+			logutil.BgLogger().Info("no leader", zap.Error(err))
 			time.Sleep(50 * time.Millisecond)
 			continue
 		} else if err != nil {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1447,7 +1447,7 @@ func forceToLeader(ctx context.Context, s sessiontypes.Session) error {
 	for !dom.DDL().OwnerManager().IsOwner() {
 		ownerID, err := dom.DDL().OwnerManager().GetOwnerID(ctx)
 		if err != nil && (errors.ErrorEqual(err, concurrency.ErrElectionNoLeader) || strings.Contains(err.Error(), "no owner")) {
-			logutil.BgLogger().Info("no leader", zap.Error(err))
+			logutil.BgLogger().Info("ddl owner not found", zap.Error(err))
 			time.Sleep(50 * time.Millisecond)
 			continue
 		} else if err != nil {

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1435,7 +1435,7 @@ func acquireLock(s sessiontypes.Session) (func(), bool) {
 			// do nothing
 		}, true
 	}
-	releaseFn, err := owner.AcquireDistributedLock(context.Background(), cli, ddl.DDLOwnerKey, 10)
+	releaseFn, err := owner.AcquireDistributedLock(context.Background(), cli, bootstrapOwnerKey, 10)
 	if err != nil {
 		return nil, false
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56375

Problem Summary:
Used the wrong mutex key. 
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
Start a v8.3.0 tidb cluster and upgrade.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
