### PR TITLE
stats: implement stats handler for DDL notifier part 3

### DIFF
--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -402,7 +402,7 @@ func RandomPickOneTableAndTryAutoAnalyze(
 	})
 	// Query locked tables once to minimize overhead.
 	// Outdated lock info is acceptable as we verify table lock status pre-analysis.
-	lockedTables, err := lockstats.QueryLockedTables(sctx)
+	lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
 	if err != nil {
 		statslogutil.StatsLogger().Error(
 			"check table lock failed",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
+	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/util"
 	"go.uber.org/zap"
 )
@@ -45,7 +46,7 @@ func FetchAllTablesAndBuildAnalysisJobs(
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 	// Query locked tables once to minimize overhead.
 	// Outdated lock info is acceptable as we verify table lock status pre-analysis.
-	lockedTables, err := lockstats.QueryLockedTables(sctx)
+	lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -15,6 +15,8 @@
 package ddl
 
 import (
+	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -189,18 +191,25 @@ func UpdateStatsWithCountDeltaAndModifyCountDeltaForTest(
 	tableID int64,
 	countDelta, modifyCountDelta int64,
 ) error {
-	return updateStatsWithCountDeltaAndModifyCountDelta(sctx, tableID, countDelta, modifyCountDelta)
+	return updateStatsWithCountDeltaAndModifyCountDelta(
+		util.StatsCtx,
+		sctx,
+		tableID,
+		countDelta,
+		modifyCountDelta,
+	)
 }
 
 // updateStatsWithCountDeltaAndModifyCountDelta updates
 // the global stats with the given count delta and modify count delta.
 // Only used by some special DDLs, such as exchange partition.
 func updateStatsWithCountDeltaAndModifyCountDelta(
+	ctx context.Context,
 	sctx sessionctx.Context,
 	tableID int64,
 	countDelta, modifyCountDelta int64,
 ) error {
-	lockedTables, err := lockstats.QueryLockedTables(sctx)
+	lockedTables, err := lockstats.QueryLockedTables(ctx, sctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/statistics/handle/ddl/drop_partition.go
+++ b/pkg/statistics/handle/ddl/drop_partition.go
@@ -15,8 +15,11 @@
 package ddl
 
 import (
+	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
@@ -28,43 +31,7 @@ func (h *ddlHandlerImpl) onDropPartitions(t *notifier.SchemaChangeEvent) error {
 	globalTableInfo, droppedPartitionInfo := t.GetDropPartitionInfo()
 	// Note: Put all the operations in a transaction.
 	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		count := int64(0)
-		for _, def := range droppedPartitionInfo.Definitions {
-			// Get the count and modify count of the partition.
-			tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(util.StatsCtx, sctx, def.ID)
-			if err != nil {
-				return err
-			}
-			count += tableCount
-		}
-		if count != 0 {
-			lockedTables, err := lockstats.QueryLockedTables(sctx)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			isLocked := false
-			if _, ok := lockedTables[globalTableInfo.ID]; ok {
-				isLocked = true
-			}
-			startTS, err := util.GetStartTS(sctx)
-			if err != nil {
-				return errors.Trace(err)
-			}
-
-			// Because we drop the partition, we should subtract the count from the global stats.
-			delta := -count
-			err = storage.UpdateStatsMeta(
-				util.StatsCtx,
-				sctx,
-				startTS,
-				variable.TableDelta{Count: count, Delta: delta},
-				globalTableInfo.ID,
-				isLocked,
-			)
-			return err
-		}
-
-		return nil
+		return updateGlobalTableStats4DropPartition(util.StatsCtx, sctx, globalTableInfo, droppedPartitionInfo)
 	}, util.FlagWrapTxn); err != nil {
 		return err
 	}
@@ -78,4 +45,48 @@ func (h *ddlHandlerImpl) onDropPartitions(t *notifier.SchemaChangeEvent) error {
 	}
 
 	return nil
+}
+
+func updateGlobalTableStats4DropPartition(
+	ctx context.Context,
+	sctx sessionctx.Context,
+	globalTableInfo *model.TableInfo,
+	droppedPartitionInfo *model.PartitionInfo,
+) error {
+	count := int64(0)
+	for _, def := range droppedPartitionInfo.Definitions {
+		// Get the count and modify count of the partition.
+		tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(ctx, sctx, def.ID)
+		if err != nil {
+			return err
+		}
+		count += tableCount
+	}
+	if count == 0 {
+		return nil
+	}
+
+	lockedTables, err := lockstats.QueryLockedTables(ctx, sctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	isLocked := false
+	if _, ok := lockedTables[globalTableInfo.ID]; ok {
+		isLocked = true
+	}
+	startTS, err := util.GetStartTS(sctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Because we drop the partition, we should subtract the count from the global stats.
+	delta := -count
+	return errors.Trace(storage.UpdateStatsMeta(
+		ctx,
+		sctx,
+		startTS,
+		variable.TableDelta{Count: count, Delta: delta},
+		globalTableInfo.ID,
+		isLocked,
+	))
 }

--- a/pkg/statistics/handle/ddl/exchange_partition.go
+++ b/pkg/statistics/handle/ddl/exchange_partition.go
@@ -15,6 +15,8 @@
 package ddl
 
 import (
+	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -31,72 +33,13 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *notifier.SchemaChangeEvent) err
 		originalTableInfo := t.GetExchangePartitionInfo()
 	// Note: Put all the operations in a transaction.
 	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		partCount, partModifyCount, tableCount, tableModifyCount, err := getCountsAndModifyCounts(
+		return updateGlobalTableStats4ExchangePartition(
+			util.StatsCtx,
 			sctx,
-			originalPartInfo.Definitions[0].ID,
-			originalTableInfo.ID,
+			globalTableInfo,
+			originalPartInfo,
+			originalTableInfo,
 		)
-		if err != nil {
-			return err
-		}
-
-		// The count of the partition should be added to the table.
-		// The formula is: total_count = original_table_count - original_partition_count + new_table_count.
-		// So the delta is : new_table_count - original_partition_count.
-		countDelta := tableCount - partCount
-		// Initially, the sum of tableCount and partCount represents
-		// the operation of deleting the partition and adding the table.
-		// Therefore, they are considered as modifyCountDelta.
-		// Next, since the old partition no longer belongs to the table,
-		// the modify count of the partition should be subtracted.
-		// The modify count of the table should be added as we are adding the table as a partition.
-		modifyCountDelta := (tableCount + partCount) - partModifyCount + tableModifyCount
-
-		// Update the global stats.
-		if modifyCountDelta != 0 || countDelta != 0 {
-			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-			globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
-			if !ok {
-				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
-			}
-			if err := updateStatsWithCountDeltaAndModifyCountDelta(
-				sctx,
-				globalTableInfo.ID, countDelta, modifyCountDelta,
-			); err != nil {
-				fields := exchangePartitionLogFields(
-					globalTableSchema.Name.O,
-					globalTableInfo,
-					originalPartInfo.Definitions[0],
-					originalTableInfo,
-					countDelta, modifyCountDelta,
-					partCount,
-					partModifyCount,
-					tableCount,
-					tableModifyCount,
-				)
-				fields = append(fields, zap.Error(err))
-				logutil.StatsLogger().Error(
-					"Update global stats after exchange partition failed",
-					fields...,
-				)
-				return err
-			}
-			logutil.StatsLogger().Info(
-				"Update global stats after exchange partition",
-				exchangePartitionLogFields(
-					globalTableSchema.Name.O,
-					globalTableInfo,
-					originalPartInfo.Definitions[0],
-					originalTableInfo,
-					countDelta, modifyCountDelta,
-					partCount,
-					partModifyCount,
-					tableCount,
-					tableModifyCount,
-				)...,
-			)
-		}
-		return nil
 	}, util.FlagWrapTxn); err != nil {
 		return err
 	}
@@ -104,16 +47,96 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *notifier.SchemaChangeEvent) err
 	return nil
 }
 
+func updateGlobalTableStats4ExchangePartition(
+	ctx context.Context,
+	sctx sessionctx.Context,
+	globalTableInfo *model.TableInfo,
+	originalPartInfo *model.PartitionInfo,
+	originalTableInfo *model.TableInfo,
+) error {
+	partCount, partModifyCount, tableCount, tableModifyCount, err := getCountsAndModifyCounts(
+		ctx,
+		sctx,
+		originalPartInfo.Definitions[0].ID,
+		originalTableInfo.ID,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// The count of the partition should be added to the table.
+	// The formula is: total_count = original_table_count - original_partition_count + new_table_count.
+	// So the delta is : new_table_count - original_partition_count.
+	countDelta := tableCount - partCount
+	// Initially, the sum of tableCount and partCount represents
+	// the operation of deleting the partition and adding the table.
+	// Therefore, they are considered as modifyCountDelta.
+	// Next, since the old partition no longer belongs to the table,
+	// the modify count of the partition should be subtracted.
+	// The modify count of the table should be added as we are adding the table as a partition.
+	modifyCountDelta := (tableCount + partCount) - partModifyCount + tableModifyCount
+
+	if modifyCountDelta == 0 && countDelta == 0 {
+		return nil
+	}
+
+	// Update the global stats.
+	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
+	if !ok {
+		return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
+	}
+	if err = updateStatsWithCountDeltaAndModifyCountDelta(
+		ctx,
+		sctx,
+		globalTableInfo.ID, countDelta, modifyCountDelta,
+	); err != nil {
+		fields := exchangePartitionLogFields(
+			globalTableSchema.Name.O,
+			globalTableInfo,
+			originalPartInfo.Definitions[0],
+			originalTableInfo,
+			countDelta, modifyCountDelta,
+			partCount,
+			partModifyCount,
+			tableCount,
+			tableModifyCount,
+		)
+		fields = append(fields, zap.Error(err))
+		logutil.StatsLogger().Error(
+			"Update global stats after exchange partition failed",
+			fields...,
+		)
+		return errors.Trace(err)
+	}
+	logutil.StatsLogger().Info(
+		"Update global stats after exchange partition",
+		exchangePartitionLogFields(
+			globalTableSchema.Name.O,
+			globalTableInfo,
+			originalPartInfo.Definitions[0],
+			originalTableInfo,
+			countDelta, modifyCountDelta,
+			partCount,
+			partModifyCount,
+			tableCount,
+			tableModifyCount,
+		)...,
+	)
+	return nil
+}
+
 func getCountsAndModifyCounts(
+	ctx context.Context,
 	sctx sessionctx.Context,
 	partitionID, tableID int64,
 ) (partCount, partModifyCount, tableCount, tableModifyCount int64, err error) {
-	partCount, partModifyCount, _, err = storage.StatsMetaCountAndModifyCount(util.StatsCtx, sctx, partitionID)
+	partCount, partModifyCount, _, err = storage.StatsMetaCountAndModifyCount(ctx, sctx, partitionID)
 	if err != nil {
 		return
 	}
 
-	tableCount, tableModifyCount, _, err = storage.StatsMetaCountAndModifyCount(util.StatsCtx, sctx, tableID)
+	tableCount, tableModifyCount, _, err = storage.StatsMetaCountAndModifyCount(ctx, sctx, tableID)
 	if err != nil {
 		return
 	}

--- a/pkg/statistics/handle/ddl/exchange_partition.go
+++ b/pkg/statistics/handle/ddl/exchange_partition.go
@@ -32,7 +32,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *notifier.SchemaChangeEvent) err
 	globalTableInfo, originalPartInfo,
 		originalTableInfo := t.GetExchangePartitionInfo()
 	// Note: Put all the operations in a transaction.
-	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
+	return util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		return updateGlobalTableStats4ExchangePartition(
 			util.StatsCtx,
 			sctx,
@@ -40,11 +40,7 @@ func (h *ddlHandlerImpl) onExchangeAPartition(t *notifier.SchemaChangeEvent) err
 			originalPartInfo,
 			originalTableInfo,
 		)
-	}, util.FlagWrapTxn); err != nil {
-		return err
-	}
-
-	return nil
+	}, util.FlagWrapTxn)
 }
 
 func updateGlobalTableStats4ExchangePartition(

--- a/pkg/statistics/handle/ddl/truncate_partition.go
+++ b/pkg/statistics/handle/ddl/truncate_partition.go
@@ -15,6 +15,8 @@
 package ddl
 
 import (
+	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -40,90 +42,12 @@ func (h *ddlHandlerImpl) onTruncatePartitions(t *notifier.SchemaChangeEvent) err
 	// Second, clean up the old stats meta from global stats meta for the dropped partitions.
 	// Do not forget to put those operations in one transaction.
 	if err := util.CallWithSCtx(h.statsHandler.SPool(), func(sctx sessionctx.Context) error {
-		count := int64(0)
-		partitionIDs := make([]int64, 0, len(droppedPartInfo.Definitions))
-		partitionNames := make([]string, 0, len(droppedPartInfo.Definitions))
-		for _, def := range droppedPartInfo.Definitions {
-			// Get the count and modify count of the partition.
-			tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(util.StatsCtx, sctx, def.ID)
-			if err != nil {
-				return err
-			}
-			count += tableCount
-			partitionIDs = append(partitionIDs, def.ID)
-			partitionNames = append(partitionNames, def.Name.O)
-		}
-
-		if count != 0 {
-			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-			globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
-			if !ok {
-				return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
-			}
-			lockedTables, err := lockstats.QueryLockedTables(sctx)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			isLocked := false
-			if _, ok := lockedTables[globalTableInfo.ID]; ok {
-				isLocked = true
-			}
-			startTS, err := util.GetStartTS(sctx)
-			if err != nil {
-				return errors.Trace(err)
-			}
-
-			// Because we drop the partition, we should subtract the count from the global stats.
-			// Note: We don't need to subtract the modify count from the global stats.
-			// For example:
-			// 1. The partition has 100 rows.
-			// 2. We deleted 100 rows from the partition.
-			// 3. The global stats has `count - 100 rows` and 100 modify count.
-			// 4. We drop the partition.
-			// 5. The global stats should not be `count` and 0 modify count. We need to keep the modify count.
-			delta := -count
-			err = storage.UpdateStatsMeta(
-				util.StatsCtx,
-				sctx,
-				startTS,
-				variable.TableDelta{Count: count, Delta: delta},
-				globalTableInfo.ID,
-				isLocked,
-			)
-			if err != nil {
-				fields := truncatePartitionsLogFields(
-					globalTableSchema,
-					globalTableInfo,
-					partitionIDs,
-					partitionNames,
-					count,
-					delta,
-					startTS,
-					isLocked,
-				)
-				fields = append(fields, zap.Error(err))
-				logutil.StatsLogger().Error("Update global stats after truncate partition failed",
-					fields...,
-				)
-				return err
-			}
-
-			logutil.StatsLogger().Info("Update global stats after truncate partition",
-				truncatePartitionsLogFields(
-					globalTableSchema,
-					globalTableInfo,
-					partitionIDs,
-					partitionNames,
-					count,
-					delta,
-					startTS,
-					isLocked,
-				)...,
-			)
-			return nil
-		}
-
-		return nil
+		return updateGlobalTableStats4TruncatePartition(
+			util.StatsCtx,
+			sctx,
+			globalTableInfo,
+			droppedPartInfo,
+		)
 	}, util.FlagWrapTxn); err != nil {
 		return err
 	}
@@ -136,6 +60,98 @@ func (h *ddlHandlerImpl) onTruncatePartitions(t *notifier.SchemaChangeEvent) err
 		}
 	}
 
