### PR TITLE
expression: Fix optimizer panic in evaluate expr with null

### DIFF
--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -228,7 +228,7 @@ func (a *AggFuncDesc) Split(ordinal []int) (partialAggDesc, finalAggDesc *AggFun
 // +------+-----------+---------+---------+------------+-------------+------------+---------+---------+------+----------+
 // |    1 |         1 |      95 | 95.0000 |         95 |          95 |         95 |      95 |      95 | NULL |     NULL |
 // +------+-----------+---------+---------+------------+-------------+------------+---------+---------+------+----------+
-func (a *AggFuncDesc) EvalNullValueInOuterJoin(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool) {
+func (a *AggFuncDesc) EvalNullValueInOuterJoin(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
 	switch a.Name {
 	case ast.AggFuncCount:
 		return a.evalNullValueInOuterJoin4Count(ctx, schema)
@@ -236,7 +236,7 @@ func (a *AggFuncDesc) EvalNullValueInOuterJoin(ctx expression.BuildContext, sche
 		ast.AggFuncFirstRow:
 		return a.evalNullValueInOuterJoin4Sum(ctx, schema)
 	case ast.AggFuncAvg, ast.AggFuncGroupConcat:
-		return types.Datum{}, false
+		return types.Datum{}, false, nil
 	case ast.AggFuncBitAnd:
 		return a.evalNullValueInOuterJoin4BitAnd(ctx, schema)
 	case ast.AggFuncBitOr, ast.AggFuncBitXor:
@@ -275,42 +275,54 @@ func (a *AggFuncDesc) GetAggFunc(ctx expression.AggFuncBuildContext) Aggregation
 	}
 }
 
-func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool) {
+func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
 	for _, arg := range a.Args {
-		result := expression.EvaluateExprWithNull(ctx, schema, arg)
+		result, err := expression.EvaluateExprWithNull(ctx, schema, arg)
+		if err != nil {
+			return types.Datum{}, false, err
+		}
 		con, ok := result.(*expression.Constant)
 		if !ok || con.Value.IsNull() {
-			return types.Datum{}, ok
+			return types.Datum{}, ok, nil
 		}
 	}
-	return types.NewDatum(1), true
+	return types.NewDatum(1), true, nil
 }
 
-func (a *AggFuncDesc) evalNullValueInOuterJoin4Sum(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool) {
-	result := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+func (a *AggFuncDesc) evalNullValueInOuterJoin4Sum(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+	if err != nil {
+		return types.Datum{}, false, err
+	}
 	con, ok := result.(*expression.Constant)
 	if !ok || con.Value.IsNull() {
-		return types.Datum{}, ok
+		return types.Datum{}, ok, nil
 	}
-	return con.Value, true
+	return con.Value, true, nil
 }
 
-func (a *AggFuncDesc) evalNullValueInOuterJoin4BitAnd(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool) {
-	result := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+func (a *AggFuncDesc) evalNullValueInOuterJoin4BitAnd(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+	if err != nil {
+		return types.Datum{}, false, err
+	}
 	con, ok := result.(*expression.Constant)
 	if !ok || con.Value.IsNull() {
-		return types.NewDatum(uint64(math.MaxUint64)), true
+		return types.NewDatum(uint64(math.MaxUint64)), true, nil
 	}
-	return con.Value, true
+	return con.Value, true, nil
 }
 
-func (a *AggFuncDesc) evalNullValueInOuterJoin4BitOr(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool) {
-	result := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+func (a *AggFuncDesc) evalNullValueInOuterJoin4BitOr(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+	if err != nil {
+		return types.Datum{}, false, err
+	}
 	con, ok := result.(*expression.Constant)
 	if !ok || con.Value.IsNull() {
-		return types.NewDatum(0), true
+		return types.NewDatum(0), true, nil
 	}
-	return con.Value, true
+	return con.Value, true, nil
 }
 
 // UpdateNotNullFlag4RetType checks if we should remove the NotNull flag for the return type of the agg.

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -49,13 +49,15 @@ func TestEvaluateExprWithNull(t *testing.T) {
 	outerIfNull, err := newFunctionForTest(ctx, ast.Ifnull, col0, innerIfNull)
 	require.NoError(t, err)
 
-	res := EvaluateExprWithNull(ctx, schema, outerIfNull)
+	res, err := EvaluateExprWithNull(ctx, schema, outerIfNull)
+	require.Nil(t, err)
 	require.Equal(t, "ifnull(Column#1, 1)", res.StringWithCtx(ctx, errors.RedactLogDisable))
 	require.Equal(t, "ifnull(Column#1, ?)", res.StringWithCtx(ctx, errors.RedactLogEnable))
 	require.Equal(t, "ifnull(Column#1, ‹1›)", res.StringWithCtx(ctx, errors.RedactLogMarker))
 	schema.Columns = append(schema.Columns, col1)
 	// ifnull(null, ifnull(null, 1))
-	res = EvaluateExprWithNull(ctx, schema, outerIfNull)
+	res, err = EvaluateExprWithNull(ctx, schema, outerIfNull)
+	require.Nil(t, err)
 	require.True(t, res.Equal(ctx, NewOne()))
 }
 
@@ -70,14 +72,16 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	// cases for parameters
 	ltWithoutParam, err := newFunctionForTest(ctx, ast.LT, col0, NewOne())
 	require.NoError(t, err)
-	res := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
+	res, err := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
+	require.Nil(t, err)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
 	param.ParamMarker = &ParamMarker{order: 0}
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)
-	res = EvaluateExprWithNull(ctx, schema, ltWithParam)
+	res, err = EvaluateExprWithNull(ctx, schema, ltWithParam)
+	require.Nil(t, err)
 	_, isConst := res.(*Constant)
 	require.True(t, isConst) // this expression is evaluated and skip-plan cache flag is set.
 	require.True(t, !ctx.GetSessionVars().StmtCtx.UseCache())

--- a/pkg/expression/integration_test/BUILD.bazel
+++ b/pkg/expression/integration_test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 47,
+    shard_count = 48,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -3952,3 +3952,15 @@ func TestIssue55885(t *testing.T) {
 
 	tk.MustQuery("SELECT subq_0.c3 as c1 FROM (select c_a90ol as c3, c_a90ol as c4, var_pop(cast(c__qy as double)) over (partition by c_a90ol, c_s order by c_z) as c5 from t_jg8o limit 65) as subq_0 LIMIT 37")
 }
+
+func TestIssue55886(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(c_foveoe text, c_jbb text, c_cz text not null);")
+	tk.MustExec("create table t2(c_g7eofzlxn int);")
+	tk.MustExec("set collation_connection='latin1_bin';")
+	tk.MustQuery("with cte_0 AS (select 1 as c1, case when ref_0.c_jbb then inet6_aton(ref_0.c_foveoe) else ref_4.c_cz end as c5 from t1 as ref_0 join " +
+		" (t1 as ref_4 right outer join t2 as ref_5 on ref_5.c_g7eofzlxn != 1)), cte_4 as (select 1 as c1 from t2) select ref_34.c1 as c5 from" +
+		" cte_0 as ref_34 where exists (select 1 from cte_4 as ref_35 where ref_34.c1 <= case when ref_34.c5 then cast(1 as char) else ref_34.c5 end);")
+}

--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/domain",
         "//pkg/expression",

--- a/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
@@ -45,7 +45,36 @@ func TestOuter2Inner(t *testing.T) {
 		Plan []string
 	}
 	suiteData := GetOuter2InnerSuiteData()
-	suiteData.LoadTestCases(t, &input, &output)
+	suiteData.LoadTestCasesByName("TestOuter2Inner", t, &input, &output)
+	for i, sql := range input {
+		plan := tk.MustQuery("explain format = 'brief' " + sql)
+		testdata.OnRecord(func() {
+			output[i].SQL = sql
+			output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
+		})
+		plan.Check(testkit.Rows(output[i].Plan...))
+	}
+}
+
+func TestOuter2InnerIssue55886(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1(c_foveoe text, c_jbb text, c_cz text not null)")
+	tk.MustExec("create table t2(c_g7eofzlxn int)")
+	// can not add this test case to TestOuter2Inner because the collation_connection is different
+	tk.MustExec("set collation_connection = 'latin1_bin'")
+
+	var input Input
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	suiteData := GetOuter2InnerSuiteData()
+	suiteData.LoadTestCasesByName("TestOuter2InnerIssue55886", t, &input, &output)
 	for i, sql := range input {
 		plan := tk.MustQuery("explain format = 'brief' " + sql)
 		testdata.OnRecord(func() {

--- a/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
+++ b/pkg/planner/core/casetest/rule/rule_outer2inner_test.go
@@ -56,6 +56,7 @@ func TestOuter2Inner(t *testing.T) {
 	}
 }
 
+// can not add this test case to TestOuter2Inner because the collation_connection is different
 func TestOuter2InnerIssue55886(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
@@ -65,7 +66,6 @@ func TestOuter2InnerIssue55886(t *testing.T) {
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t1(c_foveoe text, c_jbb text, c_cz text not null)")
 	tk.MustExec("create table t2(c_g7eofzlxn int)")
-	// can not add this test case to TestOuter2Inner because the collation_connection is different
 	tk.MustExec("set collation_connection = 'latin1_bin'")
 
 	var input Input

--- a/pkg/planner/core/casetest/rule/testdata/outer2inner_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer2inner_in.json
@@ -46,8 +46,13 @@
       "select * from t0 left outer join t11 on a0=a1 where '5' not in (t0.b0, t11.b1)",
       "select * from t0 left outer join t11 on a0=a1 where '1' in (t0.b0, t11.b1)",
       "select * from t0 left outer join t11 on a0=a1 where t0.b0 in ('5', t11.b1) -- some = in the in list is not null filtering",
-      "select * from t0 left outer join t11 on a0=a1 where '5' in (t0.b0, t11.b1) -- some = in the in list is not null filtering",
-      "select * from t1 left outer join t2 on a1=a2 where not (b2 is NOT NULL AND c2 = 5) -- NOT case "
+      "select * from t0 left outer join t11 on a0=a1 where '5' in (t0.b0, t11.b1) -- some = in the in list is not null filtering"
+    ]
+  },
+  {
+    "name": "TestOuter2InnerIssue55886",
+    "cases": [
+      "with cte_0 AS (select 1 as c1, case when ref_0.c_jbb then inet6_aton(ref_0.c_foveoe) else ref_4.c_cz end as c5 from t1 as ref_0 join (t1 as ref_4 right outer join t2 as ref_5 on ref_5.c_g7eofzlxn != 1)), cte_4 as (select 1 as c1 from t2) select ref_34.c1 as c5 from  cte_0 as ref_34 where exists (select 1 from cte_4 as ref_35 where ref_34.c1 <= case when ref_34.c5 then cast(1 as char) else ref_34.c5 end)"
     ]
   }
 ]

--- a/pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
@@ -650,5 +650,27 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestOuter2InnerIssue55886",
+    "Cases": [
+      {
+        "SQL": "with cte_0 AS (select 1 as c1, case when ref_0.c_jbb then inet6_aton(ref_0.c_foveoe) else ref_4.c_cz end as c5 from t1 as ref_0 join (t1 as ref_4 right outer join t2 as ref_5 on ref_5.c_g7eofzlxn != 1)), cte_4 as (select 1 as c1 from t2) select ref_34.c1 as c5 from  cte_0 as ref_34 where exists (select 1 from cte_4 as ref_35 where ref_34.c1 <= case when ref_34.c5 then cast(1 as char) else ref_34.c5 end)",
+        "Plan": [
+          "HashJoin 800000000000.00 root  CARTESIAN semi join",
+          "├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "│ └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─Projection(Probe) 1000000000000.00 root  1->Column#28",
+          "  └─HashJoin 1000000000000.00 root  CARTESIAN inner join, other cond:le(1, cast(case(istrue_with_null(cast(case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), from_binary(inet6_aton(test.t1.c_foveoe)), test.t1.c_cz), double BINARY)), \"1\", case(istrue_with_null(cast(test.t1.c_jbb, double BINARY)), from_binary(inet6_aton(test.t1.c_foveoe)), test.t1.c_cz)), double BINARY))",
+          "    ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "    │ └─TableFullScan 10000.00 cop[tikv] table:ref_0 keep order:false, stats:pseudo",
+          "    └─HashJoin(Probe) 100000000.00 root  CARTESIAN right outer join, right cond:ne(test.t2.c_g7eofzlxn, 1)",
+          "      ├─TableReader(Build) 10000.00 root  data:TableFullScan",
+          "      │ └─TableFullScan 10000.00 cop[tikv] table:ref_5 keep order:false, stats:pseudo",
+          "      └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+          "        └─TableFullScan 10000.00 cop[tikv] table:ref_4 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -703,7 +703,10 @@ func (la *LogicalAggregation) CanPullUp() bool {
 	}
 	for _, f := range la.AggFuncs {
 		for _, arg := range f.Args {
-			expr := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg)
+			expr, err := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg)
+			if err != nil {
+				return false
+			}
 			if con, ok := expr.(*expression.Constant); !ok || !con.Value.IsNull() {
 				return false
 			}

--- a/pkg/planner/core/rule_aggregation_push_down.go
+++ b/pkg/planner/core/rule_aggregation_push_down.go
@@ -297,8 +297,9 @@ func (a *AggregationPushDownSolver) tryToPushDownAgg(oldAgg *logicalop.LogicalAg
 func (*AggregationPushDownSolver) getDefaultValues(agg *logicalop.LogicalAggregation) ([]types.Datum, bool) {
 	defaultValues := make([]types.Datum, 0, agg.Schema().Len())
 	for _, aggFunc := range agg.AggFuncs {
-		value, existsDefaultValue := aggFunc.EvalNullValueInOuterJoin(agg.SCtx().GetExprCtx(), agg.Children()[0].Schema())
-		if !existsDefaultValue {
+		value, existsDefaultValue, err := aggFunc.EvalNullValueInOuterJoin(agg.SCtx().GetExprCtx(), agg.Children()[0].Schema())
+		// if err is not null, just treat it as no default value.
+		if err != nil || !existsDefaultValue {
 			return nil, false
 		}
 		defaultValues = append(defaultValues, value)

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -106,7 +106,10 @@ func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema
 	}
 	exprCtx := ctx.GetNullRejectCheckExprCtx()
 	sc := ctx.GetSessionVars().StmtCtx
-	result := expression.EvaluateExprWithNull(exprCtx, schema, expr)
+	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr)
+	if err != nil {
+		return false
+	}
 	x, ok := result.(*expression.Constant)
 	if ok {
 		if x.Value.IsNull() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55886

Problem Summary:

### What changed and how does it work?
1. Both `evaluateExprWithNull` and `evaluateExprWithNullInNullRejectCheck` use `NewFunction` instead of `NewFunctionInternal` to create a scalar function
2. let `EvaluateExprWithNull` return error if some error happens inside `EvaluateExprWithNull`
2. The caller of `EvaluateExprWithNull` need to decide how to handle this error, currently, all the callers of `EvaluateExprWithNull` are optimizer, and will ignore the error
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
