### PR TITLE
planner: fix cost adjustment for high risk tablescan

### DIFF
--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1205,7 +1205,7 @@ func TestIgnoreRealtimeStats(t *testing.T) {
 	testKit := testkit.NewTestKit(t, store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
-	testKit.MustExec("create table t(a int, b int, index ib(b))")
+	testKit.MustExec("create table t(a int, b int)")
 	h := dom.StatsHandle()
 	require.NoError(t, h.HandleDDLEvent(<-h.DDLEventCh()))
 

--- a/pkg/planner/core/casetest/binaryplan/testdata/binary_plan_suite_out.json
+++ b/pkg/planner/core/casetest/binaryplan/testdata/binary_plan_suite_out.json
@@ -46,7 +46,7 @@
             "children": [
               {
                 "name": "TableFullScan_4",
-                "cost": 2500387.7115728618,
+                "cost": 4546159.475587022,
                 "est_rows": 10000,
                 "act_rows": 2,
                 "task_type": 2,
@@ -54,7 +54,7 @@
                 "operator_info": "keep order:false, stats:pseudo"
               }
             ],
-            "cost": 251172.51410485746,
+            "cost": 387557.2983724681,
             "est_rows": 10000,
             "act_rows": 2,
             "task_type": 1,
@@ -104,7 +104,7 @@
                         "children": [
                           {
                             "name": "TableFullScan_16",
-                            "cost": 2500387.7115728618,
+                            "cost": 4546159.475587022,
                             "est_rows": 10000,
                             "act_rows": 4,
                             "task_type": 2,
@@ -115,7 +115,7 @@
                         "labels": [
                           1
                         ],
-                        "cost": 208932.51410485746,
+                        "cost": 345317.2983724681,
                         "est_rows": 10000,
                         "act_rows": 4,
                         "task_type": 1,
@@ -123,7 +123,7 @@
                         "operator_info": "data:TableFullScan_16"
                       }
                     ],
-                    "cost": 992002.8474381908,
+                    "cost": 1128387.6317058015,
                     "est_rows": 100000000,
                     "act_rows": 8,
                     "task_type": 1,
@@ -131,7 +131,7 @@
                     "operator_info": "CARTESIAN inner join"
                   }
                 ],
-                "cost": 998992002.8474382,
+                "cost": 999128387.6317058,
                 "est_rows": 100000000,
                 "act_rows": 8,
                 "task_type": 1,
@@ -139,7 +139,7 @@
                 "operator_info": "cast(test.t.a, decimal(10,0) BINARY)->Column#8"
               }
             ],
-            "cost": 1996993511.427438,
+            "cost": 1997129896.2117057,
             "est_rows": 1,
             "act_rows": 1,
             "task_type": 1,
@@ -184,7 +184,7 @@
                 "children": [
                   {
                     "name": "TableFullScan_5",
-                    "cost": 2500387.7115728618,
+                    "cost": 4546159.475587022,
                     "est_rows": 10000,
                     "act_rows": 2,
                     "task_type": 2,
@@ -192,14 +192,14 @@
                     "operator_info": "keep order:false, stats:pseudo"
                   }
                 ],
-                "cost": 2999387.7115728618,
+                "cost": 5045159.475587022,
                 "est_rows": 3333.3333333333335,
                 "task_type": 2,
                 "store_type": 2,
                 "operator_info": "gt(test.t.a, 100)"
               }
             ],
-            "cost": 214039.18077152412,
+            "cost": 350423.9650391348,
             "est_rows": 3333.3333333333335,
             "task_type": 1,
             "store_type": 1,
@@ -222,7 +222,7 @@
                     "children": [
                       {
                         "name": "TableFullScan_35",
-                        "cost": 2500387.7115728618,
+                        "cost": 4546159.475587022,
                         "est_rows": 10000,
                         "act_rows": 2,
                         "task_type": 2,
@@ -230,7 +230,7 @@
                         "operator_info": "keep order:false, stats:pseudo"
                       }
                     ],
-                    "cost": 2999387.7115728618,
+                    "cost": 5045159.475587022,
                     "est_rows": 9990,
                     "act_rows": 2,
                     "task_type": 2,
