### PR TITLE
executor: fix data inconsistency after `load data ... replace into ...`

### DIFF
--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -1179,11 +1179,7 @@ func (e *InsertValues) handleDuplicateKey(ctx context.Context, txn kv.Transactio
 	if handle == nil {
 		return false, nil
 	}
-	_, err = e.removeRow(ctx, txn, handle, r, true)
-	if err != nil {
-		return false, err
-	}
-	return false, nil
+	return e.removeRow(ctx, txn, handle, r, true)
 }
 
 // batchCheckAndInsert checks rows with duplicate errors.

--- a/pkg/executor/test/loaddatatest/BUILD.bazel
+++ b/pkg/executor/test/loaddatatest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -483,7 +483,8 @@ func TestFix56408(t *testing.T) {
 	tests := []testCase{
 		{[]byte("1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n2|bb|shanghai\n2|bb|shanghai\n2|bb|shanghai\n3|cc|guangzhou\n"),
 			[]string{"1 aa beijing", "2 bb shanghai", "3 cc guangzhou"},
-			"Records: 8  Deleted: 0  Skipped: 5  Warnings: 0"},
+			"Records: 8  Deleted: 0  Skipped: 5  Warnings: 0",
+		},
 	}
 	deleteSQL := "DO 1"
 	selectSQL := "TABLE a;"

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -472,3 +472,21 @@ func TestLoadDataFromServerFile(t *testing.T) {
 	err := tk.ExecToErr("load data infile 'remote.csv' into table load_data_test")
 	require.ErrorContains(t, err, "[executor:8154]Don't support load data from tidb-server's disk.")
 }
+
+func TestFix56408(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("USE test; DROP TABLE IF EXISTS load_data_replace;")
+	tk.MustExec("create table a(id int,name varchar(20),addr varchar(100),primary key (id) nonclustered);")
+	loadSQL := "LOAD DATA LOCAL INFILE '/tmp/nonexistence.csv' REPLACE INTO TABLE a FIELDS terminated by '|';"
+	ctx := tk.Session().(sessionctx.Context)
+	tests := []testCase{
+		{[]byte("1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n2|bb|shanghai\n2|bb|shanghai\n2|bb|shanghai\n3|cc|guangzhou\n"),
+			[]string{"1 aa beijing", "2 bb shanghai", "3 cc guangzhou"},
+			"Records: 8  Deleted: 0  Skipped: 5  Warnings: 0"},
+	}
+	deleteSQL := "DO 1"
+	selectSQL := "TABLE a;"
+	checkCases(tests, loadSQL, t, tk, ctx, selectSQL, deleteSQL)
+	tk.MustExec("ADMIN CHECK TABLE a")
+}

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -482,7 +482,9 @@ func TestFix56408(t *testing.T) {
 	ctx := tk.Session().(sessionctx.Context)
 	tests := []testCase{
 		{[]byte("1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n2|bb|shanghai\n2|bb|shanghai\n2|bb|shanghai\n3|cc|guangzhou\n"),
+			//[]string{"1 aa beijing", "1 aa beijing", "1 aa beijing", "1 aa beijing", "2 bb shanghai", "2 bb shanghai", "2 bb shanghai", "3 cc guangzhou"},
 			[]string{"1 aa beijing", "2 bb shanghai", "3 cc guangzhou"},
+			//"Records: 8  Deleted: 0  Skipped: 0  Warnings: 0"},
 			"Records: 8  Deleted: 0  Skipped: 5  Warnings: 0"},
 	}
 	deleteSQL := "DO 1"

--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -482,9 +482,7 @@ func TestFix56408(t *testing.T) {
 	ctx := tk.Session().(sessionctx.Context)
 	tests := []testCase{
 		{[]byte("1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n1|aa|beijing\n2|bb|shanghai\n2|bb|shanghai\n2|bb|shanghai\n3|cc|guangzhou\n"),
-			//[]string{"1 aa beijing", "1 aa beijing", "1 aa beijing", "1 aa beijing", "2 bb shanghai", "2 bb shanghai", "2 bb shanghai", "3 cc guangzhou"},
 			[]string{"1 aa beijing", "2 bb shanghai", "3 cc guangzhou"},
-			//"Records: 8  Deleted: 0  Skipped: 0  Warnings: 0"},
 			"Records: 8  Deleted: 0  Skipped: 5  Warnings: 0"},
 	}
 	deleteSQL := "DO 1"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56408

Problem Summary:

### What changed and how does it work?
The reason is the bool flag returned by `removeRow` was not rightly handled  in `handleDuplicateKey`. 
```
// removeRow removes the duplicate row and cleanup its keys in the key-value map.
// But if the to-be-removed row equals to the to-be-added row, no remove or add
// things to do and return (true, nil).
```
If we load a existed row, `removeRow` will return (true, nil), `handleDuplicateKey` should also return (true, nil) 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix data inconsistency after load data ... replace into ...
```
