### PR TITLE
test: stabilize TestAnalyzeColumnsWithVirtualColumnIndex

### DIFF
--- a/pkg/resourcegroup/runaway/manager.go
+++ b/pkg/resourcegroup/runaway/manager.go
@@ -155,8 +155,8 @@ func (rm *Manager) RunawayRecordFlushLoop() {
 	quarantineRecordCh := rm.quarantineRecordChan()
 	staleQuarantineRecordCh := rm.staleQuarantineRecordChan()
 	flushThreshold := flushThreshold()
-	// recordMap is used to deduplicate records.
-	recordMap = make(map[recordKey]*Record, flushThreshold)
+	// recordMap is used to deduplicate records which will be inserted into `mysql.tidb_runaway_queries`.
+	recordMap := make(map[recordKey]*Record, flushThreshold)
 
 	flushRunawayRecords := func() {
 		if len(recordMap) == 0 {

--- a/pkg/resourcegroup/runaway/record.go
+++ b/pkg/resourcegroup/runaway/record.go
@@ -68,9 +68,6 @@ type Record struct {
 	Repeats int
 }
 
-// recordMap is used to save records which will be inserted into `mysql.tidb_runaway_queries` by function `flushRunawayRecords`.
-var recordMap map[recordKey]*Record
-
 // recordKey represents the composite key for record key in `tidb_runaway_queries`.
 type recordKey struct {
 	ResourceGroupName string

--- a/pkg/resourcegroup/runaway/record_test.go
+++ b/pkg/resourcegroup/runaway/record_test.go
@@ -45,7 +45,7 @@ func TestRecordKey(t *testing.T) {
 	assert.NotEqual(t, hash1, hash3, "Hashes should not be equal for different keys")
 
 	// Test MapKey method
-	recordMap = make(map[recordKey]*Record)
+	recordMap := make(map[recordKey]*Record)
 	record1 := &Record{
 		ResourceGroupName: "group1",
 		SQLDigest:         "digest1",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56797

Problem Summary:

We may have multiple domains in unit test. It is better not to use global variables as soon as possible.

### What changed and how does it work?

Change global variable `recordMap` to local one.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
