### PR TITLE
statistics: process DML changes in the new PQ

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
@@ -54,7 +54,7 @@ go_test(
         "static_partitioned_table_analysis_job_test.go",
     ],
     flaky = True,
-    shard_count = 32,
+    shard_count = 34,
     deps = [
         ":priorityqueue",
         "//pkg/meta/model",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/calculatoranalysis/calculator_analysis_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/calculatoranalysis/calculator_analysis_test.go
@@ -239,6 +239,16 @@ func (j *TestJob) Analyze(statsHandle types.StatsHandle, sysProcTracker sysproct
 	panic("unimplemented")
 }
 
+// RegisterSuccessHook implements AnalysisJob.
+func (j *TestJob) RegisterSuccessHook(hook priorityqueue.JobHook) {
+	panic("unimplemented")
+}
+
+// RegisterFailureHook implements AnalysisJob.
+func (j *TestJob) RegisterFailureHook(hook priorityqueue.JobHook) {
+	panic("unimplemented")
+}
+
 // GetWeight implements AnalysisJob.
 func (j *TestJob) GetWeight() float64 {
 	panic("unimplemented")

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
@@ -43,6 +43,9 @@ type Indicators struct {
 	LastAnalysisDuration time.Duration
 }
 
+// JobHook is the successHook function that will be called after the job is completed.
+type JobHook func(job AnalysisJob)
+
 // AnalysisJob is the interface for the analysis job.
 type AnalysisJob interface {
 	// IsValidToAnalyze checks whether the table is valid to analyze.
@@ -76,6 +79,12 @@ type AnalysisJob interface {
 
 	// GetTableID gets the table ID of the job.
 	GetTableID() int64
+
+	// RegisterSuccessHook registers a successHook function that will be called after the job can be marked as successful.
+	RegisterSuccessHook(hook JobHook)
+
+	// RegisterFailureHook registers a successHook function that will be called after the job is marked as failed.
+	RegisterFailureHook(hook JobHook)
 
 	fmt.Stringer
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -17,7 +17,6 @@ package priorityqueue
 import (
 	"container/heap"
 	"context"
-	"time"
 
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -38,7 +37,6 @@ type PushJobFunc func(job AnalysisJob) error
 func FetchAllTablesAndBuildAnalysisJobs(
 	sctx sessionctx.Context,
 	parameters map[string]string,
-	autoAnalysisTimeWindow AutoAnalysisTimeWindow,
 	statsHandle statstypes.StatsHandle,
 	jobFunc PushJobFunc,
 ) error {
@@ -62,12 +60,6 @@ func FetchAllTablesAndBuildAnalysisJobs(
 
 	dbs := is.AllSchemaNames()
 	for _, db := range dbs {
-		// Sometimes the tables are too many. Auto-analyze will take too much time on it.
-		// so we need to check the available time.
-		if !autoAnalysisTimeWindow.IsWithinTimeWindow(time.Now()) {
-			return nil
-		}
-
 		// Ignore the memory and system database.
 		if util.IsMemOrSysDB(db.L) {
 			continue

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_v2.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_v2.go
@@ -16,64 +16,98 @@ package priorityqueue
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
+	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/exec"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/internal/heap"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/zap"
 )
 
+const notInitializedErrMsg = "priority queue not initialized"
+
 const (
 	lastAnalysisDurationRefreshInterval = time.Minute * 10
+	dmlChangesFetchInterval             = time.Minute * 2
 )
 
 // AnalysisPriorityQueueV2 is a priority queue for TableAnalysisJobs.
+// Testing shows that keeping all jobs in memory is feasible.
+// Memory usage for one million tables is approximately 300 to 500 MiB, which is acceptable.
+// Typically, not many tables need to be analyzed simultaneously.
+//
+//nolint:fieldalignment
 type AnalysisPriorityQueueV2 struct {
-	inner                  *heap.Heap[int64, AnalysisJob]
-	statsHandle            statstypes.StatsHandle
-	calculator             *PriorityCalculator
-	autoAnalysisTimeWindow atomic.Value // stores *autoAnalysisTimeWindow
+	statsHandle statstypes.StatsHandle
+	calculator  *PriorityCalculator
 
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     util.WaitGroupWrapper
 
-	// initialized is a flag to check if the queue is initialized.
-	initialized atomic.Bool
+	// syncFields is a substructure to hold fields protected by mu.
+	syncFields struct {
+		// mu is used to protect the following fields.
+		mu sync.RWMutex
+		// TODO: no need to keep the inner heap thread-safe since we already have a lock in the outer struct.
+		inner *heap.Heap[int64, AnalysisJob]
+		// runningJobs is a map to store the running jobs. Used to avoid duplicate jobs.
+		runningJobs map[int64]struct{}
+		// lastDMLUpdateFetchTimestamp is the timestamp of the last DML update fetch.
+		lastDMLUpdateFetchTimestamp uint64
+		// initialized is a flag to check if the queue is initialized.
+		initialized bool
+	}
 }
 
 // NewAnalysisPriorityQueueV2 creates a new AnalysisPriorityQueue2.
 func NewAnalysisPriorityQueueV2(handle statstypes.StatsHandle) *AnalysisPriorityQueueV2 {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &AnalysisPriorityQueueV2{
+	queue := &AnalysisPriorityQueueV2{
 		statsHandle: handle,
 		calculator:  NewPriorityCalculator(),
 		ctx:         ctx,
 		cancel:      cancel,
 	}
+
+	queue.syncFields.mu.Lock()
+	queue.syncFields.runningJobs = make(map[int64]struct{})
+	queue.syncFields.mu.Unlock()
+
+	return queue
 }
 
 // IsInitialized checks if the priority queue is initialized.
 func (pq *AnalysisPriorityQueueV2) IsInitialized() bool {
-	return pq.initialized.Load()
+	pq.syncFields.mu.RLock()
+	defer pq.syncFields.mu.RUnlock()
+
+	return pq.syncFields.initialized
 }
 
 // Initialize initializes the priority queue.
+// Note: This function is thread-safe.
 func (pq *AnalysisPriorityQueueV2) Initialize() error {
-	if pq.initialized.Load() {
+	pq.syncFields.mu.Lock()
+	if pq.syncFields.initialized {
 		statslogutil.StatsLogger().Warn("Priority queue already initialized")
+		pq.syncFields.mu.Unlock()
 		return nil
 	}
+	pq.syncFields.mu.Unlock()
 
 	start := time.Now()
 	defer func() {
@@ -87,41 +121,45 @@ func (pq *AnalysisPriorityQueueV2) Initialize() error {
 	lessFunc := func(a, b AnalysisJob) bool {
 		return a.GetWeight() > b.GetWeight()
 	}
-	pq.inner = heap.NewHeap(keyFunc, lessFunc)
-	if err := pq.init(); err != nil {
+	pq.syncFields.mu.Lock()
+	pq.syncFields.inner = heap.NewHeap(keyFunc, lessFunc)
+	if err := pq.rebuildWithoutLock(); err != nil {
+		pq.syncFields.mu.Unlock()
 		pq.Close()
 		return errors.Trace(err)
 	}
+	pq.syncFields.initialized = true
+	pq.syncFields.mu.Unlock()
 
 	// Start a goroutine to maintain the priority queue.
 	pq.wg.Run(pq.run)
-	pq.initialized.Store(true)
 	return nil
 }
 
-// init initializes the priority queue and adds jobs to it.
-func (pq *AnalysisPriorityQueueV2) init() error {
+// rebuildWithoutLock rebuilds the priority queue without holding the lock.
+// Note: Please hold the lock before calling this function.
+func (pq *AnalysisPriorityQueueV2) rebuildWithoutLock() error {
 	return statsutil.CallWithSCtx(pq.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		parameters := exec.GetAutoAnalyzeParameters(sctx)
-		err := pq.setAutoAnalysisTimeWindow(parameters)
-		if err != nil {
-			return err
-		}
-		if !pq.IsWithinTimeWindow() {
-			return nil
-		}
-		timeWindow := pq.autoAnalysisTimeWindow.Load().(*AutoAnalysisTimeWindow)
-
-		err = FetchAllTablesAndBuildAnalysisJobs(
+		// We need to fetch the next check version with offset before fetching all tables and building analysis jobs.
+		// Otherwise, we may miss some DML changes happened during the process because this operation takes time.
+		// For example, 1m tables will take about 1min to fetch all tables and build analysis jobs.
+		// This will guarantee that we will not miss any DML changes. But it may cause some DML changes to be processed twice.
+		// It is acceptable since the DML changes operation is idempotent.
+		nextCheckVersionWithOffset := pq.statsHandle.GetNextCheckVersionWithOffset()
+		err := FetchAllTablesAndBuildAnalysisJobs(
 			sctx,
 			parameters,
-			*timeWindow,
 			pq.statsHandle,
-			pq.Push,
+			pq.pushWithoutLock,
 		)
+
+		// Update the last fetch timestamp of DML updates.
+		pq.syncFields.lastDMLUpdateFetchTimestamp = nextCheckVersionWithOffset
 		if err != nil {
 			return errors.Trace(err)
 		}
+
 		return nil
 	}, statsutil.FlagWrapTxn)
 }
@@ -134,6 +172,8 @@ func (pq *AnalysisPriorityQueueV2) run() {
 		}
 	}()
 
+	dmlChangesFetchInterval := time.NewTicker(dmlChangesFetchInterval)
+	defer dmlChangesFetchInterval.Stop()
 	timeRefreshInterval := time.NewTicker(lastAnalysisDurationRefreshInterval)
 	defer timeRefreshInterval.Stop()
 
@@ -142,6 +182,9 @@ func (pq *AnalysisPriorityQueueV2) run() {
 		case <-pq.ctx.Done():
 			statslogutil.StatsLogger().Info("Priority queue stopped")
 			return
+		case <-dmlChangesFetchInterval.C:
+			statslogutil.StatsLogger().Info("Start to fetch DML changes of jobs")
+			pq.ProcessDMLChanges()
 		case <-timeRefreshInterval.C:
 			statslogutil.StatsLogger().Info("Start to refresh last analysis durations of jobs")
 			pq.RefreshLastAnalysisDuration()
@@ -149,22 +192,240 @@ func (pq *AnalysisPriorityQueueV2) run() {
 	}
 }
 
-// RefreshLastAnalysisDuration refreshes the last analysis duration of all jobs in the priority queue.
-func (pq *AnalysisPriorityQueueV2) RefreshLastAnalysisDuration() {
+// ProcessDMLChanges processes DML changes.
+// Note: This function is thread-safe.
+// Performance: To scan all table stats and process the DML changes, it takes about less than 100ms for 1m tables.
+func (pq *AnalysisPriorityQueueV2) ProcessDMLChanges() {
+	pq.syncFields.mu.Lock()
+	defer pq.syncFields.mu.Unlock()
+
 	if err := statsutil.CallWithSCtx(pq.statsHandle.SPool(), func(sctx sessionctx.Context) error {
+		start := time.Now()
+		defer func() {
+			statslogutil.StatsLogger().Info("DML changes processed", zap.Duration("duration", time.Since(start)))
+		}()
+
 		parameters := exec.GetAutoAnalyzeParameters(sctx)
-		if err := pq.setAutoAnalysisTimeWindow(parameters); err != nil {
-			return errors.Trace(err)
+		// We need to fetch the next check version with offset before fetching new DML changes.
+		// Otherwise, we may miss some DML changes happened during the process.
+		newMaxVersion := pq.statsHandle.GetNextCheckVersionWithOffset()
+		values := pq.statsHandle.Values()
+		lastFetchTimestamp := pq.syncFields.lastDMLUpdateFetchTimestamp
+		for _, value := range values {
+			// We only process the tables that have been updated.
+			// So here we only need to process the tables whose version is greater than the last fetch timestamp.
+			if value.Version > lastFetchTimestamp {
+				// TODO: consider locked tables and partitions. Consider move this check to
+				err := pq.processTableStats(sctx, value, parameters)
+				if err != nil {
+					statslogutil.StatsLogger().Error(
+						"Failed to process table stats",
+						zap.Error(err),
+						zap.Int64("tableID", value.PhysicalID),
+					)
+				}
+			}
 		}
-		if !pq.IsWithinTimeWindow() {
-			statslogutil.StatsLogger().Debug("Not within the auto analyze time window, skip refreshing last analysis duration")
+
+		// Only update if we've seen a newer version
+		if newMaxVersion > lastFetchTimestamp {
+			statslogutil.StatsLogger().Info("Updating last fetch timestamp", zap.Uint64("new_max_version", newMaxVersion))
+			pq.syncFields.lastDMLUpdateFetchTimestamp = newMaxVersion
+		}
+		return nil
+	}, statsutil.FlagWrapTxn); err != nil {
+		statslogutil.StatsLogger().Error("Failed to process DML changes", zap.Error(err))
+	}
+}
+
+// Note: Please hold the lock before calling this function.
+func (pq *AnalysisPriorityQueueV2) processTableStats(
+	sctx sessionctx.Context,
+	stats *statistics.Table,
+	parameters map[string]string,
+) error {
+	// Check if the table is eligible for analysis first to avoid unnecessary work.
+	if !stats.IsEligibleForAnalysis() {
+		return nil
+	}
+
+	// FIXME: What if this value changes after we fetch the table stats and process the DML changes?
+	// We may accidentally ignore some tables that need to be analyzed.
+	autoAnalyzeRatio := exec.ParseAutoAnalyzeRatio(parameters[variable.TiDBAutoAnalyzeRatio])
+	// Get current timestamp from the session context.
+	currentTs, err := getStartTs(sctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	jobFactory := NewAnalysisJobFactory(sctx, autoAnalyzeRatio, currentTs)
+	// Check if the table is needed to be analyzed.
+	// Note: Unanalyzed tables will also be considered.
+	changePercent := jobFactory.CalculateChangePercentage(stats)
+	if changePercent == 0 {
+		return nil
+	}
+	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	pruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
+
+	var job AnalysisJob
+	// For dynamic partitioned tables, we need to recreate the job if the partition stats are updated.
+	// This means we will always enter the tryCreateJob branch for these partitions.
+	// Since we store the stats meta for each partition and the parent table, there may be redundant calculations.
+	// This is acceptable for now, but in the future, we may consider separating the analysis job for each partition.
+	job, ok, _ := pq.syncFields.inner.GetByKey(stats.PhysicalID)
+	if !ok {
+		job = pq.tryCreateJob(is, stats, pruneMode, jobFactory)
+	} else {
+		job = pq.tryUpdateJob(is, stats, job, jobFactory)
+	}
+	return pq.pushWithoutLock(job)
+}
+func (pq *AnalysisPriorityQueueV2) tryCreateJob(
+	is infoschema.InfoSchema,
+	stats *statistics.Table,
+	pruneMode variable.PartitionPruneMode,
+	jobFactory *AnalysisJobFactory,
+) (job AnalysisJob) {
+	if stats == nil {
+		return nil
+	}
+
+	tableInfo, ok := pq.statsHandle.TableInfoByID(is, stats.PhysicalID)
+	tableMeta := tableInfo.Meta()
+	if !ok {
+		statslogutil.StatsLogger().Warn(
+			"Table info not found for table id",
+			zap.Int64("tableID", stats.PhysicalID),
+		)
+		return nil
+	}
+	schemaName, ok := is.SchemaNameByTableID(tableMeta.ID)
+	if !ok {
+		statslogutil.StatsLogger().Warn(
+			"Schema name not found for table id",
+			zap.Int64("tableID", stats.PhysicalID),
+		)
+		return nil
+	}
+	partitionedTable := tableMeta.GetPartitionInfo()
+	if partitionedTable == nil {
+		job = jobFactory.CreateNonPartitionedTableAnalysisJob(
+			schemaName.O,
+			tableMeta,
+			stats,
+		)
+	} else {
+		partitionDefs := partitionedTable.Definitions
+		if pruneMode == variable.Static {
+			var partitionDef model.PartitionDefinition
+			found := false
+			// Find the specific partition definition.
+			for _, def := range partitionDefs {
+				if def.ID == stats.PhysicalID {
+					partitionDef = def
+					found = true
+					break
+				}
+			}
+			if !found {
+				// This usually indicates that the stats are for the parent (global) table.
+				// In static partition mode, we do not analyze the parent table.
+				// TODO: add tests to verify this behavior.
+				return nil
+			}
+			job = jobFactory.CreateStaticPartitionAnalysisJob(
+				schemaName.O,
+				tableMeta,
+				partitionDef.ID,
+				partitionDef.Name.O,
+				stats,
+			)
+		} else {
+			partitionStats := GetPartitionStats(pq.statsHandle, tableMeta, partitionDefs)
+			job = jobFactory.CreateDynamicPartitionedTableAnalysisJob(
+				schemaName.O,
+				tableMeta,
+				// Get global stats for dynamic partitioned table.
+				pq.statsHandle.GetTableStatsForAutoAnalyze(tableMeta),
+				partitionStats,
+			)
+		}
+	}
+	return job
+}
+func (pq *AnalysisPriorityQueueV2) tryUpdateJob(
+	is infoschema.InfoSchema,
+	stats *statistics.Table,
+	oldJob AnalysisJob,
+	jobFactory *AnalysisJobFactory,
+) AnalysisJob {
+	if stats == nil {
+		return nil
+	}
+	intest.Assert(oldJob != nil)
+	indicators := oldJob.GetIndicators()
+
+	// For dynamic partitioned table, there is no way to only update the partition that has been changed.
+	// So we recreate the job for dynamic partitioned table.
+	if IsDynamicPartitionedTableAnalysisJob(oldJob) {
+		tableInfo, ok := pq.statsHandle.TableInfoByID(is, stats.PhysicalID)
+		if !ok {
+			statslogutil.StatsLogger().Warn(
+				"Table info not found during updating job",
+				zap.Int64("tableID", stats.PhysicalID),
+				zap.String("job", oldJob.String()),
+			)
 			return nil
 		}
+		tableMeta := tableInfo.Meta()
+		partitionedTable := tableMeta.GetPartitionInfo()
+		partitionDefs := partitionedTable.Definitions
+		partitionStats := GetPartitionStats(pq.statsHandle, tableMeta, partitionDefs)
+		schemaName, ok := is.SchemaNameByTableID(tableMeta.ID)
+		if !ok {
+			statslogutil.StatsLogger().Warn(
+				"Schema name not found during updating job",
+				zap.Int64("tableID", stats.PhysicalID),
+				zap.String("job", oldJob.String()),
+			)
+			return nil
+		}
+		return jobFactory.CreateDynamicPartitionedTableAnalysisJob(
+			schemaName.O,
+			tableMeta,
+			stats,
+			partitionStats,
+		)
+	}
+	// Otherwise, we update the indicators of the job.
+	indicators.ChangePercentage = jobFactory.CalculateChangePercentage(stats)
+	indicators.TableSize = jobFactory.CalculateTableSize(stats)
+	oldJob.SetIndicators(indicators)
+	return oldJob
+}
+
+// GetLastFetchTimestamp returns the last fetch timestamp of DML updates.
+// Note: This function is thread-safe.
+// Exported for testing.
+func (pq *AnalysisPriorityQueueV2) GetLastFetchTimestamp() uint64 {
+	pq.syncFields.mu.RLock()
+	defer pq.syncFields.mu.RUnlock()
+
+	return pq.syncFields.lastDMLUpdateFetchTimestamp
+}
+
+// RefreshLastAnalysisDuration refreshes the last analysis duration of all jobs in the priority queue.
+// Note: This function is thread-safe.
+func (pq *AnalysisPriorityQueueV2) RefreshLastAnalysisDuration() {
+	pq.syncFields.mu.Lock()
+	defer pq.syncFields.mu.Unlock()
+
+	if err := statsutil.CallWithSCtx(pq.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		start := time.Now()
 		defer func() {
 			statslogutil.StatsLogger().Info("Last analysis duration refreshed", zap.Duration("duration", time.Since(start)))
 		}()
-		jobs := pq.inner.List()
+		jobs := pq.syncFields.inner.List()
 		for _, job := range jobs {
 			indicators := job.GetIndicators()
 			currentTs, err := getStartTs(sctx)
@@ -179,7 +440,8 @@ func (pq *AnalysisPriorityQueueV2) RefreshLastAnalysisDuration() {
 					zap.Int64("tableID", job.GetTableID()),
 					zap.String("job", job.String()),
 				)
-				err := pq.inner.Delete(job)
+				// TODO: Remove this after handling the DDL event.
+				err := pq.syncFields.inner.Delete(job)
 				if err != nil {
 					statslogutil.StatsLogger().Error("Failed to delete job from priority queue",
 						zap.Error(err),
@@ -190,7 +452,7 @@ func (pq *AnalysisPriorityQueueV2) RefreshLastAnalysisDuration() {
 			indicators.LastAnalysisDuration = jobFactory.GetTableLastAnalyzeDuration(tableStats)
 			job.SetIndicators(indicators)
 			job.SetWeight(pq.calculator.CalculateWeight(job))
-			if err := pq.inner.Update(job); err != nil {
+			if err := pq.syncFields.inner.Update(job); err != nil {
 				statslogutil.StatsLogger().Error("Failed to add job to priority queue",
 					zap.Error(err),
 					zap.String("job", job.String()),
@@ -203,54 +465,125 @@ func (pq *AnalysisPriorityQueueV2) RefreshLastAnalysisDuration() {
 	}
 }
 
+// GetRunningJobs returns the running jobs.
+// Note: This function is thread-safe.
+// Exported for testing.
+func (pq *AnalysisPriorityQueueV2) GetRunningJobs() map[int64]struct{} {
+	pq.syncFields.mu.RLock()
+	defer pq.syncFields.mu.RUnlock()
+
+	runningJobs := make(map[int64]struct{}, len(pq.syncFields.runningJobs))
+	for id := range pq.syncFields.runningJobs {
+		runningJobs[id] = struct{}{}
+	}
+	return runningJobs
+}
+
 func (*AnalysisPriorityQueueV2) handleDDLEvent(_ context.Context, _ sessionctx.Context, _ notifier.SchemaChangeEvent) {
 	// TODO: Handle the ddl event.
 	// Only care about the add index event.
 }
 
 // Push pushes a job into the priority queue.
+// Note: This function is thread-safe.
 func (pq *AnalysisPriorityQueueV2) Push(job AnalysisJob) error {
-	return pq.inner.Add(job)
+	pq.syncFields.mu.Lock()
+	defer pq.syncFields.mu.Unlock()
+	if !pq.syncFields.initialized {
+		return errors.New(notInitializedErrMsg)
+	}
+
+	return pq.pushWithoutLock(job)
+}
+func (pq *AnalysisPriorityQueueV2) pushWithoutLock(job AnalysisJob) error {
+	if job == nil {
+		return nil
+	}
+	weight := pq.calculator.CalculateWeight(job)
+	job.SetWeight(weight)
+	// Skip the current running jobs.
+	// Safety:
+	// Let's say we have a job in the priority queue, and it is already running.
+	// Then we will not add the same job to the priority queue again. Otherwise, we will analyze the same table twice.
+	// If the job is finished, we will remove it from the running jobs.
+	// Then the next time we process the DML changes, we will add the job to the priority queue.(if it is still needed)
+	// In this process, we will not miss any DML changes of the table. Because when we try to delete the table from the current running jobs,
+	// we guarantee that the job is finished and the stats cache is updated.(The last step of the analysis job is to update the stats cache).
+	if _, ok := pq.syncFields.runningJobs[job.GetTableID()]; ok {
+		return nil
+	}
+	return pq.syncFields.inner.Add(job)
 }
 
-// Pop pops a job from the priority queue.
+// Pop pops a job from the priority queue and marks it as running.
+// Note: This function is thread-safe.
 func (pq *AnalysisPriorityQueueV2) Pop() (AnalysisJob, error) {
-	return pq.inner.Pop()
+	pq.syncFields.mu.Lock()
+	defer pq.syncFields.mu.Unlock()
+	if !pq.syncFields.initialized {
+		return nil, errors.New(notInitializedErrMsg)
+	}
+
+	job, err := pq.syncFields.inner.Pop()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	pq.syncFields.runningJobs[job.GetTableID()] = struct{}{}
+
+	job.RegisterSuccessHook(func(j AnalysisJob) {
+		pq.syncFields.mu.Lock()
+		defer pq.syncFields.mu.Unlock()
+		delete(pq.syncFields.runningJobs, j.GetTableID())
+	})
+	job.RegisterFailureHook(func(j AnalysisJob) {
+		pq.syncFields.mu.Lock()
+		defer pq.syncFields.mu.Unlock()
+		// Mark the job as failed and remove it from the running jobs.
+		delete(pq.syncFields.runningJobs, j.GetTableID())
+		// Add the job back to the priority queue.
+		if err := pq.syncFields.inner.Add(j); err != nil {
+			statslogutil.StatsLogger().Error("Failed to add job back to priority queue",
+				zap.Error(err),
+				zap.String("job", j.String()),
+			)
+		}
+	})
+	return job, nil
+}
+
+// Peek peeks the top job from the priority queue.
+func (pq *AnalysisPriorityQueueV2) Peek() (AnalysisJob, error) {
+	pq.syncFields.mu.Lock()
+	defer pq.syncFields.mu.Unlock()
+	if !pq.syncFields.initialized {
+		return nil, errors.New(notInitializedErrMsg)
+	}
+
+	return pq.syncFields.inner.Peek()
 }
 
 // IsEmpty checks whether the priority queue is empty.
-func (pq *AnalysisPriorityQueueV2) IsEmpty() bool {
-	return pq.inner.IsEmpty()
-}
-
-func (pq *AnalysisPriorityQueueV2) setAutoAnalysisTimeWindow(
-	parameters map[string]string,
-) error {
-	start, end, err := exec.ParseAutoAnalysisWindow(
-		parameters[variable.TiDBAutoAnalyzeStartTime],
-		parameters[variable.TiDBAutoAnalyzeEndTime],
-	)
-	if err != nil {
-		return errors.Wrap(err, "parse auto analyze period failed")
+// Note: This function is thread-safe.
+func (pq *AnalysisPriorityQueueV2) IsEmpty() (bool, error) {
+	pq.syncFields.mu.RLock()
+	defer pq.syncFields.mu.RUnlock()
+	if !pq.syncFields.initialized {
+		return false, errors.New(notInitializedErrMsg)
 	}
-	timeWindow := NewAutoAnalysisTimeWindow(start, end)
-	pq.autoAnalysisTimeWindow.Store(&timeWindow)
-	return nil
-}
 
-// IsWithinTimeWindow checks if the current time is within the auto analyze time window.
-func (pq *AnalysisPriorityQueueV2) IsWithinTimeWindow() bool {
-	window := pq.autoAnalysisTimeWindow.Load().(*AutoAnalysisTimeWindow)
-	return window.IsWithinTimeWindow(time.Now())
+	return pq.syncFields.inner.IsEmpty(), nil
 }
 
 // Close closes the priority queue.
+// Note: This function is thread-safe.
 func (pq *AnalysisPriorityQueueV2) Close() {
-	if !pq.initialized.Load() {
+	pq.syncFields.mu.Lock()
+	defer pq.syncFields.mu.Unlock()
+	if !pq.syncFields.initialized {
 		return
 	}
 
 	pq.cancel()
 	pq.wg.Wait()
-	pq.inner.Close()
+	pq.syncFields.inner.Close()
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_v2_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_v2_test.go
@@ -26,6 +26,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCallAPIBeforeInitialize(t *testing.T) {
+	_, dom := testkit.CreateMockStoreAndDomain(t)
+	handle := dom.StatsHandle()
+	pq := priorityqueue.NewAnalysisPriorityQueueV2(handle)
+	defer pq.Close()
+
+	t.Run("IsEmpty", func(t *testing.T) {
+		isEmpty, err := pq.IsEmpty()
+		require.Error(t, err)
+		require.False(t, isEmpty)
+	})
+
+	t.Run("Push", func(t *testing.T) {
+		err := pq.Push(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Pop", func(t *testing.T) {
+		poppedJob, err := pq.Pop()
+		require.Error(t, err)
+		require.Nil(t, poppedJob)
+	})
+
+	t.Run("GetAllJobs", func(t *testing.T) {
+		jobs := pq.GetRunningJobs()
+		require.Len(t, jobs, 0)
+	})
+
+	t.Run("Peek", func(t *testing.T) {
+		job, err := pq.Peek()
+		require.Error(t, err)
+		require.Nil(t, job)
+	})
+}
+
 func TestAnalysisPriorityQueueV2(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
@@ -58,7 +93,9 @@ func TestAnalysisPriorityQueueV2(t *testing.T) {
 	})
 
 	t.Run("IsEmpty And Pop", func(t *testing.T) {
-		require.False(t, pq.IsEmpty())
+		isEmpty, err := pq.IsEmpty()
+		require.NoError(t, err)
+		require.False(t, isEmpty)
 
 		poppedJob, err := pq.Pop()
 		require.NoError(t, err)
@@ -68,32 +105,68 @@ func TestAnalysisPriorityQueueV2(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, poppedJob)
 
-		require.True(t, pq.IsEmpty())
+		isEmpty, err = pq.IsEmpty()
+		require.NoError(t, err)
+		require.True(t, isEmpty)
+
+		runningJobs := pq.GetRunningJobs()
+		require.Len(t, runningJobs, 2)
 	})
 }
 
-func TestIsWithinTimeWindow(t *testing.T) {
+func TestRefreshLastAnalysisDuration(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
-	tk := testkit.NewTestKit(t, store)
-
 	handle := dom.StatsHandle()
-	pq := priorityqueue.NewAnalysisPriorityQueueV2(handle)
-	err := pq.Initialize()
-	require.NoError(t, err)
-	require.True(t, pq.IsWithinTimeWindow())
-	pq.Close()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int)")
+	tk.MustExec("create table t2 (a int)")
+	tk.MustExec("insert into t1 values (1)")
+	tk.MustExec("insert into t2 values (1)")
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = 1000
+	}()
 
-	tk.MustExec("set global tidb_auto_analyze_start_time = '00:00 +0000'")
-	tk.MustExec("set global tidb_auto_analyze_end_time = '00:00 +0000'")
-	// Reset the priority queue with the new time window.
-	pq = priorityqueue.NewAnalysisPriorityQueueV2(handle)
-	err = pq.Initialize()
+	ctx := context.Background()
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+	pq := priorityqueue.NewAnalysisPriorityQueueV2(handle)
+	defer pq.Close()
+	require.NoError(t, pq.Initialize())
+
+	// Check current jobs
+	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
-	require.False(t, pq.IsWithinTimeWindow())
-	pq.Close()
+	require.False(t, isEmpty)
+
+	// Analyze the tables
+	tk.MustExec("analyze table t1")
+	tk.MustExec("analyze table t2")
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+
+	// Call RefreshLastAnalysisDuration
+	pq.RefreshLastAnalysisDuration()
+
+	// Check if the jobs' last analysis durations and weights have been updated
+	updatedJob1, err := pq.Pop()
+	require.NoError(t, err)
+	require.NotZero(t, updatedJob1.GetWeight())
+	require.NotZero(t, updatedJob1.GetIndicators().LastAnalysisDuration)
+	require.NotEqual(t, time.Minute*3, updatedJob1.GetIndicators().LastAnalysisDuration)
+
+	updatedJob2, err := pq.Pop()
+	require.NoError(t, err)
+	require.NotZero(t, updatedJob2.GetWeight())
+	require.NotZero(t, updatedJob2.GetIndicators().LastAnalysisDuration)
+	require.NotEqual(t, time.Minute*3, updatedJob2.GetIndicators().LastAnalysisDuration)
+
+	// Check running jobs
+	runningJobs := pq.GetRunningJobs()
+	require.Len(t, runningJobs, 2)
 }
 
-func TestRefreshLastAnalysisDuration(t *testing.T) {
+func TestProcessDMLChanges(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	handle := dom.StatsHandle()
 	tk := testkit.NewTestKit(t, store)
@@ -124,36 +197,128 @@ func TestRefreshLastAnalysisDuration(t *testing.T) {
 	job1, err := pq.Pop()
 	require.NoError(t, err)
 	require.Equal(t, tbl1.Meta().ID, job1.GetTableID())
-	oldLastAnalysisDuration1 := job1.GetIndicators().LastAnalysisDuration
-	require.Equal(t, time.Minute*30, oldLastAnalysisDuration1)
 	job2, err := pq.Pop()
 	require.NoError(t, err)
 	require.Equal(t, tbl2.Meta().ID, job2.GetTableID())
-	oldLastAnalysisDuration2 := job2.GetIndicators().LastAnalysisDuration
-	require.Equal(t, time.Minute*30, oldLastAnalysisDuration2)
+	require.NoError(t, job1.Analyze(handle, dom.SysProcTracker()))
+	require.NoError(t, job2.Analyze(handle, dom.SysProcTracker()))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
 
-	// Push the jobs back to the queue
-	require.NoError(t, pq.Push(job1))
-	require.NoError(t, pq.Push(job2))
+	// Insert 10 rows into t1.
+	tk.MustExec("insert into t1 values (2), (3), (4), (5), (6), (7), (8), (9), (10), (11)")
+	// Insert 2 rows into t2.
+	tk.MustExec("insert into t2 values (2), (3)")
 
-	// Analyze the tables
+	// Dump the stats to kv.
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+
+	// Process the DML changes.
+	pq.ProcessDMLChanges()
+
+	// Check if the jobs have been updated.
+	updatedJob1, err := pq.Peek()
+	require.NoError(t, err)
+	require.NotZero(t, updatedJob1.GetWeight())
+	require.Equal(t, tbl1.Meta().ID, updatedJob1.GetTableID())
+
+	// Update some rows in t2.
+	tk.MustExec("update t2 set a = 3 where a = 2")
+	tk.MustExec("update t2 set a = 4 where a = 3")
+	tk.MustExec("update t2 set a = 5 where a = 4")
+
+	// Dump the stats to kv.
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+
+	// Process the DML changes.
+	pq.ProcessDMLChanges()
+
+	// Check if the jobs have been updated.
+	updatedJob2, err := pq.Peek()
+	require.NoError(t, err)
+	require.NotZero(t, updatedJob2.GetWeight())
+	require.Equal(t, tbl2.Meta().ID, updatedJob2.GetTableID(), "t2 should have higher weight due to smaller table size")
+}
+
+func TestProcessDMLChangesWithRunningJobs(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	handle := dom.StatsHandle()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (a int)")
+	tk.MustExec("create table t2 (a int)")
+	tk.MustExec("insert into t1 values (1)")
+	tk.MustExec("insert into t2 values (1)")
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = 1000
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+	schema := pmodel.NewCIStr("test")
+	tbl1, err := dom.InfoSchema().TableByName(ctx, schema, pmodel.NewCIStr("t1"))
+	require.NoError(t, err)
+	tbl2, err := dom.InfoSchema().TableByName(ctx, schema, pmodel.NewCIStr("t2"))
+	require.NoError(t, err)
 	tk.MustExec("analyze table t1")
 	tk.MustExec("analyze table t2")
 	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
 
-	// Call RefreshLastAnalysisDuration
-	pq.RefreshLastAnalysisDuration()
+	pq := priorityqueue.NewAnalysisPriorityQueueV2(handle)
+	defer pq.Close()
+	require.NoError(t, pq.Initialize())
 
-	// Check if the jobs' last analysis durations and weights have been updated
-	updatedJob1, err := pq.Pop()
+	// Check there are no running jobs.
+	runningJobs := pq.GetRunningJobs()
+	require.Len(t, runningJobs, 0)
+	// Check no jobs are in the queue.
+	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
-	require.NotZero(t, updatedJob1.GetWeight())
-	require.NotZero(t, updatedJob1.GetIndicators().LastAnalysisDuration)
-	require.NotEqual(t, oldLastAnalysisDuration1, updatedJob1.GetIndicators().LastAnalysisDuration)
+	require.True(t, isEmpty)
 
-	updatedJob2, err := pq.Pop()
+	// Insert 10 rows into t1.
+	tk.MustExec("insert into t1 values (2), (3)")
+	// Insert 2 rows into t2.
+	tk.MustExec("insert into t2 values (2), (3)")
+	// Dump the stats to kv.
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+
+	// Process the DML changes.
+	pq.ProcessDMLChanges()
+
+	// Pop the t1 job.
+	job1, err := pq.Pop()
 	require.NoError(t, err)
-	require.NotZero(t, updatedJob2.GetWeight())
-	require.NotZero(t, updatedJob2.GetIndicators().LastAnalysisDuration)
-	require.NotEqual(t, oldLastAnalysisDuration2, updatedJob2.GetIndicators().LastAnalysisDuration)
+	require.Equal(t, tbl1.Meta().ID, job1.GetTableID())
+
+	// Check if the running job is still in the queue.
+	runningJobs = pq.GetRunningJobs()
+	require.Len(t, runningJobs, 1)
+
+	job2, err := pq.Pop()
+	require.NoError(t, err)
+	require.NotZero(t, job2.GetWeight())
+	require.Equal(t, tbl2.Meta().ID, job2.GetTableID(), "t1 should not be in the queue since it's a running job")
+
+	// Analyze the job.
+	require.NoError(t, job1.Analyze(handle, dom.SysProcTracker()))
+
+	// Add more rows to t1.
+	tk.MustExec("insert into t1 values (4), (5), (6), (7), (8), (9), (10), (11), (12), (13)")
+	// Dump the stats to kv.
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
+
+	// Process the DML changes.
+	pq.ProcessDMLChanges()
+
+	// Check if the jobs have been updated.
+	job1, err = pq.Pop()
+	require.NoError(t, err)
+	require.NotZero(t, job1.GetWeight())
+	require.Equal(t, tbl1.Meta().ID, job1.GetTableID(), "t1 has been removed from running jobs and should be in the queue")
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
@@ -35,6 +35,8 @@ const (
 
 // StaticPartitionedTableAnalysisJob is a job for analyzing a static partitioned table.
 type StaticPartitionedTableAnalysisJob struct {
+	successHook         JobHook
+	failureHook         JobHook
 	TableSchema         string
 	GlobalTableName     string
 	StaticPartitionName string
@@ -88,6 +90,12 @@ func (j *StaticPartitionedTableAnalysisJob) Analyze(
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sysproctrack.Tracker,
 ) error {
+	defer func() {
+		if j.successHook != nil {
+			j.successHook(j)
+		}
+	}()
+
 	return statsutil.CallWithSCtx(statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		switch j.getAnalyzeType() {
 		case analyzeStaticPartition:
@@ -97,6 +105,16 @@ func (j *StaticPartitionedTableAnalysisJob) Analyze(
 		}
 		return nil
 	})
+}
+
+// RegisterSuccessHook registers a successHook function that will be called after the job can be marked as successful.
+func (j *StaticPartitionedTableAnalysisJob) RegisterSuccessHook(hook JobHook) {
+	j.successHook = hook
+}
+
+// RegisterFailureHook registers a failureHook function that will be called after the job can be marked as failed.
+func (j *StaticPartitionedTableAnalysisJob) RegisterFailureHook(hook JobHook) {
+	j.failureHook = hook
 }
 
 // GetIndicators implements AnalysisJob.
@@ -129,6 +147,9 @@ func (j *StaticPartitionedTableAnalysisJob) IsValidToAnalyze(
 			j.GlobalTableName,
 			partitionNames...,
 		); !valid {
+			if j.failureHook != nil {
+				j.failureHook(j)
+			}
 			return false, failReason
 		}
 	}

--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/statistics/handle/util",
         "//pkg/util",
         "//pkg/util/intest",
+        "@com_github_pingcap_errors//:errors",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/handle/autoanalyze/refresher/worker_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker_test.go
@@ -42,8 +42,13 @@ func (m *mockAnalysisJob) Analyze(h statstypes.StatsHandle, t sysproctrack.Track
 	time.Sleep(50 * time.Millisecond) // Simulate some work
 	return nil
 }
+func (m *mockAnalysisJob) RegisterSuccessHook(priorityqueue.JobHook) {
+	panic("not implemented")
+}
+func (m *mockAnalysisJob) RegisterFailureHook(priorityqueue.JobHook) {
+	panic("not implemented")
+}
 func (m *mockAnalysisJob) String() string { return "mockAnalysisJob" }
-
 func (m *mockAnalysisJob) IsValidToAnalyze(sessionctx.Context) (bool, string) {
 	panic("not implemented")
 }

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -66,7 +66,7 @@ func NewStatsCacheImplForTest() (types.StatsCache, error) {
 // Update reads stats meta from store and updates the stats map.
 func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) error {
 	start := time.Now()
-	lastVersion := s.getLastVersion()
+	lastVersion := s.GetNextCheckVersionWithOffset()
 	var (
 		rows []chunk.Row
 		err  error
@@ -156,7 +156,8 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema) e
 	return nil
 }
 
-func (s *StatsCacheImpl) getLastVersion() uint64 {
+// GetNextCheckVersionWithOffset gets the last version with offset.
+func (s *StatsCacheImpl) GetNextCheckVersionWithOffset() uint64 {
 	// Get the greatest version of the stats meta table.
 	lastVersion := s.MaxTableStatsVersion()
 	// We need this because for two tables, the smaller version may write later than the one with larger version.

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -185,6 +185,10 @@ type StatsCache interface {
 	// UpdateStatsCache updates the cache.
 	UpdateStatsCache(addedTables []*statistics.Table, deletedTableIDs []int64)
 
+	// GetNextCheckVersionWithOffset returns the last version with offset.
+	// It is used to fetch updated statistics from the stats meta table.
+	GetNextCheckVersionWithOffset() uint64
+
 	// MaxTableStatsVersion returns the version of the current cache, which is defined as
 	// the max table stats version the cache has in its lifecycle.
 	MaxTableStatsVersion() uint64


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55906

Problem Summary:

### What changed and how does it work?

This PR split from https://github.com/pingcap/tidb/pull/55889.

This pull request addresses the processing of DML changes from the stats cache. It is a continuation of the work started in [PR #55889](https://github.com/pingcap/tidb/pull/55889).

- Added functionality to process DML changes, including fetching and updating timestamps, and handling table stats.
- Added tests for processing DML changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
