### PR TITLE
ddl: introduce a new system variable to control the `store-write-bwlimit` when ingesting

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -1300,7 +1300,7 @@ func get2JobsFromTable(sess *sess.Session) (*model.Job, *model.Job, error) {
 }
 
 // cancelRunningJob cancel a DDL job that is in the concurrent state.
-func cancelRunningJob(_ *sess.Session, job *model.Job,
+func cancelRunningJob(job *model.Job,
 	byWho model.AdminCommandOperator) (err error) {
 	// These states can't be cancelled.
 	if job.IsDone() || job.IsSynced() {
@@ -1321,7 +1321,7 @@ func cancelRunningJob(_ *sess.Session, job *model.Job,
 }
 
 // pauseRunningJob check and pause the running Job
-func pauseRunningJob(_ *sess.Session, job *model.Job,
+func pauseRunningJob(job *model.Job,
 	byWho model.AdminCommandOperator) (err error) {
 	if job.IsPausing() || job.IsPaused() {
 		return dbterror.ErrPausedDDLJob.GenWithStackByArgs(job.ID)
@@ -1340,7 +1340,7 @@ func pauseRunningJob(_ *sess.Session, job *model.Job,
 }
 
 // resumePausedJob check and resume the Paused Job
-func resumePausedJob(_ *sess.Session, job *model.Job,
+func resumePausedJob(job *model.Job,
 	byWho model.AdminCommandOperator) (err error) {
 	if !job.IsResumable() {
 		errMsg := fmt.Sprintf("job has not been paused, job state:%s, schema state:%s",
@@ -1362,7 +1362,7 @@ func resumePausedJob(_ *sess.Session, job *model.Job,
 // processJobs command on the Job according to the process
 func processJobs(
 	ctx context.Context,
-	process func(*sess.Session, *model.Job, model.AdminCommandOperator) (err error),
+	process func(*model.Job, model.AdminCommandOperator) (err error),
 	sessCtx sessionctx.Context,
 	ids []int64,
 	byWho model.AdminCommandOperator,
@@ -1409,7 +1409,7 @@ func processJobs(
 			}
 			delete(jobMap, job.ID)
 
-			err = process(ns, job, byWho)
+			err = process(job, byWho)
 			if err != nil {
 				jobErrs[i] = err
 				continue
@@ -1481,7 +1481,7 @@ func ResumeJobsBySystem(se sessionctx.Context, ids []int64) (errs []error, err e
 // pprocessAllJobs processes all the jobs in the job table, 100 jobs at a time in case of high memory usage.
 func processAllJobs(
 	ctx context.Context,
-	process func(*sess.Session, *model.Job, model.AdminCommandOperator) (err error),
+	process func(*model.Job, model.AdminCommandOperator) (err error),
 	se sessionctx.Context,
 	byWho model.AdminCommandOperator,
 ) (map[int64]error, error) {
@@ -1509,7 +1509,7 @@ func processAllJobs(
 		}
 
 		for _, job := range jobs {
-			err = process(ns, job, byWho)
+			err = process(job, byWho)
 			if err != nil {
 				jobErrs[job.ID] = err
 				continue

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -68,6 +68,7 @@ func genConfig(
 		PausePDSchedulerScope:       lightning.PausePDSchedulerScopeTable,
 		TaskType:                    kvutil.ExplicitTypeDDL,
 		DisableAutomaticCompactions: true,
+		StoreWriteBWLimit:           int(variable.DDLReorgWriteLimit.Load()),
 	}
 	// Each backend will build a single dir in lightning dir.
 	if ImporterRangeConcurrencyForTest != nil {

--- a/pkg/ddl/ingest/config.go
+++ b/pkg/ddl/ingest/config.go
@@ -68,7 +68,7 @@ func genConfig(
 		PausePDSchedulerScope:       lightning.PausePDSchedulerScopeTable,
 		TaskType:                    kvutil.ExplicitTypeDDL,
 		DisableAutomaticCompactions: true,
-		StoreWriteBWLimit:           int(variable.DDLReorgWriteLimit.Load()),
+		StoreWriteBWLimit:           int(variable.DDLReorgMaxWriteSpeed.Load()),
 	}
 	// Each backend will build a single dir in lightning dir.
 	if ImporterRangeConcurrencyForTest != nil {

--- a/pkg/ddl/job_submitter.go
+++ b/pkg/ddl/job_submitter.go
@@ -337,7 +337,7 @@ func (s *JobSubmitter) addBatchDDLJobs2Table(jobWs []*JobWrapper) error {
 		setJobStateToQueueing(job)
 
 		if s.serverStateSyncer.IsUpgradingState() && !hasSysDB(job) {
-			if err = pauseRunningJob(sess.NewSession(se), job, model.AdminCommandBySystem); err != nil {
+			if err = pauseRunningJob(job, model.AdminCommandBySystem); err != nil {
 				logutil.DDLUpgradingLogger().Warn("pause user DDL by system failed", zap.Stringer("job", job), zap.Error(err))
 				jobW.cacheErr = err
 				continue

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         "//pkg/config",
         "//pkg/ddl/schematracker",

--- a/pkg/executor/test/ddl/BUILD.bazel
+++ b/pkg/executor/test/ddl/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//pkg/util/chunk",
         "//pkg/util/dbterror",
         "//pkg/util/dbterror/plannererrors",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl/schematracker"
 	ddltestutil "github.com/pingcap/tidb/pkg/ddl/testutil"
@@ -894,21 +895,23 @@ func TestSetDDLReorgMaxWriteSpeed(t *testing.T) {
 	require.Equal(t, int64(variable.DefTiDBDDLReorgMaxWriteSpeed), variable.DDLReorgMaxWriteSpeed.Load())
 
 	// valid values
-	for _, val := range []int64{1, 0, 100, 1024 * 1024, math.MaxInt64} {
+	for _, val := range []int64{1, 0, 100, 1024 * 1024, 2147483647, units.PiB} {
 		tk.MustExec(fmt.Sprintf("set @@global.tidb_ddl_reorg_max_write_speed = %d", val))
 		require.Equal(t, val, variable.DDLReorgMaxWriteSpeed.Load())
 		tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows(strconv.FormatInt(val, 10)))
 	}
+	for _, val := range []string{"1", "0", "100", "2KB", "3MiB", "4 gb", "2147483647", "1125899906842624" /* 1PiB */} {
+		tk.MustExec(fmt.Sprintf("set @@global.tidb_ddl_reorg_max_write_speed = '%s'", val))
+		expected, err := units.RAMInBytes(val)
+		require.NoError(t, err)
+		require.Equal(t, expected, variable.DDLReorgMaxWriteSpeed.Load())
+		tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows(strconv.FormatInt(expected, 10)))
+	}
 
 	// invalid values
-	tk.MustExec("set @@global.tidb_ddl_reorg_max_write_speed = -1")
-	tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_ddl_reorg_max_write_speed value: '-1'"))
-	require.Equal(t, int64(0), variable.DDLReorgMaxWriteSpeed.Load())
-	tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows("0"))
-
-	tk.MustGetDBError("set @@global.tidb_ddl_reorg_max_write_speed = invalid_val", variable.ErrWrongTypeForVar)
-	require.Equal(t, int64(0), variable.DDLReorgMaxWriteSpeed.Load())
-	tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows("0"))
+	tk.MustExecToErr("set @@global.tidb_ddl_reorg_max_write_speed = -1")
+	tk.MustExecToErr("set @@global.tidb_ddl_reorg_max_write_speed = invalid_val")
+	tk.MustExecToErr("set @@global.tidb_ddl_reorg_max_write_speed = %d", units.PiB+1)
 }
 
 func TestLoadDDLDistributeVars(t *testing.T) {

--- a/pkg/executor/test/ddl/ddl_test.go
+++ b/pkg/executor/test/ddl/ddl_test.go
@@ -888,27 +888,27 @@ func TestSetDDLErrorCountLimit(t *testing.T) {
 	res.Check(testkit.Rows("100"))
 }
 
-func TestSetDDLReorgWriteLimit(t *testing.T) {
+func TestSetDDLReorgMaxWriteSpeed(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	require.Equal(t, int64(variable.DefTiDBDDLReorgWriteLimit), variable.DDLReorgWriteLimit.Load())
+	require.Equal(t, int64(variable.DefTiDBDDLReorgMaxWriteSpeed), variable.DDLReorgMaxWriteSpeed.Load())
 
 	// valid values
 	for _, val := range []int64{1, 0, 100, 1024 * 1024, math.MaxInt64} {
-		tk.MustExec(fmt.Sprintf("set @@global.tidb_ddl_reorg_write_limit = %d", val))
-		require.Equal(t, val, variable.DDLReorgWriteLimit.Load())
-		tk.MustQuery("select @@global.tidb_ddl_reorg_write_limit").Check(testkit.Rows(strconv.FormatInt(val, 10)))
+		tk.MustExec(fmt.Sprintf("set @@global.tidb_ddl_reorg_max_write_speed = %d", val))
+		require.Equal(t, val, variable.DDLReorgMaxWriteSpeed.Load())
+		tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows(strconv.FormatInt(val, 10)))
 	}
 
 	// invalid values
-	tk.MustExec("set @@global.tidb_ddl_reorg_write_limit = -1")
-	tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_ddl_reorg_write_limit value: '-1'"))
-	require.Equal(t, int64(0), variable.DDLReorgWriteLimit.Load())
-	tk.MustQuery("select @@global.tidb_ddl_reorg_write_limit").Check(testkit.Rows("0"))
+	tk.MustExec("set @@global.tidb_ddl_reorg_max_write_speed = -1")
+	tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Truncated incorrect tidb_ddl_reorg_max_write_speed value: '-1'"))
+	require.Equal(t, int64(0), variable.DDLReorgMaxWriteSpeed.Load())
+	tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows("0"))
 
-	tk.MustGetDBError("set @@global.tidb_ddl_reorg_write_limit = invalid_val", variable.ErrWrongTypeForVar)
-	require.Equal(t, int64(0), variable.DDLReorgWriteLimit.Load())
-	tk.MustQuery("select @@global.tidb_ddl_reorg_write_limit").Check(testkit.Rows("0"))
+	tk.MustGetDBError("set @@global.tidb_ddl_reorg_max_write_speed = invalid_val", variable.ErrWrongTypeForVar)
+	require.Equal(t, int64(0), variable.DDLReorgMaxWriteSpeed.Load())
+	tk.MustQuery("select @@global.tidb_ddl_reorg_max_write_speed").Check(testkit.Rows("0"))
 }
 
 func TestLoadDDLDistributeVars(t *testing.T) {

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -782,11 +782,11 @@ var defaultSysVars = []*SysVar{
 		SetDDLReorgBatchSize(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgBatchSize)))
 		return nil
 	}},
-	{Scope: ScopeGlobal, Name: TiDBDDLReorgWriteLimit, Value: strconv.Itoa(DefTiDBDDLReorgWriteLimit), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
-		DDLReorgWriteLimit.Store(TidbOptInt64(val, DefTiDBDDLReorgWriteLimit))
+	{Scope: ScopeGlobal, Name: TiDBDDLReorgMaxWriteSpeed, Value: strconv.Itoa(DefTiDBDDLReorgMaxWriteSpeed), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+		DDLReorgMaxWriteSpeed.Store(TidbOptInt64(val, DefTiDBDDLReorgMaxWriteSpeed))
 		return nil
 	}, GetGlobal: func(_ context.Context, sv *SessionVars) (string, error) {
-		return strconv.FormatInt(DDLReorgWriteLimit.Load(), 10), nil
+		return strconv.FormatInt(DDLReorgMaxWriteSpeed.Load(), 10), nil
 	}},
 	{Scope: ScopeGlobal, Name: TiDBDDLErrorCountLimit, Value: strconv.Itoa(DefTiDBDDLErrorCountLimit), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLErrorCountLimit(TidbOptInt64(val, DefTiDBDDLErrorCountLimit))

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
@@ -782,12 +783,23 @@ var defaultSysVars = []*SysVar{
 		SetDDLReorgBatchSize(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgBatchSize)))
 		return nil
 	}},
-	{Scope: ScopeGlobal, Name: TiDBDDLReorgMaxWriteSpeed, Value: strconv.Itoa(DefTiDBDDLReorgMaxWriteSpeed), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
-		DDLReorgMaxWriteSpeed.Store(TidbOptInt64(val, DefTiDBDDLReorgMaxWriteSpeed))
-		return nil
-	}, GetGlobal: func(_ context.Context, sv *SessionVars) (string, error) {
-		return strconv.FormatInt(DDLReorgMaxWriteSpeed.Load(), 10), nil
-	}},
+	{Scope: ScopeGlobal, Name: TiDBDDLReorgMaxWriteSpeed, Value: strconv.Itoa(DefTiDBDDLReorgMaxWriteSpeed), Type: TypeStr,
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			i64, err := units.RAMInBytes(val)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if i64 < 0 || i64 > units.PiB {
+				// Here we limit the max value to 1 PiB instead of math.MaxInt64, since:
+				// 1. it is large enough
+				// 2. units.RAMInBytes would first cast the size to a float, and may lose precision when the size is too large
+				return fmt.Errorf("invalid value for '%d', it should be within [%d, %d]", i64, 0, units.PiB)
+			}
+			DDLReorgMaxWriteSpeed.Store(i64)
+			return nil
+		}, GetGlobal: func(_ context.Context, sv *SessionVars) (string, error) {
+			return strconv.FormatInt(DDLReorgMaxWriteSpeed.Load(), 10), nil
+		}},
 	{Scope: ScopeGlobal, Name: TiDBDDLErrorCountLimit, Value: strconv.Itoa(DefTiDBDDLErrorCountLimit), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLErrorCountLimit(TidbOptInt64(val, DefTiDBDDLErrorCountLimit))
 		return nil

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -782,6 +782,12 @@ var defaultSysVars = []*SysVar{
 		SetDDLReorgBatchSize(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgBatchSize)))
 		return nil
 	}},
+	{Scope: ScopeGlobal, Name: TiDBDDLReorgWriteLimit, Value: strconv.Itoa(DefTiDBDDLReorgWriteLimit), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+		DDLReorgWriteLimit.Store(TidbOptInt64(val, DefTiDBDDLReorgWriteLimit))
+		return nil
+	}, GetGlobal: func(_ context.Context, sv *SessionVars) (string, error) {
+		return strconv.FormatInt(DDLReorgWriteLimit.Load(), 10), nil
+	}},
 	{Scope: ScopeGlobal, Name: TiDBDDLErrorCountLimit, Value: strconv.Itoa(DefTiDBDDLErrorCountLimit), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		SetDDLErrorCountLimit(TidbOptInt64(val, DefTiDBDDLErrorCountLimit))
 		return nil

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -525,6 +525,9 @@ const (
 	// It can be: PRIORITY_LOW, PRIORITY_NORMAL, PRIORITY_HIGH
 	TiDBDDLReorgPriority = "tidb_ddl_reorg_priority"
 
+	// TiDBDDLReorgWriteLimit defines the max write limitation for the lightning local backend
+	TiDBDDLReorgWriteLimit = "tidb_ddl_reorg_write_limit"
+
 	// TiDBEnableAutoIncrementInGenerated disables the mysql compatibility check on using auto-incremented columns in
 	// expression indexes and generated columns described here https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html for details.
 	TiDBEnableAutoIncrementInGenerated = "tidb_enable_auto_increment_in_generated"
@@ -1324,6 +1327,7 @@ const (
 	DefTiDBDDLReorgBatchSize                = 256
 	DefTiDBDDLFlashbackConcurrency          = 64
 	DefTiDBDDLErrorCountLimit               = 512
+	DefTiDBDDLReorgWriteLimit               = 0
 	DefTiDBMaxDeltaSchemaCount              = 1024
 	DefTiDBPlacementMode                    = PlacementModeStrict
 	DefTiDBEnableAutoIncrementInGenerated   = false
@@ -1590,6 +1594,7 @@ var (
 	ddlFlashbackConcurrency int32 = DefTiDBDDLFlashbackConcurrency
 	ddlErrorCountLimit      int64 = DefTiDBDDLErrorCountLimit
 	ddlReorgRowFormat       int64 = DefTiDBRowFormatV2
+	DDLReorgWriteLimit            = atomic.NewInt64(DefTiDBDDLReorgWriteLimit)
 	maxDeltaSchemaCount     int64 = DefTiDBMaxDeltaSchemaCount
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
 	DDLSlowOprThreshold                  = config.GetGlobalConfig().Instance.DDLSlowOprThreshold

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -525,8 +525,8 @@ const (
 	// It can be: PRIORITY_LOW, PRIORITY_NORMAL, PRIORITY_HIGH
 	TiDBDDLReorgPriority = "tidb_ddl_reorg_priority"
 
-	// TiDBDDLReorgWriteLimit defines the max write limitation for the lightning local backend
-	TiDBDDLReorgWriteLimit = "tidb_ddl_reorg_write_limit"
+	// TiDBDDLReorgMaxWriteSpeed defines the max write limitation for the lightning local backend
+	TiDBDDLReorgMaxWriteSpeed = "tidb_ddl_reorg_max_write_speed"
 
 	// TiDBEnableAutoIncrementInGenerated disables the mysql compatibility check on using auto-incremented columns in
 	// expression indexes and generated columns described here https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html for details.
@@ -1327,7 +1327,7 @@ const (
 	DefTiDBDDLReorgBatchSize                = 256
 	DefTiDBDDLFlashbackConcurrency          = 64
 	DefTiDBDDLErrorCountLimit               = 512
-	DefTiDBDDLReorgWriteLimit               = 0
+	DefTiDBDDLReorgMaxWriteSpeed            = 0
 	DefTiDBMaxDeltaSchemaCount              = 1024
 	DefTiDBPlacementMode                    = PlacementModeStrict
 	DefTiDBEnableAutoIncrementInGenerated   = false
@@ -1594,7 +1594,7 @@ var (
 	ddlFlashbackConcurrency int32 = DefTiDBDDLFlashbackConcurrency
 	ddlErrorCountLimit      int64 = DefTiDBDDLErrorCountLimit
 	ddlReorgRowFormat       int64 = DefTiDBRowFormatV2
-	DDLReorgWriteLimit            = atomic.NewInt64(DefTiDBDDLReorgWriteLimit)
+	DDLReorgMaxWriteSpeed         = atomic.NewInt64(DefTiDBDDLReorgMaxWriteSpeed)
 	maxDeltaSchemaCount     int64 = DefTiDBMaxDeltaSchemaCount
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
 	DDLSlowOprThreshold                  = config.GetGlobalConfig().Instance.DDLSlowOprThreshold


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57156

Problem Summary:

See the issue description

### What changed and how does it work?

Introduce a new system variable to control the `store-write-bwlimit` when ingesting

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual test:
1. bootstrap a cluster
2. Turn on `tidb_ddl_enable_fast_reorg`, and with `tidb_enable_dist_task` on or off, do the following test:
	1. set the `tidb_ddl_reorg_max_write_speed` to `1mb`
	2. add index for a table, the speed is slow
	3. after setting the `tidb_ddl_reorg_max_write_speed` to `0`(no limitation), the speed of adding index increases

For a table containing 200,000 rows:
```sql
TiDB root@127.0.0.1:test> select count(*) from t1;
+----------+
| count(*) |
+----------+
| 200000   |
+----------+
1 row in set
Time: 0.272s
TiDB root@127.0.0.1:test> select * from t1 limit 3;
+----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id | data                                                                                                                                                                                                                                                            |
+----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 0  | fIhixzEuzMNSXLflhCwAktUGYYhXHfgqVHhmognLsnbaEQhXXvzJOehnEXunFcaeVoZSgLNXEFWTAWjfcPYCQRYNKRlHFGJCstAarZvqyeqwmJoHquIfGHFAUIUovzCeyisLSCrIeypScZdsubrPCcbiyBggiehBqnplnbRoVgNogIVdymQwXdUoyhXNzUzLdBhuqdYcznbnCbkZoFdPQiDYBhECaxNtGwbIjHqGsziqIZTHSxzxlmQVZrsUaRb |
| 1  | UdcuwmGBTvKnZbvFUISeLxhzCYmmGqBkTBodTGxKlPIheJffnZUezUAKzVSOCcIFyJxAGmWrqtJhIblTwOLuSPEbzyxGjStWbCrKQxndouhfvnbgeqzCWdNGcSPCjWOyKGixbEjHejDrCXOuhTVdMqouiEKhWPlqBGydoAVUSBHAVqSJdjIhgASkbzIWiFbrtgOMYuPqSqnoMnMaJdatMUoWofkVhRdxOorjyOyWtfaMKTdWdXxQvIjRmZUezRl |
| 2  | UJttwvfdAXHvQxCITRMoAvLNVElknAuGssAOciBtXzqtoiYISIiicCelyiWGNqjHKfXgqxUJWbbtlhFuEdhvlVPGrcwcArMwcmLaIxklvCDqOJnBNgoPMGTSQaMesuugXAuHHmgjgoIpkQGUdsCcAiDOhTmGBYhZfzqcdCXZNDOFiqOCsYQUCiFrMzEOOcZeJPTHGaZCsMHSQhXxcFqThkWUULEIQRlgBaQBgexlXOFqASzhtBGaFtRMcMlbIGF |
+----+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
3 rows in set
Time: 0.019s
TiDB root@127.0.0.1:test> show create table t1;
+-------+-------------------------------------------------------------+
| Table | Create Table                                                |
+-------+-------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (                                         |
|       |   `id` int NOT NULL,                                        |
|       |   `data` varchar(255) DEFAULT NULL,                         |
|       |   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */     |
|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+-------------------------------------------------------------+
1 row in set
Time: 0.013s
```

Setting `tidb_ddl_reorg_max_write_speed` from `4mb` to unlimited would result in different speeds of adding index:
```sql
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = '4mb';
Query OK, 0 rows affected
Time: 0.010s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 63.228s

TiDB root@127.0.0.1:test> alter table t1 drop index idx_data;
Query OK, 0 rows affected
Time: 0.107s
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = '8mb';
Query OK, 0 rows affected
Time: 0.031s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 33.176s

TiDB root@127.0.0.1:test> alter table t1 drop index idx_data;
Query OK, 0 rows affected
Time: 0.105s
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = '16mb';
Query OK, 0 rows affected
Time: 0.059s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 15.432s

TiDB root@127.0.0.1:test> alter table t1 drop index idx_data;
Query OK, 0 rows affected
Time: 0.220s
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = '32mb';
Query OK, 0 rows affected
Time: 0.026s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 7.717s

TiDB root@127.0.0.1:test> alter table t1 drop index idx_data;
Query OK, 0 rows affected
Time: 0.139s
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = '64mb';
Query OK, 0 rows affected
Time: 0.018s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 4.387s

TiDB root@127.0.0.1:test> alter table t1 drop index idx_data;
Query OK, 0 rows affected
Time: 0.140s
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = '128mb';
Query OK, 0 rows affected
Time: 0.019s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 4.375s

TiDB root@127.0.0.1:test> alter table t1 drop index idx_data;
Query OK, 0 rows affected
Time: 0.096s
TiDB root@127.0.0.1:test> set @@global.tidb_ddl_reorg_max_write_speed = 0;
Query OK, 0 rows affected
Time: 0.038s
TiDB root@127.0.0.1:test> CREATE INDEX idx_data ON test.t1 (data)
Query OK, 0 rows affected
Time: 4.229s
```

With the `tidb_ddl_reorg_max_write_speed` increased, the metric shows that the number of write operations increased as expected 
<img width="909" alt="image" src="https://github.com/user-attachments/assets/e058a6e4-2056-426e-b06c-06507081f4e5">

To verify that decreasing the `tidb_ddl_reorg_max_write_speed` helps to lower the impact of ADD INDEX on online service, we observe that with a further speed limitation, the QPS of sysbench increases.

<img width="1483" alt="image" src="https://github.com/user-attachments/assets/e89e9712-fcee-47a3-a353-0edd0036e4b4">

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add a system variable tidb_ddl_reorg_max_write_speed to limit the speed of ingesting when adding index
增加系统变量 tidb_ddl_reorg_max_write_speed 来限制加索引时 ingesting 的速度上限
```
