### PR TITLE
planner: add a new RBO rule to prune constant group by items | tidb-test=pr/2468

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "resolve_indices.go",
         "rule_aggregation_elimination.go",
         "rule_aggregation_push_down.go",
+        "rule_aggregation_simplification.go",
         "rule_aggregation_skew_rewrite.go",
         "rule_collect_plan_stats.go",
         "rule_column_pruning.go",

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
@@ -453,7 +453,7 @@
       "IndexLookUp(Index(t.b)[[1,1]], Table(t))",
       "IndexLookUp(Index(t.d)[[-inf,1991-09-05 00:00:00)], Table(t))",
       "IndexLookUp(Index(t.ts)[[-inf,1991-09-05 00:00:00)], Table(t))",
-      "IndexLookUp(Index(t1.idx)[[3,3]], Table(t1)->Sel([eq(test.t1.b, 100000)]))->Projection->Projection->StreamAgg->Limit"
+      "IndexLookUp(Index(t1.idx)[[3,3]], Table(t1)->Sel([eq(test.t1.b, 100000)]))->Projection->HashAgg->Limit"
     ]
   },
   {

--- a/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
@@ -598,7 +598,7 @@
       },
       {
         "SQL": "select sum(e) as k, avg(b + c) from t where c = 1 and b = 1 and e = 1 group by c order by k",
-        "Best": "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->Projection->Projection->StreamAgg->Sort"
+        "Best": "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->Projection->HashAgg->Sort"
       },
       {
         "SQL": "select sum(to_base64(e)) from t where c = 1",

--- a/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
@@ -578,7 +578,7 @@
       },
       {
         "SQL": "select sum(e), avg(e + c) from t where c = 1 group by c",
-        "Best": "IndexReader(Index(t.c_d_e)[[1,1]])->Projection->StreamAgg"
+        "Best": "IndexReader(Index(t.c_d_e)[[1,1]]->HashAgg)->HashAgg"
       },
       {
         "SQL": "select sum(e), avg(e + c) from t where c = 1 group by e",

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -258,6 +258,8 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, 
 	b.optFlag |= rule.FlagEliminateAgg
 	b.optFlag |= rule.FlagEliminateProjection
 
+	b.optFlag |= rule.FlagAggregationSimplifier
+	
 	if b.ctx.GetSessionVars().EnableSkewDistinctAgg {
 		b.optFlag |= rule.FlagSkewDistinctAgg
 	}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -257,9 +257,8 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p base.LogicalPlan, 
 	b.optFlag |= rule.FlagPredicatePushDown
 	b.optFlag |= rule.FlagEliminateAgg
 	b.optFlag |= rule.FlagEliminateProjection
-
 	b.optFlag |= rule.FlagAggregationSimplifier
-	
+
 	if b.ctx.GetSessionVars().EnableSkewDistinctAgg {
 		b.optFlag |= rule.FlagSkewDistinctAgg
 	}

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -83,6 +83,7 @@ var optRuleList = []base.LogicalOptRule{
 	&SkewDistinctAggRewriter{},
 	&ProjectionEliminator{},
 	&MaxMinEliminator{},
+	&AggregationSimplifier{},
 	&rule.ConstantPropagationSolver{},
 	&ConvertOuterToInnerJoin{},
 	&PPDSolver{},

--- a/pkg/planner/core/physical_plan_trace_test.go
+++ b/pkg/planner/core/physical_plan_trace_test.go
@@ -139,7 +139,7 @@ func TestPhysicalOptimizerTrace(t *testing.T) {
 	require.NoError(t, err)
 	flag := uint64(0)
 	// flagGcSubstitute | flagStabilizeResults | flagSkewDistinctAgg | flagEliminateOuterJoin | flagPushDownAgg
-	flag |= flag | 1<<1 | 1<<3 | 1<<8 | 1<<14 | 1<<17
+	flag |= flag | 1<<1 | 1<<3 | 1<<8 | 1<<15 | 1<<18
 	_, _, err = core.DoOptimize(context.TODO(), sctx, flag, plan.(base.LogicalPlan))
 	require.NoError(t, err)
 	otrace := sctx.GetSessionVars().StmtCtx.OptimizeTracer.Physical

--- a/pkg/planner/core/rule/logical_rules.go
+++ b/pkg/planner/core/rule/logical_rules.go
@@ -27,6 +27,7 @@ const (
 	FlagSkewDistinctAgg
 	FlagEliminateProjection
 	FlagMaxMinEliminate
+	FlagAggregationSimplifier
 	FlagConstantPropagation
 	FlagConvertOuterToInnerJoin
 	FlagPredicatePushDown

--- a/pkg/planner/core/rule_aggregation_simplification.go
+++ b/pkg/planner/core/rule_aggregation_simplification.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core
 
 import (

--- a/pkg/planner/core/rule_aggregation_simplification.go
+++ b/pkg/planner/core/rule_aggregation_simplification.go
@@ -46,7 +46,7 @@ func (as *AggregationSimplifier) Optimize(ctx context.Context, p base.LogicalPla
 }
 
 // tryToPruneGroupByItems will eliminate constant group by items
-func (as AggregationSimplifier) tryToPruneGroupByItems(p base.LogicalPlan, opt *optimizetrace.LogicalOptimizeOp) {
+func (AggregationSimplifier) tryToPruneGroupByItems(p base.LogicalPlan, opt *optimizetrace.LogicalOptimizeOp) {
 	la := p.(*logicalop.LogicalAggregation)
 	// pull up constant predicates below this LogicalAggregation
 	candidateConstantPredicates := la.Children()[0].PullUpConstantPredicates()
@@ -94,6 +94,6 @@ func appendAggSimplifierTraceStep(la *logicalop.LogicalAggregation, prunedItem *
 }
 
 // Name implements the base.LogicalOptRule.<1st> interface.
-func (as *AggregationSimplifier) Name() string {
+func (AggregationSimplifier) Name() string {
 	return "aggregation_simplifier"
 }

--- a/pkg/planner/core/rule_aggregation_simplification.go
+++ b/pkg/planner/core/rule_aggregation_simplification.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
+)
+
+// AggregationSimplifier is used to prune constant items in group by items
+type AggregationSimplifier struct {
+}
+
+// Optimize implements the base.LogicalOptRule.<0th> interface.
+func (as *AggregationSimplifier) Optimize(ctx context.Context, p base.LogicalPlan, opt *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
+	planChanged := false
+	if _, ok := p.(*logicalop.LogicalAggregation); ok {
+		as.tryToPruneGroupByItems(p, opt)
+	}
+	// recursive optimize
+	for _, children := range p.Children() {
+		p, planChanged, err := as.Optimize(ctx, children, opt)
+		if err != nil {
+			return p, planChanged, err
+		}
+	}
+	return p, planChanged, nil
+}
+
+// tryToPruneGroupByItems will eliminate constant group by items
+func (as AggregationSimplifier) tryToPruneGroupByItems(p base.LogicalPlan, opt *optimizetrace.LogicalOptimizeOp) {
+	la := p.(*logicalop.LogicalAggregation)
+	// pull up constant predicates below this LogicalAggregation
+	candidateConstantPredicates := la.Children()[0].PullUpConstantPredicates()
+	if len(la.GroupByItems) < 1 || candidateConstantPredicates == nil {
+		return
+	}
+	ctx := la.SCtx().GetExprCtx().GetEvalCtx()
+	for i := len(la.GroupByItems) - 1; i >= 0; i-- {
+		if item, ok := la.GroupByItems[i].(*expression.Column); ok {
+			// traverse the candidateConstantPredicates we pulled up
+			for _, candidatePredicate := range candidateConstantPredicates {
+				scalarFunction, ok := candidatePredicate.(*expression.ScalarFunction)
+				if !ok || scalarFunction.FuncName.L != ast.EQ {
+					continue
+				}
+				column, _ := expression.ValidCompareConstantPredicateHelper(ctx, scalarFunction, true)
+				if column == nil {
+					column, _ = expression.ValidCompareConstantPredicateHelper(ctx, scalarFunction, false)
+				}
+				if column == nil || !column.EqualColumn(la.GroupByItems[i]) {
+					continue
+				}
+				// new we find the item
+				la.GroupByItems = append(la.GroupByItems[:i], la.GroupByItems[i+1:]...)
+				appendAggSimplifierTraceStep(la, item, opt)
+				break
+			}
+		}
+	}
+	// If all the group by items are pruned, we should add a constant 1 to keep the correctness.
+	// Because `select count(*) from t` is different from `select count(*) from t group by 1`.
+	if len(la.GroupByItems) == 0 {
+		la.GroupByItems = []expression.Expression{expression.NewOne()}
+	}
+	return
+}
+
+func appendAggSimplifierTraceStep(la *logicalop.LogicalAggregation, prunedItem *expression.Column, opt *optimizetrace.LogicalOptimizeOp) {
+	reason := func() string {
+		return fmt.Sprintf("%s is a constant", prunedItem.String())
+	}
+	action := func() string {
+		return fmt.Sprintf("pruned %s from %v_%v.GroupByItems", prunedItem.String(), la.TP(), la.ID())
+	}
+	opt.AppendStepToCurrent(la.ID(), la.TP(), reason, action)
+}
+
+// Name implements the base.LogicalOptRule.<1st> interface.
+func (as *AggregationSimplifier) Name() string {
+	return "aggregation_simplifier"
+}

--- a/pkg/planner/core/rule_aggregation_simplification.go
+++ b/pkg/planner/core/rule_aggregation_simplification.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -80,7 +81,6 @@ func (as AggregationSimplifier) tryToPruneGroupByItems(p base.LogicalPlan, opt *
 	if len(la.GroupByItems) == 0 {
 		la.GroupByItems = []expression.Expression{expression.NewOne()}
 	}
-	return
 }
 
 func appendAggSimplifierTraceStep(la *logicalop.LogicalAggregation, prunedItem *expression.Column, opt *optimizetrace.LogicalOptimizeOp) {

--- a/tests/integrationtest/r/executor/prepared.result
+++ b/tests/integrationtest/r/executor/prepared.result
@@ -330,13 +330,13 @@ Warning	1105	skip prepared plan-cache: not a SELECT/UPDATE/INSERT/DELETE/SET sta
 set @a = 1;
 execute stmt using @a, @a;
 id	estRows	task	access object	operator info
-HashAgg_8	1.00	root		group by:executor__prepared.t.id, executor__prepared.t.k, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
+HashAgg_8	1.00	root		group by:1, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
 └─TableReader_15	0.01	root		data:Selection_14
   └─Selection_14	0.01	cop[tikv]		eq(executor__prepared.t.id, 1), eq(executor__prepared.t.k, 1)
     └─TableFullScan_13	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain select * from t where id = 1 and k = 1 group by id, k;
 id	estRows	task	access object	operator info
-HashAgg_8	1.00	root		group by:executor__prepared.t.id, executor__prepared.t.k, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
+HashAgg_8	1.00	root		group by:1, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
 └─TableReader_15	0.01	root		data:Selection_14
   └─Selection_14	0.01	cop[tikv]		eq(executor__prepared.t.id, 1), eq(executor__prepared.t.k, 1)
     └─TableFullScan_13	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
@@ -347,13 +347,13 @@ Warning	1105	skip prepared plan-cache: not a SELECT/UPDATE/INSERT/DELETE/SET sta
 set @a = 1;
 execute stmt using @a, @a;
 id	estRows	task	access object	operator info
-HashAgg_8	1.00	root		group by:executor__prepared.t.id, executor__prepared.t.k, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
+HashAgg_8	1.00	root		group by:1, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
 └─TableReader_15	0.01	root		data:Selection_14
   └─Selection_14	0.01	cop[tikv]		eq(1, executor__prepared.t.id), eq(1, executor__prepared.t.k)
     └─TableFullScan_13	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain select * from t where 1 = id and 1 = k group by id, k;
 id	estRows	task	access object	operator info
-HashAgg_8	1.00	root		group by:executor__prepared.t.id, executor__prepared.t.k, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
+HashAgg_8	1.00	root		group by:1, funcs:firstrow(executor__prepared.t.id)->executor__prepared.t.id, funcs:firstrow(executor__prepared.t.k)->executor__prepared.t.k
 └─TableReader_15	0.01	root		data:Selection_14
   └─Selection_14	0.01	cop[tikv]		eq(1, executor__prepared.t.id), eq(1, executor__prepared.t.k)
     └─TableFullScan_13	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/explain_easy_stats.result
+++ b/tests/integrationtest/r/explain_easy_stats.result
@@ -178,7 +178,7 @@ Point_Get	1.00	root	table:index_prune, index:PRIMARY(a, b)
 explain format = 'brief' select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b ORDER BY a limit 1;
 id	estRows	task	access object	operator info
 TopN	1.00	root		explain_easy_stats.index_prune.a, offset:0, count:1
-└─StreamAgg	1.00	root		group by:explain_easy_stats.index_prune.b, funcs:firstrow(explain_easy_stats.index_prune.a)->explain_easy_stats.index_prune.a, funcs:firstrow(explain_easy_stats.index_prune.b)->explain_easy_stats.index_prune.b, funcs:firstrow(explain_easy_stats.index_prune.c)->explain_easy_stats.index_prune.c
+└─HashAgg	1.00	root		group by:1, funcs:firstrow(explain_easy_stats.index_prune.a)->explain_easy_stats.index_prune.a, funcs:firstrow(explain_easy_stats.index_prune.b)->explain_easy_stats.index_prune.b, funcs:firstrow(explain_easy_stats.index_prune.c)->explain_easy_stats.index_prune.c
   └─Point_Get	1.00	root	table:index_prune, index:PRIMARY(a, b)	
 drop table if exists t1, t2, t3, index_prune;
 set @@session.tidb_opt_insubq_to_join_and_agg=1;

--- a/tests/integrationtest/r/planner/core/indexjoin.result
+++ b/tests/integrationtest/r/planner/core/indexjoin.result
@@ -123,14 +123,15 @@ a	b
 1	2
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select a, b from t where a=1 group by a, b having a>0 ) tmp, t1 where tmp.a=t1.a;
 id	estRows	task	access object	operator info
-IndexJoin	1.25	root		inner join, inner:HashAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
+IndexJoin	8.00	root		inner join, inner:Selection, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
 ├─IndexReader(Build)	3333.33	root		index:IndexRangeScan
 │ └─IndexRangeScan	3333.33	cop[tikv]	table:t1, index:idx(a, b)	range:(0,+inf], keep order:false, stats:pseudo
-└─HashAgg(Probe)	3333.33	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-  └─IndexReader	3333.33	root		index:HashAgg
-    └─HashAgg	3333.33	cop[tikv]		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, 
-      └─Selection	1.25	cop[tikv]		eq(planner__core__indexjoin.t.a, 1)
-        └─IndexRangeScan	1250.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:false, stats:pseudo
+└─Selection(Probe)	21333.33	root		gt(planner__core__indexjoin.t.a, 0), not(isnull(planner__core__indexjoin.t.a))
+  └─HashAgg	26666.67	root		group by:planner__core__indexjoin.t.b, funcs:firstrow(Column#7)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+    └─IndexReader	26666.67	root		index:HashAgg
+      └─HashAgg	26666.67	cop[tikv]		group by:planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->Column#7
+        └─Selection	8.00	cop[tikv]		eq(planner__core__indexjoin.t.a, 1)
+          └─IndexRangeScan	8000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:false, stats:pseudo
 select /*+ INL_JOIN(tmp) */ tmp.a, t1.b from (select a, b from t where a=1 group by a, b having a>0 ) tmp, t1 where tmp.a=t1.a order by tmp.a, t1.b;
 a	b
 1	1

--- a/tests/integrationtest/r/planner/core/rule_aggregation_simplification.result
+++ b/tests/integrationtest/r/planner/core/rule_aggregation_simplification.result
@@ -1,0 +1,98 @@
+drop table if exists test;
+create table test (id int, dept_id int, value int);
+explain select id, count(1) from test where id = 10 group by id;
+id	estRows	task	access object	operator info
+Projection_5	1.00	root		planner__core__rule_aggregation_simplification.test.id, Column#5
+└─HashAgg_11	1.00	root		group by:Column#6, funcs:count(Column#7)->Column#5, funcs:firstrow(Column#8)->planner__core__rule_aggregation_simplification.test.id
+  └─TableReader_12	1.00	root		data:HashAgg_6
+    └─HashAgg_6	1.00	cop[tikv]		group by:1, funcs:count(1)->Column#7, funcs:firstrow(planner__core__rule_aggregation_simplification.test.id)->Column#8
+      └─Selection_10	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.id, 10)
+        └─TableFullScan_9	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+explain select id, value, count(1) from test where id = 10 group by id, value;
+id	estRows	task	access object	operator info
+Projection_5	8.00	root		planner__core__rule_aggregation_simplification.test.id, planner__core__rule_aggregation_simplification.test.value, Column#5
+└─HashAgg_8	8.00	root		group by:planner__core__rule_aggregation_simplification.test.value, funcs:count(1)->Column#5, funcs:firstrow(planner__core__rule_aggregation_simplification.test.id)->planner__core__rule_aggregation_simplification.test.id, funcs:firstrow(planner__core__rule_aggregation_simplification.test.value)->planner__core__rule_aggregation_simplification.test.value
+  └─TableReader_15	10.00	root		data:Selection_14
+    └─Selection_14	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.id, 10)
+      └─TableFullScan_13	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+explain select id, value, dept_id, count(1) from test where id = 10 and dept_id = 20 group by id, value, dept_id;
+id	estRows	task	access object	operator info
+Projection_5	1.00	root		planner__core__rule_aggregation_simplification.test.id, planner__core__rule_aggregation_simplification.test.value, planner__core__rule_aggregation_simplification.test.dept_id, Column#5
+└─HashAgg_8	1.00	root		group by:planner__core__rule_aggregation_simplification.test.value, funcs:count(1)->Column#5, funcs:firstrow(planner__core__rule_aggregation_simplification.test.id)->planner__core__rule_aggregation_simplification.test.id, funcs:firstrow(planner__core__rule_aggregation_simplification.test.dept_id)->planner__core__rule_aggregation_simplification.test.dept_id, funcs:firstrow(planner__core__rule_aggregation_simplification.test.value)->planner__core__rule_aggregation_simplification.test.value
+  └─TableReader_15	0.01	root		data:Selection_14
+    └─Selection_14	0.01	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.dept_id, 20), eq(planner__core__rule_aggregation_simplification.test.id, 10)
+      └─TableFullScan_13	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+drop table if exists test, test2;
+create table test (id int, dept_id int, value int);
+create table test2 (id int, dept_id int, value int);
+explain select * from (select id, count(1) from test2 where id = 10 group by id) t1;
+id	estRows	task	access object	operator info
+Projection_6	1.00	root		planner__core__rule_aggregation_simplification.test2.id, Column#5
+└─HashAgg_12	1.00	root		group by:Column#6, funcs:count(Column#7)->Column#5, funcs:firstrow(Column#8)->planner__core__rule_aggregation_simplification.test2.id
+  └─TableReader_13	1.00	root		data:HashAgg_7
+    └─HashAgg_7	1.00	cop[tikv]		group by:1, funcs:count(1)->Column#7, funcs:firstrow(planner__core__rule_aggregation_simplification.test2.id)->Column#8
+      └─Selection_11	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test2.id, 10)
+        └─TableFullScan_10	10000.00	cop[tikv]	table:test2	keep order:false, stats:pseudo
+explain select t1.id from (select id, value from test2 where id = 10) t1 group by t1.id; -- pulling up constant predicates can go through the selection node below projection node.
+explain select t1.id, t1.value from (select id, value from test2 where id = 10) t1 where value = 20 group by t1.id, t1.value; -- only t1.value will be pruned, because t1.id won't be pulled up.
+explain select t1.id from (select id, value from test where id = 10 group by id, value) t1 group by t1.id; -- can't, because pulling up constant predicates can't go through aggregation node.
+id	estRows	task	access object	operator info
+HashAgg_12	1.00	root		group by:Column#5, funcs:firstrow(Column#6)->planner__core__rule_aggregation_simplification.test2.id
+└─TableReader_13	1.00	root		data:HashAgg_7
+  └─HashAgg_7	1.00	cop[tikv]		group by:1, funcs:firstrow(planner__core__rule_aggregation_simplification.test2.id)->Column#6
+    └─Selection_11	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test2.id, 10)
+      └─TableFullScan_10	10000.00	cop[tikv]	table:test2	keep order:false, stats:pseudo
+HashAgg_10	1.00	root		group by:planner__core__rule_aggregation_simplification.test2.id, funcs:firstrow(planner__core__rule_aggregation_simplification.test2.id)->planner__core__rule_aggregation_simplification.test2.id, funcs:firstrow(planner__core__rule_aggregation_simplification.test2.value)->planner__core__rule_aggregation_simplification.test2.value
+└─TableReader_17	0.01	root		data:Selection_16
+  └─Selection_16	0.01	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test2.id, 10), eq(planner__core__rule_aggregation_simplification.test2.value, 20)
+    └─TableFullScan_15	10000.00	cop[tikv]	table:test2	keep order:false, stats:pseudo
+HashAgg_8	8.00	root		group by:planner__core__rule_aggregation_simplification.test.id, funcs:firstrow(planner__core__rule_aggregation_simplification.test.id)->planner__core__rule_aggregation_simplification.test.id
+└─HashAgg_11	8.00	root		group by:planner__core__rule_aggregation_simplification.test.value, funcs:firstrow(planner__core__rule_aggregation_simplification.test.id)->planner__core__rule_aggregation_simplification.test.id
+  └─TableReader_18	10.00	root		data:Selection_17
+    └─Selection_17	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.id, 10)
+      └─TableFullScan_16	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+drop table if exists test, test2;
+create table test (id int, value int);
+create table test2 (id int, value int);
+explain select test.value, count(1) from test, test2 where test.id = test2.id and test.value = 10 group by test.value;
+id	estRows	task	access object	operator info
+Projection_8	1.00	root		planner__core__rule_aggregation_simplification.test.value, Column#7
+└─HashAgg_9	1.00	root		group by:1, funcs:count(1)->Column#7, funcs:firstrow(planner__core__rule_aggregation_simplification.test.value)->planner__core__rule_aggregation_simplification.test.value
+  └─HashJoin_11	12.49	root		inner join, equal:[eq(planner__core__rule_aggregation_simplification.test.id, planner__core__rule_aggregation_simplification.test2.id)]
+    ├─TableReader_14(Build)	9.99	root		data:Selection_13
+    │ └─Selection_13	9.99	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.value, 10), not(isnull(planner__core__rule_aggregation_simplification.test.id))
+    │   └─TableFullScan_12	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+    └─TableReader_17(Probe)	9990.00	root		data:Selection_16
+      └─Selection_16	9990.00	cop[tikv]		not(isnull(planner__core__rule_aggregation_simplification.test2.id))
+        └─TableFullScan_15	10000.00	cop[tikv]	table:test2	keep order:false, stats:pseudo
+drop table if exists test, test2;
+create table test (id int, dept_id int);
+create table test2 (id int, dept_id int);
+explain select dept_id, count(1) from test where dept_id = 10 group by dept_id
+union all
+select * from (select dept_id, count(1) from test where dept_id = 20 group by dept_id) t1
+union all
+select t2.dept_id, count(1) from test t1, test t2 where t1.dept_id = t2.dept_id and t2.dept_id = 30 group by t2.dept_id; -- this sql should match 3 times
+id	estRows	task	access object	operator info
+Union_21	3.00	root		
+├─Projection_22	1.00	root		planner__core__rule_aggregation_simplification.test.dept_id->Column#16, Column#4->Column#17
+│ └─HashAgg_28	1.00	root		group by:Column#18, funcs:count(Column#19)->Column#4, funcs:firstrow(Column#20)->planner__core__rule_aggregation_simplification.test.dept_id
+│   └─TableReader_29	1.00	root		data:HashAgg_23
+│     └─HashAgg_23	1.00	cop[tikv]		group by:1, funcs:count(1)->Column#19, funcs:firstrow(planner__core__rule_aggregation_simplification.test.dept_id)->Column#20
+│       └─Selection_27	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.dept_id, 10)
+│         └─TableFullScan_26	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+├─Projection_33	1.00	root		planner__core__rule_aggregation_simplification.test.dept_id->Column#16, Column#8->Column#17
+│ └─HashAgg_39	1.00	root		group by:Column#21, funcs:count(Column#22)->Column#8, funcs:firstrow(Column#23)->planner__core__rule_aggregation_simplification.test.dept_id
+│   └─TableReader_40	1.00	root		data:HashAgg_34
+│     └─HashAgg_34	1.00	cop[tikv]		group by:1, funcs:count(1)->Column#22, funcs:firstrow(planner__core__rule_aggregation_simplification.test.dept_id)->Column#23
+│       └─Selection_38	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.dept_id, 20)
+│         └─TableFullScan_37	10000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
+└─Projection_44	1.00	root		planner__core__rule_aggregation_simplification.test.dept_id->Column#16, Column#15->Column#17
+  └─HashAgg_45	1.00	root		group by:1, funcs:count(1)->Column#15, funcs:firstrow(planner__core__rule_aggregation_simplification.test.dept_id)->planner__core__rule_aggregation_simplification.test.dept_id
+    └─HashJoin_46	100.00	root		CARTESIAN inner join
+      ├─TableReader_53(Build)	10.00	root		data:Selection_52
+      │ └─Selection_52	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.dept_id, 30)
+      │   └─TableFullScan_51	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+      └─TableReader_50(Probe)	10.00	root		data:Selection_49
+        └─Selection_49	10.00	cop[tikv]		eq(planner__core__rule_aggregation_simplification.test.dept_id, 30)
+          └─TableFullScan_48	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/rule_aggregation_simplification.test
+++ b/tests/integrationtest/t/planner/core/rule_aggregation_simplification.test
@@ -1,0 +1,34 @@
+# TestAggregationSimplifier, see details at https://github.com/pingcap/tidb/issues/53994
+drop table if exists test;
+create table test (id int, dept_id int, value int);
+explain select id, count(1) from test where id = 10 group by id;
+explain select id, value, count(1) from test where id = 10 group by id, value;
+explain select id, value, dept_id, count(1) from test where id = 10 and dept_id = 20 group by id, value, dept_id;
+
+
+# TestSubquery
+drop table if exists test, test2;
+create table test (id int, dept_id int, value int);
+create table test2 (id int, dept_id int, value int);
+explain select * from (select id, count(1) from test2 where id = 10 group by id) t1;
+explain select t1.id from (select id, value from test2 where id = 10) t1 group by t1.id; -- pulling up constant predicates can go through the selection node below projection node.
+explain select t1.id, t1.value from (select id, value from test2 where id = 10) t1 where value = 20 group by t1.id, t1.value; -- only t1.value will be pruned, because t1.id won't be pulled up.
+explain select t1.id from (select id, value from test where id = 10 group by id, value) t1 group by t1.id; -- can't, because pulling up constant predicates can't go through aggregation node.
+
+
+# TestJoin
+drop table if exists test, test2;
+create table test (id int, value int);
+create table test2 (id int, value int);
+explain select test.value, count(1) from test, test2 where test.id = test2.id and test.value = 10 group by test.value;
+
+
+# TestMultiSubtreeMatch
+drop table if exists test, test2;
+create table test (id int, dept_id int);
+create table test2 (id int, dept_id int);
+explain select dept_id, count(1) from test where dept_id = 10 group by dept_id
+union all
+select * from (select dept_id, count(1) from test where dept_id = 20 group by dept_id) t1
+union all
+select t2.dept_id, count(1) from test t1, test t2 where t1.dept_id = t2.dept_id and t2.dept_id = 30 group by t2.dept_id; -- this sql should match 3 times


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53994 

Problem Summary:

### What changed and how does it work?
Add a new RBO rule called aggregation simplification to prune constant group by items. Aggregation simplification will pull up constant predicates from selection node and compare them with group by items, finally pruning the constant ones.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
