### PR TITLE
timer: make sure timer which has a max delay will be scheduled first

### DIFF
--- a/pkg/timer/runtime/BUILD.bazel
+++ b/pkg/timer/runtime/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     embed = [":runtime"],
     flaky = True,
     race = "on",
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/testkit/testsetup",
         "//pkg/timer/api",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57137

This issue is because a trigger action will be sent to the timer worker via the chan:

https://github.com/pingcap/tidb/blob/6004c3e109a7f70b05287563b0b192e61be87fb9/pkg/timer/runtime/runtime.go#L285-L300

If the chan is full, it will fail and retry after a while. However, some tables always have lower priorities even if they are not triggered for a long time.

### What changed and how does it work?

reorder timers by `nextEventTime` before sending them to workers to make sure the timer which has a max delay will be handled first to avoid starvation

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
ttl: fix some times TTL job can not be scheduled when there are a lot of TTL tables.
```
