### PR TITLE
unistore: fix the fair locking mechanism in unistore and make foreign key work

### DIFF
--- a/pkg/executor/test/fktest/BUILD.bazel
+++ b/pkg/executor/test/fktest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/config",
         "//pkg/executor",

--- a/tests/realtikvtest/txntest/txn_test.go
+++ b/tests/realtikvtest/txntest/txn_test.go
@@ -595,3 +595,35 @@ func TestDMLWithAddForeignKey(t *testing.T) {
 
 	require.True(t, errDML != nil || errDDL != nil)
 }
+
+func TestLockKeysInDML(t *testing.T) {
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (id int primary key);")
+	tk.MustExec("create table t2 (id int primary key, foreign key fk (id) references t1(id));")
+
+	tk.MustExec("insert into t1 values (1)")
+	tk.MustExec("BEGIN")
+	tk.MustExec("INSERT INTO t2 VALUES (1)")
+	var wg sync.WaitGroup
+	var tk2CommitTime time.Time
+	tk2StartTime := time.Now()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tk2 := testkit.NewTestKit(t, store)
+		tk2.MustExec("use test")
+		tk2.MustExec("BEGIN")
+		require.NotNil(t, tk2.ExecToErr("UPDATE t1 SET id = 2 WHERE id = 1"))
+		tk2.MustExec("COMMIT")
+		tk2CommitTime = time.Now()
+	}()
+	sleepDuration := 500 * time.Millisecond
+	time.Sleep(sleepDuration)
+	tk.MustExec("COMMIT")
+	wg.Wait()
+	require.Greater(t, tk2CommitTime.Sub(tk2StartTime), sleepDuration)
+	tk.MustQuery("SELECT * FROM t1").Check(testkit.Rows("1"))
+	tk.MustQuery("SELECT * FROM t2").Check(testkit.Rows("1"))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56663 

Problem Summary:

When there is an update for the same row in other transactions, it's necessary to update the `for_update_ts` to use the latest data to verify the constraint. Meanwhile, TiDB/TiKV has a mechanism called fair locking to lock the key with conflict. 

Therefore, when a key is locked, the storage layer (unistore or TiKV) should verify whether other transactions have written this key. If so, it should return the conflict info to TiDB, and TiDB can retry and update the `for_update_ts`.

However, the implementation of unistore has a little bug:

For TiKV, it returns the latest TS of both WRITE and LOCK, because they share the similar key (but with different value):

```rust
pub fn commit<S: Snapshot>(
    txn: &mut MvccTxn,
    reader: &mut SnapshotReader<S>,
    key: Key,
    commit_ts: TimeStamp,
) -> MvccResult<Option<ReleasedLock>> {
...
    let mut write = Write::new(
        WriteType::from_lock_type(lock.lock_type).unwrap(),
        reader.start_ts,
        lock.short_value.take(),
    )
    .set_last_change(lock.last_change.clone())
    .set_txn_source(lock.txn_source);
...
    txn.put_write(key.clone(), commit_ts, write.as_ref().to_bytes());
    Ok(txn.unlock_key(key, lock.is_pessimistic_txn(), commit_ts))
...
}
```

And in the `acquire_pessimistic_lock.rs`:

```rust
pub fn acquire_pessimistic_lock<S: Snapshot>(...) {
...
    if let Some((commit_ts, write)) = reader.seek_write(&key, TimeStamp::max())? {
...
    }
...
}
```

For unistore, the logic of handling pessimistic lock is similar, but unistore stores the LOCK info in a different key:

```go
// EncodeExtraTxnStatusKey encodes a extra transaction status key.
// It is only used for Rollback and Op_Lock.
func EncodeExtraTxnStatusKey(key []byte, startTS uint64) []byte {
	b := append([]byte{}, key...)
	ret := codec.EncodeUintDesc(b, startTS)
	ret[0]++
	return ret
}

func (wb *writeBatch) Commit(key []byte, lock *mvcc.Lock) {
...
		opLockKey := y.KeyWithTs(mvcc.EncodeExtraTxnStatusKey(key, wb.startTS), wb.startTS)
		wb.dbBatch.set(opLockKey, nil, userMeta)
...
}
```

### What changed and how does it work?

We need to also iterate (backward) through the extra txn status keys to get the latest startTS/commitTS.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note


```release-note
None
```
