### PR TITLE
executor,distsql,util: distinguish walltime from sum of walltime in execution info

### DIFF
--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/mock"
-	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/tikv"
@@ -105,7 +104,7 @@ func TestSelectWithRuntimeStats(t *testing.T) {
 
 func TestSelectResultRuntimeStats(t *testing.T) {
 	stmtStats := execdetails.NewRuntimeStatsColl(nil)
-	basic := stmtStats.GetBasicRuntimeStats(1)
+	basic := stmtStats.GetBasicRuntimeStats(1, false)
 	basic.Record(time.Second, 20)
 	s1 := &selectResultRuntimeStats{
 		backoffSleep:       map[string]time.Duration{"RegionMiss": time.Millisecond},

--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -105,7 +105,7 @@ func TestSelectWithRuntimeStats(t *testing.T) {
 
 func TestSelectResultRuntimeStats(t *testing.T) {
 	stmtStats := execdetails.NewRuntimeStatsColl(nil)
-	basic := stmtStats.GetBasicRuntimeStats(1, false)
+	basic := stmtStats.GetBasicRuntimeStats(1, true)
 	basic.Record(time.Second, 20)
 	s1 := &selectResultRuntimeStats{
 		backoffSleep:       map[string]time.Duration{"RegionMiss": time.Millisecond},

--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/tikv"

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -328,7 +328,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 		} else {
 			// CachedPlan type is already checked in last step
 			pointGetPlan := a.Plan.(*plannercore.PointGetPlan)
-			exec.Init(pointGetPlan)
+			exec.Recreated(pointGetPlan)
 			a.PsStmt.PointGet.Executor = exec
 			executor = exec
 		}

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1073,7 +1073,7 @@ func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.Select
 	idxID := w.idxLookup.getIndexPlanRootID()
 	if w.idxLookup.stmtRuntimeStatsColl != nil {
 		if idxID != w.idxLookup.ID() && w.idxLookup.stats != nil {
-			w.idxLookup.stats.indexScanBasicStats = w.idxLookup.stmtRuntimeStatsColl.GetBasicRuntimeStats(idxID)
+			w.idxLookup.stats.indexScanBasicStats = w.idxLookup.stmtRuntimeStatsColl.GetBasicRuntimeStats(idxID, false)
 		}
 	}
 	for i := 0; i < len(results); {

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1073,7 +1073,7 @@ func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.Select
 	idxID := w.idxLookup.getIndexPlanRootID()
 	if w.idxLookup.stmtRuntimeStatsColl != nil {
 		if idxID != w.idxLookup.ID() && w.idxLookup.stats != nil {
-			w.idxLookup.stats.indexScanBasicStats = w.idxLookup.stmtRuntimeStatsColl.GetBasicRuntimeStats(idxID, false)
+			w.idxLookup.stats.indexScanBasicStats = w.idxLookup.stmtRuntimeStatsColl.GetBasicRuntimeStats(idxID, true)
 		}
 	}
 	for i := 0; i < len(results); {

--- a/pkg/executor/explain_test.go
+++ b/pkg/executor/explain_test.go
@@ -322,7 +322,8 @@ func TestIssue35911(t *testing.T) {
 	timeStr1 := extractTime.FindStringSubmatch(rows[4][5].(string))[1]
 	time1, err := time.ParseDuration(timeStr1)
 	require.NoError(t, err)
-	timeStr2 := extractTime.FindStringSubmatch(rows[5][5].(string))[1]
+	extractTime2, _ := regexp.Compile("^total_time:(.*?),")
+	timeStr2 := extractTime2.FindStringSubmatch(rows[5][5].(string))[1]
 	time2, err := time.ParseDuration(timeStr2)
 	require.NoError(t, err)
 	// The duration of IndexLookUp should be longer than its build side child

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/ranger"
+	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
 

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -376,6 +376,9 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					byItems:            is.ByItems,
 					pushedLimit:        pushedIndexLimit,
 				}
+				if worker.stats != nil && worker.idxID != 0 {
+					worker.sc.GetSessionVars().StmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(worker.idxID, true)
+				}
 				if e.isCorColInPartialFilters[workID] {
 					// We got correlated column, so need to refresh Selection operator.
 					var err error

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -1800,7 +1800,7 @@ func (w *partialIndexWorker) extractTaskHandles(ctx context.Context, chk *chunk.
 			return nil, nil, err
 		}
 		if w.stats != nil && w.idxID != 0 {
-			w.sc.GetSessionVars().StmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(w.idxID).Record(time.Since(start), chk.NumRows())
+			w.sc.GetSessionVars().StmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(w.idxID, false).Record(time.Since(start), chk.NumRows())
 		}
 		if chk.NumRows() == 0 {
 			failpoint.Inject("testIndexMergeErrorPartialIndexWorker", func(v failpoint.Value) {

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -377,7 +377,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					pushedLimit:        pushedIndexLimit,
 				}
 				if worker.stats != nil && worker.idxID != 0 {
-					worker.indexScanBasicStats = worker.sc.GetSessionVars().StmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(worker.idxID, true)
+					worker.stats.indexScanBasicStats = worker.sc.GetSessionVars().StmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(worker.idxID, true)
 				}
 				if e.isCorColInPartialFilters[workID] {
 					// We got correlated column, so need to refresh Selection operator.
@@ -1667,21 +1667,20 @@ func (w *indexMergeProcessWorker) fetchLoopIntersection(ctx context.Context, fet
 }
 
 type partialIndexWorker struct {
-	stats               *IndexMergeRuntimeStat
-	indexScanBasicStats *execdetails.BasicRuntimeStats
-	sc                  sessionctx.Context
-	idxID               int
-	batchSize           int
-	maxBatchSize        int
-	maxChunkSize        int
-	memTracker          *memory.Tracker
-	partitionTableMode  bool
-	prunedPartitions    []table.PhysicalTable
-	byItems             []*plannerutil.ByItems
-	scannedKeys         uint64
-	pushedLimit         *plannercore.PushedDownLimit
-	dagPB               *tipb.DAGRequest
-	plan                []base.PhysicalPlan
+	stats              *IndexMergeRuntimeStat
+	sc                 sessionctx.Context
+	idxID              int
+	batchSize          int
+	maxBatchSize       int
+	maxChunkSize       int
+	memTracker         *memory.Tracker
+	partitionTableMode bool
+	prunedPartitions   []table.PhysicalTable
+	byItems            []*plannerutil.ByItems
+	scannedKeys        uint64
+	pushedLimit        *plannercore.PushedDownLimit
+	dagPB              *tipb.DAGRequest
+	plan               []base.PhysicalPlan
 }
 
 func syncErr(ctx context.Context, finished <-chan struct{}, errCh chan<- *indexMergeTableTask, err error) {
@@ -1803,8 +1802,8 @@ func (w *partialIndexWorker) extractTaskHandles(ctx context.Context, chk *chunk.
 		if err != nil {
 			return nil, nil, err
 		}
-		if w.indexScanBasicStats != nil {
-			w.indexScanBasicStats.Record(time.Since(start), chk.NumRows())
+		if w.stats != nil && w.stats.indexScanBasicStats != nil {
+			w.stats.indexScanBasicStats.Record(time.Since(start), chk.NumRows())
 		}
 		if chk.NumRows() == 0 {
 			failpoint.Inject("testIndexMergeErrorPartialIndexWorker", func(v failpoint.Value) {
@@ -2009,12 +2008,13 @@ func (w *indexMergeTableScanWorker) executeTask(ctx context.Context, task *index
 
 // IndexMergeRuntimeStat record the indexMerge runtime stat
 type IndexMergeRuntimeStat struct {
-	IndexMergeProcess time.Duration
-	FetchIdxTime      int64
-	WaitTime          int64
-	FetchRow          int64
-	TableTaskNum      int64
-	Concurrency       int
+	indexScanBasicStats *execdetails.BasicRuntimeStats
+	IndexMergeProcess   time.Duration
+	FetchIdxTime        int64
+	WaitTime            int64
+	FetchRow            int64
+	TableTaskNum        int64
+	Concurrency         int
 }
 
 func (e *IndexMergeRuntimeStat) String() string {

--- a/pkg/executor/internal/exec/executor.go
+++ b/pkg/executor/internal/exec/executor.go
@@ -236,7 +236,7 @@ func newExecutorStats(stmtCtx *stmtctx.StatementContext, id int) executorStats {
 
 	if stmtCtx.RuntimeStatsColl != nil {
 		if id > 0 {
-			e.runtimeStats = stmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(id)
+			e.runtimeStats = stmtCtx.RuntimeStatsColl.GetBasicRuntimeStats(id, true)
 		}
 	}
 
@@ -338,7 +338,7 @@ func (e *BaseExecutorV2) BuildNewBaseExecutorV2(stmtRuntimeStatsColl *execdetail
 	newExecutorStats := e.executorStats
 	if stmtRuntimeStatsColl != nil {
 		if id > 0 {
-			newExecutorStats.runtimeStats = stmtRuntimeStatsColl.GetBasicRuntimeStats(id)
+			newExecutorStats.runtimeStats = stmtRuntimeStatsColl.GetBasicRuntimeStats(id, true)
 		}
 	}
 

--- a/pkg/executor/internal/exec/indexusage.go
+++ b/pkg/executor/internal/exec/indexusage.go
@@ -106,7 +106,7 @@ func (e *IndexUsageReporter) ReportPointGetIndexUsage(tableID int64, physicalTab
 		return
 	}
 
-	basic := e.runtimeStatsColl.GetBasicRuntimeStats(planID)
+	basic := e.runtimeStatsColl.GetBasicRuntimeStats(planID, false)
 	if basic == nil {
 		return
 	}

--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -31,6 +31,7 @@ import (
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/stretchr/testify/require"
+	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
 

--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	"github.com/stretchr/testify/require"
 	"github.com/pingcap/tipb/go-tipb"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 

--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -53,7 +53,7 @@ func TestIndexUsageReporter(t *testing.T) {
 
 	// For PointGet and BatchPointGet
 	planID := 3
-	runtimeStatsColl.GetBasicRuntimeStats(planID, false).Record(time.Second, 2024)
+	runtimeStatsColl.GetBasicRuntimeStats(planID, true).Record(time.Second, 2024)
 	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)
 
 	require.Eventually(t, func() bool {
@@ -88,7 +88,7 @@ func TestIndexUsageReporter(t *testing.T) {
 		RealtimeCount: 100,
 	})
 	planID = 4
-	runtimeStatsColl.GetBasicRuntimeStats(planID, false).Record(time.Second, 2024)
+	runtimeStatsColl.GetBasicRuntimeStats(planID, true).Record(time.Second, 2024)
 	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)
 
 	require.Eventually(t, func() bool {

--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/logutil"
-	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -53,7 +52,7 @@ func TestIndexUsageReporter(t *testing.T) {
 
 	// For PointGet and BatchPointGet
 	planID := 3
-	runtimeStatsColl.GetBasicRuntimeStats(planID).Record(time.Second, 2024)
+	runtimeStatsColl.GetBasicRuntimeStats(planID, false).Record(time.Second, 2024)
 	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)
 
 	require.Eventually(t, func() bool {
@@ -88,7 +87,7 @@ func TestIndexUsageReporter(t *testing.T) {
 		RealtimeCount: 100,
 	})
 	planID = 4
-	runtimeStatsColl.GetBasicRuntimeStats(planID).Record(time.Second, 2024)
+	runtimeStatsColl.GetBasicRuntimeStats(planID, false).Record(time.Second, 2024)
 	reporter.ReportPointGetIndexUsage(tableID, tableID, indexID, planID, 1)
 
 	require.Eventually(t, func() bool {

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -197,6 +197,15 @@ func matchPartitionNames(pid int64, partitionNames []pmodel.CIStr, pi *model.Par
 	return false
 }
 
+// Recreated based on Init, change baseExecutor fields also
+func (e *PointGetExecutor) Recreated(p *plannercore.PointGetPlan) {
+	e.Init(p)
+	// It's necessary to at least reset the `runtimeStats` of the `BaseExecutor`.
+	// As the `StmtCtx` may have changed, a new index usage reporter should also be created.
+	e.BaseExecutor = exec.NewBaseExecutor(e.Ctx(), p.Schema(), p.ID())
+	e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
+}
+
 // Init set fields needed for PointGetExecutor reuse, this does NOT change baseExecutor field
 func (e *PointGetExecutor) Init(p *plannercore.PointGetPlan) {
 	decoder := NewRowDecoder(e.Ctx(), p.Schema(), p.TblInfo)
@@ -217,11 +226,6 @@ func (e *PointGetExecutor) Init(p *plannercore.PointGetPlan) {
 	e.partitionDefIdx = p.PartitionIdx
 	e.columns = p.Columns
 	e.buildVirtualColumnInfo()
-
-	// It's necessary to at least reset the `runtimeStats` of the `BaseExecutor`.
-	// As the `StmtCtx` may have changed, a new index usage reporter should also be created.
-	e.BaseExecutor = exec.NewBaseExecutor(e.Ctx(), p.Schema(), p.ID())
-	e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
 }
 
 // buildVirtualColumnInfo saves virtual column indices and sort them in definition order

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -654,6 +654,12 @@ func (p *PhysicalHashJoin) explainInfo(normalized bool) string {
 	}
 
 	buffer.WriteString(p.JoinType.String())
+	buffer.WriteString(", left side:")
+	if normalized {
+		buffer.WriteString(p.Children()[0].TP())
+	} else {
+		buffer.WriteString(p.Children()[0].ExplainID().String())
+	}
 
 	evalCtx := p.SCtx().GetExprCtx().GetEvalCtx()
 	if len(p.EqualConditions) > 0 {

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -654,12 +654,6 @@ func (p *PhysicalHashJoin) explainInfo(normalized bool) string {
 	}
 
 	buffer.WriteString(p.JoinType.String())
-	buffer.WriteString(", left side:")
-	if normalized {
-		buffer.WriteString(p.Children()[0].TP())
-	} else {
-		buffer.WriteString(p.Children()[0].ExplainID().String())
-	}
 
 	evalCtx := p.SCtx().GetExprCtx().GetEvalCtx()
 	if len(p.EqualConditions) > 0 {

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1502,8 +1502,8 @@ func (e *RuntimeStatsColl) RegisterStats(planID int, info RuntimeStats) {
 }
 
 // GetBasicRuntimeStats gets basicRuntimeStats for a executor
-// When rootStat is nil, the behavior is decided by initNewExecutorStats argument:
-// 1. If true, it created a new rootStat and basicRuntimeStats, increase basicRuntimeStats' executorCount
+// When rootStat/rootStat's basicRuntimeStats is nil, the behavior is decided by initNewExecutorStats argument:
+// 1. If true, it created a new one, and increase basicRuntimeStats' executorCount
 // 2. Else, it returns nil
 func (e *RuntimeStatsColl) GetBasicRuntimeStats(planID int, initNewExecutorStats bool) *BasicRuntimeStats {
 	e.mu.Lock()

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1430,14 +1430,14 @@ func (e *BasicRuntimeStats) String() string {
 	totalTime := e.consume.Load()
 	openTime := e.open.Load()
 	closeTime := e.close.Load()
-	str.WriteString(fmt.sprintf("%stime:", timePrefix))
+	str.WriteString(fmt.Sprintf("%stime:", timePrefix))
 	str.WriteString(FormatDuration(time.Duration(totalTime)))
 	if openTime >= int64(time.Millisecond) {
-		str.WriteString(fmt.sprintf(", %sopen:", timePrefix))
+		str.WriteString(fmt.Sprintf(", %sopen:", timePrefix))
 		str.WriteString(FormatDuration(time.Duration(openTime)))
 	}
 	if closeTime >= int64(time.Millisecond) {
-		str.WriteString(fmt.sprintf(", %sclose:", timePrefix))
+		str.WriteString(fmt.Sprintf(", %sclose:", timePrefix))
 		str.WriteString(FormatDuration(time.Duration(closeTime)))
 	}
 	str.WriteString(", loops:")
@@ -1665,7 +1665,7 @@ func (e *RuntimeStatsWithConcurrencyInfo) String() string {
 			if concurrency.concurrencyNum > 0 {
 				result += fmt.Sprintf("%s:%d", concurrency.concurrencyName, concurrency.concurrencyNum)
 			} else {
-				result += fmt.sprintf("%s:off", concurrency.concurrencyname)
+				result += fmt.Sprintf("%s:OFF", concurrency.concurrencyName)
 			}
 		}
 	}

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1509,24 +1509,18 @@ func (e *RuntimeStatsColl) GetBasicRuntimeStats(planID int, initNewExecutorStats
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	stats, ok := e.rootStats[planID]
-	if !ok {
-		if initNewExecutorStats {
-			stats = NewRootRuntimeStats()
-			e.rootStats[planID] = stats
-			stats.basic = &BasicRuntimeStats{}
-			stats.basic.executorCount.Add(1)
-			return stats.basic
-		}
+	if !ok && initNewExecutorStats {
+		stats = NewRootRuntimeStats()
+		e.rootStats[planID] = stats
+	}
+	if stats == nil {
 		return nil
 	}
-	if stats.basic == nil {
-		if initNewExecutorStats {
-			stats.basic = &BasicRuntimeStats{}
-			stats.basic.executorCount.Add(1)
-			return stats.basic
-		}
-		return nil
-	} else if initNewExecutorStats {
+
+	if stats.basic == nil && initNewExecutorStats {
+		stats.basic = &BasicRuntimeStats{}
+		stats.basic.executorCount.Add(1)
+	} else if stats.basic != nil && initNewExecutorStats {
 		stats.basic.executorCount.Add(1)
 	}
 	return stats.basic

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1501,7 +1501,7 @@ func (e *RuntimeStatsColl) RegisterStats(planID int, info RuntimeStats) {
 	}
 }
 
-// GetBasicRuntimeStats gets basicRuntimeStats for a executor.
+// GetBasicRuntimeStats gets basicRuntimeStats for a executor, will increase BasicRuntimeStats' executorCount when initNewExecutorStats is true
 func (e *RuntimeStatsColl) GetBasicRuntimeStats(planID int, initNewExecutorStats bool) *BasicRuntimeStats {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -453,7 +453,7 @@ func TestRootRuntimeStats(t *testing.T) {
 	pid := 1
 	stmtStats := NewRuntimeStatsColl(nil)
 	basic1 := stmtStats.GetBasicRuntimeStats(pid, true)
-	basic2 := stmtStats.GetBasicRuntimeStats(pid, true)
+	basic2 := stmtStats.GetBasicRuntimeStats(pid, false)
 	basic1.RecordOpen(time.Millisecond * 10)
 	basic1.Record(time.Second, 20)
 	basic2.Record(time.Second*2, 30)

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
 )
@@ -452,8 +451,8 @@ func TestRuntimeStatsWithCommit(t *testing.T) {
 func TestRootRuntimeStats(t *testing.T) {
 	pid := 1
 	stmtStats := NewRuntimeStatsColl(nil)
-	basic1 := stmtStats.GetBasicRuntimeStats(pid)
-	basic2 := stmtStats.GetBasicRuntimeStats(pid)
+	basic1 := stmtStats.GetBasicRuntimeStats(pid, false)
+	basic2 := stmtStats.GetBasicRuntimeStats(pid, false)
 	basic1.RecordOpen(time.Millisecond * 10)
 	basic1.Record(time.Second, 20)
 	basic2.Record(time.Second*2, 30)

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -452,8 +452,8 @@ func TestRuntimeStatsWithCommit(t *testing.T) {
 func TestRootRuntimeStats(t *testing.T) {
 	pid := 1
 	stmtStats := NewRuntimeStatsColl(nil)
-	basic1 := stmtStats.GetBasicRuntimeStats(pid, false)
-	basic2 := stmtStats.GetBasicRuntimeStats(pid, false)
+	basic1 := stmtStats.GetBasicRuntimeStats(pid, true)
+	basic2 := stmtStats.GetBasicRuntimeStats(pid, true)
 	basic1.RecordOpen(time.Millisecond * 10)
 	basic1.Record(time.Second, 20)
 	basic2.Record(time.Second*2, 30)

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -453,7 +453,7 @@ func TestRootRuntimeStats(t *testing.T) {
 	pid := 1
 	stmtStats := NewRuntimeStatsColl(nil)
 	basic1 := stmtStats.GetBasicRuntimeStats(pid, true)
-	basic2 := stmtStats.GetBasicRuntimeStats(pid, false)
+	basic2 := stmtStats.GetBasicRuntimeStats(pid, true)
 	basic1.RecordOpen(time.Millisecond * 10)
 	basic1.Record(time.Second, 20)
 	basic2.Record(time.Second*2, 30)
@@ -474,7 +474,7 @@ func TestRootRuntimeStats(t *testing.T) {
 		Commit: commitDetail,
 	})
 	stats := stmtStats.GetRootStats(1)
-	expect := "time:3.11s, open:10ms, close:100ms, loops:2, worker:15, commit_txn: {prewrite:1s, get_commit_ts:1s, commit:1s, region_num:5, write_keys:3, write_byte:66, txn_retry:2}"
+	expect := "total_time:3.11s, total_open:10ms, total_close:100ms, loops:2, worker:15, commit_txn: {prewrite:1s, get_commit_ts:1s, commit:1s, region_num:5, write_keys:3, write_byte:66, txn_retry:2}"
 	require.Equal(t, expect, stats.String())
 }
 

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/util"
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56746 

Problem Summary:

### What changed and how does it work?
Thanks to Keao's [PR ](https://github.com/pingcap/tidb/pull/56485), all executors must be created by either NewBaseExecutorV2 or BuildNewBaseExecutorV2. Thus, we can identify the "parallel time" case by checking if any existing executors have the same ID. Then use a different name, like "total_parallel_time" to display it.
Some special cases:
1. IndexLookUp & IndexMergeReader 's index plan doesn't mapping to an Executor, just mapping to several distsql calls. So need to handle them case by case.
2. PointGet's Init function not only initializes some fields but also re-constructs its BaseExecutor, which is not reasonable, split it to two functions now.

**ParallelApply & IndexLookUp Query**
```
+--------------------------------------------+---------+---------+-----------+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+-----------+------+
| id                                         | estRows | actRows | task      | access object          | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | operator info                                                                  | memory    | disk |
+--------------------------------------------+---------+---------+-----------+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+-----------+------+
| Projection_11                              | 10.00   | 2       | root      |                        | time:2.77ms, loops:3, RU:2.480302, Concurrency:OFF                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Column#13                                                                      | 2.14 KB   | N/A  |
| └─Apply_13                                 | 10.00   | 2       | root      |                        | time:2.76ms, loops:3, Concurrency:5, cache:ON, cacheHitRatio:0.000%                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | CARTESIAN left outer join                                                      | 778 Bytes | N/A  |
|   ├─TableReader_15(Build)                  | 10.00   | 2       | root      |                        | time:656.7µs, loops:2, cop_task: {num: 1, max: 557.5µs, proc_keys: 2, tot_proc: 64.4µs, tot_wait: 60.7µs, copr_cache_hit_ratio: 0.00, build_task_duration: 6.45µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:537.1µs}}                                                                                                                                                                                                                                                                                                                                                                                                                                         | data:TableRangeScan_14                                                         | 286 Bytes | N/A  |
|   │ └─TableRangeScan_14                    | 10.00   | 2       | cop[tikv] | table:alias            | tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 2, total_process_keys_size: 100, total_keys: 3, get_snapshot_time: 40µs, rocksdb: {key_skipped_count: 2, block: {}}}, time_detail: {total_process_time: 64.4µs, total_wait_time: 60.7µs, tikv_wall_time: 244.6µs}                                                                                                                                                                                                                                                                                                                                                                                                      | range:[1,1], keep order:false, stats:pseudo                                    | N/A       | N/A  |
|   └─MaxOneRow_16(Probe)                    | 10.00   | 2       | root      |                        | total_time:3.93ms, loops:4                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |                                                                                | N/A       | N/A  |
|     └─StreamAgg_21                         | 10.00   | 2       | root      |                        | total_time:3.91ms, loops:4                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | funcs:sum(Column#17)->Column#13                                                | 1.45 KB   | N/A  |
|       └─Projection_48                      | 100.00  | 2       | root      |                        | total_time:3.87ms, loops:4, Concurrency:OFF                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | cast(test.t1.c4, decimal(10,0) BINARY)->Column#17                              | 760 Bytes | N/A  |
|         └─Projection_47                    | 100.00  | 2       | root      |                        | total_time:3.81ms, loops:4, Concurrency:OFF                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | test.t1.c3, test.t1.c4                                                         | 1.48 KB   | N/A  |
|           └─IndexLookUp_46                 | 100.00  | 2       | root      |                        | total_time:3.79ms, loops:4, index_task: {total_time: 1.68ms, fetch_handle: 1.67ms, build: 2.14µs, wait: 7.05µs}, table_task: {total_time: 1.83ms, num: 2, concurrency: 5}, next: {wait_index: 1.84ms, wait_table_lookup_build: 271.8µs, wait_table_lookup_resp: 1.55ms}                                                                                                                                                                                                                                                                                                                                                                                                                |                                                                                | 18.5 KB   | N/A  |
|             ├─IndexRangeScan_44(Build)     | 100.00  | 2       | cop[tikv] | table:t1, index:c3(c3) | total_time:1.64ms, loops:6, cop_task: {num: 2, max: 750.8µs, min: 727µs, avg: 738.9µs, p95: 750.8µs, max_proc_keys: 1, p95_proc_keys: 1, tot_proc: 118µs, tot_wait: 188.2µs, copr_cache_hit_ratio: 0.00, build_task_duration: 25.3µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:2, total_time:1.45ms}}, tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:2, tasks:2}, scan_detail: {total_process_keys: 2, total_process_keys_size: 114, total_keys: 4, get_snapshot_time: 120.4µs, rocksdb: {key_skipped_count: 2, block: {}}}, time_detail: {total_process_time: 118µs, total_wait_time: 188.2µs, tikv_wall_time: 743.4µs}                                   | range: decided by [eq(test.t1.c3, test.t1.c3)], keep order:false, stats:pseudo | N/A       | N/A  |
|             └─TableRowIDScan_45(Probe)     | 100.00  | 2       | cop[tikv] | table:t1               | total_time:1.51ms, loops:4, cop_task: {num: 2, max: 665µs, min: 649.1µs, avg: 657µs, p95: 665µs, max_proc_keys: 1, p95_proc_keys: 1, tot_proc: 119.2µs, tot_wait: 170µs, copr_cache_hit_ratio: 0.00, build_task_duration: 149.7µs, max_distsql_concurrency: 1, max_extra_concurrency: 1}, rpc_info:{Cop:{num_rpc:2, total_time:1.28ms}}, tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:2, tasks:2}, scan_detail: {total_process_keys: 2, total_process_keys_size: 100, total_keys: 4, get_snapshot_time: 114.6µs, rocksdb: {key_skipped_count: 2, block: {}}}, time_detail: {total_process_time: 119.2µs, total_wait_time: 170µs, tikv_wall_time: 629.1µs}            | keep order:false, stats:pseudo                                                 | N/A       | N/A  |
+--------------------------------------------+---------+---------+-----------+------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------+-----------+------+
```

**IndexMergeReader Query**
```
+-------------------------------+----------+---------+-----------+------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+---------+------+
| id                            | estRows  | actRows | task      | access object          | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | operator info                                                       | memory  | disk |
+-------------------------------+----------+---------+-----------+------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+---------+------+
| IndexMerge_8                  | 18959.99 | 18959   | root      |                        | time:111.1ms, loops:20, RU:303.684901, index_task:{fetch_handle:13.903218ms, merge:4.080369ms}, table_task:{num:2, concurrency:5, fetch_row:199.93441ms, wait_time:20.396937ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | type: union                                                         | 1.14 MB | N/A  |
| ├─IndexRangeScan_5(Build)     | 9997.45  | 9978    | cop[tikv] | table:t, index:idx1(b) | time:6.38ms, loops:12, cop_task: {num: 1, max: 6.19ms, proc_keys: 9978, tot_proc: 5.19ms, tot_wait: 65.3µs, copr_cache_hit_ratio: 0.00, build_task_duration: 23.5µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:6.15ms}}, tikv_task:{time:4ms, loops:14}, scan_detail: {total_process_keys: 9978, total_process_keys_size: 458988, total_keys: 9979, get_snapshot_time: 45.1µs, rocksdb: {key_skipped_count: 9978, block: {cache_hit_count: 2}}}, time_detail: {total_process_time: 5.19ms, total_suspend_time: 16.5µs, total_wait_time: 65.3µs, total_kv_read_wall_time: 4ms, tikv_wall_time: 5.49ms}                                                                                                                                                                                                                                    | range:[-inf,100000), keep order:false, stats:partial[id:allEvicted] | N/A     | N/A  |
| ├─IndexRangeScan_6(Build)     | 9958.09  | 9947    | cop[tikv] | table:t, index:idx2(c) | time:6.4ms, loops:12, cop_task: {num: 1, max: 6.23ms, proc_keys: 9947, tot_proc: 5.48ms, tot_wait: 37.5µs, copr_cache_hit_ratio: 0.00, build_task_duration: 23.5µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:6.21ms}}, tikv_task:{time:5ms, loops:14}, scan_detail: {total_process_keys: 9947, total_process_keys_size: 457562, total_keys: 9948, get_snapshot_time: 25.6µs, rocksdb: {key_skipped_count: 9947, block: {cache_hit_count: 2}}}, time_detail: {total_process_time: 5.48ms, total_suspend_time: 18.8µs, total_wait_time: 37.5µs, total_kv_read_wall_time: 5ms, tikv_wall_time: 5.69ms}                                                                                                                                                                                                                                     | range:[-inf,100000), keep order:false, stats:partial[id:allEvicted] | N/A     | N/A  |
| └─TableRowIDScan_7(Probe)     | 18959.99 | 18959   | cop[tikv] | table:t                | total_time:188.9ms, loops:21, cop_task: {num: 200, max: 19.7ms, min: 8.96ms, avg: 13.7ms, p95: 18.4ms, max_proc_keys: 122, p95_proc_keys: 112, tot_proc: 530.4ms, tot_wait: 648.3ms, copr_cache_hit_ratio: 0.00, build_task_duration: 1.68ms, max_distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:200, total_time:2.73s}}, tikv_task:{proc max:16ms, min:4ms, avg: 9.73ms, p80:10ms, p95:15ms, iters:494, tasks:200}, scan_detail: {total_process_keys: 18959, total_process_keys_size: 877859, total_keys: 26786, get_snapshot_time: 6.43ms, rocksdb: {delete_skipped_count: 1434, key_skipped_count: 11028, block: {cache_hit_count: 11416, read_count: 273, read_byte: 4.24 MB, read_time: 63.8ms}}}, time_detail: {total_process_time: 530.4ms, total_suspend_time: 1.42s, total_wait_time: 648.3ms, total_kv_read_wall_time: 1.95s, tikv_wall_time: 2.65s} | keep order:false, stats:partial[id:allEvicted]                      | N/A     | N/A  |
+-------------------------------+----------+---------+-----------+------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+---------+------+
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
