### PR TITLE
statistics: handle the prune mode correctly in the refresher

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -42,6 +42,7 @@ import (
 	handleutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tipb/go-tipb"
@@ -165,6 +166,18 @@ TASKLOOP:
 		err = e.handleGlobalStats(statsHandle, globalStatsMap)
 		if err != nil {
 			return err
+		}
+	}
+
+	if intest.InTest {
+		for {
+			stop := true
+			failpoint.Inject("mockStuckAnalyze", func() {
+				stop = false
+			})
+			if stop {
+				break
+			}
 		}
 	}
 

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -333,7 +333,7 @@ func (sa *statsAnalyze) handleAutoAnalyze(sctx sessionctx.Context) bool {
 			sa.refresher.ProcessDMLChangesForTest()
 			sa.refresher.RequeueFailedJobsForTest()
 		}
-		analyzed := sa.refresher.AnalyzeHighestPriorityTables()
+		analyzed := sa.refresher.AnalyzeHighestPriorityTables(sctx)
 		// During the test, we need to wait for the auto analyze job to be finished.
 		if intest.InTest {
 			sa.refresher.WaitAutoAnalyzeFinishedForTest()

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -331,7 +331,7 @@ func (sa *statsAnalyze) handleAutoAnalyze(sctx sessionctx.Context) bool {
 		// During the test, we need to fetch all DML changes before analyzing the highest priority tables.
 		if intest.InTest {
 			sa.refresher.ProcessDMLChangesForTest()
-			sa.refresher.RequeueFailedJobsForTest()
+			sa.refresher.RequeueMustRetryJobsForTest()
 		}
 		analyzed := sa.refresher.AnalyzeHighestPriorityTables(sctx)
 		// During the test, we need to wait for the auto analyze job to be finished.

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/testkit",
         "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testsetup",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -40,7 +40,7 @@ const notInitializedErrMsg = "priority queue not initialized"
 const (
 	lastAnalysisDurationRefreshInterval = time.Minute * 10
 	dmlChangesFetchInterval             = time.Minute * 2
-	failedJobRequeueInterval            = time.Minute * 5
+	mustRetryJobRequeueInterval         = time.Minute * 5
 )
 
 // pqHeap is an interface that wraps the methods of a priority queue heap.
@@ -90,8 +90,13 @@ type AnalysisPriorityQueue struct {
 		runningJobs map[int64]struct{}
 		// lastDMLUpdateFetchTimestamp is the timestamp of the last DML update fetch.
 		lastDMLUpdateFetchTimestamp uint64
-		// failedJobs is a slice to store the failed jobs.
-		failedJobs map[int64]struct{}
+		// mustRetryJobs is a slice to store the must retry jobs.
+		// For now, we have two types of jobs:
+		// 1. The jobs that failed to be executed. We have to try it later.
+		// 2. The jobs failed to enqueue due to the ongoing analysis,
+		//    particularly for tables with new indexes created during this process.
+		// We will requeue the must retry jobs periodically.
+		mustRetryJobs map[int64]struct{}
 		// initialized is a flag to check if the queue is initialized.
 		initialized bool
 	}
@@ -142,7 +147,7 @@ func (pq *AnalysisPriorityQueue) Initialize() error {
 	pq.ctx = ctx
 	pq.syncFields.cancel = cancel
 	pq.syncFields.runningJobs = make(map[int64]struct{})
-	pq.syncFields.failedJobs = make(map[int64]struct{})
+	pq.syncFields.mustRetryJobs = make(map[int64]struct{})
 	pq.syncFields.initialized = true
 	pq.syncFields.mu.Unlock()
 
@@ -298,8 +303,8 @@ func (pq *AnalysisPriorityQueue) run() {
 	defer dmlChangesFetchInterval.Stop()
 	timeRefreshInterval := time.NewTicker(lastAnalysisDurationRefreshInterval)
 	defer timeRefreshInterval.Stop()
-	failedJobRequeueInterval := time.NewTicker(failedJobRequeueInterval)
-	defer failedJobRequeueInterval.Stop()
+	mustRetryJobRequeueInterval := time.NewTicker(mustRetryJobRequeueInterval)
+	defer mustRetryJobRequeueInterval.Stop()
 
 	for {
 		select {
@@ -312,9 +317,9 @@ func (pq *AnalysisPriorityQueue) run() {
 		case <-timeRefreshInterval.C:
 			statslogutil.StatsLogger().Info("Start to refresh last analysis durations of jobs")
 			pq.RefreshLastAnalysisDuration()
-		case <-failedJobRequeueInterval.C:
-			statslogutil.StatsLogger().Info("Start to request failed jobs")
-			pq.RequeueFailedJobs()
+		case <-mustRetryJobRequeueInterval.C:
+			statslogutil.StatsLogger().Info("Start to request must retry jobs")
+			pq.RequeueMustRetryJobs()
 		}
 	}
 }
@@ -596,23 +601,24 @@ func (pq *AnalysisPriorityQueue) GetLastFetchTimestamp() uint64 {
 	return pq.syncFields.lastDMLUpdateFetchTimestamp
 }
 
-// RequeueFailedJobs requeues the failed jobs.
-func (pq *AnalysisPriorityQueue) RequeueFailedJobs() {
+// RequeueMustRetryJobs requeues the must retry jobs.
+func (pq *AnalysisPriorityQueue) RequeueMustRetryJobs() {
 	pq.syncFields.mu.Lock()
 	defer pq.syncFields.mu.Unlock()
 
 	if err := statsutil.CallWithSCtx(pq.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		start := time.Now()
 		defer func() {
-			statslogutil.StatsLogger().Info("Failed jobs requeued", zap.Duration("duration", time.Since(start)))
+			statslogutil.StatsLogger().Info("Must retry jobs requeued", zap.Duration("duration", time.Since(start)))
 		}()
 
 		is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-		for tableID := range pq.syncFields.failedJobs {
-			delete(pq.syncFields.failedJobs, tableID)
+		for tableID := range pq.syncFields.mustRetryJobs {
+			// Note: Delete the job first to ensure it can be added back to the queue
+			delete(pq.syncFields.mustRetryJobs, tableID)
 			tblInfo, ok := pq.statsHandle.TableInfoByID(is, tableID)
 			if !ok {
-				statslogutil.StatsLogger().Warn("Table info not found during requeueing failed jobs", zap.Int64("tableID", tableID))
+				statslogutil.StatsLogger().Warn("Table info not found during requeueing must retry jobs", zap.Int64("tableID", tableID))
 				continue
 			}
 			err := pq.recreateAndPushJobForTable(sctx, tblInfo.Meta())
@@ -623,7 +629,7 @@ func (pq *AnalysisPriorityQueue) RequeueFailedJobs() {
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsLogger().Error("Failed to requeue failed jobs", zap.Error(err))
+		statslogutil.StatsLogger().Error("Failed to requeue must retry jobs", zap.Error(err))
 	}
 }
 
@@ -707,6 +713,28 @@ func (pq *AnalysisPriorityQueue) pushWithoutLock(job AnalysisJob) error {
 	if job == nil {
 		return nil
 	}
+	// Skip the must retry jobs.
+	// Avoiding requeueing the must retry jobs before the next must retry job requeue interval.
+	// Otherwise, we may requeue the same job multiple times in a short time.
+	if _, ok := pq.syncFields.mustRetryJobs[job.GetTableID()]; ok {
+		return nil
+	}
+
+	// Skip the current running jobs.
+	// Safety:
+	// Let's say we have a job in the priority queue, and it is already running.
+	// Then we will not add the same job to the priority queue again. Otherwise, we will analyze the same table twice.
+	// If the job is finished, we will remove it from the running jobs.
+	// Then the next time we process the DML changes, we will add the job to the priority queue.(if it is still needed)
+	// In this process, we will not miss any DML changes of the table. Because when we try to delete the table from the current running jobs,
+	// we guarantee that the job is finished and the stats cache is updated.(The last step of the analysis job is to update the stats cache).
+	if _, ok := pq.syncFields.runningJobs[job.GetTableID()]; ok {
+		// Mark the job as must retry.
+		// Because potentially the job can be analyzed in the near future.
+		// For example, the table has new indexes added when the job is running.
+		pq.syncFields.mustRetryJobs[job.GetTableID()] = struct{}{}
+		return nil
+	}
 	// We apply a penalty to larger tables, which can potentially result in a negative weight.
 	// To prevent this, we filter out any negative weights. Under normal circumstances, table sizes should not be negative.
 	weight := pq.calculator.CalculateWeight(job)
@@ -718,23 +746,6 @@ func (pq *AnalysisPriorityQueue) pushWithoutLock(job AnalysisJob) error {
 		)
 	}
 	job.SetWeight(weight)
-	// Skip the current running jobs.
-	// Safety:
-	// Let's say we have a job in the priority queue, and it is already running.
-	// Then we will not add the same job to the priority queue again. Otherwise, we will analyze the same table twice.
-	// If the job is finished, we will remove it from the running jobs.
-	// Then the next time we process the DML changes, we will add the job to the priority queue.(if it is still needed)
-	// In this process, we will not miss any DML changes of the table. Because when we try to delete the table from the current running jobs,
-	// we guarantee that the job is finished and the stats cache is updated.(The last step of the analysis job is to update the stats cache).
-	if _, ok := pq.syncFields.runningJobs[job.GetTableID()]; ok {
-		return nil
-	}
-	// Skip the failed jobs.
-	// Avoiding requeueing the failed jobs before the next failed job requeue interval.
-	// Otherwise, we may requeue the same job multiple times in a short time.
-	if _, ok := pq.syncFields.failedJobs[job.GetTableID()]; ok {
-		return nil
-	}
 	return pq.syncFields.inner.addOrUpdate(job)
 }
 
@@ -763,7 +774,7 @@ func (pq *AnalysisPriorityQueue) Pop() (AnalysisJob, error) {
 		defer pq.syncFields.mu.Unlock()
 		// Mark the job as failed and remove it from the running jobs.
 		delete(pq.syncFields.runningJobs, j.GetTableID())
-		pq.syncFields.failedJobs[j.GetTableID()] = struct{}{}
+		pq.syncFields.mustRetryJobs[j.GetTableID()] = struct{}{}
 	})
 	return job, nil
 }

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
@@ -348,7 +348,7 @@ func TestProcessDMLChangesWithRunningJobs(t *testing.T) {
 	require.Equal(t, tbl1.Meta().ID, job1.GetTableID(), "t1 has been removed from running jobs and should be in the queue")
 }
 
-func TestRequeueFailedJobs(t *testing.T) {
+func TestRequeueMustRetryJobs(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	handle := dom.StatsHandle()
 	tk := testkit.NewTestKit(t, store)
@@ -395,7 +395,7 @@ func TestRequeueFailedJobs(t *testing.T) {
 	require.Equal(t, 0, l)
 
 	// Requeue the failed jobs.
-	pq.RequeueFailedJobs()
+	pq.RequeueMustRetryJobs()
 	l, err = pq.Len()
 	require.NoError(t, err)
 	require.Equal(t, 1, l)

--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -33,7 +33,7 @@ go_test(
         "worker_test.go",
     ],
     flaky = True,
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         ":refresher",
         "//pkg/parser/model",
@@ -42,6 +42,7 @@ go_test(
         "//pkg/statistics",
         "//pkg/statistics/handle/autoanalyze/priorityqueue",
         "//pkg/statistics/handle/types",
+        "//pkg/statistics/handle/util",
         "//pkg/testkit",
         "//pkg/testkit/testsetup",
         "@com_github_stretchr_testify//require",

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -227,10 +227,10 @@ func (r *Refresher) ProcessDMLChangesForTest() {
 	}
 }
 
-// RequeueFailedJobsForTest requeues failed jobs for the test.
+// RequeueMustRetryJobsForTest requeues must retry jobs for the test.
 // Only used in the test.
-func (r *Refresher) RequeueFailedJobsForTest() {
-	r.jobs.RequeueFailedJobs()
+func (r *Refresher) RequeueMustRetryJobsForTest() {
+	r.jobs.RequeueMustRetryJobs()
 }
 
 // Len returns the length of the analysis job queue.

--- a/pkg/statistics/handle/updatetest/update_test.go
+++ b/pkg/statistics/handle/updatetest/update_test.go
@@ -1284,6 +1284,8 @@ func TestAutoAnalyzePartitionTableAfterAddingIndex(t *testing.T) {
 	tblInfo := tbl.Meta()
 	idxInfo := tblInfo.Indices[0]
 	require.Nil(t, h.GetTableStats(tblInfo).GetIdx(idxInfo.ID))
-	require.True(t, h.HandleAutoAnalyze())
+	require.Eventually(t, func() bool {
+		return h.HandleAutoAnalyze()
+	}, 3*time.Second, time.Millisecond*100)
 	require.NotNil(t, h.GetTableStats(tblInfo).GetIdx(idxInfo.ID))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57168

Problem Summary:

### What changed and how does it work?

Cherry-pick of https://github.com/pingcap/tidb/pull/57096
Cherry-pick of https://github.com/pingcap/tidb/pull/57113

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
