### PR TITLE
planner: fix cannot binding for deleting multi table with alias 

### DIFF
--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -281,7 +281,11 @@ type TableName struct {
 	PartitionNames []model.CIStr
 	TableSample    *TableSample
 	// AS OF is used to see the data as it was at a specific point in time.
-	AsOf    *AsOfClause
+	AsOf *AsOfClause
+	// IsAlias is true if this table name is an alias.
+	//  sometime, we need to distinguish the table name is an alias or not.
+	//   for example ```delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id```
+	//   ```tt1``` is a alias name. so we need to set IsAlias to true and restore the table name without database name.
 	IsAlias bool
 }
 

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -281,7 +281,8 @@ type TableName struct {
 	PartitionNames []model.CIStr
 	TableSample    *TableSample
 	// AS OF is used to see the data as it was at a specific point in time.
-	AsOf *AsOfClause
+	AsOf    *AsOfClause
+	IsAlias bool
 }
 
 func (*TableName) resultSet() {}
@@ -293,7 +294,7 @@ func (n *TableName) restoreName(ctx *format.RestoreCtx) {
 		if n.Schema.String() != "" {
 			ctx.WriteName(n.Schema.String())
 			ctx.WritePlain(".")
-		} else if ctx.DefaultDB != "" {
+		} else if ctx.DefaultDB != "" && !n.IsAlias {
 			// Try CTE, for a CTE table name, we shouldn't write the database name.
 			if !ctx.IsCTETableName(n.Name.L) {
 				ctx.WriteName(ctx.DefaultDB)

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1997,7 +1997,7 @@ func (p *preprocessor) skipLockMDL() bool {
 // aliasChecker is used to check the alias of the table in delete statement.
 //
 //	for example: delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id
-//	  `delete tt1```` will be transfer to `delete current_database.t1` in default.
+//	  `delete tt1` will be transformed to `delete current_database.t1` by default.
 //	   because `tt1` cannot be used as alias in delete statement.
 //	   so we have to set `tt1` as alias by aliasChecker.
 type aliasChecker struct{}

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -571,7 +571,9 @@ func (p *preprocessor) checkBindGrammar(originNode, hintedNode ast.StmtNode, def
 			TableInfo: tableInfo,
 		})
 	}
-
+	aliasChecker := &aliasChecker{}
+	originNode.Accept(aliasChecker)
+	hintedNode.Accept(aliasChecker)
 	originSQL := parser.NormalizeForBinding(utilparser.RestoreWithDefaultDB(originNode, defaultDB, originNode.Text()), false)
 	hintedSQL := parser.NormalizeForBinding(utilparser.RestoreWithDefaultDB(hintedNode, defaultDB, hintedNode.Text()), false)
 	if originSQL != hintedSQL {
@@ -1990,4 +1992,60 @@ func (p *preprocessor) skipLockMDL() bool {
 	// because it's a batch process and will do both DML and DDL.
 	// skip lock mdl for ANALYZE statement.
 	return p.flag&inImportInto > 0 || p.flag&inAnalyze > 0
+}
+
+// aliasChecker is used to check the alias of the table in delete statement.
+//
+//	for example: delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id
+//	  `delete tt1```` will be transfer to `delete current_database.t1` in default.
+//	   because `tt1` cannot be used as alias in delete statement.
+//	   so we have to set `tt1` as alias by aliasChecker.
+type aliasChecker struct{}
+
+func (*aliasChecker) Enter(in ast.Node) (ast.Node, bool) {
+	if deleteStmt, ok := in.(*ast.DeleteStmt); ok {
+		// 1. check the tableRefs of deleteStmt to find the alias
+		var aliases []*pmodel.CIStr
+		if deleteStmt.TableRefs != nil && deleteStmt.TableRefs.TableRefs != nil {
+			tableRefs := deleteStmt.TableRefs.TableRefs
+			if val := getTableRefsAlias(tableRefs.Left); val != nil {
+				aliases = append(aliases, val)
+			}
+			if val := getTableRefsAlias(tableRefs.Right); val != nil {
+				aliases = append(aliases, val)
+			}
+		}
+		// 2. check the Tables to tag the alias
+		if deleteStmt.Tables != nil && deleteStmt.Tables.Tables != nil {
+			for _, table := range deleteStmt.Tables.Tables {
+				if table.Schema.String() != "" {
+					continue
+				}
+				for _, alias := range aliases {
+					if table.Name.L == alias.L {
+						table.IsAlias = true
+						break
+					}
+				}
+			}
+		}
+		return in, true
+	}
+	return in, false
+}
+
+func getTableRefsAlias(tableRefs ast.ResultSetNode) *pmodel.CIStr {
+	switch v := tableRefs.(type) {
+	case *ast.Join:
+		if v.Left != nil {
+			return getTableRefsAlias(v.Left)
+		}
+	case *ast.TableSource:
+		return &v.AsName
+	}
+	return nil
+}
+
+func (*aliasChecker) Leave(in ast.Node) (ast.Node, bool) {
+	return in, true
 }

--- a/pkg/planner/core/preprocess_test.go
+++ b/pkg/planner/core/preprocess_test.go
@@ -414,3 +414,14 @@ func TestPreprocessCTE(t *testing.T) {
 		require.Equal(t, tc.after, rs.String())
 	}
 }
+
+func TestPreprocessDeleteFromWithAlias(t *testing.T) {
+	// https://github.com/pingcap/tidb/issues/56726
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(id int);")
+	tk.MustExec(" create table t2(id int);")
+	tk.MustExec("delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id;")
+	tk.MustExec("create global binding for delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id using delete /*+ MAX_EXECUTION_TIME(10)*/ tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id;")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56726 

Problem Summary:

### What changed and how does it work?

```delete tt1 from t1 tt1,(select max(id) id from t2)tt2 where tt1.id<=tt2.id```
```delete tt1``` will be transfer to ```delete current_database.t1``` in default when to deal with the statsment in the ```create binding```.
 because ```tt1``` cannot be used as alias in delete statement.
 so we have to set ```tt1``` as alias by aliasChecker.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix cannot binding for deleting multi table with alias

修复无法为带别名的多表删除进行 binding 的问题
```
