### PR TITLE
ttl: fix a wrong ttl's job schedule for TTL table upgraded from 6.5

### DIFF
--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1429,7 +1429,7 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *pmodel.CIS
 			restoreCtx.WriteKeyWord("TTL_JOB_INTERVAL")
 			restoreCtx.WritePlain("=")
 			if len(tableInfo.TTLInfo.JobInterval) == 0 {
-				restoreCtx.WriteString(model.DefaultJobInterval.String())
+				restoreCtx.WriteString(model.DefaultJobIntervalStr)
 			} else {
 				restoreCtx.WriteString(tableInfo.TTLInfo.JobInterval)
 			}

--- a/pkg/meta/model/BUILD.bazel
+++ b/pkg/meta/model/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
     deps = [
         "//pkg/parser/ast",
         "//pkg/parser/charset",
+        "//pkg/parser/duration",
         "//pkg/parser/model",
         "//pkg/parser/mysql",
         "//pkg/parser/terror",

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -1245,6 +1245,9 @@ func (s WindowRepeatType) String() string {
 // DefaultJobInterval sets the default interval between TTL jobs
 const DefaultJobInterval = time.Hour
 
+// DefaultJobIntervalStr is the string representation of DefaultJobInterval
+const DefaultJobIntervalStr = "1h"
+
 // TTLInfo records the TTL config
 type TTLInfo struct {
 	ColumnName      model.CIStr `json:"column"`

--- a/pkg/meta/model/table_test.go
+++ b/pkg/meta/model/table_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/pkg/parser/charset"
+	"github.com/pingcap/tidb/pkg/parser/duration"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
@@ -234,4 +235,11 @@ func TestClearReorgIntermediateInfo(t *testing.T) {
 	require.Equal(t, "", ptInfo.DDLExpr)
 	require.Equal(t, true, ptInfo.DDLColumns == nil)
 	require.Equal(t, int64(0), ptInfo.NewTableID)
+}
+
+func TestTTLDefaultJobInterval(t *testing.T) {
+	// test const `DefaultJobIntervalStr` and `DefaultJobInterval` are consistent.
+	d, err := duration.ParseDuration(DefaultJobIntervalStr)
+	require.NoError(t, err)
+	require.Equal(t, DefaultJobInterval, d)
 }

--- a/pkg/ttl/ttlworker/timer_sync.go
+++ b/pkg/ttl/ttlworker/timer_sync.go
@@ -252,9 +252,11 @@ func (g *TTLTimersSyncer) shouldSyncTimer(timer *timerapi.TimerRecord, schema pm
 
 	tags := getTimerTags(schema, tblInfo, partition)
 	ttlInfo := tblInfo.TTLInfo
+	policyType, policyExpr := getTTLSchedulePolicy(ttlInfo)
 	return !slices.Equal(timer.Tags, tags) ||
 		timer.Enable != ttlInfo.Enable ||
-		timer.SchedPolicyExpr != ttlInfo.JobInterval
+		timer.SchedPolicyType != policyType ||
+		timer.SchedPolicyExpr != policyExpr
 }
 
 func (g *TTLTimersSyncer) syncOneTimer(ctx context.Context, se session.Session, schema pmodel.CIStr, tblInfo *model.TableInfo, partition *model.PartitionDefinition, skipCache bool) (*timerapi.TimerRecord, error) {
@@ -305,12 +307,13 @@ func (g *TTLTimersSyncer) syncOneTimer(ctx context.Context, se session.Session, 
 			return nil, err
 		}
 
+		policyType, policyExpr := getTTLSchedulePolicy(ttlInfo)
 		timer, err = g.cli.CreateTimer(ctx, timerapi.TimerSpec{
 			Key:             key,
 			Tags:            tags,
 			Data:            data,
-			SchedPolicyType: timerapi.SchedEventInterval,
-			SchedPolicyExpr: ttlInfo.JobInterval,
+			SchedPolicyType: policyType,
+			SchedPolicyExpr: policyExpr,
 			HookClass:       timerHookClass,
 			Watermark:       watermark,
 			Enable:          ttlInfo.Enable,
@@ -329,7 +332,7 @@ func (g *TTLTimersSyncer) syncOneTimer(ctx context.Context, se session.Session, 
 
 	err = g.cli.UpdateTimer(ctx, timer.ID,
 		timerapi.WithSetTags(tags),
-		timerapi.WithSetSchedExpr(timerapi.SchedEventInterval, tblInfo.TTLInfo.JobInterval),
+		timerapi.WithSetSchedExpr(getTTLSchedulePolicy(tblInfo.TTLInfo)),
 		timerapi.WithSetEnable(tblInfo.TTLInfo.Enable),
 	)
 
@@ -394,4 +397,14 @@ func getTTLTableStatus(ctx context.Context, se session.Session, tblInfo *model.T
 	}
 
 	return cache.RowToTableStatus(se, rows[0])
+}
+
+// getTTLSchedulePolicy returns the timer's schedule policy and expression for a TTL job
+func getTTLSchedulePolicy(info *model.TTLInfo) (timerapi.SchedPolicyType, string) {
+	interval := info.JobInterval
+	if interval == "" {
+		// This only happens when the table is created from 6.5 in which the `tidb_job_interval` is not introduced yet.
+		interval = model.DefaultJobIntervalStr
+	}
+	return timerapi.SchedEventInterval, interval
 }

--- a/pkg/ttl/ttlworker/timer_test.go
+++ b/pkg/ttl/ttlworker/timer_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	timerapi "github.com/pingcap/tidb/pkg/timer/api"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -566,4 +567,24 @@ func TestTTLTimerRuntime(t *testing.T) {
 	require.NotNil(t, r.rt)
 	r.Pause()
 	require.Nil(t, r.rt)
+}
+
+func TestGetTTLSchedulePolicy(t *testing.T) {
+	// normal case
+	tp, expr := getTTLSchedulePolicy(&model.TTLInfo{
+		JobInterval: "12h",
+	})
+	require.Equal(t, timerapi.SchedEventInterval, tp)
+	require.Equal(t, "12h", expr)
+	_, err := timerapi.CreateSchedEventPolicy(tp, expr)
+	require.NoError(t, err)
+
+	// empty job interval
+	tp, expr = getTTLSchedulePolicy(&model.TTLInfo{
+		JobInterval: "",
+	})
+	require.Equal(t, timerapi.SchedEventInterval, tp)
+	require.Equal(t, model.DefaultJobIntervalStr, expr)
+	_, err = timerapi.CreateSchedEventPolicy(tp, expr)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56539

Problem Summary:

In 6.5, the TTL table is created without meta `ttl_job_interval`, so after upgraded, the `SCHED_POLICY_EXPR` in `mysql.tidb_timers` is also empty that causing the frequent scheduling of TTL job.

### What changed and how does it work?

When syncing the timer, insert a default value if `ttl_job_interval` is empty

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
