### PR TITLE
br: fix br integration test file corruption

### DIFF
--- a/br/tests/br_pitr/run.sh
+++ b/br/tests/br_pitr/run.sh
@@ -174,8 +174,7 @@ restart_services
 
 file_corruption() {
     echo "corrupt the whole log files"
-    filenames=$(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta")
-    for filename in "${filenames[@]}"; do
+    for filename in $(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta"); do
         echo "corrupt the log file $filename"
         filename_temp=$filename"_temp"
         echo "corruption" > $filename_temp
@@ -198,8 +197,7 @@ fi
 
 file_lost() {
     echo "lost the whole log files"
-    filenames=$(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta")
-    for filename in "${filenames[@]}"; do
+    for filename in $(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta"); do
         echo "lost the log file $filename"
         filename_temp=$filename"_temp"
         mv $filename $filename_temp

--- a/br/tests/br_pitr/run.sh
+++ b/br/tests/br_pitr/run.sh
@@ -180,7 +180,7 @@ file_corruption() {
         echo "corruption" > $filename_temp
         cat $filename >> $filename_temp
         mv $filename_temp $filename
-        truncate --size=-11 $filename
+        truncate -s -11 $filename
     done
 }
 
@@ -194,6 +194,10 @@ if [ $restore_fail -ne 1 ]; then
     echo 'pitr success on file corruption'
     exit 1
 fi
+
+# start a new cluster for corruption
+echo "restart a services"
+restart_services
 
 file_lost() {
     echo "lost the whole log files"

--- a/br/tests/br_pitr/run.sh
+++ b/br/tests/br_pitr/run.sh
@@ -172,32 +172,47 @@ fi
 echo "restart a services"
 restart_services
 
-echo "corrupt a log file"
-filename=$(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta" | tail -n 1)
-filename_temp=$filename"_temp"
-filename_bak=$filename"_bak"
-echo "corruption" > $filename_temp
-cat $filename >> $filename_temp
-
-# file lost
-mv $filename $filename_bak
-export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/utils/set-import-attempt-to-one=return(true)"
-restore_fail=0
-run_br --pd $PD_ADDR restore point -s "local://$TEST_DIR/$PREFIX/log" --full-backup-storage "local://$TEST_DIR/$PREFIX/full" || restore_fail=1
-export GO_FAILPOINTS=""
-if [ $restore_fail -ne 1 ]; then
-    echo 'pitr success on file lost'
-    exit 1
-fi
+file_corruption() {
+    echo "corrupt the whole log files"
+    filenames=$(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta")
+    for filename in "${filenames[@]}"; do
+        echo "corrupt the log file $filename"
+        filename_temp=$filename"_temp"
+        echo "corruption" > $filename_temp
+        cat $filename >> $filename_temp
+        mv $filename_temp $filename
+        truncate --size=-11 $filename
+    done
+}
 
 # file corruption
-mv $filename_temp $filename
-truncate --size=-11 $filename
+file_corruption
 export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/utils/set-import-attempt-to-one=return(true)"
 restore_fail=0
 run_br --pd $PD_ADDR restore point -s "local://$TEST_DIR/$PREFIX/log" --full-backup-storage "local://$TEST_DIR/$PREFIX/full" || restore_fail=1
 export GO_FAILPOINTS=""
 if [ $restore_fail -ne 1 ]; then
     echo 'pitr success on file corruption'
+    exit 1
+fi
+
+file_lost() {
+    echo "lost the whole log files"
+    filenames=$(find $TEST_DIR/$PREFIX/log -regex ".*\.log" | grep -v "schema-meta")
+    for filename in "${filenames[@]}"; do
+        echo "lost the log file $filename"
+        filename_temp=$filename"_temp"
+        mv $filename $filename_temp
+    done
+}
+
+# file lost
+file_lost
+export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/utils/set-import-attempt-to-one=return(true)"
+restore_fail=0
+run_br --pd $PD_ADDR restore point -s "local://$TEST_DIR/$PREFIX/log" --full-backup-storage "local://$TEST_DIR/$PREFIX/full" || restore_fail=1
+export GO_FAILPOINTS=""
+if [ $restore_fail -ne 1 ]; then
+    echo 'pitr success on file lost'
     exit 1
 fi


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53835

Problem Summary:
The log file may not be restored so sometimes corrupting one log file does not make restore fail.
### What changed and how does it work?
lost/corrupt all the files.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
