### PR TITLE
ddl: support dropping multiple foreign keys

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -5163,6 +5163,17 @@ func (e *executor) DropForeignKey(ctx sessionctx.Context, ti ast.Ident, fkName p
 		return errors.Trace(infoschema.ErrTableNotExists.GenWithStackByArgs(ti.Schema, ti.Name))
 	}
 
+	foundFK := false
+	for _, fk := range t.Meta().ForeignKeys {
+		if fk.Name.L == fkName.L {
+			foundFK = true
+			break
+		}
+	}
+	if !foundFK {
+		return infoschema.ErrForeignKeyNotExists.GenWithStackByArgs(fkName)
+	}
+
 	job := &model.Job{
 		Version:        model.GetJobVerInUse(),
 		SchemaID:       schema.ID,

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -262,6 +262,8 @@ func fillMultiSchemaInfo(info *model.MultiSchemaInfo, job *JobWrapper) error {
 			Name: fkInfo.Name,
 			Cols: fkInfo.Cols,
 		})
+	case model.ActionDropForeignKey:
+		// there is nothing to verify for `DROP FOREIGN KEY`
 	default:
 		return dbterror.ErrRunMultiSchemaChanges.FastGenByArgs(job.Type.String())
 	}

--- a/tests/integrationtest/r/ddl/multi_schema_change.result
+++ b/tests/integrationtest/r/ddl/multi_schema_change.result
@@ -436,3 +436,23 @@ t	CREATE TABLE `t` (
   KEY `i` (`a`),
   PRIMARY KEY (`a`) /*T![clustered_index] NONCLUSTERED */
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists child, parent;
+create table parent (ref int, key(ref));
+create table child (ref int, constraint fk1 foreign key (ref) references parent(ref), constraint fk2 foreign key (ref) references parent(ref));
+alter table child drop foreign key fk1, drop foreign key fk3;
+Error 1091 (42000): Can't DROP 'fk3'; check that column/key exists
+show create table child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `ref` int DEFAULT NULL,
+  KEY `fk1` (`ref`),
+  CONSTRAINT `fk1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`),
+  CONSTRAINT `fk2` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+alter table child drop foreign key fk1, drop foreign key fk2;
+show create table child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `ref` int DEFAULT NULL,
+  KEY `fk1` (`ref`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin

--- a/tests/integrationtest/t/ddl/multi_schema_change.test
+++ b/tests/integrationtest/t/ddl/multi_schema_change.test
@@ -365,3 +365,12 @@ insert into t values (123);
 alter table t add index i(a), add primary key (a);
 show create table t;
 
+# TestMultiSchemaChangeDropForeignKey
+drop table if exists child, parent;
+create table parent (ref int, key(ref));
+create table child (ref int, constraint fk1 foreign key (ref) references parent(ref), constraint fk2 foreign key (ref) references parent(ref));
+-- error 1091
+alter table child drop foreign key fk1, drop foreign key fk3;
+show create table child;
+alter table child drop foreign key fk1, drop foreign key fk2;
+show create table child;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #28421 

Problem Summary:

Previously, TiDB doesn't support dropping multiple foreign keys.

### What changed and how does it work?

Add support for dropping multiple foreign keys.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
