### PR TITLE
ddl: make meta mutator part of jobContext

### DIFF
--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/exprctx"
 	"github.com/pingcap/tidb/pkg/infoschema"
-	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -52,10 +51,10 @@ import (
 	"go.uber.org/zap"
 )
 
-func onAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func onAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	// Handle the rolling back job.
 	if job.IsRollingback() {
-		ver, err = onDropColumn(jobCtx, t, job)
+		ver, err = onDropColumn(jobCtx, job)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -69,7 +68,7 @@ func onAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 		}
 	})
 
-	tblInfo, columnInfo, colFromArgs, pos, ifNotExists, err := checkAddColumn(t, job)
+	tblInfo, columnInfo, colFromArgs, pos, ifNotExists, err := checkAddColumn(jobCtx.metaMut, job)
 	if err != nil {
 		if ifNotExists && infoschema.ErrColumnExists.Equal(err) {
 			job.Warning = toTError(err)
@@ -92,7 +91,7 @@ func onAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 	case model.StateNone:
 		// none -> delete only
 		columnInfo.State = model.StateDeleteOnly
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, originalState != columnInfo.State)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -100,7 +99,7 @@ func onAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 	case model.StateDeleteOnly:
 		// delete only -> write only
 		columnInfo.State = model.StateWriteOnly
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != columnInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -109,7 +108,7 @@ func onAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 	case model.StateWriteOnly:
 		// write only -> reorganization
 		columnInfo.State = model.StateWriteReorganization
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != columnInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -126,7 +125,7 @@ func onAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 		}
 		tblInfo.MoveColumnInfo(columnInfo.Offset, offset)
 		columnInfo.State = model.StatePublic
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != columnInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}

