### PR TITLE
lightning: delete job.injected length check in TestDoImport

### DIFF
--- a/pkg/lightning/backend/local/local_test.go
+++ b/pkg/lightning/backend/local/local_test.go
@@ -2081,11 +2081,6 @@ func TestDoImport(t *testing.T) {
 	}
 	err = l.doImport(ctx, e, initRegionKeys, int64(config.SplitRegionSize), int64(config.SplitRegionKeys))
 	require.ErrorContains(t, err, "fatal error")
-	for _, v := range fakeRegionJobs {
-		for _, job := range v.jobs {
-			require.Len(t, job.injected, 0)
-		}
-	}
 }
 
 func TestRegionJobResetRetryCounter(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56413

Problem Summary: The result of TestDoImport (the last subtest) is flaky.

### What changed and how does it work?

Delete the "check if empty" for `job.injected` in the last subtest.

In the last subtest of TestDoImport, we check if `job.injected` is empty after running all jobs. However, a fatal error job will break the flow in advance, and it is possible that this happens before other jobs are executed, which may lead to test failure when checking their `job.injected`.

It is hard to controll the execution order of the jobs, since in `storeBalancer.pickJob()` sync.Map iterate items in a uncertain order. In addition, the first subtest already tested the length of `job.injected`, and the last test is intended for retryable error, so it is reasonable to delete the check in the last subtask.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
