### PR TITLE
executor: improve retrieval logic in hugeMemTableRetriever and add tests

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -921,10 +921,7 @@ type hugeMemTableRetriever struct {
 
 // retrieve implements the infoschemaRetriever interface
 func (e *hugeMemTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error) {
-	if e.extractor.SkipRequest {
-		e.retrieved = true
-	}
-	if e.retrieved {
+	if e.extractor.SkipRequest || e.retrieved {
 		return nil, nil
 	}
 

--- a/tests/integrationtest/r/executor/infoschema_reader.result
+++ b/tests/integrationtest/r/executor/infoschema_reader.result
@@ -445,3 +445,23 @@ alter table t add index idx_t (c(16));
 select SUB_PART from information_schema.statistics where TABLE_SCHEMA = 'executor__infoschema_reader' and TABLE_NAME = 't';
 SUB_PART
 16
+select table_name from information_schema.columns where table_name = 'a' and table_name = 'b';
+table_name
+select table_name from information_schema.columns where table_schema = 'a' and table_schema = 'b';
+table_name
+select table_name from information_schema.tables where table_name = 'a' and table_name = 'b';
+table_name
+select table_name from information_schema.tables where table_schema = 'a' and table_schema = 'b';
+table_name
+select table_name from information_schema.partitions where table_name = 'a' and table_name = 'b';
+table_name
+select table_name from information_schema.partitions where table_schema = 'a' and table_schema = 'b';
+table_name
+select table_name from information_schema.statistics where table_name = 'a' and table_name = 'b';
+table_name
+select table_name from information_schema.statistics where table_schema = 'a' and table_schema = 'b';
+table_name
+select table_name from information_schema.referential_constraints where table_name = 'a' and table_name = 'b';
+table_name
+select table_name from information_schema.referential_constraints where constraint_schema = 'a' and constraint_schema = 'b';
+table_name

--- a/tests/integrationtest/t/executor/infoschema_reader.test
+++ b/tests/integrationtest/t/executor/infoschema_reader.test
@@ -320,3 +320,16 @@ drop table if exists t;
 create table t (c text);
 alter table t add index idx_t (c(16));
 select SUB_PART from information_schema.statistics where TABLE_SCHEMA = 'executor__infoschema_reader' and TABLE_NAME = 't';
+
+# Query should return nothing when WHERE clauses are always false.
+# https://github.com/pingcap/tidb/issues/57345
+select table_name from information_schema.columns where table_name = 'a' and table_name = 'b';
+select table_name from information_schema.columns where table_schema = 'a' and table_schema = 'b';
+select table_name from information_schema.tables where table_name = 'a' and table_name = 'b';
+select table_name from information_schema.tables where table_schema = 'a' and table_schema = 'b';
+select table_name from information_schema.partitions where table_name = 'a' and table_name = 'b';
+select table_name from information_schema.partitions where table_schema = 'a' and table_schema = 'b';
+select table_name from information_schema.statistics where table_name = 'a' and table_name = 'b';
+select table_name from information_schema.statistics where table_schema = 'a' and table_schema = 'b';
+select table_name from information_schema.referential_constraints where table_name = 'a' and table_name = 'b';
+select table_name from information_schema.referential_constraints where constraint_schema = 'a' and constraint_schema = 'b';


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57345

Problem Summary:

The issue was introduced by #31463 and accidentally fixed by #55263. Since #55263 involves a lot of refactoring code, it is not easy to cherry-pick, so I filed this PR for cherry-picking.

### What changed and how does it work?

- Improve retrieval logic. If `extractor.SkipRequest` is true, we should return the empty result directly.
- Add integration tests.

This PR doesn't fix the issue, it is only used to cherry-pick 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