+	return nil
+}
+
+func updateGlobalTableStats4TruncatePartition(
+	ctx context.Context,
+	sctx sessionctx.Context,
+	globalTableInfo *model.TableInfo,
+	droppedPartInfo *model.PartitionInfo,
+) error {
+	count := int64(0)
+	partitionIDs := make([]int64, 0, len(droppedPartInfo.Definitions))
+	partitionNames := make([]string, 0, len(droppedPartInfo.Definitions))
+	for _, def := range droppedPartInfo.Definitions {
+		// Get the count and modify count of the partition.
+		tableCount, _, _, err := storage.StatsMetaCountAndModifyCount(ctx, sctx, def.ID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		count += tableCount
+		partitionIDs = append(partitionIDs, def.ID)
+		partitionNames = append(partitionNames, def.Name.O)
+	}
+
+	if count == 0 {
+		return nil
+	}
+
+	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
+	if !ok {
+		return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
+	}
+	lockedTables, err := lockstats.QueryLockedTables(ctx, sctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	isLocked := false
+	if _, ok := lockedTables[globalTableInfo.ID]; ok {
+		isLocked = true
+	}
+	startTS, err := util.GetStartTS(sctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Because we drop the partition, we should subtract the count from the global stats.
+	// Note: We don't need to subtract the modify count from the global stats.
+	// For example:
+	// 1. The partition has 100 rows.
+	// 2. We deleted 100 rows from the partition.
+	// 3. The global stats has `count - 100 rows` and 100 modify count.
+	// 4. We drop the partition.
+	// 5. The global stats should not be `count` and 0 modify count. We need to keep the modify count.
+	delta := -count
+	err = storage.UpdateStatsMeta(
+		ctx,
+		sctx,
+		startTS,
+		variable.TableDelta{Count: count, Delta: delta},
+		globalTableInfo.ID,
+		isLocked,
+	)
+	if err != nil {
+		fields := truncatePartitionsLogFields(
+			globalTableSchema,
+			globalTableInfo,
+			partitionIDs,
+			partitionNames,
+			count,
+			delta,
+			startTS,
+			isLocked,
+		)
+		fields = append(fields, zap.Error(err))
+		logutil.StatsLogger().Error("Update global stats after truncate partition failed",
+			fields...,
+		)
+		return errors.Trace(err)
+	}
+
+	logutil.StatsLogger().Info("Update global stats after truncate partition",
+		truncatePartitionsLogFields(
+			globalTableSchema,
+			globalTableInfo,
+			partitionIDs,
+			partitionNames,
+			count,
+			delta,
+			startTS,
+			isLocked,
+		)...,
+	)
 	return nil
 }
 

--- a/pkg/statistics/handle/lockstats/lock_stats.go
+++ b/pkg/statistics/handle/lockstats/lock_stats.go
@@ -108,7 +108,7 @@ func (sl *statsLockImpl) RemoveLockedPartitions(
 // queryLockedTables query locked tables from store.
 func (sl *statsLockImpl) queryLockedTables() (tables map[int64]struct{}, err error) {
 	err = util.CallWithSCtx(sl.pool, func(sctx sessionctx.Context) error {
-		tables, err = QueryLockedTables(sctx)
+		tables, err = QueryLockedTables(util.StatsCtx, sctx)
 		return err
 	})
 	return
@@ -144,7 +144,7 @@ func AddLockedTables(
 	tables map[int64]*types.StatsLockTable,
 ) (string, error) {
 	// Load tables to check duplicate before insert.
-	lockedTables, err := QueryLockedTables(sctx)
+	lockedTables, err := QueryLockedTables(util.StatsCtx, sctx)
 	if err != nil {
 		return "", err
 	}
@@ -200,7 +200,7 @@ func AddLockedPartitions(
 	pidNames map[int64]string,
 ) (string, error) {
 	// Load tables to check duplicate before insert.
-	lockedTables, err := QueryLockedTables(sctx)
+	lockedTables, err := QueryLockedTables(util.StatsCtx, sctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/statistics/handle/lockstats/query_lock.go
+++ b/pkg/statistics/handle/lockstats/query_lock.go
@@ -15,6 +15,8 @@
 package lockstats
 
 import (
+	"context"
+
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 )
@@ -23,8 +25,8 @@ const selectSQL = "SELECT table_id FROM mysql.stats_table_locked"
 
 // QueryLockedTables loads locked tables from mysql.stats_table_locked.
 // Return it as a map for fast query.
-func QueryLockedTables(sctx sessionctx.Context) (map[int64]struct{}, error) {
-	rows, _, err := util.ExecRows(sctx, selectSQL)
+func QueryLockedTables(ctx context.Context, sctx sessionctx.Context) (map[int64]struct{}, error) {
+	rows, _, err := util.ExecRowsWithCtx(ctx, sctx, selectSQL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/statistics/handle/lockstats/query_lock_test.go
+++ b/pkg/statistics/handle/lockstats/query_lock_test.go
@@ -132,7 +132,7 @@ func executeQueryLockedTables(exec *mock.MockRestrictedSQLExecutor, numRows int,
 			statsutil.UseCurrentSessionOpt,
 			selectSQL,
 		).Return(nil, nil, errors.New("error"))
-		return QueryLockedTables(wrapAsSCtx(exec))
+		return QueryLockedTables(statsutil.StatsCtx, wrapAsSCtx(exec))
 	}
 
 	c := chunk.NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, numRows)
@@ -149,5 +149,5 @@ func executeQueryLockedTables(exec *mock.MockRestrictedSQLExecutor, numRows int,
 		selectSQL,
 	).Return(rows, nil, nil)
 
-	return QueryLockedTables(wrapAsSCtx(exec))
+	return QueryLockedTables(statsutil.StatsCtx, wrapAsSCtx(exec))
 }

--- a/pkg/statistics/handle/lockstats/unlock_stats.go
+++ b/pkg/statistics/handle/lockstats/unlock_stats.go
@@ -41,7 +41,7 @@ func RemoveLockedTables(
 	tables map[int64]*types.StatsLockTable,
 ) (string, error) {
 	// Load tables to check locked before delete.
-	lockedTables, err := QueryLockedTables(sctx)
+	lockedTables, err := QueryLockedTables(util.StatsCtx, sctx)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +98,7 @@ func RemoveLockedPartitions(
 	pidNames map[int64]string,
 ) (string, error) {
 	// Load tables to check locked before delete.
-	lockedTables, err := QueryLockedTables(sctx)
+	lockedTables, err := QueryLockedTables(util.StatsCtx, sctx)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55722

Problem Summary:

### What changed and how does it work?

port the handling logic of ActionTruncateTablePartition ActionDropTablePartition ActionExchangeTablePartition to DDL notifier subscriber. Should finish the porting now.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > will test it after the publisher is ready

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
