### PR TITLE
ddl,statistics: handle the drop database event in the PQ

### DIFF
--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -883,7 +883,7 @@ func (w *worker) runOneJobStep(
 	case model.ActionModifySchemaCharsetAndCollate:
 		ver, err = onModifySchemaCharsetAndCollate(jobCtx, job)
 	case model.ActionDropSchema:
-		ver, err = onDropSchema(jobCtx, job)
+		ver, err = w.onDropSchema(jobCtx, job)
 	case model.ActionRecoverSchema:
 		ver, err = w.onRecoverSchema(jobCtx, job)
 	case model.ActionModifySchemaDefaultPlacement:

--- a/pkg/ddl/notifier/BUILD.bazel
+++ b/pkg/ddl/notifier/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kv",
         "//pkg/meta/model",
         "//pkg/owner",
+        "//pkg/parser/model",
         "//pkg/sessionctx",
         "//pkg/util",
         "//pkg/util/intest",

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -446,17 +446,26 @@ func NewDropSchemaEvent(dbInfo *model.DBInfo, tables []*model.TableInfo) *Schema
 	}
 	return &SchemaChangeEvent{
 		inner: &jsonSchemaChangeEvent{
-			Tp:     model.ActionDropSchema,
-			DBInfo: dbInfo,
-			Tables: miniTables,
+			Tp: model.ActionDropSchema,
+			DBInfo: &MiniDBInfoForSchemaEvent{
+				ID:     dbInfo.ID,
+				Name:   dbInfo.Name,
+				Tables: miniTables,
+			},
 		},
 	}
 }
 
 // GetDropSchemaInfo returns the database info and tables of the SchemaChangeEvent whose type is ActionDropSchema.
