### PR TITLE
testkit: unify the behavior for methods `MustXXXX`

### DIFF
--- a/pkg/bindinfo/capture_test.go
+++ b/pkg/bindinfo/capture_test.go
@@ -253,7 +253,7 @@ func TestCapturePreparedStmt(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, c int, key idx_b(b), key idx_c(c))")
-	require.True(t, tk.MustUseIndex("select * from t where b = 1 and c > 1", "idx_b(b)"))
+	tk.MustUseIndex("select * from t where b = 1 and c > 1", "idx_b(b)")
 	tk.MustExec("prepare stmt from 'select /*+ use_index(t,idx_c) */ * from t where b = ? and c > ?'")
 	tk.MustExec("set @p = 1")
 	tk.MustExec("execute stmt using @p, @p")
@@ -266,7 +266,7 @@ func TestCapturePreparedStmt(t *testing.T) {
 	require.Equal(t, "select * from `test` . `t` where `b` = ? and `c` > ?", rows[0][0])
 	require.Equal(t, "SELECT /*+ use_index(@`sel_1` `test`.`t` `idx_c`), no_order_index(@`sel_1` `test`.`t` `idx_c`)*/ * FROM `test`.`t` WHERE `b` = ? AND `c` > ?", rows[0][1])
 
-	require.True(t, tk.MustUseIndex("select /*+ use_index(t,idx_b) */ * from t where b = 1 and c > 1", "idx_c(c)"))
+	tk.MustUseIndex("select /*+ use_index(t,idx_b) */ * from t where b = 1 and c > 1", "idx_c(c)")
 	tk.MustExec("admin flush bindings")
 	tk.MustExec("admin evolve bindings")
 	rows = tk.MustQuery("show global bindings").Rows()
@@ -455,12 +455,12 @@ func TestIssue20417(t *testing.T) {
 	require.Len(t, rows, 1)
 	require.Equal(t, "select * from `test` . `t`", rows[0][0])
 	require.Equal(t, "SELECT /*+ use_index(`t` `idxb`)*/ * FROM `test`.`t`", rows[0][1])
-	require.True(t, tk.MustUseIndex("select * from t", "idxb(b)"))
-	require.True(t, tk.MustUseIndex("select * from test.t", "idxb(b)"))
+	tk.MustUseIndex("select * from t", "idxb(b)")
+	tk.MustUseIndex("select * from test.t", "idxb(b)")
 
 	tk.MustExec("create global binding for select * from t WHERE b=2 AND c=3924541 using select /*+ use_index(@sel_1 test.t idxb) */ * from t WHERE b=2 AND c=3924541")
-	require.True(t, tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `test`.`t` WHERE `b`=2 AND `c`=3924541", "idxb(b)"))
-	require.True(t, tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `t` WHERE `b`=2 AND `c`=3924541", "idxb(b)"))
+	tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `test`.`t` WHERE `b`=2 AND `c`=3924541", "idxb(b)")
+	tk.MustUseIndex("SELECT /*+ use_index(@`sel_1` `test`.`t` `idxc`)*/ * FROM `t` WHERE `b`=2 AND `c`=3924541", "idxb(b)")
 
 	// Test for capture baseline
 	internal.UtilCleanBindingEnv(tk, dom)

--- a/pkg/bindinfo/fuzzy_binding_test.go
+++ b/pkg/bindinfo/fuzzy_binding_test.go
@@ -61,9 +61,9 @@ func TestFuzzyBindingBasic(t *testing.T) {
 				tk.MustExec("use " + useDB)
 				for _, testDB := range []string{"", "test.", "test1.", "test2."} {
 					tk.MustExec(`set @@tidb_opt_enable_fuzzy_binding=1`) // enabled
-					require.True(t, tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx))
+					tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx)
 					tk.MustQuery(`select @@last_plan_from_binding`).Check(testkit.Rows("1"))
-					require.True(t, tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx))
+					tk.MustUseIndex(fmt.Sprintf("select * from %vt", testDB), idx)
 					tk.MustQuery(`show warnings`).Check(testkit.Rows())  // no warning
 					tk.MustExec(`set @@tidb_opt_enable_fuzzy_binding=0`) // disabled
 					tk.MustQuery(fmt.Sprintf("select * from %vt", testDB))

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -54,8 +54,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess := tk.Session().ShowProcess()
 	ps := []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res := tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_b(b)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_b(b)")
 	tk.MustExec("execute stmt1;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -66,16 +65,14 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_c(c)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_c(c)")
 
 	tk.MustExec("prepare stmt2 from 'delete t1, t2 from t1 inner join t2 on t1.b = t2.b';")
 	tk.MustExec("execute stmt2;")
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "HashJoin"), res.Rows())
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "HashJoin")
 	tk.MustExec("execute stmt2;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -85,8 +82,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "IndexJoin"), res.Rows())
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexJoin")
 
 	tk.MustExec("prepare stmt3 from 'update t1 set a = 1 where b = 1 and c > 1';")
 	tk.MustExec("execute stmt3;")
@@ -94,8 +90,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_b(b)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_b(b)")
 	tk.MustExec("execute stmt3;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -106,16 +101,14 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_c(c)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_c(c)")
 
 	tk.MustExec("prepare stmt4 from 'update t1, t2 set t1.a = 1 where t1.b = t2.b';")
 	tk.MustExec("execute stmt4;")
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "HashJoin"), res.Rows())
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "HashJoin")
 	tk.MustExec("execute stmt4;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -125,8 +118,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "IndexJoin"), res.Rows())
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexJoin")
 
 	tk.MustExec("prepare stmt5 from 'insert into t1 select * from t2 where t2.b = 2 and t2.c > 2';")
 	tk.MustExec("execute stmt5;")
@@ -134,8 +126,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_b(b)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_b(b)")
 	tk.MustExec("execute stmt5;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -146,8 +137,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_b(b)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_b(b)")
 
 	tk.MustExec("drop global binding for insert into t1 select * from t2 where t2.b = 1 and t2.c > 1")
 	tk.MustExec("create global binding for insert into t1 select * from t2 where t2.b = 1 and t2.c > 1 using insert into t1 select /*+ use_index(t2,idx_c) */ * from t2 where t2.b = 1 and t2.c > 1")
@@ -157,8 +147,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_c(c)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_c(c)")
 
 	tk.MustExec("prepare stmt6 from 'replace into t1 select * from t2 where t2.b = 2 and t2.c > 2';")
 	tk.MustExec("execute stmt6;")
@@ -166,8 +155,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_b(b)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_b(b)")
 	tk.MustExec("execute stmt6;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -178,8 +166,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "idx_c(c)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "idx_c(c)")
 
 	// TestExplain
 	tk.MustExec("drop table if exists t1")
@@ -192,8 +179,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "HashJoin"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "HashJoin")
 	tk.MustExec("execute stmt1;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -202,8 +188,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "MergeJoin"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "MergeJoin")
 	tk.MustExec("execute stmt2;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -213,8 +198,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "MergeJoin"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "MergeJoin")
 
 	tk.MustExec("drop global binding for SELECT * from t1,t2 where t1.id = t2.id")
 
@@ -224,8 +208,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "IndexReader"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexReader")
 	tk.MustExec("execute stmt1;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -234,8 +217,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.False(t, tk.HasPlan4ExplainFor(res, "IndexReader"))
+	tk.MustNotHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexReader")
 	tk.MustExec("execute stmt1;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -245,8 +227,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "IndexReader"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexReader")
 	tk.MustExec("execute stmt1;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -255,8 +236,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "IndexReader"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexReader")
 	tk.MustExec("execute stmt2;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -266,8 +246,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.HasPlan4ExplainFor(res, "IndexReader"))
+	tk.MustHavePlan("for connection "+strconv.FormatUint(tkProcess.ID, 10), "IndexReader")
 
 	tk.MustExec("drop global binding for SELECT * from t1 union SELECT * from t1")
 
@@ -281,8 +260,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "ia(a)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "ia(a)")
 	tk.MustExec("execute stmt1;")
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 
@@ -294,8 +272,7 @@ func TestPrepareCacheWithBinding(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	res = tk.MustQuery("explain for connection " + strconv.FormatUint(tkProcess.ID, 10))
-	require.True(t, tk.MustUseIndex4ExplainFor(res, "ib(b)"), res.Rows())
+	tk.MustUseIndexForConnection(strconv.FormatUint(tkProcess.ID, 10), "ib(b)")
 }
 
 // TestBindingSymbolList tests sql with "?, ?, ?, ?", fixes #13871
@@ -311,14 +288,14 @@ func TestBindingSymbolList(t *testing.T) {
 	// before binding
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 100")
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)")
 
 	tk.MustExec(`create global binding for select a, b from t where a = 1 limit 0, 1 using select a, b from t use index (ib) where a = 1 limit 0, 1`)
 
 	// after binding
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 100")
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ib(b)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ib(b)")
 
 	// Normalize
 	stmt, err := parser.New().ParseOneStmt("select a, b from test . t where a = 1 limit 0, 1", "", "")
@@ -354,14 +331,14 @@ func TestBindingInListWithSingleLiteral(t *testing.T) {
 	// before binding
 	tk.MustQuery(sqlcmd)
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex(sqlcmd, "ia(a)"))
+	tk.MustUseIndex(sqlcmd, "ia(a)")
 
 	tk.MustExec(bindingStmt)
 
 	// after binding
 	tk.MustQuery(sqlcmd)
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex(sqlcmd, "ib(b)"))
+	tk.MustUseIndex(sqlcmd, "ib(b)")
 
 	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
 
@@ -394,11 +371,11 @@ func TestBestPlanInBaselines(t *testing.T) {
 	// before binding
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 100")
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)")
 
 	tk.MustQuery("select a, b from t where b = 3 limit 1, 100")
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)"))
+	tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)")
 
 	tk.MustExec(`create global binding for select a, b from t where a = 1 limit 0, 1 using select /*+ use_index(@sel_1 test.t ia) */ a, b from t where a = 1 limit 0, 1`)
 	tk.MustExec(`create global binding for select a, b from t where b = 1 limit 0, 1 using select /*+ use_index(@sel_1 test.t ib) */ a, b from t where b = 1 limit 0, 1`)
@@ -415,11 +392,11 @@ func TestBestPlanInBaselines(t *testing.T) {
 
 	tk.MustQuery("select a, b from t where a = 3 limit 1, 10")
 	require.Equal(t, "t:ia", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)"))
+	tk.MustUseIndex("select a, b from t where a = 3 limit 1, 100", "ia(a)")
 
 	tk.MustQuery("select a, b from t where b = 3 limit 1, 100")
 	require.Equal(t, "t:ib", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)"))
+	tk.MustUseIndex("select a, b from t where b = 3 limit 1, 100", "ib(b)")
 }
 
 func TestIssue50646(t *testing.T) {
@@ -603,7 +580,7 @@ func TestInvisibleIndex(t *testing.T) {
 
 	tk.MustQuery("select * from t")
 	require.Equal(t, "t:idx_a", tk.Session().GetSessionVars().StmtCtx.IndexNames[0])
-	require.True(t, tk.MustUseIndex("select * from t", "idx_a(a)"))
+	tk.MustUseIndex("select * from t", "idx_a(a)")
 
 	tk.MustExec(`prepare stmt1 from 'select * from t'`)
 	tk.MustExec("execute stmt1")

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -687,16 +687,16 @@ func TestStaticPartitionPruneMode(t *testing.T) {
 					partition p1 values less than (22))`)
 	tk.MustExec(`insert into t values (1), (2), (3), (10), (11)`)
 	tk.MustExec(`analyze table t`)
-	require.True(t, tk.MustNoGlobalStats("t"))
+	tk.MustNoGlobalStats("t")
 	tk.MustExec("set @@tidb_partition_prune_mode='" + string(variable.Dynamic) + "'")
-	require.True(t, tk.MustNoGlobalStats("t"))
+	tk.MustNoGlobalStats("t")
 
 	tk.MustExec("set @@tidb_partition_prune_mode='" + string(variable.Static) + "'")
 	tk.MustExec(`insert into t values (4), (5), (6)`)
 	tk.MustExec(`analyze table t partition p0`)
-	require.True(t, tk.MustNoGlobalStats("t"))
+	tk.MustNoGlobalStats("t")
 	tk.MustExec("set @@tidb_partition_prune_mode='" + string(variable.Dynamic) + "'")
-	require.True(t, tk.MustNoGlobalStats("t"))
+	tk.MustNoGlobalStats("t")
 	tk.MustExec("set @@tidb_partition_prune_mode='" + string(variable.Static) + "'")
 }
 

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -386,16 +386,6 @@ func (tk *TestKit) NotHasKeywordInOperatorInfo(sql string, keyword string, args 
 	return true
 }
 
-// HasPlan4ExplainFor checks if the result execution plan contains specific plan.
-func (tk *TestKit) HasPlan4ExplainFor(result *Result, plan string) bool {
-	for i := range result.rows {
-		if strings.Contains(result.rows[i][0], plan) {
-			return true
-		}
-	}
-	return false
-}
-
 // Exec executes a sql statement using the prepared stmt API
 func (tk *TestKit) Exec(sql string, args ...any) (sqlexec.RecordSet, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
@@ -551,28 +541,25 @@ func (tk *TestKit) MustMatchErrMsg(sql string, errRx any) {
 }
 
 // MustUseIndex checks if the result execution plan contains specific index(es).
-func (tk *TestKit) MustUseIndex(sql string, index string, args ...any) bool {
+func (tk *TestKit) MustUseIndex(sql string, index string, args ...any) {
 	rs := tk.MustQuery("explain "+sql, args...)
 	for i := range rs.rows {
 		if strings.Contains(rs.rows[i][3], "index:"+index) {
-			return true
+			return
 		}
 	}
-	return false
+	tk.require.Fail("index not used", "sql:%s, args: %v, index:%s, plan:%v", sql, args, index, rs.rows)
 }
 
-// MustUseIndex4ExplainFor checks if the result execution plan contains specific index(es).
-func (tk *TestKit) MustUseIndex4ExplainFor(result *Result, index string) bool {
-	for i := range result.rows {
-		// It depends on whether we enable to collect the execution info.
-		if strings.Contains(result.rows[i][3], "index:"+index) {
-			return true
-		}
-		if strings.Contains(result.rows[i][4], "index:"+index) {
-			return true
+// MustUseIndexForConnection checks if the result execution plan contains specific index(es) for a connection.
+func (tk *TestKit) MustUseIndexForConnection(connID string, index string) {
+	rs := tk.MustQuery("explain for connection " + connID)
+	for i := range rs.rows {
+		if strings.Contains(rs.rows[i][4], "index:"+index) {
+			return
 		}
 	}
-	return false
+	tk.require.Fail("index not used", "connID:%s, index:%s, plan:%v", connID, index, rs.rows)
 }
 
 // CheckExecResult checks the affected rows and the insert id after executing MustExec.
@@ -623,17 +610,16 @@ func containGlobal(rs *Result) bool {
 }
 
 // MustNoGlobalStats checks if there is no global stats.
-func (tk *TestKit) MustNoGlobalStats(table string) bool {
+func (tk *TestKit) MustNoGlobalStats(table string) {
 	if containGlobal(tk.MustQuery("show stats_meta where table_name like '" + table + "'")) {
-		return false
+		tk.require.Fail("global stats should not be found")
 	}
 	if containGlobal(tk.MustQuery("show stats_buckets where table_name like '" + table + "'")) {
-		return false
+		tk.require.Fail("global stats should not be found")
 	}
 	if containGlobal(tk.MustQuery("show stats_histograms where table_name like '" + table + "'")) {
-		return false
+		tk.require.Fail("global stats should not be found")
 	}
-	return true
 }
 
 // CheckLastMessage checks last message after executing MustExec


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

Our `MustXXX` testkit should throw an error inside it, instead of returning a bool value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
