### PR TITLE
table: fix the issue that the default value for `BIT` column is wrong | tidb-test=pr/2424

### DIFF
--- a/tests/integrationtest/r/ddl/column.result
+++ b/tests/integrationtest/r/ddl/column.result
@@ -84,3 +84,15 @@ t	CREATE TABLE `t` (
   `a` decimal(10,0) DEFAULT NULL,
   `b` decimal(10,0) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists t;
+create table t(a bit(2) default b'111');
+Error 1067 (42000): Invalid default value for 'a'
+create table t(a bit(65) default b'111');
+Error 1439 (42000): Display width out of range for column 'a' (max = 64)
+create table t(a bit(64) default b'1111111111111111111111111111111111111111111111111111111111111111');
+drop table t;
+create table t(a bit(3) default b'111');
+drop table t;
+create table t(a bit(3) default b'000111');
+drop table t;
+create table t(a bit(32) default b'1111111111111111111111111111111');

--- a/tests/integrationtest/r/table/tables.result
+++ b/tests/integrationtest/r/table/tables.result
@@ -24,3 +24,9 @@ select count(distinct(_tidb_rowid>>48)) from shard_t;
 count(distinct(_tidb_rowid>>48))
 3
 set @@tidb_shard_allocate_step=default;
+drop table if exists t;
+create table t(a bit(32) default b'1100010001001110011000100100111');
+insert into t values ();
+select hex(a) from t;
+hex(a)
+62273127

--- a/tests/integrationtest/t/ddl/column.test
+++ b/tests/integrationtest/t/ddl/column.test
@@ -44,3 +44,17 @@ alter table t1 add column d date default '2024-10';
 drop table if exists t;
 create table t(a decimal(0,0), b decimal(0));
 show create table t;
+
+# TestTooLongDefaultValueForBit
+drop table if exists t;
+-- error 1067
+create table t(a bit(2) default b'111');
+-- error 1439
+create table t(a bit(65) default b'111');
+create table t(a bit(64) default b'1111111111111111111111111111111111111111111111111111111111111111');
+drop table t;
+create table t(a bit(3) default b'111');
+drop table t;
+create table t(a bit(3) default b'000111');
+drop table t;
+create table t(a bit(32) default b'1111111111111111111111111111111');

--- a/tests/integrationtest/t/table/tables.test
+++ b/tests/integrationtest/t/table/tables.test
@@ -22,3 +22,9 @@ insert into shard_t values (12);
 select count(distinct(_tidb_rowid>>48)) from shard_t;
 
 set @@tidb_shard_allocate_step=default;
+
+# TestInsertBitDefaultValue
+drop table if exists t;
+create table t(a bit(32) default b'1100010001001110011000100100111');
+insert into t values ();
+select hex(a) from t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57301, close https://github.com/pingcap/tidb/issues/57312

Problem Summary:

1. The `CREATE TABLE` statement didn't assert whether the default value for `BIT` is valid.
2. The default value for `BIT` column is casted multiple times and may cause unexpected behavior.

### What changed and how does it work?

1. Revert part of #21310
2. Validate the length of `BIT` default value.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
