### PR TITLE
expression: fix tikv crash when `bool like cast(bit as char)`

### DIFF
--- a/pkg/expression/builtin_convert_charset.go
+++ b/pkg/expression/builtin_convert_charset.go
@@ -173,6 +173,7 @@ type builtinInternalFromBinarySig struct {
 func (b *builtinInternalFromBinarySig) Clone() builtinFunc {
 	newSig := &builtinInternalFromBinarySig{}
 	newSig.cloneFrom(&b.baseBuiltinFunc)
+	newSig.cannotConvertStringAsWarning = b.cannotConvertStringAsWarning
 	return newSig
 }
 

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1583,6 +1583,7 @@ func TestExprPushDownToTiKV(t *testing.T) {
 
 	// Test Conv function, `conv` function for a BIT column should not be pushed down for its special behavior which
 	// is only handled in TiDB currently.
+	// see issue: https://github.com/pingcap/tidb/issues/51877
 	exprs = exprs[:0]
 	function, err = NewFunction(mock.NewContext(), ast.Conv, types.NewFieldType(mysql.TypeString), stringColumn, intColumn, intColumn)
 	require.NoError(t, err)

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1581,7 +1581,8 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	require.Len(t, pushed, 0)
 	require.Len(t, remained, len(exprs))
 
-	// Test Conv function
+	// Test Conv function, `conv` function for a BIT column should not be pushed down for its special behavior which
+	// is only handled in TiDB currently.
 	exprs = exprs[:0]
 	function, err = NewFunction(mock.NewContext(), ast.Conv, types.NewFieldType(mysql.TypeString), stringColumn, intColumn, intColumn)
 	require.NoError(t, err)
@@ -1590,7 +1591,11 @@ func TestExprPushDownToTiKV(t *testing.T) {
 	require.Len(t, pushed, len(exprs))
 	require.Len(t, remained, 0)
 	exprs = exprs[:0]
-	castByteAsStringFunc, err := NewFunction(mock.NewContext(), ast.Cast, types.NewFieldType(mysql.TypeString), byteColumn)
+	// when conv a column with type BIT, a cast function will be used to cast bit to a binary string
+	castTp := types.NewFieldType(mysql.TypeString)
+	castTp.SetCharset(charset.CharsetBin)
+	castTp.SetCollate(charset.CollationBin)
+	castByteAsStringFunc, err := NewFunction(mock.NewContext(), ast.Cast, castTp, byteColumn)
 	require.NoError(t, err)
 	function, err = NewFunction(mock.NewContext(), ast.Conv, types.NewFieldType(mysql.TypeString), castByteAsStringFunc, intColumn, intColumn)
 	require.NoError(t, err)

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -309,7 +309,7 @@ func TestBitColumnPushDown(t *testing.T) {
 	tk.MustQuery(sql).Check(testkit.Rows("A"))
 	tk.MustQuery(fmt.Sprintf("explain analyze %s", sql)).CheckAt([]int{0, 3, 6}, rows)
 
-	rows[1][2] = `eq(cast(test.t1.a, var_string(1)), "A")`
+	rows[1][2] = `eq(cast(from_binary(cast(test.t1.a, binary(1))), var_string(1)), "A")`
 	sql = "select a from t1 where cast(a as char)='A'"
 	tk.MustQuery(sql).Check(testkit.Rows("A"))
 	tk.MustQuery(fmt.Sprintf("explain analyze %s", sql)).CheckAt([]int{0, 3, 6}, rows)
@@ -317,7 +317,7 @@ func TestBitColumnPushDown(t *testing.T) {
 	tk.MustExec("insert into mysql.expr_pushdown_blacklist values('bit', 'tikv','');")
 	tk.MustExec("admin reload expr_pushdown_blacklist;")
 	rows = [][]any{
-		{"Selection_5", "root", `eq(cast(test.t1.a, var_string(1)), "A")`},
+		{"Selection_5", "root", `eq(cast(from_binary(cast(test.t1.a, binary(1))), var_string(1)), "A")`},
 		{"└─TableReader_7", "root", "data:TableFullScan_6"},
 		{"  └─TableFullScan_6", "cop[tikv]", "keep order:false, stats:pseudo"},
 	}

--- a/tests/integrationtest/r/expression/cast.result
+++ b/tests/integrationtest/r/expression/cast.result
@@ -178,3 +178,18 @@ id	update_user
 2	李四
 4	李四
 1	张三
+drop table if exists test;
+create table test(a bit(24));
+insert into test values('中');
+select a from test where '中' like convert(a, char);
+a
+中
+select a from test where false not like convert(a, char);
+a
+中
+select a from test where false like convert(a, char);
+a
+truncate table test;
+insert into test values(0xffffff);
+select a from test where false not like convert(a, char);
+Error 1105 (HY000): Cannot convert string '\xFF\xFF\xFF' from binary to utf8mb4

--- a/tests/integrationtest/t/expression/cast.test
+++ b/tests/integrationtest/t/expression/cast.test
@@ -113,3 +113,14 @@ insert into test values(3,'张三');
 insert into test values(4,'李四');
 select * from test order by cast(update_user as char) desc , id limit 3;
 
+# issue #56494, cast bit as char
+drop table if exists test;
+create table test(a bit(24));
+insert into test values('中');
+select a from test where '中' like convert(a, char);
+select a from test where false not like convert(a, char);
+select a from test where false like convert(a, char);
+truncate table test;
+insert into test values(0xffffff);
+-- error 1105
+select a from test where false not like convert(a, char);

--- a/tests/realtikvtest/pushdowntest/BUILD.bazel
+++ b/tests/realtikvtest/pushdowntest/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "pushdowntest_test",
+    timeout = "short",
+    srcs = [
+        "expr_test.go",
+        "main_test.go",
+    ],
+    flaky = True,
+    deps = [
+        "//pkg/testkit",
+        "//tests/realtikvtest",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/tests/realtikvtest/pushdowntest/expr_test.go
+++ b/tests/realtikvtest/pushdowntest/expr_test.go
@@ -1,0 +1,36 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pushdowntest
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBitCastInTiKV see issue: https://github.com/pingcap/tidb/issues/56494
+func TestBitCastInTiKV(t *testing.T) {
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	defer tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(a bit(24))")
+	tk.MustExec("insert into t1 values(0xffffff)")
+	err := tk.QueryToErr("select a from t1 where false not like convert(a, char)")
+	require.EqualError(t, err, "[tikv:3854]Cannot convert string '\\xFF\\xFF\\xFF' from binary to utf8mb4")
+}

--- a/tests/realtikvtest/pushdowntest/main_test.go
+++ b/tests/realtikvtest/pushdowntest/main_test.go
@@ -1,0 +1,25 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pushdowntest
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/tests/realtikvtest"
+)
+
+func TestMain(m *testing.M) {
+	realtikvtest.RunTestMain(m)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56494

### What changed and how does it work?

When casting the bit type to a non binary string, this PR first convert bits to binary string first. This can ensure `HandleBinaryLiteral` can be used in the following code and convert binary to the specified collation with right behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix tikv crash when `bool like cast(bit as char)`
```
