### PR TITLE
owner: fix unlimited log print "meet lease not found error, refresh session"

### DIFF
--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -404,6 +404,7 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 		// In this time if we do the campaign operation, the etcd server will return ErrLeaseNotFound.
 		if terror.ErrorEqual(err, rpctypes.ErrLeaseNotFound) {
 			close(leaseNotFoundCh)
+			err = nil
 			continue
 		}
 

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -381,7 +381,6 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 				logutil.Logger(logCtx).Info("break campaign loop, refresh session failed", zap.Error(err2))
 				return
 			}
-			err = nil
 		case <-leaseNotFoundCh:
 			logutil.Logger(logCtx).Info("meet lease not found error, refresh session")
 			if err2 := m.refreshSession(util2.NewSessionRetryUnlimited, ManagerSessionTTL); err2 != nil {
@@ -389,7 +388,6 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 				return
 			}
 			leaseNotFoundCh = make(chan struct{})
-			err = nil
 		case <-campaignContext.Done():
 			failpoint.Inject("MockDelOwnerKey", func(v failpoint.Value) {
 				if v.(string) == "delOwnerKeyAndNotOwner" {
@@ -406,6 +404,7 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 		// In this time if we do the campaign operation, the etcd server will return ErrLeaseNotFound.
 		if terror.ErrorEqual(err, rpctypes.ErrLeaseNotFound) {
 			close(leaseNotFoundCh)
+			err = nil
 			continue
 		}
 

--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -381,6 +381,7 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 				logutil.Logger(logCtx).Info("break campaign loop, refresh session failed", zap.Error(err2))
 				return
 			}
+			err = nil
 		case <-leaseNotFoundCh:
 			logutil.Logger(logCtx).Info("meet lease not found error, refresh session")
 			if err2 := m.refreshSession(util2.NewSessionRetryUnlimited, ManagerSessionTTL); err2 != nil {
@@ -388,6 +389,7 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 				return
 			}
 			leaseNotFoundCh = make(chan struct{})
+			err = nil
 		case <-campaignContext.Done():
 			failpoint.Inject("MockDelOwnerKey", func(v failpoint.Value) {
 				if v.(string) == "delOwnerKeyAndNotOwner" {
@@ -404,7 +406,6 @@ func (m *ownerManager) campaignLoop(campaignContext context.Context) {
 		// In this time if we do the campaign operation, the etcd server will return ErrLeaseNotFound.
 		if terror.ErrorEqual(err, rpctypes.ErrLeaseNotFound) {
 			close(leaseNotFoundCh)
-			err = nil
 			continue
 		}
 


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57533

Problem Summary:

### What changed and how does it work?

I'm not sure how the error is triggered.
But reading the code, I can see that line 405, if condition `terror.ErrorEqual(err, rpctypes.ErrLeaseNotFound)` hold, the error is not reset. So this loop will happen again and again, cause the log print.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Don't know how to reproduce but it's easy to fix by reading the code 

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
