### PR TITLE
planner: fix RANGE COLUMNS partition prune gives wrong result with special collation

### DIFF
--- a/pkg/planner/core/partition_pruning_test.go
+++ b/pkg/planner/core/partition_pruning_test.go
@@ -575,6 +575,60 @@ func TestPartitionRangeColumnsForExpr(t *testing.T) {
 	}
 }
 
+func TestPartitionRangeColumnsForExprWithSpecialCollation(t *testing.T) {
+	tc := prepareTestCtx(t, "create table t (a varchar(255) COLLATE utf8mb4_0900_ai_ci, b varchar(255) COLLATE utf8mb4_unicode_ci)", "a,b")
+	lessThan := make([][]*expression.Expression, 0, 6)
+	partDefs := [][]string{
+		{"'i'", "'i'"},
+		{"MAXVALUE", "MAXVALUE"},
+	}
+	for i := range partDefs {
+		l := make([]*expression.Expression, 0, 2)
+		for j := range []int{0, 1} {
+			v := partDefs[i][j]
+			var e *expression.Expression
+			if v == "MAXVALUE" {
+				e = nil // MAXVALUE
+			} else {
+				expr, err := expression.ParseSimpleExpr(tc.sctx, v, expression.WithInputSchemaAndNames(tc.schema, tc.names, nil))
+				require.NoError(t, err)
+				e = &expr
+			}
+			l = append(l, e)
+		}
+		lessThan = append(lessThan, l)
+	}
+	pruner := &rangeColumnsPruner{lessThan, tc.columns[:2]}
+	cases := []struct {
+		input  string
+		result partitionRangeOR
+	}{
+		{"a = 'q'", partitionRangeOR{{1, 2}}},
+		{"a = 'Q'", partitionRangeOR{{1, 2}}},
+		{"a = 'a'", partitionRangeOR{{0, 1}}},
+		{"a = 'A'", partitionRangeOR{{0, 1}}},
+		{"a > 'a'", partitionRangeOR{{0, 2}}},
+		{"a > 'q'", partitionRangeOR{{1, 2}}},
+		{"a = 'i' and b = 'q'", partitionRangeOR{{1, 2}}},
+		{"a = 'i' and b = 'Q'", partitionRangeOR{{1, 2}}},
+		{"a = 'i' and b = 'a'", partitionRangeOR{{0, 1}}},
+		{"a = 'i' and b = 'A'", partitionRangeOR{{0, 1}}},
+		{"a = 'i' and b > 'a'", partitionRangeOR{{0, 2}}},
+		{"a = 'i' and b > 'q'", partitionRangeOR{{1, 2}}},
+		{"a = 'i' or a = 'h'", partitionRangeOR{{0, 2}}},
+		{"a = 'h' and a = 'j'", partitionRangeOR{}},
+	}
+
+	for _, ca := range cases {
+		expr, err := expression.ParseSimpleExpr(tc.sctx, ca.input, expression.WithInputSchemaAndNames(tc.schema, tc.names, nil))
+		require.NoError(t, err)
+		result := fullRange(len(lessThan))
+		e := expression.SplitCNFItems(expr)
+		result = partitionRangeForCNFExpr(tc.sctx, e, pruner, result)
+		require.Truef(t, equalPartitionRangeOR(ca.result, result), "unexpected: %v %v != %v", ca.input, ca.result, result)
+	}
+}
+
 func benchmarkRangeColumnsPruner(b *testing.B, parts int) {
 	tc := prepareBenchCtx("create table t (a bigint unsigned, b int, c int)", "a")
 	if tc == nil {

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -1320,7 +1320,7 @@ func multiColumnRangeColumnsPruner(sctx base.PlanContext, exprs []expression.Exp
 		lens = append(lens, columnsPruner.partCols[i].RetType.GetFlen())
 	}
 
-	res, err := ranger.DetachCondAndBuildRangeForIndex(sctx.GetRangerCtx(), exprs, columnsPruner.partCols, lens, sctx.GetSessionVars().RangeMaxSize)
+	res, err := ranger.DetachCondAndBuildRangeForPartition(sctx.GetRangerCtx(), exprs, columnsPruner.partCols, lens, sctx.GetSessionVars().RangeMaxSize)
 	if err != nil {
 		return fullRange(len(columnsPruner.lessThan))
 	}

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -1335,16 +1335,12 @@ func multiColumnRangeColumnsPruner(sctx base.PlanContext, exprs []expression.Exp
 
 	rangeOr := make([]partitionRange, 0, len(res.Ranges))
 
-	comparer := make([]collate.Collator, 0, len(columnsPruner.partCols))
-	for i := range columnsPruner.partCols {
-		comparer = append(comparer, collate.GetCollator(columnsPruner.partCols[i].RetType.GetCollate()))
-	}
 	gotError := false
 	// Create a sort.Search where the compare loops over ColumnValues
 	// Loop over the different ranges and extend/include all the partitions found
 	for idx := range res.Ranges {
-		minComparer := minCmp(sctx, res.Ranges[idx].LowVal, columnsPruner, comparer, res.Ranges[idx].LowExclude, &gotError)
-		maxComparer := maxCmp(sctx, res.Ranges[idx].HighVal, columnsPruner, comparer, res.Ranges[idx].HighExclude, &gotError)
+		minComparer := minCmp(sctx, res.Ranges[idx].LowVal, columnsPruner, res.Ranges[idx].Collators, res.Ranges[idx].LowExclude, &gotError)
+		maxComparer := maxCmp(sctx, res.Ranges[idx].HighVal, columnsPruner, res.Ranges[idx].Collators, res.Ranges[idx].HighExclude, &gotError)
 		if gotError {
 			// the compare function returned error, use all partitions.
 			return fullRange(len(columnsPruner.lessThan))
@@ -1953,10 +1949,9 @@ func makeRangeColumnPruner(columns []*expression.Column, pi *model.PartitionInfo
 	if len(pi.Definitions) != len(from.LessThan) {
 		return nil, errors.Trace(fmt.Errorf("internal error len(pi.Definitions) != len(from.LessThan) %d != %d", len(pi.Definitions), len(from.LessThan)))
 	}
-	schema := expression.NewSchema(columns...)
 	partCols := make([]*expression.Column, len(offsets))
 	for i, offset := range offsets {
-		partCols[i] = schema.Columns[offset]
+		partCols[i] = columns[offset]
 	}
 	lessThan := make([][]*expression.Expression, 0, len(from.LessThan))
 	for i := range from.LessThan {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57261

Problem Summary: Don't use `sortKey` to do partition prune.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
