### PR TITLE
variables: Increase default innodb_buffer_pool_size to 4GiB

### DIFF
--- a/pkg/sessionctx/variable/noop.go
+++ b/pkg/sessionctx/variable/noop.go
@@ -547,7 +547,7 @@ var noopSysVars = []*SysVar{
 	{Scope: ScopeNone, Name: "report_port", Value: "3306"},
 	{Scope: ScopeGlobal | ScopeSession, Name: ShowOldTemporals, Value: Off, Type: TypeBool},
 	{Scope: ScopeGlobal, Name: "query_cache_limit", Value: "1048576"},
-	{Scope: ScopeGlobal, Name: "innodb_buffer_pool_size", Value: "134217728"},
+	{Scope: ScopeGlobal, Name: "innodb_buffer_pool_size", Value: "4294967296"},
 	{Scope: ScopeGlobal, Name: InnodbAdaptiveFlushing, Value: On, Type: TypeBool, AutoConvertNegativeBool: true},
 	{Scope: ScopeGlobal, Name: "innodb_monitor_enable", Value: ""},
 	{Scope: ScopeNone, Name: "date_format", Value: "%Y-%m-%d"},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57459 

<img width="626" alt="image" src="https://github.com/user-attachments/assets/e2e61512-8dc2-41e8-a0ad-2a8c482dbe86">

Problem Summary: Some applications are complaining that the innodb_buffer_pool_size is too small. Since it doesn't affect any logic in TiDB, we can safely increase the default value so it will work out of box in this situation

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The noop global variable innodb_buffer_pool_size is increased to 4GiB 
```
