### PR TITLE
statsitstics: avoid sync load column which is skiped type to analyze

### DIFF
--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/parser/mysql",
         "//pkg/sessionctx",
         "//pkg/sessionctx/stmtctx",
+        "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/handle/storage",
         "//pkg/statistics/handle/types",

--- a/pkg/statistics/handle/syncload/BUILD.bazel
+++ b/pkg/statistics/handle/syncload/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     srcs = ["stats_syncload_test.go"],
     flaky = True,
     race = "on",
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         ":syncload",
         "//pkg/config",

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	statstypes "github.com/pingcap/tidb/pkg/statistics/handle/types"
@@ -300,8 +301,11 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 			s.statsHandle.SPool().Put(se)
 		}
 	}()
-
-	skipTypes := sctx.GetSessionVars().AnalyzeSkipColumnTypes
+	val, err := sctx.GetSessionVars().GlobalVarsAccessor.GetGlobalSysVar(variable.TiDBAnalyzeSkipColumnTypes)
+	if err != nil {
+		logutil.BgLogger().Warn("failed to get global variable", zap.Error(err))
+	}
+	skipTypes := variable.ParseAnalyzeSkipColumnTypes(val)
 	item := task.Item.TableItemID
 	tbl, ok := s.statsHandle.Get(item.TableID)
 

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -337,7 +337,7 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 			// so we have to get the column info from the domain.
 			wrapper.colInfo = tblInfo.Meta().GetColumnByID(item.ID)
 		}
-		_, skip := skipTypes[types.TypeToStr(col.Info.FieldType.GetType(), col.Info.FieldType.GetCharset())]
+		_, skip := skipTypes[types.TypeToStr(wrapper.colInfo.FieldType.GetType(), wrapper.colInfo.FieldType.GetCharset())]
 		if skip {
 			return nil
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57138

Problem Summary:

### What changed and how does it work?

Sometimes, we disable the analysis of certain columns using analyze_skip_column. However, these columns may still retain outdated statistics, especially after being modified. Since their statistics are larger, syncing them via sync load can be very slow and prone to timeouts. To address this, we filter out these columns.

<img width="692" alt="image" src="https://github.com/user-attachments/assets/69332f9b-df6e-4918-b8f2-aba9bfa34703">

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
statsitstics: avoid sync load column which is skiped to analyze

避免将 skip analyze 的列通过 sync load 加载
```
