### PR TITLE
linter: enable defers linter in the govet

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -118,6 +118,7 @@ nogo(
                "@org_golang_x_tools//go/analysis/passes/composite:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/copylock:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/ctrlflow:go_default_library",
+               "@org_golang_x_tools//go/analysis/passes/defer:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/deepequalerrors:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/errorsas:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/fieldalignment:go_default_library",

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -118,7 +118,7 @@ nogo(
                "@org_golang_x_tools//go/analysis/passes/composite:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/copylock:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/ctrlflow:go_default_library",
-               "@org_golang_x_tools//go/analysis/passes/defer:go_default_library",
+               "@org_golang_x_tools//go/analysis/passes/defers:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/deepequalerrors:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/errorsas:go_default_library",
                "@org_golang_x_tools//go/analysis/passes/fieldalignment:go_default_library",

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -134,6 +134,13 @@
       ".*_generated\\.go$": "ignore generated code"
     }
   },
+  "defers": {
+    "exclude_files": {
+      "pkg/parser/parser.go": "parser/parser.go code",
+      "external/": "no need to vet third party code",
+      ".*_generated\\.go$": "ignore generated code"
+    }
+  },
   "deepequalerrors": {
     "exclude_files": {
       "pkg/parser/parser.go": "parser/parser.go code",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

in go1.22, 

#### New warnings for deferring time.Since[¶](https://tip.golang.org/doc/go1.22#vet-defers)

The vet tool now reports a non-deferred call to [time.Since(t)](https://tip.golang.org/pkg/time/#Since) within a defer statement. This is equivalent to calling time.Now().Sub(t) before the defer statement, not when the deferred function is called. In nearly all cases, the correct code requires deferring the time.Since call. For example:

```
t := time.Now()
defer log.Println(time.Since(t)) // non-deferred call to time.Since
tmp := time.Since(t); defer log.Println(tmp) // equivalent to the previous defer

defer func() {
  log.Println(time.Since(t)) // a correctly deferred call to time.Since
}()
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
