### PR TITLE
planner: convert schema_name from NULL to "" for index advisor

### DIFF
--- a/pkg/planner/indexadvisor/indexadvisor.go
+++ b/pkg/planner/indexadvisor/indexadvisor.go
@@ -153,14 +153,14 @@ func prepareQuerySet(ctx context.Context, sctx sessionctx.Context,
 }
 
 func loadQuerySetFromStmtSummary(sctx sessionctx.Context, option *Option) (s.Set[Query], error) {
-	template := `SELECT any_value(schema_name) as schema_name,
+	template := `SELECT any_value(ifnull(schema_name, "")) as schema_name,
 				any_value(query_sample_text) as query_sample_text,
 				sum(cast(exec_count as double)) as exec_count
 			FROM information_schema.statements_summary_history
 			WHERE stmt_type = "Select" AND
 				summary_begin_time >= date_sub(now(), interval 1 day) AND
 				prepared = 0 AND
-				upper(schema_name) not in ("MYSQL", "INFORMATION_SCHEMA", "METRICS_SCHEMA", "PERFORMANCE_SCHEMA")
+				upper(ifnull(schema_name, "")) not in ("MYSQL", "INFORMATION_SCHEMA", "METRICS_SCHEMA", "PERFORMANCE_SCHEMA")
 			GROUP BY digest
 			ORDER BY sum(exec_count) DESC
 			LIMIT %?`

--- a/pkg/util/stmtsummary/v2/tests/BUILD.bazel
+++ b/pkg/util/stmtsummary/v2/tests/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "table_test.go",
     ],
     flaky = True,
-    shard_count = 13,
+    shard_count = 14,
     deps = [
         "//pkg/config",
         "//pkg/kv",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #12303

Problem Summary: planner: convert schema_name from NULL to "" for index advisor

### What changed and how does it work?

planner: convert schema_name from NULL to "" for index advisor

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
