### PR TITLE
variable: session variable tidb_enable_commit_ts_order_check

### DIFF
--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -955,6 +955,9 @@ type SessionVars struct {
 	// Value set to `false` means never use mpp.
 	allowMPPExecution bool
 
+	// EnableCommitTSOrderCheck enables checking order of commit_ts for transactions within a session.
+	EnableCommitTSOrderCheck bool
+
 	// allowTiFlashCop means if we must use mpp way to execute query.
 	// Default value is `false`, means to be determined by the optimizer.
 	// Value set to `true` means we may fall back to TiFlash cop if possible.
@@ -2252,6 +2255,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 	vars.DMLBatchSize = DefDMLBatchSize
 	vars.AllowBatchCop = DefTiDBAllowBatchCop
 	vars.allowMPPExecution = DefTiDBAllowMPPExecution
+	vars.EnableCommitTSOrderCheck = DefTiDBEnableCommitTSOrderCheck
 	vars.HashExchangeWithNewCollation = DefTiDBHashExchangeWithNewCollation
 	vars.enforceMPPExecution = DefTiDBEnforceMPPExecution
 	vars.TiFlashMaxThreads = DefTiFlashMaxThreads

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1936,6 +1936,10 @@ var defaultSysVars = []*SysVar{
 		s.allowTiFlashCop = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeSession, Name: TiDBEnableCommitTSOrderCheck, Value: Off, Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnableCommitTSOrderCheck = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiFlashFastScan, Type: TypeBool, Value: BoolToOnOff(DefTiFlashFastScan), SetSession: func(s *SessionVars, val string) error {
 		s.TiFlashFastScan = TiDBOptOn(val)
 		return nil

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -791,6 +791,19 @@ func TestDefaultMemoryDebugModeValue(t *testing.T) {
 	require.Equal(t, val, "0")
 }
 
+func TestEnableCommitTSOrderCheck(t *testing.T) {
+	sv := GetSysVar(TiDBEnableCommitTSOrderCheck)
+	require.True(t, sv.HasSessionScope())
+	require.False(t, sv.HasGlobalScope())
+
+	vars := NewSessionVars(nil)
+	require.Equal(t, false, vars.EnableCommitTSOrderCheck)
+
+	err := sv.SetSession(vars, On)
+	require.NoError(t, err)
+	require.Equal(t, true, vars.EnableCommitTSOrderCheck)
+}
+
 func TestSetTIDBDistributeReorg(t *testing.T) {
 	vars := NewSessionVars(nil)
 	mock := NewMockGlobalAccessor4Tests()

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -402,6 +402,10 @@ const (
 	// Value set to `false` means never use mpp.
 	TiDBAllowMPPExecution = "tidb_allow_mpp"
 
+	// TiDBEnableCommitTSOrderCheck enables checking the order of commit_ts for transactions within a session.
+	// Default value is `false`, means not to check the order of commit_ts within a session.
+	TiDBEnableCommitTSOrderCheck = "tidb_enable_commit_ts_order_check"
+
 	// TiDBAllowTiFlashCop means we only use MPP mode to query data.
 	// Default value is `true`, means to be determined by the optimizer.
 	// Value set to `false` means we may fall back to TiFlash cop plan if possible.
@@ -1309,6 +1313,7 @@ const (
 	DefPreSplitRegions                      = 0
 	DefBlockEncryptionMode                  = "aes-128-ecb"
 	DefTiDBAllowMPPExecution                = true
+	DefTiDBEnableCommitTSOrderCheck         = false
 	DefTiDBAllowTiFlashCop                  = false
 	DefTiDBHashExchangeWithNewCollation     = true
 	DefTiDBEnforceMPPExecution              = false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #57165

Problem Summary:

Add a session variable `tidb_enable_commit_ts_order_check` to enable checking `commit_ts` in https://github.com/pingcap/tidb/pull/57305.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
