### PR TITLE
*: replace reflect.TypeOf((*T)(nil)).Elem() with reflect.TypeFor[T]()

### DIFF
--- a/pkg/disttask/framework/taskexecutor/execute/interface.go
+++ b/pkg/disttask/framework/taskexecutor/execute/interface.go
@@ -68,7 +68,7 @@ type StepExecFrameworkInfo interface {
 	GetResource() *proto.StepResource
 }
 
-var stepExecFrameworkInfoName = reflect.TypeOf((*StepExecFrameworkInfo)(nil)).Elem().Name()
+var stepExecFrameworkInfoName = reflect.TypeFor[StepExecFrameworkInfo]().Name()
 
 type frameworkInfo struct {
 	resource *proto.StepResource


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

in go.122

The new function [TypeFor](https://tip.golang.org/pkg/reflect/#TypeFor) returns the [Type](https://tip.golang.org/pkg/reflect/#Type) that represents the type argument T. Previously, to get the reflect.Type value for a type, one had to use reflect.TypeOf((*T)(nil)).Elem(). This may now be written as reflect.TypeFor[T]().


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
