### PR TITLE
table: fix wrong handle comparation in index double write

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2025,14 +2025,6 @@ func (w *addIndexTxnWorker) checkHandleExists(idxInfo *model.IndexInfo, key kv.K
 	if hasBeenBackFilled {
 		return nil
 	}
-	if idxInfo.Global {
-		// 'handle' comes from reading directly from a partition, without partition id,
-		// so we can only compare the handle part of the key.
-		if ph, ok := h.(kv.PartitionHandle); ok && ph.Handle.Equal(handle) {
-			// table row has been back-filled already, OK to add the index entry
-			return nil
-		}
-	}
 	return ddlutil.GenKeyExistsErr(key, value, idxInfo, tblInfo)
 }
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1352,7 +1352,7 @@ func doReorgWorkForCreateIndex(
 				MockDMLExecutionStateBeforeMerge()
 			}
 		})
-		failpoint.InjectCall("BeforeBackfillMerge", job)
+		failpoint.InjectCall("BeforeBackfillMerge")
 		logutil.DDLLogger().Info("index backfill state ready to merge",
 			zap.Int64("job ID", job.ID),
 			zap.String("table", tbl.Meta().Name.O),

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1352,6 +1352,7 @@ func doReorgWorkForCreateIndex(
 				MockDMLExecutionStateBeforeMerge()
 			}
 		})
+		failpoint.InjectCall("BeforeBackfillMerge", job)
 		logutil.DDLLogger().Info("index backfill state ready to merge",
 			zap.Int64("job ID", job.ID),
 			zap.String("table", tbl.Meta().Name.O),

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -1433,10 +1433,10 @@ func TestInsertDuplicateBeforeIndexMerge(t *testing.T) {
 	tk.MustExec("use test")
 	tk2.MustExec("use test")
 
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/BeforeBackfillMerge", func(job *model.Job) {
+	// Test issue 57414.
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/BeforeBackfillMerge", func() {
 		tk2.MustExec("insert ignore into t values (1, 2), (1, 2) on duplicate key update col1 = 0, col2 = 0")
 	})
-	defer testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/BeforeBackfillMerge")
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (col1 int, col2 int, unique index i1(col2) /*T![global_index] GLOBAL */) PARTITION BY HASH (col1) PARTITIONS 2")

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -1423,13 +1423,12 @@ func TestAddVectorIndexRollback(t *testing.T) {
 	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/MockCheckVectorIndexProcess")
 }
 
-func TestAddIndex(t *testing.T) {
+func TestInsertDuplicateBeforeIndexMerge(t *testing.T) {
 	store := testkit.CreateMockStore(t)
-	tkVar := testkit.NewTestKit(t, store)
-	tkVar.MustExec("set @@global.tidb_ddl_enable_fast_reorg = 1")
-	tkVar.MustExec("set @@global.tidb_enable_dist_task=0")
 	tk := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("set @@global.tidb_ddl_enable_fast_reorg = 1")
+	tk2.MustExec("set @@global.tidb_enable_dist_task=0")
 
 	tk.MustExec("use test")
 	tk2.MustExec("use test")

--- a/pkg/ddl/index_modify_test.go
+++ b/pkg/ddl/index_modify_test.go
@@ -1422,3 +1422,25 @@ func TestAddVectorIndexRollback(t *testing.T) {
 
 	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/MockCheckVectorIndexProcess")
 }
+
+func TestAddIndex(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tkVar := testkit.NewTestKit(t, store)
+	tkVar.MustExec("set @@global.tidb_ddl_enable_fast_reorg = 1")
+	tkVar.MustExec("set @@global.tidb_enable_dist_task=0")
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (col1 int, col2 int, unique index i1(col2) /*T![global_index] GLOBAL */) PARTITION BY HASH (col1) PARTITIONS 2")
+
+	tk2 := testkit.NewTestKit(t, store)
+	tk2.MustExec("use test")
+
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/BeforeBackfillMerge", func(job *model.Job) {
+		tk2.MustExec("insert ignore into t values (1, 2), (1, 2) on duplicate key update col1 = 0, col2 = 0")
+	})
+	defer testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/BeforeBackfillMerge")
+
+	tk.MustExec("alter table t add unique index i(col1, col2)")
+	tk.MustExec("admin check table t")
+}

