### PR TITLE
chore: use `slices.Clone` to replace CloneSlice

### DIFF
--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"slices"
 	"strings"
 	"sync"

--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -233,7 +235,7 @@ func (c *CheckpointAdvancer) tryAdvance(ctx context.Context, length int,
 		defer c.checkpointsMu.Unlock()
 		c.checkpoints.Merge(spans.Valued{Key: kr, Value: u})
 	})
-	clampedRanges := utils.IntersectAll(ranges, utils.CloneSlice(c.taskRange))
+	clampedRanges := utils.IntersectAll(ranges, slices.Clone(c.taskRange))
 	for _, r := range clampedRanges {
 		workers.ApplyOnErrorGroup(eg, func() (e error) {
 			defer c.recordTimeCost("get regions in range")()

--- a/br/pkg/utils/key.go
+++ b/br/pkg/utils/key.go
@@ -143,13 +143,6 @@ func clampInOneRange(rng kv.KeyRange, clampIn kv.KeyRange) (kv.KeyRange, failedT
 	return rng, successClamp
 }
 
-// CloneSlice sallowly clones a slice.
-func CloneSlice[T any](s []T) []T {
-	r := make([]T, len(s))
-	copy(r, s)
-	return r
-}
-
 // IntersectAll returns the intersect of two set of segments.
 // OWNERSHIP INFORMATION:
 // For running faster, this function would MUTATE the input slice. (i.e. takes its ownership.)

--- a/br/pkg/utils/key_test.go
+++ b/br/pkg/utils/key_test.go
@@ -5,6 +5,7 @@ package utils
 import (
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/kv"
@@ -162,7 +163,7 @@ func TestClampKeyRanges(t *testing.T) {
 	run := func(t *testing.T, c Case) {
 		require.ElementsMatch(
 			t,
-			IntersectAll(CloneSlice(c.ranges), CloneSlice(c.clampIn)),
+			IntersectAll(slices.Clone(c.ranges), slices.Clone(c.clampIn)),
 			c.result)
 		require.ElementsMatch(
 			t,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Close #57316

Problem Summary:

See the issue.

### What changed and how does it work?

Replaced all `CloneSlice` with `slices.Clone`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
