### PR TITLE
br: use a unique session for checkpoint runner

### DIFF
--- a/br/pkg/checkpoint/checkpoint.go
+++ b/br/pkg/checkpoint/checkpoint.go
@@ -262,6 +262,7 @@ func (r *CheckpointRunner[K, V]) WaitForFinish(ctx context.Context, flush bool) 
 	r.wg.Wait()
 	// remove the checkpoint lock
 	r.checkpointStorage.deleteLock(ctx)
+	r.checkpointStorage.close()
 }
 
 // Send the checksum to the flush goroutine, and reset the CheckpointRunner's checksum

--- a/br/pkg/checkpoint/checkpoint_test.go
+++ b/br/pkg/checkpoint/checkpoint_test.go
@@ -326,6 +326,8 @@ func TestCheckpointRestoreRunner(t *testing.T) {
 
 	checkpointRunner.WaitForFinish(ctx, true)
 
+	se, err = g.CreateSession(s.Mock.Storage)
+	require.NoError(t, err)
 	respCount := 0
 	checker := func(tableID int64, resp checkpoint.RestoreValueType) {
 		require.NotNil(t, resp)
@@ -395,6 +397,8 @@ func TestCheckpointRunnerRetry(t *testing.T) {
 	err = checkpointRunner.FlushChecksum(ctx, 3, 3, 3, 3)
 	require.NoError(t, err)
 	checkpointRunner.WaitForFinish(ctx, true)
+	se, err = g.CreateSession(s.Mock.Storage)
+	require.NoError(t, err)
 	recordSet := make(map[string]int)
 	_, err = checkpoint.LoadCheckpointDataForSnapshotRestore(ctx, se.GetSessionCtx().GetRestrictedSQLExecutor(),
 		func(tableID int64, rangeKey checkpoint.RestoreValueType) {
@@ -433,6 +437,8 @@ func TestCheckpointRunnerNoRetry(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(time.Second)
 	checkpointRunner.WaitForFinish(ctx, true)
+	se, err = g.CreateSession(s.Mock.Storage)
+	require.NoError(t, err)
 	recordSet := make(map[string]int)
 	_, err = checkpoint.LoadCheckpointDataForSnapshotRestore(ctx, se.GetSessionCtx().GetRestrictedSQLExecutor(),
 		func(tableID int64, rangeKey checkpoint.RestoreValueType) {
@@ -501,6 +507,8 @@ func TestCheckpointLogRestoreRunner(t *testing.T) {
 
 	checkpointRunner.WaitForFinish(ctx, true)
 
+	se, err = g.CreateSession(s.Mock.Storage)
+	require.NoError(t, err)
 	respCount := 0
 	checker := func(metaKey string, resp checkpoint.LogRestoreValueMarshaled) {
 		require.NotNil(t, resp)

--- a/br/pkg/checkpoint/external_storage.go
+++ b/br/pkg/checkpoint/external_storage.go
@@ -57,6 +57,8 @@ func newExternalCheckpointStorage(
 	return checkpointStorage, nil
 }
 
+func (s *externalCheckpointStorage) close() {}
+
 func (s *externalCheckpointStorage) flushCheckpointData(ctx context.Context, data []byte) error {
 	fname := fmt.Sprintf("%s/%x.cpt", s.CheckpointDataDir, uuid.New())
 	return s.storage.WriteFile(ctx, fname, data)

--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -120,6 +120,7 @@ func StartCheckpointLogRestoreRunnerForTest(
 	return runner, nil
 }
 
+// Notice that the session is owned by the checkpoint runner, and it will be also closed by it.
 func StartCheckpointRunnerForLogRestore(
 	ctx context.Context,
 	se glue.Session,

--- a/br/pkg/checkpoint/restore.go
+++ b/br/pkg/checkpoint/restore.go
@@ -56,6 +56,7 @@ func StartCheckpointRestoreRunnerForTest(
 	return runner, nil
 }
 
+// Notice that the session is owned by the checkpoint runner, and it will be also closed by it.
 func StartCheckpointRunnerForRestore(
 	ctx context.Context,
 	se glue.Session,

--- a/br/pkg/checkpoint/storage.go
+++ b/br/pkg/checkpoint/storage.go
@@ -39,6 +39,8 @@ type checkpointStorage interface {
 	initialLock(ctx context.Context) error
 	updateLock(ctx context.Context) error
 	deleteLock(ctx context.Context)
+
+	close()
 }
 
 // Notice that:
@@ -122,6 +124,12 @@ func chunkInsertCheckpointSQLs(dbName, tableName string, data []byte) ([]string,
 type tableCheckpointStorage struct {
 	se               glue.Session
 	checkpointDBName string
+}
+
+func (s *tableCheckpointStorage) close() {
+	if s.se != nil {
+		s.se.Close()
+	}
 }
 
 func (s *tableCheckpointStorage) initialLock(ctx context.Context) error {

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -214,8 +214,12 @@ func (rc *LogClient) CleanUpKVFiles(
 	return rc.fileImporter.ClearFiles(ctx, rc.pdClient, "v1")
 }
 
-func (rc *LogClient) StartCheckpointRunnerForLogRestore(ctx context.Context) (*checkpoint.CheckpointRunner[checkpoint.LogRestoreKeyType, checkpoint.LogRestoreValueType], error) {
-	runner, err := checkpoint.StartCheckpointRunnerForLogRestore(ctx, rc.se)
+func (rc *LogClient) StartCheckpointRunnerForLogRestore(ctx context.Context, g glue.Glue, store kv.Storage) (*checkpoint.CheckpointRunner[checkpoint.LogRestoreKeyType, checkpoint.LogRestoreValueType], error) {
+	se, err := g.CreateSession(store)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	runner, err := checkpoint.StartCheckpointRunnerForLogRestore(ctx, se)
 	return runner, errors.Trace(err)
 }
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -905,7 +905,7 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	// reload or register the checkpoint
 	var checkpointSetWithTableID map[int64]map[string]struct{}
 	if cfg.UseCheckpoint {
-		sets, restoreSchedulersConfigFromCheckpoint, err := client.InitCheckpoint(ctx, s, schedulersConfig, checkpointFirstRun)
+		sets, restoreSchedulersConfigFromCheckpoint, err := client.InitCheckpoint(ctx, g, mgr.GetStorage(), schedulersConfig, checkpointFirstRun)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1350,7 +1350,7 @@ func restoreStream(
 		}
 		oldRatio = oldRatioFromCheckpoint
 
-		checkpointRunner, err = client.StartCheckpointRunnerForLogRestore(ctx)
+		checkpointRunner, err = client.StartCheckpointRunnerForLogRestore(ctx, g, mgr.GetStorage())
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56488 #56308 #56410 #56450

Problem Summary:
the session cannot be used concurrently.
### What changed and how does it work?
use a unique session for checkpoint runner.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
