### PR TITLE
stmtsummary: reduce the memory consumption by information_schema.statements_summary_evicted

### DIFF
--- a/pkg/infoschema/test/clustertablestest/tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/tables_test.go
@@ -1157,7 +1157,7 @@ func TestStmtSummaryEvictedPointGet(t *testing.T) {
 		tk.MustExec(fmt.Sprintf("select p from th%v where p=2333;", i%6))
 	}
 	tk.MustQuery("select EVICTED_COUNT from information_schema.statements_summary_evicted;").
-		Check(testkit.Rows("7"))
+		Check(testkit.Rows("996"))
 
 	tk.MustExec("set @@global.tidb_enable_stmt_summary=0;")
 	tk.MustQuery("select count(*) from information_schema.statements_summary_evicted;").

--- a/pkg/util/stmtsummary/evicted.go
+++ b/pkg/util/stmtsummary/evicted.go
@@ -38,8 +38,8 @@ type stmtSummaryByDigestEvictedElement struct {
 	beginTime int64
 	// endTime is the end time of current interval
 	endTime int64
-	// digestKeyMap contains *Kinds* of digest being evicted
-	digestKeyMap map[string]struct{}
+	// count is the number of digest being evicted
+	count int64
 	// otherSummary contains summed up information of evicted elements
 	otherSummary *stmtSummaryByDigestElement
 }
