### PR TITLE
test: fix the flaky test `TestDeleteIgnoreWithFK`

### DIFF
--- a/pkg/executor/delete_test.go
+++ b/pkg/executor/delete_test.go
@@ -139,9 +139,9 @@ func TestDeleteIgnoreWithFK(t *testing.T) {
 	tk.MustExec("insert into child2 values (1)")
 	require.NotNil(t, tk.ExecToErr("delete from parent, parent2 using parent inner join parent2 where parent.a = parent2.a"))
 	tk.MustExec("delete ignore from parent, parent2 using parent inner join parent2 where parent.a = parent2.a")
-	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1451 Cannot delete or update a parent row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))",
-		"Warning 1451 Cannot delete or update a parent row: a foreign key constraint fails (`test`.`child2`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent2` (`a`))"))
+	tk.MustQuery("show warnings").Sort().Check(testkit.Rows(
+		"Warning 1451 Cannot delete or update a parent row: a foreign key constraint fails (`test`.`child2`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent2` (`a`))",
+		"Warning 1451 Cannot delete or update a parent row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a`) REFERENCES `parent` (`a`))"))
 	tk.MustQuery("select * from parent").Check(testkit.Rows("1"))
 	tk.MustQuery("select * from parent2").Check(testkit.Rows("1"))
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57094

Problem Summary:

The test `TestDeleteIgnoreWithFK` is flaky because of the order of warnings.

### What changed and how does it work?

Sort the warnings before the assertion.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