-func (s *SchemaChangeEvent) GetDropSchemaInfo() (dbInfo *model.DBInfo, tables []*MiniTableInfoForSchemaEvent) {
+func (s *SchemaChangeEvent) GetDropSchemaInfo() (dbInfo *MiniDBInfoForSchemaEvent) {
 	intest.Assert(s.inner.Tp == model.ActionDropSchema)
-	return s.inner.DBInfo, s.inner.Tables
+	return s.inner.DBInfo
+}
+
+type MiniDBInfoForSchemaEvent struct {
+	ID     int64                          `json:"id"`
+	Name   pmodel.CIStr                   `json:"name"`
+	Tables []*MiniTableInfoForSchemaEvent `json:"tables,omitempty"`
 }
 
 // MiniTableInfoForSchemaEvent is a mini version of TableInfo for DropSchemaEvent only.
@@ -481,14 +490,13 @@ type MiniPartitionInfoForSchemaEvent struct {
 // jsonSchemaChangeEvent is used by SchemaChangeEvent when needed to (un)marshal data,
 // we want to hide the details to subscribers, so SchemaChangeEvent contain this struct.
 type jsonSchemaChangeEvent struct {
-	DBInfo          *model.DBInfo                  `json:"db_info,omitempty"`
-	Tables          []*MiniTableInfoForSchemaEvent `json:"tables,omitempty"`
-	TableInfo       *model.TableInfo               `json:"table_info,omitempty"`
-	OldTableInfo    *model.TableInfo               `json:"old_table_info,omitempty"`
-	AddedPartInfo   *model.PartitionInfo           `json:"added_partition_info,omitempty"`
-	DroppedPartInfo *model.PartitionInfo           `json:"dropped_partition_info,omitempty"`
-	Columns         []*model.ColumnInfo            `json:"columns,omitempty"`
-	Indexes         []*model.IndexInfo             `json:"indexes,omitempty"`
+	DBInfo          *MiniDBInfoForSchemaEvent `json:"db_info,omitempty"`
+	TableInfo       *model.TableInfo          `json:"table_info,omitempty"`
+	OldTableInfo    *model.TableInfo          `json:"old_table_info,omitempty"`
+	AddedPartInfo   *model.PartitionInfo      `json:"added_partition_info,omitempty"`
+	DroppedPartInfo *model.PartitionInfo      `json:"dropped_partition_info,omitempty"`
+	Columns         []*model.ColumnInfo       `json:"columns,omitempty"`
+	Indexes         []*model.IndexInfo        `json:"indexes,omitempty"`
 	// OldTableID4Partition is used to store the table ID when a table transitions from being partitioned to non-partitioned,
 	// or vice versa.
 	OldTableID4Partition int64 `json:"old_table_id_for_partition,omitempty"`

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -426,9 +426,28 @@ func NewFlashbackClusterEvent() *SchemaChangeEvent {
 	}
 }
 
+// NewDropSchemaEvent creates a schema change event whose type is ActionDropSchema.
+func NewDropSchemaEvent(dbInfo *model.DBInfo, tables []*model.TableInfo) *SchemaChangeEvent {
+	return &SchemaChangeEvent{
+		inner: &jsonSchemaChangeEvent{
+			Tp:     model.ActionDropSchema,
+			DBInfo: dbInfo,
+			Tables: tables,
+		},
+	}
+}
+
+// GetDropSchemaInfo returns the database info and tables of the SchemaChangeEvent whose type is ActionDropSchema.
+func (s *SchemaChangeEvent) GetDropSchemaInfo() (dbInfo *model.DBInfo, tables []*model.TableInfo) {
+	intest.Assert(s.inner.Tp == model.ActionDropSchema)
+	return s.inner.DBInfo, s.inner.Tables
+}
+
 // jsonSchemaChangeEvent is used by SchemaChangeEvent when needed to (un)marshal data,
 // we want to hide the details to subscribers, so SchemaChangeEvent contain this struct.
 type jsonSchemaChangeEvent struct {
+	DBInfo          *model.DBInfo        `json:"db_info,omitempty"`
+	Tables          []*model.TableInfo   `json:"tables,omitempty"`
 	TableInfo       *model.TableInfo     `json:"table_info,omitempty"`
 	OldTableInfo    *model.TableInfo     `json:"old_table_info,omitempty"`
 	AddedPartInfo   *model.PartitionInfo `json:"added_partition_info,omitempty"`

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -462,6 +462,7 @@ func (s *SchemaChangeEvent) GetDropSchemaInfo() (dbInfo *MiniDBInfoForSchemaEven
 	return s.inner.DBInfo
 }
 
+// MiniDBInfoForSchemaEvent is a mini version of DBInfo for DropSchemaEvent only.
 type MiniDBInfoForSchemaEvent struct {
 	ID     int64                          `json:"id"`
 	Name   pmodel.CIStr                   `json:"name"`

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -436,6 +436,7 @@ func NewDropSchemaEvent(dbInfo *model.DBInfo, tables []*model.TableInfo) *Schema
 			Name: table.Name,
 		}
 		if table.Partition != nil {
+			miniTables[i].Partitions = make([]*MiniPartitionInfoForSchemaEvent, 0, len(table.Partition.Definitions))
 			for _, part := range table.Partition.Definitions {
 				miniTables[i].Partitions = append(miniTables[i].Partitions, &MiniPartitionInfoForSchemaEvent{
 					ID:   part.ID,

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -447,7 +447,7 @@ func NewDropSchemaEvent(dbInfo *model.DBInfo, tables []*model.TableInfo) *Schema
 	return &SchemaChangeEvent{
 		inner: &jsonSchemaChangeEvent{
 			Tp: model.ActionDropSchema,
-			DBInfo: &MiniDBInfoForSchemaEvent{
+			MiniDBInfo: &MiniDBInfoForSchemaEvent{
 				ID:     dbInfo.ID,
 				Name:   dbInfo.Name,
 				Tables: miniTables,
@@ -457,9 +457,9 @@ func NewDropSchemaEvent(dbInfo *model.DBInfo, tables []*model.TableInfo) *Schema
 }
 
 // GetDropSchemaInfo returns the database info and tables of the SchemaChangeEvent whose type is ActionDropSchema.
-func (s *SchemaChangeEvent) GetDropSchemaInfo() (dbInfo *MiniDBInfoForSchemaEvent) {
+func (s *SchemaChangeEvent) GetDropSchemaInfo() (miniDBInfo *MiniDBInfoForSchemaEvent) {
 	intest.Assert(s.inner.Tp == model.ActionDropSchema)
-	return s.inner.DBInfo
+	return s.inner.MiniDBInfo
 }
 
 // MiniDBInfoForSchemaEvent is a mini version of DBInfo for DropSchemaEvent only.
@@ -491,7 +491,7 @@ type MiniPartitionInfoForSchemaEvent struct {
 // jsonSchemaChangeEvent is used by SchemaChangeEvent when needed to (un)marshal data,
 // we want to hide the details to subscribers, so SchemaChangeEvent contain this struct.
 type jsonSchemaChangeEvent struct {
-	DBInfo          *MiniDBInfoForSchemaEvent `json:"db_info,omitempty"`
+	MiniDBInfo      *MiniDBInfoForSchemaEvent `json:"mini_db_info,omitempty"`
 	TableInfo       *model.TableInfo          `json:"table_info,omitempty"`
 	OldTableInfo    *model.TableInfo          `json:"old_table_info,omitempty"`
 	AddedPartInfo   *model.PartitionInfo      `json:"added_partition_info,omitempty"`

--- a/pkg/ddl/notifier/events.go
+++ b/pkg/ddl/notifier/events.go
@@ -436,12 +436,13 @@ func NewDropSchemaEvent(dbInfo *model.DBInfo, tables []*model.TableInfo) *Schema
 			Name: table.Name,
 		}
 		if table.Partition != nil {
-			miniTables[i].Partitions = make([]*MiniPartitionInfoForSchemaEvent, 0, len(table.Partition.Definitions))
-			for _, part := range table.Partition.Definitions {
-				miniTables[i].Partitions = append(miniTables[i].Partitions, &MiniPartitionInfoForSchemaEvent{
+			partLen := len(table.Partition.Definitions)
+			miniTables[i].Partitions = make([]*MiniPartitionInfoForSchemaEvent, partLen)
+			for j, part := range table.Partition.Definitions {
+				miniTables[i].Partitions[j] = &MiniPartitionInfoForSchemaEvent{
 					ID:   part.ID,
 					Name: part.Name,
-				})
+				}
 			}
 		}
 	}

--- a/pkg/ddl/notifier/testkit_test.go
+++ b/pkg/ddl/notifier/testkit_test.go
@@ -254,11 +254,12 @@ func TestPubSub(t *testing.T) {
 	tk.MustExec("alter table t add index(b)")
 	tk.MustExec("create table t1(a int, b int key, FOREIGN KEY (b) REFERENCES t(b) ON DELETE CASCADE);") // ActionCreateTable with foreign key
 	tk.MustExec("alter table t1 add column c int, add index idx_a(a)")                                   // ActionAddColumn
+	tk.MustExec("drop database test")                                                                    // ActionDropSchema
 
 	require.Eventually(t, func() bool {
 		eventsLock.Lock()
 		defer eventsLock.Unlock()
-		return len(events) == 17
+		return len(events) == 18
 	}, 5*time.Second, 500*time.Millisecond)
 
 	tps := make([]model.ActionType, len(events))
@@ -283,6 +284,7 @@ func TestPubSub(t *testing.T) {
 		model.ActionCreateTable,
 		model.ActionAddColumn,
 		model.ActionAddIndex,
+		model.ActionDropSchema,
 	}, tps)
 }
 

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -220,8 +220,9 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 		}
 
 		// Split tables into multiple jobs to avoid too big transaction.
+		const tooManyTablesThreshold = 100000
 		tablesPerJob := 100
-		if len(tables) > 100000 {
+		if len(tables) > tooManyTablesThreshold {
 			tablesPerJob = 500
 		}
 		for i := 0; i < len(tables); i += tablesPerJob {

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/label"
+	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
@@ -153,7 +154,7 @@ func onModifySchemaDefaultPlacement(jobCtx *jobContext, job *model.Job) (ver int
 	return ver, nil
 }
 
-func onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
+func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 	metaMut := jobCtx.metaMut
 	dbInfo, err := checkSchemaExistAndCancelNotExistJob(metaMut, job)
 	if err != nil {
@@ -218,6 +219,11 @@ func onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
 			break
 		}
 
+		dropSchemaEvent := notifier.NewDropSchemaEvent(dbInfo, tables)
+		err = asyncNotifyEvent(jobCtx, dropSchemaEvent, job, noSubJob, w.sess)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
 		// Finish this job.
 		job.FillFinishedArgs(&model.DropSchemaArgs{
 			AllDroppedTableIDs: getIDs(tables),

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -219,7 +219,7 @@ func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ 
 			break
 		}
 
-		// Split tables into multiple jobs to avoid too big transaction.
+		// Split tables into multiple jobs to avoid too big records in the notifier.
 		const tooManyTablesThreshold = 100000
 		tablesPerJob := 100
 		if len(tables) > tooManyTablesThreshold {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -410,8 +410,8 @@ func (pq *AnalysisPriorityQueue) handleRemovePartitioningEvent(sctx sessionctx.C
 }
 
 func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, event *notifier.SchemaChangeEvent) error {
-	dbInfo, tables := event.GetDropSchemaInfo()
-	for _, tbl := range tables {
+	dbInfo := event.GetDropSchemaInfo()
+	for _, tbl := range dbInfo.Tables {
 		// For static partitioned tables.
 		for _, partition := range tbl.Partitions {
 			if err := pq.getAndDeleteJob(partition.ID); err != nil {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -410,8 +410,8 @@ func (pq *AnalysisPriorityQueue) handleRemovePartitioningEvent(sctx sessionctx.C
 }
 
 func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, event *notifier.SchemaChangeEvent) error {
-	dbInfo := event.GetDropSchemaInfo()
-	for _, tbl := range dbInfo.Tables {
+	miniDBInfo := event.GetDropSchemaInfo()
+	for _, tbl := range miniDBInfo.Tables {
 		// For static partitioned tables.
 		for _, partition := range tbl.Partitions {
 			if err := pq.getAndDeleteJob(partition.ID); err != nil {
@@ -419,7 +419,7 @@ func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, eve
 				statslogutil.StatsLogger().Error(
 					"Failed to delete table from priority queue",
 					zap.Error(err),
-					zap.String("db", dbInfo.Name.O),
+					zap.String("db", miniDBInfo.Name.O),
 					zap.Int64("tableID", tbl.ID),
 					zap.String("tableName", tbl.Name.O),
 					zap.Int64("partitionID", partition.ID),
@@ -433,7 +433,7 @@ func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, eve
 			statslogutil.StatsLogger().Error(
 				"Failed to delete table from priority queue",
 				zap.Error(err),
-				zap.String("db", dbInfo.Name.O),
+				zap.String("db", miniDBInfo.Name.O),
 				zap.Int64("tableID", tbl.ID),
 				zap.String("tableName", tbl.Name.O),
 			)

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler_test.go
@@ -740,6 +740,127 @@ func TestRemovePartitioning(t *testing.T) {
 	require.True(t, isEmpty)
 }
 
+func TestDropSchemaEventWithDynamicPartition(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t (c1 int, c2 int, index idx(c1, c2)) partition by range columns (c1) (partition p0 values less than (5), partition p1 values less than (10))")
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), pmodel.NewCIStr("test"), pmodel.NewCIStr("t"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	h := do.StatsHandle()
+	// Analyze table.
+	testKit.MustExec("analyze table t")
+	require.NoError(t, h.Update(context.Background(), do.InfoSchema()))
+	// Insert some data.
+	testKit.MustExec("insert into t values (1,2),(2,2)")
+	require.NoError(t, h.DumpStatsDeltaToKV(true))
+	require.NoError(t, h.Update(context.Background(), do.InfoSchema()))
+	// Create a non-partitioned table.
+	testKit.MustExec("create table t2 (c1 int, c2 int, index idx(c1, c2))")
+	testKit.MustExec("analyze table t2")
+	require.NoError(t, h.Update(context.Background(), do.InfoSchema()))
+	// Insert some data.
+	testKit.MustExec("insert into t2 values (1,2),(2,2)")
+	require.NoError(t, h.DumpStatsDeltaToKV(true))
+	require.NoError(t, h.Update(context.Background(), do.InfoSchema()))
+
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = 1000
+	}()
+
+	pq := priorityqueue.NewAnalysisPriorityQueue(h)
+	defer pq.Close()
+	require.NoError(t, pq.Initialize())
+	isEmpty, err := pq.IsEmpty()
+	require.NoError(t, err)
+	require.False(t, isEmpty)
+	job, err := pq.Peek()
+	require.NoError(t, err)
+	require.Equal(t, tableInfo.ID, job.GetTableID())
+	len, err := pq.Len()
+	require.NoError(t, err)
+	require.Equal(t, len, 2)
+
+	// Drop schema.
+	testKit.MustExec("drop database test")
+
+	// Find the drop schema event.
+	dropSchemaEvent := findEvent(h.DDLEventCh(), model.ActionDropSchema)
+	require.NotNil(t, dropSchemaEvent)
+
+	// Handle the drop schema event.
+	require.NoError(t, h.HandleDDLEvent(dropSchemaEvent))
+
+	ctx := context.Background()
+	require.NoError(t, statsutil.CallWithSCtx(
+		h.SPool(),
+		func(sctx sessionctx.Context) error {
+			require.NoError(t, pq.HandleDDLEvent(ctx, sctx, dropSchemaEvent))
+			return nil
+		}, statsutil.FlagWrapTxn),
+	)
+
+	// The table should be removed from the priority queue.
+	isEmpty, err = pq.IsEmpty()
+	require.NoError(t, err)
+	require.True(t, isEmpty)
+}
+
+func TestDropSchemaEventWithStaticPartition(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t (c1 int, c2 int, index idx(c1, c2)) partition by range columns (c1) (partition p0 values less than (5), partition p1 values less than (10))")
+	testKit.MustExec("set global tidb_partition_prune_mode='static'")
+	h := do.StatsHandle()
+	// Insert some data.
+	testKit.MustExec("insert into t values (1,2),(6,6)")
+	require.NoError(t, h.DumpStatsDeltaToKV(true))
+	require.NoError(t, h.Update(context.Background(), do.InfoSchema()))
+
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = 1000
+	}()
+
+	pq := priorityqueue.NewAnalysisPriorityQueue(h)
+	defer pq.Close()
+	require.NoError(t, pq.Initialize())
+	isEmpty, err := pq.IsEmpty()
+	require.NoError(t, err)
+	require.False(t, isEmpty)
+	len, err := pq.Len()
+	require.NoError(t, err)
+	require.Equal(t, len, 2)
+
+	// Drop schema.
+	testKit.MustExec("drop database test")
+
+	// Find the drop schema event.
+	dropSchemaEvent := findEvent(h.DDLEventCh(), model.ActionDropSchema)
+	require.NotNil(t, dropSchemaEvent)
+
+	// Handle the drop schema event.
+	require.NoError(t, h.HandleDDLEvent(dropSchemaEvent))
+
+	ctx := context.Background()
+	require.NoError(t, statsutil.CallWithSCtx(
+		h.SPool(),
+		func(sctx sessionctx.Context) error {
+			require.NoError(t, pq.HandleDDLEvent(ctx, sctx, dropSchemaEvent))
+			return nil
+		}, statsutil.FlagWrapTxn),
+	)
+
+	// The table should be removed from the priority queue.
+	isEmpty, err = pq.IsEmpty()
+	require.NoError(t, err)
+	require.True(t, isEmpty)
+}
+
 const tiflashReplicaLease = 600 * time.Millisecond
 
 func TestVectorIndexTriggerAutoAnalyze(t *testing.T) {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler_test.go
@@ -780,9 +780,9 @@ func TestDropSchemaEventWithDynamicPartition(t *testing.T) {
 	job, err := pq.Peek()
 	require.NoError(t, err)
 	require.Equal(t, tableInfo.ID, job.GetTableID())
-	len, err := pq.Len()
+	l, err := pq.Len()
 	require.NoError(t, err)
-	require.Equal(t, len, 2)
+	require.Equal(t, l, 2)
 
 	// Drop schema.
 	testKit.MustExec("drop database test")
@@ -832,9 +832,9 @@ func TestDropSchemaEventWithStaticPartition(t *testing.T) {
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
-	len, err := pq.Len()
+	l, err := pq.Len()
 	require.NoError(t, err)
-	require.Equal(t, len, 2)
+	require.Equal(t, l, 2)
 
 	// Drop schema.
 	testKit.MustExec("drop database test")

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -181,7 +181,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(s *notifier.SchemaChangeEvent) error {
 	case model.ActionAddIndex:
 		// No need to update the stats meta for the adding index event.
 	case model.ActionDropSchema:
-		// No need to update the stats meta for the drop schema event.
+		// TODO: handle the drop schema event.
 	default:
 		intest.Assert(false)
 		logutil.StatsLogger().Error("Unhandled schema change event", zap.Stringer("type", s))

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -180,6 +180,8 @@ func (h *ddlHandlerImpl) HandleDDLEvent(s *notifier.SchemaChangeEvent) error {
 		return h.statsWriter.UpdateStatsVersion()
 	case model.ActionAddIndex:
 		// No need to update the stats meta for the adding index event.
+	case model.ActionDropSchema:
+		// No need to update the stats meta for the drop schema event.
 	default:
 		intest.Assert(false)
 		logutil.StatsLogger().Error("Unhandled schema change event", zap.Stringer("type", s))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/57227

Problem Summary:

### What changed and how does it work?

We forget to handle the drop schema event in the PQ. So in this PR, we used the DDL notifier to deliver the drop schema event to the PQ. In the PQ, we try to delete the table jobs for the tables that come from this schema.

To avoid a transition that is too large, I created some mini-structs to include only the essential information for the schema event.

I also split the job into smaller jobs so that the subscriber can avoid performing a bulk update.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
