### PR TITLE
planner: Using converted value in newBatchPointGetPlan, fix for partitioned table and IN

### DIFF
--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -817,8 +817,8 @@ func newBatchPointGetPlan(
 					if dval == nil {
 						return nil
 					}
-					values[permIndex] = innerX.Datum
-					pairs = append(pairs, nameValuePair{colName: whereColNames[index], value: innerX.Datum})
+					values[permIndex] = *dval
+					pairs = append(pairs, nameValuePair{colName: whereColNames[index], value: *dval})
 				case *driver.ParamMarkerExpr:
 					con, err := expression.ParamMarkerExpression(ctx, innerX, true)
 					if err != nil {
@@ -832,12 +832,12 @@ func newBatchPointGetPlan(
 					if dval == nil {
 						return nil
 					}
-					values[permIndex] = innerX.Datum
+					values[permIndex] = *dval
 					valuesParams[permIndex] = con
 					if initTypes {
 						indexTypes[permIndex] = &colInfos[index].FieldType
 					}
-					pairs = append(pairs, nameValuePair{colName: whereColNames[index], value: innerX.Datum})
+					pairs = append(pairs, nameValuePair{colName: whereColNames[index], value: *dval})
 				default:
 					return nil
 				}

--- a/tests/integrationtest/r/planner/core/casetest/partition/integration_partition.result
+++ b/tests/integrationtest/r/planner/core/casetest/partition/integration_partition.result
@@ -750,3 +750,19 @@ id	estRows	task	access object	operator info
 TableReader	10.00	root		data:Selection
 └─Selection	10.00	cop[tikv]		eq(list_partition_pruning.t.col, "LINPIN")
   └─TableFullScan	10000.00	cop[tikv]	table:t, partition:p4	keep order:false, stats:pseudo
+drop table if exists t;
+CREATE TABLE `t` (`tenant_id` bigint(20) NOT NULL DEFAULT '0',`order_id` bigint(20) NOT NULL DEFAULT '0',UNIQUE KEY `uk_ten_ord` (`order_id`, `tenant_id`))  PARTITION BY HASH(`tenant_id`) PARTITIONS 32;
+INSERT INTO t(tenant_id, order_id) VALUES (123, 456);
+select * from t where (tenant_id, order_id) in (('123','456'));
+tenant_id	order_id
+123	456
+select * from t where (tenant_id, order_id) in (('0123','456'));
+tenant_id	order_id
+123	456
+alter table t remove partitioning;
+select * from t where (tenant_id, order_id) in (('123','456'));
+tenant_id	order_id
+123	456
+select * from t where (tenant_id, order_id) in (('0123','456'));
+tenant_id	order_id
+123	456

--- a/tests/integrationtest/t/planner/core/casetest/partition/integration_partition.test
+++ b/tests/integrationtest/t/planner/core/casetest/partition/integration_partition.test
@@ -185,3 +185,13 @@ drop table if exists t;
 create table t(col varchar(32) COLLATE utf8mb4_general_ci DEFAULT NULL) PARTITION BY KEY (`col`) PARTITIONS 7;
 explain format = brief select * from t where col = 'linpin';
 explain format = brief select * from t where col = 'LINPIN';
+
+# TestIssue54746
+drop table if exists t;
+CREATE TABLE `t` (`tenant_id` bigint(20) NOT NULL DEFAULT '0',`order_id` bigint(20) NOT NULL DEFAULT '0',UNIQUE KEY `uk_ten_ord` (`order_id`, `tenant_id`))  PARTITION BY HASH(`tenant_id`) PARTITIONS 32;
+INSERT INTO t(tenant_id, order_id) VALUES (123, 456);
+select * from t where (tenant_id, order_id) in (('123','456'));
+select * from t where (tenant_id, order_id) in (('0123','456'));
+alter table t remove partitioning;
+select * from t where (tenant_id, order_id) in (('123','456'));
+select * from t where (tenant_id, order_id) in (('0123','456'));


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #54746

Problem Summary:
`newBatchPointGetPlan()` did not use the converted `datum` resulting in no found row for partitioned tables that used ` IN ()` with non-matching types.

### What changed and how does it work?
Using the converted `datum`, like it was done for some other item types.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed matching rows for partitioned tables using IN function which also needed type conversion.
```
