### PR TITLE
statstics: fix wrong stats health metrics 

### DIFF
--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -261,7 +261,7 @@ func (s *StatsCacheImpl) UpdateStatsHealthyMetrics() {
 	distribution := make([]int64, 9)
 	uneligibleAnalyze := 0
 	for _, tbl := range s.Values() {
-		distribution[4]++ // total table count
+		distribution[7]++ // total table count
 		isEligibleForAnalysis := tbl.IsEligibleForAnalysis()
 		if !isEligibleForAnalysis {
 			uneligibleAnalyze++

--- a/pkg/statistics/handle/metrics/metrics.go
+++ b/pkg/statistics/handle/metrics/metrics.go
@@ -34,15 +34,15 @@ func init() {
 // InitMetricsVars init statistics metrics vars.
 func InitMetricsVars() {
 	StatsHealthyGauges = []prometheus.Gauge{
-		metrics.StatsHealthyGauge.WithLabelValues("[0,50)"),
-		metrics.StatsHealthyGauge.WithLabelValues("[50,55)"),
-		metrics.StatsHealthyGauge.WithLabelValues("[55,60)"),
-		metrics.StatsHealthyGauge.WithLabelValues("[60,70)"),
-		metrics.StatsHealthyGauge.WithLabelValues("[70,80)"),
-		metrics.StatsHealthyGauge.WithLabelValues("[80,100)"),
-		metrics.StatsHealthyGauge.WithLabelValues("[100,100]"),
-		metrics.StatsHealthyGauge.WithLabelValues("[0,100]"),
-		metrics.StatsHealthyGauge.WithLabelValues("unneeded analyze"),
+		metrics.StatsHealthyGauge.WithLabelValues("[0,50)"),           // 0
+		metrics.StatsHealthyGauge.WithLabelValues("[50,55)"),          // 1
+		metrics.StatsHealthyGauge.WithLabelValues("[55,60)"),          // 2
+		metrics.StatsHealthyGauge.WithLabelValues("[60,70)"),          // 3
+		metrics.StatsHealthyGauge.WithLabelValues("[70,80)"),          // 4
+		metrics.StatsHealthyGauge.WithLabelValues("[80,100)"),         // 5
+		metrics.StatsHealthyGauge.WithLabelValues("[100,100]"),        // 6
+		metrics.StatsHealthyGauge.WithLabelValues("[0,100]"),          // 7
+		metrics.StatsHealthyGauge.WithLabelValues("unneeded analyze"), // 8
 	}
 
 	DumpHistoricalStatsSuccessCounter = metrics.HistoricalStatsCounter.WithLabelValues("dump", "success")

--- a/pkg/statistics/handle/metrics/metrics.go
+++ b/pkg/statistics/handle/metrics/metrics.go
@@ -41,7 +41,6 @@ func InitMetricsVars() {
 		metrics.StatsHealthyGauge.WithLabelValues("[70,80)"),
 		metrics.StatsHealthyGauge.WithLabelValues("[80,100)"),
 		metrics.StatsHealthyGauge.WithLabelValues("[100,100]"),
-		// [0,100] should always be the last
 		metrics.StatsHealthyGauge.WithLabelValues("[0,100]"),
 		metrics.StatsHealthyGauge.WithLabelValues("unneeded analyze"),
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57176

Problem Summary:

### What changed and how does it work?

we use the wrong index of total table count metrics. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
