### PR TITLE
ddl: fix some limitation of primary key + global index

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1275,9 +1275,15 @@ func BuildTableInfo(
 				}
 			}
 			if tbInfo.HasClusteredIndex() {
-				// Primary key cannot be invisible.
-				if constr.Option != nil && constr.Option.Visibility == ast.IndexVisibilityInvisible {
-					return nil, dbterror.ErrPKIndexCantBeInvisible
+				if constr.Option != nil {
+					// Primary key cannot be invisible.
+					if constr.Option.Visibility == ast.IndexVisibilityInvisible {
+						return nil, dbterror.ErrPKIndexCantBeInvisible
+					}
+					// A clustered index cannot be a global index.
+					if constr.Option.Global {
+						return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("create an index that is both a global index and a clustered index")
+					}
 				}
 			}
 			if tbInfo.PKIsHandle {
@@ -1570,10 +1576,6 @@ func isSingleIntPK(constr *ast.Constraint, lastCol *model.ColumnInfo) bool {
 // ShouldBuildClusteredIndex is used to determine whether the CREATE TABLE statement should build a clustered index table.
 func ShouldBuildClusteredIndex(mode variable.ClusteredIndexDefMode, opt *ast.IndexOption, isSingleIntPK bool) bool {
 	if opt == nil || opt.PrimaryKeyTp == pmodel.PrimaryKeyTypeDefault {
-		// The primary key is also a global index, shouldn't be a clustered index.
-		if opt != nil && opt.Global {
-			return false
-		}
 		switch mode {
 		case variable.ClusteredIndexDefModeOn:
 			return true

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1274,16 +1274,14 @@ func BuildTableInfo(
 					tbInfo.CommonHandleVersion = 1
 				}
 			}
-			if tbInfo.HasClusteredIndex() {
-				if constr.Option != nil {
-					// Primary key cannot be invisible.
-					if constr.Option.Visibility == ast.IndexVisibilityInvisible {
-						return nil, dbterror.ErrPKIndexCantBeInvisible
-					}
-					// A clustered index cannot be a global index.
-					if constr.Option.Global {
-						return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("create an index that is both a global index and a clustered index")
-					}
+			if tbInfo.HasClusteredIndex() && constr.Option != nil {
+				// Primary key cannot be invisible.
+				if constr.Option.Visibility == ast.IndexVisibilityInvisible {
+					return nil, dbterror.ErrPKIndexCantBeInvisible
+				}
+				// A clustered index cannot be a global index.
+				if constr.Option.Global {
+					return nil, dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("create an index that is both a global index and a clustered index")
 				}
 			}
 			if tbInfo.PKIsHandle {

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -1570,6 +1570,10 @@ func isSingleIntPK(constr *ast.Constraint, lastCol *model.ColumnInfo) bool {
 // ShouldBuildClusteredIndex is used to determine whether the CREATE TABLE statement should build a clustered index table.
 func ShouldBuildClusteredIndex(mode variable.ClusteredIndexDefMode, opt *ast.IndexOption, isSingleIntPK bool) bool {
 	if opt == nil || opt.PrimaryKeyTp == pmodel.PrimaryKeyTypeDefault {
+		// The primary key is also a global index, shouldn't be a clustered index.
+		if opt != nil && opt.Global {
+			return false
+		}
 		switch mode {
 		case variable.ClusteredIndexDefModeOn:
 			return true

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -4573,6 +4573,8 @@ func (e *executor) CreatePrimaryKey(ctx sessionctx.Context, ti ast.Ident, indexN
 			}
 			validateGlobalIndexWithGeneratedColumns(ctx.GetSessionVars().StmtCtx.ErrCtx(), tblInfo, indexName.O, indexColumns)
 		}
+	} else if indexOption != nil && indexOption.Global {
+		return dbterror.ErrGeneralUnsupportedDDL.GenWithStackByArgs("Global Index on non-partitioned table")
 	}
 
 	// May be truncate comment here, when index comment too long and sql_mode is't strict.

--- a/tests/integrationtest/r/globalindex/ddl.result
+++ b/tests/integrationtest/r/globalindex/ddl.result
@@ -86,8 +86,8 @@ create table t(a int, b int, primary key (b) global) partition by hash(a) partit
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
-  `a` int(11) DEFAULT NULL,
-  `b` int(11) NOT NULL,
+  `a` int DEFAULT NULL,
+  `b` int NOT NULL,
   PRIMARY KEY (`b`) /*T![clustered_index] NONCLUSTERED */ /*T![global_index] GLOBAL */
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY HASH (`a`) PARTITIONS 5

--- a/tests/integrationtest/r/globalindex/ddl.result
+++ b/tests/integrationtest/r/globalindex/ddl.result
@@ -41,7 +41,7 @@ Error 8200 (HY000): Unsupported GLOBAL IndexOption on non-unique index
 create table t (a int not null, b int, primary key(a) nonclustered, unique idx_b(b) global) partition by hash(a) partitions 3;
 drop table t;
 create table t (a int key global, b int) partition by hash(b) partitions 3;
-Error 1503 (HY000): A CLUSTERED INDEX must include all columns in the table's partitioning function
+drop table t;
 create table t (a int unique, b int) partition by hash(b) partitions 3;
 Error 8264 (HY000): Global Index is needed for index 'a', since the unique index is not including all partitioning columns, and GLOBAL is not given as IndexOption
 create table t (a int unique key, b int) partition by hash(b) partitions 3;
@@ -77,3 +77,21 @@ Error 8200 (HY000): Unsupported Global IndexOption on non-unique index
 create unique index idxOK2 on t (a) global;
 create unique index idxErr on t (b) global;
 Error 8200 (HY000): Unsupported Global IndexOption on index including all columns in the partitioning expression
+drop table t;
+create table t(a int, b int, primary key (a) global);
+Error 8200 (HY000): Unsupported Global Index on non-partitioned table
+create table t(a int, b int, primary key (a) global) partition by hash(a) partitions 5;
+Error 8200 (HY000): Unsupported Global Index including all columns in the partitioning expression
+create table t(a int, b int, primary key (b) global) partition by hash(a) partitions 5;
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) NOT NULL,
+  PRIMARY KEY (`b`) /*T![clustered_index] NONCLUSTERED */ /*T![global_index] GLOBAL */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`a`) PARTITIONS 5
+drop table t;
+create table t(a int, b int);
+alter table t add primary key (a) global;
+Error 8200 (HY000): Unsupported Global Index on non-partitioned table

--- a/tests/integrationtest/r/globalindex/ddl.result
+++ b/tests/integrationtest/r/globalindex/ddl.result
@@ -41,7 +41,7 @@ Error 8200 (HY000): Unsupported GLOBAL IndexOption on non-unique index
 create table t (a int not null, b int, primary key(a) nonclustered, unique idx_b(b) global) partition by hash(a) partitions 3;
 drop table t;
 create table t (a int key global, b int) partition by hash(b) partitions 3;
-drop table t;
+Error 8200 (HY000): Unsupported create an index that is both a global index and a clustered index
 create table t (a int unique, b int) partition by hash(b) partitions 3;
 Error 8264 (HY000): Global Index is needed for index 'a', since the unique index is not including all partitioning columns, and GLOBAL is not given as IndexOption
 create table t (a int unique key, b int) partition by hash(b) partitions 3;
@@ -78,20 +78,14 @@ create unique index idxOK2 on t (a) global;
 create unique index idxErr on t (b) global;
 Error 8200 (HY000): Unsupported Global IndexOption on index including all columns in the partitioning expression
 drop table t;
-create table t(a int, b int, primary key (a) global);
+create table t(a int, b int, primary key (a) nonclustered global);
 Error 8200 (HY000): Unsupported Global Index on non-partitioned table
+create table t(a int, b int, primary key (a) global);
+Error 8200 (HY000): Unsupported create an index that is both a global index and a clustered index
 create table t(a int, b int, primary key (a) global) partition by hash(a) partitions 5;
-Error 8200 (HY000): Unsupported Global Index including all columns in the partitioning expression
+Error 8200 (HY000): Unsupported create an index that is both a global index and a clustered index
 create table t(a int, b int, primary key (b) global) partition by hash(a) partitions 5;
-show create table t;
-Table	Create Table
-t	CREATE TABLE `t` (
-  `a` int DEFAULT NULL,
-  `b` int NOT NULL,
-  PRIMARY KEY (`b`) /*T![clustered_index] NONCLUSTERED */ /*T![global_index] GLOBAL */
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
-PARTITION BY HASH (`a`) PARTITIONS 5
-drop table t;
+Error 8200 (HY000): Unsupported create an index that is both a global index and a clustered index
 create table t(a int, b int);
 alter table t add primary key (a) global;
 Error 8200 (HY000): Unsupported Global Index on non-partitioned table

--- a/tests/integrationtest/r/globalindex/misc.result
+++ b/tests/integrationtest/r/globalindex/misc.result
@@ -18,14 +18,14 @@ partition by range( a ) (
 partition p1 values less than (10),
 partition p2 values less than (20)
 );
-Error 1503 (HY000): A CLUSTERED INDEX must include all columns in the table's partitioning function
+Error 8200 (HY000): Unsupported create an index that is both a global index and a clustered index
 drop table if exists test_global;
 create table test_global ( a int, b int, c int, primary key p_b_c(b, c) /*T![clustered_index] CLUSTERED */ GLOBAL)
 partition by range( a ) (
 partition p1 values less than (10),
 partition p2 values less than (20)
 );
-Error 1503 (HY000): A CLUSTERED INDEX must include all columns in the table's partitioning function
+Error 8200 (HY000): Unsupported create an index that is both a global index and a clustered index
 drop table if exists test_global;
 create table test_global ( a int, b int, c int, primary key (b) /*T![clustered_index] NONCLUSTERED */ GLOBAL)
 partition by range( a ) (

--- a/tests/integrationtest/t/globalindex/ddl.test
+++ b/tests/integrationtest/t/globalindex/ddl.test
@@ -41,8 +41,8 @@ create table t (a int, b int, index idx(a) global);
 create table t (a int, b int, index idx(a) global) partition by hash(b) partitions 3;
 create table t (a int not null, b int, primary key(a) nonclustered, unique idx_b(b) global) partition by hash(a) partitions 3;
 drop table t;
+-- error 8200
 create table t (a int key global, b int) partition by hash(b) partitions 3;
-drop table t;
 -- error 8264
 create table t (a int unique, b int) partition by hash(b) partitions 3;
 -- error 8264
@@ -74,13 +74,14 @@ create unique index idxErr on t (b) global;
 
 drop table t;
 --error 8200
+create table t(a int, b int, primary key (a) nonclustered global);
+--error 8200
 create table t(a int, b int, primary key (a) global);
 --error 8200
 create table t(a int, b int, primary key (a) global) partition by hash(a) partitions 5;
+--error 8200
 create table t(a int, b int, primary key (b) global) partition by hash(a) partitions 5;
-show create table t;
 
-drop table t;
 create table t(a int, b int);
 --error 8200
 alter table t add primary key (a) global;

--- a/tests/integrationtest/t/globalindex/ddl.test
+++ b/tests/integrationtest/t/globalindex/ddl.test
@@ -41,8 +41,8 @@ create table t (a int, b int, index idx(a) global);
 create table t (a int, b int, index idx(a) global) partition by hash(b) partitions 3;
 create table t (a int not null, b int, primary key(a) nonclustered, unique idx_b(b) global) partition by hash(a) partitions 3;
 drop table t;
--- error 1503
 create table t (a int key global, b int) partition by hash(b) partitions 3;
+drop table t;
 -- error 8264
 create table t (a int unique, b int) partition by hash(b) partitions 3;
 -- error 8264
@@ -71,3 +71,17 @@ create index idxErr on t (b) global;
 create unique index idxOK2 on t (a) global;
 -- error 8200
 create unique index idxErr on t (b) global;
+
+drop table t;
+--error 8200
+create table t(a int, b int, primary key (a) global);
+--error 8200
+create table t(a int, b int, primary key (a) global) partition by hash(a) partitions 5;
+create table t(a int, b int, primary key (b) global) partition by hash(a) partitions 5;
+show create table t;
+
+drop table t;
+create table t(a int, b int);
+--error 8200
+alter table t add primary key (a) global;
+

--- a/tests/integrationtest/t/globalindex/misc.test
+++ b/tests/integrationtest/t/globalindex/misc.test
@@ -16,7 +16,7 @@ insert into test_global(a,c) values (1,2);
 insert into test_global(a,c) values (11,2);
 
 drop table if exists test_global;
--- error 1503
+-- error 8200
 create table test_global ( a int, b int, c int, primary key p_b(b) /*T![clustered_index] CLUSTERED */ GLOBAL)
 partition by range( a ) (
 	partition p1 values less than (10),
@@ -24,7 +24,7 @@ partition by range( a ) (
 );
 
 drop table if exists test_global;
--- error 1503
+-- error 8200
 create table test_global ( a int, b int, c int, primary key p_b_c(b, c) /*T![clustered_index] CLUSTERED */ GLOBAL)
 partition by range( a ) (
 	partition p1 values less than (10),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56804 

Problem Summary: If the primary index mentioned is a global index, then it should be a non-clustered index.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
