### PR TITLE
ddl: check index key length when convert charset

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -51,6 +51,7 @@ import (
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	parser_types "github.com/pingcap/tidb/pkg/parser/types"
 	"github.com/pingcap/tidb/pkg/privilege"
 	rg "github.com/pingcap/tidb/pkg/resourcegroup"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -3971,6 +3972,10 @@ func checkAlterTableCharset(tblInfo *model.TableInfo, dbInfo *model.DBInfo, toCh
 		return doNothing, nil
 	}
 
+	if err = checkIndexLengthWithNewCharset(tblInfo, toCharset, toCollate); err != nil {
+		return doNothing, err
+	}
+
 	for _, col := range tblInfo.Columns {
 		if col.GetType() == mysql.TypeVarchar {
 			if err = types.IsVarcharTooBigFieldLength(col.GetFlen(), col.Name.O, toCharset); err != nil {
@@ -3992,6 +3997,30 @@ func checkAlterTableCharset(tblInfo *model.TableInfo, dbInfo *model.DBInfo, toCh
 		}
 	}
 	return doNothing, nil
+}
+
+func checkIndexLengthWithNewCharset(tblInfo *model.TableInfo, toCharset, toCollate string) error {
+	// Copy all columns and replace the charset and collate.
+	columns := make([]*model.ColumnInfo, 0, len(tblInfo.Columns))
+	for _, col := range tblInfo.Columns {
+		newCol := col.Clone()
+		if parser_types.HasCharset(&newCol.FieldType) {
+			newCol.SetCharset(toCharset)
+			newCol.SetCollate(toCollate)
+		} else {
+			newCol.SetCharset(charset.CharsetBin)
+			newCol.SetCollate(charset.CharsetBin)
+		}
+		columns = append(columns, newCol)
+	}
+
+	for _, indexInfo := range tblInfo.Indices {
+		err := checkIndexPrefixLength(columns, indexInfo.Columns)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RenameIndex renames an index.

--- a/tests/integrationtest/r/session/common.result
+++ b/tests/integrationtest/r/session/common.result
@@ -137,6 +137,18 @@ create table t (a blob(10000), b timestamp, index idx(a(3069), b));
 Error 1071 (42000): Specified key was too long (3073 bytes); max key length is 3072 bytes
 create table t (a blob(10000), b timestamp, index idx(a(3068), b));
 drop table if exists t;
+create table posts (id int auto_increment primary key, title varchar(500) character set utf8, subtitle varchar(500) character set utf8, unique key(title, subtitle));
+alter table posts convert to character set utf8mb4;
+Error 1071 (42000): Specified key was too long (4000 bytes); max key length is 3072 bytes
+drop table if exists posts;
+create table t(a varchar(1000) character set utf8, primary key(a));
+alter table t convert to character set utf8mb4;
+Error 1071 (42000): Specified key was too long (4000 bytes); max key length is 3072 bytes
+drop table if exists t;
+create table t(a varchar(1000) character set utf8, key(a));
+alter table t convert to character set utf8mb4;
+Error 1071 (42000): Specified key was too long (4000 bytes); max key length is 3072 bytes
+drop table if exists t;
 drop table if exists t1; create table t1(id int ); insert into t1 values (1);
 select * from t1;
 id

--- a/tests/integrationtest/t/session/common.test
+++ b/tests/integrationtest/t/session/common.test
@@ -140,6 +140,18 @@ drop table if exists t;
 create table t (a blob(10000), b timestamp, index idx(a(3069), b));
 create table t (a blob(10000), b timestamp, index idx(a(3068), b));
 drop table if exists t;
+create table posts (id int auto_increment primary key, title varchar(500) character set utf8, subtitle varchar(500) character set utf8, unique key(title, subtitle));
+-- error 1071
+alter table posts convert to character set utf8mb4;
+drop table if exists posts;
+create table t(a varchar(1000) character set utf8, primary key(a));
+-- error 1071
+alter table t convert to character set utf8mb4;
+drop table if exists t;
+create table t(a varchar(1000) character set utf8, key(a));
+-- error 1071
+alter table t convert to character set utf8mb4;
+drop table if exists t;
 
 # TestMultiStmts
 drop table if exists t1; create table t1(id int ); insert into t1 values (1);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56930

Problem Summary:
Miss the check of index length.
### What changed and how does it work?
Check the index length when convert to new charset.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
