### PR TITLE
statistics: add the refresher as a stats owner listener

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2360,7 +2360,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 	variable.EnableStatsOwner = do.enableStatsOwner
 	variable.DisableStatsOwner = do.disableStatsOwner
 	do.statsOwner = do.newOwnerManager(handle.StatsPrompt, handle.StatsOwnerKey)
-	do.statsOwner.SetListener(owner.NewListenersWrapper(do.ddlNotifier, statsHandle))
+	do.statsOwner.SetListener(owner.NewListenersWrapper(statsHandle, do.ddlNotifier))
 	do.wg.Run(func() {
 		do.indexUsageWorker()
 	}, "indexUsageWorker")

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2360,7 +2360,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 	variable.EnableStatsOwner = do.enableStatsOwner
 	variable.DisableStatsOwner = do.disableStatsOwner
 	do.statsOwner = do.newOwnerManager(handle.StatsPrompt, handle.StatsOwnerKey)
-	do.statsOwner.SetListener(do.ddlNotifier)
+	do.statsOwner.SetListener(owner.NewOwnerListeners(do.ddlNotifier, statsHandle))
 	do.wg.Run(func() {
 		do.indexUsageWorker()
 	}, "indexUsageWorker")

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2360,7 +2360,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) err
 	variable.EnableStatsOwner = do.enableStatsOwner
 	variable.DisableStatsOwner = do.disableStatsOwner
 	do.statsOwner = do.newOwnerManager(handle.StatsPrompt, handle.StatsOwnerKey)
-	do.statsOwner.SetListener(owner.NewOwnerListeners(do.ddlNotifier, statsHandle))
+	do.statsOwner.SetListener(owner.NewListenersWrapper(do.ddlNotifier, statsHandle))
 	do.wg.Run(func() {
 		do.indexUsageWorker()
 	}, "indexUsageWorker")

--- a/pkg/owner/BUILD.bazel
+++ b/pkg/owner/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     ],
     embed = [":owner"],
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/ddl",
         "//pkg/infoschema",

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -554,3 +554,28 @@ func AcquireDistributedLock(
 		}
 	}, nil
 }
+
+// OwnerListeners is a list of listeners.
+// A way to broadcast events to multiple listeners.
+type OwnerListeners struct {
+	listeners []Listener
+}
+
+// OnBecomeOwner broadcasts the OnBecomeOwner event to all listeners.
+func (ol *OwnerListeners) OnBecomeOwner() {
+	for _, l := range ol.listeners {
+		l.OnBecomeOwner()
+	}
+}
+
+// OnRetireOwner broadcasts the OnRetireOwner event to all listeners.
+func (ol *OwnerListeners) OnRetireOwner() {
+	for _, l := range ol.listeners {
+		l.OnRetireOwner()
+	}
+}
+
+// NewOwnerListeners creates a new OwnerListeners.
+func NewOwnerListeners(listeners ...Listener) *OwnerListeners {
+	return &OwnerListeners{listeners: listeners}
+}

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -555,27 +555,27 @@ func AcquireDistributedLock(
 	}, nil
 }
 
-// OwnerListeners is a list of listeners.
+// ListenersWrapper is a list of listeners.
 // A way to broadcast events to multiple listeners.
-type OwnerListeners struct {
+type ListenersWrapper struct {
 	listeners []Listener
 }
 
 // OnBecomeOwner broadcasts the OnBecomeOwner event to all listeners.
-func (ol *OwnerListeners) OnBecomeOwner() {
+func (ol *ListenersWrapper) OnBecomeOwner() {
 	for _, l := range ol.listeners {
 		l.OnBecomeOwner()
 	}
 }
 
 // OnRetireOwner broadcasts the OnRetireOwner event to all listeners.
-func (ol *OwnerListeners) OnRetireOwner() {
+func (ol *ListenersWrapper) OnRetireOwner() {
 	for _, l := range ol.listeners {
 		l.OnRetireOwner()
 	}
 }
 
-// NewOwnerListeners creates a new OwnerListeners.
-func NewOwnerListeners(listeners ...Listener) *OwnerListeners {
-	return &OwnerListeners{listeners: listeners}
+// NewListenersWrapper creates a new OwnerListeners.
+func NewListenersWrapper(listeners ...Listener) *ListenersWrapper {
+	return &ListenersWrapper{listeners: listeners}
 }

--- a/pkg/owner/manager_test.go
+++ b/pkg/owner/manager_test.go
@@ -560,3 +560,19 @@ func TestAcquireDistributedLock(t *testing.T) {
 		release2()
 	})
 }
+
+func TestListenersWrapper(t *testing.T) {
+	lis1 := &listener{}
+	lis2 := &listener{}
+	wrapper := owner.NewListenersWrapper(lis1, lis2)
+
+	// Test OnBecomeOwner
+	wrapper.OnBecomeOwner()
+	require.True(t, lis1.val.Load())
+	require.True(t, lis2.val.Load())
+
+	// Test OnRetireOwner
+	wrapper.OnRetireOwner()
+	require.False(t, lis1.val.Load())
+	require.False(t, lis2.val.Load())
+}

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -138,6 +138,16 @@ func (sa *statsAnalyze) CleanupCorruptedAnalyzeJobsOnDeadInstances() error {
 	}, statsutil.FlagWrapTxn)
 }
 
