### PR TITLE
txn: test the `SAVEPOINT` statement with `foreign key`

### DIFF
--- a/pkg/executor/test/txn/BUILD.bazel
+++ b/pkg/executor/test/txn/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "txn_test.go",
     ],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/config",
         "//pkg/errno",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56562

### What changed and how does it work?

Add test about using both `foreign key` and `savepoint`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
