### PR TITLE
planner: shallow copy more field for Instance Plan Cache to improve performance

### DIFF
--- a/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "others_test.go",
     ],
     flaky = True,
-    shard_count = 31,
+    shard_count = 32,
     deps = [
         "//pkg/parser/auth",
         "//pkg/testkit",

--- a/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "others_test.go",
     ],
     flaky = True,
-    shard_count = 28,
+    shard_count = 31,
     deps = [
         "//pkg/parser/auth",
         "//pkg/testkit",

--- a/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
@@ -454,6 +454,66 @@ func TestInstancePlanCacheConcurrencyPoint(t *testing.T) {
 	testWithWorkers(TKs, stmts)
 }
 
+func TestInstancePlanCacheConcurrencyPartitioning(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
+	tk.MustExec(`create table t (a int) partition by range (a) (
+    			partition p0 values less than (10),
+    			partition p1 values less than (20),
+    			partition p2 values less than (30),
+    			partition p3 values less than (40),
+    			partition p4 values less than (50),
+    			partition p5 values less than (60),
+    			partition p6 values less than (70),
+    			partition p7 values less than (80),
+    			partition p8 values less than (90),
+    			partition p9 values less than (100))`)
+	for i := 0; i < 100; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t values (%v)", i))
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tki := testkit.NewTestKit(t, store)
+			tki.MustExec(`use test`)
+
+			for k := 0; k < 100; k++ {
+				switch rand.Intn(3) {
+				case 0: // point get
+					tki.MustExec(`prepare st from 'select * from t where a=?'`)
+					v := rand.Intn(100)
+					tki.MustExec("set @v = ?", v)
+					tki.MustQuery("execute st using @v").Check(testkit.Rows(fmt.Sprintf("%v", v)))
+				case 1: // batch get
+					tki.MustExec(`prepare st from 'select * from t where a in (?, ?)'`)
+					v1, v2 := rand.Intn(50), 50+rand.Intn(50)
+					tki.MustExec("set @v1 = ?, @v2 = ?", v1, v2)
+					v1s, v2s := fmt.Sprintf("%v", v1), fmt.Sprintf("%v", v2)
+					if v1s > v2s {
+						v1s, v2s = v2s, v1s
+					}
+					tki.MustQuery("execute st using @v1, @v2").Sort().Check(testkit.Rows(v1s, v2s))
+				case 2: // range scan
+					tki.MustExec(`prepare st from 'select * from t where a between ? and ?'`)
+					v1, v2 := rand.Intn(50), 50+rand.Intn(50)
+					tki.MustExec("set @v1 = ?, @v2 = ?", v1, v2)
+					expected := make([]string, 0, v2-v1+1)
+					for v := v1; v <= v2; v++ {
+						expected = append(expected, fmt.Sprintf("%v", v))
+					}
+					sort.Strings(expected)
+					tki.MustQuery("execute st using @v1, @v2").Sort().Check(testkit.Rows(expected...))
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func TestInstancePlanCacheConcurrencyComp(t *testing.T) {
 	// cases from https://github.com/PingCAP-QE/qa/tree/master/comp/yy/plan-cache
 	store := testkit.CreateMockStore(t)

--- a/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
@@ -17,6 +17,7 @@ package instanceplancache
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -266,11 +267,80 @@ func TestInstancePlanCacheConcurrencySysbench(t *testing.T) {
 	testWithWorkers(TKs, stmts)
 }
 
+func TestInstancePlanCacheIndexLookup(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t1 (a int, b int)`)
+	tk.MustExec(`create table t2 (a int, key(a))`)
+	for i := 0; i < 100; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t1 values (%v, %v)", i, i))
+		tk.MustExec(fmt.Sprintf("insert into t2 values (%v)", i))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tki := testkit.NewTestKit(t, store)
+			tki.MustExec(`use test`)
+			tki.MustExec(`prepare st from 'select /*+ tidb_inlj(t2) */ t2.a from t1, t2 where t1.a=t2.a and t1.b=?'`)
+			for k := 0; k < 100; k++ {
+				v := rand.Intn(100)
+				tki.MustExec("set @v = ?", v)
+				tki.MustQuery("execute st using @v").Check(testkit.Rows(fmt.Sprintf("%v", v)))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInstancePlanCacheTableIndexScan(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t (a int, b int, primary key(a), key(b))`)
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
+	for i := 0; i < 100; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t values (%v, %v)", i, i))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tki := testkit.NewTestKit(t, store)
+			tki.MustExec(`use test`)
+
+			for k := 0; k < 100; k++ {
+				if rand.Intn(2) == 0 { // table scan
+					tki.MustExec(`prepare st from 'select a from t use index(primary) where a>=? and a<=?'`)
+				} else { // index scan
+					tki.MustExec(`prepare st from 'select b from t use index(b) where b>=? and b<=?'`)
+				}
+				v1, v2 := rand.Intn(50), rand.Intn(50)+50
+				expected := make([]string, 0, v2-v1)
+				for v := v1; v <= v2; v++ {
+					expected = append(expected, fmt.Sprintf("%v", v))
+				}
+				sort.Strings(expected)
+
+				tki.MustExec(`set @v1 = ?, @v2 = ?`, v1, v2)
+				tki.MustQuery("execute st using @v1, @v2").Sort().Check(testkit.Rows(expected...))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func TestInstancePlanCacheConcurrencyPointNoTxn(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec(`use test`)
 	tk.MustExec(`create table t (a int, b int, primary key(a))`)
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
 	for i := 0; i < 100; i++ {
 		tk.MustExec(fmt.Sprintf("insert into t values (%v, %v)", i, i))
 	}
@@ -287,6 +357,39 @@ func TestInstancePlanCacheConcurrencyPointNoTxn(t *testing.T) {
 				a := rand.Intn(100)
 				tki.MustExec("set @a = ?", a)
 				tki.MustQuery("execute st using @a").Check(testkit.Rows(fmt.Sprintf("%v %v", a, a)))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInstancePlanCacheConcurrencyBatchPointNoTxn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t (a int, b int, primary key(a))`)
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
+	for i := 0; i < 100; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t values (%v, %v)", i, i))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tki := testkit.NewTestKit(t, store)
+			tki.MustExec(`use test`)
+			tki.MustExec(`prepare st from 'select a from t where a in (?, ?)'`)
+			for k := 0; k < 100; k++ {
+				a1, a2 := rand.Intn(50), 50+rand.Intn(50)
+				tki.MustExec("set @a1 = ?, @a2 = ?", a1, a2)
+				v1, v2 := fmt.Sprintf("%v", a1), fmt.Sprintf("%v", a2)
+				if v1 > v2 {
+					v1, v2 = v2, v1
+				}
+				tki.MustQuery("execute st using @a1, @a2").Sort().Check(
+					testkit.Rows(v1, v2))
 			}
 		}()
 	}

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -351,10 +351,9 @@ type InsertGeneratedColumns struct {
 	OnDuplicates []*expression.Assignment
 }
 
-// Copy clones InsertGeneratedColumns.
-func (i InsertGeneratedColumns) Copy() InsertGeneratedColumns {
+func (i InsertGeneratedColumns) cloneForPlanCache() InsertGeneratedColumns {
 	return InsertGeneratedColumns{
-		Exprs:        util.CloneExpressions(i.Exprs),
+		Exprs:        cloneExpressionsForPlanCache(i.Exprs),
 		OnDuplicates: util.CloneAssignments(i.OnDuplicates),
 	}
 }

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -174,16 +174,15 @@ type PhysPlanPartInfo struct {
 
 const emptyPartitionInfoSize = int64(unsafe.Sizeof(PhysPlanPartInfo{}))
 
-// Clone clones the PhysPlanPartInfo.
-func (pi *PhysPlanPartInfo) Clone() *PhysPlanPartInfo {
+func (pi *PhysPlanPartInfo) cloneForPlanCache() *PhysPlanPartInfo {
 	if pi == nil {
 		return nil
 	}
 	cloned := new(PhysPlanPartInfo)
-	cloned.PruningConds = util.CloneExprs(pi.PruningConds)
-	cloned.PartitionNames = util.CloneCIStrs(pi.PartitionNames)
-	cloned.Columns = util.CloneCols(pi.Columns)
-	cloned.ColumnNames = util.CloneFieldNames(pi.ColumnNames)
+	cloned.PruningConds = cloneExpressionsForPlanCache(pi.PruningConds)
+	cloned.PartitionNames = pi.PartitionNames
+	cloned.Columns = cloneColumnsForPlanCache(pi.Columns)
+	cloned.ColumnNames = pi.ColumnNames
 	return cloned
 }
 
@@ -737,7 +736,7 @@ type PhysicalIndexScan struct {
 	Index      *model.IndexInfo `plan-cache-clone:"shallow"`
 	IdxCols    []*expression.Column
 	IdxColLens []int
-	Ranges     []*ranger.Range
+	Ranges     []*ranger.Range     `plan-cache-clone:"shallow"`
 	Columns    []*model.ColumnInfo `plan-cache-clone:"shallow"`
 	DBName     pmodel.CIStr        `plan-cache-clone:"shallow"`
 
@@ -913,7 +912,7 @@ type PhysicalTableScan struct {
 	Table   *model.TableInfo    `plan-cache-clone:"shallow"`
 	Columns []*model.ColumnInfo `plan-cache-clone:"shallow"`
 	DBName  pmodel.CIStr        `plan-cache-clone:"shallow"`
-	Ranges  []*ranger.Range
+	Ranges  []*ranger.Range     `plan-cache-clone:"shallow"`
 
 	TableAsName *pmodel.CIStr `plan-cache-clone:"shallow"`
 
@@ -1354,21 +1353,21 @@ func (p *basePhysicalJoin) cloneForPlanCacheWithSelf(newCtx base.PlanContext, ne
 	}
 	cloned.physicalSchemaProducer = *base
 	cloned.JoinType = p.JoinType
-	cloned.LeftConditions = util.CloneExprs(p.LeftConditions)
-	cloned.RightConditions = util.CloneExprs(p.RightConditions)
-	cloned.OtherConditions = util.CloneExprs(p.OtherConditions)
+	cloned.LeftConditions = cloneExpressionsForPlanCache(p.LeftConditions)
+	cloned.RightConditions = cloneExpressionsForPlanCache(p.RightConditions)
+	cloned.OtherConditions = cloneExpressionsForPlanCache(p.OtherConditions)
 	cloned.InnerChildIdx = p.InnerChildIdx
-	cloned.OuterJoinKeys = util.CloneCols(p.OuterJoinKeys)
-	cloned.InnerJoinKeys = util.CloneCols(p.InnerJoinKeys)
-	cloned.LeftJoinKeys = util.CloneCols(p.LeftJoinKeys)
-	cloned.RightJoinKeys = util.CloneCols(p.RightJoinKeys)
+	cloned.OuterJoinKeys = cloneColumnsForPlanCache(p.OuterJoinKeys)
+	cloned.InnerJoinKeys = cloneColumnsForPlanCache(p.InnerJoinKeys)
+	cloned.LeftJoinKeys = cloneColumnsForPlanCache(p.LeftJoinKeys)
+	cloned.RightJoinKeys = cloneColumnsForPlanCache(p.RightJoinKeys)
 	cloned.IsNullEQ = make([]bool, len(p.IsNullEQ))
 	copy(cloned.IsNullEQ, p.IsNullEQ)
 	for _, d := range p.DefaultValues {
 		cloned.DefaultValues = append(cloned.DefaultValues, *d.Clone())
 	}
-	cloned.LeftNAJoinKeys = util.CloneCols(p.LeftNAJoinKeys)
-	cloned.RightNAJoinKeys = util.CloneCols(p.RightNAJoinKeys)
+	cloned.LeftNAJoinKeys = cloneColumnsForPlanCache(p.LeftNAJoinKeys)
+	cloned.RightNAJoinKeys = cloneColumnsForPlanCache(p.RightNAJoinKeys)
 	return cloned, true
 }
 

--- a/pkg/planner/core/plan_cache_rebuild_test.go
+++ b/pkg/planner/core/plan_cache_rebuild_test.go
@@ -236,7 +236,9 @@ func testCachedPlanClone(t *testing.T, tk1, tk2 *testkit.TestKit, prep, set, exe
 		require.NoError(t, checkUnclearPlanCacheClone(plan, cloned,
 			".ctx", ".AccessCondition", ".filterCondition", ".Conditions", ".Exprs", ".IndexConstants",
 			"*collate", ".IdxCols", ".OutputColumns", ".EqualConditions", ".OuterHashKeys", ".InnerHashKeys",
-			".HandleParams", ".IndexValueParams", ".Insert.Lists", ".accessCols"))
+			".HandleParams", ".IndexValueParams", ".Insert.Lists", ".accessCols", ".physicalSchemaProducer.schema",
+			".PruningConds", ".PlanPartInfo.Columns", ".PlanPartInfo.ColumnNames", ".baseSchemaProducer.schema",
+			".pkIsHandleCol", "JoinKeys", ".OtherConditions", ".ExtraHandleCol", ".PointGetPlan.HandleConstant"))
 	})
 	if isDML {
 		tk2.MustExecWithContext(ctx, exec2)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -82,12 +82,12 @@ type PointGetPlan struct {
 	// Please see comments in PhysicalPlan for details.
 	probeParents []base.PhysicalPlan
 	// explicit partition selection
-	PartitionNames []pmodel.CIStr
+	PartitionNames []pmodel.CIStr `plan-cache-clone:"shallow"`
 
 	dbName           string
-	schema           *expression.Schema
-	TblInfo          *model.TableInfo `plan-cache-clone:"shallow"`
-	IndexInfo        *model.IndexInfo `plan-cache-clone:"shallow"`
+	schema           *expression.Schema `plan-cache-clone:"shallow"`
+	TblInfo          *model.TableInfo   `plan-cache-clone:"shallow"`
+	IndexInfo        *model.IndexInfo   `plan-cache-clone:"shallow"`
 	PartitionIdx     *int
 	Handle           kv.Handle
 	HandleConstant   *expression.Constant
@@ -420,7 +420,7 @@ type BatchPointGetPlan struct {
 	// Please see comments in PhysicalPlan for details.
 	probeParents []base.PhysicalPlan
 	// explicit partition selection
-	PartitionNames []pmodel.CIStr
+	PartitionNames []pmodel.CIStr `plan-cache-clone:"shallow"`
 
 	ctx              base.PlanContext
 	dbName           string

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -103,7 +103,7 @@ type physicalSchemaProducer struct {
 
 func (s *physicalSchemaProducer) cloneForPlanCacheWithSelf(newCtx base.PlanContext, newSelf base.PhysicalPlan) (*physicalSchemaProducer, bool) {
 	cloned := new(physicalSchemaProducer)
-	cloned.schema = s.Schema().Clone()
+	cloned.schema = s.schema
 	base, ok := s.BasePhysicalPlan.CloneForPlanCacheWithSelf(newCtx, newSelf)
 	if !ok {
 		return nil, false
@@ -159,11 +159,10 @@ type baseSchemaProducer struct {
 	baseimpl.Plan
 }
 
-// CloneWithNewCtx clones the baseSchemaProducer with new context.
-func (s *baseSchemaProducer) CloneWithNewCtx(newCtx base.PlanContext) *baseSchemaProducer {
+func (s *baseSchemaProducer) cloneForPlanCache(newCtx base.PlanContext) *baseSchemaProducer {
 	cloned := new(baseSchemaProducer)
 	cloned.Plan = *s.Plan.CloneWithNewCtx(newCtx)
-	cloned.schema = s.schema.Clone()
+	cloned.schema = s.schema
 	cloned.names = s.names
 	return cloned
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54057

Problem Summary: planner: shallow copy more field for Instance Plan Cache to improve performance

### What changed and how does it work?

planner: shallow copy more field for Instance Plan Cache to improve performance

These unnecessary clone operations could cause more than 10% regression in some benchmarks:
![image](https://github.com/user-attachments/assets/49b82bf6-f62e-45ce-acc4-17c22d4ef432)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