@@ -241,7 +241,7 @@
                 "labels": [
                   2
                 ],
-                "cost": 284354.70077152416,
+                "cost": 420739.48503913474,
                 "est_rows": 9990,
                 "act_rows": 2,
                 "task_type": 1,
@@ -256,7 +256,7 @@
                     "children": [
                       {
                         "name": "TableFullScan_32",
-                        "cost": 2500387.7115728618,
+                        "cost": 4546159.475587022,
                         "est_rows": 10000,
                         "act_rows": 4,
                         "task_type": 2,
@@ -264,7 +264,7 @@
                         "operator_info": "keep order:false, stats:pseudo"
                       }
                     ],
-                    "cost": 2999387.7115728618,
+                    "cost": 5045159.475587022,
                     "est_rows": 9990,
                     "act_rows": 4,
                     "task_type": 2,
@@ -275,7 +275,7 @@
                 "labels": [
                   1
                 ],
-                "cost": 284354.70077152416,
+                "cost": 420739.48503913474,
                 "est_rows": 9990,
                 "act_rows": 4,
                 "task_type": 1,
@@ -283,7 +283,7 @@
                 "operator_info": "data:Selection_33"
               }
             ],
-            "cost": 1830544.8015430481,
+            "cost": 2103314.3700782694,
             "est_rows": 12487.5,
             "task_type": 1,
             "store_type": 1,
@@ -389,7 +389,7 @@
                     "children": [
                       {
                         "name": "TableFullScan_6",
-                        "cost": 2500387.7115728618,
+                        "cost": 4546159.475587022,
                         "est_rows": 10000,
                         "act_rows": 4,
                         "task_type": 2,
@@ -397,14 +397,14 @@
                         "operator_info": "keep order:false, stats:pseudo"
                       }
                     ],
-                    "cost": 2999387.7115728618,
+                    "cost": 5045159.475587022,
                     "est_rows": 3333.3333333333335,
                     "task_type": 2,
                     "store_type": 2,
                     "operator_info": "gt(test.t2.b, 10)"
                   }
                 ],
-                "cost": 242199.18077152412,
+                "cost": 378583.9650391348,
                 "est_rows": 3333.3333333333335,
                 "task_type": 1,
                 "store_type": 1,
@@ -441,7 +441,7 @@
                 "children": [
                   {
                     "name": "TableFullScan_6",
-                    "cost": 2500387.7115728618,
+                    "cost": 4546159.475587022,
                     "est_rows": 10000,
                     "act_rows": 2,
                     "task_type": 2,
@@ -449,7 +449,7 @@
                     "operator_info": "keep order:false, stats:pseudo"
                   }
                 ],
-                "cost": 251172.51410485746,
+                "cost": 387557.2983724681,
                 "est_rows": 10000,
                 "act_rows": 2,
                 "task_type": 1,
@@ -475,7 +475,7 @@
                 "children": [
                   {
                     "name": "TableFullScan_5",
-                    "cost": 2500387.7115728618,
+                    "cost": 4546159.475587022,
                     "est_rows": 10000,
                     "act_rows": 8,
                     "task_type": 2,
@@ -483,7 +483,7 @@
                     "operator_info": "keep order:false, stats:pseudo"
                   }
                 ],
-                "cost": 208932.51410485746,
+                "cost": 345317.2983724681,
                 "est_rows": 10000,
                 "act_rows": 8,
                 "task_type": 1,

--- a/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
@@ -48,7 +48,7 @@
       },
       {
         "SQL": "select c from t order by t.a limit 1",
-        "Best": "TableReader(Table(t)->Limit)->Limit->Projection"
+        "Best": "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->TopN([test.t.a],0,1))->TopN([test.t.a],0,1)->Projection"
       },
       {
         "SQL": "select c from t order by t.a + t.b limit 1",
@@ -508,7 +508,7 @@
       },
       {
         "SQL": "select a from t union all (select c from t) order by a limit 1",
-        "Best": "UnionAll{TableReader(Table(t)->Limit)->Limit->IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Limit)->Limit}->TopN([Column#25],0,1)"
+        "Best": "UnionAll{IndexReader(Index(t.f)[[NULL,+inf]]->TopN([test.t.a],0,1))->TopN([test.t.a],0,1)->IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Limit)->Limit}->TopN([Column#25],0,1)"
       }
     ]
   },

