### PR TITLE
executor: add nil check protection for non-related subquery which base plan will be nil

### DIFF
--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -177,11 +177,12 @@ func NewLocalMPPCoordinator(ctx context.Context, sctx sessionctx.Context, is inf
 
 	value := sctx.GetSessionVars().StmtCtx.GetPlan()
 	if value != nil {
-		p := value.(base.Plan)
-		pp := getActualPhysicalPlan(p)
-		if pp != nil {
-			if len(coordinatorAddr) > 0 && needReportExecutionSummary(pp, coord.originalPlan.ID(), false) {
-				coord.reportExecutionInfo = true
+		if p, ok := value.(base.Plan); ok {
+			pp := getActualPhysicalPlan(p)
+			if pp != nil {
+				if len(coordinatorAddr) > 0 && needReportExecutionSummary(pp, coord.originalPlan.ID(), false) {
+					coord.reportExecutionInfo = true
+				}
 			}
 		}
 	}

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -176,11 +176,13 @@ func NewLocalMPPCoordinator(ctx context.Context, sctx sessionctx.Context, is inf
 	}
 
 	value := sctx.GetSessionVars().StmtCtx.GetPlan()
-	p := value.(base.Plan)
-	pp := getActualPhysicalPlan(p)
-	if pp != nil {
-		if len(coordinatorAddr) > 0 && needReportExecutionSummary(pp, coord.originalPlan.ID(), false) {
-			coord.reportExecutionInfo = true
+	if value != nil {
+		p := value.(base.Plan)
+		pp := getActualPhysicalPlan(p)
+		if pp != nil {
+			if len(coordinatorAddr) > 0 && needReportExecutionSummary(pp, coord.originalPlan.ID(), false) {
+				coord.reportExecutionInfo = true
+			}
 		}
 	}
 	return coord

--- a/pkg/executor/test/tiflashtest/BUILD.bazel
+++ b/pkg/executor/test/tiflashtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/config",
         "//pkg/domain",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57149 

Problem Summary:
Introduced in https://github.com/pingcap/tidb/pull/57101. 
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
