### PR TITLE
ddl: make args/DecodeArgs un-exported

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -240,7 +240,6 @@ func onCreateTables(jobCtx *jobContext, job *model.Job) (int64, error) {
 	//
 	// it clones a stub job from the ActionCreateTables job
 	stubJob := job.Clone()
-	stubJob.Args = make([]any, 1)
 	for i := range args.Tables {
 		tblArgs := args.Tables[i]
 		tableInfo := tblArgs.TableInfo

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -233,12 +233,7 @@ func (jobW *JobWrapper) FillArgsWithSubJobs() {
 		jobW.FillArgs(jobW.JobArgs)
 	} else {
 		for _, sub := range jobW.MultiSchemaInfo.SubJobs {
-			fakeJob := model.Job{
-				Version: jobW.Version,
-				Type:    sub.Type,
-			}
-			fakeJob.FillArgs(sub.JobArgs)
-			sub.Args = fakeJob.Args
+			sub.FillArgs(jobW.Job)
 		}
 	}
 }

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -233,7 +233,7 @@ func (jobW *JobWrapper) FillArgsWithSubJobs() {
 		jobW.FillArgs(jobW.JobArgs)
 	} else {
 		for _, sub := range jobW.MultiSchemaInfo.SubJobs {
-			sub.FillArgs(jobW.Job)
+			sub.FillArgs(jobW.Version)
 		}
 	}
 }

