### PR TITLE
expression,json: make the behavior of `JSON_VALID` consistent

### DIFF
--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -1089,7 +1089,8 @@ func (b *builtinJSONValidOthersSig) Clone() builtinFunc {
 // evalInt evals a builtinJSONValidOthersSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-valid
 func (b *builtinJSONValidOthersSig) evalInt(ctx EvalContext, row chunk.Row) (val int64, isNull bool, err error) {
-	return 0, false, nil
+	datum, err := b.args[0].Eval(ctx, row)
+	return 0, datum.IsNull(), err
 }
 
 type jsonArrayAppendFunctionClass struct {

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -765,3 +765,9 @@ Error 3853 (22032): Invalid JSON type in argument 1 to function json_schema_vali
 select json_type(cast(cast('2024' as year) as json));
 json_type(cast(cast('2024' as year) as json))
 UNSIGNED INTEGER
+drop table if exists t;
+create table t(j json, str varchar(255), other int);
+insert into t values (NULL, NULL, NULL);
+select json_valid(j), json_valid(str), json_valid(other) from t;
+json_valid(j)	json_valid(str)	json_valid(other)
+NULL	NULL	NULL

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -484,3 +484,9 @@ SELECT JSON_SCHEMA_VALID('{"properties": {"a": {"exclusiveMinimum": true}}}', '{
 # TestIssue54494
 # https://github.com/pingcap/tidb/issues/54494
 select json_type(cast(cast('2024' as year) as json));
+
+# TestJSONValidForNull
+drop table if exists t;
+create table t(j json, str varchar(255), other int);
+insert into t values (NULL, NULL, NULL);
+select json_valid(j), json_valid(str), json_valid(other) from t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56293

Problem Summary:

The `JSON_VALID` function behavior is inconsistent between different types, between TiDB and TiKV.

### What changed and how does it work?

This PR changes the behavior of returning `0` directly for "other" types. With this modification, the behavior is consistent for `JSON`, `STRING` and all other types. Also, it's compatible between TiDB and TiKV.

The strange behavior described in #56293 is caused by different behavior between the `SELECTION` pushed down to TiKV, and the `PROJECTION` in TiDB. This PR should fix it.

Please be careful that this behavior is **not** compatible with MySQL. Because the behavior of MySQL is not consistent to its document (https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-valid) and is also not consistent between different types, columns and literals. I submitted a bug report to MySQL : https://bugs.mysql.com/bug.php?id=116703

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
