### PR TITLE
tablecodec: fix global index + commonHandle + restoredValues panic

### DIFF
--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -832,13 +832,13 @@ func reEncodeHandleConsiderNewCollation(handle kv.Handle, columns []rowcodec.Col
 	if len(restoreData) == 0 {
 		return cHandleBytes, nil
 	}
-	// Remove global index extra column,
-	// because the type of `model.ExtraPhysTblID` always is int
-	// which means docode restore is not needed.
-	if len(columns) > 0 && columns[len(columns)-1].ID == model.ExtraPhysTblID {
-		columns = columns[:len(columns)-1]
+	// Remove some extra columns(ID < 0), such like `model.ExtraPhysTblID`.
+	// They are not belong to common handle and no need to restore data.
+	idx := len(columns)
+	for idx > 0 && columns[idx-1].ID < 0 {
+		idx--
 	}
-	return decodeRestoredValuesV5(columns, cHandleBytes, restoreData)
+	return decodeRestoredValuesV5(columns[:idx], cHandleBytes, restoreData)
 }
 
 func decodeRestoredValues(columns []rowcodec.ColInfo, restoredVal []byte) ([][]byte, error) {

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -832,6 +832,12 @@ func reEncodeHandleConsiderNewCollation(handle kv.Handle, columns []rowcodec.Col
 	if len(restoreData) == 0 {
 		return cHandleBytes, nil
 	}
+	// Remove global index extra column,
+	// because the type of `model.ExtraPhysTblID` always is int
+	// which means docode restore is not needed.
+	if len(columns) > 0 && columns[len(columns)-1].ID == model.ExtraPhysTblID {
+		columns = columns[:len(columns)-1]
+	}
 	return decodeRestoredValuesV5(columns, cHandleBytes, restoreData)
 }
 

--- a/tests/integrationtest/r/globalindex/misc.result
+++ b/tests/integrationtest/r/globalindex/misc.result
@@ -238,3 +238,12 @@ t	CREATE TABLE `t` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
 PARTITION BY KEY (`b`) PARTITIONS 3
 drop table t;
+drop table if exists t;
+create table t (a int, b varchar(255), c varchar (255), primary key (a,b), unique key (c) global) partition by list columns (a,b) (partition p0 values in ((1,"1"),(2,"2"),(3,"3")), partition p1 values in ((100,"100"),(101,"101"),(102,"102"),DEFAULT));
+insert into t values (1,1,1),(2,2,2),(101,101,101),(102,102,102);
+select * from t;
+a	b	c
+1	1	1
+101	101	101
+102	102	102
+2	2	2

--- a/tests/integrationtest/t/globalindex/misc.test
+++ b/tests/integrationtest/t/globalindex/misc.test
@@ -152,3 +152,11 @@ show create table t;
 alter table t partition by key (b) partitions 3;
 show create table t;
 drop table t;
+
+# TestRestoreValuedWithGlobalIndex
+drop table if exists t;
+create table t (a int, b varchar(255), c varchar (255), primary key (a,b), unique key (c) global) partition by list columns (a,b) (partition p0 values in ((1,"1"),(2,"2"),(3,"3")), partition p1 values in ((100,"100"),(101,"101"),(102,"102"),DEFAULT));
+insert into t values (1,1,1),(2,2,2),(101,101,101),(102,102,102);
+--sorted_result
+select * from t;
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57087

Problem Summary: In `reEncodeHandleConsiderNewCollation`, we assume all columns in `columns[colLen:]` related with Common Handle. But it contains `model.ExtraPhysTblID` when use global index.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
