### PR TITLE
planner: fix inner subq build process will ref-use outer's expand meta 

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -439,11 +439,6 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 	case *Column:
 		id := schema.ColumnIndex(v)
 		if id == -1 {
-			if fail1Return {
-				// one fail1Return is switched on, it requires that once a column can't be
-				// substituted by schema, the whole expr substitution should be failed.
-				return false, true, v
-			}
 			return false, false, v
 		}
 		newExpr := newExprs[id]

--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -439,6 +439,11 @@ func ColumnSubstituteImpl(ctx BuildContext, expr Expression, schema *Schema, new
 	case *Column:
 		id := schema.ColumnIndex(v)
 		if id == -1 {
+			if fail1Return {
+				// one fail1Return is switched on, it requires that once a column can't be
+				// substituted by schema, the whole expr substitution should be failed.
+				return false, true, v
+			}
 			return false, false, v
 		}
 		newExpr := newExprs[id]

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -472,6 +472,8 @@ func (er *expressionRewriter) buildSubquery(ctx context.Context, planCtx *exprRe
 		b.outerSchemas = append(b.outerSchemas, outerSchema)
 		b.outerNames = append(b.outerNames, er.names)
 		b.outerBlockExpand = append(b.outerBlockExpand, b.currentBlockExpand)
+		// set it to nil, otherwise, inner qb will use outer expand meta to rewrite expressions.
+		b.currentBlockExpand = nil
 		defer func() {
 			b.outerSchemas = b.outerSchemas[0 : len(b.outerSchemas)-1]
 			b.outerNames = b.outerNames[0 : len(b.outerNames)-1]

--- a/tests/integrationtest/r/executor/expand.result
+++ b/tests/integrationtest/r/executor/expand.result
@@ -515,3 +515,67 @@ NULL	NULL	NULL
 4	NULL	NULL
 4	1	NULL
 DROP TABLE t1;
+
+SELECT
+(SELECT 100.00
+FROM
+(SELECT '2024-09-15' AS DATE ) newTb
+WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 1 MONTH)) AS 'PROFIT'
+FROM
+(SELECT '2024-09-15' AS DATE) T0
+GROUP BY T0.DATE WITH ROLLUP;
+PROFIT
+NULL
+NULL
+
+EXPLAIN SELECT
+(SELECT 100.00
+FROM
+(SELECT '2024-09-15' AS DATE ) newTb
+WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 1 MONTH)) AS 'PROFIT'
+FROM
+(SELECT '2024-09-15' AS DATE) T0
+GROUP BY T0.DATE WITH ROLLUP;
+id	estRows	task	access object	operator info
+Projection_18	1.00	root		Column#6
+└─Apply_20	1.00	root		CARTESIAN left outer join
+  ├─HashAgg_21(Build)	1.00	root		group by:Column#3, gid, funcs:firstrow(Column#1)->Column#1
+  │ └─Expand_24	1.00	root		level-projection:[Column#1, <nil>->Column#3, 0->gid],[Column#1, Column#3, 1->gid]; schema: [Column#1,Column#3,gid]
+  │   └─Projection_26	1.00	root		2024-09-15->Column#1, 2024-09-15->Column#3
+  │     └─TableDual_27	1.00	root		rows:1
+  └─Projection_30(Probe)	0.80	root		100.00->Column#6
+    └─Selection_31	0.80	root		eq(Column#1, "2024-10-15")
+      └─TableDual_32	1.00	root		rows:1
+drop table if exists tr;
+create table tr(a date);
+insert into tr values('2024-09-15');
+
+SELECT
+(SELECT 100.00
+FROM  (SELECT '2024-09-15' AS DATE ) newTb
+WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 0 MONTH)
+) AS 'PROFIT'
+FROM  (select tr.a as DATE from tr) T0
+GROUP BY T0.DATE WITH ROLLUP;
+PROFIT
+100.00
+100.00
+
+EXPLAIN SELECT
+(SELECT 100.00
+FROM  (SELECT '2024-09-15' AS DATE ) newTb
+WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 0 MONTH)
+) AS 'PROFIT'
+FROM  (select tr.a as DATE from tr) T0
+GROUP BY T0.DATE WITH ROLLUP;
+id	estRows	task	access object	operator info
+Projection_18	8000.00	root		Column#7
+└─Apply_20	8000.00	root		CARTESIAN left outer join
+  ├─HashAgg_21(Build)	8000.00	root		group by:Column#4, gid, funcs:firstrow(executor__expand.tr.a)->executor__expand.tr.a
+  │ └─Expand_25	10000.00	root		level-projection:[executor__expand.tr.a, <nil>->Column#4, 0->gid],[executor__expand.tr.a, Column#4, 1->gid]; schema: [executor__expand.tr.a,Column#4,gid]
+  │   └─Projection_27	10000.00	root		executor__expand.tr.a, executor__expand.tr.a->Column#4
+  │     └─TableReader_29	10000.00	root		data:TableFullScan_28
+  │       └─TableFullScan_28	10000.00	cop[tikv]	table:tr	keep order:false, stats:pseudo
+  └─Projection_30(Probe)	6400.00	root		100.00->Column#7
+    └─Selection_31	6400.00	root		eq(executor__expand.tr.a, 2024-09-15 00:00:00.000000)
+      └─TableDual_32	8000.00	root		rows:1

--- a/tests/integrationtest/t/executor/expand.test
+++ b/tests/integrationtest/t/executor/expand.test
@@ -270,3 +270,49 @@ SELECT a,b,SUM(c) FROM t1 GROUP BY a,b,c WITH ROLLUP;
 SELECT distinct a,b,SUM(c) FROM t1 GROUP BY a,b,c WITH ROLLUP;
 
 DROP TABLE t1;
+
+# Test Issue 56218
+# Test with normal constant case
+
+--echo
+SELECT
+    (SELECT 100.00
+     FROM
+         (SELECT '2024-09-15' AS DATE ) newTb
+     WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 1 MONTH)) AS 'PROFIT'
+FROM
+    (SELECT '2024-09-15' AS DATE) T0
+GROUP BY T0.DATE WITH ROLLUP;
+
+--echo
+EXPLAIN SELECT
+            (SELECT 100.00
+             FROM
+                 (SELECT '2024-09-15' AS DATE ) newTb
+             WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 1 MONTH)) AS 'PROFIT'
+        FROM
+            (SELECT '2024-09-15' AS DATE) T0
+        GROUP BY T0.DATE WITH ROLLUP;
+
+# Test with real correlated column case
+drop table if exists tr;
+create table tr(a date);
+insert into tr values('2024-09-15');
+
+--echo
+SELECT
+    (SELECT 100.00
+     FROM  (SELECT '2024-09-15' AS DATE ) newTb
+     WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 0 MONTH)
+     ) AS 'PROFIT'
+FROM  (select tr.a as DATE from tr) T0
+GROUP BY T0.DATE WITH ROLLUP;
+
+--echo
+EXPLAIN SELECT
+    (SELECT 100.00
+     FROM  (SELECT '2024-09-15' AS DATE ) newTb
+     WHERE T0.DATE = DATE_ADD(newTb.DATE, INTERVAL 0 MONTH)
+     ) AS 'PROFIT'
+FROM  (select tr.a as DATE from tr) T0
+GROUP BY T0.DATE WITH ROLLUP;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/56218

Problem Summary:

### What changed and how does it work?
the details is commented here: https://github.com/pingcap/tidb/issues/56218#issuecomment-2382278367
mainly about two points
* in plan building process, outer's scope's expand should be pushed into stack, while at the same time it should be cleaned from current plan builder as well.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix inner subq build process will ref-use outer's expand meta
优化器：修复了内层子查询构建时候会引用外层 scope 中的 expand 元信息
```
