### PR TITLE
realtikvtest/sessiontest: fix data race for test TestGetTSFailDirtyState

### DIFF
--- a/tests/realtikvtest/sessiontest/session_fail_test.go
+++ b/tests/realtikvtest/sessiontest/session_fail_test.go
@@ -65,10 +65,13 @@ func TestGetTSFailDirtyState(t *testing.T) {
 	ctx := failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
 		return fpname == "github.com/pingcap/tidb/pkg/session/mockGetTSFail"
 	})
-	_, err := tk.Session().Execute(ctx, "select * from t")
+	rss, err := tk.Session().Execute(ctx, "select * from t")
 	if config.GetGlobalConfig().Store == "unistore" {
 		require.Error(t, err)
 	} else {
+		for _, rs := range rss {
+			rs.Close()
+		}
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57221

Problem Summary:

### What changed and how does it work?

- Why there is a DATA RACE?

Because there are some goroutine resource leak.
And the leaked background goroutine conflict with the main goroutine when executing the next SQL statement.

- Why the test code cause resource leak?

As you can see, for unistore and real tikv, the behaviour differs.
The failpoint cause error on unistore, but it success on tikv.
Then, on the real tikv case, the code is not rubost, it forget to close the result when the SQL actually success.

https://github.com/pingcap/tidb/blob/1770006c2e8f40bcc79068e8d8210de0768a8b83/tests/realtikvtest/sessiontest/session_fail_test.go#L68-L73

- So why the behaviour differs on real tikv and unistore?

Here, when we use the failpoint mock, we return error on unistore.
But for real tikv, we don't know whether it's a real error, we just retry the get tso operation to make the produce resistent to some failures.  It's better to keep that behavior.

https://github.com/pingcap/tidb/blob/1770006c2e8f40bcc79068e8d8210de0768a8b83/pkg/session/txn.go#L675-L677


### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
