### PR TITLE
ddl: enable the ddl notifier by default

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -587,29 +587,27 @@ func asyncNotifyEvent(jobCtx *jobContext, e *notifier.SchemaChangeEvent, job *mo
 		logutil.DDLLogger().Warn("fail to notify DDL event", zap.Stringer("event", e))
 	}
 
-	if intest.InTest && jobCtx.eventPublishStore != nil {
-		failpoint.Inject("asyncNotifyEventError", func() {
-			failpoint.Return(errors.New("mock publish event error"))
-		})
-		if subJobID == noSubJob && job.MultiSchemaInfo != nil {
-			subJobID = int64(job.MultiSchemaInfo.Seq)
-		}
-		err := notifier.PubSchemeChangeToStore(
-			jobCtx.stepCtx,
-			sctx,
-			job.ID,
-			subJobID,
-			e,
-			jobCtx.eventPublishStore,
-		)
-		if err != nil {
-			logutil.DDLLogger().Error("Error publish schema change event",
-				zap.Int64("jobID", job.ID),
-				zap.Int64("subJobID", subJobID),
-				zap.String("event", e.String()), zap.Error(err))
-			return err
-		}
-		return nil
+	intest.Assert(jobCtx.eventPublishStore != nil, "eventPublishStore should not be nil")
+	failpoint.Inject("asyncNotifyEventError", func() {
+		failpoint.Return(errors.New("mock publish event error"))
+	})
+	if subJobID == noSubJob && job.MultiSchemaInfo != nil {
+		subJobID = int64(job.MultiSchemaInfo.Seq)
+	}
+	err := notifier.PubSchemeChangeToStore(
+		jobCtx.stepCtx,
+		sctx,
+		job.ID,
+		subJobID,
+		e,
+		jobCtx.eventPublishStore,
+	)
+	if err != nil {
+		logutil.DDLLogger().Error("Error publish schema change event",
+			zap.Int64("jobID", job.ID),
+			zap.Int64("subJobID", subJobID),
+			zap.String("event", e.String()), zap.Error(err))
+		return err
 	}
 	return nil
 }

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1376,18 +1376,14 @@ func (do *Domain) Init(
 	do.cancelFns.fns = append(do.cancelFns.fns, cancelFunc)
 	do.cancelFns.mu.Unlock()
 
-	var ddlNotifierStore notifier.Store
-	if intest.InTest {
-		ddlNotifierStore = notifier.OpenTableStore("mysql", ddl.NotifierTableName)
-		do.ddlNotifier = notifier.NewDDLNotifier(
-			do.sysSessionPool,
-			ddlNotifierStore,
-			time.Second,
-		)
-
-		// TODO(lance6716): find a more representative place for subscriber
-		failpoint.InjectCall("afterDDLNotifierCreated", do.ddlNotifier)
-	}
+	ddlNotifierStore := notifier.OpenTableStore("mysql", ddl.NotifierTableName)
+	do.ddlNotifier = notifier.NewDDLNotifier(
+		do.sysSessionPool,
+		ddlNotifierStore,
+		time.Second,
+	)
+	// TODO(lance6716): find a more representative place for subscriber
+	failpoint.InjectCall("afterDDLNotifierCreated", do.ddlNotifier)
 
 	d := do.ddl
 	eBak := do.ddlExecutor

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2360,9 +2360,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 	variable.EnableStatsOwner = do.enableStatsOwner
 	variable.DisableStatsOwner = do.disableStatsOwner
 	do.statsOwner = do.newOwnerManager(handle.StatsPrompt, handle.StatsOwnerKey)
-	if intest.InTest {
-		do.statsOwner.SetListener(do.ddlNotifier)
-	}
+	do.statsOwner.SetListener(do.ddlNotifier)
 	do.wg.Run(func() {
 		do.indexUsageWorker()
 	}, "indexUsageWorker")

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -164,6 +164,8 @@ const (
 	MDLTableVersion DDLTableVersion = 2
 	// BackfillTableVersion is for support distributed reorg stage, it added tidb_background_subtask, tidb_background_subtask_history.
 	BackfillTableVersion DDLTableVersion = 3
+	// DDLNotifierTableVersion is for support ddl notifier, it added tidb_ddl_notifier.
+	DDLNotifierTableVersion DDLTableVersion = 4
 )
 
 // Bytes returns the byte slice.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3206,6 +3206,11 @@ var (
 		table_ids text(65535),
 		owner_id varchar(64) NOT NULL DEFAULT ''
 	);`
+	// DDLNotifierTables contains the table definitions used in DDL notifier.
+	// It only contains the notifier table. Put it here to reuse a unified initialization function.
+	DDLNotifierTables = []tableBasicInfo{
+		{ddl.NotifierTableSQL, ddl.NotifierTableID},
+	}
 )
 
 func splitAndScatterTable(store kv.Storage, tableIDs []int64) {
@@ -3228,7 +3233,9 @@ func InitDDLJobTables(store kv.Storage, targetVer meta.DDLTableVersion) error {
 	targetTables := DDLJobTables
 	if targetVer == meta.BackfillTableVersion {
 		targetTables = BackfillTables
-		targetTables = append(targetTables, tableBasicInfo{ddl.NotifierTableSQL, ddl.NotifierTableID})
+	}
+	if targetVer == meta.DDLNotifierTableVersion {
+		targetTables = DDLNotifierTables
 	}
 	return kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, true, func(_ context.Context, txn kv.Transaction) error {
 		t := meta.NewMutator(txn)
@@ -3437,6 +3444,10 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 		return nil, err
 	}
 	err = InitDDLJobTables(store, meta.BackfillTableVersion)
+	if err != nil {
+		return nil, err
+	}
+	err = InitDDLJobTables(store, meta.DDLNotifierTableVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3207,7 +3207,8 @@ var (
 		owner_id varchar(64) NOT NULL DEFAULT ''
 	);`
 	// DDLNotifierTables contains the table definitions used in DDL notifier.
-	// It only contains the notifier table. Put it here to reuse a unified initialization function.
+	// It only contains the notifier table.
+	// Put it here to reuse a unified initialization function and make it easier to find.
 	DDLNotifierTables = []tableBasicInfo{
 		{ddl.NotifierTableSQL, ddl.NotifierTableID},
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3228,10 +3228,7 @@ func InitDDLJobTables(store kv.Storage, targetVer meta.DDLTableVersion) error {
 	targetTables := DDLJobTables
 	if targetVer == meta.BackfillTableVersion {
 		targetTables = BackfillTables
-		if intest.InTest {
-			// create the system tables to test ddl notifier
-			targetTables = append(targetTables, tableBasicInfo{ddl.NotifierTableSQL, ddl.NotifierTableID})
-		}
+		targetTables = append(targetTables, tableBasicInfo{ddl.NotifierTableSQL, ddl.NotifierTableID})
 	}
 	return kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), store, true, func(_ context.Context, txn kv.Transaction) error {
 		t := meta.NewMutator(txn)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55722

Problem Summary:

### What changed and how does it work?

Enable the DDL notifier by default.
I added the `DDLNotifierTableVersion` to init the DDL notifier table.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test See: https://github.com/pingcap/tidb/pull/56864#issuecomment-2440712627
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
