### PR TITLE
statistics: handle lock and unlock operations correctly

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
@@ -55,7 +55,7 @@ go_test(
         "static_partitioned_table_analysis_job_test.go",
     ],
     flaky = True,
-    shard_count = 45,
+    shard_count = 48,
     deps = [
         ":priorityqueue",
         "//pkg/ddl/notifier",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_v2.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_v2.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/exec"
 	"github.com/pingcap/tidb/pkg/statistics/handle/autoanalyze/internal/heap"
+	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
 	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
@@ -229,14 +230,19 @@ func (pq *AnalysisPriorityQueueV2) ProcessDMLChanges() {
 		// We need to fetch the next check version with offset before fetching new DML changes.
 		// Otherwise, we may miss some DML changes happened during the process.
 		newMaxVersion := pq.statsHandle.GetNextCheckVersionWithOffset()
+		// Query locked tables once to minimize overhead.
+		// Outdated lock info is acceptable as we verify table lock status pre-analysis.
+		lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
+		if err != nil {
+			return err
+		}
 		values := pq.statsHandle.Values()
 		lastFetchTimestamp := pq.syncFields.lastDMLUpdateFetchTimestamp
 		for _, value := range values {
 			// We only process the tables that have been updated.
 			// So here we only need to process the tables whose version is greater than the last fetch timestamp.
 			if value.Version > lastFetchTimestamp {
-				// TODO: consider locked tables and partitions. Consider move this check to
-				err := pq.processTableStats(sctx, value, parameters)
+				err := pq.processTableStats(sctx, value, parameters, lockedTables)
 				if err != nil {
 					statslogutil.StatsLogger().Error(
 						"Failed to process table stats",
@@ -263,6 +269,7 @@ func (pq *AnalysisPriorityQueueV2) processTableStats(
 	sctx sessionctx.Context,
 	stats *statistics.Table,
 	parameters map[string]string,
+	lockedTables map[int64]struct{},
 ) error {
 	// Check if the table is eligible for analysis first to avoid unnecessary work.
 	if !stats.IsEligibleForAnalysis() {
@@ -292,8 +299,25 @@ func (pq *AnalysisPriorityQueueV2) processTableStats(
 	// This is acceptable for now, but in the future, we may consider separating the analysis job for each partition.
 	job, ok, _ := pq.syncFields.inner.GetByKey(stats.PhysicalID)
 	if !ok {
-		job = pq.tryCreateJob(is, stats, pruneMode, jobFactory)
+		job = pq.tryCreateJob(is, stats, pruneMode, jobFactory, lockedTables)
 	} else {
+		// Skip analysis if the table is locked.
+		// Dynamic partitioned tables are managed in the tryCreateJob branch.
+		// Non-partitioned tables can be skipped entirely here.
+		// For static partitioned tables, skip either the locked partition or the whole table if all partitions are locked.
+		// For dynamic partitioned tables, if the parent table is locked, we skip the whole table here as well.
+		if _, ok := lockedTables[stats.PhysicalID]; ok {
+			// Clean up the job if the table is locked.
+			err := pq.syncFields.inner.Delete(job)
+			if err != nil {
+				statslogutil.StatsLogger().Error(
+					"Failed to delete job from priority queue",
+					zap.Error(err),
+					zap.String("job", job.String()),
+				)
+			}
+			return nil
+		}
 		job = pq.tryUpdateJob(is, stats, job, jobFactory)
 	}
 	return pq.pushWithoutLock(job)
@@ -303,6 +327,7 @@ func (pq *AnalysisPriorityQueueV2) tryCreateJob(
 	stats *statistics.Table,
 	pruneMode variable.PartitionPruneMode,
 	jobFactory *AnalysisJobFactory,
+	lockedTables map[int64]struct{},
 ) (job AnalysisJob) {
 	if stats == nil {
 		return nil
@@ -327,6 +352,10 @@ func (pq *AnalysisPriorityQueueV2) tryCreateJob(
 	}
 	partitionedTable := tableMeta.GetPartitionInfo()
 	if partitionedTable == nil {
+		// If the table is locked, we do not analyze it.
+		if _, ok := lockedTables[tableMeta.ID]; ok {
+			return nil
+		}
 		job = jobFactory.CreateNonPartitionedTableAnalysisJob(
 			schemaName.O,
 			tableMeta,
@@ -351,6 +380,10 @@ func (pq *AnalysisPriorityQueueV2) tryCreateJob(
 				// TODO: add tests to verify this behavior.
 				return nil
 			}
+			// If the partition is locked, we do not analyze it.
+			if _, ok := lockedTables[partitionDef.ID]; ok {
+				return nil
+			}
 			job = jobFactory.CreateStaticPartitionAnalysisJob(
 				schemaName.O,
 				tableMeta,
@@ -359,7 +392,32 @@ func (pq *AnalysisPriorityQueueV2) tryCreateJob(
 				stats,
 			)
 		} else {
-			partitionStats := GetPartitionStats(pq.statsHandle, tableMeta, partitionDefs)
+			// If the table is locked, we do not analyze it.
+			// Note: the table meta is the parent table meta.
+			if _, ok := lockedTables[tableMeta.ID]; ok {
+				return nil
+			}
+
+			// Only analyze the partition that has not been locked.
+			// Special case for dynamic partitioned tables:
+			// 1. Initially, neither the table nor any partitions are locked.
+			// 2. Once partition p1 reaches the auto-analyze threshold, a job is created for the entire table.
+			// 3. At this point, partition p1 is locked.
+			// 4. There are no further partitions requiring analysis for this table because the only partition needing analysis is locked.
+			//
+			// Normally, we would remove the table's job in this scenario, but that is not handled here.
+			// The primary responsibility of this function is to create jobs for tables needing analysis,
+			// and deleting jobs falls outside its scope.
+			//
+			// This behavior is acceptable, as lock statuses will be validated before running the analysis.
+			// So let keep it simple and ignore this edge case here.
+			filteredPartitionDefs := make([]model.PartitionDefinition, 0, len(partitionDefs))
+			for _, def := range partitionDefs {
+				if _, ok := lockedTables[def.ID]; !ok {
+					filteredPartitionDefs = append(filteredPartitionDefs, def)
+				}
+			}
+			partitionStats := GetPartitionStats(pq.statsHandle, tableMeta, filteredPartitionDefs)
 			job = jobFactory.CreateDynamicPartitionedTableAnalysisJob(
 				schemaName.O,
 				tableMeta,

--- a/pkg/statistics/handle/handletest/lockstats/lock_partition_stats_test.go
+++ b/pkg/statistics/handle/handletest/lockstats/lock_partition_stats_test.go
@@ -59,7 +59,7 @@ func TestLockAndUnlockPartitionStats(t *testing.T) {
 		"Warning 1105 skip analyze locked table: test.t partition (p0)",
 	))
 	partitionStats1 := handle.GetPartitionStats(tbl, p0Id)
-	require.Equal(t, partitionStats, partitionStats1)
+	require.Equal(t, partitionStats.RealtimeCount, partitionStats1.RealtimeCount)
 	require.Equal(t, int64(0), partitionStats1.RealtimeCount)
 
 	tk.MustExec("unlock stats t partition p0")

--- a/pkg/statistics/handle/lockstats/BUILD.bazel
+++ b/pkg/statistics/handle/lockstats/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/sqlexec",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@org_uber_go_zap//:zap",
     ],
 )
@@ -46,6 +47,7 @@ go_test(
         "//pkg/util/mock",
         "//pkg/util/sqlexec/mock",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/statistics/handle/lockstats/lock_stats_test.go
+++ b/pkg/statistics/handle/lockstats/lock_stats_test.go
@@ -162,7 +162,13 @@ func TestInsertIntoStatsTableLocked(t *testing.T) {
 		gomock.Eq(insertSQL),
 		gomock.Eq([]any{int64(1), int64(1)}),
 	)
-	err := insertIntoStatsTableLocked(wrapAsSCtx(exec), 1)
+	exec.EXPECT().ExecRestrictedSQL(
+		util.StatsCtx,
+		util.UseCurrentSessionOpt,
+		gomock.Eq(updateMetaVersionSQL),
+		gomock.Any(),
+	)
+	err := insertIntoStatsTableLockedAndUpdateStatsVersion(wrapAsSCtx(exec), 1)
 	require.NoError(t, err)
 
 	// Error should be returned when ExecRestrictedSQL returns error.
@@ -173,7 +179,7 @@ func TestInsertIntoStatsTableLocked(t *testing.T) {
 		gomock.Any(),
 	).Return(nil, nil, errors.New("test error"))
 
-	err = insertIntoStatsTableLocked(wrapAsSCtx(exec), 1)
+	err = insertIntoStatsTableLockedAndUpdateStatsVersion(wrapAsSCtx(exec), 1)
 	require.Equal(t, "test error", err.Error())
 }
 
@@ -199,19 +205,35 @@ func TestAddLockedTables(t *testing.T) {
 		gomock.Eq([]any{int64(2), int64(2)}),
 	)
 	exec.EXPECT().ExecRestrictedSQL(
+		util.StatsCtx,
+		util.UseCurrentSessionOpt,
+		gomock.Eq(updateMetaVersionSQL),
+		gomock.Any(),
+	)
+	exec.EXPECT().ExecRestrictedSQL(
 		gomock.All(&ctxMatcher{}),
 		util.UseCurrentSessionOpt,
 		insertSQL,
 		gomock.Eq([]any{int64(3), int64(3)}),
 	)
-
+	exec.EXPECT().ExecRestrictedSQL(
+		util.StatsCtx,
+		util.UseCurrentSessionOpt,
+		gomock.Eq(updateMetaVersionSQL),
+		gomock.Any(),
+	)
 	exec.EXPECT().ExecRestrictedSQL(
 		gomock.All(&ctxMatcher{}),
 		util.UseCurrentSessionOpt,
 		insertSQL,
 		gomock.Eq([]any{int64(4), int64(4)}),
 	)
-
+	exec.EXPECT().ExecRestrictedSQL(
+		util.StatsCtx,
+		util.UseCurrentSessionOpt,
+		gomock.Eq(updateMetaVersionSQL),
+		gomock.Any(),
+	)
 	tables := map[int64]*statstypes.StatsLockTable{
 		1: {
 			FullName: "test.t1",
@@ -254,10 +276,22 @@ func TestAddLockedPartitions(t *testing.T) {
 		gomock.Eq([]any{int64(2), int64(2)}),
 	)
 	exec.EXPECT().ExecRestrictedSQL(
+		util.StatsCtx,
+		util.UseCurrentSessionOpt,
+		gomock.Eq(updateMetaVersionSQL),
+		gomock.Any(),
+	)
+	exec.EXPECT().ExecRestrictedSQL(
 		gomock.All(&ctxMatcher{}),
 		util.UseCurrentSessionOpt,
 		insertSQL,
 		gomock.Eq([]any{int64(3), int64(3)}),
+	)
+	exec.EXPECT().ExecRestrictedSQL(
+		util.StatsCtx,
+		util.UseCurrentSessionOpt,
+		gomock.Eq(updateMetaVersionSQL),
+		gomock.Any(),
 	)
 
 	msg, err := AddLockedPartitions(

--- a/pkg/statistics/handle/updatetest/update_test.go
+++ b/pkg/statistics/handle/updatetest/update_test.go
@@ -1097,7 +1097,7 @@ func TestStatsLockUnlockForAutoAnalyze(t *testing.T) {
 	require.False(t, h.HandleAutoAnalyze())
 
 	tblStats1 := h.GetTableStats(tbl.Meta())
-	require.Equal(t, tblStats, tblStats1)
+	require.Equal(t, tblStats.ModifyCount, tblStats1.ModifyCount)
 
 	tk.MustExec("unlock stats t")
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55906

Problem Summary:

### What changed and how does it work?

Handle the lock and unlock operations correctly.

1. When we unlock the tables, we need to update the version in order to trigger an update, allowing the priority queue to check the latest count and the modify_count.
2. When we lock the tables, we need to update the version as well. This lets the priority queue know that the table has been changed, and we need to evaluate it again.
3. In the priority queue, when we enqueue the table, we will check if this table has been locked or unlocked.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
