### PR TITLE
planner: play replay load restore the table with foreign key with right order.

### DIFF
--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -110,20 +110,32 @@ func (tne *tableNameExtractor) getTablesAndViews() (map[tableNamePair]struct{}, 
 			r[tablePair] = struct{}{}
 		}
 		// if the table has a foreign key, we need to add the referenced table to the list
-		tblInfo, err := tne.is.TableByName(tne.ctx, model.NewCIStr(tablePair.DBName), model.NewCIStr(tablePair.TableName))
+		err := findFK(tne.is, tablePair.DBName, tablePair.TableName, r)
 		if err != nil {
 			return nil, err
 		}
-		for _, fk := range tblInfo.Meta().ForeignKeys {
-			key := tableNamePair{
-				DBName:    fk.RefSchema.L,
-				TableName: fk.RefTable.L,
-				IsView:    false,
-			}
-			r[key] = struct{}{}
-		}
 	}
 	return r, nil
+}
+
+func findFK(is infoschema.InfoSchema, dbName, tableName string, tableMap map[tableNamePair]struct{}) error {
+	tblInfo, err := is.TableByName(context.Background(), model.NewCIStr(dbName), model.NewCIStr(tableName))
+	if err != nil {
+		return err
+	}
+	for _, fk := range tblInfo.Meta().ForeignKeys {
+		key := tableNamePair{
+			DBName:    fk.RefSchema.L,
+			TableName: fk.RefTable.L,
+			IsView:    false,
+		}
+		tableMap[key] = struct{}{}
+		err := findFK(is, key.DBName, key.TableName, tableMap)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (*tableNameExtractor) Enter(in ast.Node) (ast.Node, bool) {

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -525,6 +525,8 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 
 func (e *PlanReplayerLoadInfo) createTable(z *zip.Reader) error {
 	origin := e.Ctx.GetSessionVars().ForeignKeyChecks
+	// We need to disable foreign key check when we create schema and tables.
+	// because the order of creating schema and tables is not guaranteed.
 	e.Ctx.GetSessionVars().ForeignKeyChecks = false
 	defer func() {
 		e.Ctx.GetSessionVars().ForeignKeyChecks = origin

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -495,6 +495,7 @@ func topoSortTable(input []*zip.File) (result []*zip.File, err error) {
 	outMap := make(map[string]int) // table -> out degree
 	stmtCache := make(map[string]*ast.CreateTableStmt)
 	zipMap := make(map[string]*zip.File)
+	// 1. build graph and out degree
 	for _, f := range input {
 		originText, err := unzip(f)
 		if err != nil {
@@ -520,6 +521,7 @@ func topoSortTable(input []*zip.File) (result []*zip.File, err error) {
 	}
 	cnt := 0
 	taskCount := len(outMap)
+	// 2. topological sort
 OUTLOOP:
 	for len(outMap) != 0 {
 		cnt++
@@ -527,6 +529,8 @@ OUTLOOP:
 			return nil, errors.New("plan replayer: unknown table")
 		}
 		for k, v := range outMap {
+			// find the table which out degree is 0, remove it from the graph and add it to the result
+			// decrease the out degree of the table which has a foreign key constraint to the table
 			if v == 0 {
 				delete(outMap, k)
 				result = append(result, zipMap[k])

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -544,6 +544,7 @@ OUTLOOP:
 						}
 						schema := c.Refer.Table.Schema.L
 						if schema == "" {
+							// if schema is empty, use the default schema
 							t := strings.Split(name, ".")
 							schema = t[0]
 						}

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -524,9 +524,10 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 }
 
 func (e *PlanReplayerLoadInfo) createTable(z *zip.Reader) error {
+	origin := e.Ctx.GetSessionVars().ForeignKeyChecks
 	e.Ctx.GetSessionVars().ForeignKeyChecks = false
 	defer func() {
-		e.Ctx.GetSessionVars().ForeignKeyChecks = true
+		e.Ctx.GetSessionVars().ForeignKeyChecks = origin
 	}()
 	for _, zipFile := range z.File {
 		if zipFile.Name == fmt.Sprintf("schema/%v", domain.PlanReplayerSchemaMetaFile) {

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -484,7 +484,7 @@ func unzip(z *zip.File) (string, error) {
 	return bufa.String(), err
 }
 
-func compareTable(a, b *zip.File) int {
+func compareRestoreTable(a, b *zip.File) int {
 	originTexta, err := unzip(a)
 	if err == nil {
 		return 0
@@ -510,10 +510,10 @@ func compareTable(a, b *zip.File) int {
 		}
 		at := astmt[len(astmt)-1].(*ast.CreateTableStmt)
 		bt := bstmt[len(bstmt)-1].(*ast.CreateTableStmt)
-		afc, bfc := 0, 0
+		aFKCount, bFkCount := 0, 0
 		for _, c := range at.Constraints {
 			if c.Tp == ast.ConstraintForeignKey {
-				afc++
+				aFKCount++
 				if c.Refer.Table.Name.L == bt.Table.Name.L {
 					return 1
 				}
@@ -521,13 +521,13 @@ func compareTable(a, b *zip.File) int {
 		}
 		for _, c := range bt.Constraints {
 			if c.Tp == ast.ConstraintForeignKey {
-				bfc++
+				bFkCount++
 				if c.Refer.Table.Name.L == at.Table.Name.L {
 					return -1
 				}
 			}
 		}
-		return cmp.Compare(afc, bfc)
+		return cmp.Compare(aFKCount, bFkCount)
 	}
 	return 0
 }
@@ -557,7 +557,7 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 			fss = append(fss, zipFile)
 		}
 	}
-	slices.SortStableFunc(fss, compareTable)
+	slices.SortStableFunc(fss, compareRestoreTable)
 	for _, f := range fss {
 		err = createSchemaAndItems(e.Ctx, f)
 		if err != nil {

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -544,7 +544,7 @@ OUTLOOP:
 			}
 		}
 	}
-	for k, _ := range outMap {
+	for k := range outMap {
 		result = append(result, zipMap[k])
 	}
 	return result, nil

--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -520,7 +520,7 @@ func topoSortTable(input []*zip.File) (result []*zip.File, err error) {
 	cnt := 0
 	taskCount := len(outMap)
 OUTLOOP:
-	for len(outMap) != 0 {
+	for len(outMap) > 1 {
 		cnt++
 		if cnt > taskCount {
 			return nil, errors.New("plan replayer: unknown table")
@@ -543,6 +543,9 @@ OUTLOOP:
 				continue OUTLOOP
 			}
 		}
+	}
+	for k, _ := range outMap {
+		result = append(result, zipMap[k])
 	}
 	return result, nil
 }

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -251,7 +251,7 @@ func prepareData4PlanReplayer(t *testing.T, client *testserverclient.TestServerC
 	return filename, filename3
 }
 
-func TestIssue56458(t *testing.T) {
+func TestPlanReplayerWithMultiForeignKey(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	dom, err := session.GetDomain(store)
 	require.NoError(t, err)

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -215,6 +215,8 @@ func prepareData4PlanReplayer(t *testing.T, client *testserverclient.TestServerC
 	tk.MustExec("create database planReplayer")
 	tk.MustExec("use planReplayer")
 	tk.MustExec("create table t(a int)")
+	tk.MustExec("CREATE TABLE authors (id INT PRIMARY KEY AUTO_INCREMENT,name VARCHAR(100) NOT NULL,email VARCHAR(100) UNIQUE NOT NULL);")
+	tk.MustExec("CREATE TABLE books (id INT PRIMARY KEY AUTO_INCREMENT,title VARCHAR(200) NOT NULL,publication_date DATE NOT NULL,author_id INT,FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE CASCADE);")
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)
 	tk.MustExec("insert into t values(1), (2), (3), (4)")

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -298,6 +298,45 @@ func TestIssue56458(t *testing.T) {
 		"table_tiflash_replica.txt",
 		"variables.toml",
 	}, filesInReplayer)
+
+	// 3. check plan replayer load
+	// 3-1. write the plan replayer file from manual command to a file
+	path := "/tmp/plan_replayer.zip"
+	fp, err := os.Create(path)
+	require.NoError(t, err)
+	require.NotNil(t, fp)
+	defer func() {
+		require.NoError(t, fp.Close())
+		require.NoError(t, os.Remove(path))
+	}()
+
+	_, err = io.Copy(fp, bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NoError(t, fp.Sync())
+
+	// 3-2. connect to tidb and use PLAN REPLAYER LOAD to load this file
+	db, err := sql.Open("mysql", client.GetDSN(func(config *mysql.Config) {
+		config.AllowAllFiles = true
+	}))
+	require.NoError(t, err, "Error connecting")
+	defer func() {
+		err := db.Close()
+		require.NoError(t, err)
+	}()
+	tk := testkit.NewDBTestKit(t, db)
+	tk.MustExec("use planReplayer")
+	tk.MustExec("drop table planReplayer.t")
+	tk.MustExec("drop table planReplayer.v")
+	tk.MustExec(`plan replayer load "/tmp/plan_replayer.zip"`)
+
+	// 3-3. check whether binding takes effect
+	tk.MustExec(`select a, b from t where a in (1, 2, 3)`)
+	rows := tk.MustQuery("select @@last_plan_from_binding")
+	require.True(t, rows.Next(), "unexpected data")
+	var count int64
+	err = rows.Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
 }
 
 func TestIssue43192(t *testing.T) {
@@ -408,6 +447,8 @@ func prepareData4Issue56458(t *testing.T, client *testserverclient.TestServerCli
 	tk.MustExec("create database planReplayer")
 	tk.MustExec("use planReplayer")
 	tk.MustExec("CREATE TABLE v(id INT PRIMARY KEY AUTO_INCREMENT);")
+	err = h.HandleDDLEvent(<-h.DDLEventCh())
+	require.NoError(t, err)
 	tk.MustExec("create table t(a int, b int, INDEX ia (a), INDEX ib (b), author_id int, FOREIGN KEY (author_id) REFERENCES v(id) ON DELETE CASCADE);")
 	err = h.HandleDDLEvent(<-h.DDLEventCh())
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56456

Problem Summary:

### What changed and how does it work?

when restoring the table schema, some tables have these dependencies between each other. so we need to disable the ForeignKeyChecks to create table.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: play replay load restore the table with foreign key with right order
```