--- a/pkg/ddl/ddl_error_test.go
+++ b/pkg/ddl/ddl_error_test.go
@@ -46,12 +46,6 @@ func TestTableError(t *testing.T) {
 	require.Error(t, err)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobTableId"))
 
-	// Args is wrong, so creating table is failed.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg", `return(true)`))
-	err = tk.ExecToErr("create table test.t1(a int)")
-	require.Error(t, err)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg"))
-
 	// Table exists, so creating table is failed.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockModifyJobSchemaId", `return(-1)`))
 	err = tk.ExecToErr("create table test.t1(a int)")
@@ -68,12 +62,6 @@ func TestViewError(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int)")
-
-	// Args is wrong, so creating view is failed.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg", `return(true)`))
-	err := tk.ExecToErr("create view v as select * from t")
-	require.Error(t, err)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg"))
 }
 
 func TestForeignKeyError(t *testing.T) {
@@ -106,14 +94,6 @@ func TestIndexError(t *testing.T) {
 	err = tk.ExecToErr("alter table t1 drop a")
 	require.Error(t, err)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockModifyJobSchemaId"))
-
-	// for adding index
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg", `return(true)`))
-	err = tk.ExecToErr("alter table t add index idx(a)")
-	require.Error(t, err)
-	err = tk.ExecToErr("alter table t drop index a")
-	require.Error(t, err)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg"))
 }
 
 func TestColumnError(t *testing.T) {
@@ -151,20 +131,6 @@ func TestColumnError(t *testing.T) {
 	err = tk.ExecToErr("alter table t drop column aa, drop column ab")
 	require.Error(t, err)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobTableId"))
-
-	// Invalid argument.
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg", `return(true)`))
-	err = tk.ExecToErr("alter table t add column ta int")
-	require.Error(t, err)
-	err = tk.ExecToErr("alter table t drop column aa")
-	require.Error(t, err)
-	err = tk.ExecToErr("alter table t drop column aa")
-	require.Error(t, err)
-	err = tk.ExecToErr("alter table t add column ta int, add column tb int")
-	require.Error(t, err)
-	err = tk.ExecToErr("alter table t drop column aa, drop column ab")
-	require.Error(t, err)
-	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/MockModifyJobArg"))
 
 	tk.MustGetErrCode("alter table t add column c int after c5", errno.ErrBadField)
 	tk.MustGetErrCode("alter table t drop column c5", errno.ErrCantDropFieldOrKey)

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2013,7 +2013,6 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 		TableName:           t.Meta().Name.L,
 		Type:                model.ActionMultiSchemaChange,
 		BinlogInfo:          &model.HistoryInfo{},
-		Args:                nil,
 		MultiSchemaInfo:     info,
 		ReorgMeta:           nil,
 		CDCWriteSource:      ctx.GetSessionVars().CDCWriteSource,

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -372,7 +372,7 @@ func (w *worker) finishDDLJob(jobCtx *jobContext, job *model.Job) (err error) {
 		if job.IsCancelled() {
 			// it may be too large that it can not be added to the history queue, so
 			// delete its arguments
-			job.Args = nil
+			job.ClearDecodedArgs()
 		}
 	}
 	if err != nil {

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -188,7 +188,6 @@ func appendToSubJobs(m *model.MultiSchemaInfo, jobW *JobWrapper) error {
 	m.SubJobs = append(m.SubJobs, &model.SubJob{
 		Type:        jobW.Type,
 		JobArgs:     jobW.JobArgs,
-		Args:        jobW.Args,
 		RawArgs:     jobW.RawArgs,
 		SchemaState: jobW.SchemaState,
 		SnapshotVer: jobW.SnapshotVer,
@@ -335,9 +334,7 @@ func mergeAddIndex(info *model.MultiSchemaInfo) {
 		if subJob.Type == model.ActionAddIndex {
 			mergeCnt++
 			if mergedSubJob == nil {
-				clonedSubJob := *subJob
-				mergedSubJob = &clonedSubJob
-				mergedSubJob.Args = nil
+				mergedSubJob = subJob.Clone()
 				mergedSubJob.RawArgs = nil
 			}
 		}

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -522,11 +522,11 @@ func (job *Job) Encode(updateRawArgs bool) ([]byte, error) {
 		if job.MultiSchemaInfo != nil {
 			for _, sub := range job.MultiSchemaInfo.SubJobs {
 				// Only update the args of executing sub-jobs.
-				if sub.args == nil {
+				if sub.Args == nil {
 					continue
 				}
 
-				sub.RawArgs, err = marshalArgs(job.Version, sub.args)
+				sub.RawArgs, err = marshalArgs(job.Version, sub.Args)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -862,9 +862,9 @@ func (job *Job) ClearDecodedArgs() {
 // SubJob is a representation of one DDL schema change. A Job may contain zero
 // (when multi-schema change is not applicable) or more SubJobs.
 type SubJob struct {
-	Type        ActionType `json:"type"`
-	JobArgs     JobArgs    `json:"-"`
-	args        []any
+	Type        ActionType      `json:"type"`
+	JobArgs     JobArgs         `json:"-"`
+	Args        []any           `json:"-"`
 	RawArgs     json.RawMessage `json:"raw_args"`
 	SchemaState SchemaState     `json:"schema_state"`
 	SnapshotVer uint64          `json:"snapshot_ver"`
@@ -913,7 +913,7 @@ func (sub *SubJob) ToProxyJob(parentJob *Job, seq int) Job {
 		RowCount:        sub.RowCount,
 		Mu:              sync.Mutex{},
 		CtxVars:         sub.CtxVars,
-		Args:            sub.args,
+		Args:            sub.Args,
 		RawArgs:         sub.RawArgs,
 		SchemaState:     sub.SchemaState,
 		SnapshotVer:     sub.SnapshotVer,
@@ -939,7 +939,7 @@ func (sub *SubJob) FromProxyJob(proxyJob *Job, ver int64) {
 	sub.SchemaState = proxyJob.SchemaState
 	sub.SnapshotVer = proxyJob.SnapshotVer
 	sub.RealStartTS = proxyJob.RealStartTS
-	sub.args = proxyJob.Args
+	sub.Args = proxyJob.Args
 	sub.State = proxyJob.State
 	sub.Warning = proxyJob.Warning
 	sub.RowCount = proxyJob.RowCount
@@ -955,14 +955,14 @@ func (sub *SubJob) FillArgs(jobVer JobVersion) {
 		Type:    sub.Type,
 	}
 	fakeJob.FillArgs(sub.JobArgs)
-	sub.args = fakeJob.Args
+	sub.Args = fakeJob.Args
 }
 
 // Clone returns a copy of the sub-job.
 // Note: private args fields are not copied.
 func (sub *SubJob) Clone() *SubJob {
 	clonedSubJob := *sub
-	clonedSubJob.args = nil
+	clonedSubJob.Args = nil
 	return &clonedSubJob
 }
 

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -568,10 +568,6 @@ func (job *Job) decodeArgs(args ...any) error {
 			return errors.Trace(err)
 		}
 	}
-	// TODO(lance6716): don't assign to job.Args here, because the types of argument
-	// `args` are always pointer type. But sometimes in the `job` literals we don't
-	// use pointer
-	job.args = args[:sz]
 	return nil
 }
 

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -946,8 +946,11 @@ func (sub *SubJob) FromProxyJob(proxyJob *Job, ver int64) {
 }
 
 // FillArgs fills args.
-func (sub *SubJob) FillArgs(job *Job) {
-	sub.args = sub.JobArgs.getArgsV1(job)
+func (sub *SubJob) FillArgs(ver JobVersion) {
+	sub.args = sub.JobArgs.getArgsV1(&Job{
+		Version: ver,
+		Type:    sub.Type,
+	})
 }
 
 // Clone returns a copy of the sub-job.

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -308,15 +308,9 @@ type Job struct {
 	// E.g. passing arguments between functions by one single *Job pointer.
 	// for ExchangeTablePartition, RenameTables, RenameTable, it's [slice-of-db-id, slice-of-table-id]
 	CtxVars []any `json:"-"`
-	// Note: it might change when state changes, such as when rollback on AddColumn.
-	// - CreateTable, it's [TableInfo, foreignKeyCheck]
-	// - AddIndex or AddPrimaryKey: [unique, ....
-	// - TruncateTable: [new-table-id, foreignKeyCheck, ...
-	// - RenameTable: [old-db-id, new-table-name, old-db-name]
-	// - ExchangeTablePartition: [partition-id, pt-db-id, pt-id, partition-name, with-validation]
+	// it's a temporary place to cache job args.
 	// when Version is JobVersion2, Args contains a single element of type JobArgs.
-	// TODO make it private after we finish the migration to JobVersion2.
-	Args []any `json:"-"`
+	args []any
 	// we use json raw message to delay parsing special args.
 	// the args are cleared out unless Job.FillFinishedArgs is called.
 	RawArgs json.RawMessage `json:"raw_args"`
@@ -427,6 +421,7 @@ func (job *Job) MarkNonRevertible() {
 }
 
 // Clone returns a copy of the job.
+// Note: private args fields are not copied.
 func (job *Job) Clone() *Job {
 	encode, err := job.Encode(true)
 	if err != nil {
@@ -437,15 +432,9 @@ func (job *Job) Clone() *Job {
 	if err != nil {
 		return nil
 	}
-	if len(job.Args) > 0 {
-		clone.Args = make([]any, len(job.Args))
-		copy(clone.Args, job.Args)
-	}
 	if job.MultiSchemaInfo != nil {
 		for i, sub := range job.MultiSchemaInfo.SubJobs {
 			clone.MultiSchemaInfo.SubJobs[i].JobArgs = sub.JobArgs
-			clone.MultiSchemaInfo.SubJobs[i].Args = make([]any, len(sub.Args))
-			copy(clone.MultiSchemaInfo.SubJobs[i].Args, sub.Args)
 		}
 	}
 	return &clone
@@ -487,20 +476,20 @@ func (job *Job) GetWarnings() (map[errors.ErrorID]*terror.Error, map[errors.Erro
 func (job *Job) FillArgs(args JobArgs) {
 	intest.Assert(job.Version == JobVersion1 || job.Version == JobVersion2, "job version is invalid")
 	if job.Version == JobVersion1 {
-		job.Args = args.getArgsV1(job)
+		job.args = args.getArgsV1(job)
 		return
 	}
-	job.Args = []any{args}
+	job.args = []any{args}
 }
 
 // FillFinishedArgs fills args for finished job.
 func (job *Job) FillFinishedArgs(args FinishedJobArgs) {
 	intest.Assert(job.Version == JobVersion1 || job.Version == JobVersion2, "job version is invalid")
 	if job.Version == JobVersion1 {
-		job.Args = args.getFinishedArgsV1(job)
+		job.args = args.getFinishedArgsV1(job)
 		return
 	}
-	job.Args = []any{args}
+	job.args = []any{args}
 }
 
 func marshalArgs(jobVer JobVersion, args []any) (json.RawMessage, error) {
@@ -512,7 +501,7 @@ func marshalArgs(jobVer JobVersion, args []any) (json.RawMessage, error) {
 	intest.Assert(jobVer == JobVersion2, "job version is not v2")
 	var arg any
 	if len(args) > 0 {
-		intest.Assert(len(args) == 1, "Job.Args should have only one element")
+		intest.Assert(len(args) == 1, "args should have only one element")
 		arg = args[0]
 	}
 
@@ -525,7 +514,7 @@ func marshalArgs(jobVer JobVersion, args []any) (json.RawMessage, error) {
 func (job *Job) Encode(updateRawArgs bool) ([]byte, error) {
 	var err error
 	if updateRawArgs {
-		job.RawArgs, err = marshalArgs(job.Version, job.Args)
+		job.RawArgs, err = marshalArgs(job.Version, job.args)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -533,11 +522,11 @@ func (job *Job) Encode(updateRawArgs bool) ([]byte, error) {
 		if job.MultiSchemaInfo != nil {
 			for _, sub := range job.MultiSchemaInfo.SubJobs {
 				// Only update the args of executing sub-jobs.
-				if sub.Args == nil {
+				if sub.args == nil {
 					continue
 				}
 
-				sub.RawArgs, err = marshalArgs(job.Version, sub.Args)
+				sub.RawArgs, err = marshalArgs(job.Version, sub.args)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -553,18 +542,17 @@ func (job *Job) Encode(updateRawArgs bool) ([]byte, error) {
 	return b, errors.Trace(err)
 }
 
-// Decode decodes job from the json buffer, we must use DecodeArgs later to
+// Decode decodes job from the json buffer, we must use decodeArgs later to
 // decode special args for this job.
 func (job *Job) Decode(b []byte) error {
 	err := json.Unmarshal(b, job)
 	return errors.Trace(err)
 }
 
-// DecodeArgs decodes serialized job arguments from job.RawArgs into the given
+// decodeArgs decodes serialized job arguments from job.RawArgs into the given
 // variables, and also save the result in job.Args. It's for JobVersion1.
-// TODO make it un-exported after we finish the migration to JobVersion2.
-func (job *Job) DecodeArgs(args ...any) error {
-	intest.Assert(job.Version == JobVersion1, "Job.DecodeArgs is only used for JobVersion1")
+func (job *Job) decodeArgs(args ...any) error {
+	intest.Assert(job.Version == JobVersion1, "Job.decodeArgs is only used for JobVersion1")
 	var rawArgs []json.RawMessage
 	if err := json.Unmarshal(job.RawArgs, &rawArgs); err != nil {
 		return errors.Trace(err)
@@ -583,7 +571,7 @@ func (job *Job) DecodeArgs(args ...any) error {
 	// TODO(lance6716): don't assign to job.Args here, because the types of argument
 	// `args` are always pointer type. But sometimes in the `job` literals we don't
 	// use pointer
-	job.Args = args[:sz]
+	job.args = args[:sz]
 	return nil
 }
 
@@ -591,7 +579,7 @@ func (job *Job) DecodeArgs(args ...any) error {
 func (job *Job) String() string {
 	rowCount := job.GetRowCount()
 	ret := fmt.Sprintf("ID:%d, Type:%s, State:%s, SchemaState:%s, SchemaID:%d, TableID:%d, RowCount:%d, ArgLen:%d, start time: %v, Err:%v, ErrCount:%d, SnapshotVersion:%v, Version: %s",
-		job.ID, job.Type, job.State, job.SchemaState, job.SchemaID, job.TableID, rowCount, len(job.Args), TSConvert2Time(job.StartTS), job.Error, job.ErrorCount, job.SnapshotVer, job.Version)
+		job.ID, job.Type, job.State, job.SchemaState, job.SchemaID, job.TableID, rowCount, len(job.args), TSConvert2Time(job.StartTS), job.Error, job.ErrorCount, job.SnapshotVer, job.Version)
 	if job.ReorgMeta != nil {
 		warnings, _ := job.GetWarnings()
 		ret += fmt.Sprintf(", UniqueWarnings:%d", len(warnings))
@@ -866,12 +854,15 @@ func (job *Job) GetInvolvingSchemaInfo() []InvolvingSchemaInfo {
 	}
 }
 
+// ClearDecodedArgs clears the decoded args.
+func (job *Job) ClearDecodedArgs() {
+	job.args = nil
+}
+
 // SubJob is a representation of one DDL schema change. A Job may contain zero
 // (when multi-schema change is not applicable) or more SubJobs.
 type SubJob struct {
 	Type        ActionType      `json:"type"`
-	JobArgs     JobArgs         `json:"-"`
-	Args        []any           `json:"-"`
 	RawArgs     json.RawMessage `json:"raw_args"`
 	SchemaState SchemaState     `json:"schema_state"`
 	SnapshotVer uint64          `json:"snapshot_ver"`
@@ -884,6 +875,9 @@ type SubJob struct {
 	SchemaVer   int64           `json:"schema_version"`
 	ReorgTp     ReorgType       `json:"reorg_tp"`
 	UseCloud    bool            `json:"use_cloud"`
+
+	JobArgs JobArgs `json:"-"`
+	args    []any
 }
 
 // IsNormal returns true if the sub-job is normally running.
@@ -920,7 +914,7 @@ func (sub *SubJob) ToProxyJob(parentJob *Job, seq int) Job {
 		RowCount:        sub.RowCount,
 		Mu:              sync.Mutex{},
 		CtxVars:         sub.CtxVars,
-		Args:            sub.Args,
+		args:            sub.args,
 		RawArgs:         sub.RawArgs,
 		SchemaState:     sub.SchemaState,
 		SnapshotVer:     sub.SnapshotVer,
@@ -946,13 +940,26 @@ func (sub *SubJob) FromProxyJob(proxyJob *Job, ver int64) {
 	sub.SchemaState = proxyJob.SchemaState
 	sub.SnapshotVer = proxyJob.SnapshotVer
 	sub.RealStartTS = proxyJob.RealStartTS
-	sub.Args = proxyJob.Args
+	sub.args = proxyJob.args
 	sub.State = proxyJob.State
 	sub.Warning = proxyJob.Warning
 	sub.RowCount = proxyJob.RowCount
 	sub.SchemaVer = ver
 	sub.ReorgTp = proxyJob.ReorgMeta.ReorgTp
 	sub.UseCloud = proxyJob.ReorgMeta.UseCloudStorage
+}
+
+// FillArgs fills args.
+func (sub *SubJob) FillArgs(job *Job) {
+	sub.args = sub.JobArgs.getArgsV1(job)
+}
+
+// Clone returns a copy of the sub-job.
+// Note: private args fields are not copied.
+func (sub *SubJob) Clone() *SubJob {
+	clonedSubJob := *sub
+	clonedSubJob.args = nil
+	return &clonedSubJob
 }
 
 // MultiSchemaInfo keeps some information for multi schema change.

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -73,15 +73,15 @@ func getOrDecodeArgsV1[T JobArgs](args T, job *Job) (T, error) {
 // and cache in job.Args.
 func getOrDecodeArgsV2[T JobArgs](job *Job) (T, error) {
 	intest.Assert(job.Version == JobVersion2, "job version is not v2")
-	if len(job.Args) > 0 {
-		intest.Assert(len(job.Args) == 1, "job args length is not 1")
-		return job.Args[0].(T), nil
+	if len(job.args) > 0 {
+		intest.Assert(len(job.args) == 1, "job args length is not 1")
+		return job.args[0].(T), nil
 	}
 	var v T
 	if err := json.Unmarshal(job.RawArgs, &v); err != nil {
 		return v, errors.Trace(err)
 	}
-	job.Args = []any{v}
+	job.args = []any{v}
 	return v, nil
 }
 
@@ -132,7 +132,7 @@ func (a *CreateSchemaArgs) getArgsV1(*Job) []any {
 
 func (a *CreateSchemaArgs) decodeV1(job *Job) error {
 	a.DBInfo = &DBInfo{}
-	return errors.Trace(job.DecodeArgs(a.DBInfo))
+	return errors.Trace(job.decodeArgs(a.DBInfo))
 }
 
 // GetCreateSchemaArgs gets the args for create schema job.
@@ -157,7 +157,7 @@ func (a *DropSchemaArgs) getFinishedArgsV1(*Job) []any {
 }
 
 func (a *DropSchemaArgs) decodeV1(job *Job) error {
-	return job.DecodeArgs(&a.FKCheck)
+	return job.decodeArgs(&a.FKCheck)
 }
 
 // GetDropSchemaArgs gets the args for drop schema job.
@@ -169,7 +169,7 @@ func GetDropSchemaArgs(job *Job) (*DropSchemaArgs, error) {
 func GetFinishedDropSchemaArgs(job *Job) (*DropSchemaArgs, error) {
 	if job.Version == JobVersion1 {
 		var physicalTableIDs []int64
-		if err := job.DecodeArgs(&physicalTableIDs); err != nil {
+		if err := job.decodeArgs(&physicalTableIDs); err != nil {
 			return nil, err
 		}
 		return &DropSchemaArgs{AllDroppedTableIDs: physicalTableIDs}, nil
@@ -196,9 +196,9 @@ func (a *ModifySchemaArgs) getArgsV1(job *Job) []any {
 
 func (a *ModifySchemaArgs) decodeV1(job *Job) error {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
-		return errors.Trace(job.DecodeArgs(&a.ToCharset, &a.ToCollate))
+		return errors.Trace(job.decodeArgs(&a.ToCharset, &a.ToCollate))
 	}
-	return errors.Trace(job.DecodeArgs(&a.PolicyRef))
+	return errors.Trace(job.decodeArgs(&a.PolicyRef))
 }
 
 // GetModifySchemaArgs gets the modify schema args.
@@ -232,11 +232,11 @@ func (a *CreateTableArgs) decodeV1(job *Job) error {
 	a.TableInfo = &TableInfo{}
 	switch job.Type {
 	case ActionCreateTable:
-		return errors.Trace(job.DecodeArgs(a.TableInfo, &a.FKCheck))
+		return errors.Trace(job.decodeArgs(a.TableInfo, &a.FKCheck))
 	case ActionCreateView:
-		return errors.Trace(job.DecodeArgs(a.TableInfo, &a.OnExistReplace, &a.OldViewTblID))
+		return errors.Trace(job.decodeArgs(a.TableInfo, &a.OnExistReplace, &a.OldViewTblID))
 	case ActionCreateSequence:
-		return errors.Trace(job.DecodeArgs(a.TableInfo))
+		return errors.Trace(job.decodeArgs(a.TableInfo))
 	}
 	return nil
 }
@@ -264,7 +264,7 @@ func (a *BatchCreateTableArgs) decodeV1(job *Job) error {
 		tableInfos []*TableInfo
 		fkCheck    bool
 	)
-	if err := job.DecodeArgs(&tableInfos, &fkCheck); err != nil {
+	if err := job.decodeArgs(&tableInfos, &fkCheck); err != nil {
 		return errors.Trace(err)
 	}
 	a.Tables = make([]*CreateTableArgs, 0, len(tableInfos))
@@ -308,7 +308,7 @@ func (a *DropTableArgs) getFinishedArgsV1(*Job) []any {
 
 func (a *DropTableArgs) decodeV1(job *Job) error {
 	if job.Type == ActionDropTable {
-		return job.DecodeArgs(&a.Identifiers, &a.FKCheck)
+		return job.decodeArgs(&a.Identifiers, &a.FKCheck)
 	}
 	return nil
 }
@@ -326,7 +326,7 @@ func GetFinishedDropTableArgs(job *Job) (*DropTableArgs, error) {
 			oldPartitionIDs []int64
 			oldRuleIDs      []string
 		)
-		if err := job.DecodeArgs(&startKey, &oldPartitionIDs, &oldRuleIDs); err != nil {
+		if err := job.decodeArgs(&startKey, &oldPartitionIDs, &oldRuleIDs); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &DropTableArgs{
@@ -364,9 +364,9 @@ func (a *TruncateTableArgs) getArgsV1(job *Job) []any {
 
 func (a *TruncateTableArgs) decodeV1(job *Job) error {
 	if job.Type == ActionTruncateTable {
-		return errors.Trace(job.DecodeArgs(&a.NewTableID, &a.FKCheck, &a.NewPartitionIDs))
+		return errors.Trace(job.decodeArgs(&a.NewTableID, &a.FKCheck, &a.NewPartitionIDs))
 	}
-	return errors.Trace(job.DecodeArgs(&a.OldPartitionIDs, &a.NewPartitionIDs))
+	return errors.Trace(job.decodeArgs(&a.OldPartitionIDs, &a.NewPartitionIDs))
 }
 
 func (a *TruncateTableArgs) getFinishedArgsV1(job *Job) []any {
@@ -390,13 +390,13 @@ func GetFinishedTruncateTableArgs(job *Job) (*TruncateTableArgs, error) {
 		if job.Type == ActionTruncateTable {
 			var startKey []byte
 			var oldPartitionIDs []int64
-			if err := job.DecodeArgs(&startKey, &oldPartitionIDs); err != nil {
+			if err := job.decodeArgs(&startKey, &oldPartitionIDs); err != nil {
 				return nil, errors.Trace(err)
 			}
 			return &TruncateTableArgs{OldPartitionIDs: oldPartitionIDs}, nil
 		}
 		var oldPartitionIDs []int64
-		if err := job.DecodeArgs(&oldPartitionIDs); err != nil {
+		if err := job.decodeArgs(&oldPartitionIDs); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &TruncateTableArgs{OldPartitionIDs: oldPartitionIDs}, nil
@@ -445,20 +445,20 @@ func (a *TablePartitionArgs) decodeV1(job *Job) error {
 	)
 	if job.Type == ActionAddTablePartition {
 		if job.State == JobStateRollingback {
-			if err := job.DecodeArgs(&partNames); err != nil {
+			if err := job.decodeArgs(&partNames); err != nil {
 				return err
 			}
 		} else {
-			if err := job.DecodeArgs(partInfo); err != nil {
+			if err := job.decodeArgs(partInfo); err != nil {
 				return err
 			}
 		}
 	} else if job.Type == ActionDropTablePartition {
-		if err := job.DecodeArgs(&partNames); err != nil {
+		if err := job.decodeArgs(&partNames); err != nil {
 			return err
 		}
 	} else {
-		if err := job.DecodeArgs(&partNames, partInfo); err != nil {
+		if err := job.decodeArgs(&partNames, partInfo); err != nil {
 			return err
 		}
 	}
@@ -485,7 +485,7 @@ func GetTablePartitionArgs(job *Job) (*TablePartitionArgs, error) {
 func GetFinishedTablePartitionArgs(job *Job) (*TablePartitionArgs, error) {
 	if job.Version == JobVersion1 {
 		var oldPhysicalTblIDs []int64
-		if err := job.DecodeArgs(&oldPhysicalTblIDs); err != nil {
+		if err := job.decodeArgs(&oldPhysicalTblIDs); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &TablePartitionArgs{OldPhysicalTblIDs: oldPhysicalTblIDs}, nil
@@ -506,7 +506,7 @@ func FillRollbackArgsForAddPartition(job *Job, args *TablePartitionArgs) {
 	fake.FillArgs(&TablePartitionArgs{
 		PartNames: args.PartNames,
 	})
-	job.Args = fake.Args
+	job.args = fake.args
 }
 
 // ExchangeTablePartitionArgs is the arguments for exchange table partition job.
@@ -525,7 +525,7 @@ func (a *ExchangeTablePartitionArgs) getArgsV1(*Job) []any {
 }
 
 func (a *ExchangeTablePartitionArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.PartitionID, &a.PTSchemaID, &a.PTTableID, &a.PartitionName, &a.WithValidation))
+	return errors.Trace(job.decodeArgs(&a.PartitionID, &a.PTSchemaID, &a.PTTableID, &a.PartitionName, &a.WithValidation))
 }
 
 // GetExchangeTablePartitionArgs gets the exchange table partition args.
@@ -552,9 +552,9 @@ func (a *AlterTablePartitionArgs) getArgsV1(job *Job) []any {
 
 func (a *AlterTablePartitionArgs) decodeV1(job *Job) error {
 	if job.Type == ActionAlterTablePartitionAttributes {
-		return errors.Trace(job.DecodeArgs(&a.PartitionID, &a.LabelRule))
+		return errors.Trace(job.decodeArgs(&a.PartitionID, &a.LabelRule))
 	}
-	return errors.Trace(job.DecodeArgs(&a.PartitionID, &a.PolicyRefInfo))
+	return errors.Trace(job.decodeArgs(&a.PartitionID, &a.PolicyRefInfo))
 }
 
 // GetAlterTablePartitionArgs gets the alter table partition args.
@@ -584,7 +584,7 @@ func (rt *RenameTableArgs) getArgsV1(*Job) []any {
 }
 
 func (rt *RenameTableArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&rt.OldSchemaID, &rt.NewTableName, &rt.OldSchemaName))
+	return errors.Trace(job.decodeArgs(&rt.OldSchemaID, &rt.NewTableName, &rt.OldSchemaName))
 }
 
 // GetRenameTableArgs get the arguments from job.
@@ -620,9 +620,9 @@ func (a *ResourceGroupArgs) getArgsV1(job *Job) []any {
 func (a *ResourceGroupArgs) decodeV1(job *Job) error {
 	a.RGInfo = &ResourceGroupInfo{}
 	if job.Type == ActionCreateResourceGroup || job.Type == ActionAlterResourceGroup {
-		return errors.Trace(job.DecodeArgs(a.RGInfo))
+		return errors.Trace(job.decodeArgs(a.RGInfo))
 	} else if job.Type == ActionDropResourceGroup {
-		return errors.Trace(job.DecodeArgs(&a.RGInfo.Name))
+		return errors.Trace(job.decodeArgs(&a.RGInfo.Name))
 	}
 	return nil
 }
@@ -644,7 +644,7 @@ func (a *RebaseAutoIDArgs) getArgsV1(*Job) []any {
 }
 
 func (a *RebaseAutoIDArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.NewBase, &a.Force))
+	return errors.Trace(job.decodeArgs(&a.NewBase, &a.Force))
 }
 
 // GetRebaseAutoIDArgs the args for ActionRebaseAutoID/ActionRebaseAutoRandomBase ddl.
@@ -662,7 +662,7 @@ func (a *ModifyTableCommentArgs) getArgsV1(*Job) []any {
 }
 
 func (a *ModifyTableCommentArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.Comment))
+	return errors.Trace(job.decodeArgs(&a.Comment))
 }
 
 // GetModifyTableCommentArgs gets the args for ActionModifyTableComment.
@@ -682,7 +682,7 @@ func (a *ModifyTableCharsetAndCollateArgs) getArgsV1(*Job) []any {
 }
 
 func (a *ModifyTableCharsetAndCollateArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.ToCharset, &a.ToCollate, &a.NeedsOverwriteCols))
+	return errors.Trace(job.decodeArgs(&a.ToCharset, &a.ToCollate, &a.NeedsOverwriteCols))
 }
 
 // GetModifyTableCharsetAndCollateArgs gets the args for ActionModifyTableCharsetAndCollate ddl.
@@ -701,7 +701,7 @@ func (a *AlterIndexVisibilityArgs) getArgsV1(*Job) []any {
 }
 
 func (a *AlterIndexVisibilityArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.IndexName, &a.Invisible))
+	return errors.Trace(job.decodeArgs(&a.IndexName, &a.Invisible))
 }
 
 // GetAlterIndexVisibilityArgs gets the args for AlterIndexVisibility ddl.
@@ -720,7 +720,7 @@ func (a *AddForeignKeyArgs) getArgsV1(*Job) []any {
 }
 
 func (a *AddForeignKeyArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.FkInfo, &a.FkCheck))
+	return errors.Trace(job.decodeArgs(&a.FkInfo, &a.FkCheck))
 }
 
 // GetAddForeignKeyArgs get the args for AddForeignKey ddl.
@@ -738,7 +738,7 @@ func (a *DropForeignKeyArgs) getArgsV1(*Job) []any {
 }
 
 func (a *DropForeignKeyArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.FkName))
+	return errors.Trace(job.decodeArgs(&a.FkName))
 }
 
 // GetDropForeignKeyArgs gets the args for DropForeignKey ddl.
@@ -774,10 +774,10 @@ func (a *TableColumnArgs) decodeV1(job *Job) error {
 
 	// when rollbacking add-columm, it's arguments is same as drop-column
 	if job.Type == ActionDropColumn || job.State == JobStateRollingback {
-		return errors.Trace(job.DecodeArgs(&a.Col.Name, &a.IgnoreExistenceErr, &a.IndexIDs, &a.PartitionIDs))
+		return errors.Trace(job.decodeArgs(&a.Col.Name, &a.IgnoreExistenceErr, &a.IndexIDs, &a.PartitionIDs))
 	}
 	// for add column ddl.
-	return errors.Trace(job.DecodeArgs(a.Col, a.Pos, &a.Offset, &a.IgnoreExistenceErr))
+	return errors.Trace(job.decodeArgs(a.Col, a.Pos, &a.Offset, &a.IgnoreExistenceErr))
 }
 
 // FillRollBackArgsForAddColumn fills the args for rollback add column ddl.
@@ -788,7 +788,7 @@ func FillRollBackArgsForAddColumn(job *Job, args *TableColumnArgs) {
 		Type:    ActionDropColumn,
 	}
 	fakeJob.FillArgs(args)
-	job.Args = fakeJob.Args
+	job.args = fakeJob.args
 }
 
 // GetTableColumnArgs gets the args for dropping column ddl or Adding column ddl.
@@ -832,7 +832,7 @@ func (a *RenameTablesArgs) decodeV1(job *Job) error {
 		newTableNames  []pmodel.CIStr
 		tableIDs       []int64
 	)
-	if err := job.DecodeArgs(
+	if err := job.decodeArgs(
 		&oldSchemaIDs, &newSchemaIDs, &newTableNames,
 		&tableIDs, &oldSchemaNames, &oldTableNames); err != nil {
 		return errors.Trace(err)
@@ -885,7 +885,7 @@ func (a *AlterSequenceArgs) getArgsV1(*Job) []any {
 }
 
 func (a *AlterSequenceArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.Ident, &a.SeqOptions))
+	return errors.Trace(job.decodeArgs(&a.Ident, &a.SeqOptions))
 }
 
 // GetAlterSequenceArgs gets the args for alter Sequence ddl job.
@@ -903,7 +903,7 @@ func (a *ModifyTableAutoIDCacheArgs) getArgsV1(*Job) []any {
 }
 
 func (a *ModifyTableAutoIDCacheArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.NewCache))
+	return errors.Trace(job.decodeArgs(&a.NewCache))
 }
 
 // GetModifyTableAutoIDCacheArgs gets the args for modify table autoID cache ddl job.
@@ -921,7 +921,7 @@ func (a *ShardRowIDArgs) getArgsV1(*Job) []any {
 }
 
 func (a *ShardRowIDArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.ShardRowIDBits))
+	return errors.Trace(job.decodeArgs(&a.ShardRowIDBits))
 }
 
 // GetShardRowIDArgs gets the args for shard row ID ddl job.
@@ -941,7 +941,7 @@ func (a *AlterTTLInfoArgs) getArgsV1(*Job) []any {
 }
 
 func (a *AlterTTLInfoArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.TTLInfo, &a.TTLEnable, &a.TTLCronJobSchedule))
+	return errors.Trace(job.decodeArgs(&a.TTLInfo, &a.TTLEnable, &a.TTLCronJobSchedule))
 }
 
 // GetAlterTTLInfoArgs gets the args for alter ttl info job.
@@ -960,7 +960,7 @@ func (a *CheckConstraintArgs) getArgsV1(*Job) []any {
 }
 
 func (a *CheckConstraintArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.ConstraintName, &a.Enforced))
+	return errors.Trace(job.decodeArgs(&a.ConstraintName, &a.Enforced))
 }
 
 // GetCheckConstraintArgs gets the AlterCheckConstraint args.
@@ -979,7 +979,7 @@ func (a *AddCheckConstraintArgs) getArgsV1(*Job) []any {
 
 func (a *AddCheckConstraintArgs) decodeV1(job *Job) error {
 	a.Constraint = &ConstraintInfo{}
-	return errors.Trace(job.DecodeArgs(&a.Constraint))
+	return errors.Trace(job.decodeArgs(&a.Constraint))
 }
 
 // GetAddCheckConstraintArgs gets the AddCheckConstraint args.
@@ -998,7 +998,7 @@ func (a *AlterTablePlacementArgs) getArgsV1(*Job) []any {
 
 func (a *AlterTablePlacementArgs) decodeV1(job *Job) error {
 	// when the target policy is 'default', policy info is nil
-	return errors.Trace(job.DecodeArgs(&a.PlacementPolicyRef))
+	return errors.Trace(job.decodeArgs(&a.PlacementPolicyRef))
 }
 
 // GetAlterTablePlacementArgs gets the args for alter table placements ddl job.
@@ -1016,7 +1016,7 @@ func (a *SetTiFlashReplicaArgs) getArgsV1(*Job) []any {
 }
 
 func (a *SetTiFlashReplicaArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.TiflashReplica))
+	return errors.Trace(job.decodeArgs(&a.TiflashReplica))
 }
 
 // GetSetTiFlashReplicaArgs gets the args for setting TiFlash replica ddl.
@@ -1035,7 +1035,7 @@ func (a *UpdateTiFlashReplicaStatusArgs) getArgsV1(*Job) []any {
 }
 
 func (a *UpdateTiFlashReplicaStatusArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.Available, &a.PhysicalID))
+	return errors.Trace(job.decodeArgs(&a.Available, &a.PhysicalID))
 }
 
 // GetUpdateTiFlashReplicaStatusArgs gets the args for updating TiFlash replica status ddl.
@@ -1058,7 +1058,7 @@ func (a *LockTablesArgs) getArgsV1(*Job) []any {
 }
 
 func (a *LockTablesArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(a))
+	return errors.Trace(job.decodeArgs(a))
 }
 
 // GetLockTablesArgs get the LockTablesArgs argument.
@@ -1076,7 +1076,7 @@ func (a *RepairTableArgs) getArgsV1(*Job) []any {
 }
 
 func (a *RepairTableArgs) decodeV1(job *Job) error {
-	return errors.Trace(job.DecodeArgs(&a.TableInfo))
+	return errors.Trace(job.decodeArgs(&a.TableInfo))
 }
 
 // GetRepairTableArgs get the repair table args.
@@ -1095,7 +1095,7 @@ func (a *AlterTableAttributesArgs) getArgsV1(*Job) []any {
 
 func (a *AlterTableAttributesArgs) decodeV1(job *Job) error {
 	a.LabelRule = &pdhttp.LabelRule{}
-	return errors.Trace(job.DecodeArgs(a.LabelRule))
+	return errors.Trace(job.decodeArgs(a.LabelRule))
 }
 
 // GetAlterTableAttributesArgs get alter table attribute args from job.
@@ -1126,13 +1126,13 @@ func (a *RecoverArgs) decodeV1(job *Job) error {
 		recoverCheckFlag  int64
 	)
 	if job.Type == ActionRecoverTable {
-		err := job.DecodeArgs(&recoverTableInfo, &recoverCheckFlag)
+		err := job.decodeArgs(&recoverTableInfo, &recoverCheckFlag)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		recoverSchemaInfo.RecoverTableInfos = []*RecoverTableInfo{recoverTableInfo}
 	} else {
-		err := job.DecodeArgs(recoverSchemaInfo, &recoverCheckFlag)
+		err := job.decodeArgs(recoverSchemaInfo, &recoverCheckFlag)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1175,11 +1175,11 @@ func (a *PlacementPolicyArgs) decodeV1(job *Job) error {
 	a.PolicyID = job.SchemaID
 
 	if job.Type == ActionCreatePlacementPolicy {
-		return errors.Trace(job.DecodeArgs(&a.Policy, &a.ReplaceOnExist))
+		return errors.Trace(job.decodeArgs(&a.Policy, &a.ReplaceOnExist))
 	} else if job.Type == ActionAlterPlacementPolicy {
-		return errors.Trace(job.DecodeArgs(&a.Policy))
+		return errors.Trace(job.decodeArgs(&a.Policy))
 	}
-	return errors.Trace(job.DecodeArgs(&a.PolicyName))
+	return errors.Trace(job.decodeArgs(&a.PolicyName))
 }
 
 // GetPlacementPolicyArgs gets the placement policy args.
@@ -1198,7 +1198,7 @@ func (a *SetDefaultValueArgs) getArgsV1(*Job) []any {
 
 func (a *SetDefaultValueArgs) decodeV1(job *Job) error {
 	a.Col = &ColumnInfo{}
-	return errors.Trace(job.DecodeArgs(a.Col))
+	return errors.Trace(job.decodeArgs(a.Col))
 }
 
 // GetSetDefaultValueArgs get the args for setting default value ddl.
@@ -1251,7 +1251,7 @@ func (a *FlashbackClusterArgs) getArgsV1(*Job) []any {
 func (a *FlashbackClusterArgs) decodeV1(job *Job) error {
 	var autoAnalyzeValue, readOnlyValue, ttlJobEnableValue string
 
-	if err := job.DecodeArgs(
+	if err := job.decodeArgs(
 		&a.FlashbackTS, &a.PDScheduleValue, &a.EnableGC,
 		&autoAnalyzeValue, &readOnlyValue, &a.LockedRegionCnt,
 		&a.StartTS, &a.CommitTS, &ttlJobEnableValue, &a.FlashbackKeyRanges,
@@ -1417,7 +1417,7 @@ func (a *ModifyIndexArgs) decodeV1(job *Job) error {
 
 func (a *ModifyIndexArgs) decodeRenameIndexV1(job *Job) error {
 	var from, to pmodel.CIStr
-	if err := job.DecodeArgs(&from, &to); err != nil {
+	if err := job.decodeArgs(&from, &to); err != nil {
 		return errors.Trace(err)
 	}
 	a.IndexArgs = []*IndexArg{
@@ -1430,8 +1430,8 @@ func (a *ModifyIndexArgs) decodeRenameIndexV1(job *Job) error {
 func (a *ModifyIndexArgs) decodeDropIndexV1(job *Job) error {
 	indexNames := make([]pmodel.CIStr, 1)
 	ifExists := make([]bool, 1)
-	if err := job.DecodeArgs(&indexNames[0], &ifExists[0]); err != nil {
-		if err = job.DecodeArgs(&indexNames, &ifExists); err != nil {
+	if err := job.decodeArgs(&indexNames[0], &ifExists[0]); err != nil {
+		if err = job.decodeArgs(&indexNames, &ifExists); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -1454,10 +1454,10 @@ func (a *ModifyIndexArgs) decodeAddIndexV1(job *Job) error {
 	hiddenCols := make([][]*ColumnInfo, 1)
 	globals := make([]bool, 1)
 
-	if err := job.DecodeArgs(
+	if err := job.decodeArgs(
 		&uniques, &indexNames, &indexPartSpecifications,
 		&indexOptions, &hiddenCols, &globals); err != nil {
-		if err = job.DecodeArgs(
+		if err = job.decodeArgs(
 			&uniques[0], &indexNames[0], &indexPartSpecifications[0],
 			&indexOptions[0], &hiddenCols[0], &globals[0]); err != nil {
 			return errors.Trace(err)
@@ -1480,7 +1480,7 @@ func (a *ModifyIndexArgs) decodeAddIndexV1(job *Job) error {
 func (a *ModifyIndexArgs) decodeAddPrimaryKeyV1(job *Job) error {
 	a.IndexArgs = []*IndexArg{{IsPK: true}}
 	var unused any
-	if err := job.DecodeArgs(
+	if err := job.decodeArgs(
 		&a.IndexArgs[0].Unique, &a.IndexArgs[0].IndexName, &a.IndexArgs[0].IndexPartSpecifications,
 		&a.IndexArgs[0].IndexOption, &a.IndexArgs[0].SQLMode,
 		&unused, &a.IndexArgs[0].Global); err != nil {
@@ -1497,7 +1497,7 @@ func (a *ModifyIndexArgs) decodeAddVectorIndexV1(job *Job) error {
 		funcExpr               string
 	)
 
-	if err := job.DecodeArgs(
+	if err := job.decodeArgs(
 		&indexName, &indexPartSpecification, &indexOption, &funcExpr); err != nil {
 		return errors.Trace(err)
 	}
@@ -1594,10 +1594,10 @@ func GetFinishedModifyIndexArgs(job *Job) (*ModifyIndexArgs, error) {
 
 		if job.IsRollingback() {
 			// Rollback add indexes
-			err = job.DecodeArgs(&indexNames, &ifExists, &partitionIDs, &isVector)
+			err = job.decodeArgs(&indexNames, &ifExists, &partitionIDs, &isVector)
 		} else {
 			// Finish drop index
-			err = job.DecodeArgs(&indexNames[0], &ifExists[0], &indexIDs[0], &partitionIDs, &isVector)
+			err = job.decodeArgs(&indexNames[0], &ifExists[0], &indexIDs[0], &partitionIDs, &isVector)
 		}
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1629,8 +1629,8 @@ func GetFinishedModifyIndexArgs(job *Job) (*ModifyIndexArgs, error) {
 	var partitionIDs []int64
 
 	// add vector index args doesn't store slice.
-	if err := job.DecodeArgs(&addIndexIDs[0], &ifExists[0], &partitionIDs, &isGlobals[0]); err != nil {
-		if err = job.DecodeArgs(&addIndexIDs, &ifExists, &partitionIDs, &isGlobals); err != nil {
+	if err := job.decodeArgs(&addIndexIDs[0], &ifExists[0], &partitionIDs, &isGlobals[0]); err != nil {
+		if err = job.decodeArgs(&addIndexIDs, &ifExists, &partitionIDs, &isGlobals); err != nil {
 			return nil, errors.Errorf("Failed to decode finished arguments from job version 1")
 		}
 	}
@@ -1674,7 +1674,7 @@ func (a *ModifyColumnArgs) getArgsV1(*Job) []any {
 }
 
 func (a *ModifyColumnArgs) decodeV1(job *Job) error {
-	return job.DecodeArgs(
+	return job.decodeArgs(
 		&a.Column, &a.OldColumnName, &a.Position, &a.ModifyColumnType,
 		&a.NewShardBits, &a.ChangingColumn, &a.ChangingIdxs, &a.RedundantIdxs,
 	)
@@ -1696,7 +1696,7 @@ func GetFinishedModifyColumnArgs(job *Job) (*ModifyColumnArgs, error) {
 			indexIDs     []int64
 			partitionIDs []int64
 		)
-		if err := job.DecodeArgs(&indexIDs, &partitionIDs); err != nil {
+		if err := job.decodeArgs(&indexIDs, &partitionIDs); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &ModifyColumnArgs{

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -73,15 +73,15 @@ func getOrDecodeArgsV1[T JobArgs](args T, job *Job) (T, error) {
 // and cache in job.Args.
 func getOrDecodeArgsV2[T JobArgs](job *Job) (T, error) {
 	intest.Assert(job.Version == JobVersion2, "job version is not v2")
-	if len(job.args) > 0 {
-		intest.Assert(len(job.args) == 1, "job args length is not 1")
-		return job.args[0].(T), nil
+	if len(job.Args) > 0 {
+		intest.Assert(len(job.Args) == 1, "job args length is not 1")
+		return job.Args[0].(T), nil
 	}
 	var v T
 	if err := json.Unmarshal(job.RawArgs, &v); err != nil {
 		return v, errors.Trace(err)
 	}
-	job.args = []any{v}
+	job.Args = []any{v}
 	return v, nil
 }
 
@@ -506,7 +506,7 @@ func FillRollbackArgsForAddPartition(job *Job, args *TablePartitionArgs) {
 	fake.FillArgs(&TablePartitionArgs{
 		PartNames: args.PartNames,
 	})
-	job.args = fake.args
+	job.Args = fake.Args
 }
 
 // ExchangeTablePartitionArgs is the arguments for exchange table partition job.
@@ -788,7 +788,7 @@ func FillRollBackArgsForAddColumn(job *Job, args *TableColumnArgs) {
 		Type:    ActionDropColumn,
 	}
 	fakeJob.FillArgs(args)
-	job.args = fakeJob.args
+	job.Args = fakeJob.Args
 }
 
 // GetTableColumnArgs gets the args for dropping column ddl or Adding column ddl.

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -73,15 +73,15 @@ func getOrDecodeArgsV1[T JobArgs](args T, job *Job) (T, error) {
 // and cache in job.Args.
 func getOrDecodeArgsV2[T JobArgs](job *Job) (T, error) {
 	intest.Assert(job.Version == JobVersion2, "job version is not v2")
-	if len(job.Args) > 0 {
-		intest.Assert(len(job.Args) == 1, "job args length is not 1")
-		return job.Args[0].(T), nil
+	if len(job.args) > 0 {
+		intest.Assert(len(job.args) == 1, "job args length is not 1")
+		return job.args[0].(T), nil
 	}
 	var v T
 	if err := json.Unmarshal(job.RawArgs, &v); err != nil {
 		return v, errors.Trace(err)
 	}
-	job.Args = []any{v}
+	job.args = []any{v}
 	return v, nil
 }
 
@@ -506,7 +506,7 @@ func FillRollbackArgsForAddPartition(job *Job, args *TablePartitionArgs) {
 	fake.FillArgs(&TablePartitionArgs{
 		PartNames: args.PartNames,
 	})
-	job.Args = fake.Args
+	job.args = fake.args
 }
 
 // ExchangeTablePartitionArgs is the arguments for exchange table partition job.
@@ -788,7 +788,7 @@ func FillRollBackArgsForAddColumn(job *Job, args *TableColumnArgs) {
 		Type:    ActionDropColumn,
 	}
 	fakeJob.FillArgs(args)
-	job.Args = fakeJob.Args
+	job.args = fakeJob.args
 }
 
 // GetTableColumnArgs gets the args for dropping column ddl or Adding column ddl.

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -39,10 +39,10 @@ func TestGetOrDecodeArgsV2(t *testing.T) {
 	// return existing argsV2
 	argsV2, err := getOrDecodeArgsV2[*TruncateTableArgs](j)
 	require.NoError(t, err)
-	require.Same(t, j.Args[0], argsV2)
+	require.Same(t, j.args[0], argsV2)
 	// unmarshal from json
 	var argsBak *TruncateTableArgs
-	argsBak, j.Args = j.Args[0].(*TruncateTableArgs), nil
+	argsBak, j.args = j.args[0].(*TruncateTableArgs), nil
 	argsV2, err = getOrDecodeArgsV2[*TruncateTableArgs](j)
 	require.NoError(t, err)
 	require.NotNil(t, argsV2)
@@ -346,11 +346,11 @@ func TestTablePartitionArgs(t *testing.T) {
 					{ID: 2, Name: model.NewCIStr("bbb"), LessThan: []string{"2"}},
 				}},
 			})
-		require.Len(t, j.Args, 1)
+		require.Len(t, j.args, 1)
 		if ver == JobVersion1 {
-			require.EqualValues(t, partNames, j.Args[0].([]string))
+			require.EqualValues(t, partNames, j.args[0].([]string))
 		} else {
-			args := j.Args[0].(*TablePartitionArgs)
+			args := j.args[0].(*TablePartitionArgs)
 			require.EqualValues(t, partNames, args.PartNames)
 			require.Nil(t, args.PartInfo)
 			require.Nil(t, args.OldPhysicalTblIDs)

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -39,10 +39,10 @@ func TestGetOrDecodeArgsV2(t *testing.T) {
 	// return existing argsV2
 	argsV2, err := getOrDecodeArgsV2[*TruncateTableArgs](j)
 	require.NoError(t, err)
-	require.Same(t, j.args[0], argsV2)
+	require.Same(t, j.Args[0], argsV2)
 	// unmarshal from json
 	var argsBak *TruncateTableArgs
-	argsBak, j.args = j.args[0].(*TruncateTableArgs), nil
+	argsBak, j.Args = j.Args[0].(*TruncateTableArgs), nil
 	argsV2, err = getOrDecodeArgsV2[*TruncateTableArgs](j)
 	require.NoError(t, err)
 	require.NotNil(t, argsV2)
@@ -346,11 +346,11 @@ func TestTablePartitionArgs(t *testing.T) {
 					{ID: 2, Name: model.NewCIStr("bbb"), LessThan: []string{"2"}},
 				}},
 			})
-		require.Len(t, j.args, 1)
+		require.Len(t, j.Args, 1)
 		if ver == JobVersion1 {
-			require.EqualValues(t, partNames, j.args[0].([]string))
+			require.EqualValues(t, partNames, j.Args[0].([]string))
 		} else {
-			args := j.args[0].(*TablePartitionArgs)
+			args := j.Args[0].(*TablePartitionArgs)
 			require.EqualValues(t, partNames, args.PartNames)
 			require.Nil(t, args.PartInfo)
 			require.Nil(t, args.OldPhysicalTblIDs)

--- a/pkg/meta/model/job_test.go
+++ b/pkg/meta/model/job_test.go
@@ -460,5 +460,5 @@ func TestJobEncodeV2(t *testing.T) {
 	require.NotNil(t, j.RawArgs)
 	args := &TruncateTableArgs{}
 	require.NoError(t, json.Unmarshal(j.RawArgs, args))
-	require.EqualValues(t, j.Args[0], args)
+	require.EqualValues(t, j.args[0], args)
 }

--- a/pkg/meta/model/job_test.go
+++ b/pkg/meta/model/job_test.go
@@ -460,5 +460,5 @@ func TestJobEncodeV2(t *testing.T) {
 	require.NotNil(t, j.RawArgs)
 	args := &TruncateTableArgs{}
 	require.NoError(t, json.Unmarshal(j.RawArgs, args))
-	require.EqualValues(t, j.args[0], args)
+	require.EqualValues(t, j.Args[0], args)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54436

Problem Summary:

### What changed and how does it work?
- make args in job/subjob and DecodeArgs unexported, now caller should use GetXXXArgs function instead
- remove change fields inside job.decodeArgs
- remove tests related to `MockModifyJobArg` failpoint, it only test how we handle corrupted args, and the job is cancelled in this case.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test, use existing cases to cover it, we mainly rename fields/methods
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