--- a/pkg/ddl/cluster.go
+++ b/pkg/ddl/cluster.go
@@ -700,7 +700,7 @@ func splitRegionsByKeyRanges(ctx context.Context, store kv.Storage, keyRanges []
 // 2. before flashback start, check timestamp, disable GC and close PD schedule, get flashback key ranges.
 // 3. phase 1, lock flashback key ranges.
 // 4. phase 2, send flashback RPC, do flashback jobs.
-func (w *worker) onFlashbackCluster(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func (w *worker) onFlashbackCluster(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	inFlashbackTest := false
 	failpoint.Inject("mockFlashbackTest", func(val failpoint.Value) {
 		if val.(bool) {
@@ -768,7 +768,7 @@ func (w *worker) onFlashbackCluster(jobCtx *jobContext, t *meta.Mutator, job *mo
 		return ver, nil
 	// Stage 2, check flashbackTS, close GC and PD schedule, get flashback key ranges.
 	case model.StateDeleteOnly:
-		if err = checkAndSetFlashbackClusterInfo(w.ctx, sess, jobCtx.store, t, job, flashbackTS); err != nil {
+		if err = checkAndSetFlashbackClusterInfo(w.ctx, sess, jobCtx.store, jobCtx.metaMut, job, flashbackTS); err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
@@ -785,13 +785,13 @@ func (w *worker) onFlashbackCluster(jobCtx *jobContext, t *meta.Mutator, job *mo
 		}
 		job.Args[keyRangesOffset] = keyRanges
 		job.SchemaState = model.StateWriteOnly
-		return updateSchemaVersion(jobCtx, t, job)
+		return updateSchemaVersion(jobCtx, job)
 	// Stage 3, lock related key ranges.
 	case model.StateWriteOnly:
 		// TODO: Support flashback in unistore.
 		if inFlashbackTest {
 			job.SchemaState = model.StateWriteReorganization
-			return updateSchemaVersion(jobCtx, t, job)
+			return updateSchemaVersion(jobCtx, job)
 		}
 		// Split region by keyRanges, make sure no unrelated key ranges be locked.
 		splitRegionsByKeyRanges(w.ctx, jobCtx.store, keyRanges)
@@ -847,7 +847,7 @@ func (w *worker) onFlashbackCluster(jobCtx *jobContext, t *meta.Mutator, job *mo
 		asyncNotifyEvent(jobCtx, notifier.NewFlashbackClusterEvent(), job)
 		job.State = model.JobStateDone
 		job.SchemaState = model.StatePublic
-		return updateSchemaVersion(jobCtx, t, job)
+		return updateSchemaVersion(jobCtx, job)
 	}
 	return ver, nil
 }

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -138,8 +138,8 @@ func checkDropColumnForStatePublic(colInfo *model.ColumnInfo) (err error) {
 	return nil
 }
 
-func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	tblInfo, colInfo, idxInfos, ifExists, err := checkDropColumn(jobCtx, t, job)
+func onDropColumn(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, colInfo, idxInfos, ifExists, err := checkDropColumn(jobCtx, job)
 	if err != nil {
 		if ifExists && dbterror.ErrCantDropFieldOrKey.Equal(err) {
 			// Convert the "not exists" error to a warning.
@@ -153,7 +153,7 @@ func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 		job.MarkNonRevertible()
 		job.SchemaState = colInfo.State
 		// Store the mark and enter the next DDL handling loop.
-		return updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, false)
+		return updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, false)
 	}
 
 	originalState := colInfo.State
@@ -167,7 +167,7 @@ func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, originalState != colInfo.State)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, originalState != colInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -185,7 +185,7 @@ func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 			}
 			tblInfo.Indices = newIndices
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != colInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != colInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -199,7 +199,7 @@ func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 		// delete only -> reorganization
 		colInfo.State = model.StateDeleteReorganization
 		tblInfo.MoveColumnInfo(colInfo.Offset, len(tblInfo.Columns)-1)
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != colInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != colInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -209,7 +209,7 @@ func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 		tblInfo.MoveColumnInfo(colInfo.Offset, len(tblInfo.Columns)-1)
 		tblInfo.Columns = tblInfo.Columns[:len(tblInfo.Columns)-1]
 		colInfo.State = model.StateNone
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != colInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != colInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -234,9 +234,9 @@ func onDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 	return ver, errors.Trace(err)
 }
 
-func checkDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (*model.TableInfo, *model.ColumnInfo, []*model.IndexInfo, bool /* ifExists */, error) {
+func checkDropColumn(jobCtx *jobContext, job *model.Job) (*model.TableInfo, *model.ColumnInfo, []*model.IndexInfo, bool /* ifExists */, error) {
 	schemaID := job.SchemaID
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
 		return nil, nil, nil, false, errors.Trace(err)
 	}
@@ -291,7 +291,7 @@ func isDroppableColumn(tblInfo *model.TableInfo, colName pmodel.CIStr) error {
 	return nil
 }
 
-func onSetDefaultValue(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onSetDefaultValue(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	newCol := &model.ColumnInfo{}
 	err := job.DecodeArgs(newCol)
 	if err != nil {
@@ -299,7 +299,7 @@ func onSetDefaultValue(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver
 		return ver, errors.Trace(err)
 	}
 
-	return updateColumnDefaultValue(jobCtx, t, job, newCol, &newCol.Name)
+	return updateColumnDefaultValue(jobCtx, job, newCol, &newCol.Name)
 }
 
 func setIdxIDName(idxInfo *model.IndexInfo, newID int64, newName pmodel.CIStr) {
@@ -896,17 +896,18 @@ func updateChangingObjState(changingCol *model.ColumnInfo, changingIdxs []*model
 	}
 }
 
-func checkAndApplyAutoRandomBits(jobCtx *jobContext, m *meta.Mutator, dbInfo *model.DBInfo, tblInfo *model.TableInfo,
+func checkAndApplyAutoRandomBits(jobCtx *jobContext, dbInfo *model.DBInfo, tblInfo *model.TableInfo,
 	oldCol *model.ColumnInfo, newCol *model.ColumnInfo, newAutoRandBits uint64) error {
 	if newAutoRandBits == 0 {
 		return nil
 	}
-	idAcc := m.GetAutoIDAccessors(dbInfo.ID, tblInfo.ID)
+	metaMut := jobCtx.metaMut
+	idAcc := metaMut.GetAutoIDAccessors(dbInfo.ID, tblInfo.ID)
 	err := checkNewAutoRandomBits(idAcc, oldCol, newCol, newAutoRandBits, tblInfo.AutoRandomRangeBits, tblInfo.SepAutoInc())
 	if err != nil {
 		return err
 	}
-	return applyNewAutoRandomBits(jobCtx, m, dbInfo, tblInfo, oldCol, newAutoRandBits)
+	return applyNewAutoRandomBits(jobCtx, dbInfo, tblInfo, oldCol, newAutoRandBits)
 }
 
 // checkNewAutoRandomBits checks whether the new auto_random bits number can cause overflow.
@@ -967,7 +968,7 @@ func (r *asAutoIDRequirement) AutoIDClient() *autoid.ClientDiscover {
 
 // applyNewAutoRandomBits set auto_random bits to TableInfo and
 // migrate auto_increment ID to auto_random ID if possible.
-func applyNewAutoRandomBits(jobCtx *jobContext, m *meta.Mutator, dbInfo *model.DBInfo,
+func applyNewAutoRandomBits(jobCtx *jobContext, dbInfo *model.DBInfo,
 	tblInfo *model.TableInfo, oldCol *model.ColumnInfo, newAutoRandBits uint64) error {
 	tblInfo.AutoRandomBits = newAutoRandBits
 	needMigrateFromAutoIncToAutoRand := mysql.HasAutoIncrementFlag(oldCol.GetFlag())
@@ -979,7 +980,7 @@ func applyNewAutoRandomBits(jobCtx *jobContext, m *meta.Mutator, dbInfo *model.D
 		errMsg := fmt.Sprintf(autoid.AutoRandomAllocatorNotFound, dbInfo.Name.O, tblInfo.Name.O)
 		return dbterror.ErrInvalidAutoRandom.GenWithStackByArgs(errMsg)
 	}
-	idAcc := m.GetAutoIDAccessors(dbInfo.ID, tblInfo.ID).RowID()
+	idAcc := jobCtx.metaMut.GetAutoIDAccessors(dbInfo.ID, tblInfo.ID).RowID()
 	nextAutoIncID, err := idAcc.Get()
 	if err != nil {
 		return errors.Trace(err)
@@ -1037,8 +1038,8 @@ func checkForNullValue(ctx context.Context, sctx sessionctx.Context, isDataTrunc
 	return nil
 }
 
-func updateColumnDefaultValue(jobCtx *jobContext, t *meta.Mutator, job *model.Job, newCol *model.ColumnInfo, oldColName *pmodel.CIStr) (ver int64, _ error) {
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+func updateColumnDefaultValue(jobCtx *jobContext, job *model.Job, newCol *model.ColumnInfo, oldColName *pmodel.CIStr) (ver int64, _ error) {
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1046,7 +1047,7 @@ func updateColumnDefaultValue(jobCtx *jobContext, t *meta.Mutator, job *model.Jo
 	if job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
 		job.MarkNonRevertible()
 		// Store the mark and enter the next DDL handling loop.
-		return updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, false)
+		return updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, false)
 	}
 
 	oldCol := model.FindColumnInfo(tblInfo.Columns, oldColName.L)
@@ -1078,7 +1079,7 @@ func updateColumnDefaultValue(jobCtx *jobContext, t *meta.Mutator, job *model.Jo
 		}
 	}
 
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)

--- a/pkg/ddl/constraint.go
+++ b/pkg/ddl/constraint.go
@@ -32,10 +32,10 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 )
 
-func (w *worker) onAddCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func (w *worker) onAddCheckConstraint(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	// Handle the rolling back job.
 	if job.IsRollingback() {
-		return rollingBackAddConstraint(jobCtx, t, job)
+		return rollingBackAddConstraint(jobCtx, job)
 	}
 
 	failpoint.Inject("errorBeforeDecodeArgs", func(val failpoint.Value) {
@@ -44,7 +44,7 @@ func (w *worker) onAddCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *
 		}
 	})
 
-	dbInfo, tblInfo, constraintInfoInMeta, constraintInfoInJob, err := checkAddCheckConstraint(t, job)
+	dbInfo, tblInfo, constraintInfoInMeta, constraintInfoInJob, err := checkAddCheckConstraint(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -81,7 +81,7 @@ func (w *worker) onAddCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *
 	// If not enforced, add it directly.
 	if !constraintInfoInMeta.Enforced {
 		constraintInfoInMeta.State = model.StatePublic
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -94,11 +94,11 @@ func (w *worker) onAddCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *
 	case model.StateNone:
 		job.SchemaState = model.StateWriteOnly
 		constraintInfoInMeta.State = model.StateWriteOnly
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 	case model.StateWriteOnly:
 		job.SchemaState = model.StateWriteReorganization
 		constraintInfoInMeta.State = model.StateWriteReorganization
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 	case model.StateWriteReorganization:
 		err = w.verifyRemainRecordsForCheckConstraint(dbInfo, tblInfo, constraintInfoInMeta)
 		if err != nil {
@@ -108,7 +108,7 @@ func (w *worker) onAddCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *
 			return ver, errors.Trace(err)
 		}
 		constraintInfoInMeta.State = model.StatePublic
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -162,8 +162,8 @@ func checkAddCheckConstraint(t *meta.Mutator, job *model.Job) (*model.DBInfo, *m
 // onDropCheckConstraint can be called from two case:
 // 1: rollback in add constraint.(in rollback function the job.args will be changed)
 // 2: user drop constraint ddl.
-func onDropCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	tblInfo, constraintInfo, err := checkDropCheckConstraint(t, job)
+func onDropCheckConstraint(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, constraintInfo, err := checkDropCheckConstraint(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -172,7 +172,7 @@ func onDropCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) 
 	case model.StatePublic:
 		job.SchemaState = model.StateWriteOnly
 		constraintInfo.State = model.StateWriteOnly
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 	case model.StateWriteOnly:
 		// write only state constraint will still take effect to check the newly inserted data.
 		// So the dependent column shouldn't be dropped even in this intermediate state.
@@ -183,7 +183,7 @@ func onDropCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) 
 				tblInfo.Constraints = append(tblInfo.Constraints[0:i], tblInfo.Constraints[i+1:]...)
 			}
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -216,14 +216,14 @@ func checkDropCheckConstraint(t *meta.Mutator, job *model.Job) (*model.TableInfo
 	return tblInfo, constraintInfo, nil
 }
 
-func (w *worker) onAlterCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	dbInfo, tblInfo, constraintInfo, enforced, err := checkAlterCheckConstraint(t, job)
+func (w *worker) onAlterCheckConstraint(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	dbInfo, tblInfo, constraintInfo, enforced, err := checkAlterCheckConstraint(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
 	if job.IsRollingback() {
-		return rollingBackAlterConstraint(jobCtx, t, job)
+		return rollingBackAlterConstraint(jobCtx, job)
 	}
 
 	// Current State is desired.
@@ -239,11 +239,11 @@ func (w *worker) onAlterCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job
 			job.SchemaState = model.StateWriteReorganization
 			constraintInfo.State = model.StateWriteReorganization
 			constraintInfo.Enforced = enforced
-			ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+			ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 		case model.StateWriteReorganization:
 			job.SchemaState = model.StateWriteOnly
 			constraintInfo.State = model.StateWriteOnly
-			ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+			ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 		case model.StateWriteOnly:
 			err = w.verifyRemainRecordsForCheckConstraint(dbInfo, tblInfo, constraintInfo)
 			if err != nil {
@@ -253,7 +253,7 @@ func (w *worker) onAlterCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job
 				return ver, errors.Trace(err)
 			}
 			constraintInfo.State = model.StatePublic
-			ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+			ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 			if err != nil {
 				return ver, errors.Trace(err)
 			}
@@ -261,7 +261,7 @@ func (w *worker) onAlterCheckConstraint(jobCtx *jobContext, t *meta.Mutator, job
 		}
 	} else {
 		constraintInfo.Enforced = enforced
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 		if err != nil {
 			// update version and tableInfo error will cause retry.
 			return ver, errors.Trace(err)

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -56,7 +56,7 @@ import (
 // DANGER: it is an internal function used by onCreateTable and onCreateTables, for reusing code. Be careful.
 // 1. it expects the argument of job has been deserialized.
 // 2. it won't call updateSchemaVersion, FinishTableJob and asyncNotifyEvent.
-func createTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *model.CreateTableArgs) (*model.TableInfo, error) {
+func createTable(jobCtx *jobContext, job *model.Job, args *model.CreateTableArgs) (*model.TableInfo, error) {
 	schemaID := job.SchemaID
 	tbInfo, fkCheck := args.TableInfo, args.FKCheck
 
@@ -69,7 +69,8 @@ func createTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *mode
 		return tbInfo, errors.Trace(err)
 	}
 
-	err = checkConstraintNamesNotExists(t, schemaID, tbInfo.Constraints)
+	metaMut := jobCtx.metaMut
+	err = checkConstraintNamesNotExists(metaMut, schemaID, tbInfo.Constraints)
 	if err != nil {
 		if infoschema.ErrCheckConstraintDupName.Equal(err) {
 			job.State = model.JobStateCancelled
@@ -93,8 +94,8 @@ func createTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *mode
 	case model.StateNone:
 		// none -> public
 		tbInfo.State = model.StatePublic
-		tbInfo.UpdateTS = t.StartTS
-		err = createTableOrViewWithCheck(t, job, schemaID, tbInfo)
+		tbInfo.UpdateTS = metaMut.StartTS
+		err = createTableOrViewWithCheck(metaMut, job, schemaID, tbInfo)
 		if err != nil {
 			return tbInfo, errors.Trace(err)
 		}
@@ -106,7 +107,7 @@ func createTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *mode
 		})
 
 		// build table & partition bundles if any.
-		if err = checkAllTablePlacementPoliciesExistAndCancelNonExistJob(t, job, tbInfo); err != nil {
+		if err = checkAllTablePlacementPoliciesExistAndCancelNonExistJob(jobCtx.metaMut, job, tbInfo); err != nil {
 			return tbInfo, errors.Trace(err)
 		}
 
@@ -132,7 +133,7 @@ func createTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *mode
 			}
 		}
 
-		bundles, err := placement.NewFullTableBundles(t, tbInfo)
+		bundles, err := placement.NewFullTableBundles(metaMut, tbInfo)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return tbInfo, errors.Trace(err)
@@ -151,7 +152,7 @@ func createTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *mode
 	}
 }
 
-func onCreateTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onCreateTable(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	failpoint.Inject("mockExceedErrorLimit", func(val failpoint.Value) {
 		if val.(bool) {
 			failpoint.Return(ver, errors.New("mock do job error"))
@@ -167,15 +168,15 @@ func onCreateTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	tbInfo := args.TableInfo
 
 	if len(tbInfo.ForeignKeys) > 0 {
-		return createTableWithForeignKeys(jobCtx, t, job, args)
+		return createTableWithForeignKeys(jobCtx, job, args)
 	}
 
-	tbInfo, err = createTable(jobCtx, t, job, args)
+	tbInfo, err = createTable(jobCtx, job, args)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
-	ver, err = updateSchemaVersion(jobCtx, t, job)
+	ver, err = updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -187,7 +188,7 @@ func onCreateTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	return ver, errors.Trace(err)
 }
 
-func createTableWithForeignKeys(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *model.CreateTableArgs) (ver int64, err error) {
+func createTableWithForeignKeys(jobCtx *jobContext, job *model.Job, args *model.CreateTableArgs) (ver int64, err error) {
 	tbInfo := args.TableInfo
 	switch tbInfo.State {
 	case model.StateNone, model.StatePublic:
@@ -195,19 +196,19 @@ func createTableWithForeignKeys(jobCtx *jobContext, t *meta.Mutator, job *model.
 		// the `tbInfo.State` with `model.StateNone`, so it's fine to just call the `createTable` with
 		// public state.
 		// when `br` restores table, the state of `tbInfo` will be public.
-		tbInfo, err = createTable(jobCtx, t, job, args)
+		tbInfo, err = createTable(jobCtx, job, args)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		tbInfo.State = model.StateWriteOnly
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tbInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tbInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		job.SchemaState = model.StateWriteOnly
 	case model.StateWriteOnly:
 		tbInfo.State = model.StatePublic
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tbInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tbInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -221,7 +222,7 @@ func createTableWithForeignKeys(jobCtx *jobContext, t *meta.Mutator, job *model.
 	return ver, errors.Trace(err)
 }
 
-func onCreateTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (int64, error) {
+func onCreateTables(jobCtx *jobContext, job *model.Job) (int64, error) {
 	var ver int64
 
 	args, err := model.GetBatchCreateTableArgs(job)
@@ -243,14 +244,14 @@ func onCreateTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (int64,
 		tableInfo := tblArgs.TableInfo
 		stubJob.TableID = tableInfo.ID
 		if tableInfo.Sequence != nil {
-			err := createSequenceWithCheck(t, stubJob, tableInfo)
+			err := createSequenceWithCheck(jobCtx.metaMut, stubJob, tableInfo)
 			if err != nil {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)
 			}
 			tableInfos = append(tableInfos, tableInfo)
 		} else {
-			tbInfo, err := createTable(jobCtx, t, stubJob, tblArgs)
+			tbInfo, err := createTable(jobCtx, stubJob, tblArgs)
 			if err != nil {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)
@@ -259,7 +260,7 @@ func onCreateTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (int64,
 		}
 	}
 
-	ver, err = updateSchemaVersion(jobCtx, t, job)
+	ver, err = updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -284,7 +285,7 @@ func createTableOrViewWithCheck(t *meta.Mutator, job *model.Job, schemaID int64,
 	return t.CreateTableOrView(schemaID, tbInfo)
 }
 
-func onCreateView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onCreateView(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
 	args, err := model.GetCreateTableArgs(job)
 	if err != nil {
@@ -295,7 +296,8 @@ func onCreateView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 	tbInfo, orReplace := args.TableInfo, args.OnExistReplace
 	tbInfo.State = model.StateNone
 
-	oldTableID, err := findTableIDByName(jobCtx.infoCache, t, schemaID, tbInfo.Name.L)
+	metaMut := jobCtx.metaMut
+	oldTableID, err := findTableIDByName(jobCtx.infoCache, metaMut, schemaID, tbInfo.Name.L)
 	if infoschema.ErrTableNotExists.Equal(err) {
 		err = nil
 	}
@@ -312,7 +314,7 @@ func onCreateView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 			return ver, errors.Trace(err)
 		}
 	}
-	ver, err = updateSchemaVersion(jobCtx, t, job)
+	ver, err = updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -320,20 +322,20 @@ func onCreateView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int6
 	case model.StateNone:
 		// none -> public
 		tbInfo.State = model.StatePublic
-		tbInfo.UpdateTS = t.StartTS
+		tbInfo.UpdateTS = metaMut.StartTS
 		if oldTableID > 0 && orReplace {
-			err = t.DropTableOrView(schemaID, oldTableID)
+			err = metaMut.DropTableOrView(schemaID, oldTableID)
 			if err != nil {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)
 			}
-			err = t.GetAutoIDAccessors(schemaID, oldTableID).Del()
+			err = metaMut.GetAutoIDAccessors(schemaID, oldTableID).Del()
 			if err != nil {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)
 			}
 		}
-		err = createTableOrViewWithCheck(t, job, schemaID, tbInfo)
+		err = createTableOrViewWithCheck(metaMut, job, schemaID, tbInfo)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)

--- a/pkg/ddl/delete_range.go
+++ b/pkg/ddl/delete_range.go
@@ -256,7 +256,7 @@ func (dr *delRange) doTask(sctx sessionctx.Context, r util.DelRangeTask) error {
 				return errors.Trace(err)
 			}
 			startKey, endKey := r.Range()
-			logutil.DDLLogger().Info("delRange emulator complete task", zap.String("category", "ddl"),
+			logutil.DDLLogger().Info("delRange emulator complete task",
 				zap.Int64("jobID", r.JobID),
 				zap.Int64("elementID", r.ElementID),
 				zap.Stringer("startKey", startKey),

--- a/pkg/ddl/foreign_key.go
+++ b/pkg/ddl/foreign_key.go
@@ -33,9 +33,9 @@ import (
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
 )
 
-func (w *worker) onCreateForeignKey(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onCreateForeignKey(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -48,7 +48,7 @@ func (w *worker) onCreateForeignKey(jobCtx *jobContext, t *meta.Mutator, job *mo
 	fkInfo, fkCheck := args.FkInfo, args.FkCheck
 
 	if job.IsRollingback() {
-		return dropForeignKey(jobCtx, t, job, tblInfo, fkInfo.Name)
+		return dropForeignKey(jobCtx, job, tblInfo, fkInfo.Name)
 	}
 	switch job.SchemaState {
 	case model.StateNone:
@@ -60,7 +60,7 @@ func (w *worker) onCreateForeignKey(jobCtx *jobContext, t *meta.Mutator, job *mo
 		fkInfo.State = model.StateWriteOnly
 		fkInfo.ID = allocateFKIndexID(tblInfo)
 		tblInfo.ForeignKeys = append(tblInfo.ForeignKeys, fkInfo)
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -73,14 +73,14 @@ func (w *worker) onCreateForeignKey(jobCtx *jobContext, t *meta.Mutator, job *mo
 			return ver, err
 		}
 		tblInfo.ForeignKeys[len(tblInfo.ForeignKeys)-1].State = model.StateWriteReorganization
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		job.SchemaState = model.StateWriteReorganization
 	case model.StateWriteReorganization:
 		tblInfo.ForeignKeys[len(tblInfo.ForeignKeys)-1].State = model.StatePublic
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -93,9 +93,9 @@ func (w *worker) onCreateForeignKey(jobCtx *jobContext, t *meta.Mutator, job *mo
 	return ver, nil
 }
 
-func onDropForeignKey(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onDropForeignKey(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -105,10 +105,10 @@ func onDropForeignKey(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver 
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
-	return dropForeignKey(jobCtx, t, job, tblInfo, args.FkName)
+	return dropForeignKey(jobCtx, job, tblInfo, args.FkName)
 }
 
-func dropForeignKey(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tblInfo *model.TableInfo, fkName pmodel.CIStr) (ver int64, err error) {
+func dropForeignKey(jobCtx *jobContext, job *model.Job, tblInfo *model.TableInfo, fkName pmodel.CIStr) (ver int64, err error) {
 	var fkInfo *model.FKInfo
 	for _, fk := range tblInfo.ForeignKeys {
 		if fk.Name.L == fkName.L {
@@ -127,7 +127,7 @@ func dropForeignKey(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tblInfo
 		}
 	}
 	tblInfo.ForeignKeys = nfks
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -419,8 +419,8 @@ func ValidateRenameIndex(from, to pmodel.CIStr, tbl *model.TableInfo) (ignore bo
 	return false, nil
 }
 
-func onRenameIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	tblInfo, from, to, err := checkRenameIndex(t, job)
+func onRenameIndex(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, from, to, err := checkRenameIndex(jobCtx.metaMut, job)
 	if err != nil || tblInfo == nil {
 		return ver, errors.Trace(err)
 	}
@@ -431,13 +431,13 @@ func onRenameIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	if job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
 		job.MarkNonRevertible()
 		// Store the mark and enter the next DDL handling loop.
-		return updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, false)
+		return updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, false)
 	}
 
 	renameIndexes(tblInfo, from, to)
 	renameHiddenColumns(tblInfo, from, to)
 
-	if ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true); err != nil {
+	if ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true); err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
@@ -459,19 +459,19 @@ func validateAlterIndexVisibility(ctx sessionctx.Context, indexName pmodel.CIStr
 	return false, nil
 }
 
-func onAlterIndexVisibility(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	tblInfo, from, invisible, err := checkAlterIndexVisibility(t, job)
+func onAlterIndexVisibility(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, from, invisible, err := checkAlterIndexVisibility(jobCtx.metaMut, job)
 	if err != nil || tblInfo == nil {
 		return ver, errors.Trace(err)
 	}
 
 	if job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
 		job.MarkNonRevertible()
-		return updateVersionAndTableInfo(jobCtx, t, job, tblInfo, false)
+		return updateVersionAndTableInfo(jobCtx, job, tblInfo, false)
 	}
 
 	setIndexVisibility(tblInfo, from, invisible)
-	if ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true); err != nil {
+	if ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true); err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
@@ -498,13 +498,13 @@ func getNullColInfos(tblInfo *model.TableInfo, indexInfo *model.IndexInfo) ([]*m
 	return nullCols, nil
 }
 
-func checkPrimaryKeyNotNull(jobCtx *jobContext, w *worker, t *meta.Mutator, job *model.Job,
+func checkPrimaryKeyNotNull(jobCtx *jobContext, w *worker, job *model.Job,
 	tblInfo *model.TableInfo, indexInfo *model.IndexInfo) (warnings []string, err error) {
 	if !indexInfo.Primary {
 		return nil, nil
 	}
 
-	dbInfo, err := checkSchemaExistAndCancelNotExistJob(t, job)
+	dbInfo, err := checkSchemaExistAndCancelNotExistJob(jobCtx.metaMut, job)
 	if err != nil {
 		return nil, err
 	}
@@ -520,7 +520,7 @@ func checkPrimaryKeyNotNull(jobCtx *jobContext, w *worker, t *meta.Mutator, job 
 	if err == nil {
 		return nil, nil
 	}
-	_, err = convertAddIdxJob2RollbackJob(jobCtx, t, job, tblInfo, []*model.IndexInfo{indexInfo}, err)
+	_, err = convertAddIdxJob2RollbackJob(jobCtx, job, tblInfo, []*model.IndexInfo{indexInfo}, err)
 	// TODO: Support non-strict mode.
 	// warnings = append(warnings, ErrWarnDataTruncated.GenWithStackByArgs(oldCol.Name.L, 0).Error())
 	return nil, err
@@ -584,10 +584,10 @@ func decodeAddIndexArgs(job *model.Job) (
 	return
 }
 
-func (w *worker) onCreateIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job, isPK bool) (ver int64, err error) {
+func (w *worker) onCreateIndex(jobCtx *jobContext, job *model.Job, isPK bool) (ver int64, err error) {
 	// Handle the rolling back job.
 	if job.IsRollingback() {
-		ver, err = onDropIndex(jobCtx, t, job)
+		ver, err = onDropIndex(jobCtx, job)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -596,7 +596,7 @@ func (w *worker) onCreateIndex(jobCtx *jobContext, t *meta.Mutator, job *model.J
 
 	// Handle normal job.
 	schemaID := job.SchemaID
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -717,7 +717,7 @@ SwitchIndexState:
 			indexInfo.State = model.StateDeleteOnly
 			moveAndUpdateHiddenColumnsToPublic(tblInfo, indexInfo)
 		}
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, originalState != model.StateDeleteOnly)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, originalState != model.StateDeleteOnly)
 		if err != nil {
 			return ver, err
 		}
@@ -726,13 +726,13 @@ SwitchIndexState:
 		// delete only -> write only
 		for _, indexInfo := range allIndexInfos {
 			indexInfo.State = model.StateWriteOnly
-			_, err = checkPrimaryKeyNotNull(jobCtx, w, t, job, tblInfo, indexInfo)
+			_, err = checkPrimaryKeyNotNull(jobCtx, w, job, tblInfo, indexInfo)
 			if err != nil {
 				break SwitchIndexState
 			}
 		}
 
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StateWriteOnly)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StateWriteOnly)
 		if err != nil {
 			return ver, err
 		}
@@ -741,13 +741,13 @@ SwitchIndexState:
 		// write only -> reorganization
 		for _, indexInfo := range allIndexInfos {
 			indexInfo.State = model.StateWriteReorganization
-			_, err = checkPrimaryKeyNotNull(jobCtx, w, t, job, tblInfo, indexInfo)
+			_, err = checkPrimaryKeyNotNull(jobCtx, w, job, tblInfo, indexInfo)
 			if err != nil {
 				break SwitchIndexState
 			}
 		}
 
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StateWriteReorganization)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StateWriteReorganization)
 		if err != nil {
 			return ver, err
 		}
@@ -763,9 +763,9 @@ SwitchIndexState:
 
 		var done bool
 		if job.MultiSchemaInfo != nil {
-			done, ver, err = doReorgWorkForCreateIndexMultiSchema(w, jobCtx, t, job, tbl, allIndexInfos)
+			done, ver, err = doReorgWorkForCreateIndexMultiSchema(w, jobCtx, job, tbl, allIndexInfos)
 		} else {
-			done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, t, job, tbl, allIndexInfos)
+			done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, allIndexInfos)
 		}
 		if !done {
 			return ver, err
@@ -798,7 +798,7 @@ SwitchIndexState:
 			}
 		})
 
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StatePublic)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StatePublic)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -869,14 +869,14 @@ func loadCloudStorageURI(w *worker, job *model.Job) {
 	job.ReorgMeta.UseCloudStorage = len(jc.cloudStorageURI) > 0
 }
 
-func doReorgWorkForCreateIndexMultiSchema(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job,
+func doReorgWorkForCreateIndexMultiSchema(w *worker, jobCtx *jobContext, job *model.Job,
 	tbl table.Table, allIndexInfos []*model.IndexInfo) (done bool, ver int64, err error) {
 	if job.MultiSchemaInfo.Revertible {
-		done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, t, job, tbl, allIndexInfos)
+		done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, allIndexInfos)
 		if done {
 			job.MarkNonRevertible()
 			if err == nil {
-				ver, err = updateVersionAndTableInfo(jobCtx, t, job, tbl.Meta(), true)
+				ver, err = updateVersionAndTableInfo(jobCtx, job, tbl.Meta(), true)
 			}
 		}
 		// We need another round to wait for all the others sub-jobs to finish.
@@ -888,7 +888,6 @@ func doReorgWorkForCreateIndexMultiSchema(w *worker, jobCtx *jobContext, t *meta
 func doReorgWorkForCreateIndex(
 	w *worker,
 	jobCtx *jobContext,
-	t *meta.Mutator,
 	job *model.Job,
 	tbl table.Table,
 	allIndexInfos []*model.IndexInfo,
@@ -899,7 +898,7 @@ func doReorgWorkForCreateIndex(
 		return false, ver, err
 	}
 	if !reorgTp.NeedMergeProcess() {
-		return runReorgJobAndHandleErr(w, jobCtx, t, job, tbl, allIndexInfos, false)
+		return runReorgJobAndHandleErr(w, jobCtx, job, tbl, allIndexInfos, false)
 	}
 	switch allIndexInfos[0].BackfillState {
 	case model.BackfillStateRunning:
@@ -910,12 +909,12 @@ func doReorgWorkForCreateIndex(
 		switch reorgTp {
 		case model.ReorgTypeLitMerge:
 			if job.ReorgMeta.IsDistReorg {
-				done, ver, err = runIngestReorgJobDist(w, jobCtx, t, job, tbl, allIndexInfos)
+				done, ver, err = runIngestReorgJobDist(w, jobCtx, job, tbl, allIndexInfos)
 			} else {
-				done, ver, err = runIngestReorgJob(w, jobCtx, t, job, tbl, allIndexInfos)
+				done, ver, err = runIngestReorgJob(w, jobCtx, job, tbl, allIndexInfos)
 			}
 		case model.ReorgTypeTxnMerge:
-			done, ver, err = runReorgJobAndHandleErr(w, jobCtx, t, job, tbl, allIndexInfos, false)
+			done, ver, err = runReorgJobAndHandleErr(w, jobCtx, job, tbl, allIndexInfos, false)
 		}
 		if err != nil || !done {
 			return false, ver, errors.Trace(err)
@@ -923,7 +922,7 @@ func doReorgWorkForCreateIndex(
 		for _, indexInfo := range allIndexInfos {
 			indexInfo.BackfillState = model.BackfillStateReadyToMerge
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tbl.Meta(), true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tbl.Meta(), true)
 		return false, ver, errors.Trace(err)
 	case model.BackfillStateReadyToMerge:
 		failpoint.Inject("mockDMLExecutionStateBeforeMerge", func(_ failpoint.Value) {
@@ -942,10 +941,10 @@ func doReorgWorkForCreateIndex(
 			ingest.LitBackCtxMgr.Unregister(job.ID)
 		}
 		job.SnapshotVer = 0 // Reset the snapshot version for merge index reorg.
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tbl.Meta(), true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tbl.Meta(), true)
 		return false, ver, errors.Trace(err)
 	case model.BackfillStateMerging:
-		done, ver, err = runReorgJobAndHandleErr(w, jobCtx, t, job, tbl, allIndexInfos, true)
+		done, ver, err = runReorgJobAndHandleErr(w, jobCtx, job, tbl, allIndexInfos, true)
 		if !done {
 			return false, ver, err
 		}
@@ -958,9 +957,9 @@ func doReorgWorkForCreateIndex(
 	}
 }
 
-func runIngestReorgJobDist(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job,
+func runIngestReorgJobDist(w *worker, jobCtx *jobContext, job *model.Job,
 	tbl table.Table, allIndexInfos []*model.IndexInfo) (done bool, ver int64, err error) {
-	done, ver, err = runReorgJobAndHandleErr(w, jobCtx, t, job, tbl, allIndexInfos, false)
+	done, ver, err = runReorgJobAndHandleErr(w, jobCtx, job, tbl, allIndexInfos, false)
 	if err != nil {
 		return false, ver, errors.Trace(err)
 	}
@@ -972,17 +971,17 @@ func runIngestReorgJobDist(w *worker, jobCtx *jobContext, t *meta.Mutator, job *
 	return true, ver, nil
 }
 
-func runIngestReorgJob(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job,
+func runIngestReorgJob(w *worker, jobCtx *jobContext, job *model.Job,
 	tbl table.Table, allIndexInfos []*model.IndexInfo) (done bool, ver int64, err error) {
-	done, ver, err = runReorgJobAndHandleErr(w, jobCtx, t, job, tbl, allIndexInfos, false)
+	done, ver, err = runReorgJobAndHandleErr(w, jobCtx, job, tbl, allIndexInfos, false)
 	if err != nil {
 		if kv.ErrKeyExists.Equal(err) {
 			logutil.DDLLogger().Warn("import index duplicate key, convert job to rollback", zap.Stringer("job", job), zap.Error(err))
-			ver, err = convertAddIdxJob2RollbackJob(jobCtx, t, job, tbl.Meta(), allIndexInfos, err)
+			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), allIndexInfos, err)
 		} else if !errorIsRetryable(err, job) {
 			logutil.DDLLogger().Warn("run reorg job failed, convert job to rollback",
 				zap.String("job", job.String()), zap.Error(err))
-			ver, err = convertAddIdxJob2RollbackJob(jobCtx, t, job, tbl.Meta(), allIndexInfos, err)
+			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), allIndexInfos, err)
 		} else {
 			logutil.DDLLogger().Warn("run add index ingest job error", zap.Error(err))
 		}
@@ -1009,7 +1008,6 @@ func errorIsRetryable(err error, job *model.Job) bool {
 func runReorgJobAndHandleErr(
 	w *worker,
 	jobCtx *jobContext,
-	t *meta.Mutator,
 	job *model.Job,
 	tbl table.Table,
 	allIndexInfos []*model.IndexInfo,
@@ -1035,7 +1033,7 @@ func runReorgJobAndHandleErr(
 	}
 	defer w.sessPool.Put(sctx)
 	rh := newReorgHandler(sess.NewSession(sctx))
-	dbInfo, err := t.GetDatabase(job.SchemaID)
+	dbInfo, err := jobCtx.metaMut.GetDatabase(job.SchemaID)
 	if err != nil {
 		return false, ver, errors.Trace(err)
 	}
@@ -1068,7 +1066,7 @@ func runReorgJobAndHandleErr(
 		err = ingest.TryConvertToKeyExistsErr(err, allIndexInfos[0], tbl.Meta())
 		if !errorIsRetryable(err, job) {
 			logutil.DDLLogger().Warn("run add index job failed, convert job to rollback", zap.Stringer("job", job), zap.Error(err))
-			ver, err = convertAddIdxJob2RollbackJob(jobCtx, t, job, tbl.Meta(), allIndexInfos, err)
+			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), allIndexInfos, err)
 			if err1 := rh.RemoveDDLReorgHandle(job, reorgInfo.elements); err1 != nil {
 				logutil.DDLLogger().Warn("run add index job failed, convert job to rollback, RemoveDDLReorgHandle failed", zap.Stringer("job", job), zap.Error(err1))
 			}
@@ -1083,8 +1081,8 @@ func runReorgJobAndHandleErr(
 	return true, ver, nil
 }
 
-func onDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	tblInfo, allIndexInfos, ifExists, err := checkDropIndex(jobCtx.infoCache, t, job)
+func onDropIndex(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, allIndexInfos, ifExists, err := checkDropIndex(jobCtx.infoCache, jobCtx.metaMut, job)
 	if err != nil {
 		if ifExists && dbterror.ErrCantDropFieldOrKey.Equal(err) {
 			job.Warning = toTError(err)
@@ -1100,7 +1098,7 @@ func onDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 	if job.MultiSchemaInfo != nil && !job.IsRollingback() && job.MultiSchemaInfo.Revertible {
 		job.MarkNonRevertible()
 		job.SchemaState = allIndexInfos[0].State
-		return updateVersionAndTableInfo(jobCtx, t, job, tblInfo, false)
+		return updateVersionAndTableInfo(jobCtx, job, tblInfo, false)
 	}
 
 	originalState := allIndexInfos[0].State
@@ -1110,7 +1108,7 @@ func onDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 		for _, indexInfo := range allIndexInfos {
 			indexInfo.State = model.StateWriteOnly
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StateWriteOnly)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StateWriteOnly)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -1119,7 +1117,7 @@ func onDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 		for _, indexInfo := range allIndexInfos {
 			indexInfo.State = model.StateDeleteOnly
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StateDeleteOnly)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StateDeleteOnly)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -1128,7 +1126,7 @@ func onDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 		for _, indexInfo := range allIndexInfos {
 			indexInfo.State = model.StateDeleteReorganization
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StateDeleteReorganization)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StateDeleteReorganization)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -1151,7 +1149,7 @@ func onDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64
 			}
 		})
 
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, originalState != model.StateNone)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, originalState != model.StateNone)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}

--- a/pkg/ddl/job_scheduler.go
+++ b/pkg/ddl/job_scheduler.go
@@ -471,7 +471,7 @@ func (s *jobScheduler) deliveryJob(wk *worker, pool *workerPool, job *model.Job)
 	jobID, involvedSchemaInfos := job.ID, job.GetInvolvingSchemaInfo()
 	s.runningJobs.addRunning(jobID, involvedSchemaInfos)
 	metrics.DDLRunningJobCount.WithLabelValues(pool.tp().String()).Inc()
-	jobCtx := s.getJobRunCtx(job.ID)
+	jobCtx := s.getJobRunCtx(job.ID, job.TraceInfo)
 	s.wg.Run(func() {
 		defer func() {
 			r := recover()
@@ -524,7 +524,7 @@ func (s *jobScheduler) deliveryJob(wk *worker, pool *workerPool, job *model.Job)
 	})
 }
 
-func (s *jobScheduler) getJobRunCtx(jobID int64) *jobContext {
+func (s *jobScheduler) getJobRunCtx(jobID int64, traceInfo *model.TraceInfo) *jobContext {
 	ch, _ := s.ddlJobDoneChMap.Load(jobID)
 	return &jobContext{
 		ctx:                  s.schCtx,
@@ -536,6 +536,10 @@ func (s *jobScheduler) getJobRunCtx(jobID int64) *jobContext {
 		schemaVerSyncer:      s.schemaVerSyncer,
 
 		notifyCh: ch,
+		logger: tidblogutil.LoggerWithTraceInfo(
+			logutil.DDLLogger().With(zap.Int64("jobID", jobID)),
+			traceInfo,
+		),
 
 		oldDDLCtx: s.ddlCtx,
 	}
@@ -561,7 +565,7 @@ func (s *jobScheduler) transitOneJobStepAndWaitSync(wk *worker, jobCtx *jobConte
 				}
 				s.cleanMDLInfo(job, ownerID)
 			} else if err != systable.ErrNotFound {
-				wk.jobLogger(job).Warn("check MDL info failed", zap.Error(err))
+				jobCtx.logger.Warn("check MDL info failed", zap.Error(err))
 				return err
 			}
 		} else {
@@ -576,7 +580,7 @@ func (s *jobScheduler) transitOneJobStepAndWaitSync(wk *worker, jobCtx *jobConte
 
 	schemaVer, err := wk.transitOneJobStep(jobCtx, job)
 	if err != nil {
-		tidblogutil.Logger(wk.logCtx).Info("handle ddl job failed", zap.Error(err), zap.Stringer("job", job))
+		jobCtx.logger.Info("handle ddl job failed", zap.Error(err), zap.Stringer("job", job))
 		return err
 	}
 	failpoint.Inject("mockDownBeforeUpdateGlobalVersion", func(val failpoint.Value) {

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -704,7 +704,7 @@ func (w *worker) countForError(jobCtx *jobContext, job *model.Job, err error) er
 	return err
 }
 
-func (w *worker) processJobPausingRequest(jobCtx *jobContext, job *model.Job) (isRunnable bool, err error) {
+func (*worker) processJobPausingRequest(jobCtx *jobContext, job *model.Job) (isRunnable bool, err error) {
 	if job.IsPaused() {
 		jobCtx.logger.Debug("paused DDL job ", zap.String("job", job.String()))
 		return false, err

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -25,7 +25,8 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 )
 
-func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	metaMut := jobCtx.metaMut
 	if job.MultiSchemaInfo.Revertible {
 		// Handle the rolling back job.
 		if job.IsRollingback() {
@@ -36,7 +37,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 					continue
 				}
 				proxyJob := sub.ToProxyJob(job, i)
-				ver, _, err = w.runOneJobStep(jobCtx, t, &proxyJob)
+				ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
 				err = handleRollbackException(err, proxyJob.Error)
 				if err != nil {
 					return ver, err
@@ -59,7 +60,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 				continue
 			}
 			proxyJob := sub.ToProxyJob(job, i)
-			ver, _, err = w.runOneJobStep(jobCtx, t, &proxyJob)
+			ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
 			sub.FromProxyJob(&proxyJob, ver)
 			handleRevertibleException(job, sub, proxyJob.Error)
 			return ver, err
@@ -67,7 +68,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 
 		// Save table info and sub-jobs for rolling back.
 		var tblInfo *model.TableInfo
-		tblInfo, err = t.GetTable(job.SchemaID, job.TableID)
+		tblInfo, err = metaMut.GetTable(job.SchemaID, job.TableID)
 		if err != nil {
 			return ver, err
 		}
@@ -85,7 +86,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 			if schemaVersionGenerated {
 				proxyJob.MultiSchemaInfo.SkipVersion = true
 			}
-			proxyJobVer, _, err := w.runOneJobStep(jobCtx, t, &proxyJob)
+			proxyJobVer, _, err := w.runOneJobStep(jobCtx, &proxyJob)
 			if !schemaVersionGenerated && proxyJobVer != 0 {
 				schemaVersionGenerated = true
 				ver = proxyJobVer
@@ -105,7 +106,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 				// if we fail on "add column c int", the allocator is rebased to 100
 				// which cannot be rollback, but it's table-info.AutoIncID is rollback by below call.
 				// TODO we should also change schema diff of 'ver' if len(actionTypes) > 1.
-				return updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+				return updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 			}
 			actionTypes = append(actionTypes, sub.Type)
 		}
@@ -114,7 +115,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 			// job except AddForeignKey which is handled separately in the first loop.
 			// so this diff is enough, but it wound be better to accumulate all the diffs,
 			// and then merge them into a single diff.
-			if err = t.SetSchemaDiff(&model.SchemaDiff{
+			if err = metaMut.SetSchemaDiff(&model.SchemaDiff{
 				Version:        ver,
 				Type:           job.Type,
 				TableID:        job.TableID,
@@ -134,11 +135,11 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, t *meta.Mutator, job *mo
 			continue
 		}
 		proxyJob := sub.ToProxyJob(job, i)
-		ver, _, err = w.runOneJobStep(jobCtx, t, &proxyJob)
+		ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
 		sub.FromProxyJob(&proxyJob, ver)
 		return ver, err
 	}
-	return finishMultiSchemaJob(job, t)
+	return finishMultiSchemaJob(job, metaMut)
 }
 
 func handleRevertibleException(job *model.Job, subJob *model.SubJob, err *terror.Error) {

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -94,10 +94,10 @@ func checkAddPartition(t *meta.Mutator, job *model.Job) (*model.TableInfo, *mode
 }
 
 // TODO: Move this into reorganize partition!
-func (w *worker) onAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onAddTablePartition(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	// Handle the rolling back job
 	if job.IsRollingback() {
-		ver, err := w.onDropTablePartition(jobCtx, t, job)
+		ver, err := w.onDropTablePartition(jobCtx, job)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -105,7 +105,7 @@ func (w *worker) onAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *m
 	}
 
 	// notice: addingDefinitions is empty when job is in state model.StateNone
-	tblInfo, partInfo, addingDefinitions, err := checkAddPartition(t, job)
+	tblInfo, partInfo, addingDefinitions, err := checkAddPartition(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, err
 	}
@@ -136,14 +136,14 @@ func (w *worker) onAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *m
 
 		// move the adding definition into tableInfo.
 		updateAddingPartitionInfo(partInfo, tblInfo)
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 
 		// modify placement settings
 		for _, def := range tblInfo.Partition.AddingDefinitions {
-			if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(t, job, def.PlacementPolicyRef); err != nil {
+			if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(jobCtx.metaMut, job, def.PlacementPolicyRef); err != nil {
 				return ver, errors.Trace(err)
 			}
 		}
@@ -156,7 +156,7 @@ func (w *worker) onAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *m
 			}
 		}
 
-		bundles, err := alterTablePartitionBundles(t, tblInfo, tblInfo.Partition.AddingDefinitions)
+		bundles, err := alterTablePartitionBundles(jobCtx.metaMut, tblInfo, tblInfo.Partition.AddingDefinitions)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
@@ -191,7 +191,7 @@ func (w *worker) onAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *m
 			// be finished. Otherwise the query to this partition will be blocked.
 			needRetry, err := checkPartitionReplica(tblInfo.TiFlashReplica.Count, addingDefinitions, jobCtx)
 			if err != nil {
-				return convertAddTablePartitionJob2RollbackJob(jobCtx, t, job, err, tblInfo)
+				return convertAddTablePartitionJob2RollbackJob(jobCtx, job, err, tblInfo)
 			}
 			if needRetry {
 				// The new added partition hasn't been replicated.
@@ -222,7 +222,7 @@ func (w *worker) onAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *m
 
 		preSplitAndScatter(w.sess.Context, jobCtx.store, tblInfo, addingDefinitions)
 
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2145,14 +2145,15 @@ func dropLabelRules(ctx context.Context, schemaName, tableName string, partNames
 }
 
 // onDropTablePartition deletes old partition meta.
-func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onDropTablePartition(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetTablePartitionArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 	partNames, partInfo := args.PartNames, args.PartInfo
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	metaMut := jobCtx.metaMut
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2204,7 +2205,7 @@ func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *
 		} else {
 			tblInfo.Partition.ClearReorgIntermediateInfo()
 		}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2241,7 +2242,7 @@ func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *
 		var bundles []*placement.Bundle
 		// create placement groups for each dropped partition to keep the data's placement before GC
 		// These placements groups will be deleted after GC
-		bundles, err = droppedPartitionBundles(t, tblInfo, tblInfo.Partition.DroppingDefinitions)
+		bundles, err = droppedPartitionBundles(metaMut, tblInfo, tblInfo.Partition.DroppingDefinitions)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, err
@@ -2249,7 +2250,7 @@ func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *
 
 		var tableBundle *placement.Bundle
 		// Recompute table bundle to remove dropped partitions rules from its group
-		tableBundle, err = placement.NewTableBundle(t, tblInfo)
+		tableBundle, err = placement.NewTableBundle(metaMut, tblInfo)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
@@ -2265,13 +2266,13 @@ func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *
 		}
 
 		job.SchemaState = model.StateDeleteOnly
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != job.SchemaState)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != job.SchemaState)
 	case model.StateDeleteOnly:
 		// This state is not a real 'DeleteOnly' state, because tidb does not maintaining the state check in partitionDefinition.
 		// Insert this state to confirm all servers can not see the old partitions when reorg is running,
 		// so that no new data will be inserted into old partitions when reorganizing.
 		job.SchemaState = model.StateDeleteReorganization
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != job.SchemaState)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != job.SchemaState)
 	case model.StateDeleteReorganization:
 		oldTblInfo := getTableInfoWithDroppingPartitions(tblInfo)
 		physicalTableIDs = getPartitionIDsFromDefinitions(tblInfo.Partition.DroppingDefinitions)
@@ -2279,7 +2280,7 @@ func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		dbInfo, err := t.GetDatabase(job.SchemaID)
+		dbInfo, err := metaMut.GetDatabase(job.SchemaID)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2331,7 +2332,7 @@ func (w *worker) onDropTablePartition(jobCtx *jobContext, t *meta.Mutator, job *
 		tblInfo.Partition.DroppingDefinitions = nil
 		// used by ApplyDiff in updateSchemaVersion
 		job.CtxVars = []any{physicalTableIDs} // TODO remove it.
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2369,7 +2370,7 @@ func removeTiFlashAvailablePartitionIDs(tblInfo *model.TableInfo, pids []int64) 
 }
 
 // onTruncateTablePartition truncates old partition meta.
-func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (int64, error) {
+func (w *worker) onTruncateTablePartition(jobCtx *jobContext, job *model.Job) (int64, error) {
 	var ver int64
 	args, err := model.GetTruncateTableArgs(job)
 	if err != nil {
@@ -2381,7 +2382,8 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(errors.New("len(oldIDs) must be the same as len(newIDs)"))
 	}
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	metaMut := jobCtx.metaMut
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2415,7 +2417,7 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 			return ver, err
 		}
 
-		if err = updateTruncatePartitionLabelRules(job, t, oldPartitions, newPartitions, tblInfo, oldIDs); err != nil {
+		if err = updateTruncatePartitionLabelRules(job, jobCtx.metaMut, oldPartitions, newPartitions, tblInfo, oldIDs); err != nil {
 			job.State = model.JobStateCancelled
 			return ver, err
 		}
@@ -2423,7 +2425,7 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 		preSplitAndScatter(w.sess.Context, jobCtx.store, tblInfo, newPartitions)
 
 		job.CtxVars = []any{oldIDs, newIDs}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2463,13 +2465,13 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 		pi.NewPartitionIDs = newIDs[:]
 
 		job.SchemaState = model.StateDeleteOnly
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	case model.StateDeleteOnly:
 		// This state is not a real 'DeleteOnly' state, because tidb does not maintaining the state check in partitionDefinition.
 		// Insert this state to confirm all servers can not see the old partitions when reorg is running,
 		// so that no new data will be inserted into old partitions when reorganizing.
 		job.SchemaState = model.StateDeleteReorganization
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	case model.StateDeleteReorganization:
 		// Step2: clear global index rows.
 		physicalTableIDs := oldIDs
@@ -2479,7 +2481,7 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		dbInfo, err := t.GetDatabase(job.SchemaID)
+		dbInfo, err := metaMut.GetDatabase(job.SchemaID)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2551,7 +2553,7 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 			return ver, err
 		}
 
-		if err = updateTruncatePartitionLabelRules(job, t, oldPartitions, newPartitions, tblInfo, oldIDs); err != nil {
+		if err = updateTruncatePartitionLabelRules(job, jobCtx.metaMut, oldPartitions, newPartitions, tblInfo, oldIDs); err != nil {
 			job.State = model.JobStateCancelled
 			return ver, err
 		}
@@ -2564,7 +2566,7 @@ func (w *worker) onTruncateTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 
 		// used by ApplyDiff in updateSchemaVersion
 		job.CtxVars = []any{oldIDs, newIDs}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -2669,7 +2671,7 @@ func updateTruncatePartitionLabelRules(job *model.Job, t *meta.Mutator, oldParti
 }
 
 // onExchangeTablePartition exchange partition data
-func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onExchangeTablePartition(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetExchangeTablePartitionArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -2678,28 +2680,29 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 
 	defID, ptSchemaID, ptID, partName :=
 		args.PartitionID, args.PTSchemaID, args.PTTableID, args.PartitionName
+	metaMut := jobCtx.metaMut
 
-	ntDbInfo, err := checkSchemaExistAndCancelNotExistJob(t, job)
+	ntDbInfo, err := checkSchemaExistAndCancelNotExistJob(metaMut, job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 
-	ptDbInfo, err := t.GetDatabase(ptSchemaID)
+	ptDbInfo, err := metaMut.GetDatabase(ptSchemaID)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 
-	nt, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	nt, err := GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
 	if job.IsRollingback() {
-		return rollbackExchangeTablePartition(jobCtx, t, job, nt)
+		return rollbackExchangeTablePartition(jobCtx, job, nt)
 	}
-	pt, err := getTableInfo(t, ptID, ptSchemaID)
+	pt, err := getTableInfo(metaMut, ptID, ptSchemaID)
 	if err != nil {
 		if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
 			job.State = model.JobStateCancelled
@@ -2728,7 +2731,7 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 			return ver, errors.Trace(err)
 		}
 
-		err = checkExchangePartitionPlacementPolicy(t, nt.PlacementPolicyRef, pt.PlacementPolicyRef, partDef.PlacementPolicyRef)
+		err = checkExchangePartitionPlacementPolicy(metaMut, nt.PlacementPolicyRef, pt.PlacementPolicyRef, partDef.PlacementPolicyRef)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
@@ -2765,7 +2768,7 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 		// into the table using the schema version
 		// before the exchange is made.
 		job.SchemaState = model.StateWriteOnly
-		return updateVersionAndTableInfoWithCheck(jobCtx, t, job, nt, true, ptInfo...)
+		return updateVersionAndTableInfoWithCheck(jobCtx, job, nt, true, ptInfo...)
 	}
 	// From now on, nt (the non-partitioned table) has
 	// ExchangePartitionInfo set, meaning it is restricted
@@ -2807,12 +2810,12 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 	}
 
 	// partition table auto IDs.
-	ptAutoIDs, err := t.GetAutoIDAccessors(ptSchemaID, ptID).Get()
+	ptAutoIDs, err := metaMut.GetAutoIDAccessors(ptSchemaID, ptID).Get()
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 	// non-partition table auto IDs.
-	ntAutoIDs, err := t.GetAutoIDAccessors(job.SchemaID, nt.ID).Get()
+	ntAutoIDs, err := metaMut.GetAutoIDAccessors(job.SchemaID, nt.ID).Get()
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2828,7 +2831,7 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 
 	// Recreate non-partition table meta info,
 	// by first delete it with the old table id
-	err = t.DropTableOrView(job.SchemaID, nt.ID)
+	err = metaMut.DropTableOrView(job.SchemaID, nt.ID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2840,12 +2843,12 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 	originalNt := nt.Clone()
 	partDef.ID, nt.ID = nt.ID, partDef.ID
 
-	err = t.UpdateTable(ptSchemaID, pt)
+	err = metaMut.UpdateTable(ptSchemaID, pt)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
-	err = t.CreateTableOrView(job.SchemaID, nt)
+	err = metaMut.CreateTableOrView(job.SchemaID, nt)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2864,11 +2867,11 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 		IncrementID: mathutil.Max(ptAutoIDs.IncrementID, ntAutoIDs.IncrementID),
 		RandomID:    mathutil.Max(ptAutoIDs.RandomID, ntAutoIDs.RandomID),
 	}
-	err = t.GetAutoIDAccessors(ptSchemaID, pt.ID).Put(newAutoIDs)
+	err = metaMut.GetAutoIDAccessors(ptSchemaID, pt.ID).Put(newAutoIDs)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	err = t.GetAutoIDAccessors(job.SchemaID, nt.ID).Put(newAutoIDs)
+	err = metaMut.GetAutoIDAccessors(job.SchemaID, nt.ID).Put(newAutoIDs)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2891,7 +2894,7 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 	// the follow code is a swap function for rules of two partitions
 	// though partitions has exchanged their ID, swap still take effect
 
-	bundles, err := bundlesForExchangeTablePartition(t, pt, partDef, nt)
+	bundles, err := bundlesForExchangeTablePartition(metaMut, pt, partDef, nt)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -2937,7 +2940,7 @@ func (w *worker) onExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, j
 
 	job.SchemaState = model.StatePublic
 	nt.ExchangePartitionInfo = nil
-	ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, nt, true)
+	ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, nt, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -3066,21 +3069,22 @@ func getReorgPartitionInfo(t *meta.Mutator, job *model.Job) (*model.TableInfo, [
 //
 //	Everything now looks as it should, no memory of old partitions/indexes,
 //	and no more double writing, since the previous state is only reading the new partitions/indexes.
-func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onReorganizePartition(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	// Handle the rolling back job
 	if job.IsRollingback() {
-		ver, err := w.onDropTablePartition(jobCtx, t, job)
+		ver, err := w.onDropTablePartition(jobCtx, job)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		return ver, nil
 	}
 
-	tblInfo, partNames, partInfo, _, addingDefinitions, err := getReorgPartitionInfo(t, job)
+	tblInfo, partNames, partInfo, _, addingDefinitions, err := getReorgPartitionInfo(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, err
 	}
 
+	metaMut := jobCtx.metaMut
 	switch job.SchemaState {
 	case model.StateNone:
 		// job.SchemaState == model.StateNone means the job is in the initial state of reorg partition.
@@ -3141,7 +3145,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 
 		// modify placement settings
 		for _, def := range tblInfo.Partition.AddingDefinitions {
-			if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(t, job, def.PlacementPolicyRef); err != nil {
+			if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(metaMut, job, def.PlacementPolicyRef); err != nil {
 				// job.State = model.JobStateCancelled may be set depending on error in function above.
 				return ver, errors.Trace(err)
 			}
@@ -3223,13 +3227,13 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 			// In the next step, StateDeleteOnly, wait to verify the TiFlash replicas are OK
 		}
 
-		bundles, err := alterTablePartitionBundles(t, tblInfo, tblInfo.Partition.AddingDefinitions)
+		bundles, err := alterTablePartitionBundles(metaMut, tblInfo, tblInfo.Partition.AddingDefinitions)
 		if err != nil {
 			if !changesMade {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)
 			}
-			return rollbackReorganizePartitionWithErr(jobCtx, t, job, err)
+			return rollbackReorganizePartitionWithErr(jobCtx, job, err)
 		}
 
 		if len(bundles) > 0 {
@@ -3238,7 +3242,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 					job.State = model.JobStateCancelled
 					return ver, errors.Wrapf(err, "failed to notify PD the placement rules")
 				}
-				return rollbackReorganizePartitionWithErr(jobCtx, t, job, err)
+				return rollbackReorganizePartitionWithErr(jobCtx, job, err)
 			}
 			changesMade = true
 		}
@@ -3254,7 +3258,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 				job.State = model.JobStateCancelled
 				return ver, err
 			}
-			return rollbackReorganizePartitionWithErr(jobCtx, t, job, err)
+			return rollbackReorganizePartitionWithErr(jobCtx, job, err)
 		}
 
 		// Doing the preSplitAndScatter here, since all checks are completed,
@@ -3273,14 +3277,14 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String()).Set(0.1 / float64(math.MaxUint64))
 		job.SchemaState = model.StateDeleteOnly
 		tblInfo.Partition.DDLState = model.StateDeleteOnly
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		failpoint.Inject("reorgPartRollback1", func(val failpoint.Value) {
 			if val.(bool) {
 				err = errors.New("Injected error by reorgPartRollback1")
-				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, t, job, err))
+				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, job, err))
 			}
 		})
 
@@ -3311,7 +3315,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 			count := tblInfo.TiFlashReplica.Count
 			needRetry, err := checkPartitionReplica(count, addingDefinitions, jobCtx)
 			if err != nil {
-				return rollbackReorganizePartitionWithErr(jobCtx, t, job, err)
+				return rollbackReorganizePartitionWithErr(jobCtx, job, err)
 			}
 			if needRetry {
 				// The new added partition hasn't been replicated.
@@ -3338,10 +3342,10 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 		failpoint.Inject("reorgPartRollback2", func(val failpoint.Value) {
 			if val.(bool) {
 				err = errors.New("Injected error by reorgPartRollback2")
-				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, t, job, err))
+				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, job, err))
 			}
 		})
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		job.SchemaState = model.StateWriteOnly
 	case model.StateWriteOnly:
 		// Insert this state to confirm all servers can see the new partitions when reorg is running,
@@ -3354,7 +3358,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 		}
 		tblInfo.Partition.DDLState = model.StateWriteReorganization
 		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String()).Set(0.3 / float64(math.MaxUint64))
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		job.SchemaState = model.StateWriteReorganization
 	case model.StateWriteReorganization:
 		physicalTableIDs := getPartitionIDsFromDefinitions(tblInfo.Partition.DroppingDefinitions)
@@ -3372,11 +3376,11 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 		failpoint.Inject("reorgPartRollback3", func(val failpoint.Value) {
 			if val.(bool) {
 				err = errors.New("Injected error by reorgPartRollback3")
-				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, t, job, err))
+				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, job, err))
 			}
 		})
 		var done bool
-		done, ver, err = doPartitionReorgWork(w, jobCtx, t, job, tbl, physicalTableIDs)
+		done, ver, err = doPartitionReorgWork(w, jobCtx, job, tbl, physicalTableIDs)
 
 		if !done {
 			return ver, err
@@ -3385,7 +3389,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 		failpoint.Inject("reorgPartRollback4", func(val failpoint.Value) {
 			if val.(bool) {
 				err = errors.New("Injected error by reorgPartRollback4")
-				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, t, job, err))
+				failpoint.Return(rollbackReorganizePartitionWithErr(jobCtx, job, err))
 			}
 		})
 
@@ -3404,7 +3408,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 				} else {
 					inAllPartitionColumns, err := checkPartitionKeysConstraint(partInfo, index.Columns, tblInfo)
 					if err != nil {
-						return rollbackReorganizePartitionWithErr(jobCtx, t, job, err)
+						return rollbackReorganizePartitionWithErr(jobCtx, job, err)
 					}
 					if !inAllPartitionColumns {
 						// Mark the old unique index as non-readable, and to be dropped,
@@ -3441,7 +3445,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 		// since they are a part of the normal Definitions that other nodes with
 		// the current schema version. So we need to double write for one more schema version
 		tblInfo.Partition.DDLState = model.StateDeleteReorganization
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		job.SchemaState = model.StateDeleteReorganization
 
 	case model.StateDeleteReorganization:
@@ -3496,11 +3500,11 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 			// TODO: Will this result in big gaps?
 			// TODO: How to carrie over AUTO_INCREMENT etc.?
 			// Check if they are carried over in ApplyDiff?!?
-			autoIDs, err := t.GetAutoIDAccessors(job.SchemaID, tblInfo.ID).Get()
+			autoIDs, err := metaMut.GetAutoIDAccessors(job.SchemaID, tblInfo.ID).Get()
 			if err != nil {
 				return ver, errors.Trace(err)
 			}
-			err = t.DropTableOrView(job.SchemaID, tblInfo.ID)
+			err = metaMut.DropTableOrView(job.SchemaID, tblInfo.ID)
 			if err != nil {
 				return ver, errors.Trace(err)
 			}
@@ -3522,11 +3526,11 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 					failpoint.Return(ver, errors.New("Injected error by reorgPartFail4"))
 				}
 			})
-			err = t.GetAutoIDAccessors(job.SchemaID, tblInfo.ID).Put(autoIDs)
+			err = metaMut.GetAutoIDAccessors(job.SchemaID, tblInfo.ID).Put(autoIDs)
 			if err != nil {
 				return ver, errors.Trace(err)
 			}
-			err = t.CreateTableOrView(job.SchemaID, tblInfo)
+			err = metaMut.CreateTableOrView(job.SchemaID, tblInfo)
 			if err != nil {
 				return ver, errors.Trace(err)
 			}
@@ -3538,7 +3542,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, t *meta.Mutator, job 
 			}
 		})
 		job.CtxVars = []any{physicalTableIDs, newIDs}
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -3603,7 +3607,7 @@ func newStatsDDLEventForJob(
 	return event, nil
 }
 
-func doPartitionReorgWork(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job, tbl table.Table, physTblIDs []int64) (done bool, ver int64, err error) {
+func doPartitionReorgWork(w *worker, jobCtx *jobContext, job *model.Job, tbl table.Table, physTblIDs []int64) (done bool, ver int64, err error) {
 	job.ReorgMeta.ReorgTp = model.ReorgTypeTxn
 	sctx, err1 := w.sessPool.Get()
 	if err1 != nil {
@@ -3624,7 +3628,7 @@ func doPartitionReorgWork(w *worker, jobCtx *jobContext, t *meta.Mutator, job *m
 	if !ok {
 		return false, ver, dbterror.ErrUnsupportedReorganizePartition.GenWithStackByArgs()
 	}
-	dbInfo, err := t.GetDatabase(job.SchemaID)
+	dbInfo, err := jobCtx.metaMut.GetDatabase(job.SchemaID)
 	if err != nil {
 		return false, ver, errors.Trace(err)
 	}
@@ -3653,7 +3657,7 @@ func doPartitionReorgWork(w *worker, jobCtx *jobContext, t *meta.Mutator, job *m
 				zap.Stringer("job", job), zap.Error(err1))
 		}
 		logutil.DDLLogger().Warn("reorg partition job failed, convert job to rollback", zap.Stringer("job", job), zap.Error(err))
-		ver, err = rollbackReorganizePartitionWithErr(jobCtx, t, job, err)
+		ver, err = rollbackReorganizePartitionWithErr(jobCtx, job, err)
 		return false, ver, errors.Trace(err)
 	}
 	return true, ver, err

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
-	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -47,7 +46,6 @@ func UpdateColsNull2NotNull(tblInfo *model.TableInfo, indexInfo *model.IndexInfo
 
 func convertAddIdxJob2RollbackJob(
 	jobCtx *jobContext,
-	t *meta.Mutator,
 	job *model.Job,
 	tblInfo *model.TableInfo,
 	allIndexInfos []*model.IndexInfo,
@@ -85,7 +83,7 @@ func convertAddIdxJob2RollbackJob(
 	// the second and the third args will be used in onDropIndex.
 	job.Args = []any{idxNames, ifExists, getPartitionIDs(tblInfo)}
 	job.SchemaState = model.StateDeleteOnly
-	ver, err1 := updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != model.StateDeleteOnly)
+	ver, err1 := updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != model.StateDeleteOnly)
 	if err1 != nil {
 		return ver, errors.Trace(err1)
 	}
@@ -100,14 +98,14 @@ func convertAddIdxJob2RollbackJob(
 
 // convertNotReorgAddIdxJob2RollbackJob converts the add index job that are not started workers to rollingbackJob,
 // to rollback add index operations. job.SnapshotVer == 0 indicates the workers are not started.
-func convertNotReorgAddIdxJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator, job *model.Job, occuredErr error) (ver int64, err error) {
+func convertNotReorgAddIdxJob2RollbackJob(jobCtx *jobContext, job *model.Job, occuredErr error) (ver int64, err error) {
 	defer func() {
 		if ingest.LitBackCtxMgr != nil {
 			ingest.LitBackCtxMgr.Unregister(job.ID)
 		}
 	}()
 	schemaID := job.SchemaID
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -137,22 +135,22 @@ func convertNotReorgAddIdxJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator, j
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrCancelledDDLJob
 	}
-	return convertAddIdxJob2RollbackJob(jobCtx, t, job, tblInfo, indexesInfo, occuredErr)
+	return convertAddIdxJob2RollbackJob(jobCtx, job, tblInfo, indexesInfo, occuredErr)
 }
 
 // rollingbackModifyColumn change the modifying-column job into rolling back state.
 // Since modifying column job has two types: normal-type and reorg-type, we should handle it respectively.
 // normal-type has only two states:    None -> Public
 // reorg-type has five states:         None -> Delete-only -> Write-only -> Write-org -> Public
-func rollingbackModifyColumn(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func rollingbackModifyColumn(w *worker, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	if needNotifyAndStopReorgWorker(job) {
 		// column type change workers are started. we have to ask them to exit.
 		w.jobLogger(job).Info("run the cancelling DDL job", zap.String("job", job.String()))
 		jobCtx.oldDDLCtx.notifyReorgWorkerJobStateChange(job)
 		// Give the this kind of ddl one more round to run, the dbterror.ErrCancelledDDLJob should be fetched from the bottom up.
-		return w.onModifyColumn(jobCtx, t, job)
+		return w.onModifyColumn(jobCtx, job)
 	}
-	_, tblInfo, oldCol, jp, err := getModifyColumnInfo(t, job)
+	_, tblInfo, oldCol, jp, err := getModifyColumnInfo(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, err
 	}
@@ -184,8 +182,8 @@ func rollingbackModifyColumn(w *worker, jobCtx *jobContext, t *meta.Mutator, job
 	return ver, dbterror.ErrCancelledDDLJob
 }
 
-func rollingbackAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	tblInfo, columnInfo, col, _, _, err := checkAddColumn(t, job)
+func rollingbackAddColumn(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	tblInfo, columnInfo, col, _, _, err := checkAddColumn(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -199,7 +197,7 @@ func rollingbackAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 	job.SchemaState = model.StateDeleteOnly
 
 	job.Args = []any{col.Name}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != columnInfo.State)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != columnInfo.State)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -208,8 +206,8 @@ func rollingbackAddColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 	return ver, dbterror.ErrCancelledDDLJob
 }
 
-func rollingbackDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, colInfo, idxInfos, _, err := checkDropColumn(jobCtx, t, job)
+func rollingbackDropColumn(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, colInfo, idxInfos, _, err := checkDropColumn(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -240,8 +238,8 @@ func rollingbackDropColumn(jobCtx *jobContext, t *meta.Mutator, job *model.Job) 
 	return ver, nil
 }
 
-func rollingbackDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, indexInfo, _, err := checkDropIndex(jobCtx.infoCache, t, job)
+func rollingbackDropIndex(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, indexInfo, _, err := checkDropIndex(jobCtx.infoCache, jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -260,15 +258,15 @@ func rollingbackDropIndex(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 	}
 }
 
-func rollingbackAddIndex(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job, isPK bool) (ver int64, err error) {
+func rollingbackAddIndex(w *worker, jobCtx *jobContext, job *model.Job, isPK bool) (ver int64, err error) {
 	if needNotifyAndStopReorgWorker(job) {
 		// add index workers are started. need to ask them to exit.
 		w.jobLogger(job).Info("run the cancelling DDL job", zap.String("job", job.String()))
 		jobCtx.oldDDLCtx.notifyReorgWorkerJobStateChange(job)
-		ver, err = w.onCreateIndex(jobCtx, t, job, isPK)
+		ver, err = w.onCreateIndex(jobCtx, job, isPK)
 	} else {
 		// add index's reorg workers are not running, remove the indexInfo in tableInfo.
-		ver, err = convertNotReorgAddIdxJob2RollbackJob(jobCtx, t, job, dbterror.ErrCancelledDDLJob)
+		ver, err = convertNotReorgAddIdxJob2RollbackJob(jobCtx, job, dbterror.ErrCancelledDDLJob)
 	}
 	return
 }
@@ -288,18 +286,18 @@ func needNotifyAndStopReorgWorker(job *model.Job) bool {
 
 // rollbackExchangeTablePartition will clear the non-partitioned
 // table's ExchangePartitionInfo state.
-func rollbackExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tblInfo *model.TableInfo) (ver int64, err error) {
+func rollbackExchangeTablePartition(jobCtx *jobContext, job *model.Job, tblInfo *model.TableInfo) (ver int64, err error) {
 	tblInfo.ExchangePartitionInfo = nil
 	job.State = model.JobStateRollbackDone
 	job.SchemaState = model.StatePublic
 	if len(tblInfo.Constraints) == 0 {
-		return updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+		return updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	}
 	args, err := model.GetExchangeTablePartitionArgs(job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	pt, err := getTableInfo(t, args.PTTableID, args.PTSchemaID)
+	pt, err := getTableInfo(jobCtx.metaMut, args.PTTableID, args.PTSchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -309,26 +307,26 @@ func rollbackExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, job *mo
 		schemaID: args.PTSchemaID,
 		tblInfo:  pt,
 	})
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true, ptInfo...)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true, ptInfo...)
 	return ver, errors.Trace(err)
 }
 
-func rollingbackExchangeTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func rollingbackExchangeTablePartition(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	if job.SchemaState == model.StateNone {
 		// Nothing is changed
 		job.State = model.JobStateCancelled
 		return ver, dbterror.ErrCancelledDDLJob
 	}
 	var nt *model.TableInfo
-	nt, err = GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	nt, err = GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	ver, err = rollbackExchangeTablePartition(jobCtx, t, job, nt)
+	ver, err = rollbackExchangeTablePartition(jobCtx, job, nt)
 	return ver, errors.Trace(err)
 }
 
-func convertAddTablePartitionJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator, job *model.Job, otherwiseErr error, tblInfo *model.TableInfo) (ver int64, err error) {
+func convertAddTablePartitionJob2RollbackJob(jobCtx *jobContext, job *model.Job, otherwiseErr error, tblInfo *model.TableInfo) (ver int64, err error) {
 	addingDefinitions := tblInfo.Partition.AddingDefinitions
 	partNames := make([]string, 0, len(addingDefinitions))
 	for _, pd := range addingDefinitions {
@@ -347,7 +345,7 @@ func convertAddTablePartitionJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator
 		}
 
 	*/
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -355,22 +353,22 @@ func convertAddTablePartitionJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator
 	return ver, errors.Trace(otherwiseErr)
 }
 
-func rollbackReorganizePartitionWithErr(jobCtx *jobContext, t *meta.Mutator, job *model.Job, otherwiseErr error) (ver int64, err error) {
+func rollbackReorganizePartitionWithErr(jobCtx *jobContext, job *model.Job, otherwiseErr error) (ver int64, err error) {
 	if job.SchemaState == model.StateNone {
 		job.State = model.JobStateCancelled
 		return ver, otherwiseErr
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
 	// addingDefinitions is also in tblInfo, here pass the tblInfo as parameter directly.
-	return convertReorgPartitionJob2RollbackJob(jobCtx, t, job, otherwiseErr, tblInfo)
+	return convertReorgPartitionJob2RollbackJob(jobCtx, job, otherwiseErr, tblInfo)
 }
 
-func convertReorgPartitionJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator, job *model.Job, otherwiseErr error, tblInfo *model.TableInfo) (ver int64, err error) {
+func convertReorgPartitionJob2RollbackJob(jobCtx *jobContext, job *model.Job, otherwiseErr error, tblInfo *model.TableInfo) (ver int64, err error) {
 	pi := tblInfo.Partition
 	addingDefinitions := pi.AddingDefinitions
 	partNames := make([]string, 0, len(addingDefinitions))
@@ -495,7 +493,7 @@ func convertReorgPartitionJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator, j
 		}
 
 	*/
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -503,8 +501,8 @@ func convertReorgPartitionJob2RollbackJob(jobCtx *jobContext, t *meta.Mutator, j
 	return ver, errors.Trace(otherwiseErr)
 }
 
-func rollingbackAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	tblInfo, _, addingDefinitions, err := checkAddPartition(t, job)
+func rollingbackAddTablePartition(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	tblInfo, _, addingDefinitions, err := checkAddPartition(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -514,11 +512,11 @@ func rollingbackAddTablePartition(jobCtx *jobContext, t *meta.Mutator, job *mode
 		return ver, errors.Trace(dbterror.ErrCancelledDDLJob)
 	}
 	// addingDefinitions is also in tblInfo, here pass the tblInfo as parameter directly.
-	return convertAddTablePartitionJob2RollbackJob(jobCtx, t, job, dbterror.ErrCancelledDDLJob, tblInfo)
+	return convertAddTablePartitionJob2RollbackJob(jobCtx, job, dbterror.ErrCancelledDDLJob, tblInfo)
 }
 
-func rollingbackDropTableOrView(t *meta.Mutator, job *model.Job) error {
-	tblInfo, err := checkTableExistAndCancelNonExistJob(t, job, job.SchemaID)
+func rollingbackDropTableOrView(jobCtx *jobContext, job *model.Job) error {
+	tblInfo, err := checkTableExistAndCancelNonExistJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -532,16 +530,16 @@ func rollingbackDropTableOrView(t *meta.Mutator, job *model.Job) error {
 	return nil
 }
 
-func rollingbackDropTablePartition(t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, err = GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+func rollingbackDropTablePartition(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, err = GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 	return cancelOnlyNotHandledJob(job, model.StatePublic)
 }
 
-func rollingbackDropSchema(t *meta.Mutator, job *model.Job) error {
-	dbInfo, err := checkSchemaExistAndCancelNotExistJob(t, job)
+func rollingbackDropSchema(jobCtx *jobContext, job *model.Job) error {
+	dbInfo, err := checkSchemaExistAndCancelNotExistJob(jobCtx.metaMut, job)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -555,8 +553,8 @@ func rollingbackDropSchema(t *meta.Mutator, job *model.Job) error {
 	return nil
 }
 
-func rollingbackRenameIndex(t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	tblInfo, from, _, err := checkRenameIndex(t, job)
+func rollingbackRenameIndex(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	tblInfo, from, _, err := checkRenameIndex(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -582,8 +580,8 @@ func cancelOnlyNotHandledJob(job *model.Job, initialState model.SchemaState) (ve
 	return ver, nil
 }
 
-func rollingbackTruncateTable(t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, err = GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+func rollingbackTruncateTable(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, err = GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -599,37 +597,37 @@ func pauseReorgWorkers(w *worker, d *ddlCtx, job *model.Job) (err error) {
 	return dbterror.ErrPausedDDLJob.GenWithStackByArgs(job.ID)
 }
 
-func convertJob2RollbackJob(w *worker, jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func convertJob2RollbackJob(w *worker, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	switch job.Type {
 	case model.ActionAddColumn:
-		ver, err = rollingbackAddColumn(jobCtx, t, job)
+		ver, err = rollingbackAddColumn(jobCtx, job)
 	case model.ActionAddIndex:
-		ver, err = rollingbackAddIndex(w, jobCtx, t, job, false)
+		ver, err = rollingbackAddIndex(w, jobCtx, job, false)
 	case model.ActionAddPrimaryKey:
-		ver, err = rollingbackAddIndex(w, jobCtx, t, job, true)
+		ver, err = rollingbackAddIndex(w, jobCtx, job, true)
 	case model.ActionAddTablePartition:
-		ver, err = rollingbackAddTablePartition(jobCtx, t, job)
+		ver, err = rollingbackAddTablePartition(jobCtx, job)
 	case model.ActionReorganizePartition, model.ActionRemovePartitioning,
 		model.ActionAlterTablePartitioning:
-		ver, err = rollbackReorganizePartitionWithErr(jobCtx, t, job, dbterror.ErrCancelledDDLJob)
+		ver, err = rollbackReorganizePartitionWithErr(jobCtx, job, dbterror.ErrCancelledDDLJob)
 	case model.ActionDropColumn:
-		ver, err = rollingbackDropColumn(jobCtx, t, job)
+		ver, err = rollingbackDropColumn(jobCtx, job)
 	case model.ActionDropIndex, model.ActionDropPrimaryKey:
-		ver, err = rollingbackDropIndex(jobCtx, t, job)
+		ver, err = rollingbackDropIndex(jobCtx, job)
 	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
-		err = rollingbackDropTableOrView(t, job)
+		err = rollingbackDropTableOrView(jobCtx, job)
 	case model.ActionDropTablePartition:
-		ver, err = rollingbackDropTablePartition(t, job)
+		ver, err = rollingbackDropTablePartition(jobCtx, job)
 	case model.ActionExchangeTablePartition:
-		ver, err = rollingbackExchangeTablePartition(jobCtx, t, job)
+		ver, err = rollingbackExchangeTablePartition(jobCtx, job)
 	case model.ActionDropSchema:
-		err = rollingbackDropSchema(t, job)
+		err = rollingbackDropSchema(jobCtx, job)
 	case model.ActionRenameIndex:
-		ver, err = rollingbackRenameIndex(t, job)
+		ver, err = rollingbackRenameIndex(jobCtx, job)
 	case model.ActionTruncateTable:
-		ver, err = rollingbackTruncateTable(t, job)
+		ver, err = rollingbackTruncateTable(jobCtx, job)
 	case model.ActionModifyColumn:
-		ver, err = rollingbackModifyColumn(w, jobCtx, t, job)
+		ver, err = rollingbackModifyColumn(w, jobCtx, job)
 	case model.ActionDropForeignKey, model.ActionTruncateTablePartition:
 		ver, err = cancelOnlyNotHandledJob(job, model.StatePublic)
 	case model.ActionRebaseAutoID, model.ActionShardRowID, model.ActionAddForeignKey,
@@ -642,11 +640,11 @@ func convertJob2RollbackJob(w *worker, jobCtx *jobContext, t *meta.Mutator, job 
 	case model.ActionMultiSchemaChange:
 		err = rollingBackMultiSchemaChange(job)
 	case model.ActionAddCheckConstraint:
-		ver, err = rollingBackAddConstraint(jobCtx, t, job)
+		ver, err = rollingBackAddConstraint(jobCtx, job)
 	case model.ActionDropCheckConstraint:
-		ver, err = rollingBackDropConstraint(t, job)
+		ver, err = rollingBackDropConstraint(jobCtx, job)
 	case model.ActionAlterCheckConstraint:
-		ver, err = rollingBackAlterConstraint(jobCtx, t, job)
+		ver, err = rollingBackAlterConstraint(jobCtx, job)
 	default:
 		job.State = model.JobStateCancelled
 		err = dbterror.ErrCancelledDDLJob
@@ -693,8 +691,8 @@ func convertJob2RollbackJob(w *worker, jobCtx *jobContext, t *meta.Mutator, job 
 	return
 }
 
-func rollingBackAddConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, tblInfo, constrInfoInMeta, _, err := checkAddCheckConstraint(t, job)
+func rollingBackAddConstraint(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, tblInfo, constrInfoInMeta, _, err := checkAddCheckConstraint(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -713,12 +711,12 @@ func rollingBackAddConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Jo
 	if job.IsRollingback() {
 		job.State = model.JobStateRollbackDone
 	}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	return ver, errors.Trace(err)
 }
 
-func rollingBackDropConstraint(t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, constrInfoInMeta, err := checkDropCheckConstraint(t, job)
+func rollingBackDropConstraint(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, constrInfoInMeta, err := checkDropCheckConstraint(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -733,8 +731,8 @@ func rollingBackDropConstraint(t *meta.Mutator, job *model.Job) (ver int64, err 
 	return ver, nil
 }
 
-func rollingBackAlterConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	_, tblInfo, constraintInfo, enforced, err := checkAlterCheckConstraint(t, job)
+func rollingBackAlterConstraint(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	_, tblInfo, constraintInfo, enforced, err := checkAlterCheckConstraint(jobCtx.metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -751,6 +749,6 @@ func rollingBackAlterConstraint(jobCtx *jobContext, t *meta.Mutator, job *model.
 	if job.IsRollingback() {
 		job.State = model.JobStateRollbackDone
 	}
-	ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
 	return ver, errors.Trace(err)
 }

--- a/pkg/ddl/schema_version.go
+++ b/pkg/ddl/schema_version.go
@@ -310,7 +310,7 @@ func SetSchemaDiffForMultiInfos(diff *model.SchemaDiff, multiInfos ...schemaIDAn
 }
 
 // updateSchemaVersion increments the schema version by 1 and sets SchemaDiff.
-func updateSchemaVersion(jobCtx *jobContext, t *meta.Mutator, job *model.Job, multiInfos ...schemaIDAndTableInfo) (int64, error) {
+func updateSchemaVersion(jobCtx *jobContext, job *model.Job, multiInfos ...schemaIDAndTableInfo) (int64, error) {
 	schemaVersion, err := jobCtx.setSchemaVersion(job)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -354,7 +354,7 @@ func updateSchemaVersion(jobCtx *jobContext, t *meta.Mutator, job *model.Job, mu
 		return 0, err
 	}
 	SetSchemaDiffForMultiInfos(diff, multiInfos...)
-	err = t.SetSchemaDiff(diff)
+	err = jobCtx.metaMut.SetSchemaDiff(diff)
 	return schemaVersion, errors.Trace(err)
 }
 

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -58,8 +58,8 @@ func repairTableOrViewWithCheck(t *meta.Mutator, job *model.Job, schemaID int64,
 	return t.UpdateTable(schemaID, tbInfo)
 }
 
-func onDropTableOrView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	tblInfo, err := checkTableExistAndCancelNonExistJob(t, job, job.SchemaID)
+func onDropTableOrView(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	tblInfo, err := checkTableExistAndCancelNonExistJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -75,14 +75,14 @@ func onDropTableOrView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver
 			}
 		}
 		tblInfo.State = model.StateWriteOnly
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != tblInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != tblInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 	case model.StateWriteOnly:
 		// write only -> delete only
 		tblInfo.State = model.StateDeleteOnly
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != tblInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != tblInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -92,19 +92,20 @@ func onDropTableOrView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver
 		ruleIDs := append(getPartitionRuleIDs(job.SchemaName, tblInfo), fmt.Sprintf(label.TableIDFormat, label.IDPrefix, job.SchemaName, tblInfo.Name.L))
 		job.CtxVars = []any{oldIDs}
 
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, originalState != tblInfo.State)
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, originalState != tblInfo.State)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
+		metaMut := jobCtx.metaMut
 		if tblInfo.IsSequence() {
-			if err = t.DropSequence(job.SchemaID, job.TableID); err != nil {
+			if err = metaMut.DropSequence(job.SchemaID, job.TableID); err != nil {
 				return ver, errors.Trace(err)
 			}
 		} else {
-			if err = t.DropTableOrView(job.SchemaID, job.TableID); err != nil {
+			if err = metaMut.DropTableOrView(job.SchemaID, job.TableID); err != nil {
 				return ver, errors.Trace(err)
 			}
-			if err = t.GetAutoIDAccessors(job.SchemaID, job.TableID).Del(); err != nil {
+			if err = metaMut.GetAutoIDAccessors(job.SchemaID, job.TableID).Del(); err != nil {
 				return ver, errors.Trace(err)
 			}
 		}
@@ -136,7 +137,7 @@ func onDropTableOrView(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver
 	return ver, errors.Trace(err)
 }
 
-func (w *worker) onRecoverTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func (w *worker) onRecoverTable(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	args, err := model.GetRecoverArgs(job)
 	if err != nil {
 		// Invalid arguments, cancel this job.
@@ -167,7 +168,8 @@ func (w *worker) onRecoverTable(jobCtx *jobContext, t *meta.Mutator, job *model.
 		return ver, errors.Trace(err)
 	}
 
-	err = checkTableIDNotExists(t, schemaID, tblInfo.ID)
+	metaMut := jobCtx.metaMut
+	err = checkTableIDNotExists(metaMut, schemaID, tblInfo.ID)
 	if err != nil {
 		if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableExists.Equal(err) {
 			job.State = model.JobStateCancelled
@@ -220,19 +222,19 @@ func (w *worker) onRecoverTable(jobCtx *jobContext, t *meta.Mutator, job *model.
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
-		ver, err = w.recoverTable(t, job, recoverInfo)
+		ver, err = w.recoverTable(metaMut, job, recoverInfo)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		tableInfo := tblInfo.Clone()
 		tableInfo.State = model.StatePublic
-		tableInfo.UpdateTS = t.StartTS
-		ver, err = updateVersionAndTableInfo(jobCtx, t, job, tableInfo, true)
+		tableInfo.UpdateTS = metaMut.StartTS
+		ver, err = updateVersionAndTableInfo(jobCtx, job, tableInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		tblInfo.State = model.StatePublic
-		tblInfo.UpdateTS = t.StartTS
+		tblInfo.UpdateTS = metaMut.StartTS
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	default:
@@ -425,14 +427,15 @@ func getTableInfo(t *meta.Mutator, tableID, schemaID int64) (*model.TableInfo, e
 // onTruncateTable delete old table meta, and creates a new table identical to old table except for table ID.
 // As all the old data is encoded with old table ID, it can not be accessed anymore.
 // A background job will be created to delete old data.
-func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onTruncateTable(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
 	args, err := model.GetTruncateTableArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	metaMut := jobCtx.metaMut
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, schemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -446,12 +449,12 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model
 	if err != nil {
 		return ver, err
 	}
-	err = t.DropTableOrView(schemaID, tblInfo.ID)
+	err = metaMut.DropTableOrView(schemaID, tblInfo.ID)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
-	err = t.GetAutoIDAccessors(schemaID, tblInfo.ID).Del()
+	err = metaMut.GetAutoIDAccessors(schemaID, tblInfo.ID).Del()
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -478,7 +481,7 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model
 	if tblInfo.GetPartitionInfo() != nil {
 		oldPartitionIDs = getPartitionIDs(tblInfo)
 		// We use the new partition ID because all the old data is encoded with the old partition ID, it can not be accessed anymore.
-		newPartitionIDs, err = truncateTableByReassignPartitionIDs(t, tblInfo, newPartitionIDs)
+		newPartitionIDs, err = truncateTableByReassignPartitionIDs(metaMut, tblInfo, newPartitionIDs)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -539,7 +542,7 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model
 	tblInfo.ID = args.NewTableID
 
 	// build table & partition bundles if any.
-	bundles, err := placement.NewFullTableBundles(t, tblInfo)
+	bundles, err := placement.NewFullTableBundles(metaMut, tblInfo)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -551,7 +554,7 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model
 		return 0, errors.Wrapf(err, "failed to notify PD the placement rules")
 	}
 
-	err = t.CreateTableOrView(schemaID, tblInfo)
+	err = metaMut.CreateTableOrView(schemaID, tblInfo)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -569,7 +572,7 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model
 	}
 	preSplitAndScatter(w.sess.Context, jobCtx.store, tblInfo, partitions)
 
-	ver, err = updateSchemaVersion(jobCtx, t, job)
+	ver, err = updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -583,15 +586,15 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, t *meta.Mutator, job *model
 	return ver, nil
 }
 
-func onRebaseAutoIncrementIDType(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	return onRebaseAutoID(jobCtx, t, job, autoid.AutoIncrementType)
+func onRebaseAutoIncrementIDType(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	return onRebaseAutoID(jobCtx, job, autoid.AutoIncrementType)
 }
 
-func onRebaseAutoRandomType(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
-	return onRebaseAutoID(jobCtx, t, job, autoid.AutoRandomType)
+func onRebaseAutoRandomType(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+	return onRebaseAutoID(jobCtx, job, autoid.AutoRandomType)
 }
 
-func onRebaseAutoID(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tp autoid.AllocatorType) (ver int64, _ error) {
+func onRebaseAutoID(jobCtx *jobContext, job *model.Job, tp autoid.AllocatorType) (ver int64, _ error) {
 	args, err := model.GetRebaseAutoIDArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -606,7 +609,7 @@ func onRebaseAutoID(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tp auto
 		return ver, nil
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, schemaID)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -650,7 +653,7 @@ func onRebaseAutoID(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tp auto
 			return ver, errors.Trace(err)
 		}
 	}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -658,20 +661,20 @@ func onRebaseAutoID(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tp auto
 	return ver, nil
 }
 
-func onModifyTableAutoIDCache(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (int64, error) {
+func onModifyTableAutoIDCache(jobCtx *jobContext, job *model.Job) (int64, error) {
 	args, err := model.GetModifyTableAutoIDCacheArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
 
 	tblInfo.AutoIDCache = args.NewCache
-	ver, err := updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err := updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -679,7 +682,7 @@ func onModifyTableAutoIDCache(jobCtx *jobContext, t *meta.Mutator, job *model.Jo
 	return ver, nil
 }
 
-func (w *worker) onShardRowID(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onShardRowID(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetShardRowIDArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -687,7 +690,7 @@ func (w *worker) onShardRowID(jobCtx *jobContext, t *meta.Mutator, job *model.Jo
 	}
 
 	shardRowIDBits := args.ShardRowIDBits
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -708,7 +711,7 @@ func (w *worker) onShardRowID(jobCtx *jobContext, t *meta.Mutator, job *model.Jo
 		// MaxShardRowIDBits use to check the overflow of auto ID.
 		tblInfo.MaxShardRowIDBits = shardRowIDBits
 	}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -737,7 +740,7 @@ func verifyNoOverflowShardBits(s *sess.Pool, tbl table.Table, shardRowIDBits uin
 	return nil
 }
 
-func onRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onRenameTable(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetRenameTableArgs(job)
 	if err != nil {
 		// Invalid arguments, cancel this job.
@@ -747,7 +750,7 @@ func onRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 
 	oldSchemaID, oldSchemaName, tableName := args.OldSchemaID, args.OldSchemaName, args.NewTableName
 	if job.SchemaState == model.StatePublic {
-		return finishJobRenameTable(jobCtx, t, job)
+		return finishJobRenameTable(jobCtx, job)
 	}
 	newSchemaID := job.SchemaID
 	err = checkTableNotExists(jobCtx.infoCache, newSchemaID, tableName.L)
@@ -758,22 +761,23 @@ func onRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 		return ver, errors.Trace(err)
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, oldSchemaID)
+	metaMut := jobCtx.metaMut
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, oldSchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 	oldTableName := tblInfo.Name
-	ver, err = checkAndRenameTables(t, job, tblInfo, args)
+	ver, err = checkAndRenameTables(metaMut, job, tblInfo, args)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 	fkh := newForeignKeyHelper()
-	err = adjustForeignKeyChildTableInfoAfterRenameTable(jobCtx.infoCache, t,
+	err = adjustForeignKeyChildTableInfoAfterRenameTable(jobCtx.infoCache, metaMut,
 		job, &fkh, tblInfo, oldSchemaName, oldTableName, tableName, newSchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
-	ver, err = updateSchemaVersion(jobCtx, t, job, fkh.getLoadedTables()...)
+	ver, err = updateSchemaVersion(jobCtx, job, fkh.getLoadedTables()...)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -781,7 +785,7 @@ func onRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	return ver, nil
 }
 
-func onRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onRenameTables(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetRenameTablesArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -789,30 +793,31 @@ func onRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver in
 	}
 
 	if job.SchemaState == model.StatePublic {
-		return finishJobRenameTables(jobCtx, t, job, args)
+		return finishJobRenameTables(jobCtx, job, args)
 	}
 
 	fkh := newForeignKeyHelper()
+	metaMut := jobCtx.metaMut
 	for _, info := range args.RenameTableInfos {
 		job.TableID = info.TableID
 		job.TableName = info.OldTableName.L
-		tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, info.OldSchemaID)
+		tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, info.OldSchemaID)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		ver, err := checkAndRenameTables(t, job, tblInfo, info)
+		ver, err := checkAndRenameTables(metaMut, job, tblInfo, info)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 		err = adjustForeignKeyChildTableInfoAfterRenameTable(
-			jobCtx.infoCache, t, job, &fkh, tblInfo,
+			jobCtx.infoCache, metaMut, job, &fkh, tblInfo,
 			info.OldSchemaName, info.OldTableName, info.NewTableName, info.NewSchemaID)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
 	}
 
-	ver, err = updateSchemaVersion(jobCtx, t, job, fkh.getLoadedTables()...)
+	ver, err = updateSchemaVersion(jobCtx, job, fkh.getLoadedTables()...)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -923,8 +928,8 @@ func adjustForeignKeyChildTableInfoAfterRenameTable(
 //     there may be DMLs that use the old schema.
 //   - TiCDC cannot handle the DMLs that use the old schema, because
 //     the commit TS of the DMLs are greater than the job state updating TS.
-func finishJobRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (int64, error) {
-	tblInfo, err := getTableInfo(t, job.TableID, job.SchemaID)
+func finishJobRenameTable(jobCtx *jobContext, job *model.Job) (int64, error) {
+	tblInfo, err := getTableInfo(jobCtx.metaMut, job.TableID, job.SchemaID)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
@@ -937,7 +942,7 @@ func finishJobRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 		return 0, errors.Trace(err)
 	}
 
-	ver, err := updateSchemaVersion(jobCtx, t, job)
+	ver, err := updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -946,7 +951,7 @@ func finishJobRenameTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 	return ver, nil
 }
 
-func finishJobRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job, args *model.RenameTablesArgs) (int64, error) {
+func finishJobRenameTables(jobCtx *jobContext, job *model.Job, args *model.RenameTablesArgs) (int64, error) {
 	infos := args.RenameTableInfos
 	tblSchemaIDs := make(map[int64]int64, len(infos))
 	for _, info := range infos {
@@ -955,7 +960,7 @@ func finishJobRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job, 
 	tblInfos := make([]*model.TableInfo, 0, len(infos))
 	for _, info := range infos {
 		tblID := info.TableID
-		tblInfo, err := getTableInfo(t, tblID, tblSchemaIDs[tblID])
+		tblInfo, err := getTableInfo(jobCtx.metaMut, tblID, tblSchemaIDs[tblID])
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return 0, errors.Trace(err)
@@ -976,7 +981,7 @@ func finishJobRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job, 
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	ver, err := updateSchemaVersion(jobCtx, t, job)
+	ver, err := updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -985,14 +990,14 @@ func finishJobRenameTables(jobCtx *jobContext, t *meta.Mutator, job *model.Job, 
 	return ver, nil
 }
 
-func onModifyTableComment(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onModifyTableComment(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetModifyTableCommentArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1003,7 +1008,7 @@ func onModifyTableComment(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 	}
 
 	tblInfo.Comment = args.Comment
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1011,20 +1016,20 @@ func onModifyTableComment(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (
 	return ver, nil
 }
 
-func onModifyTableCharsetAndCollate(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onModifyTableCharsetAndCollate(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetModifyTableCharsetAndCollateArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 	toCharset, toCollate, needsOverwriteCols := args.ToCharset, args.ToCollate, args.NeedsOverwriteCols
-
-	dbInfo, err := checkSchemaExistAndCancelNotExistJob(t, job)
+	metaMut := jobCtx.metaMut
+	dbInfo, err := checkSchemaExistAndCancelNotExistJob(metaMut, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1057,7 +1062,7 @@ func onModifyTableCharsetAndCollate(jobCtx *jobContext, t *meta.Mutator, job *mo
 		}
 	}
 
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1065,7 +1070,7 @@ func onModifyTableCharsetAndCollate(jobCtx *jobContext, t *meta.Mutator, job *mo
 	return ver, nil
 }
 
-func (w *worker) onSetTableFlashReplica(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func (w *worker) onSetTableFlashReplica(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetSetTiFlashReplicaArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -1073,7 +1078,7 @@ func (w *worker) onSetTableFlashReplica(jobCtx *jobContext, t *meta.Mutator, job
 	}
 	replicaInfo := args.TiflashReplica
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1128,7 +1133,7 @@ func (w *worker) onSetTableFlashReplica(jobCtx *jobContext, t *meta.Mutator, job
 		tblInfo.TiFlashReplica = nil
 	}
 
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1146,7 +1151,7 @@ func (w *worker) checkTiFlashReplicaCount(replicaCount uint64) error {
 	return checkTiFlashReplicaCount(ctx, replicaCount)
 }
 
-func onUpdateTiFlashReplicaStatus(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onUpdateTiFlashReplicaStatus(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	args, err := model.GetUpdateTiFlashReplicaStatusArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
@@ -1154,7 +1159,7 @@ func onUpdateTiFlashReplicaStatus(jobCtx *jobContext, t *meta.Mutator, job *mode
 	}
 	available, physicalID := args.Available, args.PhysicalID
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1198,7 +1203,7 @@ func onUpdateTiFlashReplicaStatus(jobCtx *jobContext, t *meta.Mutator, job *mode
 	if tblInfo.TiFlashReplica.Available {
 		logutil.DDLLogger().Info("TiFlash replica available", zap.Int64("tableID", tblInfo.ID))
 	}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1273,7 +1278,7 @@ func checkTableNotExistsFromInfoSchema(is infoschema.InfoSchema, schemaID int64,
 }
 
 // updateVersionAndTableInfoWithCheck checks table info validate and updates the schema version and the table information
-func updateVersionAndTableInfoWithCheck(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tblInfo *model.TableInfo, shouldUpdateVer bool, multiInfos ...schemaIDAndTableInfo) (
+func updateVersionAndTableInfoWithCheck(jobCtx *jobContext, job *model.Job, tblInfo *model.TableInfo, shouldUpdateVer bool, multiInfos ...schemaIDAndTableInfo) (
 	ver int64, err error) {
 	err = checkTableInfoValid(tblInfo)
 	if err != nil {
@@ -1287,11 +1292,11 @@ func updateVersionAndTableInfoWithCheck(jobCtx *jobContext, t *meta.Mutator, job
 			return ver, errors.Trace(err)
 		}
 	}
-	return updateVersionAndTableInfo(jobCtx, t, job, tblInfo, shouldUpdateVer, multiInfos...)
+	return updateVersionAndTableInfo(jobCtx, job, tblInfo, shouldUpdateVer, multiInfos...)
 }
 
 // updateVersionAndTableInfo updates the schema version and the table information.
-func updateVersionAndTableInfo(jobCtx *jobContext, t *meta.Mutator, job *model.Job, tblInfo *model.TableInfo, shouldUpdateVer bool, multiInfos ...schemaIDAndTableInfo) (
+func updateVersionAndTableInfo(jobCtx *jobContext, job *model.Job, tblInfo *model.TableInfo, shouldUpdateVer bool, multiInfos ...schemaIDAndTableInfo) (
 	ver int64, err error) {
 	failpoint.Inject("mockUpdateVersionAndTableInfoErr", func(val failpoint.Value) {
 		switch val.(int) {
@@ -1306,18 +1311,18 @@ func updateVersionAndTableInfo(jobCtx *jobContext, t *meta.Mutator, job *model.J
 		}
 	})
 	if shouldUpdateVer && (job.MultiSchemaInfo == nil || !job.MultiSchemaInfo.SkipVersion) {
-		ver, err = updateSchemaVersion(jobCtx, t, job, multiInfos...)
+		ver, err = updateSchemaVersion(jobCtx, job, multiInfos...)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
 	}
 
-	err = updateTable(t, job.SchemaID, tblInfo)
+	err = updateTable(jobCtx.metaMut, job.SchemaID, tblInfo)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
 	for _, info := range multiInfos {
-		err = updateTable(t, info.schemaID, info.tblInfo)
+		err = updateTable(jobCtx.metaMut, info.schemaID, info.tblInfo)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
@@ -1337,9 +1342,9 @@ type schemaIDAndTableInfo struct {
 	tblInfo  *model.TableInfo
 }
 
-func onRepairTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, _ error) {
+func onRepairTable(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
-
+	metaMut := jobCtx.metaMut
 	args, err := model.GetRepairTableArgs(job)
 	if err != nil {
 		// Invalid arguments, cancel this job.
@@ -1351,7 +1356,7 @@ func onRepairTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	tblInfo.State = model.StateNone
 
 	// Check the old DB and old table exist.
-	_, err = GetTableInfoAndCancelFaultJob(t, job, schemaID)
+	_, err = GetTableInfoAndCancelFaultJob(metaMut, job, schemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1359,7 +1364,7 @@ func onRepairTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	// When in repair mode, the repaired table in a server is not access to user,
 	// the table after repairing will be removed from repair list. Other server left
 	// behind alive may need to restart to get the latest schema version.
-	ver, err = updateSchemaVersion(jobCtx, t, job)
+	ver, err = updateSchemaVersion(jobCtx, job)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1367,8 +1372,8 @@ func onRepairTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	case model.StateNone:
 		// none -> public
 		tblInfo.State = model.StatePublic
-		tblInfo.UpdateTS = t.StartTS
-		err = repairTableOrViewWithCheck(t, job, schemaID, tblInfo)
+		tblInfo.UpdateTS = metaMut.StartTS
+		err = repairTableOrViewWithCheck(metaMut, job, schemaID, tblInfo)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
@@ -1380,7 +1385,7 @@ func onRepairTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int
 	}
 }
 
-func onAlterTableAttributes(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func onAlterTableAttributes(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	rule := label.NewRule()
 	err = job.DecodeArgs(rule)
 	if err != nil {
@@ -1388,7 +1393,7 @@ func onAlterTableAttributes(jobCtx *jobContext, t *meta.Mutator, job *model.Job)
 		return 0, errors.Trace(err)
 	}
 
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, err
 	}
@@ -1403,7 +1408,7 @@ func onAlterTableAttributes(jobCtx *jobContext, t *meta.Mutator, job *model.Job)
 		job.State = model.JobStateCancelled
 		return 0, errors.Wrapf(err, "failed to notify PD the label rules")
 	}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1412,14 +1417,14 @@ func onAlterTableAttributes(jobCtx *jobContext, t *meta.Mutator, job *model.Job)
 	return ver, nil
 }
 
-func onAlterTablePartitionAttributes(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func onAlterTablePartitionAttributes(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	args, err := model.GetAlterTablePartitionArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
 	}
 	partitionID, rule := args.PartitionID, args.LabelRule
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, err
 	}
@@ -1441,7 +1446,7 @@ func onAlterTablePartitionAttributes(jobCtx *jobContext, t *meta.Mutator, job *m
 		job.State = model.JobStateCancelled
 		return 0, errors.Wrapf(err, "failed to notify PD the label rules")
 	}
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
@@ -1450,14 +1455,15 @@ func onAlterTablePartitionAttributes(jobCtx *jobContext, t *meta.Mutator, job *m
 	return ver, nil
 }
 
-func onAlterTablePartitionPlacement(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func onAlterTablePartitionPlacement(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	args, err := model.GetAlterTablePartitionArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
 	}
 	partitionID, policyRefInfo := args.PartitionID, args.PolicyRefInfo
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	metaMut := jobCtx.metaMut
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, err
 	}
@@ -1481,16 +1487,16 @@ func onAlterTablePartitionPlacement(jobCtx *jobContext, t *meta.Mutator, job *mo
 		return 0, errors.Trace(table.ErrUnknownPartition.GenWithStackByArgs("drop?", tblInfo.Name.O))
 	}
 
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
-	if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(t, job, partitionDef.PlacementPolicyRef); err != nil {
+	if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(metaMut, job, partitionDef.PlacementPolicyRef); err != nil {
 		return ver, errors.Trace(err)
 	}
 
-	bundle, err := placement.NewPartitionBundle(t, *partitionDef)
+	bundle, err := placement.NewPartitionBundle(metaMut, *partitionDef)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -1514,31 +1520,31 @@ func onAlterTablePartitionPlacement(jobCtx *jobContext, t *meta.Mutator, job *mo
 	return ver, nil
 }
 
-func onAlterTablePlacement(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
+func onAlterTablePlacement(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	args, err := model.GetAlterTablePlacementArgs(job)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Trace(err)
 	}
 	policyRefInfo := args.PlacementPolicyRef
-
-	tblInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	metaMut := jobCtx.metaMut
+	tblInfo, err := GetTableInfoAndCancelFaultJob(metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, err
 	}
 
-	if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(t, job, policyRefInfo); err != nil {
+	if _, err = checkPlacementPolicyRefValidAndCanNonValidJob(metaMut, job, policyRefInfo); err != nil {
 		return 0, errors.Trace(err)
 	}
 
 	oldTableEnablesPlacement := tblInfo.PlacementPolicyRef != nil
 	tblInfo.PlacementPolicyRef = policyRefInfo
-	ver, err = updateVersionAndTableInfo(jobCtx, t, job, tblInfo, true)
+	ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}
 
-	bundle, err := placement.NewTableBundle(t, tblInfo)
+	bundle, err := placement.NewTableBundle(metaMut, tblInfo)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
@@ -1604,8 +1610,8 @@ func updateLabelRules(job *model.Job, tblInfo *model.TableInfo, oldRules map[str
 	return infosync.UpdateLabelRules(context.TODO(), patch)
 }
 
-func onAlterCacheTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	tbInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+func onAlterCacheTable(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	tbInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
@@ -1627,14 +1633,14 @@ func onAlterCacheTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver
 	case model.TableCacheStatusDisable:
 		// disable -> switching
 		tbInfo.TableCacheStatusType = model.TableCacheStatusSwitching
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tbInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tbInfo, true)
 		if err != nil {
 			return ver, err
 		}
 	case model.TableCacheStatusSwitching:
 		// switching -> enable
 		tbInfo.TableCacheStatusType = model.TableCacheStatusEnable
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tbInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tbInfo, true)
 		if err != nil {
 			return ver, err
 		}
@@ -1647,8 +1653,8 @@ func onAlterCacheTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver
 	return ver, err
 }
 
-func onAlterNoCacheTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (ver int64, err error) {
-	tbInfo, err := GetTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+func onAlterNoCacheTable(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	tbInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
@@ -1662,14 +1668,14 @@ func onAlterNoCacheTable(jobCtx *jobContext, t *meta.Mutator, job *model.Job) (v
 	case model.TableCacheStatusEnable:
 		//  enable ->  switching
 		tbInfo.TableCacheStatusType = model.TableCacheStatusSwitching
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tbInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tbInfo, true)
 		if err != nil {
 			return ver, err
 		}
 	case model.TableCacheStatusSwitching:
 		// switching -> disable
 		tbInfo.TableCacheStatusType = model.TableCacheStatusDisable
-		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, t, job, tbInfo, true)
+		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tbInfo, true)
 		if err != nil {
 			return ver, err
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54436

Problem Summary:

### What changed and how does it work?
- make meta mutator part of jobContext to avoid passing everywhere
- move job logger from worker to jobContext
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test. existing tests should cover it, we only move method parameter location
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
