### PR TITLE
executor, session: fix ExecStmt.OriginText to use the actual original text

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -378,7 +378,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 
 // OriginText returns original statement as a string.
 func (a *ExecStmt) OriginText() string {
-	return a.Text
+	return a.StmtNode.OriginalText()
 }
 
 // IsPrepared returns true if stmt is a prepare statement.
@@ -2067,7 +2067,7 @@ func (a *ExecStmt) GetTextToLog(keepHint bool) string {
 	} else if sensitiveStmt, ok := a.StmtNode.(ast.SensitiveStmtNode); ok {
 		sql = sensitiveStmt.SecureText()
 	} else {
-		sql = redact.String(rmode, sessVars.StmtCtx.OriginalSQL+sessVars.PlanCacheParams.String())
+		sql = redact.String(rmode, a.OriginText()+sessVars.PlanCacheParams.String())
 	}
 	return sql
 }

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -2067,7 +2067,7 @@ func (a *ExecStmt) GetTextToLog(keepHint bool) string {
 	} else if sensitiveStmt, ok := a.StmtNode.(ast.SensitiveStmtNode); ok {
 		sql = sensitiveStmt.SecureText()
 	} else {
-		sql = redact.String(rmode, a.OriginText()+sessVars.PlanCacheParams.String())
+		sql = redact.String(rmode, sessVars.StmtCtx.OriginalSQL+sessVars.PlanCacheParams.String())
 	}
 	return sql
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -129,6 +129,7 @@ import (
 	"github.com/tikv/client-go/v2/oracle"
 	tikvutil "github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func init() {
@@ -4132,7 +4133,8 @@ func logGeneralQuery(execStmt *executor.ExecStmt, s *session, isPrepared bool) {
 		if vars.EnableRedactLog != errors.RedactLogEnable {
 			query += redact.String(vars.EnableRedactLog, vars.PlanCacheParams.String())
 		}
-		logutil.GeneralLogger.Info("GENERAL_LOG",
+
+		fields := []zapcore.Field{
 			zap.Uint64("conn", vars.ConnectionID),
 			zap.String("session_alias", vars.SessionAlias),
 			zap.String("user", vars.User.LoginString()),
@@ -4143,7 +4145,12 @@ func logGeneralQuery(execStmt *executor.ExecStmt, s *session, isPrepared bool) {
 			zap.String("currentDB", vars.CurrentDB),
 			zap.Bool("isPessimistic", vars.TxnCtx.IsPessimistic),
 			zap.String("sessionTxnMode", vars.GetReadableTxnMode()),
-			zap.String("sql", query))
+			zap.String("sql", query),
+		}
+		if execStmt.OriginText() != execStmt.Text {
+			fields = append(fields, zap.String("sqlQuoted", strconv.Quote(query)))
+		}
+		logutil.GeneralLogger.Info("GENERAL_LOG", fields...)
 	}
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4147,8 +4147,8 @@ func logGeneralQuery(execStmt *executor.ExecStmt, s *session, isPrepared bool) {
 			zap.String("sessionTxnMode", vars.GetReadableTxnMode()),
 			zap.String("sql", query),
 		}
-		if execStmt.OriginText() != execStmt.Text {
-			fields = append(fields, zap.String("sqlQuoted", strconv.Quote(query)))
+		if ot := execStmt.OriginText(); ot != execStmt.Text {
+			fields = append(fields, zap.String("originText", strconv.Quote(ot)))
 		}
 		logutil.GeneralLogger.Info("GENERAL_LOG", fields...)
 	}

--- a/pkg/session/test/variable/BUILD.bazel
+++ b/pkg/session/test/variable/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "variable_test.go",
     ],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/config",
         "//pkg/kv",

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -455,7 +455,8 @@ func TestGeneralLogBinaryText(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set session tidb_general_log = 1")
 	tk.MustExec("select * /*+ no_quoted */ from mysql.user")
-	tk.MustExec(fmt.Sprintf("select * /*+ yes_quoted */ from mysql.user where User = _binary '%s'", b))
+	sqlBinary := fmt.Sprintf("select * /*+ yes_quoted */ from mysql.user where User = _binary '%s'", b)
+	tk.MustExec(sqlBinary)
 
 	getSQLFields := func(s string) (sql zapcore.Field, originText zapcore.Field, ok bool) {
 		for _, fields := range mzc.fields {
@@ -474,9 +475,8 @@ func TestGeneralLogBinaryText(t *testing.T) {
 	sql, originText, ok = getSQLFields("yes_quote")
 	require.True(t, ok)
 	require.NotEmpty(t, sql.String)
-	require.True(t, strings.Contains(sql.String, string(b)))
 	require.NotEmpty(t, originText.String)
-	s, err := strconv.Unquote(originText.String)
+	ot, err := strconv.Unquote(originText.String)
 	require.NoError(t, err)
-	require.Equal(t, sql.String, s)
+	require.Equal(t, sqlBinary, ot)
 }

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -457,26 +457,26 @@ func TestGeneralLogBinaryText(t *testing.T) {
 	tk.MustExec("select * /*+ no_quoted */ from mysql.user")
 	tk.MustExec(fmt.Sprintf("select * /*+ yes_quoted */ from mysql.user where User = _binary '%s'", b))
 
-	getSQLFields := func(s string) (sql zapcore.Field, sqlQuoted zapcore.Field, ok bool) {
+	getSQLFields := func(s string) (sql zapcore.Field, originText zapcore.Field, ok bool) {
 		for _, fields := range mzc.fields {
 			if sql, ok := fields["sql"]; ok && strings.Contains(sql.String, s) {
-				return sql, fields["sqlQuoted"], true
+				return sql, fields["originText"], true
 			}
 		}
 		return zapcore.Field{}, zapcore.Field{}, false
 	}
 
-	sql, sqlQuoted, ok := getSQLFields("no_quoted")
+	sql, originText, ok := getSQLFields("no_quoted")
 	require.True(t, ok)
 	require.NotEmpty(t, sql.String)
-	require.Empty(t, sqlQuoted.String)
+	require.Empty(t, originText.String)
 
-	sql, sqlQuoted, ok = getSQLFields("yes_quote")
+	sql, originText, ok = getSQLFields("yes_quote")
 	require.True(t, ok)
 	require.NotEmpty(t, sql.String)
 	require.True(t, strings.Contains(sql.String, string(b)))
-	require.NotEmpty(t, sqlQuoted.String)
-	s, err := strconv.Unquote(sqlQuoted.String)
+	require.NotEmpty(t, originText.String)
+	s, err := strconv.Unquote(originText.String)
 	require.NoError(t, err)
 	require.Equal(t, sql.String, s)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57396

Problem Summary:

When a query statement is not in utf-8, e.g. `_binary 'some_binary_data'`, `GENERAL_LOG` logs the utf-8 text, not the original text. This is because `ExecStmt.OriginText` simply returns `Text`, not `StmtNode.OriginalText`.

This PR fixes `ExecStmt.OriginText` to return `StmtNode.OriginalText`, and includes the quoted query in `GENERAL_LOG`.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