--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -2021,9 +2021,9 @@
       },
       {
         "SQL": "select /*+ USE_INDEX_MERGE(t1, c_d_e, f_g) */ * from t where c < 1 or f > 2",
-        "Best": "TableReader(Table(t)->Sel([or(lt(test.t.c, 1), gt(test.t.f, 2))]))",
+        "Best": "IndexMergeReader(PartialPlans->[Index(t.c_d_e)[[-inf,1)], Index(t.f)[(2,+inf]]], TablePlan->Table(t))",
         "HasWarn": true,
-        "Hints": "use_index(@`sel_1` `test`.`t` ), no_order_index(@`sel_1` `test`.`t` `primary`)"
+        "Hints": "use_index_merge(@`sel_1` `t` `c_d_e`, `f`)"
       },
       {
         "SQL": "select /*+ NO_INDEX_MERGE(), USE_INDEX_MERGE(t, primary, f_g, c_d_e) */ * from t where a < 1 or f > 2",
@@ -2039,15 +2039,15 @@
       },
       {
         "SQL": "select /*+ USE_INDEX_MERGE(db2.t) */ * from t where c < 1 or f > 2",
-        "Best": "TableReader(Table(t)->Sel([or(lt(test.t.c, 1), gt(test.t.f, 2))]))",
+        "Best": "IndexMergeReader(PartialPlans->[Index(t.c_d_e)[[-inf,1)], Index(t.f)[(2,+inf]]], TablePlan->Table(t))",
         "HasWarn": true,
-        "Hints": "use_index(@`sel_1` `test`.`t` ), no_order_index(@`sel_1` `test`.`t` `primary`)"
+        "Hints": "use_index_merge(@`sel_1` `t` `c_d_e`, `f`)"
       },
       {
         "SQL": "select /*+ USE_INDEX_MERGE(db2.t, c_d_e, f_g) */ * from t where c < 1 or f > 2",
-        "Best": "TableReader(Table(t)->Sel([or(lt(test.t.c, 1), gt(test.t.f, 2))]))",
+        "Best": "IndexMergeReader(PartialPlans->[Index(t.c_d_e)[[-inf,1)], Index(t.f)[(2,+inf]]], TablePlan->Table(t))",
         "HasWarn": true,
-        "Hints": "use_index(@`sel_1` `test`.`t` ), no_order_index(@`sel_1` `test`.`t` `primary`)"
+        "Hints": "use_index_merge(@`sel_1` `t` `c_d_e`, `f`)"
       }
     ]
   },
