### PR TITLE
*: force forbiding to use `mock.NewContext` in production code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,9 +231,9 @@ enterprise-docker: init-submodule enterprise-prepare
 enterprise-server-build: TIDB_EDITION=Enterprise
 enterprise-server-build:
 ifeq ($(TARGET), "")
-	CGO_ENABLED=1 $(GOBUILD) -tags enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o bin/tidb-server cmd/tidb-server/main.go
+	CGO_ENABLED=1 $(GOBUILD) -tags=codes,enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o bin/tidb-server cmd/tidb-server/main.go
 else
-	CGO_ENABLED=1 $(GOBUILD) -tags enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o '$(TARGET)' cmd/tidb-server/main.go
+	CGO_ENABLED=1 $(GOBUILD) -tags=codes,enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o '$(TARGET)' cmd/tidb-server/main.go
 endif
 
 .PHONY: enterprise-server
@@ -387,7 +387,7 @@ lightning_web:
 
 .PHONY: build_br
 build_br:
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) ./br/cmd/br
+	CGO_ENABLED=1 $(GOBUILD) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) ./br/cmd/br
 
 .PHONY: build_lightning_for_web
 build_lightning_for_web:
@@ -395,7 +395,7 @@ build_lightning_for_web:
 
 .PHONY: build_lightning
 build_lightning:
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) ./lightning/cmd/tidb-lightning
+	CGO_ENABLED=1 $(GOBUILD) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) ./lightning/cmd/tidb-lightning
 
 .PHONY: build_lightning-ctl
 build_lightning-ctl:

--- a/Makefile
+++ b/Makefile
@@ -646,12 +646,12 @@ bazel_build:
 	bazel $(BAZEL_GLOBAL_CONFIG) build $(BAZEL_CMD_CONFIG) \
 		//... --//build:with_nogo_flag=$(NOGO_FLAG)
 	bazel $(BAZEL_GLOBAL_CONFIG) build $(BAZEL_CMD_CONFIG) \
-		//cmd/importer:importer //cmd/tidb-server:tidb-server //cmd/tidb-server:tidb-server-check --//build:with_nogo_flag=$(NOGO_FLAG)
+		//cmd/importer:importer //cmd/tidb-server:tidb-server //cmd/tidb-server:tidb-server-check --define gotags=codes --//build:with_nogo_flag=$(NOGO_FLAG)
 	cp bazel-out/k8-fastbuild/bin/cmd/tidb-server/tidb-server_/tidb-server ./bin
 	cp bazel-out/k8-fastbuild/bin/cmd/importer/importer_/importer      ./bin
 	cp bazel-out/k8-fastbuild/bin/cmd/tidb-server/tidb-server-check_/tidb-server-check ./bin
 	bazel $(BAZEL_GLOBAL_CONFIG) build $(BAZEL_CMD_CONFIG) \
-		//cmd/tidb-server:tidb-server --stamp --workspace_status_command=./build/print-enterprise-workspace-status.sh --define gotags=enterprise
+		//cmd/tidb-server:tidb-server --stamp --workspace_status_command=./build/print-enterprise-workspace-status.sh --define gotags=codes,enterprise
 	./bazel-out/k8-fastbuild/bin/cmd/tidb-server/tidb-server_/tidb-server -V
 
 .PHONY: bazel_fail_build

