### PR TITLE
test: fix the flaky integration test for foreign key.

### DIFF
--- a/tests/integrationtest/r/executor/delete.result
+++ b/tests/integrationtest/r/executor/delete.result
@@ -144,7 +144,7 @@ create table child2 (a int, foreign key (a) references parent2(a));
 insert into parent2 values (1), (2);
 insert into child2 values (1);
 delete parent, parent2 from parent join parent2 on parent.a = parent2.a;
-Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))
+Got one of the listed errors
 delete ignore parent, parent2 from parent join parent2 on parent.a = parent2.a;
 Level	Code	Message
 Warning	1451	Cannot delete or update a parent row: a foreign key constraint fails (`executor__delete`.`child2`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent2` (`a`))

--- a/tests/integrationtest/t/executor/delete.test
+++ b/tests/integrationtest/t/executor/delete.test
@@ -135,7 +135,7 @@ create table parent2 (a int primary key);
 create table child2 (a int, foreign key (a) references parent2(a));
 insert into parent2 values (1), (2);
 insert into child2 values (1);
--- error 1451
+-- error 1451, 1451
 delete parent, parent2 from parent join parent2 on parent.a = parent2.a;
 delete ignore parent, parent2 from parent join parent2 on parent.a = parent2.a;
 select * from parent;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56978 

Problem Summary:

The query `delete parent, parent2 from parent join parent2 on parent.a = parent2.a;` is possible to give two errors:

1. Delete from parent2 will break the foreign key constraint in `child2`.
2. Delete from parent will break the foreign key constraint in `child`.

It caused the flaky.

### What changed and how does it work?

A `replace` is added to make these two errors appear the same.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
