### PR TITLE
planner: Fix predicate simplification panic caused by zero-argument expressions like rand()

### DIFF
--- a/pkg/planner/core/rule_predicate_simplification.go
+++ b/pkg/planner/core/rule_predicate_simplification.go
@@ -55,6 +55,9 @@ func findPredicateType(expr expression.Expression) (*expression.Column, predicat
 			return nil, orPredicate
 		}
 		args := v.GetArgs()
+		if len(args) == 0 {
+			return nil, otherPredicate
+		}
 		col, colOk := args[0].(*expression.Column)
 		if !colOk {
 			return nil, otherPredicate

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -750,3 +750,9 @@ NULL	NULL	2	2	4	2
 show warnings;
 Level	Code	Message
 drop table if exists t1, t2, t3, t4;
+drop table if exists t0, v0;
+drop view if exists v0;
+CREATE  TABLE  t0(c0 INTEGER);
+CREATE VIEW v0(c0) AS SELECT 'a' FROM t0 WHERE (CASE t0.c0 WHEN t0.c0 THEN false END );
+SELECT t0.c0 FROM v0, t0 WHERE RAND();
+c0

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -517,3 +517,10 @@ SELECT t2.a,t2.b,t3.a,t3.b,t4.a,t4.b
        ON t3.a=1 AND t3.b=t2.b AND t2.b=t4.b order by 1, 2, 3, 4, 5;
 show warnings;
 drop table if exists t1, t2, t3, t4;
+
+# TestIssue56270
+drop table if exists t0, v0;
+drop view if exists v0;
+CREATE  TABLE  t0(c0 INTEGER);
+CREATE VIEW v0(c0) AS SELECT 'a' FROM t0 WHERE (CASE t0.c0 WHEN t0.c0 THEN false END );
+SELECT t0.c0 FROM v0, t0 WHERE RAND();


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56270

Problem Summary:

### What changed and how does it work?
When checking predicate type in predicate simplification, it will use arg[0] to judge if the arg is *expression.Column, however, "rand()" has 0 argument, which will lead a panic.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
