### PR TITLE
statistics: wrong NDV when to merge global stats with index

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -1289,7 +1289,7 @@ func (h *Handle) indexStatsFromStorage(reader *statsReader, row chunk.Row, table
 		if histID != idxInfo.ID {
 			continue
 		}
-		if idx == nil || idx.LastUpdateVersion < histVer {
+		if idx == nil || idx.LastUpdateVersion < histVer || loadAll {
 			hg, err := h.histogramFromStorage(reader, table.PhysicalID, histID, types.NewFieldType(mysql.TypeBlob), distinct, 1, histVer, nullCount, 0, 0)
 			if err != nil {
 				return errors.Trace(err)

--- a/statistics/handle/handle_hist_test.go
+++ b/statistics/handle/handle_hist_test.go
@@ -331,3 +331,66 @@ func TestRetry(t *testing.T) {
 	}
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/statistics/handle/mockReadStatsForOneFail"))
 }
+
+func TestMergeGlobalStatsIndex(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE employees3 (
+  emp_id int(11) NOT NULL,
+  emp_name varchar(25) NOT NULL,
+  salary int(11) NOT NULL,
+  dept_id int(11) NOT NULL,
+  PRIMARY KEY (emp_id) /*T![clustered_index] NONCLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE (emp_id)
+(
+  PARTITION p0 VALUES LESS THAN (1000),
+  PARTITION p1 VALUES LESS THAN (4000),
+  PARTITION p2 VALUES LESS THAN (12000),
+  PARTITION p3 VALUES LESS THAN (16000),
+  PARTITION p4 VALUES LESS THAN (20000),
+  PARTITION p5 VALUES LESS THAN (25000),
+  PARTITION p6 VALUES LESS THAN (30000),
+  PARTITION p7 VALUES LESS THAN (35000),
+  PARTITION p8 VALUES LESS THAN (40000),
+  PARTITION p9 VALUES LESS THAN (45000),
+  PARTITION p10 VALUES LESS THAN (50000),
+  PARTITION p11 VALUES LESS THAN (55000),
+  PARTITION p12 VALUES LESS THAN (65000),
+  PARTITION p13 VALUES LESS THAN (75000),
+  PARTITION p14 VALUES LESS THAN (85000),
+  PARTITION p15 VALUES LESS THAN (95000),
+  PARTITION p16 VALUES LESS THAN (105000),
+  PARTITION p17 VALUES LESS THAN (115000),
+  PARTITION p18 VALUES LESS THAN (125000),
+  PARTITION pmax VALUES LESS THAN (MAXVALUE)
+);`)
+	tk.MustExec(`
+SET cte_max_recursion_depth = 1000000000;
+INSERT INTO employees3
+WITH RECURSIVE EmployeeGenerator AS (
+    SELECT
+        101 AS emp_id,
+        'Emp00001' AS emp_name,
+        FLOOR(RAND() * (150000 - 50000) + 50000) AS salary,
+        FLOOR(RAND() * 3 + 1) AS dept_id
+    UNION ALL
+    SELECT
+        emp_id + 1,
+        CONCAT('Emp', LPAD(CAST(emp_id - 100 AS CHAR), 5, '0')),
+        FLOOR(RAND() * (150000 - 50000) + 50000),
+        FLOOR(RAND() * 3 + 1)
+    FROM
+        EmployeeGenerator
+    WHERE
+        emp_id < 20100
+)
+SELECT * FROM EmployeeGenerator;
+`)
+	tk.MustExec("analyze table employees3")
+	tk.MustExec("analyze table employees3 partition p12")
+	tk.MustQuery("show stats_histograms where table_name='employees3' and Column_name='PRIMARY' and Partition_name='global'").CheckContain("19958")
+	tk.MustExec("analyze table employees3 partition p1")
+	tk.MustQuery("show stats_histograms where table_name='employees3' and Column_name='PRIMARY' and Partition_name='global'").CheckContain("19958")
+}

--- a/statistics/handle/handle_hist_test.go
+++ b/statistics/handle/handle_hist_test.go
@@ -389,8 +389,8 @@ WITH RECURSIVE EmployeeGenerator AS (
 SELECT * FROM EmployeeGenerator;
 `)
 	tk.MustExec("analyze table employees3")
-	tk.MustExec("analyze table employees3 partition p12")
-	tk.MustQuery("show stats_histograms where table_name='employees3' and Column_name='PRIMARY' and Partition_name='global'").CheckContain("19958")
-	tk.MustExec("analyze table employees3 partition p1")
-	tk.MustQuery("show stats_histograms where table_name='employees3' and Column_name='PRIMARY' and Partition_name='global'").CheckContain("19958")
+	for i := 0; i <= 12; i++ {
+		tk.MustExec("analyze table employees3 partition p" + string(i))
+		tk.MustQuery("show stats_histograms where table_name='employees3' and Column_name='PRIMARY' and Partition_name='global'").CheckContain("19958")
+	}
 }

--- a/statistics/handle/handle_hist_test.go
+++ b/statistics/handle/handle_hist_test.go
@@ -15,6 +15,7 @@
 package handle_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -390,7 +391,7 @@ SELECT * FROM EmployeeGenerator;
 `)
 	tk.MustExec("analyze table employees3")
 	for i := 0; i <= 12; i++ {
-		tk.MustExec("analyze table employees3 partition p" + string(i))
+		tk.MustExec(fmt.Sprintf("analyze table employees3 partition p%d", i))
 		tk.MustQuery("show stats_histograms where table_name='employees3' and Column_name='PRIMARY' and Partition_name='global'").CheckContain("19958")
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57264

Problem Summary:

### What changed and how does it work?

when we read stats for merge global stats, we forget to force to load fm skretch. so it will lead wrong NDV.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
