### PR TITLE
planner: make pattern match case-insensitive for some infoschema tables

### DIFF
--- a/pkg/parser/mysql/charset.go
+++ b/pkg/parser/mysql/charset.go
@@ -541,6 +541,7 @@ const (
 	BinaryDefaultCollationID  = 63
 	UTF8MB4DefaultCollation   = "utf8mb4_bin"
 	DefaultCollationName      = UTF8MB4DefaultCollation
+	UTF8MB4GeneralCICollation = "utf8mb4_general_ci"
 
 	// MaxBytesOfCharacter, is the max bytes length of a character,
 	// refer to RFC3629, in UTF-8, characters from the U+0000..U+10FFFF range

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -198,9 +198,15 @@ func (e *InfoSchemaBaseExtractor) Extract(
 		}
 		var likePatterns []string
 		remained, likePatterns = e.extractLikePatternCol(ctx, schema, names, remained, colName, true, false)
+		if len(likePatterns) == 0 {
+			continue
+		}
 		regexp := make([]collate.WildcardPattern, len(likePatterns))
 		for i, pattern := range likePatterns {
-			regexp[i] = collate.GetCollatorByID(collate.CollationName2ID(mysql.UTF8MB4DefaultCollation)).Pattern()
+			// Because @@lower_case_table_names is always 2 in TiDB,
+			// schema object names comparison should be case insensitive.
+			ciCollateID := collate.CollationName2ID(mysql.UTF8MB4GeneralCICollation)
+			regexp[i] = collate.GetCollatorByID(ciCollateID).Pattern()
 			regexp[i].Compile(pattern, byte('\\'))
 		}
 		e.LikePatterns[colName] = likePatterns
@@ -248,6 +254,11 @@ func (e *InfoSchemaBaseExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 func (e *InfoSchemaBaseExtractor) filter(colName string, val string) bool {
 	if e.SkipRequest {
 		return true
+	}
+	for _, re := range e.colsRegexp[colName] {
+		if !re.DoMatch(val) {
+			return true
+		}
 	}
 	predVals, ok := e.ColPredicates[colName]
 	if ok && len(predVals) > 0 {
@@ -661,6 +672,13 @@ func findTableAndSchemaByName(
 		schemaSlice = append(schemaSlice, st.schema)
 		tableSlice = append(tableSlice, st.table)
 	}
+	sort.Slice(schemaSlice, func(i, j int) bool {
+		cmp := schemaSlice[i].L < schemaSlice[j].L
+		if cmp {
+			tableSlice[i], tableSlice[j] = tableSlice[j], tableSlice[i]
+		}
+		return cmp
+	})
 	return schemaSlice, tableSlice, nil
 }
 
@@ -721,6 +739,13 @@ func findSchemasForTables(
 			remains = append(remains, tbl)
 		}
 	}
+	sort.Slice(schemaSlice, func(i, j int) bool {
+		cmp := schemaSlice[i].L < schemaSlice[j].L
+		if cmp {
+			remains[i], remains[j] = remains[j], remains[i]
+		}
+		return cmp
+	})
 	return schemaSlice, remains, nil
 }
 

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -673,11 +673,13 @@ func findTableAndSchemaByName(
 		tableSlice = append(tableSlice, st.table)
 	}
 	sort.Slice(schemaSlice, func(i, j int) bool {
-		cmp := schemaSlice[i].L < schemaSlice[j].L
-		if cmp {
+		iSchema, jSchema := schemaSlice[i].L, schemaSlice[j].L
+		less := iSchema < jSchema ||
+			(iSchema == jSchema && tableSlice[i].Name.L < tableSlice[j].Name.L)
+		if less {
 			tableSlice[i], tableSlice[j] = tableSlice[j], tableSlice[i]
 		}
-		return cmp
+		return less
 	})
 	return schemaSlice, tableSlice, nil
 }
@@ -705,6 +707,9 @@ func listTablesForEachSchema(
 	return schemaSlice, tableSlice, nil
 }
 
+// findSchemasForTables finds a schema for each tableInfo, and it
+// returns a schema slice and a table slice that has the same length.
+// Note that input arg "tableSlice" will be changed in place.
 func findSchemasForTables(
 	ctx context.Context,
 	is infoschema.InfoSchema,
@@ -740,11 +745,13 @@ func findSchemasForTables(
 		}
 	}
 	sort.Slice(schemaSlice, func(i, j int) bool {
-		cmp := schemaSlice[i].L < schemaSlice[j].L
-		if cmp {
+		iSchema, jSchema := schemaSlice[i].L, schemaSlice[j].L
+		less := iSchema < jSchema ||
+			(iSchema == jSchema && remains[i].Name.L < remains[j].Name.L)
+		if less {
 			remains[i], remains[j] = remains[j], remains[i]
 		}
-		return cmp
+		return less
 	})
 	return schemaSlice, remains, nil
 }

--- a/tests/integrationtest/r/infoschema/infoschema.result
+++ b/tests/integrationtest/r/infoschema/infoschema.result
@@ -134,6 +134,16 @@ engine	DATA_LENGTH
 InnoDB	8
 drop table infoschema__infoschema.t4;
 drop table infoschema__infoschema.t5;
+create table caseSensitive (a int);
+create table unrelatedTable (a int);
+select table_schema, table_name from information_schema.tables where table_schema = 'infoschema__infoschema' and table_name like '%aseSensitive';
+table_schema	table_name
+infoschema__infoschema	caseSensitive
+select table_schema, table_name, tidb_pk_type from information_schema.tables where table_schema = 'infoschema__infoschema' and table_name like '%aseSensitive';
+table_schema	table_name	tidb_pk_type
+infoschema__infoschema	caseSensitive	NONCLUSTERED
+drop table caseSensitive;
+drop table unrelatedTable;
 create table pt1(a int primary key, b int) partition by hash(a) partitions 4;
 create table pt2(a int primary key, b int) partition by hash(a) partitions 4;
 select TABLE_NAME, PARTITION_NAME from information_schema.partitions where table_schema = 'infoschema__infoschema';
@@ -477,5 +487,6 @@ Projection_4	10000.00	root		Column#2, Column#3
 └─MemTableScan_5	10000.00	root	table:SEQUENCES	sequence_schema_pattern:[%db1%]
 select sequence_schema, sequence_name from information_schema.sequences where sequence_schema like '%db1%';
 sequence_schema	sequence_name
+Db1	s1
 drop database db1;
 drop database db2;

--- a/tests/integrationtest/t/infoschema/infoschema.test
+++ b/tests/integrationtest/t/infoschema/infoschema.test
@@ -60,6 +60,12 @@ explain select engine, DATA_LENGTH from information_schema.tables where table_na
 select engine, DATA_LENGTH from information_schema.tables where table_name ='t4' and upper(table_name) ='T4' and table_schema = 'infoschema__infoschema';
 drop table infoschema__infoschema.t4;
 drop table infoschema__infoschema.t5;
+create table caseSensitive (a int);
+create table unrelatedTable (a int);
+select table_schema, table_name from information_schema.tables where table_schema = 'infoschema__infoschema' and table_name like '%aseSensitive';
+select table_schema, table_name, tidb_pk_type from information_schema.tables where table_schema = 'infoschema__infoschema' and table_name like '%aseSensitive';
+drop table caseSensitive;
+drop table unrelatedTable;
 
 # TestPartitionsColumn
 create table pt1(a int primary key, b int) partition by hash(a) partitions 4;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56377

Problem Summary: 

There are two problems with #55844:
  - When pattern match is pushed down to memory table reader, it is case sensitive. For example, `LIKE '%T'` cannot match `"tt"`.
  - Pattern match does not work for the fast path introduced by #55574.

### What changed and how does it work?

- Make memory table reader pattern match case-insensitive.
- Consider pattern match when filtering schema object.
- Sort the result returned from `ListSchemasAndTables` to make test stable.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