@@ -2257,11 +2257,11 @@
     "Cases": [
       {
         "SQL": "select max(a) from t;",
-        "Best": "TableReader(Table(t)->Limit)->Limit->StreamAgg"
+        "Best": "IndexReader(Index(t.f)[[NULL,+inf]]->TopN([test.t.a true],0,1))->TopN([test.t.a true],0,1)->StreamAgg"
       },
       {
         "SQL": "select min(a) from t;",
-        "Best": "TableReader(Table(t)->Limit)->Limit->StreamAgg"
+        "Best": "IndexReader(Index(t.f)[[NULL,+inf]]->TopN([test.t.a],0,1))->TopN([test.t.a],0,1)->StreamAgg"
       },
       {
         "SQL": "select min(c_str) from t;",
@@ -2277,7 +2277,7 @@
       },
       {
         "SQL": "select max(a), min(a) from t;",
-        "Best": "LeftHashJoin{TableReader(Table(t)->Limit)->Limit->StreamAgg->TableReader(Table(t)->Limit)->Limit->StreamAgg}"
+        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]]->TopN([test.t.a true],0,1))->TopN([test.t.a true],0,1)->StreamAgg->IndexReader(Index(t.f)[[NULL,+inf]]->TopN([test.t.a],0,1))->TopN([test.t.a],0,1)->StreamAgg}"
       },
       {
         "SQL": "select max(a), min(a) from t where a > 10",
@@ -2289,7 +2289,7 @@
       },
       {
         "SQL": "select max(a), max(c), min(f) from t",
-        "Best": "LeftHashJoin{LeftHashJoin{TableReader(Table(t)->Limit)->Limit->StreamAgg->IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Limit)->Limit->StreamAgg}->IndexReader(Index(t.f)[[NULL,+inf]]->Limit)->Limit->StreamAgg}"
+        "Best": "LeftHashJoin{LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]]->TopN([test.t.a true],0,1))->TopN([test.t.a true],0,1)->StreamAgg->IndexReader(Index(t.c_d_e)[[NULL,+inf]]->Limit)->Limit->StreamAgg}->IndexReader(Index(t.f)[[NULL,+inf]]->Limit)->Limit->StreamAgg}"
       },
       {
         "SQL": "select max(a), max(b) from t",

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -173,7 +173,7 @@ func (p *PhysicalTableScan) GetPlanCostVer2(taskType property.TaskType, option *
 		// hasHighModifyCount tracks the high risk of a tablescan where auto-analyze had not yet updated the table row count
 		hasHighModifyCount := tblColHists.ModifyCount > tblColHists.RealtimeCount
 		// hasLowEstimate is a check to capture a unique customer case where modifyCount is used for tablescan estimate (but it not adequately understood why)
-		hasLowEstimate := rows > 1 && int64(rows) < tblColHists.RealtimeCount && int64(rows) <= tblColHists.ModifyCount
+		hasLowEstimate := rows > 1 && tblColHists.ModifyCount < tblColHists.RealtimeCount && int64(rows) <= tblColHists.ModifyCount
 		var unsignedIntHandle bool
 		if p.Table.PKIsHandle {
 			if pkColInfo := p.Table.GetPkColInfo(); pkColInfo != nil {
@@ -184,7 +184,7 @@ func (p *PhysicalTableScan) GetPlanCostVer2(taskType property.TaskType, option *
 
 		shouldApplyPenalty := hasFullRangeScan && (preferRangeScanCondition || hasHighModifyCount || hasLowEstimate)
 		if shouldApplyPenalty {
-			newRowCount := math.Min(MaxPenaltyRowCount, max(float64(tblColHists.ModifyCount), float64(tblColHists.RealtimeCount)))
+			newRowCount := max(MaxPenaltyRowCount, max(float64(tblColHists.ModifyCount), float64(tblColHists.RealtimeCount)))
 			p.PlanCostVer2 = costusage.SumCostVer2(p.PlanCostVer2, scanCostVer2(option, newRowCount, rowSize, scanFactor))
 		}
 	}

--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -162,27 +162,29 @@ func (p *PhysicalTableScan) GetPlanCostVer2(taskType property.TaskType, option *
 	// Apply TiFlash startup cost to prefer TiKV for small table scans
 	if p.StoreType == kv.TiFlash {
 		p.PlanCostVer2 = costusage.SumCostVer2(p.PlanCostVer2, scanCostVer2(option, TiFlashStartupRowPenalty, rowSize, scanFactor))
-	} else {
+	} else if !p.isChildOfIndexLookUp {
 		// Apply cost penalty for full scans that carry high risk of underestimation
 		sessionVars := p.SCtx().GetSessionVars()
 		allowPreferRangeScan := sessionVars.GetAllowPreferRangeScan()
 		tblColHists := p.tblColHists
 
-		// preferRangeScan check here is same as in skylinePruning
-		preferRangeScanCondition := allowPreferRangeScan && (tblColHists.Pseudo || tblColHists.RealtimeCount < 1)
+		// hasUnreliableStats is a check for pseudo or zero stats
+		hasUnreliableStats := tblColHists.Pseudo || tblColHists.RealtimeCount < 1
 		// hasHighModifyCount tracks the high risk of a tablescan where auto-analyze had not yet updated the table row count
 		hasHighModifyCount := tblColHists.ModifyCount > tblColHists.RealtimeCount
 		// hasLowEstimate is a check to capture a unique customer case where modifyCount is used for tablescan estimate (but it not adequately understood why)
 		hasLowEstimate := rows > 1 && tblColHists.ModifyCount < tblColHists.RealtimeCount && int64(rows) <= tblColHists.ModifyCount
+		// preferRangeScan check here is same as in skylinePruning
+		preferRangeScanCondition := allowPreferRangeScan && (hasUnreliableStats || hasHighModifyCount || hasLowEstimate)
 		var unsignedIntHandle bool
 		if p.Table.PKIsHandle {
 			if pkColInfo := p.Table.GetPkColInfo(); pkColInfo != nil {
 				unsignedIntHandle = mysql.HasUnsignedFlag(pkColInfo.GetFlag())
 			}
 		}
-		hasFullRangeScan := !p.isChildOfIndexLookUp && ranger.HasFullRange(p.Ranges, unsignedIntHandle)
+		hasFullRangeScan := ranger.HasFullRange(p.Ranges, unsignedIntHandle)
 
-		shouldApplyPenalty := hasFullRangeScan && (preferRangeScanCondition || hasHighModifyCount || hasLowEstimate)
+		shouldApplyPenalty := hasFullRangeScan && preferRangeScanCondition
 		if shouldApplyPenalty {
 			newRowCount := max(MaxPenaltyRowCount, max(float64(tblColHists.ModifyCount), float64(tblColHists.RealtimeCount)))
 			p.PlanCostVer2 = costusage.SumCostVer2(p.PlanCostVer2, scanCostVer2(option, newRowCount, rowSize, scanFactor))

--- a/pkg/planner/core/plan_cost_ver2_test.go
+++ b/pkg/planner/core/plan_cost_ver2_test.go
@@ -59,9 +59,9 @@ func TestCostModelVer2ScanRowSize(t *testing.T) {
 		{"select a, b from t use index(abc) where a=1 and b=1", "scan(1*logrowsize(48)*tikv_scan_factor(40.7))"},
 		{"select a, b, c from t use index(abc) where a=1 and b=1 and c=1", "scan(1*logrowsize(48)*tikv_scan_factor(40.7))"},
 		// table scan row-size is always equal to row-size(*)
-		{"select a from t use index(primary) where a=1", "(scan(1*logrowsize(80)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(80)*tikv_scan_factor(40.7)))"},
-		{"select a, d from t use index(primary) where a=1", "(scan(1*logrowsize(80)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(80)*tikv_scan_factor(40.7)))"},
-		{"select * from t use index(primary) where a=1", "(scan(1*logrowsize(80)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(80)*tikv_scan_factor(40.7)))"},
+		{"select a from t use index(primary) where a=1", "(scan(1*logrowsize(80)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(80)*tikv_scan_factor(40.7)))"},
+		{"select a, d from t use index(primary) where a=1", "(scan(1*logrowsize(80)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(80)*tikv_scan_factor(40.7)))"},
+		{"select * from t use index(primary) where a=1", "(scan(1*logrowsize(80)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(80)*tikv_scan_factor(40.7)))"},
 	}
 	for _, c := range cases {
 		rs := tk.MustQuery("explain analyze format=true_card_cost " + c.query).Rows()

--- a/tests/integrationtest/r/executor/chunk_reuse.result
+++ b/tests/integrationtest/r/executor/chunk_reuse.result
@@ -223,14 +223,16 @@ explain format='brief' select id1 from t3 where id2 > '3' or id8 < 10 union (sel
 id	estRows	task	access object	operator info
 HashAgg	8878.22	root		group by:Column#17, funcs:firstrow(Column#17)->Column#17
 └─Union	11097.78	root		
-  ├─TableReader	5548.89	root		data:Projection
-  │ └─Projection	5548.89	cop[tikv]		executor__chunk_reuse.t3.id1->Column#17
-  │   └─Selection	5548.89	cop[tikv]		or(gt(executor__chunk_reuse.t3.id2, "3"), lt(executor__chunk_reuse.t3.id8, 10))
-  │     └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-  └─TableReader	5548.89	root		data:Projection
-    └─Projection	5548.89	cop[tikv]		executor__chunk_reuse.t3.id1->Column#17
-      └─Selection	5548.89	cop[tikv]		or(gt(executor__chunk_reuse.t3.id2, "4"), lt(executor__chunk_reuse.t3.id8, 7))
-        └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  ├─Projection	5548.89	root		executor__chunk_reuse.t3.id1->Column#17
+  │ └─IndexMerge	5548.89	root		type: union
+  │   ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t3, index:id2(id2)	range:("3",+inf], keep order:false, stats:pseudo
+  │   ├─IndexRangeScan(Build)	3323.33	cop[tikv]	table:t3, index:id8(id8)	range:[-inf,10), keep order:false, stats:pseudo
+  │   └─TableRowIDScan(Probe)	5548.89	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  └─Projection	5548.89	root		executor__chunk_reuse.t3.id1->Column#17
+    └─IndexMerge	5548.89	root		type: union
+      ├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t3, index:id2(id2)	range:("4",+inf], keep order:false, stats:pseudo
+      ├─IndexRangeScan(Build)	3323.33	cop[tikv]	table:t3, index:id8(id8)	range:[-inf,7), keep order:false, stats:pseudo
+      └─TableRowIDScan(Probe)	5548.89	cop[tikv]	table:t3	keep order:false, stats:pseudo
 select id1 from t3 where id2 > '3' or id8 < 10 union (select id1 from t3 where id2 > '4' or id8 < 7);
 id1
 1

--- a/tests/integrationtest/r/executor/explain.result
+++ b/tests/integrationtest/r/executor/explain.result
@@ -205,8 +205,8 @@ select @@last_plan_from_cache;
 0
 explain format = 'verbose' select * from t;
 id	estRows	estCost	task	access object	operator info
-TableReader_5	10000.00	191473.33	root		data:TableFullScan_4
-└─TableFullScan_4	10000.00	2238500.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader_5	10000.00	313573.33	root		data:TableFullScan_4
+└─TableFullScan_4	10000.00	4070000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select @@last_plan_from_cache;
 @@last_plan_from_cache
 0
@@ -219,7 +219,7 @@ select @@last_plan_from_cache;
 0
 explain format = 'binary' select * from t;
 binary plan
-4QFYCtwBCg1UYWJsZVJlYWRlcl81EncKD1QBEUxGdWxsU2Nhbl80IQAAAAASFEFBKQEJ8EYAiMNAOAJAAkoYChYKEWV4ZWN1dG9yX19leHBsYWluEgF0Uh5rZWVwIG9yZGVyOmZhbHNlLCBzdGF0czpwc2V1ZG9w/////wUDBAF4BQcBASABIauqqqqKXwcdZigBQAFSFGRhdGE6VDaSAEhaEHRpbWU6MHMsIGxvb3BzOjBwAUQFATQBeP///////////wEYAQ==
+4QFYCtwBCg1UYWJsZVJlYWRlcl81EncKD1QBEVBGdWxsU2Nhbl80IQEAAAA4DU9BKQABAfBGiMNAOAJAAkoYChYKEWV4ZWN1dG9yX19leHBsYWluEgF0Uh5rZWVwIG9yZGVyOmZhbHNlLCBzdGF0czpwc2V1ZG9w//////8BAwQBeAEGBQEgASFVVVVVlSMTHWYoAUABUhRkYXRhOlQ2kgBIWhB0aW1lOjBzLCBsb29wczowcAVFAQE0AXj///////////8BGAE=
 select @@last_plan_from_cache;
 @@last_plan_from_cache
 0
@@ -248,8 +248,8 @@ select @@last_plan_from_cache;
 0
 explain format = 'cost_trace' select * from t;
 id	estRows	estCost	costFormula	task	access object	operator info
-TableReader_5	10000.00	191473.33	(((scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))) + (net(10000*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	root		data:TableFullScan_4
-└─TableFullScan_4	10000.00	2238500.00	(scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader_5	10000.00	313573.33	(((scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))) + (net(10000*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	root		data:TableFullScan_4
+└─TableFullScan_4	10000.00	4070000.00	(scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))	cop[tikv]	table:t	keep order:false, stats:pseudo
 select @@last_plan_from_cache;
 @@last_plan_from_cache
 0

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -1102,9 +1102,9 @@ Note	1105	[t,f,f_g] remain after pruning paths for t given Prop{SortItems: [{pla
 Note	1105	[t] remain after pruning paths for t given Prop{SortItems: [], TaskTp: rootTask}
 explain format = 'verbose' select * from t where f > 1;
 id	estRows	estCost	task	access object	operator info
-TableReader_7	3333.33	335003.52	root		data:Selection_6
-└─Selection_6	3333.33	3546652.80	cop[tikv]		gt(planner__core__casetest__integration.t.f, 1)
-  └─TableFullScan_5	10000.00	3047652.80	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader_7	3333.33	501239.13	root		data:Selection_6
+└─Selection_6	3333.33	6040186.91	cop[tikv]		gt(planner__core__casetest__integration.t.f, 1)
+  └─TableFullScan_5	10000.00	5541186.91	cop[tikv]	table:t	keep order:false, stats:pseudo
 Level	Code	Message
 Note	1105	[t,f,f_g] remain after pruning paths for t given Prop{SortItems: [], TaskTp: rootTask}
 explain format = 'verbose' select f from t where f > 1;

--- a/tests/integrationtest/r/planner/core/cbo.result
+++ b/tests/integrationtest/r/planner/core/cbo.result
@@ -43,12 +43,12 @@ insert into t values (1);
 set tidb_cost_model_version=2;
 explain format='cost_trace' select * from t;
 id	estRows	estCost	costFormula	task	access object	operator info
-TableReader_5	10000.00	191473.33	(((scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))) + (net(10000*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	root		data:TableFullScan_4
-└─TableFullScan_4	10000.00	2238500.00	(scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader_5	10000.00	313573.33	(((scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))) + (net(10000*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	root		data:TableFullScan_4
+└─TableFullScan_4	10000.00	4070000.00	(scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain analyze format='cost_trace' select * from t;
 id	estRows	estCost	costFormula	actRows	task	access object	execution info	operator info	memory	disk
-TableReader_5	10000.00	191473.33	(((scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))) + (net(10000*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	1	root		<execution_info>	<operator_info>	<memory>	<disk>
-└─TableFullScan_4	10000.00	2238500.00	(scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))	1	cop[tikv]	table:t	<execution_info>	<operator_info>	<memory>	<disk>
+TableReader_5	10000.00	313573.33	(((scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))) + (net(10000*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	1	root		<execution_info>	<operator_info>	<memory>	<disk>
+└─TableFullScan_4	10000.00	4070000.00	(scan(10000*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))	1	cop[tikv]	table:t	<execution_info>	<operator_info>	<memory>	<disk>
 set tidb_cost_model_version=1;
 explain format='cost_trace' select * from t;
 id	estRows	estCost	costFormula	task	access object	operator info

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -312,16 +312,16 @@ drop table if exists t;
 create table t(a int);
 explain format='verbose' select /*+ stream_agg() */ count(*) from t;
 id	estRows	estCost	task	access object	operator info
-StreamAgg_14	1.00	182552.01	root		funcs:count(Column#4)->Column#3
-└─TableReader_15	1.00	182502.11	root		data:StreamAgg_8
-  └─StreamAgg_8	1.00	2737500.00	cop[tikv]		funcs:count(1)->Column#4
-    └─TableFullScan_13	10000.00	2238500.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+StreamAgg_14	1.00	304652.01	root		funcs:count(Column#4)->Column#3
+└─TableReader_15	1.00	304602.11	root		data:StreamAgg_8
+  └─StreamAgg_8	1.00	4569000.00	cop[tikv]		funcs:count(1)->Column#4
+    └─TableFullScan_13	10000.00	4070000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain format='verbose' select /*+ hash_agg() */ count(*) from t;
 id	estRows	estCost	task	access object	operator info
-HashAgg_9	1.00	164169.86	root		funcs:count(Column#4)->Column#3
-└─TableReader_10	1.00	162642.60	root		data:HashAgg_5
-  └─HashAgg_5	1.00	2439607.30	cop[tikv]		funcs:count(1)->Column#4
-    └─TableFullScan_8	10000.00	2238500.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+HashAgg_9	1.00	286269.86	root		funcs:count(Column#4)->Column#3
+└─TableReader_10	1.00	284742.60	root		data:HashAgg_5
+  └─HashAgg_5	1.00	4271107.30	cop[tikv]		funcs:count(1)->Column#4
+    └─TableFullScan_8	10000.00	4070000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t, pt, vt;
 create table t(a int, b int);
 insert into t values(1, 1);

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -2303,9 +2303,9 @@ select @@last_plan_from_cache;
 0
 explain format=verbose select * from t where a=2;
 id	estRows	estCost	task	access object	operator info
-TableReader_7	10.00	182542.24	root		data:Selection_6
-└─Selection_6	10.00	2737500.00	cop[tikv]		eq(planner__core__plan_cache.t.a, 2)
-  └─TableFullScan_5	10000.00	2238500.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader_7	10.00	304642.24	root		data:Selection_6
+└─Selection_6	10.00	4569000.00	cop[tikv]		eq(planner__core__plan_cache.t.a, 2)
+  └─TableFullScan_5	10000.00	4070000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select @@last_plan_from_cache;
 @@last_plan_from_cache
 0

--- a/tests/integrationtest/r/planner/core/plan_cost_ver2.result
+++ b/tests/integrationtest/r/planner/core/plan_cost_ver2.result
@@ -254,7 +254,7 @@ explain format='true_card_cost' select * from t;
 Error 1105 (HY000): 'explain format=true_card_cost' cannot work without 'analyze', please use 'explain analyze format=true_card_cost'
 explain analyze format='true_card_cost' select * from t where a<3;
 id	estRows	estCost	costFormula	actRows	task	access object	execution info	operator info	memory	disk
-TableReader_7	3323.33	13580.23	(((cpu(0*filters(1)*tikv_cpu_factor(49.9))) + ((scan(1*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7))))) + (net(0*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	0	root		<execution_info>	<operator_info>	<memory>	<disk>
-└─Selection_6	3323.33	203703.50	(cpu(0*filters(1)*tikv_cpu_factor(49.9))) + ((scan(1*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7))))	0	cop[tikv]		<execution_info>	<operator_info>	<memory>	<disk>
-  └─TableFullScan_5	10000.00	203703.50	(scan(1*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(1000*logrowsize(32)*tikv_scan_factor(40.7)))	0	cop[tikv]	table:t	<execution_info>	<operator_info>	<memory>	<disk>
+TableReader_7	3323.33	135680.23	(((cpu(0*filters(1)*tikv_cpu_factor(49.9))) + ((scan(1*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7))))) + (net(0*rowsize(16)*tidb_kv_net_factor(3.96))))/15.00	0	root		<execution_info>	<operator_info>	<memory>	<disk>
+└─Selection_6	3323.33	2035203.50	(cpu(0*filters(1)*tikv_cpu_factor(49.9))) + ((scan(1*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7))))	0	cop[tikv]		<execution_info>	<operator_info>	<memory>	<disk>
+  └─TableFullScan_5	10000.00	2035203.50	(scan(1*logrowsize(32)*tikv_scan_factor(40.7))) + (scan(10000*logrowsize(32)*tikv_scan_factor(40.7)))	0	cop[tikv]	table:t	<execution_info>	<operator_info>	<memory>	<disk>
 set @@tidb_cost_model_version=DEFAULT;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57085 

Problem Summary:

### What changed and how does it work?

Code to provide a minimum cost to table scan - should use "max" rather than "min" to ensure that the minimum is actually applied. Current code will produce a lower cost for tablescans greater than 1000 rows that fit the other criteria for requiring a minimum cost to table scans.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
