### PR TITLE
executor: fix data inconsistency after `load data ... replace into ...` | tidb-test=e5f82b826aeb7e912c2d4dc36389960daac36d96

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -1201,9 +1201,12 @@ func (e *InsertValues) batchCheckAndInsert(ctx context.Context, rows [][]types.D
 					if handle == nil {
 						continue
 					}
-					_, err = e.removeRow(ctx, txn, handle, r, true)
+					skip, err = e.removeRow(ctx, txn, handle, r, true)
 					if err != nil {
 						return err
+					}
+					if skip {
+						break
 					}
 				} else {
 					// If duplicate keys were found in BatchGet, mark row = nil.


### PR DESCRIPTION
This is an cherry-pick of #56415
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56408

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
