### PR TITLE
server: replace session in statsHistoryHandler with `types.Context`

### DIFF
--- a/pkg/server/handler/optimizor/BUILD.bazel
+++ b/pkg/server/handler/optimizor/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/parser/model",
         "//pkg/parser/mysql",
         "//pkg/server/handler",
-        "//pkg/session",
         "//pkg/sessionctx/variable",
         "//pkg/statistics/handle",
         "//pkg/statistics/handle/util",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56782

Problem Summary:

A simple tidy PR, it removes an use of `session` and replace it with a `types.Context`.

### What changed and how does it work?

Instead of creating a fully functional session, it creates a `types.Context` instead.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > It has been covered by `TestDumpStatsAPI` test.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