--- a/pkg/kv/key.go
+++ b/pkg/kv/key.go
@@ -723,10 +723,13 @@ func (ph PartitionHandle) Copy() Handle {
 
 // Equal implements the Handle interface.
 func (ph PartitionHandle) Equal(h Handle) bool {
+	// Compare pid and handle if both sides are `PartitionHandle`.
 	if ph2, ok := h.(PartitionHandle); ok {
 		return ph.PartitionID == ph2.PartitionID && ph.Handle.Equal(ph2.Handle)
 	}
-	return false
+
+	// Otherwise, use underlying handle to do comparation.
+	return ph.Handle.Equal(h)
 }
 
 // Compare implements the Handle interface.

--- a/pkg/kv/key_test.go
+++ b/pkg/kv/key_test.go
@@ -146,6 +146,14 @@ func TestHandle(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "abc", d.GetString())
 	assert.Equal(t, "{100, abc}", ch.String())
+
+	ph1 := NewPartitionHandle(2, ih)
+	assert.True(t, ph1.Equal(ih))
+	assert.True(t, ih.Equal(ph1))
+
+	ph2 := NewPartitionHandle(1, ch2)
+	assert.True(t, ph2.Equal(ch2))
+	assert.True(t, ch2.Equal(ph2))
 }
 
 func TestPaddingHandle(t *testing.T) {

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -386,13 +386,6 @@ func needPresumeKeyNotExistsFlag(ctx context.Context, txn kv.Transaction, key, t
 	return false, nil
 }
 
-func handleEqual(dupHandle, prevHandle kv.Handle) bool {
-	if dupPartition, ok := dupHandle.(kv.PartitionHandle); ok {
-		return dupPartition.Handle.Equal(prevHandle)
-	}
-	return dupHandle.Equal(prevHandle)
-}
-
 // Delete removes the entry for handle h and indexedValues from KV index.
 func (c *index) Delete(ctx table.MutateContext, txn kv.Transaction, indexedValue []types.Datum, h kv.Handle) error {
 	indexedValues := c.getIndexedValue(indexedValue)
@@ -436,7 +429,7 @@ func (c *index) Delete(ctx table.MutateContext, txn kv.Transaction, indexedValue
 						}
 						// The handle passed in may be a `PartitionHandle`,
 						// so we can't directly do comparation with them.
-						if !handleEqual(h, oh) {
+						if !h.Equal(oh) {
 							okToDelete = false
 						}
 					}

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -387,14 +387,10 @@ func needPresumeKeyNotExistsFlag(ctx context.Context, txn kv.Transaction, key, t
 }
 
 func handleEqual(dupHandle, prevHandle kv.Handle) bool {
-	dup, prev := dupHandle, prevHandle
 	if dupPartition, ok := dupHandle.(kv.PartitionHandle); ok {
-		dup = dupPartition.Handle
+		return dupPartition.Handle.Equal(prevHandle)
 	}
-	if prevPartition, ok := prevHandle.(kv.PartitionHandle); ok {
-		prev = prevPartition.Handle
-	}
-	return dup.Equal(prev)
+	return dupHandle.Equal(prevHandle)
 }
 
 // Delete removes the entry for handle h and indexedValues from KV index.
@@ -440,7 +436,7 @@ func (c *index) Delete(ctx table.MutateContext, txn kv.Transaction, indexedValue
 						}
 						// The handle passed in may be a `PartitionHandle`,
 						// so we can't directly compare it with the original handle.
-						if !handleEqual(h, oh) {
+						if !h.Equal(oh) {
 							okToDelete = false
 						}
 					}

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -435,8 +435,8 @@ func (c *index) Delete(ctx table.MutateContext, txn kv.Transaction, indexedValue
 							return err
 						}
 						// The handle passed in may be a `PartitionHandle`,
-						// so we can't directly compare it with the original handle.
-						if !h.Equal(oh) {
+						// so we can't directly do comparation with them.
+						if !handleEqual(h, oh) {
 							okToDelete = false
 						}
 					}

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -387,10 +387,14 @@ func needPresumeKeyNotExistsFlag(ctx context.Context, txn kv.Transaction, key, t
 }
 
 func handleEqual(dupHandle, prevHandle kv.Handle) bool {
-	if partitionHandle, ok := dupHandle.(kv.PartitionHandle); ok {
-		return partitionHandle.Handle.Equal(prevHandle)
+	dup, prev := dupHandle, prevHandle
+	if dupPartition, ok := dupHandle.(kv.PartitionHandle); ok {
+		dup = dupPartition.Handle
 	}
-	return dupHandle.Equal(prevHandle)
+	if prevPartition, ok := prevHandle.(kv.PartitionHandle); ok {
+		prev = prevPartition.Handle
+	}
+	return dup.Equal(prev)
 }
 
 // Delete removes the entry for handle h and indexedValues from KV index.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57414

Problem Summary:

### What changed and how does it work?

Unlike other indices, global index encodes the value of its key-value pairs with a partition ID:

https://github.com/pingcap/tidb/blob/2ca497e23e1488a1675dfe5793296b8b367c261b/pkg/tablecodec/tablecodec.go#L1630-L1649

So during the double write process, we may do comparison between partition handles and non-partition handles.

https://github.com/pingcap/tidb/blob/2ca497e23e1488a1675dfe5793296b8b367c261b/pkg/table/tables/index.go#L419-L432

For example, in #57414, `h` is the handle of global index `i1` whose type is `PartitionHandle` while `oh` is `IntHandle` of the current index. Thus, `!h.Equal(oh)` will return false.



### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