--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -142,6 +142,7 @@ func main() {
 	outputFile := filepath.Join(outDir, pluginName+"-"+version+".so")
 	ctx := context.Background()
 	buildCmd := exec.CommandContext(ctx, "go", "build",
+		"-tags=codes",
 		"-buildmode=plugin",
 		"-o", outputFile, pkgDir)
 	buildCmd.Dir = pkgDir

--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -162,7 +162,6 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/mathutil",
         "//pkg/util/memory",
-        "//pkg/util/mock",
         "//pkg/util/ppcpuusage",
         "//pkg/util/ranger",
         "//pkg/util/rowDecoder",

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -56,7 +56,6 @@ import (
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/intest"
-	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tidb/pkg/util/timeutil"
@@ -553,12 +552,6 @@ func getTableTotalCount(w *worker, tblInfo *model.TableInfo) int64 {
 		return statistics.PseudoRowCount
 	}
 	defer w.sessPool.Put(ctx)
-
-	// `mock.Context` is used in tests, which doesn't support sql exec
-	if _, ok := ctx.(*mock.Context); ok {
-		return statistics.PseudoRowCount
-	}
-
 	executor := ctx.GetRestrictedSQLExecutor()
 	var rows []chunk.Row
 	if tblInfo.Partition != nil && len(tblInfo.Partition.DroppingDefinitions) > 0 {

--- a/pkg/ddl/util/BUILD.bazel
+++ b/pkg/ddl/util/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/table/tables",
         "//pkg/util/chunk",
-        "//pkg/util/mock",
         "//pkg/util/sqlexec",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/executor/benchmark_test.go
+++ b/pkg/executor/benchmark_test.go
@@ -210,7 +210,7 @@ func BenchmarkShuffleStreamAggRows(b *testing.B) {
 	for _, row := range rows {
 		for _, con := range concurrencies {
 			for _, sorted := range sortTypes {
-				cas := testutil.DefaultAggTestCase("stream")
+				cas := testutil.DefaultAggTestCase(mock.NewContext(), "stream")
 				cas.Rows = row
 				cas.DataSourceSorted = sorted
 				cas.Concurrency = con
@@ -227,7 +227,7 @@ func BenchmarkHashAggRows(b *testing.B) {
 	concurrencies := []int{1, 4, 8, 15, 20, 30, 40}
 	for _, row := range rows {
 		for _, con := range concurrencies {
-			cas := testutil.DefaultAggTestCase("hash")
+			cas := testutil.DefaultAggTestCase(mock.NewContext(), "hash")
 			cas.Rows = row
 			cas.Concurrency = con
 			b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
@@ -241,7 +241,7 @@ func BenchmarkAggGroupByNDV(b *testing.B) {
 	NDVs := []int{10, 100, 1000, 10000, 100000, 1000000, 10000000}
 	for _, NDV := range NDVs {
 		for _, exec := range []string{"hash", "stream"} {
-			cas := testutil.DefaultAggTestCase(exec)
+			cas := testutil.DefaultAggTestCase(mock.NewContext(), exec)
 			cas.GroupByNDV = NDV
 			b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 				benchmarkAggExecWithCase(b, cas)
@@ -254,7 +254,7 @@ func BenchmarkAggConcurrency(b *testing.B) {
 	concs := []int{1, 4, 8, 15, 20, 30, 40}
 	for _, con := range concs {
 		for _, exec := range []string{"hash", "stream"} {
-			cas := testutil.DefaultAggTestCase(exec)
+			cas := testutil.DefaultAggTestCase(mock.NewContext(), exec)
 			cas.Concurrency = con
 			b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 				benchmarkAggExecWithCase(b, cas)
@@ -269,7 +269,7 @@ func BenchmarkAggDistinct(b *testing.B) {
 	for _, row := range rows {
 		for _, exec := range []string{"hash", "stream"} {
 			for _, distinct := range distincts {
-				cas := testutil.DefaultAggTestCase(exec)
+				cas := testutil.DefaultAggTestCase(mock.NewContext(), exec)
 				cas.Rows = row
 				cas.HasDistinct = distinct
 				b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
@@ -414,7 +414,7 @@ func baseBenchmarkWindowRows(b *testing.B, pipelined int) {
 	for _, row := range rows {
 		for _, ndv := range ndvs {
 			for _, con := range concs {
-				cas := testutil.DefaultWindowTestCase()
+				cas := testutil.DefaultWindowTestCase(mock.NewContext())
 				cas.Rows = row
 				cas.Ndv = ndv
 				cas.Concurrency = con
@@ -452,7 +452,7 @@ func baseBenchmarkWindowFunctions(b *testing.B, pipelined int) {
 	concs := []int{1, 4}
 	for _, windowFunc := range windowFuncs {
 		for _, con := range concs {
-			cas := testutil.DefaultWindowTestCase()
+			cas := testutil.DefaultWindowTestCase(mock.NewContext())
 			cas.Rows = 100000
 			cas.Ndv = 1000
 			cas.Concurrency = con
@@ -487,7 +487,7 @@ func baseBenchmarkWindowFunctionsWithFrame(b *testing.B, pipelined int) {
 		for _, sorted := range sortTypes {
 			for _, numFunc := range numFuncs {
 				for _, con := range concs {
-					cas := testutil.DefaultWindowTestCase()
+					cas := testutil.DefaultWindowTestCase(mock.NewContext())
 					cas.Rows = 100000
 					cas.Ndv = 1000
 					cas.Concurrency = con
@@ -516,7 +516,7 @@ func baseBenchmarkWindowFunctionsAggWindowProcessorAboutFrame(b *testing.B, pipe
 	b.ReportAllocs()
 	windowFunc := ast.AggFuncMax
 	frame := &logicalop.WindowFrame{Type: ast.Rows, Start: &logicalop.FrameBound{UnBounded: true}, End: &logicalop.FrameBound{UnBounded: true}}
-	cas := testutil.DefaultWindowTestCase()
+	cas := testutil.DefaultWindowTestCase(mock.NewContext())
 	cas.Rows = 10000
 	cas.Ndv = 10
 	cas.Concurrency = 1
@@ -560,7 +560,7 @@ func baseBenchmarkWindowFunctionsWithSlidingWindow(b *testing.B, frameType ast.F
 		End:   &logicalop.FrameBound{Type: ast.Following, Num: 10},
 	}
 	for _, windowFunc := range windowFuncs {
-		cas := testutil.DefaultWindowTestCase()
+		cas := testutil.DefaultWindowTestCase(mock.NewContext())
 		cas.Ctx.GetSessionVars().WindowingUseHighPrecision = false
 		cas.Rows = row
 		cas.Ndv = ndv
@@ -1843,7 +1843,7 @@ func benchmarkLimitExec(b *testing.B, cas *testutil.LimitCase) {
 
 func BenchmarkLimitExec(b *testing.B) {
 	b.ReportAllocs()
-	cas := testutil.DefaultLimitTestCase()
+	cas := testutil.DefaultLimitTestCase(mock.NewContext())
 	usingInlineProjection := []bool{false, true}
 	for _, inlineProjection := range usingInlineProjection {
 		cas.UsingInlineProjection = inlineProjection

--- a/pkg/executor/internal/testutil/BUILD.bazel
+++ b/pkg/executor/internal/testutil/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/types",
         "//pkg/util/chunk",
         "//pkg/util/memory",
-        "//pkg/util/mock",
         "//pkg/util/serialization",
         "//pkg/util/stringutil",
     ],

--- a/pkg/executor/internal/testutil/agg.go
+++ b/pkg/executor/internal/testutil/agg.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
 // AggTestCase has a fixed schema (aggCol Double, groupBy LongLong).
@@ -53,8 +52,7 @@ func (a AggTestCase) String() string {
 }
 
 // DefaultAggTestCase returns default agg test case
-func DefaultAggTestCase(exec string) *AggTestCase {
-	ctx := mock.NewContext()
+func DefaultAggTestCase(ctx sessionctx.Context, exec string) *AggTestCase {
 	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
 	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
 	// return &AggTestCase{exec, ast.AggFuncSum, 1000, false, 10000000, 4, true, ctx}

--- a/pkg/executor/internal/testutil/limit.go
+++ b/pkg/executor/internal/testutil/limit.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/memory"
-	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
 // LimitCase is the limit case
@@ -51,8 +50,7 @@ func (tc LimitCase) String() string {
 }
 
 // DefaultLimitTestCase returns default limit test case
-func DefaultLimitTestCase() *LimitCase {
-	ctx := mock.NewContext()
+func DefaultLimitTestCase(ctx sessionctx.Context) *LimitCase {
 	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
 	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
 	ctx.GetSessionVars().StmtCtx.MemTracker = memory.NewTracker(-1, -1)

--- a/pkg/executor/internal/testutil/sort.go
+++ b/pkg/executor/internal/testutil/sort.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/memory"
-	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
 // SortCase is the sort case
@@ -48,8 +47,7 @@ func (tc SortCase) String() string {
 }
 
 // DefaultSortTestCase returns default sort test case
-func DefaultSortTestCase() *SortCase {
-	ctx := mock.NewContext()
+func DefaultSortTestCase(ctx sessionctx.Context) *SortCase {
 	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
 	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
 	ctx.GetSessionVars().StmtCtx.MemTracker = memory.NewTracker(-1, -1)
@@ -58,8 +56,7 @@ func DefaultSortTestCase() *SortCase {
 }
 
 // SortTestCaseWithMemoryLimit returns sort test case
-func SortTestCaseWithMemoryLimit(bytesLimit int64) *SortCase {
-	ctx := mock.NewContext()
+func SortTestCaseWithMemoryLimit(ctx sessionctx.Context, bytesLimit int64) *SortCase {
 	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
 	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
 	ctx.GetSessionVars().MemTracker = memory.NewTracker(-1, bytesLimit)

--- a/pkg/executor/internal/testutil/window.go
+++ b/pkg/executor/internal/testutil/window.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
 // WindowTestCase has a fixed schema (col Double, partitionBy LongLong, rawData VarString(16), col LongLong).
@@ -50,8 +49,7 @@ func (a WindowTestCase) String() string {
 }
 
 // DefaultWindowTestCase returns default window test case
-func DefaultWindowTestCase() *WindowTestCase {
-	ctx := mock.NewContext()
+func DefaultWindowTestCase(ctx sessionctx.Context) *WindowTestCase {
 	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
 	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
 	return &WindowTestCase{

--- a/pkg/executor/sortexec/benchmark_test.go
+++ b/pkg/executor/sortexec/benchmark_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/mock"
 )
 
 func benchmarkSortExec(b *testing.B, cas *testutil.SortCase) {
@@ -101,7 +102,7 @@ func benchmarkSortExecDerivateCases(b *testing.B, cas *testutil.SortCase) {
 
 func BenchmarkSortExec(b *testing.B) {
 	b.ReportAllocs()
-	cas := testutil.DefaultSortTestCase()
+	cas := testutil.DefaultSortTestCase(mock.NewContext())
 	benchmarkSortExecDerivateCases(b, cas)
 }
 
@@ -111,6 +112,6 @@ func BenchmarkSortExecSpillToDisk(b *testing.B) {
 	defer variable.EnableTmpStorageOnOOM.Store(enableTmpStorageOnOOMCurrentVal)
 
 	b.ReportAllocs()
-	cas := testutil.SortTestCaseWithMemoryLimit(1)
+	cas := testutil.SortTestCaseWithMemoryLimit(mock.NewContext(), 1)
 	benchmarkSortExecDerivateCases(b, cas)
 }

--- a/pkg/planner/core/mock.go
+++ b/pkg/planner/core/mock.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !codes
+
 package core
 
 import (

--- a/pkg/statistics/handle/autoanalyze/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/testkit",
         "//pkg/types",
         "//pkg/util/chunk",
+        "//pkg/util/mock",
         "//pkg/util/sqlexec/mock",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",

--- a/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze_test.go
@@ -36,11 +36,19 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	mockexec "github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/pingcap/tidb/pkg/util/sqlexec/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/mock/gomock"
 )
+
+// WrapAsSCtx wraps the MockRestrictedSQLExecutor into sessionctx.Context.
+func WrapAsSCtx(exec *mock.MockRestrictedSQLExecutor) sessionctx.Context {
+	sctx := mockexec.NewContext()
+	sctx.SetValue(mock.RestrictedSQLExecutorKey{}, exec)
+	return sctx
+}
 
 func TestEnableAutoAnalyzePriorityQueue(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
@@ -506,7 +514,7 @@ func TestCleanupCorruptedAnalyzeJobsOnCurrentInstance(t *testing.T) {
 	).Return(nil, nil, nil)
 
 	err := autoanalyze.CleanupCorruptedAnalyzeJobsOnCurrentInstance(
-		mock.WrapAsSCtx(exec),
+		WrapAsSCtx(exec),
 		map[uint64]struct{}{
 			3: {},
 			4: {},
@@ -531,7 +539,7 @@ func TestCleanupCorruptedAnalyzeJobsOnCurrentInstance(t *testing.T) {
 
 	// No running analyze jobs on current instance.
 	err = autoanalyze.CleanupCorruptedAnalyzeJobsOnCurrentInstance(
-		mock.WrapAsSCtx(exec),
+		WrapAsSCtx(exec),
 		map[uint64]struct{}{},
 	)
 	require.NoError(t, err)
@@ -587,7 +595,7 @@ func TestCleanupCorruptedAnalyzeJobsOnDeadInstances(t *testing.T) {
 	).Return(nil, nil, nil)
 
 	err := autoanalyze.CleanupCorruptedAnalyzeJobsOnDeadInstances(
-		mock.WrapAsSCtx(exec),
+		WrapAsSCtx(exec),
 	)
 	require.NoError(t, err)
 }

--- a/pkg/store/mockstore/mockcopr/cop_handler_dag.go
+++ b/pkg/store/mockstore/mockcopr/cop_handler_dag.go
@@ -470,7 +470,7 @@ func (e *evalContext) decodeRelatedColumnVals(relatedColOffsets []int, value [][
 
 // flagsAndTzToSessionContext creates a StatementContext from a `tipb.SelectRequest.Flags`.
 func flagsAndTzToSessionContext(flags uint64, tz *time.Location) sessionctx.Context {
-	sctx := mock.NewContext()
+	sctx := mock.NewContextDeprecated()
 	sc := stmtctx.NewStmtCtx()
 	sc.InitFromPBFlagAndTz(flags, tz)
 	sctx.GetSessionVars().StmtCtx = sc

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler.go
@@ -470,7 +470,7 @@ func newRowDecoder(columnInfos []*tipb.ColumnInfo, fieldTps []*types.FieldType, 
 func flagsAndTzToSessionContext(flags uint64, tz *time.Location) sessionctx.Context {
 	sc := stmtctx.NewStmtCtx()
 	sc.InitFromPBFlagAndTz(flags, tz)
-	sctx := mock.NewContext()
+	sctx := mock.NewContextDeprecated()
 	sctx.GetSessionVars().StmtCtx = sc
 	sctx.GetSessionVars().TimeZone = tz
 	return sctx

--- a/pkg/util/mock/BUILD.bazel
+++ b/pkg/util/mock/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "client.go",
         "context.go",
+        "fortest.go",
         "iter.go",
         "metrics.go",
         "store.go",

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -617,8 +617,15 @@ func (*Context) GetCommitWaitGroup() *sync.WaitGroup {
 	return nil
 }
 
-// NewContext creates a new mocked sessionctx.Context.
-func NewContext() *Context {
+// NewContextDeprecated creates a new mocked sessionctx.Context.
+// Deprecated: This method is only used for some legacy code.
+// DO NOT use mock.Context in new production code, and use the real Context instead.
+func NewContextDeprecated() *Context {
+	return newContext()
+}
+
+// newContext creates a new mocked sessionctx.Context.
+func newContext() *Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	sctx := &Context{
 		values: make(map[fmt.Stringer]any),

--- a/pkg/util/mock/fortest.go
+++ b/pkg/util/mock/fortest.go
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This files only expose some functions for testing propose, it should not be used in production code.
+// So we use `//go:build !codes` to exclude this file in production code.
+
+//go:build !codes
+
 package mock
 
-// RestrictedSQLExecutorKey is the key to represent MockRestrictedSQLExecutorMockRecorder in ctx.
-type RestrictedSQLExecutorKey struct{}
-
-// String implements the string.Stringer interface.
-func (k RestrictedSQLExecutorKey) String() string {
-	return "__MockRestrictedSQLExecutor"
+// NewContext creates a new mocked sessionctx.Context.
+// This function should only be used for testing.
+func NewContext() *Context {
+	return newContext()
 }

--- a/pkg/util/sqlexec/mock/BUILD.bazel
+++ b/pkg/util/sqlexec/mock/BUILD.bazel
@@ -11,9 +11,7 @@ go_library(
     deps = [
         "//pkg/parser/ast",
         "//pkg/planner/core/resolve",
-        "//pkg/sessionctx",
         "//pkg/util/chunk",
-        "//pkg/util/mock",
         "//pkg/util/sqlexec",
         "@org_uber_go_mock//gomock",
     ],


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53388

### What changed and how does it work?

Add checks to avoid to use `mock.NewContext` in production code.

1. Move the function `mock.NewContext` to a standalone file which has a `//go:build !codes` header to avoid to build this function in production code. So if some one uses `mock.NewContext` in some production code, `make server` will fail.
2. Introduce a function `mock.NewContextDeprecated` and add a `// Deprecated` comment for it. This method should only be used in some legacy code.
3. Remove `mock.NewContext` usage in other production codes. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
