### PR TITLE
exeuctor: add a helper variable to help ga hash join v2 step by step for all kinds of join types

### DIFF
--- a/pkg/executor/join/joinversion/join_version.go
+++ b/pkg/executor/join/joinversion/join_version.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	// This variable is set to true for test, need to be set back to false in a release version
+	// This variable is set to true for test, need to be set back to false in release version
 	UseHashJoinV2ForNonGAJoin = true
 }
 

--- a/pkg/executor/join/joinversion/join_version.go
+++ b/pkg/executor/join/joinversion/join_version.go
@@ -25,6 +25,20 @@ const (
 	HashJoinVersionOptimized = "optimized"
 )
 
+var (
+	// This variable is added because Hash join contains a lots of types(like inner join, outer join, semi join, nullaware semi join, etc)
+	// we want to GA these different kind of joins step by step, but don't want to add a new session variable for each of the join, 
+	// so we add this variable to control whether to use hash join v2 for nonGA joins(enable it for test, disable it in a release version).
+	// PhysicalHashJoin.isGAForHashJoinV2() defines whether the join is GA for hash join v2, we can make each join GA seperately by updating 
+	// this function one by one
+	UseHashJoinV2ForNonGAJoin = false
+)
+
+func init() {
+	// This variable is set to true for test, need to be set back to false in a release version
+	UseHashJoinV2ForNonGAJoin = true
+}
+
 // IsOptimizedVersion returns true if hashJoinVersion equals to HashJoinVersionOptimized
 func IsOptimizedVersion(hashJoinVersion string) bool {
 	return strings.ToLower(hashJoinVersion) == HashJoinVersionOptimized

--- a/pkg/executor/join/joinversion/join_version.go
+++ b/pkg/executor/join/joinversion/join_version.go
@@ -26,10 +26,10 @@ const (
 )
 
 var (
-	// This variable is added because Hash join contains a lots of types(like inner join, outer join, semi join, nullaware semi join, etc)
+	// UseHashJoinV2ForNonGAJoin is added because Hash join contains a lots of types(like inner join, outer join, semi join, nullaware semi join, etc)
 	// we want to GA these different kind of joins step by step, but don't want to add a new session variable for each of the join,
 	// so we add this variable to control whether to use hash join v2 for nonGA joins(enable it for test, disable it in a release version).
-	// PhysicalHashJoin.isGAForHashJoinV2() defines whether the join is GA for hash join v2, we can make each join GA seperately by updating
+	// PhysicalHashJoin.isGAForHashJoinV2() defines whether the join is GA for hash join v2, we can make each join GA separately by updating
 	// this function one by one
 	UseHashJoinV2ForNonGAJoin = false
 )

--- a/pkg/executor/join/joinversion/join_version.go
+++ b/pkg/executor/join/joinversion/join_version.go
@@ -27,9 +27,9 @@ const (
 
 var (
 	// This variable is added because Hash join contains a lots of types(like inner join, outer join, semi join, nullaware semi join, etc)
-	// we want to GA these different kind of joins step by step, but don't want to add a new session variable for each of the join, 
+	// we want to GA these different kind of joins step by step, but don't want to add a new session variable for each of the join,
 	// so we add this variable to control whether to use hash join v2 for nonGA joins(enable it for test, disable it in a release version).
-	// PhysicalHashJoin.isGAForHashJoinV2() defines whether the join is GA for hash join v2, we can make each join GA seperately by updating 
+	// PhysicalHashJoin.isGAForHashJoinV2() defines whether the join is GA for hash join v2, we can make each join GA seperately by updating
 	// this function one by one
 	UseHashJoinV2ForNonGAJoin = false
 )

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -96,6 +96,7 @@ go_library(
         "//pkg/distsql",
         "//pkg/domain",
         "//pkg/errctx",
+        "//pkg/executor/join/joinversion",
         "//pkg/expression",
         "//pkg/expression/aggregation",
         "//pkg/expression/exprctx",

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1472,6 +1472,7 @@ type PhysicalHashJoin struct {
 	// for runtime filter
 	runtimeFilterList []*RuntimeFilter `plan-cache-clone:"must-nil"` // plan with runtime filter is not cached
 }
+
 func (p *PhysicalHashJoin) isGAForHashJoinV2() bool {
 	// nullaware join
 	if len(p.LeftNAJoinKeys) > 0 {
@@ -1488,10 +1489,10 @@ func (p *PhysicalHashJoin) isGAForHashJoinV2() bool {
 		}
 	}
 	switch p.JoinType {
-		case logicalop.LeftOuterJoin, logicalop.RightOuterJoin, logicalop.InnerJoin:
-			return true
-		default:
-			return false
+	case logicalop.LeftOuterJoin, logicalop.RightOuterJoin, logicalop.InnerJoin:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -1471,9 +1472,34 @@ type PhysicalHashJoin struct {
 	// for runtime filter
 	runtimeFilterList []*RuntimeFilter `plan-cache-clone:"must-nil"` // plan with runtime filter is not cached
 }
+func (p *PhysicalHashJoin) isGAForHashJoinV2() bool {
+	// nullaware join
+	if len(p.LeftNAJoinKeys) > 0 {
+		return false
+	}
+	// cross join
+	if len(p.LeftJoinKeys) == 0 {
+		return false
+	}
+	// join with null equal condition
+	for _, value := range p.IsNullEQ {
+		if value {
+			return false
+		}
+	}
+	switch p.JoinType {
+		case logicalop.LeftOuterJoin, logicalop.RightOuterJoin, logicalop.InnerJoin:
+			return true
+		default:
+			return false
+	}
+}
 
 // CanUseHashJoinV2 returns true if current join is supported by hash join v2
 func (p *PhysicalHashJoin) CanUseHashJoinV2() bool {
+	if !p.isGAForHashJoinV2() && !joinversion.UseHashJoinV2ForNonGAJoin {
+		return false
+	}
 	switch p.JoinType {
 	case logicalop.LeftOuterJoin, logicalop.RightOuterJoin, logicalop.InnerJoin:
 		// null aware join is not supported yet


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127
Add an internal variable so we can control which kind of join can use hash join v2 when `tidb_hash_join_version` is set to `optimized`, in this way we can GA hash join v2 step by step for all kinds of join types
Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
