### PR TITLE
sessionctx: Deprecate static prune mode

### DIFF
--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2394,6 +2394,9 @@ var defaultSysVars = []*SysVar{
 		return s.PartitionPruneMode.Load(), nil
 	}, SetSession: func(s *SessionVars, val string) error {
 		newMode := strings.ToLower(strings.TrimSpace(val))
+		if PartitionPruneMode(newMode) == Static {
+			s.StmtCtx.AppendWarning(ErrWarnDeprecatedSyntaxSimpleMsg.FastGen("static prune mode is deprecated and will be removed in the future release."))
+		}
 		if PartitionPruneMode(s.PartitionPruneMode.Load()) == Static && PartitionPruneMode(newMode) == Dynamic {
 			s.StmtCtx.AppendWarning(errors.NewNoStackError("Please analyze all partition tables again for consistency between partition and global stats"))
 			s.StmtCtx.AppendWarning(errors.NewNoStackError("Please avoid setting partition prune mode to dynamic at session level and set partition prune mode to dynamic at global level"))
@@ -2402,6 +2405,9 @@ var defaultSysVars = []*SysVar{
 		return nil
 	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		newMode := strings.ToLower(strings.TrimSpace(val))
+		if PartitionPruneMode(newMode) == Static {
+			s.StmtCtx.AppendWarning(ErrWarnDeprecatedSyntaxSimpleMsg.FastGen("static prune mode is deprecated and will be removed in the future release."))
+		}
 		if PartitionPruneMode(newMode) == Dynamic {
 			s.StmtCtx.AppendWarning(errors.NewNoStackError("Please analyze all partition tables again for consistency between partition and global stats"))
 		}

--- a/pkg/table/tables/test/partition/partition_test.go
+++ b/pkg/table/tables/test/partition/partition_test.go
@@ -2066,7 +2066,7 @@ func TestPruneModeWarningInfo(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set @@tidb_partition_prune_mode = 'static'")
-	tk.MustQuery("show warnings").Check(testkit.Rows())
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1681 static prune mode is deprecated and will be removed in the future release."))
 	tk.MustExec("set session tidb_partition_prune_mode = 'dynamic'")
 	tk.MustQuery("show warnings").Sort().Check(testkit.Rows("Warning 1105 Please analyze all partition tables again for consistency between partition and global stats",
 		"Warning 1105 Please avoid setting partition prune mode to dynamic at session level and set partition prune mode to dynamic at global level"))

--- a/tests/integrationtest/r/executor/partition/table.result
+++ b/tests/integrationtest/r/executor/partition/table.result
@@ -14,11 +14,11 @@ dynamic
 set @@session.tidb_partition_prune_mode = "static";
 show warnings;
 Level	Code	Message
-Warning	1681	Static prune mode is deprecated and will be removed in a future release.
+Warning	1681	static prune mode is deprecated and will be removed in the future release.
 set @@global.tidb_partition_prune_mode = "static";
 show warnings;
 Level	Code	Message
-Warning	1681	Static prune mode is deprecated and will be removed in a future release.
+Warning	1681	static prune mode is deprecated and will be removed in the future release.
 select @@session.tidb_partition_prune_mode;
 @@session.tidb_partition_prune_mode
 static

--- a/tests/integrationtest/r/executor/partition/table.result
+++ b/tests/integrationtest/r/executor/partition/table.result
@@ -14,9 +14,11 @@ dynamic
 set @@session.tidb_partition_prune_mode = "static";
 show warnings;
 Level	Code	Message
+Warning	1681	Static prune mode is deprecated and will be removed in a future release.
 set @@global.tidb_partition_prune_mode = "static";
 show warnings;
 Level	Code	Message
+Warning	1681	Static prune mode is deprecated and will be removed in a future release.
 select @@session.tidb_partition_prune_mode;
 @@session.tidb_partition_prune_mode
 static


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #56490

Problem Summary: As #56490 mentioned, we will deprecate `static prune mode` at v8.5. And plan to remove it after v9.1 released.

ref doc link https://github.com/pingcap/docs-cn/pull/18857

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
