### PR TITLE
executor: fix random cte error under apply

### DIFF
--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -90,16 +90,16 @@ func (e *CTEExec) Open(ctx context.Context) (err error) {
 	defer e.producer.resTbl.Unlock()
 
 	if e.producer.checkAndUpdateCorColHashCode() {
-		e.producer.reset()
-		if err = e.producer.reopenTbls(); err != nil {
+		err = e.producer.reset()
+		if err != nil {
 			return err
 		}
 	}
 	if e.producer.openErr != nil {
 		return e.producer.openErr
 	}
-	if !e.producer.opened {
-		if err = e.producer.openProducer(ctx, e); err != nil {
+	if !e.producer.hasCTEResult() && !e.producer.executorOpened {
+		if err = e.producer.openProducerExecutor(ctx, e); err != nil {
 			return err
 		}
 	}
@@ -110,14 +110,14 @@ func (e *CTEExec) Open(ctx context.Context) (err error) {
 func (e *CTEExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	e.producer.resTbl.Lock()
 	defer e.producer.resTbl.Unlock()
-	if !e.producer.resTbl.Done() {
-		// in case that another CTEExec call close without calling Next().
-		if !e.producer.opened {
-			if err = e.producer.openProducer(ctx, e); err != nil {
+	if !e.producer.hasCTEResult() {
+		// in case that another CTEExec call close without generate CTE result.
+		if !e.producer.executorOpened {
+			if err = e.producer.openProducerExecutor(ctx, e); err != nil {
 				return err
 			}
 		}
-		if err = e.producer.produce(ctx); err != nil {
+		if err = e.producer.genCTEResult(ctx); err != nil {
 			return err
 		}
 	}
@@ -139,7 +139,7 @@ func (e *CTEExec) Close() (firstErr error) {
 	func() {
 		e.producer.resTbl.Lock()
 		defer e.producer.resTbl.Unlock()
-		if e.producer.opened {
+		if e.producer.executorOpened {
 			failpoint.Inject("mock_cte_exec_panic_avoid_deadlock", func(v failpoint.Value) {
 				ok := v.(bool)
 				if ok {
@@ -147,15 +147,16 @@ func (e *CTEExec) Close() (firstErr error) {
 					panic(exeerrors.ErrMemoryExceedForQuery)
 				}
 			})
-			// closeProducer() only close seedExec and recursiveExec, will not touch resTbl.
-			// It means you can still read resTbl after call closeProducer().
-			// You can even call all three functions(openProducer/produce/closeProducer) in CTEExec.Next().
+			// closeProducerExecutor() only close seedExec and recursiveExec, will not touch resTbl.
+			// It means you can still read resTbl after call closeProducerExecutor().
+			// You can even call all three functions(openProducerExecutor/genCTEResult/closeProducerExecutor) in CTEExec.Next().
 			// Separating these three function calls is only to follow the abstraction of the volcano model.
-			err := e.producer.closeProducer()
+			err := e.producer.closeProducerExecutor()
 			firstErr = setFirstErr(firstErr, err, "close cte producer error")
-			if !e.producer.resTbl.Done() {
-				// `produce` is not called, in this case, we reset it
-				e.producer.reset()
+			if !e.producer.hasCTEResult() {
+				// CTE result is not generated, in this case, we reset it
+				err = e.producer.reset()
+				firstErr = setFirstErr(firstErr, err, "close cte producer error")
 			}
 		}
 	}()
@@ -171,8 +172,10 @@ func (e *CTEExec) reset() {
 }
 
 type cteProducer struct {
-	// opened should be false when not open or open fail(a.k.a. openErr != nil)
-	opened bool
+	// executorOpened is used to indicate whether the executor(seedExec/recursiveExec) is opened.
+	// when executorOpened is true, the executor is opened, otherwise it means the executor is
+	// not opened or is already closed.
+	executorOpened bool
 
 	// cteProducer is shared by multiple operators, so if the first operator tries to open
 	// and got error, the second should return open error directly instead of open again.
@@ -211,10 +214,10 @@ type cteProducer struct {
 	corColHashCodes [][]byte
 }
 
-func (p *cteProducer) openProducer(ctx context.Context, cteExec *CTEExec) (err error) {
+func (p *cteProducer) openProducerExecutor(ctx context.Context, cteExec *CTEExec) (err error) {
 	defer func() {
 		p.openErr = err
-		p.opened = true
+		p.executorOpened = true
 	}()
 	if p.seedExec == nil {
 		return errors.New("seedExec for CTEExec is nil")
@@ -257,7 +260,7 @@ func (p *cteProducer) openProducer(ctx context.Context, cteExec *CTEExec) (err e
 	return nil
 }
 
-func (p *cteProducer) closeProducer() (firstErr error) {
+func (p *cteProducer) closeProducerExecutor() (firstErr error) {
 	err := exec.Close(p.seedExec)
 	firstErr = setFirstErr(firstErr, err, "close seedExec err")
 
@@ -276,6 +279,7 @@ func (p *cteProducer) closeProducer() (firstErr error) {
 	// because ExplainExec still needs tracker to get mem usage info.
 	p.memTracker = nil
 	p.diskTracker = nil
+	p.executorOpened = false
 	return
 }
 
@@ -342,7 +346,13 @@ func (p *cteProducer) nextChunkLimit(cteExec *CTEExec, req *chunk.Chunk) error {
 	return nil
 }
 
-func (p *cteProducer) produce(ctx context.Context) (err error) {
+func (p *cteProducer) hasCTEResult() bool {
+	return p.resTbl.Done()
+}
+
+// genCTEResult generates the result of CTE, and stores the result in resTbl.
+// This is a synchronous function, which means it will block until the result is generated.
+func (p *cteProducer) genCTEResult(ctx context.Context) (err error) {
 	if p.resTbl.Error() != nil {
 		return p.resTbl.Error()
 	}
@@ -535,12 +545,16 @@ func (p *cteProducer) setupTblsForNewIteration() (err error) {
 	return nil
 }
 
-func (p *cteProducer) reset() {
+func (p *cteProducer) reset() error {
 	p.curIter = 0
 	p.hashTbl = nil
-
-	p.opened = false
+	p.executorOpened = false
 	p.openErr = nil
+
+	if err := p.reopenTbls(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p *cteProducer) resetTracker() {
@@ -559,7 +573,7 @@ func (p *cteProducer) reopenTbls() (err error) {
 		p.hashTbl = join.NewConcurrentMapHashTable()
 	}
 	// Normally we need to setup tracker after calling Reopen(),
-	// But reopen resTbl means we need to call produce() again, it will setup tracker.
+	// But reopen resTbl means we need to call genCTEResult() again, it will setup tracker.
 	if err := p.resTbl.Reopen(); err != nil {
 		return err
 	}

--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -139,8 +139,7 @@ func (e *CTEExec) Close() (firstErr error) {
 	func() {
 		e.producer.resTbl.Lock()
 		defer e.producer.resTbl.Unlock()
-		// if producer is opened, close it.
-		if e.producer.opened && !e.producer.closed {
+		if !e.producer.closed {
 			failpoint.Inject("mock_cte_exec_panic_avoid_deadlock", func(v failpoint.Value) {
 				ok := v.(bool)
 				if ok {
@@ -155,7 +154,7 @@ func (e *CTEExec) Close() (firstErr error) {
 			err := e.producer.closeProducer()
 			firstErr = setFirstErr(firstErr, err, "close cte producer error")
 			if !e.producer.resTbl.Done() {
-				// `produce` is never called, in this case, we reset it
+				// `produce` is not called, in this case, we reset it
 				e.producer.reset()
 			}
 		}

--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -139,7 +139,8 @@ func (e *CTEExec) Close() (firstErr error) {
 	func() {
 		e.producer.resTbl.Lock()
 		defer e.producer.resTbl.Unlock()
-		if !e.producer.closed {
+		// if producer is opened, close it.
+		if e.producer.opened && !e.producer.closed {
 			failpoint.Inject("mock_cte_exec_panic_avoid_deadlock", func(v failpoint.Value) {
 				ok := v.(bool)
 				if ok {

--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -569,9 +569,6 @@ func (p *cteProducer) resetTracker() {
 }
 
 func (p *cteProducer) reopenTbls() (err error) {
-	if p.isDistinct {
-		p.hashTbl = join.NewConcurrentMapHashTable()
-	}
 	// Normally we need to setup tracker after calling Reopen(),
 	// But reopen resTbl means we need to call genCTEResult() again, it will setup tracker.
 	if err := p.resTbl.Reopen(); err != nil {

--- a/pkg/executor/cte.go
+++ b/pkg/executor/cte.go
@@ -551,10 +551,12 @@ func (p *cteProducer) reset() error {
 	p.executorOpened = false
 	p.openErr = nil
 
-	if err := p.reopenTbls(); err != nil {
+	// Normally we need to setup tracker after calling Reopen(),
+	// But reopen resTbl means we need to call genCTEResult() again, it will setup tracker.
+	if err := p.resTbl.Reopen(); err != nil {
 		return err
 	}
-	return nil
+	return p.iterInTbl.Reopen()
 }
 
 func (p *cteProducer) resetTracker() {
@@ -566,15 +568,6 @@ func (p *cteProducer) resetTracker() {
 		p.diskTracker.Reset()
 		p.diskTracker = nil
 	}
-}
-
-func (p *cteProducer) reopenTbls() (err error) {
-	// Normally we need to setup tracker after calling Reopen(),
-	// But reopen resTbl means we need to call genCTEResult() again, it will setup tracker.
-	if err := p.resTbl.Reopen(); err != nil {
-		return err
-	}
-	return p.iterInTbl.Reopen()
 }
 
 // Check if tbl meets the requirement of limit.

--- a/pkg/executor/test/issuetest/BUILD.bazel
+++ b/pkg/executor/test/issuetest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 23,
+    shard_count = 24,
     deps = [
         "//pkg/autoid_service",
         "//pkg/config",

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -758,9 +758,9 @@ func TestIssue55881(t *testing.T) {
 	tk.MustExec("insert into bbb values(1,2),(2,3),(3,4)")
 	// set tidb_executor_concurrency to 1 to let the issue happens with high probability.
 	tk.MustExec("set tidb_executor_concurrency=1;")
-	// this is a random issue, so run it 20 times to increase the probability of the issue.
-	for i := 0; i < 20; i++ {
-		tk.MustQuery("with cte as (select * from aaa) select id, (select id from (select * from aaa where aaa.id != bbb.id union all select * from cte) d limit 1)," +
-			"(select max(value) from (select * from cte union all select * from aaa where aaa.id > bbb.id)) from bbb;")
+	// this is a random issue, so run it 100 times to increase the probability of the issue.
+	for i := 0; i < 100; i++ {
+		tk.MustQuery("with cte as (select * from aaa) select id, (select id from (select * from aaa where aaa.id != bbb.id union all select * from cte union all select * from cte) d limit 1)," +
+			"(select max(value) from (select * from cte union all select * from cte union all select * from aaa where aaa.id > bbb.id)) from bbb;")
 	}
 }

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -745,3 +745,22 @@ func TestCalculateBatchSize(t *testing.T) {
 	require.Equal(t, 258, executor.CalculateBatchSize(10, 1024, 258))
 	require.Equal(t, 1024, executor.CalculateBatchSize(0, 1024, 20000))
 }
+
+func TestIssue55881(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists aaa;")
+	tk.MustExec("drop table if exists bbb;")
+	tk.MustExec("create table aaa(id int, value int);")
+	tk.MustExec("create table bbb(id int, value int);")
+	tk.MustExec("insert into aaa values(1,2),(2,3)")
+	tk.MustExec("insert into bbb values(1,2),(2,3),(3,4)")
+	// set tidb_executor_concurrency to 1 to let the issue happens with high probability.
+	tk.MustExec("set tidb_executor_concurrency=1;")
+	// this is a random issue, so run it 20 times to increase the probability of the issue.
+	for i := 0; i < 20; i++ {
+		tk.MustQuery("with cte as (select * from aaa) select id, (select id from (select * from aaa where aaa.id != bbb.id union all select * from cte) d limit 1)," +
+			"(select max(value) from (select * from cte union all select * from aaa where aaa.id > bbb.id)) from bbb;")
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55881

Problem Summary:
The root cause is described in https://github.com/pingcap/tidb/issues/55881#issuecomment-2348366506

This pr fix it by 
1. when close the cte producer, check if `e.producer.resTbl.Done()` is false, which means the producer is opened without produce, in this case, close will reset the cte producer
2. before produce the cte producer, double check if it is already opened, if not, then open the cte producer before actually produce it.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
