### PR TITLE
planner: Do not allow variables in create view

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -901,6 +901,11 @@ error = '''
 View's SELECT contains a '%s' clause
 '''
 
+["ddl:1351"]
+error = '''
+View's SELECT contains a variable or parameter
+'''
+
 ["ddl:1353"]
 error = '''
 In definition of view, derived table or common table expression, SELECT list and column names list have different column counts

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -229,6 +229,8 @@ var (
 	ErrErrorOnRename = ClassDDL.NewStd(mysql.ErrErrorOnRename)
 	// ErrViewSelectClause returns error for create view with select into clause
 	ErrViewSelectClause = ClassDDL.NewStd(mysql.ErrViewSelectClause)
+	// ErrViewSelectVariable returns error for create view with select into clause
+	ErrViewSelectVariable = ClassDDL.NewStd(mysql.ErrViewSelectVariable)
 
 	// ErrNotAllowedTypeInPartition returns not allowed type error when creating table partition with unsupported expression type.
 	ErrNotAllowedTypeInPartition = ClassDDL.NewStd(mysql.ErrFieldTypeNotAllowedAsPartitionField)

--- a/tests/integrationtest/r/ddl/ddl_error.result
+++ b/tests/integrationtest/r/ddl/ddl_error.result
@@ -11,3 +11,11 @@ Error 1450 (HY000): Changing schema from 'ddl__ddl_error' to 'ddl__ddl_error2' i
 rename table ddl__ddl_error.view_1 to ddl__ddl_error2.view_1;
 Error 1450 (HY000): Changing schema from 'ddl__ddl_error' to 'ddl__ddl_error2' is not allowed.
 rename table ddl__ddl_error.view_1 to ddl__ddl_error.view_1000;
+create view sql_mode_view as select @@sql_mode;
+Error 1351 (HY000): View's SELECT contains a variable or parameter
+create view sql_mode_view as select @@global.sql_mode;
+Error 1351 (HY000): View's SELECT contains a variable or parameter
+create view sql_mode_view as select @a;
+Error 1351 (HY000): View's SELECT contains a variable or parameter
+create view sql_mode_view as select 1 where @a = 4;
+Error 1351 (HY000): View's SELECT contains a variable or parameter

--- a/tests/integrationtest/r/executor/ddl.result
+++ b/tests/integrationtest/r/executor/ddl.result
@@ -314,9 +314,9 @@ create view v7 (c,d,e) as select * from t1;
 Error 1353 (HY000): In definition of view, derived table or common table expression, SELECT list and column names list have different column counts
 drop view v1,v2,v3,v4,v5,v6;
 create view v1 (c,d) as select a,b+@@global.max_user_connections from t1;
+Error 1351 (HY000): View's SELECT contains a variable or parameter
 create view v1 (c,d) as select a,b from t1 where a = @@global.max_user_connections;
-Error 1050 (42S01): Table 'executor__ddl.v1' already exists
-drop view v1;
+Error 1351 (HY000): View's SELECT contains a variable or parameter
 create view v1 (c,d,e) as select a,b from t1 ;
 Error 1353 (HY000): In definition of view, derived table or common table expression, SELECT list and column names list have different column counts
 create view v1 (c) as select a,b from t1 ;

--- a/tests/integrationtest/t/ddl/ddl_error.test
+++ b/tests/integrationtest/t/ddl/ddl_error.test
@@ -13,3 +13,12 @@ rename table ddl__ddl_error.view_1 to ddl__ddl_error2.view_1;
 rename table ddl__ddl_error.view_1 to ddl__ddl_error2.view_1;
 rename table ddl__ddl_error.view_1 to ddl__ddl_error.view_1000;
 
+# issue 53176
+-- error 1351
+create view sql_mode_view as select @@sql_mode;
+-- error 1351
+create view sql_mode_view as select @@global.sql_mode;
+-- error 1351
+create view sql_mode_view as select @a;
+-- error 1351
+create view sql_mode_view as select 1 where @a = 4;

--- a/tests/integrationtest/t/executor/ddl.test
+++ b/tests/integrationtest/t/executor/ddl.test
@@ -258,10 +258,10 @@ create view v6 (c,d) as select * from t1;
 -- error 1353
 create view v7 (c,d,e) as select * from t1;
 drop view v1,v2,v3,v4,v5,v6;
+-- error 1351
 create view v1 (c,d) as select a,b+@@global.max_user_connections from t1;
--- error 1050
+-- error 1351
 create view v1 (c,d) as select a,b from t1 where a = @@global.max_user_connections;
-drop view v1;
 -- error 1353
 create view v1 (c,d,e) as select a,b from t1 ;
 -- error 1353


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53176

Problem Summary:
No check if there were variables in the CREATE VIEW statement.
### What changed and how does it work?
Added a visitor to check for `VariableExpr` and give an error for such CREATE VIEW

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Do not allow Variables or Parameters in CREATE VIEW, just like MySQL.
```
