### PR TITLE
infoschema: improve usability of SchemaByTable

### DIFF
--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -292,7 +292,14 @@ func SchemaByTable(is InfoSchema, tableInfo *model.TableInfo) (val *model.DBInfo
 	if tableInfo == nil {
 		return nil, false
 	}
-	return is.SchemaByID(tableInfo.DBID)
+	if tableInfo.DBID > 0 {
+		return is.SchemaByID(tableInfo.DBID)
+	}
+	tbl, ok := is.TableByID(stdctx.Background(), tableInfo.ID)
+	if !ok {
+		return nil, false
+	}
+	return is.SchemaByID(tbl.Meta().DBID)
 }
 
 func (is *infoSchema) TableByID(_ stdctx.Context, id int64) (val table.Table, ok bool) {

--- a/pkg/infoschema/infoschema_test.go
+++ b/pkg/infoschema/infoschema_test.go
@@ -149,6 +149,15 @@ func TestBasic(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, schema)
 
+	b, err := json.Marshal(tblInfo)
+	require.NoError(t, err)
+	tblUnmarshal := &model.TableInfo{}
+	err = json.Unmarshal(b, tblUnmarshal)
+	require.NoError(t, err)
+	schema2, ok := infoschema.SchemaByTable(is, tblUnmarshal)
+	require.True(t, ok)
+	require.Equal(t, schema, schema2)
+
 	noexistTblInfo := &model.TableInfo{ID: 12345, Name: tblInfo.Name}
 	schema, ok = infoschema.SchemaByTable(is, noexistTblInfo)
 	require.False(t, ok)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/50959

Problem Summary:

### What changed and how does it work?

In development, we store the TableInfo in a system table. After unmarshal, we use `SchemaByTable` to find its database. However `SchemaByTable` can only be used with TableInfo that are not go through de(serialization).

So change `SchemaByTable` to support all `TableInfo` 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
