### PR TITLE
executor: ignore foreign key error in `UPDATE/INSERT/DELETE ignore`

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -974,6 +974,7 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) exec.Executor {
 		hasRefCols:                v.NeedFillDefaultValue,
 		SelectExec:                selectExec,
 		rowLen:                    v.RowLen,
+		ignoreErr:                 v.IgnoreErr,
 	}
 	err := ivs.initInsertColumns()
 	if err != nil {
@@ -995,7 +996,6 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) exec.Executor {
 	insert := &InsertExec{
 		InsertValues: ivs,
 		OnDuplicate:  append(v.OnDuplicate, v.GenCols.OnDuplicates...),
-		IgnoreErr:    v.IgnoreErr,
 	}
 	return insert
 }
@@ -2687,6 +2687,7 @@ func (b *executorBuilder) buildDelete(v *plannercore.Delete) exec.Executor {
 		tblID2Table:    tblID2table,
 		IsMultiTable:   v.IsMultiTable,
 		tblColPosInfos: v.TblColPosInfos,
+		ignoreErr:      v.IgnoreErr,
 	}
 	deleteExec.fkChecks, b.err = buildTblID2FKCheckExecs(b.ctx, tblID2table, v.FKChecks)
 	if b.err != nil {

--- a/pkg/executor/foreign_key.go
+++ b/pkg/executor/foreign_key.go
@@ -619,6 +619,30 @@ func (fkc FKCheckExec) checkRows(ctx context.Context, sc *stmtctx.StatementConte
 	return nil
 }
 
+// checkFKIgnoreErr will use `fkc.checkRows` to check the rows. The `fkc.checkRows` will ignore the error and append the error as warning to the statement context.
+// It'll return whether an error has been ignored. If an error has been ignored, it'll return `true, nil`.
+func checkFKIgnoreErr(ctx context.Context, sctx sessionctx.Context, fkChecks []*FKCheckExec, row []types.Datum) (bool, error) {
+	txn, err := sctx.Txn(true)
+	if err != nil {
+		return false, err
+	}
+
+	fkToBeCheckedRows := [1]toBeCheckedRow{{row: row, ignored: false}}
+
+	for _, fkc := range fkChecks {
+		err := fkc.checkRows(ctx, sctx.GetSessionVars().StmtCtx, txn, fkToBeCheckedRows[:])
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if fkToBeCheckedRows[0].ignored {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func (b *executorBuilder) buildTblID2FKCascadeExecs(tblID2Table map[int64]table.Table, tblID2FKCascades map[int64][]*plannercore.FKCascade) (map[int64][]*FKCascadeExec, error) {
 	fkCascadesMap := make(map[int64][]*FKCascadeExec)
 	for tid, tbl := range tblID2Table {

--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -95,6 +95,8 @@ type InsertValues struct {
 	// fkChecks contains the foreign key checkers.
 	fkChecks   []*FKCheckExec
 	fkCascades []*FKCascadeExec
+
+	ignoreErr bool
 }
 
 type defaultVal struct {
@@ -1370,7 +1372,7 @@ func (e *InsertValues) removeRow(
 	if err != nil {
 		return false, err
 	}
-	err = onRemoveRowForFK(e.Ctx(), oldRow, e.fkChecks, e.fkCascades)
+	err = onRemoveRowForFK(e.Ctx(), oldRow, e.fkChecks, e.fkCascades, e.ignoreErr)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -56,7 +56,7 @@ var (
 func updateRecord(
 	ctx context.Context, sctx sessionctx.Context, h kv.Handle, oldData, newData []types.Datum, modified []bool,
 	t table.Table,
-	onDup bool, _ *memory.Tracker, fkChecks []*FKCheckExec, fkCascades []*FKCascadeExec, dupKeyMode table.DupKeyCheckMode,
+	onDup bool, _ *memory.Tracker, fkChecks []*FKCheckExec, fkCascades []*FKCascadeExec, dupKeyMode table.DupKeyCheckMode, ignoreErr bool,
 ) (bool, error) {
 	r, ctx := tracing.StartRegionEx(ctx, "executor.updateRecord")
 	defer r.End()
@@ -221,10 +221,12 @@ func updateRecord(
 			}
 		}
 	}
-	for _, fkt := range fkChecks {
-		err := fkt.updateRowNeedToCheck(sc, oldData, newData)
-		if err != nil {
-			return false, err
+	if !ignoreErr {
+		for _, fkt := range fkChecks {
+			err := fkt.updateRowNeedToCheck(sc, oldData, newData)
+			if err != nil {
+				return false, err
+			}
 		}
 	}
 	for _, fkc := range fkCascades {

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -517,6 +517,8 @@ type Delete struct {
 
 	FKChecks   map[int64][]*FKCheck   `plan-cache-clone:"must-nil"`
 	FKCascades map[int64][]*FKCascade `plan-cache-clone:"must-nil"`
+
+	IgnoreErr bool
 }
 
 // MemoryUsage return the memory usage of Delete

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5945,6 +5945,7 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, ds *ast.DeleteStmt) (base
 
 	del := Delete{
 		IsMultiTable: ds.IsMultiTable,
+		IgnoreErr:    ds.IgnoreErr,
 	}.Init(b.ctx)
 
 	localResolveCtx := resolve.NewContext()

--- a/tests/integrationtest/r/executor/delete.result
+++ b/tests/integrationtest/r/executor/delete.result
@@ -122,3 +122,43 @@ update t set id = '1' where cast(id as unsigned) = 1;
 Level	Code	Message
 Warning	1292	Truncated incorrect INTEGER value: '18446744073709551616'
 set sql_mode=DEFAULT
+drop table if exists parent, child;
+create table parent (a int primary key);
+create table child (a int, foreign key (a) references parent(a));
+insert into parent values (1), (2);
+insert into child values (1);
+delete from parent where a = 1;
+Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+delete ignore from parent where a = 1;
+Level	Code	Message
+Warning	1451	Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+delete ignore from parent;
+Level	Code	Message
+Warning	1451	Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+select * from parent;
+a
+1
+insert into parent values (2);
+create table parent2 (a int primary key);
+create table child2 (a int, foreign key (a) references parent2(a));
+insert into parent2 values (1), (2);
+insert into child2 values (1);
+delete parent, parent2 from parent join parent2 on parent.a = parent2.a;
+Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+delete ignore parent, parent2 from parent join parent2 on parent.a = parent2.a;
+Level	Code	Message
+Warning	1451	Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child2`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent2` (`a`))
+Warning	1451	Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+select * from parent;
+a
+1
+select * from parent2;
+a
+1
+batch on `a` limit 1000 delete from parent where a = 1;
+Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+batch on `a` limit 1000 delete ignore from parent where a = 1;
+number of jobs	job status
+1	all succeeded
+Level	Code	Message
+Warning	1451	Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))

--- a/tests/integrationtest/r/executor/insert.result
+++ b/tests/integrationtest/r/executor/insert.result
@@ -2128,3 +2128,17 @@ Level	Code	Message
 Warning	1264	Out of range value for column 'd' at row 1
 Warning	1292	Truncated incorrect INTEGER value: '18446744073709551616'
 set sql_mode=DEFAULT;
+drop table if exists parent, child;
+create table parent (id int primary key, ref int, key(ref));
+create table child (id int primary key, ref int, foreign key (ref) references parent(ref));
+insert into parent values (1, 1), (2, 2);
+insert into child values (1, 1);
+insert into child values (1, 2) on duplicate key update ref = 2;
+insert into child values (1, 3) on duplicate key update ref = 3;
+Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`executor__insert`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
+insert ignore into child values (1, 3) on duplicate key update ref = 3;
+Level	Code	Message
+Warning	1452	Cannot add or update a child row: a foreign key constraint fails (`executor__insert`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
+insert into parent values (2, 3) on duplicate key update ref = 3;
+Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__insert`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
+insert ignore into parent values (2, 3) on duplicate key update ref = 3;

--- a/tests/integrationtest/r/executor/update.result
+++ b/tests/integrationtest/r/executor/update.result
@@ -889,3 +889,17 @@ SELECT b FROM update_with_diff_type;
 b
 {"a": "测试"}
 set SQL_MODE=default;
+drop table if exists parent, child;
+create table parent (id int primary key, ref int, key(ref));
+create table child (id int primary key, ref int, foreign key (ref) references parent(ref));
+insert into parent values (1, 1), (2, 2);
+insert into child values (1, 1);
+update child set ref = 2 where id = 1;
+update child set ref = 3 where id = 1;
+Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`executor__update`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
+update ignore child set ref = 3 where id = 1;
+Level	Code	Message
+Warning	1452	Cannot add or update a child row: a foreign key constraint fails (`executor__update`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
+update parent set ref = 3 where id = 2;
+Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__update`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
+update ignore parent set ref = 3 where id = 2;

--- a/tests/integrationtest/t/executor/delete.test
+++ b/tests/integrationtest/t/executor/delete.test
@@ -117,3 +117,30 @@ update t set id = '1' where cast(id as unsigned) = 1;
 -- disable_warnings
 set sql_mode=DEFAULT
 
+# TestDeleteIgnoreWithFK
+drop table if exists parent, child;
+create table parent (a int primary key);
+create table child (a int, foreign key (a) references parent(a));
+insert into parent values (1), (2);
+insert into child values (1);
+-- error 1451
+delete from parent where a = 1;
+--enable_warnings
+delete ignore from parent where a = 1;
+delete ignore from parent;
+select * from parent;
+insert into parent values (2);
+
+create table parent2 (a int primary key);
+create table child2 (a int, foreign key (a) references parent2(a));
+insert into parent2 values (1), (2);
+insert into child2 values (1);
+-- error 1451
+delete parent, parent2 from parent join parent2 on parent.a = parent2.a;
+delete ignore parent, parent2 from parent join parent2 on parent.a = parent2.a;
+select * from parent;
+select * from parent2;
+-- error 1451
+batch on `a` limit 1000 delete from parent where a = 1;
+batch on `a` limit 1000 delete ignore from parent where a = 1;
+--disable_warnings

--- a/tests/integrationtest/t/executor/insert.test
+++ b/tests/integrationtest/t/executor/insert.test
@@ -1600,3 +1600,23 @@ set sql_mode='';
 insert into t values (cast('18446744073709551616' as unsigned));
 --disable_warnings
 set sql_mode=DEFAULT;
+
+# TestInsertIgnoreOnDupWithFK
+drop table if exists parent, child;
+create table parent (id int primary key, ref int, key(ref));
+create table child (id int primary key, ref int, foreign key (ref) references parent(ref));
+insert into parent values (1, 1), (2, 2);
+insert into child values (1, 1);
+
+insert into child values (1, 2) on duplicate key update ref = 2;
+-- error 1452
+insert into child values (1, 3) on duplicate key update ref = 3;
+--enable_warnings
+insert ignore into child values (1, 3) on duplicate key update ref = 3;
+--disable_warnings
+
+-- error 1451
+insert into parent values (2, 3) on duplicate key update ref = 3;
+--enable_warnings
+insert ignore into parent values (2, 3) on duplicate key update ref = 3;
+--disable_warnings

--- a/tests/integrationtest/t/executor/update.test
+++ b/tests/integrationtest/t/executor/update.test
@@ -694,3 +694,22 @@ UPDATE update_with_diff_type SET b = '{"a":   "\\u6d4b\\u8bd5"}';
 SELECT b FROM update_with_diff_type;
 set SQL_MODE=default;
 
+# TestUpdateIgnoreWithFK
+drop table if exists parent, child;
+create table parent (id int primary key, ref int, key(ref));
+create table child (id int primary key, ref int, foreign key (ref) references parent(ref));
+insert into parent values (1, 1), (2, 2);
+insert into child values (1, 1);
+
+update child set ref = 2 where id = 1;
+-- error 1452
+update child set ref = 3 where id = 1;
+--enable_warnings
+update ignore child set ref = 3 where id = 1;
+--disable_warnings
+
+-- error 1451
+update parent set ref = 3 where id = 2;
+--enable_warnings
+update ignore parent set ref = 3 where id = 2;
+--disable_warnings


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56678, close #56681, close #39712

Problem Summary:

In the following cases, the foreign key error should be omitted and placed in the warning:

1. `INSERT IGNORE ... ON DUPLICATE UPDATE ...`
2. `DELETE IGNORE ...`
3. `UPDATE IGNORE ...`

### What changed and how does it work?

Introduce a function `checkFKIgnoreErr` to check rows explicitly, and use this function to check each rows in these three cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
