### PR TITLE
planner: fix mustUseIndex doesn't have a assertion inside.

### DIFF
--- a/pkg/bindinfo/capture_test.go
+++ b/pkg/bindinfo/capture_test.go
@@ -253,7 +253,7 @@ func TestCapturePreparedStmt(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, c int, key idx_b(b), key idx_c(c))")
-	require.True(t, tk.MustUseIndex("select * from t where b = 1 and c > 1", "idx_b(b)"))
+	tk.MustUseIndex("select * from t where b = 1 and c > 1", "idx_b(b)")
 	tk.MustExec("prepare stmt from 'select /*+ use_index(t,idx_c) */ * from t where b = ? and c > ?'")
 	tk.MustExec("set @p = 1")
 	tk.MustExec("execute stmt using @p, @p")
@@ -266,7 +266,7 @@ func TestCapturePreparedStmt(t *testing.T) {
 	require.Equal(t, "select * from `test` . `t` where `b` = ? and `c` > ?", rows[0][0])
 	require.Equal(t, "SELECT /*+ use_index(@`sel_1` `test`.`t` `idx_c`), no_order_index(@`sel_1` `test`.`t` `idx_c`)*/ * FROM `test`.`t` WHERE `b` = ? AND `c` > ?", rows[0][1])
 
-	require.True(t, tk.MustUseIndex("select /*+ use_index(t,idx_b) */ * from t where b = 1 and c > 1", "idx_c(c)"))
+	tk.MustUseIndex("select /*+ use_index(t,idx_b) */ * from t where b = 1 and c > 1", "idx_c(c)")
 	tk.MustExec("admin flush bindings")
 	tk.MustExec("admin evolve bindings")
 	rows = tk.MustQuery("show global bindings").Rows()
@@ -455,12 +455,12 @@ func TestIssue20417(t *testing.T) {
 	require.Len(t, rows, 1)
 	require.Equal(t, "select * from `test` . `t`", rows[0][0])
 	require.Equal(t, "SELECT /*+ use_index(`t` `idxb`)*/ * FROM `test`.`t`", rows[0][1])
-	require.True(t, tk.MustUseIndex("select * from t", "idxb(b)"))
-	require.True(t, tk.MustUseIndex("select * from test.t", "idxb(b)"))
+	tk.MustUseIndex("select * from t", "idxb(b)")
+	tk.MustUseIndex("select * from test.t", "idxb(b)")
 
 	tk.MustExec("create global binding for select * from t WHERE b=2 AND c=3924541 using select /*+ use_index(@sel_1 test.t idxb) */ * from t WHERE b=2 AND c=3924541")
-	require.True(t, tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `test`.`t` WHERE `b`=2 AND `c`=3924541", "idxb(b)"))
-	require.True(t, tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `t` WHERE `b`=2 AND `c`=3924541", "idxb(b)"))
+	tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `test`.`t` WHERE `b`=2 AND `c`=3924541", "idxb(b)")
+	tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `t` WHERE `b`=2 AND `c`=3924541", "idxb(b)")
 
 	// Test for capture baseline
 	internal.UtilCleanBindingEnv(tk, dom)

--- a/pkg/bindinfo/fuzzy_binding_test.go
+++ b/pkg/bindinfo/fuzzy_binding_test.go
@@ -61,9 +61,9 @@ func TestFuzzyBindingBasic(t *testing.T) {
 				tk.MustExec("use " + useDB)
 				for _, testDB := range []string{"", "test.", "test1.", "test2."} {
 					tk.MustExec(`set @@tidb_opt_enable_fuzzy_binding=1`) // enabled
-					require.True(t, tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx))
+					tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx)
 					tk.MustQuery(`select @@last_plan_from_binding`).Check(testkit.Rows("1"))
-					require.True(t, tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx))
+					tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx)
 					tk.MustQuery(`show warnings`).Check(testkit.Rows())  // no warning
 					tk.MustExec(`set @@tidb_opt_enable_fuzzy_binding=0`) // disabled
 					tk.MustQuery(fmt.Sprintf("select * from %vt", testDB))

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -311,14 +311,14 @@ func TestBindingSymbolList(t *testing.T) {
 	// before binding
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 100")
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)")
 
 	tk.MustExec(`create global binding for select a, b from t where a = 1 limit 0, 1 using select a, b from t use index (ib) where a = 1 limit 0, 1`)
 
 	// after binding
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 100")
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ib(b)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ib(b)")
 
 	// Normalize
 	stmt, err := parser.New().ParseOneStmt("select a, b from test . t where a = 1 limit 0, 1", "", "")
@@ -354,14 +354,14 @@ func TestBindingInListWithSingleLiteral(t *testing.T) {
 	// before binding
 	tk.MustQuery(sqlcmd)
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex(sqlcmd, "ia(a)"))
+	tk.MustUseIndex(sqlcmd, "ia(a)")
 
 	tk.MustExec(bindingStmt)
 
 	// after binding
 	tk.MustQuery(sqlcmd)
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex(sqlcmd, "ib(b)"))
+	tk.MustUseIndex(sqlcmd, "ib(b)")
 
 	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
 
@@ -394,11 +394,11 @@ func TestBestPlanInBaselines(t *testing.T) {
 	// before binding
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 100")
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)")
 
 	tk.MustQuery("select a, b from t where b = 3 limit 1, 100")
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)"))
+	tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)")
 
 	tk.MustExec(`create global binding for select a, b from t where a = 1 limit 0, 1 using select /*+ use_index(@sel_1 test.t ia) */ a, b from t where a = 1 limit 0, 1`)
 	tk.MustExec(`create global binding for select a, b from t where b = 1 limit 0, 1 using select /*+ use_index(@sel_1 test.t ib) */ a, b from t where b = 1 limit 0, 1`)
@@ -415,11 +415,11 @@ func TestBestPlanInBaselines(t *testing.T) {
 
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 10")
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)")
 
 	tk.MustQuery("select a, b from t where b = 3 limit 1, 100")
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)"))
+	tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)")
 }
 
 func TestIssue50646(t *testing.T) {
@@ -603,7 +603,7 @@ func TestInvisibleIndex(t *testing.T) {
 
 	tk.MustQuery("select * from t")
 	require.Equal(t, "t:idx_a", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select * from t", "idx_a(a)"))
+	tk.MustUseIndex("select * from t", "idx_a(a)")
 
 	tk.MustExec(`prepare stmt1 from 'select * from t'`)
 	tk.MustExec("execute stmt1")

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -551,7 +551,10 @@ func (tk *TestKit) MustMatchErrMsg(sql string, errRx any) {
 }
 
 // MustUseIndex checks if the result execution plan contains specific index(es).
-func (tk *TestKit) MustUseIndex(sql string, index string, args ...any) bool {
+func (tk *TestKit) MustUseIndex(sql string, index string, args ...any) (res bool) {
+	defer func() {
+		tk.require.True(res)
+	}()
 	rs := tk.MustQuery("explain "+sql, args...)
 	for i := range rs.rows {
 		if strings.Contains(rs.rows[i][3], "index:"+index) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
