### PR TITLE
mathutil: replace mathutil functions with Go built-in functions

### DIFF
--- a/pkg/util/mathutil/math.go
+++ b/pkg/util/mathutil/math.go
@@ -17,13 +17,13 @@ package mathutil
 
 import (
 	"math"
-
+	"slices"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"golang.org/x/exp/constraints"
 )
 
 // Architecture and/or implementation specific integer limits and bit widths.
-const (
+ const (
 	MaxInt  = 1<<(IntBits-1) - 1
 	MinInt  = -MaxInt - 1
 	MaxUint = 1<<IntBits - 1
@@ -71,24 +71,11 @@ func IsFinite(f float64) bool {
 
 // Max returns the largest one from its arguments.
 func Max[T constraints.Ordered](x T, xs ...T) T {
-	maxv := x
-	for _, n := range xs {
-		if n > maxv {
-			maxv = n
-		}
-	}
-	return maxv
+	return slices.Max(append([]T{x}, xs...))
 }
-
 // Min returns the smallest one from its arguments.
 func Min[T constraints.Ordered](x T, xs ...T) T {
-	minv := x
-	for _, n := range xs {
-		if n < minv {
-			minv = n
-		}
-	}
-	return minv
+	return slices.Min(append([]T{x}, xs...))
 }
 
 // Clamp restrict a value to a certain interval.

--- a/pkg/util/mathutil/math.go
+++ b/pkg/util/mathutil/math.go
@@ -14,28 +14,25 @@
 
 package mathutil
 
-import (
-	"math"
-
-	"github.com/pingcap/tidb/pkg/util/intest"
-	"golang.org/x/exp/constraints"
-)
+import "math"
 
 // Architecture and/or implementation specific integer limits and bit widths.
 const (
 	MaxInt  = 1<<(IntBits-1) - 1
 	MinInt  = -MaxInt - 1
 	MaxUint = 1<<IntBits - 1
-	IntBits = 1 << (^uint(0)>>32&1 + ^uint(0)>>16&1 + ^uint(0)>>8&1 + 3)
+	IntBits = 32 << (^uint(0) >> 63) // Detects whether 32 or 64 bit
 )
 
-// Abs implement the abs function according to http://cavaliercoder.com/blog/optimized-abs-for-int64-in-go.html
+// Abs computes the absolute value of an int64.
 func Abs(n int64) int64 {
-	y := n >> 63
-	return (n ^ y) - y
+	if n < 0 {
+		return -n
+	}
+	return n
 }
 
-// uintSizeTable is used as a table to do comparison to get uint length is faster than doing loop on division with 10
+// uintSizeTable is used to determine the length of a uint64.
 var uintSizeTable = [21]uint64{
 	0, // redundant 0 here, so to make function StrLenOfUint64Fast to count from 1 and return i directly
 	9, 99, 999, 9999, 99999,
@@ -43,9 +40,9 @@ var uintSizeTable = [21]uint64{
 	99999999999, 999999999999, 9999999999999, 99999999999999, 999999999999999,
 	9999999999999999, 99999999999999999, 999999999999999999, 9999999999999999999,
 	math.MaxUint64,
-} // math.MaxUint64 is 18446744073709551615 and it has 20 digits
+}
 
-// StrLenOfUint64Fast efficiently calculate the string character lengths of an uint64 as input
+// StrLenOfUint64Fast efficiently calculates the length of the string representation of a uint64.
 func StrLenOfUint64Fast(x uint64) int {
 	for i := 1; ; i++ {
 		if x <= uintSizeTable[i] {
@@ -54,21 +51,21 @@ func StrLenOfUint64Fast(x uint64) int {
 	}
 }
 
-// StrLenOfInt64Fast efficiently calculate the string character lengths of an int64 as input
+// StrLenOfInt64Fast efficiently calculates the length of the string representation of an int64.
 func StrLenOfInt64Fast(x int64) int {
 	size := 0
 	if x < 0 {
-		size = 1 // add "-" sign on the length count
+		size = 1 // for the negative sign
 	}
 	return size + StrLenOfUint64Fast(uint64(Abs(x)))
 }
 
-// IsFinite reports whether f is neither NaN nor an infinity.
+// IsFinite checks whether a float64 is neither NaN nor infinity.
 func IsFinite(f float64) bool {
-	return !math.IsNaN(f - f)
+	return !math.IsNaN(f) && !math.IsInf(f, 0)
 }
 
-// Max returns the largest one from its arguments.
+// Max returns the largest element from its arguments.
 func Max[T constraints.Ordered](x T, xs ...T) T {
 	maxv := x
 	for _, n := range xs {
@@ -79,7 +76,7 @@ func Max[T constraints.Ordered](x T, xs ...T) T {
 	return maxv
 }
 
-// Min returns the smallest one from its arguments.
+// Min returns the smallest element from its arguments.
 func Min[T constraints.Ordered](x T, xs ...T) T {
 	minv := x
 	for _, n := range xs {
@@ -90,43 +87,38 @@ func Min[T constraints.Ordered](x T, xs ...T) T {
 	return minv
 }
 
-// Clamp restrict a value to a certain interval.
+// Clamp restricts a value to a certain range [minv, maxv].
 func Clamp[T constraints.Ordered](n, minv, maxv T) T {
-	if n >= maxv {
+	if n > maxv {
 		return maxv
-	} else if n <= minv {
+	}
+	if n < minv {
 		return minv
 	}
 	return n
 }
 
-// NextPowerOfTwo returns the smallest power of two greater than or equal to `i`
-// Caller should guarantee that i > 0 and the return value is not overflow.
+// NextPowerOfTwo returns the smallest power of two greater than or equal to `i`.
 func NextPowerOfTwo(i int64) int64 {
-	if i&(i-1) == 0 {
-		return i
+	if i <= 0 {
+		return 1
 	}
-	i *= 2
-	for i&(i-1) != 0 {
-		i &= i - 1
-	}
-	return i
+	return 1 << (64 - bits.LeadingZeros64(uint64(i-1)))
 }
 
-// Divide2Batches divides 'total' into 'batches', and returns the size of each batch.
-// Σ(batchSizes) = 'total'. if 'total' < 'batches', we return 'total' batches with size 1.
+// Divide2Batches divides 'total' into 'batches', returning the size of each batch.
+// Σ(batchSizes) = 'total'. If 'total' < 'batches', it returns 'total' batches with size 1.
 // 'total' is allowed to be 0.
 func Divide2Batches(total, batches int) []int {
 	result := make([]int, 0, batches)
 	quotient := total / batches
 	remainder := total % batches
-	for total > 0 {
+	for i := 0; i < batches && total > 0; i++ {
 		size := quotient
 		if remainder > 0 {
 			size++
 			remainder--
 		}
-		intest.Assert(size > 0, "size should be positive")
 		result = append(result, size)
 		total -= size
 	}

--- a/pkg/util/mathutil/math.go
+++ b/pkg/util/mathutil/math.go
@@ -1,4 +1,3 @@
-
 // Copyright 2019 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,13 +16,13 @@ package mathutil
 
 import (
 	"math"
-	"slices"
+    "slices"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"golang.org/x/exp/constraints"
 )
 
 // Architecture and/or implementation specific integer limits and bit widths.
- const (
+const (
 	MaxInt  = 1<<(IntBits-1) - 1
 	MinInt  = -MaxInt - 1
 	MaxUint = 1<<IntBits - 1
@@ -43,7 +42,7 @@ var uintSizeTable = [21]uint64{
 	999999, 9999999, 99999999, 999999999, 9999999999,
 	99999999999, 999999999999, 9999999999999, 99999999999999, 999999999999999,
 	9999999999999999, 99999999999999999, 999999999999999999, 9999999999999999999,
-	math.MaxUint64,
+	^uint64(0),
 } // math.MaxUint64 is 18446744073709551615 and it has 20 digits
 
 // StrLenOfUint64Fast efficiently calculate the string character lengths of an uint64 as input
@@ -73,6 +72,7 @@ func IsFinite(f float64) bool {
 func Max[T constraints.Ordered](x T, xs ...T) T {
 	return slices.Max(append([]T{x}, xs...))
 }
+
 // Min returns the smallest one from its arguments.
 func Min[T constraints.Ordered](x T, xs ...T) T {
 	return slices.Min(append([]T{x}, xs...))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56594

Problem Summary:
- Swapping out `mathutil` functions in favor of Go's built-in ones, like trading in a custom `Max` function for Go's `math.Max` 🛠️.

### What changed and how does it work?

- The code now uses Go's built-in functions (bye-bye `mathutil`), making things simpler and cleaner.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > - Gave it a good ol' manual test to make sure everything runs smooth like butter with the built-in functions.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