+// OnBecomeOwner is used to handle the event when the current TiDB instance becomes the stats owner.
+func (sa *statsAnalyze) OnBecomeOwner() {
+	sa.refresher.OnBecomeOwner()
+}
+
+// OnRetireOwner is used to handle the event when the current TiDB instance retires from being the stats owner.
+func (sa *statsAnalyze) OnRetireOwner() {
+	sa.refresher.OnRetireOwner()
+}
+
 // SelectAnalyzeJobsOnCurrentInstanceSQL is the SQL to select the analyze jobs whose
 // state is `pending` or `running` and the update time is more than 10 minutes ago
 // and the instance is current instance.

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -812,6 +812,9 @@ func (pq *AnalysisPriorityQueue) Close() {
 		return
 	}
 
-	pq.syncFields.cancel()
+	// It is possible that the priority queue is not initialized.
+	if pq.syncFields.cancel != nil {
+		pq.syncFields.cancel()
+	}
 	pq.wg.Wait()
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -72,18 +72,20 @@ type pqHeap interface {
 //
 //nolint:fieldalignment
 type AnalysisPriorityQueue struct {
+	ctx         context.Context
 	statsHandle statstypes.StatsHandle
 	calculator  *PriorityCalculator
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     util.WaitGroupWrapper
+	wg util.WaitGroupWrapper
 
 	// syncFields is a substructure to hold fields protected by mu.
 	syncFields struct {
 		// mu is used to protect the following fields.
-		mu    sync.RWMutex
-		inner pqHeap
+		mu sync.RWMutex
+		// Because the Initialize and Close functions can be called concurrently,
+		// so we need to protect the cancel function to avoid data race.
+		cancel context.CancelFunc
+		inner  pqHeap
 		// runningJobs is a map to store the running jobs. Used to avoid duplicate jobs.
 		runningJobs map[int64]struct{}
 		// lastDMLUpdateFetchTimestamp is the timestamp of the last DML update fetch.
@@ -97,19 +99,10 @@ type AnalysisPriorityQueue struct {
 
 // NewAnalysisPriorityQueue creates a new AnalysisPriorityQueue2.
 func NewAnalysisPriorityQueue(handle statstypes.StatsHandle) *AnalysisPriorityQueue {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	queue := &AnalysisPriorityQueue{
 		statsHandle: handle,
 		calculator:  NewPriorityCalculator(),
-		ctx:         ctx,
-		cancel:      cancel,
 	}
-
-	queue.syncFields.mu.Lock()
-	queue.syncFields.runningJobs = make(map[int64]struct{})
-	queue.syncFields.failedJobs = make(map[int64]struct{})
-	queue.syncFields.mu.Unlock()
 
 	return queue
 }
@@ -144,6 +137,12 @@ func (pq *AnalysisPriorityQueue) Initialize() error {
 		pq.Close()
 		return errors.Trace(err)
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pq.ctx = ctx
+	pq.syncFields.cancel = cancel
+	pq.syncFields.runningJobs = make(map[int64]struct{})
+	pq.syncFields.failedJobs = make(map[int64]struct{})
 	pq.syncFields.initialized = true
 	pq.syncFields.mu.Unlock()
 
@@ -813,6 +812,6 @@ func (pq *AnalysisPriorityQueue) Close() {
 		return
 	}
 
-	pq.cancel()
+	pq.syncFields.cancel()
 	pq.wg.Wait()
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -100,7 +100,6 @@ func (r *Refresher) AnalyzeHighestPriorityTables() bool {
 	if !r.isWithinTimeWindow() {
 		return false
 	}
-	intest.Assert(r.jobs.IsInitialized(), "The queue should be initialized when the node becomes the owner")
 	if !r.jobs.IsInitialized() {
 		if err := r.jobs.Initialize(); err != nil {
 			statslogutil.StatsLogger().Error("Failed to initialize the queue", zap.Error(err))
@@ -255,7 +254,8 @@ func (r *Refresher) Close() {
 
 // OnBecomeOwner is used to handle the event when the current TiDB instance becomes the stats owner.
 func (r *Refresher) OnBecomeOwner() {
-	r.jobs.Initialize()
+	// No action is taken when becoming the stats owner.
+	// Initialization of the Refresher can fail, so operations are deferred until the first auto-analyze check.
 }
 
 // OnRetireOwner is used to handle the event when the current TiDB instance retires from being the stats owner.

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -253,7 +253,7 @@ func (r *Refresher) Close() {
 }
 
 // OnBecomeOwner is used to handle the event when the current TiDB instance becomes the stats owner.
-func (r *Refresher) OnBecomeOwner() {
+func (*Refresher) OnBecomeOwner() {
 	// No action is taken when becoming the stats owner.
 	// Initialization of the Refresher can fail, so operations are deferred until the first auto-analyze check.
 }

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -100,6 +100,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables() bool {
 	if !r.isWithinTimeWindow() {
 		return false
 	}
+	intest.Assert(r.jobs.IsInitialized(), "The queue should be initialized when the node becomes the owner")
 	if !r.jobs.IsInitialized() {
 		if err := r.jobs.Initialize(); err != nil {
 			statslogutil.StatsLogger().Error("Failed to initialize the queue", zap.Error(err))

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -251,3 +251,14 @@ func (r *Refresher) Close() {
 		r.jobs.Close()
 	}
 }
+
+// OnBecomeOwner is used to handle the event when the current TiDB instance becomes the stats owner.
+func (r *Refresher) OnBecomeOwner() {
+	r.jobs.Initialize()
+}
+
+// OnRetireOwner is used to handle the event when the current TiDB instance retires from being the stats owner.
+func (r *Refresher) OnRetireOwner() {
+	// Stop the worker and close the queue.
+	r.jobs.Close()
+}

--- a/pkg/statistics/handle/types/BUILD.bazel
+++ b/pkg/statistics/handle/types/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/ddl/notifier",
         "//pkg/infoschema",
         "//pkg/meta/model",
+        "//pkg/owner",
         "//pkg/parser/ast",
         "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/owner"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
@@ -119,6 +120,8 @@ type StatsHistory interface {
 
 // StatsAnalyze is used to handle auto-analyze and manage analyze jobs.
 type StatsAnalyze interface {
+	owner.Listener
+
 	// InsertAnalyzeJob inserts analyze job into mysql.analyze_jobs and gets job ID for further updating job.
 	InsertAnalyzeJob(job *statistics.AnalyzeJob, instance string, procID uint64) error
 
@@ -157,12 +160,6 @@ type StatsAnalyze interface {
 
 	// CheckAnalyzeVersion checks whether all the statistics versions of this table's columns and indexes are the same.
 	CheckAnalyzeVersion(tblInfo *model.TableInfo, physicalIDs []int64, version *int) bool
-
-	// OnBecomeOwner is used to handle the event when the current TiDB instance becomes the stats owner.
-	OnBecomeOwner()
-
-	// OnRetireOwner is used to handle the event when the current TiDB instance retires from being the stats owner.
-	OnRetireOwner()
 
 	// Close closes the analyze worker.
 	Close()

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -158,6 +158,12 @@ type StatsAnalyze interface {
 	// CheckAnalyzeVersion checks whether all the statistics versions of this table's columns and indexes are the same.
 	CheckAnalyzeVersion(tblInfo *model.TableInfo, physicalIDs []int64, version *int) bool
 
+	// OnBecomeOwner is used to handle the event when the current TiDB instance becomes the stats owner.
+	OnBecomeOwner()
+
+	// OnRetireOwner is used to handle the event when the current TiDB instance retires from being the stats owner.
+	OnRetireOwner()
+
 	// Close closes the analyze worker.
 	Close()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55906

Problem Summary:

### What changed and how does it work?

In this PR, I added the refresher as a listener for the stats owner, to ensure that after a stats owner changes, the background process can stop correctly.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
