### PR TITLE
planner: fix `count(*)` return wrong value for `information_schema.tables`

### DIFF
--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -552,6 +552,15 @@ func TestTablesTable(t *testing.T) {
 		testkit.Rows())
 	tk.MustQuery(fmt.Sprintf("select table_schema, table_name, tidb_table_id from information_schema.tables where table_schema = 'db1' and table_name = 't1' and tidb_table_id in (%s,%s)", tableMetas[0].id, tableMetas[1].id)).Check(
 		testkit.Rows(toString(tableMetas[0])))
+
+	selectTables, err := strconv.Atoi(tk.MustQuery("select count(*) from information_schema.tables where upper(table_name) = 'T1'").Rows()[0][0].(string))
+	require.NoError(t, err)
+	totalTables, err := strconv.Atoi(tk.MustQuery("select count(*) from information_schema.tables").Rows()[0][0].(string))
+	require.NoError(t, err)
+	remainTables, err := strconv.Atoi(tk.MustQuery("select count(*) from information_schema.tables where upper(table_name) != 'T1'").Rows()[0][0].(string))
+	require.NoError(t, err)
+	require.Equal(t, 2, selectTables)
+	require.Equal(t, totalTables, remainTables+selectTables)
 }
 
 func TestColumnTable(t *testing.T) {

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -251,7 +251,7 @@ func (e *InfoSchemaBaseExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 // Filter use the col predicates to filter records.
 // Return true if the underlying row does not match predicate,
 // then it should be filtered and not shown in the result.
-func (e *InfoSchemaBaseExtractor) filter(colName string, val string) bool {
+func (e *InfoSchemaBaseExtractor) filter(colName string, val string, toLower bool) bool {
 	if e.SkipRequest {
 		return true
 	}
@@ -262,6 +262,9 @@ func (e *InfoSchemaBaseExtractor) filter(colName string, val string) bool {
 	}
 	predVals, ok := e.ColPredicates[colName]
 	if ok && len(predVals) > 0 {
+		if toLower {
+			return !predVals.Exist(strings.ToLower(val))
+		}
 		fn, ok := e.pushedDownFuncs[colName]
 		if ok {
 			return !predVals.Exist(fn(val))
@@ -307,12 +310,12 @@ func NewInfoSchemaTablesExtractor() *InfoSchemaTablesExtractor {
 
 // HasTableName returns true if table name is specified in predicates.
 func (e *InfoSchemaTablesExtractor) HasTableName(name string) bool {
-	return !e.filter(TableName, name)
+	return !e.filter(TableName, name, true)
 }
 
 // HasTableSchema returns true if table schema is specified in predicates.
 func (e *InfoSchemaTablesExtractor) HasTableSchema(name string) bool {
-	return !e.filter(TableSchema, name)
+	return !e.filter(TableSchema, name, true)
 }
 
 // InfoSchemaDDLExtractor is the predicate extractor for information_schema.ddl_jobs.
@@ -383,17 +386,17 @@ func NewInfoSchemaKeyColumnUsageExtractor() *InfoSchemaKeyColumnUsageExtractor {
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name)
+	return !e.filter(ConstraintName, name, false)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasPrimaryKey() bool {
-	return !e.filter(ConstraintName, primaryKeyName)
+	return !e.filter(ConstraintName, primaryKeyName, false)
 }
 
 // HasConstraintSchema returns true if constraint schema is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraintSchema(name string) bool {
-	return !e.filter(ConstraintSchema, name)
+	return !e.filter(ConstraintSchema, name, false)
 }
 
 // InfoSchemaTableConstraintsExtractor is the predicate extractor for information_schema.constraints.
@@ -416,17 +419,17 @@ func NewInfoSchemaTableConstraintsExtractor() *InfoSchemaTableConstraintsExtract
 
 // HasConstraintSchema returns true if constraint schema is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraintSchema(name string) bool {
-	return !e.filter(ConstraintSchema, name)
+	return !e.filter(ConstraintSchema, name, false)
 }
 
 // HasConstraint returns true if constraint is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name)
+	return !e.filter(ConstraintName, name, false)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasPrimaryKey() bool {
-	return !e.filter(ConstraintName, primaryKeyName)
+	return !e.filter(ConstraintName, primaryKeyName, false)
 }
 
 // InfoSchemaPartitionsExtractor is the predicate extractor for information_schema.partitions.
@@ -449,7 +452,7 @@ func NewInfoSchemaPartitionsExtractor() *InfoSchemaPartitionsExtractor {
 
 // HasPartition returns true if partition name matches the one in predicates.
 func (e *InfoSchemaPartitionsExtractor) HasPartition(name string) bool {
-	return !e.filter(PartitionName, name)
+	return !e.filter(PartitionName, name, false)
 }
 
 // HasPartitionPred returns true if partition name is specified in predicates.
@@ -476,12 +479,12 @@ func NewInfoSchemaStatisticsExtractor() *InfoSchemaStatisticsExtractor {
 
 // HasIndex returns true if index name is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasIndex(val string) bool {
-	return !e.filter(IndexName, val)
+	return !e.filter(IndexName, val, false)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasPrimaryKey() bool {
-	return !e.filter(IndexName, primaryKeyName)
+	return !e.filter(IndexName, primaryKeyName, false)
 }
 
 // InfoSchemaSchemataExtractor is the predicate extractor for information_schema.schemata.
@@ -517,7 +520,7 @@ func NewInfoSchemaCheckConstraintsExtractor() *InfoSchemaCheckConstraintsExtract
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaCheckConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name)
+	return !e.filter(ConstraintName, name, false)
 }
 
 // InfoSchemaTiDBCheckConstraintsExtractor is the predicate extractor for information_schema.tidb_check_constraints.
@@ -540,7 +543,7 @@ func NewInfoSchemaTiDBCheckConstraintsExtractor() *InfoSchemaTiDBCheckConstraint
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaTiDBCheckConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name)
+	return !e.filter(ConstraintName, name, false)
 }
 
 // InfoSchemaReferConstExtractor is the predicate extractor for information_schema.referential_constraints.
@@ -562,7 +565,7 @@ func NewInfoSchemaReferConstExtractor() *InfoSchemaReferConstExtractor {
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaReferConstExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name)
+	return !e.filter(ConstraintName, name, false)
 }
 
 // InfoSchemaSequenceExtractor is the predicate extractor for information_schema.sequences.

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -261,7 +261,11 @@ func (e *InfoSchemaBaseExtractor) filter(colName string, val string) bool {
 		}
 	}
 
-	toLower := e.extractLowerString[colName]
+	toLower := false
+	if e.extractLowerString != nil {
+		toLower = e.extractLowerString[colName]
+	}
+
 	predVals, ok := e.ColPredicates[colName]
 	if ok && len(predVals) > 0 {
 		if toLower {

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -251,7 +251,7 @@ func (e *InfoSchemaBaseExtractor) ExplainInfo(_ base.PhysicalPlan) string {
 // Filter use the col predicates to filter records.
 // Return true if the underlying row does not match predicate,
 // then it should be filtered and not shown in the result.
-func (e *InfoSchemaBaseExtractor) filter(colName string, val string, toLower bool) bool {
+func (e *InfoSchemaBaseExtractor) filter(colName string, val string) bool {
 	if e.SkipRequest {
 		return true
 	}
@@ -260,6 +260,8 @@ func (e *InfoSchemaBaseExtractor) filter(colName string, val string, toLower boo
 			return true
 		}
 	}
+
+	toLower := e.extractLowerString[colName]
 	predVals, ok := e.ColPredicates[colName]
 	if ok && len(predVals) > 0 {
 		if toLower {
@@ -310,12 +312,12 @@ func NewInfoSchemaTablesExtractor() *InfoSchemaTablesExtractor {
 
 // HasTableName returns true if table name is specified in predicates.
 func (e *InfoSchemaTablesExtractor) HasTableName(name string) bool {
-	return !e.filter(TableName, name, true)
+	return !e.filter(TableName, name)
 }
 
 // HasTableSchema returns true if table schema is specified in predicates.
 func (e *InfoSchemaTablesExtractor) HasTableSchema(name string) bool {
-	return !e.filter(TableSchema, name, true)
+	return !e.filter(TableSchema, name)
 }
 
 // InfoSchemaDDLExtractor is the predicate extractor for information_schema.ddl_jobs.
@@ -386,17 +388,17 @@ func NewInfoSchemaKeyColumnUsageExtractor() *InfoSchemaKeyColumnUsageExtractor {
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name, false)
+	return !e.filter(ConstraintName, name)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasPrimaryKey() bool {
-	return !e.filter(ConstraintName, primaryKeyName, false)
+	return !e.filter(ConstraintName, primaryKeyName)
 }
 
 // HasConstraintSchema returns true if constraint schema is specified in predicates.
 func (e *InfoSchemaKeyColumnUsageExtractor) HasConstraintSchema(name string) bool {
-	return !e.filter(ConstraintSchema, name, false)
+	return !e.filter(ConstraintSchema, name)
 }
 
 // InfoSchemaTableConstraintsExtractor is the predicate extractor for information_schema.constraints.
@@ -419,17 +421,17 @@ func NewInfoSchemaTableConstraintsExtractor() *InfoSchemaTableConstraintsExtract
 
 // HasConstraintSchema returns true if constraint schema is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraintSchema(name string) bool {
-	return !e.filter(ConstraintSchema, name, false)
+	return !e.filter(ConstraintSchema, name)
 }
 
 // HasConstraint returns true if constraint is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name, false)
+	return !e.filter(ConstraintName, name)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaTableConstraintsExtractor) HasPrimaryKey() bool {
-	return !e.filter(ConstraintName, primaryKeyName, false)
+	return !e.filter(ConstraintName, primaryKeyName)
 }
 
 // InfoSchemaPartitionsExtractor is the predicate extractor for information_schema.partitions.
@@ -452,7 +454,7 @@ func NewInfoSchemaPartitionsExtractor() *InfoSchemaPartitionsExtractor {
 
 // HasPartition returns true if partition name matches the one in predicates.
 func (e *InfoSchemaPartitionsExtractor) HasPartition(name string) bool {
-	return !e.filter(PartitionName, name, false)
+	return !e.filter(PartitionName, name)
 }
 
 // HasPartitionPred returns true if partition name is specified in predicates.
@@ -479,12 +481,12 @@ func NewInfoSchemaStatisticsExtractor() *InfoSchemaStatisticsExtractor {
 
 // HasIndex returns true if index name is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasIndex(val string) bool {
-	return !e.filter(IndexName, val, false)
+	return !e.filter(IndexName, val)
 }
 
 // HasPrimaryKey returns true if primary key is specified in predicates.
 func (e *InfoSchemaStatisticsExtractor) HasPrimaryKey() bool {
-	return !e.filter(IndexName, primaryKeyName, false)
+	return !e.filter(IndexName, primaryKeyName)
 }
 
 // InfoSchemaSchemataExtractor is the predicate extractor for information_schema.schemata.
@@ -520,7 +522,7 @@ func NewInfoSchemaCheckConstraintsExtractor() *InfoSchemaCheckConstraintsExtract
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaCheckConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name, false)
+	return !e.filter(ConstraintName, name)
 }
 
 // InfoSchemaTiDBCheckConstraintsExtractor is the predicate extractor for information_schema.tidb_check_constraints.
@@ -543,7 +545,7 @@ func NewInfoSchemaTiDBCheckConstraintsExtractor() *InfoSchemaTiDBCheckConstraint
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaTiDBCheckConstraintsExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name, false)
+	return !e.filter(ConstraintName, name)
 }
 
 // InfoSchemaReferConstExtractor is the predicate extractor for information_schema.referential_constraints.
@@ -565,7 +567,7 @@ func NewInfoSchemaReferConstExtractor() *InfoSchemaReferConstExtractor {
 
 // HasConstraint returns true if constraint name is specified in predicates.
 func (e *InfoSchemaReferConstExtractor) HasConstraint(name string) bool {
-	return !e.filter(ConstraintName, name, false)
+	return !e.filter(ConstraintName, name)
 }
 
 // InfoSchemaSequenceExtractor is the predicate extractor for information_schema.sequences.

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -345,6 +345,10 @@ func (helper *extractHelper) extractCol(
 			break
 		}
 	}
+
+	if helper.extractLowerString == nil {
+		helper.extractLowerString = make(map[string]bool)
+	}
 	helper.extractLowerString[extractColName] = valueToLower
 	return
 }

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -51,6 +51,9 @@ import (
 type extractHelper struct {
 	enableScalarPushDown bool
 	pushedDownFuncs      map[string]func(string) string
+
+	// Store whether the extracted strings for a specific column are converted to lower case
+	extractLowerString map[string]bool
 }
 
 func (extractHelper) extractColInConsExpr(ctx base.PlanContext, extractCols map[int64]*types.FieldName, expr *expression.ScalarFunction) (string, []types.Datum) {
@@ -342,6 +345,7 @@ func (helper *extractHelper) extractCol(
 			break
 		}
 	}
+	helper.extractLowerString[extractColName] = valueToLower
 	return
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56987

Problem Summary:

`InfoSchemaBaseExtractor` wrongly filter table names for the fast path introduced by https://github.com/pingcap/tidb/pull/55574 

### What changed and how does it work?

Introduce a new variable `extractLowerString` to dertermine whether to do case-insensitive comparisons for specific columns.

Test case is not added in integration test because we don't want to write some hardcoded value. (ref #57306)

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
