### PR TITLE
executor: fix the issue that `INSERT IGNORE` doesn't lock the parent table

### DIFF
--- a/pkg/executor/foreign_key.go
+++ b/pkg/executor/foreign_key.go
@@ -223,7 +223,7 @@ func (fkc *FKCheckExec) doCheck(ctx context.Context) error {
 		fkc.stats = &FKCheckRuntimeStats{}
 		defer fkc.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(fkc.ID(), fkc.stats)
 	}
-	if len(fkc.toBeCheckedKeys) == 0 && len(fkc.toBeCheckedPrefixKeys) == 0 {
+	if len(fkc.toBeCheckedKeys) == 0 && len(fkc.toBeCheckedPrefixKeys) == 0 && len(fkc.toBeLockedKeys) == 0 {
 		return nil
 	}
 	start := time.Now()
@@ -248,6 +248,7 @@ func (fkc *FKCheckExec) doCheck(ctx context.Context) error {
 	if fkc.stats != nil {
 		fkc.stats.Check = time.Since(start)
 	}
+
 	if len(fkc.toBeLockedKeys) == 0 {
 		return nil
 	}
@@ -542,7 +543,7 @@ type fkCheckKey struct {
 	isPrefix bool
 }
 
-func (fkc FKCheckExec) checkRows(ctx context.Context, sc *stmtctx.StatementContext, txn kv.Transaction, rows []toBeCheckedRow) error {
+func (fkc *FKCheckExec) checkRows(ctx context.Context, sc *stmtctx.StatementContext, txn kv.Transaction, rows []toBeCheckedRow) error {
 	if fkc.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl != nil {
 		fkc.stats = &FKCheckRuntimeStats{}
 		defer fkc.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(fkc.ID(), fkc.stats)

--- a/pkg/executor/test/fktest/BUILD.bazel
+++ b/pkg/executor/test/fktest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         "//pkg/config",
         "//pkg/executor",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56655 

Problem Summary:

`INSERT IGNORE` cannot lock the rows in parent, so the constraint may be broken.

### What changed and how does it work?

Try to lock the rows even when the `toBeCheckedKeys` and `toBeCheckedPrefixKeys` are empty.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
None
```
