### PR TITLE
ddl_notifier: create system table in test and escape the string literal

### DIFF
--- a/pkg/ddl/constant.go
+++ b/pkg/ddl/constant.go
@@ -38,6 +38,8 @@ const (
 	BackgroundSubtaskTableID = meta.MaxInt48 - 5
 	// BackgroundSubtaskHistoryTableID is the table ID of `tidb_background_subtask_history`.
 	BackgroundSubtaskHistoryTableID = meta.MaxInt48 - 6
+	// NotifierTableID is the table ID of `tidb_ddl_notifier`.
+	NotifierTableID = meta.MaxInt48 - 7
 
 	// JobTableSQL is the CREATE TABLE SQL of `tidb_ddl_job`.
 	JobTableSQL = "create table " + JobTable + `(
@@ -117,4 +119,13 @@ const (
 		summary json,
 		key idx_task_key(task_key),
 		key idx_state_update_time(state_update_time))`
+
+	// NotifierTableSQL is the CREATE TABLE SQL of `tidb_ddl_notifier`.
+	// TODO(lance6716): update the column name multi_schema_change_seq
+	NotifierTableSQL = `CREATE TABLE tidb_ddl_notifier (
+		ddl_job_id BIGINT,
+		multi_schema_change_seq BIGINT COMMENT '-1 if the schema change does not belong to a multi-schema change DDL. 0 or positive numbers representing the sub-job index of a multi-schema change DDL',
+		schema_change LONGBLOB COMMENT 'SchemaChangeEvent at rest',
+		processed_by_flag BIGINT UNSIGNED DEFAULT 0 COMMENT 'flag to mark which subscriber has processed the event',
+		PRIMARY KEY(ddl_job_id, multi_schema_change_seq))`
 )

--- a/pkg/ddl/notifier/store.go
+++ b/pkg/ddl/notifier/store.go
@@ -56,11 +56,13 @@ func (t *tableStore) Insert(ctx context.Context, s *sess.Session, change *schema
 			multi_schema_change_seq,
 			schema_change,
 			processed_by_flag
-		) VALUES (%d, %d, '%s', 0)`,
+		) VALUES (%%?, %%?, %%?, 0)`,
 		t.db, t.table,
+	)
+	_, err = s.Execute(
+		ctx, sql, "ddl_notifier",
 		change.ddlJobID, change.multiSchemaChangeSeq, event,
 	)
-	_, err = s.Execute(ctx, sql, "ddl_notifier")
 	return err
 }
 

--- a/pkg/ddl/notifier/testkit_test.go
+++ b/pkg/ddl/notifier/testkit_test.go
@@ -114,7 +114,7 @@ func TestBasicPubSub(t *testing.T) {
 	event1 := notifier.NewCreateTablesEvent([]*model.TableInfo{{ID: 1000, Name: pmodel.NewCIStr("t1")}})
 	err := notifier.PubSchemeChangeToStore(ctx, se, 1, -1, event1, s)
 	require.NoError(t, err)
-	event2 := notifier.NewDropTableEvent(&model.TableInfo{ID: 1001, Name: pmodel.NewCIStr("t2")})
+	event2 := notifier.NewDropTableEvent(&model.TableInfo{ID: 1001, Name: pmodel.NewCIStr("t2#special-char?in'name")})
 	err = notifier.PubSchemeChangeToStore(ctx, se, 2, -1, event2, s)
 	require.NoError(t, err)
 	event3 := notifier.NewDropTableEvent(&model.TableInfo{ID: 1002, Name: pmodel.NewCIStr("t3")})

--- a/pkg/ddl/notifier/testkit_test.go
+++ b/pkg/ddl/notifier/testkit_test.go
@@ -46,12 +46,12 @@ CREATE TABLE ddl_notifier (
 func TestPublishToTableStore(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("USE test")
-	tk.MustExec("DROP TABLE IF EXISTS ddl_notifier")
-	tk.MustExec(tableStructure)
+	t.Cleanup(func() {
+		tk.MustExec("TRUNCATE mysql.tidb_ddl_notifier")
+	})
 
 	ctx := context.Background()
-	s := notifier.OpenTableStore("test", "ddl_notifier")
+	s := notifier.OpenTableStore("mysql", "tidb_ddl_notifier")
 	se := sess.NewSession(tk.Session())
 	event1 := notifier.NewCreateTablesEvent([]*model.TableInfo{{ID: 1000, Name: pmodel.NewCIStr("t1")}})
 	err := notifier.PubSchemeChangeToStore(ctx, se, 1, -1, event1, s)

--- a/pkg/ddl/session/session.go
+++ b/pkg/ddl/session/session.go
@@ -72,7 +72,7 @@ func (s *Session) Reset() {
 }
 
 // Execute executes a query.
-func (s *Session) Execute(ctx context.Context, query string, label string) ([]chunk.Row, error) {
+func (s *Session) Execute(ctx context.Context, query string, label string, args ...any) ([]chunk.Row, error) {
 	startTime := time.Now()
 	var err error
 	defer func() {
@@ -82,7 +82,7 @@ func (s *Session) Execute(ctx context.Context, query string, label string) ([]ch
 	if ctx.Value(kv.RequestSourceKey) == nil {
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnDDL)
 	}
-	rs, err := s.Context.GetSQLExecutor().ExecuteInternal(ctx, query)
+	rs, err := s.Context.GetSQLExecutor().ExecuteInternal(ctx, query, args...)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -393,7 +393,7 @@ func TestTableStorageStats(t *testing.T) {
 		"test 2",
 	))
 	rows := tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()
-	result := 57
+	result := 58
 	require.Len(t, rows, result)
 
 	// More tests about the privileges.

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -654,7 +654,7 @@ func TestIndexUsageTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|idt2|idx_4"))
 	tk.MustQuery(`select count(*) from information_schema.tidb_index_usage;`).Check(
-		testkit.RowsWithSep("|", "77"))
+		testkit.RowsWithSep("|", "78"))
 
 	tk.MustQuery(`select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage
 				where TABLE_SCHEMA = 'test1';`).Check(testkit.Rows())

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -607,7 +607,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "4979"))
+		testkit.RowsWithSep("|", "4983"))
 }
 
 func TestIndexUsageTable(t *testing.T) {

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -250,6 +250,8 @@ func TestDDLTableCreateBackfillTable(t *testing.T) {
 	m.SetDDLTables(meta.MDLTableVersion)
 	MustExec(t, se, "drop table mysql.tidb_background_subtask")
 	MustExec(t, se, "drop table mysql.tidb_background_subtask_history")
+	// TODO(lance6716): remove it after tidb_ddl_notifier GA
+	MustExec(t, se, "drop table mysql.tidb_ddl_notifier")
 	err = txn.Commit(context.Background())
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55722

Problem Summary:

### What changed and how does it work?

- create system table when bootstrap
- fix a bug that can't insert schema change events containing `'`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
