### PR TITLE
expression: fix expression that duration type null equal with const null

### DIFF
--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1632,6 +1632,10 @@ func (c *compareFunctionClass) handleDurationTypeComparison(ctx BuildContext, ar
 
 	var isNull bool
 	if arg0IsCon && arg0Const.DeferredExpr == nil && !arg1IsCon && arg1.GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeDuration {
+		if arg0Const.Value.IsNull() {
+			// This is a const null, there is no need to re-write the expression
+			return nil, nil
+		}
 		isNull, err = castToDurationIsNull(ctx, arg0)
 	} else if arg1IsCon && arg1Const.DeferredExpr == nil && !arg0IsCon && arg0.GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeDuration {
 		if arg1Const.Value.IsNull() {

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1603,7 +1603,7 @@ func matchRefineRule3Pattern(conEvalType types.EvalType, exprType *types.FieldTy
 		(conEvalType == types.ETReal || conEvalType == types.ETDecimal || conEvalType == types.ETInt)
 }
 
-// handleDurationTypeComparison handles comparisons between a duration type column and a non-duration type constant.
+// handleDurationTypeComparisonForNullEq handles comparisons between a duration type column and a non-duration type constant.
 // If the constant cannot be cast to a duration type and the comparison operator is `<=>`, the expression is rewritten as `0 <=> 1`.
 // This is necessary to maintain compatibility with MySQL behavior under the following conditions:
 //  1. When a duration type column is compared with a non-duration type constant, MySQL casts the duration column to the non-duration type.
@@ -1616,7 +1616,7 @@ func matchRefineRule3Pattern(conEvalType types.EvalType, exprType *types.FieldTy
 //
 // To ensure MySQL compatibility, we need to handle this case specifically. If the non-duration type constant cannot be cast to a duration type,
 // we rewrite the expression to always return false by converting it to `0 <=> 1`.
-func (c *compareFunctionClass) handleDurationTypeComparison(ctx BuildContext, arg0, arg1 Expression) (_ []Expression, err error) {
+func (c *compareFunctionClass) handleDurationTypeComparisonForNullEq(ctx BuildContext, arg0, arg1 Expression) (_ []Expression, err error) {
 	// check if a constant value becomes null after being cast to a duration type.
 	castToDurationIsNull := func(ctx BuildContext, arg Expression) (bool, error) {
 		f := WrapWithCastAsDuration(ctx, arg)
@@ -1732,7 +1732,7 @@ func (c *compareFunctionClass) refineArgs(ctx BuildContext, args []Expression) (
 
 	// Handle comparison between a duration type column and a non-duration type constant.
 	if c.op == opcode.NullEQ {
-		if result, err := c.handleDurationTypeComparison(ctx, args[0], args[1]); err != nil || result != nil {
+		if result, err := c.handleDurationTypeComparisonForNullEq(ctx, args[0], args[1]); err != nil || result != nil {
 			return result, err
 		}
 	}

--- a/pkg/expression/builtin_compare.go
+++ b/pkg/expression/builtin_compare.go
@@ -1634,6 +1634,10 @@ func (c *compareFunctionClass) handleDurationTypeComparison(ctx BuildContext, ar
 	if arg0IsCon && arg0Const.DeferredExpr == nil && !arg1IsCon && arg1.GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeDuration {
 		isNull, err = castToDurationIsNull(ctx, arg0)
 	} else if arg1IsCon && arg1Const.DeferredExpr == nil && !arg0IsCon && arg0.GetType(ctx.GetEvalCtx()).GetType() == mysql.TypeDuration {
+		if arg1Const.Value.IsNull() {
+			// This is a const null, there is no need to re-write the expression
+			return nil, nil
+		}
 		isNull, err = castToDurationIsNull(ctx, arg1)
 	}
 	if err != nil {

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -3888,6 +3888,8 @@ func TestIssue51842(t *testing.T) {
 	tk.MustExec("insert into lrr(col2) values('-229:53:34');")
 	resultRows := tk.MustQuery("select * from lrr where col1 <=> null;").Rows() // test const null
 	require.Equal(t, 1, len(resultRows))
+	resultRows = tk.MustQuery("select * from lrr where null <=> col1;").Rows() // test const null
+	require.Equal(t, 1, len(resultRows))
 }
 
 func TestIssue44706(t *testing.T) {

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -3881,6 +3881,13 @@ func TestIssue51842(t *testing.T) {
 	require.Equal(t, 0, len(res))
 	res = tk.MustQuery("SELECT f1 FROM (SELECT NULLIF(v0.c0, 1371581446) AS f1 FROM v0, t0) AS t WHERE f1 <=> cast('2024-1-1 10:10:10' as datetime);").String() // test datetime
 	require.Equal(t, 0, len(res))
+
+	// Test issue 56744
+	tk.MustExec("drop table if exists lrr;")
+	tk.MustExec("create table lrr(`COL1` time DEFAULT NULL,`COL2` time DEFAULT NULL);")
+	tk.MustExec("insert into lrr(col2) values('-229:53:34');")
+	resultRows := tk.MustQuery("select * from lrr where col1 <=> null;").Rows() // test const null
+	require.Equal(t, 1, len(resultRows))
 }
 
 func TestIssue44706(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56744

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix issue that fail to evaluate the expression that duration type null equal with const null
```