@@ -54,9 +54,8 @@ func newStmtSummaryByDigestEvicted() *stmtSummaryByDigestEvicted {
 // spawn a new pointer to stmtSummaryByDigestEvictedElement
 func newStmtSummaryByDigestEvictedElement(beginTime int64, endTime int64) *stmtSummaryByDigestEvictedElement {
 	return &stmtSummaryByDigestEvictedElement{
-		beginTime:    beginTime,
-		endTime:      endTime,
-		digestKeyMap: make(map[string]struct{}),
+		beginTime: beginTime,
+		endTime:   endTime,
 		otherSummary: &stmtSummaryByDigestElement{
 			beginTime:    beginTime,
 			endTime:      endTime,
@@ -153,7 +152,7 @@ func (ssbde *stmtSummaryByDigestEvicted) Clear() {
 // add an evicted record to stmtSummaryByDigestEvictedElement
 func (seElement *stmtSummaryByDigestEvictedElement) addEvicted(digestKey *stmtSummaryByDigestKey, digestValue *stmtSummaryByDigestElement) {
 	if digestKey != nil {
-		seElement.digestKeyMap[string(digestKey.Hash())] = struct{}{}
+		seElement.count++
 		addInfo(seElement.otherSummary, digestValue)
 	}
 }
@@ -199,7 +198,7 @@ func (seElement *stmtSummaryByDigestEvictedElement) toEvictedCountDatum() []type
 	datum := types.MakeDatums(
 		types.NewTime(types.FromGoTime(time.Unix(seElement.beginTime, 0)), mysql.TypeTimestamp, 0),
 		types.NewTime(types.FromGoTime(time.Unix(seElement.endTime, 0)), mysql.TypeTimestamp, 0),
-		int64(len(seElement.digestKeyMap)),
+		seElement.count,
 	)
 	return datum
 }

--- a/pkg/util/stmtsummary/evicted_test.go
+++ b/pkg/util/stmtsummary/evicted_test.go
@@ -166,19 +166,19 @@ func TestSimpleStmtSummaryByDigestEvicted(t *testing.T) {
 	require.Equal(t, "{begin: 1, end: 2, count: 1}", getAllEvicted(ssbde))
 	// test insert same *kind* of digest
 	ssbde.AddEvicted(evictedKey, evictedValue, 1)
-	require.Equal(t, "{begin: 1, end: 2, count: 1}", getAllEvicted(ssbde))
+	require.Equal(t, "{begin: 1, end: 2, count: 2}", getAllEvicted(ssbde))
 
 	evictedKey, evictedValue = generateStmtSummaryByDigestKeyValue("b", 1, 2)
 	ssbde.AddEvicted(evictedKey, evictedValue, 1)
-	require.Equal(t, "{begin: 1, end: 2, count: 2}", getAllEvicted(ssbde))
+	require.Equal(t, "{begin: 1, end: 2, count: 3}", getAllEvicted(ssbde))
 
 	evictedKey, evictedValue = generateStmtSummaryByDigestKeyValue("b", 5, 6)
 	ssbde.AddEvicted(evictedKey, evictedValue, 2)
-	require.Equal(t, "{begin: 5, end: 6, count: 1}, {begin: 1, end: 2, count: 2}", getAllEvicted(ssbde))
+	require.Equal(t, "{begin: 5, end: 6, count: 1}, {begin: 1, end: 2, count: 3}", getAllEvicted(ssbde))
 
 	evictedKey, evictedValue = generateStmtSummaryByDigestKeyValue("b", 3, 4)
 	ssbde.AddEvicted(evictedKey, evictedValue, 3)
-	require.Equal(t, "{begin: 5, end: 6, count: 1}, {begin: 3, end: 4, count: 1}, {begin: 1, end: 2, count: 2}", getAllEvicted(ssbde))
+	require.Equal(t, "{begin: 5, end: 6, count: 1}, {begin: 3, end: 4, count: 1}, {begin: 1, end: 2, count: 3}", getAllEvicted(ssbde))
 
 	// test evicted element with multi-time range value.
 	ssbde = newStmtSummaryByDigestEvicted()
@@ -235,13 +235,13 @@ func TestStmtSummaryByDigestEvictedElement(t *testing.T) {
 
 	// test add same *kind* of values.
 	record.addEvicted(evictedKey, digestValue)
-	require.Equal(t, "{begin: 0, end: 1, count: 1}", getEvicted(record))
+	require.Equal(t, "{begin: 0, end: 1, count: 2}", getEvicted(record))
 
 	// test add different *kind* of values.
 	evictedKey, evictedValue = generateStmtSummaryByDigestKeyValue("bravo", 0, 1)
 	digestValue = evictedValue.history.Back().Value.(*stmtSummaryByDigestElement)
 	record.addEvicted(evictedKey, digestValue)
-	require.Equal(t, "{begin: 0, end: 1, count: 2}", getEvicted(record))
+	require.Equal(t, "{begin: 0, end: 1, count: 3}", getEvicted(record))
 }
 
 // test stmtSummaryByDigestEvicted.addEvicted
@@ -315,7 +315,7 @@ func TestNewStmtSummaryByDigestEvictedElement(t *testing.T) {
 	stmtEvictedElement := newStmtSummaryByDigestEvictedElement(now, end)
 	require.Equal(t, now, stmtEvictedElement.beginTime)
 	require.Equal(t, end, stmtEvictedElement.endTime)
-	require.Equal(t, 0, len(stmtEvictedElement.digestKeyMap))
+	require.Equal(t, int64(0), stmtEvictedElement.count)
 }
 
 func TestStmtSummaryByDigestEvicted(t *testing.T) {
@@ -624,13 +624,13 @@ func getAllEvicted(ssdbe *stmtSummaryByDigestEvicted) string {
 			buf.WriteString(", ")
 		}
 		val := e.Value.(*stmtSummaryByDigestEvictedElement)
-		buf.WriteString(fmt.Sprintf("{begin: %v, end: %v, count: %v}", val.beginTime, val.endTime, len(val.digestKeyMap)))
+		buf.WriteString(fmt.Sprintf("{begin: %v, end: %v, count: %v}", val.beginTime, val.endTime, val.count))
 	}
 	return buf.String()
 }
 
 func getEvicted(ssbdee *stmtSummaryByDigestEvictedElement) string {
 	buf := bytes.NewBuffer(nil)
-	buf.WriteString(fmt.Sprintf("{begin: %v, end: %v, count: %v}", ssbdee.beginTime, ssbdee.endTime, len(ssbdee.digestKeyMap)))
+	buf.WriteString(fmt.Sprintf("{begin: %v, end: %v, count: %v}", ssbdee.beginTime, ssbdee.endTime, ssbdee.count))
 	return buf.String()
 }


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56629

Problem Summary: reduce the memory consumption by information_schema.statements_summary_evicted

### What changed and how does it work?

Remove the digest map of `statements_summary_evicted`, use a counter to count evicted digest.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
