### PR TITLE
session: track LastCommitTS in SessionVars and check timestamps of later txns are larger

### DIFF
--- a/pkg/kv/interface_mock_test.go
+++ b/pkg/kv/interface_mock_test.go
@@ -75,6 +75,10 @@ func (t *mockTxn) StartTS() uint64 {
 	return uint64(0)
 }
 
+func (t *mockTxn) CommitTS() uint64 {
+	return 0
+}
+
 func (t *mockTxn) Get(ctx context.Context, k Key) ([]byte, error) {
 	return nil, nil
 }

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -251,7 +251,7 @@ type Transaction interface {
 	IsReadOnly() bool
 	// StartTS returns the transaction start timestamp.
 	StartTS() uint64
-	// CommitTS returns the transaction commit timestamp.
+	// CommitTS returns the transaction commit timestamp if it is committed; otherwise it returns 0.
 	CommitTS() uint64
 	// Valid returns if the transaction is valid.
 	// A transaction become invalid after commit or rollback.

--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -251,6 +251,8 @@ type Transaction interface {
 	IsReadOnly() bool
 	// StartTS returns the transaction start timestamp.
 	StartTS() uint64
+	// CommitTS returns the transaction commit timestamp.
+	CommitTS() uint64
 	// Valid returns if the transaction is valid.
 	// A transaction become invalid after commit or rollback.
 	Valid() bool

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -936,9 +936,8 @@ func (s *session) CommitTxn(ctx context.Context) error {
 				zap.String("sql", redact.String(s.sessionVars.EnableRedactLog, s.sessionVars.StmtCtx.OriginalSQL)),
 			)
 			return kv.ErrAssertionFailed
-		} else {
-			s.sessionVars.LastCommitTS = s.txn.lastCommitTS
 		}
+		s.sessionVars.LastCommitTS = s.txn.lastCommitTS
 	}
 
 	// record the TTLInsertRows in the metric

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -930,7 +930,7 @@ func (s *session) CommitTxn(ctx context.Context) error {
 	if err == nil && s.txn.lastCommitTS > 0 {
 		// lastCommitTS could be the same, e.g. when the txn is considered readonly
 		if s.txn.lastCommitTS < s.sessionVars.LastCommitTS {
-			logutil.BgLogger().Fatal("check lastCommitTS failed",
+			logutil.BgLogger().Panic("check lastCommitTS failed",
 				zap.Uint64("sessionLastCommitTS", s.sessionVars.LastCommitTS),
 				zap.Uint64("txnLastCommitTS", s.txn.lastCommitTS),
 				zap.String("sql", s.sessionVars.StmtCtx.OriginalSQL),

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -927,6 +927,19 @@ func (s *session) CommitTxn(ctx context.Context) error {
 		s.sessionVars.StmtCtx.MergeExecDetails(nil, commitDetail)
 	}
 
+	if err == nil && s.txn.lastCommitTS > 0 {
+		// lastCommitTS could be the same, e.g. when the txn is considered readonly
+		if s.txn.lastCommitTS < s.sessionVars.LastCommitTS {
+			logutil.BgLogger().Fatal("check lastCommitTS failed",
+				zap.Uint64("sessionLastCommitTS", s.sessionVars.LastCommitTS),
+				zap.Uint64("txnLastCommitTS", s.txn.lastCommitTS),
+				zap.String("sql", s.sessionVars.StmtCtx.OriginalSQL),
+			)
+		} else {
+			s.sessionVars.LastCommitTS = s.txn.lastCommitTS
+		}
+	}
+
 	// record the TTLInsertRows in the metric
 	metrics.TTLInsertRowsCount.Add(float64(s.sessionVars.TxnCtx.InsertTTLRowsCount))
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -933,7 +933,7 @@ func (s *session) CommitTxn(ctx context.Context) error {
 			logutil.BgLogger().Panic("check lastCommitTS failed",
 				zap.Uint64("sessionLastCommitTS", s.sessionVars.LastCommitTS),
 				zap.Uint64("txnLastCommitTS", s.txn.lastCommitTS),
-				zap.String("sql", s.sessionVars.StmtCtx.OriginalSQL),
+				zap.String("sql", redact.String(s.sessionVars.EnableRedactLog, s.sessionVars.StmtCtx.OriginalSQL)),
 			)
 		} else {
 			s.sessionVars.LastCommitTS = s.txn.lastCommitTS

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -930,11 +930,12 @@ func (s *session) CommitTxn(ctx context.Context) error {
 	if err == nil && s.txn.lastCommitTS > 0 {
 		// lastCommitTS could be the same, e.g. when the txn is considered readonly
 		if s.txn.lastCommitTS < s.sessionVars.LastCommitTS {
-			logutil.BgLogger().Panic("check lastCommitTS failed",
+			logutil.BgLogger().Error("check lastCommitTS failed",
 				zap.Uint64("sessionLastCommitTS", s.sessionVars.LastCommitTS),
 				zap.Uint64("txnLastCommitTS", s.txn.lastCommitTS),
 				zap.String("sql", redact.String(s.sessionVars.EnableRedactLog, s.sessionVars.StmtCtx.OriginalSQL)),
 			)
+			return kv.ErrAssertionFailed
 		} else {
 			s.sessionVars.LastCommitTS = s.txn.lastCommitTS
 		}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -935,7 +935,8 @@ func (s *session) CommitTxn(ctx context.Context) error {
 				zap.Uint64("txnLastCommitTS", s.txn.lastCommitTS),
 				zap.String("sql", redact.String(s.sessionVars.EnableRedactLog, s.sessionVars.StmtCtx.OriginalSQL)),
 			)
-			return kv.ErrAssertionFailed
+			return fmt.Errorf("txn commit_ts:%d is before session last_commit_ts:%d",
+				s.txn.lastCommitTS, s.sessionVars.LastCommitTS)
 		}
 		s.sessionVars.LastCommitTS = s.txn.lastCommitTS
 	}

--- a/pkg/session/test/txn/BUILD.bazel
+++ b/pkg/session/test/txn/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/config",
         "//pkg/kv",

--- a/pkg/session/test/txn/BUILD.bazel
+++ b/pkg/session/test/txn/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//pkg/util/dbterror/plannererrors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
+        "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//tikv",
         "@org_uber_go_goleak//:goleak",
     ],

--- a/pkg/session/test/txn/txn_test.go
+++ b/pkg/session/test/txn/txn_test.go
@@ -428,7 +428,7 @@ func TestCommitTSOrderCheck(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/mockFutureCommitTS", fmt.Sprintf("return(%d)", ts)))
 	tk.MustExec("insert into t values(123)")
 	_, err := tk.Exec("select * from t")
-	require.True(t, kv.ErrAssertionFailed.Equal(err))
+	require.Regexp(t, fmt.Sprintf(`start_ts:\d+ is before session last_commit_ts:%d`, ts), err.Error())
 }
 
 func TestMemBufferSnapshotRead(t *testing.T) {

--- a/pkg/session/test/txn/txn_test.go
+++ b/pkg/session/test/txn/txn_test.go
@@ -427,9 +427,8 @@ func TestCommitTSOrderCheck(t *testing.T) {
 	ts := oracle.GoTimeToTS(time.Now().Add(time.Minute))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/mockFutureCommitTS", fmt.Sprintf("return(%d)", ts)))
 	tk.MustExec("insert into t values(123)")
-	require.Panics(t, func() {
-		tk.Exec("select * from t")
-	})
+	_, err := tk.Exec("select * from t")
+	require.True(t, kv.ErrAssertionFailed.Equal(err))
 }
 
 func TestMemBufferSnapshotRead(t *testing.T) {

--- a/pkg/session/test/txn/txn_test.go
+++ b/pkg/session/test/txn/txn_test.go
@@ -424,10 +424,12 @@ func TestCommitTSOrderCheck(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t(id int)")
-	ts := oracle.GoTimeToTS(time.Now().Add(time.Minute))
+	currentTS, err := store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+	require.NoError(t, err)
+	ts := oracle.GoTimeToTS(oracle.GetTimeFromTS(currentTS).Add(time.Minute))
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/session/mockFutureCommitTS", fmt.Sprintf("return(%d)", ts)))
 	tk.MustExec("insert into t values(123)")
-	_, err := tk.Exec("select * from t")
+	_, err = tk.Exec("select * from t")
 	require.Regexp(t, fmt.Sprintf(`start_ts:\d+ is before session last_commit_ts:%d`, ts), err.Error())
 }
 

--- a/pkg/session/txn.go
+++ b/pkg/session/txn.go
@@ -437,6 +437,11 @@ func (txn *LazyTxn) Commit(ctx context.Context) error {
 	err := txn.Transaction.Commit(ctx)
 	if err == nil {
 		txn.lastCommitTS = txn.Transaction.CommitTS()
+		failpoint.Inject("mockFutureCommitTS", func(val failpoint.Value) {
+			if ts, ok := val.(int); ok {
+				txn.lastCommitTS = uint64(ts)
+			}
+		})
 	}
 	return err
 }

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -866,6 +866,9 @@ type SessionVars struct {
 	// SnapshotTS is used for reading history data. For simplicity, SnapshotTS only supports distsql request.
 	SnapshotTS uint64
 
+	// LastCommitTS is the commit_ts of the last successful transaction in this session.
+	LastCommitTS uint64
+
 	// TxnReadTS is used for staleness transaction, it provides next staleness transaction startTS.
 	TxnReadTS *TxnReadTS
 

--- a/pkg/sessiontxn/isolation/BUILD.bazel
+++ b/pkg/sessiontxn/isolation/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/table/temptable",
         "//pkg/tablecodec",
         "//pkg/util/logutil",
+        "//pkg/util/redact",
         "//pkg/util/tableutil",
         "//pkg/util/tracing",
         "@com_github_pingcap_errors//:errors",

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -273,6 +273,8 @@ func (p *baseTxnContextProvider) getTxnStartTS() (uint64, error) {
 	return txn.StartTS(), nil
 }
 
+// TODO: replace usePresetStartTS with a new method StartTSFromPD to make it clear that
+// the timestamp is not allocated by TSO.
 func (p *baseTxnContextProvider) usePresetStartTS() bool {
 	return p.constStartTS != 0 || p.sctx.GetSessionVars().SnapshotTS != 0
 }

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table/temptable"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/redact"
 	"github.com/pingcap/tidb/pkg/util/tableutil"
 	"github.com/pingcap/tidb/pkg/util/tracing"
 	tikvstore "github.com/tikv/client-go/v2/kv"
@@ -316,7 +317,7 @@ func (p *baseTxnContextProvider) ActivateTxn() (kv.Transaction, error) {
 		logutil.BgLogger().Panic("check session lastCommitTS failed",
 			zap.Uint64("lastCommitTS", sessVars.LastCommitTS),
 			zap.Uint64("startTS", sessVars.TxnCtx.StartTS),
-			zap.String("sql", sessVars.StmtCtx.OriginalSQL),
+			zap.String("sql", redact.String(sessVars.EnableRedactLog, sessVars.StmtCtx.OriginalSQL)),
 		)
 	}
 

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -16,6 +16,7 @@ package isolation
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -319,7 +320,8 @@ func (p *baseTxnContextProvider) ActivateTxn() (kv.Transaction, error) {
 			zap.Uint64("startTS", sessVars.TxnCtx.StartTS),
 			zap.String("sql", redact.String(sessVars.EnableRedactLog, sessVars.StmtCtx.OriginalSQL)),
 		)
-		return nil, kv.ErrAssertionFailed
+		return nil, fmt.Errorf("txn start_ts:%d is before session last_commit_ts:%d",
+			sessVars.TxnCtx.StartTS, sessVars.LastCommitTS)
 	}
 
 	txn.SetVars(sessVars.KVVars)

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -314,11 +314,12 @@ func (p *baseTxnContextProvider) ActivateTxn() (kv.Transaction, error) {
 
 	// verify start_ts is later than any previous commit_ts in the session
 	if !p.usePresetStartTS() && sessVars.LastCommitTS > 0 && sessVars.LastCommitTS > sessVars.TxnCtx.StartTS {
-		logutil.BgLogger().Panic("check session lastCommitTS failed",
+		logutil.BgLogger().Error("check session lastCommitTS failed",
 			zap.Uint64("lastCommitTS", sessVars.LastCommitTS),
 			zap.Uint64("startTS", sessVars.TxnCtx.StartTS),
 			zap.String("sql", redact.String(sessVars.EnableRedactLog, sessVars.StmtCtx.OriginalSQL)),
 		)
+		return nil, kv.ErrAssertionFailed
 	}
 
 	txn.SetVars(sessVars.KVVars)

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -309,7 +309,7 @@ func (p *baseTxnContextProvider) ActivateTxn() (kv.Transaction, error) {
 
 	// verify start_ts is later than any previous commit_ts in the session
 	if sessVars.LastCommitTS > 0 && sessVars.LastCommitTS > sessVars.TxnCtx.StartTS {
-		logutil.BgLogger().Fatal("check session lastCommitTS failed",
+		logutil.BgLogger().Panic("check session lastCommitTS failed",
 			zap.Uint64("lastCommitTS", sessVars.LastCommitTS),
 			zap.Uint64("startTS", sessVars.TxnCtx.StartTS),
 			zap.String("sql", sessVars.StmtCtx.OriginalSQL),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57165

Problem Summary:

This PR checks the invariant that timestamps of transactions in a session should increase monotonically.

It saves the timestamp of the last transaction in `SessionVars`, after the transaction is committed. The saved timestamp is compared with the `start_ts` and the `commit_ts` of the next transaction.

This PR depends on the TiKV client-go PR, https://github.com/tikv/client-go/pull/1489, which exports `commit_ts` of the transaction.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
