### PR TITLE
planner/core: fix a wrong privilege check for CTE & UPDATE statement

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -269,8 +269,10 @@ type PlanBuilder struct {
 	allocIDForCTEStorage        int
 	buildingRecursivePartForCTE bool
 	buildingCTE                 bool
-	//Check whether the current building query is a CTE
+	// Check whether the current building query is a CTE
 	isCTE bool
+	// CTE table name in lower case, it can be nil
+	nameMapCTE map[string]struct{}
 
 	// subQueryCtx and subQueryHintFlags are for handling subquery related hints.
 	// Note: "subquery" here only contains subqueries that are handled by the expression rewriter, i.e., [NOT] IN,

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -647,3 +647,19 @@ ADMIN SHOW SLOW TOP ALL 3;
 Error 8121 (HY000): privilege check for 'Super' fail
 ADMIN ALTER DDL JOBS 10 THREAD = 3, BATCH_SIZE = 100, MAX_WRITE_SPEED = '10MiB';
 Error 8121 (HY000): privilege check for 'Super' fail
+create table privilege__privileges.tt1 (id bigint,pid bigint,name varchar(20),fullname varchar(20));
+insert into privilege__privileges.tt1 values (1,null,'a',''),(2,1,'b',''),(3,2,'c','');
+CREATE USER u53490;
+GRANT USAGE ON *.* TO 'u53490';
+GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,CREATE ROUTINE,ALTER ROUTINE,ALTER,EXECUTE,INDEX,CREATE VIEW,SHOW VIEW ON privilege__privileges.* TO 'u53490';
+with t_f as (
+select id,pid,name,'AAA' fullname from privilege__privileges.tt1 )
+update privilege__privileges.tt1 inner join t_f
+set tt1.fullname=t_f.fullname
+where tt1.id=t_f.id;
+with t_f as (
+select id,pid,name,'AAA' fullname from privilege__privileges.tt1 )
+update privilege__privileges.tt1 inner join t_f
+set t_f.fullname=t_f.fullname
+where tt1.id=t_f.id;
+Error 1288 (HY000): The target table t_f of the UPDATE is not updatable

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -895,3 +895,6 @@ with t_f as (
          update privilege__privileges.tt1 inner join t_f
          set t_f.fullname=t_f.fullname
          where tt1.id=t_f.id;
+
+disconnect u53490;
+connection default;

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -871,3 +871,27 @@ ADMIN ALTER DDL JOBS 10 THREAD = 3, BATCH_SIZE = 100, MAX_WRITE_SPEED = '10MiB';
 
 disconnect without_super;
 connection default;
+
+# TestIssue53490
+create table privilege__privileges.tt1 (id bigint,pid bigint,name varchar(20),fullname varchar(20));
+insert into privilege__privileges.tt1 values (1,null,'a',''),(2,1,'b',''),(3,2,'c','');
+
+CREATE USER u53490;
+GRANT USAGE ON *.* TO 'u53490';
+GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,CREATE ROUTINE,ALTER ROUTINE,ALTER,EXECUTE,INDEX,CREATE VIEW,SHOW VIEW ON privilege__privileges.* TO 'u53490';
+
+connect (u53490,localhost,u53490,,);
+connection u53490;
+
+with t_f as (
+         select id,pid,name,'AAA' fullname from privilege__privileges.tt1 )
+         update privilege__privileges.tt1 inner join t_f
+         set tt1.fullname=t_f.fullname
+         where tt1.id=t_f.id;
+
+-- error 1288
+with t_f as (
+         select id,pid,name,'AAA' fullname from privilege__privileges.tt1 )
+         update privilege__privileges.tt1 inner join t_f
+         set t_f.fullname=t_f.fullname
+         where tt1.id=t_f.id;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53490

Problem Summary:

### What changed and how does it work?

See https://github.com/pingcap/tidb/issues/53490#issuecomment-2128700572, for statement like:
```
with t_f as (
         select id,pid,name,'AAA' fullname from test.tt1 )
         update test.tt1 inner join t_f
         set tt1.fullname=t_f.fullname
         where tt1.id=t_f.id;
```
The privilege check for CTE in the update statement should be avoided.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Therocially it consumes more CPU to remove the privilege check, but I believe the real world performance will not be impacted.

Documentation

- NA

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a wrong privilege check when using the `UPDATE` statement with CTE
```
