### PR TITLE
planner: reverse the OFFSET when outer join's inner side is unique

### DIFF
--- a/pkg/expression/schema.go
+++ b/pkg/expression/schema.go
@@ -129,21 +129,47 @@ func (s *Schema) RetrieveColumn(col *Column) *Column {
 }
 
 // IsUniqueKey checks if this column is a unique key.
-func (s *Schema) IsUniqueKey(col *Column) bool {
+func (s *Schema) IsUniqueKey(cols ...*Column) bool {
 	for _, key := range s.Keys {
-		if len(key) == 1 && key[0].EqualColumn(col) {
-			return true
+		if len(key) > len(cols) {
+			continue
 		}
+		allFound := true
+		for _, keyCols := range key {
+			for _, col := range cols {
+				if !keyCols.EqualColumn(col) {
+					allFound = false
+					break
+				}
+			}
+		}
+		if !allFound {
+			continue
+		}
+		return true
 	}
 	return false
 }
 
 // IsUnique checks if this column is a unique key which may contain duplicate nulls .
-func (s *Schema) IsUnique(col *Column) bool {
+func (s *Schema) IsUnique(cols ...*Column) bool {
 	for _, key := range s.UniqueKeys {
-		if len(key) == 1 && key[0].EqualColumn(col) {
-			return true
+		if len(key) > len(cols) {
+			continue
 		}
+		allFound := true
+		for _, keyCols := range key {
+			for _, col := range cols {
+				if !keyCols.EqualColumn(col) {
+					allFound = false
+					break
+				}
+			}
+		}
+		if !allFound {
+			continue
+		}
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56321

Problem Summary:

### What changed and how does it work?

When the outer join's inner side has a unique key on the join key.
The relationship between the outer join's output and its outer child's output is one-to-one.
So we can reserve the OFFSET of the LIMIT.

This can reduce the input to the outer join.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
