### PR TITLE
ddl: add `lease not found` and `deadline exceed` to retryable errors

### DIFF
--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -17,7 +17,6 @@ package ddl
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
@@ -28,10 +27,8 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/table"
-	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/tikv/client-go/v2/tikv"
 	"go.uber.org/zap"
 )
@@ -222,23 +219,6 @@ func (s *backfillDistExecutor) GetStepExecutor(task *proto.Task) (execute.StepEx
 
 func (*backfillDistExecutor) IsIdempotent(*proto.Subtask) bool {
 	return true
-}
-
-func isRetryableError(err error) bool {
-	errMsg := err.Error()
-	for _, m := range dbterror.ReorgRetryableErrMsgs {
-		if strings.Contains(errMsg, m) {
-			return true
-		}
-	}
-	originErr := errors.Cause(err)
-	if tErr, ok := originErr.(*terror.Error); ok {
-		sqlErr := terror.ToSQLError(tErr)
-		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]
-		return ok
-	}
-	// can't retry Unknown err.
-	return false
 }
 
 func (*backfillDistExecutor) IsRetryableError(err error) bool {

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -225,6 +225,9 @@ func (*backfillDistExecutor) IsIdempotent(*proto.Subtask) bool {
 
 func isRetryableError(err error) bool {
 	originErr := errors.Cause(err)
+	if _, ok := originErr.(dbterror.ReorgRetryableError); ok {
+		return true
+	}
 	if tErr, ok := originErr.(*terror.Error); ok {
 		sqlErr := terror.ToSQLError(tErr)
 		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1268,6 +1268,9 @@ func errorIsRetryable(err error, job *model.Job) bool {
 		return false
 	}
 	originErr := errors.Cause(err)
+	if _, ok := originErr.(dbterror.ReorgRetryableError); ok {
+		return true
+	}
 	if tErr, ok := originErr.(*terror.Error); ok {
 		sqlErr := terror.ToSQLError(tErr)
 		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -832,7 +832,7 @@ func (w *worker) checkVectorIndexProcessOnTiFlash(jobCtx *jobContext, job *model
 		if dbterror.ErrWaitReorgTimeout.Equal(err) {
 			return false, ver, nil
 		}
-		if !errorIsRetryable(err, job) {
+		if !isRetryableJobError(err, job.ErrorCount) {
 			logutil.DDLLogger().Warn("run add vector index job failed, convert job to rollback", zap.Stringer("job", job), zap.Error(err))
 			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), []*model.IndexInfo{indexInfo}, err)
 		}
@@ -970,7 +970,7 @@ SwitchIndexState:
 		var reorgTp model.ReorgType
 		reorgTp, err = pickBackfillType(job)
 		if err != nil {
-			if !errorIsRetryable(err, job) {
+			if !isRetryableJobError(err, job.ErrorCount) {
 				job.State = model.JobStateCancelled
 			}
 			return ver, err
@@ -1250,7 +1250,7 @@ func runIngestReorgJob(w *worker, jobCtx *jobContext, job *model.Job,
 		if kv.ErrKeyExists.Equal(err) {
 			logutil.DDLLogger().Warn("import index duplicate key, convert job to rollback", zap.Stringer("job", job), zap.Error(err))
 			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), allIndexInfos, err)
-		} else if !errorIsRetryable(err, job) {
+		} else if !isRetryableJobError(err, job.ErrorCount) {
 			logutil.DDLLogger().Warn("run reorg job failed, convert job to rollback",
 				zap.String("job", job.String()), zap.Error(err))
 			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), allIndexInfos, err)
@@ -1263,10 +1263,14 @@ func runIngestReorgJob(w *worker, jobCtx *jobContext, job *model.Job,
 	return done, ver, nil
 }
 
-func errorIsRetryable(err error, job *model.Job) bool {
-	if job.ErrorCount+1 >= variable.GetDDLErrorCountLimit() {
+func isRetryableJobError(err error, jobErrCnt int64) bool {
+	if jobErrCnt+1 >= variable.GetDDLErrorCountLimit() {
 		return false
 	}
+	return isRetryableError(err)
+}
+
+func isRetryableError(err error) bool {
 	errMsg := err.Error()
 	for _, m := range dbterror.ReorgRetryableErrMsgs {
 		if strings.Contains(errMsg, m) {
@@ -1342,7 +1346,7 @@ func runReorgJobAndHandleErr(
 		}
 		// TODO(tangenta): get duplicate column and match index.
 		err = ingest.TryConvertToKeyExistsErr(err, allIndexInfos[0], tbl.Meta())
-		if !errorIsRetryable(err, job) {
+		if !isRetryableJobError(err, job.ErrorCount) {
 			logutil.DDLLogger().Warn("run add index job failed, convert job to rollback", zap.Stringer("job", job), zap.Error(err))
 			ver, err = convertAddIdxJob2RollbackJob(jobCtx, job, tbl.Meta(), allIndexInfos, err)
 			if err1 := rh.RemoveDDLReorgHandle(job, reorgInfo.elements); err1 != nil {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1267,10 +1267,13 @@ func errorIsRetryable(err error, job *model.Job) bool {
 	if job.ErrorCount+1 >= variable.GetDDLErrorCountLimit() {
 		return false
 	}
-	originErr := errors.Cause(err)
-	if _, ok := originErr.(dbterror.ReorgRetryableError); ok {
-		return true
+	errMsg := err.Error()
+	for _, m := range dbterror.ReorgRetryableErrMsgs {
+		if strings.Contains(errMsg, m) {
+			return true
+		}
 	}
+	originErr := errors.Cause(err)
 	if tErr, ok := originErr.(*terror.Error); ok {
 		sqlErr := terror.ToSQLError(tErr)
 		_, ok := dbterror.ReorgRetryableErrCodes[sqlErr.Code]

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -604,7 +604,7 @@ func (w *worker) transitOneJobStep(jobCtx *jobContext, job *model.Job) (int64, e
 	jobCtx.addUnSynced(job.ID)
 
 	// If error is non-retryable, we can ignore the sleep.
-	if runJobErr != nil && errorIsRetryable(runJobErr, job) {
+	if runJobErr != nil && isRetryableJobError(runJobErr, job.ErrorCount) {
 		jobCtx.logger.Info("run DDL job failed, sleeps a while then retries it.",
 			zap.Duration("waitTime", GetWaitTimeWhenErrorOccurred()), zap.Error(runJobErr))
 		// wait a while to retry again. If we don't wait here, DDL will retry this job immediately,

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -530,10 +530,8 @@ func AcquireDistributedLock(
 		}
 		return false, nil
 	})
-	failpoint.Inject("mockAcquireDistLockFailed", func(val failpoint.Value) {
-		if ok := val.(bool); ok {
-			err = errors.Errorf("requested lease not found")
-		}
+	failpoint.Inject("mockAcquireDistLockFailed", func() {
+		err = errors.Errorf("requested lease not found")
 	})
 	if err != nil {
 		err1 := se.Close()

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -503,7 +503,7 @@ var (
 	ErrWarnGlobalIndexNeedManuallyAnalyze = ClassDDL.NewStd(mysql.ErrWarnGlobalIndexNeedManuallyAnalyze)
 )
 
-// ReorgRetryableErrCodes is the error codes that are retryable for reorganization.
+// ReorgRetryableErrCodes are the error codes that are retryable for reorganization.
 var ReorgRetryableErrCodes = map[uint16]struct{}{
 	mysql.ErrPDServerTimeout:           {},
 	mysql.ErrTiKVServerTimeout:         {},
@@ -527,17 +527,8 @@ var ReorgRetryableErrCodes = map[uint16]struct{}{
 	uint16(terror.CodeResultUndetermined): {},
 }
 
-// ReorgRetryableError is the retryable error during DDL reorganization.
-type ReorgRetryableError struct {
-	message string
-}
-
-// Error implements error interface.
-func (r ReorgRetryableError) Error() string {
-	return r.message
-}
-
-// NewReorgRetryableError creates a new ReorgRetryableError.
-func NewReorgRetryableError(msg string) ReorgRetryableError {
-	return ReorgRetryableError{message: msg}
+// ReorgRetryableErrMsgs are the error messages that are retryable for reorganization.
+var ReorgRetryableErrMsgs = []string{
+	"context deadline exceeded",
+	"requested lease not found",
 }

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -526,3 +526,18 @@ var ReorgRetryableErrCodes = map[uint16]struct{}{
 	// Temporary network partitioning may cause pk commit failure.
 	uint16(terror.CodeResultUndetermined): {},
 }
+
+// ReorgRetryableError is the retryable error during DDL reorganization.
+type ReorgRetryableError struct {
+	message string
+}
+
+// Error implements error interface.
+func (r ReorgRetryableError) Error() string {
+	return r.message
+}
+
+// NewReorgRetryableError creates a new ReorgRetryableError.
+func NewReorgRetryableError(msg string) ReorgRetryableError {
+	return ReorgRetryableError{message: msg}
+}

--- a/tests/realtikvtest/addindextest3/ingest_test.go
+++ b/tests/realtikvtest/addindextest3/ingest_test.go
@@ -538,14 +538,14 @@ func TestAddIndexIngestFailures(t *testing.T) {
 	tk.MustExec("insert into t values (1, 1, 1);")
 
 	// Test precheck failed.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed", "return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed", "1*return"))
 	tk.MustGetErrMsg("alter table t add index idx(b);", "[ddl:8256]Check ingest environment failed: mock error")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockIngestCheckEnvFailed"))
 
 	tk.MustExec(`set global tidb_enable_dist_task=on;`)
 	// Test reset engine failed.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed", "return"))
-	tk.MustGetErrMsg("alter table t add index idx(b);", "[0]mock reset engine failed")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed", "1*return"))
+	tk.MustExec("alter table t add index idx(b);")
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/ingest/mockResetEngineFailed"))
 	tk.MustExec(`set global tidb_enable_dist_task=off;`)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56550

Problem Summary:

```
[2024/10/02 17:46:51.687 +08:00] [INFO] [info.go:1001] ["get key failed"] [key=/tidb/server/info] [error="context deadline exceeded"]
[2024/10/02 17:46:52.841 +08:00] [WARN] [manager.go:536] ["close session error"] [error="etcdserver: requested lease not found"]
[2024/10/02 17:46:52.841 +08:00] [ERROR] [backfilling_operators.go:962] ["import error"] [task-id=120028] [subtask-id=120055] [category=ddl] [error="etcdserver: requested lease not found"]
[2024/10/02 17:46:52.841 +08:00] [INFO] [backend.go:352] ["engine close start"] [category=ddl-ingest] [engineTag=sbtest1:35] [engineUUID=dd035f55-b760-5f2e-b67a-4e79ffec0f3d]
[2024/10/02 17:46:52.842 +08:00] [INFO] [backend.go:354] ["engine close completed"] [category=ddl-ingest] [engineTag=sbtest1:35] [engineUUID=dd035f55-b760-5f2e-b67a-4e79ffec0f3d] [takeTime=860.297µs] []
[2024/10/02 17:46:52.842 +08:00] [INFO] [backend.go:413] ["cleanup start"] [category=ddl-ingest] [engineTag=sbtest1:35] [engineUUID=dd035f55-b760-5f2e-b67a-4e79ffec0f3d]
[2024/10/02 17:46:52.948 +08:00] [INFO] [reorg.go:451] ["run reorg job wait timeout"] [category=ddl] ["wait time"=5s] ["total added row count"=70003100]
[2024/10/02 17:46:52.949 +08:00] [INFO] [job_worker.go:981] ["schema version doesn't change"] [category=ddl] [jobID=430]
[2024/10/02 17:46:52.956 +08:00] [INFO] [job_worker.go:763] ["run DDL job"] [category=ddl] [jobID=430] [conn=3544189572] [job="ID:430, Type:add index, State:running, SchemaState:write reorganization, SchemaID:358, TableID:245, RowCount:70003100, ArgLen:0, start time: 2024-10-02 17:43:21.782 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:452948709115691080, Version: v1, UniqueWarnings:0"]
[2024/10/02 17:46:52.960 +08:00] [INFO] [index.go:1211] ["index backfill state running"] [category=ddl] ["job ID"=430] [table=sbtest1] ["ingest mode"=true] [index=index_test_1727862201803]
```

This is introduced by #56184.

### What changed and how does it work?

Add "lease not found" and "deadline exceed" to retryable errors.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
