### PR TITLE
executor: fix admin check return wrong result for index containing generated columns

### DIFF
--- a/pkg/executor/test/admintest/BUILD.bazel
+++ b/pkg/executor/test/admintest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/executor/test/admintest/admin_test.go
+++ b/pkg/executor/test/admintest/admin_test.go
@@ -2098,3 +2098,43 @@ func TestAdminCheckGlobalIndexDuringDDL(t *testing.T) {
 		}
 	}
 }
+
+func TestAdminCheckGeneratedColumns(t *testing.T) {
+	store, domain := testkit.CreateMockStoreAndDomain(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("DROP TABLE IF EXISTS t")
+	tk.MustExec("CREATE TABLE t(pk int PRIMARY KEY CLUSTERED, gen int GENERATED ALWAYS AS (pk * pk) VIRTUAL, KEY idx_gen(gen))")
+	tk.MustExec("INSERT INTO t(pk) VALUES (2)")
+	tk.MustExec("ADMIN CHECK TABLE t")
+
+	// Make some corrupted index. Build the index information.
+	sctx := mock.NewContext()
+	sctx.Store = store
+	ctx := sctx.GetTableCtx()
+	is := domain.InfoSchema()
+	dbName := pmodel.NewCIStr("test")
+	tblName := pmodel.NewCIStr("t")
+	tbl, err := is.TableByName(context.Background(), dbName, tblName)
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	idxInfo := tblInfo.Indices[0]
+	tk.Session().GetSessionVars().IndexLookupSize = 3
+	tk.Session().GetSessionVars().MaxChunkSize = 3
+
+	indexOpr := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
+
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	err = indexOpr.Delete(ctx, txn, types.MakeDatums(4), kv.IntHandle(2))
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	require.NoError(t, err)
+
+	for _, enabled := range []bool{false, true} {
+		tk.MustExec(fmt.Sprintf("set tidb_enable_fast_table_check = %v", enabled))
+		err = tk.ExecToErr("admin check table t")
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57153

Problem Summary:

### What changed and how does it work?

When generating index SQL under fast admin check mode, use the correct names for virtual columns.

More specifically, only use `GeneratedExprString` when column is hidden.

https://github.com/pingcap/tidb/blob/7fe6cfec152ce6e102cb672f6de559f954005644/pkg/executor/check_table_index.go#L377-L380

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
