### PR TITLE
executor,planner: Fix tiflash plan with limit operator may lose execution summary problem

### DIFF
--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
-	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,11 +27,28 @@ func TestNeedReportExecutionSummary(t *testing.T) {
 	passSender := &plannercore.PhysicalExchangeSender{
 		ExchangeType: tipb.ExchangeType_PassThrough,
 	}
-
+	passSender.SetID(10)
+	tableReader := &plannercore.PhysicalTableReader{}
+	tableReader.SetTablePlanForTest(passSender)
+	limitTIDB := &plannercore.PhysicalLimit{}
+	limitTIDB.SetChildren(tableReader)
 	passSender.SetChildren(limit)
 	limit.SetChildren(tableScan)
-	require.True(t, needReportExecutionSummary(passSender))
 
-	passSender.SetChildren(tableScan)
-	require.False(t, needReportExecutionSummary(passSender))
+	require.True(t, needReportExecutionSummary(limitTIDB, 10, false))
+	require.False(t, needReportExecutionSummary(limitTIDB, 11, false))
+
+	projection := &plannercore.PhysicalProjection{}
+	projection.SetChildren(tableReader)
+	require.False(t, needReportExecutionSummary(projection, 10, false))
+
+	join := &plannercore.PhysicalHashJoin{}
+	tableScan2 := &plannercore.PhysicalTableScan{}
+	tableScan2.SetID(20)
+	tableReader2 := &plannercore.PhysicalTableReader{}
+	tableReader2.SetTablePlanForTest(tableScan2)
+	join.SetChildren(tableReader2, projection)
+	limitTIDB2 := &plannercore.PhysicalLimit{}
+	limitTIDB2.SetChildren(join)
+	require.True(t, needReportExecutionSummary(limitTIDB2, 10, false))
 }

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -208,6 +208,11 @@ func (pi *PhysPlanPartInfo) MemoryUsage() (sum int64) {
 	return
 }
 
+// SetTablePlanForTest sets tablePlan field for test usage only
+func (p *PhysicalTableReader) SetTablePlanForTest(pp base.PhysicalPlan) {
+	p.tablePlan = pp
+}
+
 // GetTablePlan exports the tablePlan.
 func (p *PhysicalTableReader) GetTablePlan() base.PhysicalPlan {
 	return p.tablePlan


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50455 

Problem Summary:
Currently, if limit operator is not pushed down to tiflash side, then execution summary in tiflash side will be lost. This is because we only check if limit operator exists under TableReader. Refine the logic so that it checks if limit operator exists in the path from TableReader to Root.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Manually verified explain analyze insert/update/delete statements' execution summary.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
