### PR TITLE
executor: fix plan replay cannot deal with placement mode

### DIFF
--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -524,12 +524,15 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 }
 
 func (e *PlanReplayerLoadInfo) createTable(z *zip.Reader) error {
-	origin := e.Ctx.GetSessionVars().ForeignKeyChecks
+	originForeignKeyChecks := e.Ctx.GetSessionVars().ForeignKeyChecks
+	originPlacementMode := e.Ctx.GetSessionVars().PlacementMode
 	// We need to disable foreign key check when we create schema and tables.
 	// because the order of creating schema and tables is not guaranteed.
 	e.Ctx.GetSessionVars().ForeignKeyChecks = false
+	e.Ctx.GetSessionVars().PlacementMode = variable.PlacementModeIgnore
 	defer func() {
-		e.Ctx.GetSessionVars().ForeignKeyChecks = origin
+		e.Ctx.GetSessionVars().ForeignKeyChecks = originForeignKeyChecks
+		e.Ctx.GetSessionVars().PlacementMode = originPlacementMode
 	}()
 	for _, zipFile := range z.File {
 		if zipFile.Name == fmt.Sprintf("schema/%v", domain.PlanReplayerSchemaMetaFile) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54961

Problem Summary:

### What changed and how does it work?

when we restore the table with plan replay. we will ignore the placement rules to success to create table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
