### PR TITLE
Lightning: Skip apply ioworkers when seek(0, io.SeekCurrent)

### DIFF
--- a/pkg/lightning/mydump/reader.go
+++ b/pkg/lightning/mydump/reader.go
@@ -189,7 +189,8 @@ func (pr PooledReader) Read(p []byte) (n int, err error) {
 
 // Seek implements io.Seeker
 func (pr PooledReader) Seek(offset int64, whence int) (int64, error) {
-	if pr.ioWorkers != nil {
+	// Seek(0, io.SeekCurrent) is used to get the current offset, which will not cause any Disk I/O.
+	if pr.ioWorkers != nil && !(offset == 0 && whence == io.SeekCurrent) {
 		w := pr.ioWorkers.Apply()
 		defer pr.ioWorkers.Recycle(w)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57413

Problem Summary:
When importing from cloud storage, high concurrency can lead to bottlenecks in mydump.PooledReader.Seek(0, io.SeekCurrent) due to the application of ioWorkers. Seek(0, io.SeekCurrent) does not cause disk IO operations, applying ioWorkers is unnecessary.

### What changed and how does it work?

Skip apply ioworkers when seek(0, io.SeekCurrent)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
