### PR TITLE
lightning: remove some `NOT NULL` constraints on lightning table

### DIFF
--- a/pkg/lightning/errormanager/errormanager.go
+++ b/pkg/lightning/errormanager/errormanager.go
@@ -89,10 +89,10 @@ const (
 		CREATE TABLE IF NOT EXISTS %s.` + ConflictErrorTableName + ` (
 			task_id     bigint NOT NULL,
 			create_time datetime(6) NOT NULL DEFAULT now(6),
-			table_name  varchar(261) NOT NULL,
-			index_name  varchar(128) NOT NULL,
-			key_data    text NOT NULL COMMENT 'decoded from raw_key, human readable only, not for machine use',
-			row_data    text NOT NULL COMMENT 'decoded from raw_row, human readable only, not for machine use',
+			table_name  varchar(261),
+			index_name  varchar(128),
+			key_data    text COMMENT 'decoded from raw_key, human readable only, not for machine use',
+			row_data    text COMMENT 'decoded from raw_row, human readable only, not for machine use',
 			raw_key     mediumblob NOT NULL COMMENT 'the conflicted key',
 			raw_value   mediumblob NOT NULL COMMENT 'the value of the conflicted key',
 			raw_handle  mediumblob NOT NULL COMMENT 'the data handle derived from the conflicted key or value',
@@ -150,7 +150,7 @@ const (
 	`
 
 	insertIntoConflictErrorData = `
-		INSERT IGNORE INTO %s.` + ConflictErrorTableName + `
+		INSERT INTO %s.` + ConflictErrorTableName + `
 		(task_id, table_name, index_name, key_data, row_data, raw_key, raw_value, raw_handle, raw_row, kv_type)
 		VALUES
 	`

--- a/pkg/lightning/errormanager/errormanager.go
+++ b/pkg/lightning/errormanager/errormanager.go
@@ -89,8 +89,8 @@ const (
 		CREATE TABLE IF NOT EXISTS %s.` + ConflictErrorTableName + ` (
 			task_id     bigint NOT NULL,
 			create_time datetime(6) NOT NULL DEFAULT now(6),
-			table_name  varchar(261),
-			index_name  varchar(128),
+			table_name  varchar(261) NOT NULL,
+			index_name  varchar(128) NOT NULL,
 			key_data    text COMMENT 'decoded from raw_key, human readable only, not for machine use',
 			row_data    text COMMENT 'decoded from raw_row, human readable only, not for machine use',
 			raw_key     mediumblob NOT NULL COMMENT 'the conflicted key',

--- a/pkg/lightning/errormanager/errormanager_test.go
+++ b/pkg/lightning/errormanager/errormanager_test.go
@@ -497,7 +497,7 @@ func TestReplaceConflictOneUniqueKey(t *testing.T) {
 			AddRow(3, data3IndexKey, "uni_b", data3IndexValue, data3RowKey).
 			AddRow(4, data3IndexKey, "uni_b", data4IndexValue, data4RowKey))
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec("INSERT IGNORE INTO `lightning_task_info`\\.conflict_error_v3.*").
+	mockDB.ExpectExec("INSERT INTO `lightning_task_info`\\.conflict_error_v3.*").
 		WithArgs(0, "test", nil, nil, data2RowKey, data2RowValue, 2,
 			0, "test", nil, nil, data4RowKey, data4RowValue, 2).
 		WillReturnResult(driver.ResultNoRows)

--- a/pkg/lightning/errormanager/resolveconflict_test.go
+++ b/pkg/lightning/errormanager/resolveconflict_test.go
@@ -178,7 +178,7 @@ func TestReplaceConflictMultipleKeysNonclusteredPk(t *testing.T) {
 			AddRow(3, data6RowKey, "PRIMARY", data6RowValue, data5RowKey).
 			AddRow(4, data6RowKey, "PRIMARY", data7NonclusteredValue, data6NonclusteredKey))
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec("INSERT IGNORE INTO `lightning_task_info`\\.conflict_error_v3.*").
+	mockDB.ExpectExec("INSERT INTO `lightning_task_info`\\.conflict_error_v3.*").
 		WithArgs(0, "a", nil, nil, data2NonclusteredKey, data2NonclusteredValue, 2,
 			0, "a", nil, nil, data6NonclusteredKey, data6NonclusteredValue, 2).
 		WillReturnResult(driver.ResultNoRows)
@@ -361,7 +361,7 @@ func TestReplaceConflictOneKeyNonclusteredPk(t *testing.T) {
 			AddRow(1, data3IndexKey, "PRIMARY", data3IndexValue, data3RowKey).
 			AddRow(2, data3IndexKey, "PRIMARY", data4IndexValue, data4RowKey))
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec("INSERT IGNORE INTO `lightning_task_info`\\.conflict_error_v3.*").
+	mockDB.ExpectExec("INSERT INTO `lightning_task_info`\\.conflict_error_v3.*").
 		WithArgs(0, "a", nil, nil, data4RowKey, data4RowValue, 2).
 		WillReturnResult(driver.ResultNoRows)
 	mockDB.ExpectCommit()
@@ -547,7 +547,7 @@ func TestReplaceConflictOneUniqueKeyNonclusteredPk(t *testing.T) {
 			AddRow(5, data3IndexKey, "PRIMARY", data3IndexValue, data3RowKey).
 			AddRow(6, data3IndexKey, "PRIMARY", data4NonclusteredValue, data4RowKey))
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec("INSERT IGNORE INTO `lightning_task_info`\\.conflict_error_v3.*").
+	mockDB.ExpectExec("INSERT INTO `lightning_task_info`\\.conflict_error_v3.*").
 		WithArgs(0, "a", nil, nil, data5RowKey, data5RowValue, 2,
 			0, "a", nil, nil, data2RowKey, data2RowValue, 2,
 			0, "a", nil, nil, data4RowKey, data4RowValue, 2).
@@ -754,7 +754,7 @@ func TestReplaceConflictOneUniqueKeyNonclusteredVarcharPk(t *testing.T) {
 			AddRow(5, data3IndexKey, "PRIMARY", data3IndexValue, data3RowKey).
 			AddRow(6, data3IndexKey, "PRIMARY", data4IndexValue, data4RowKey))
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec("INSERT IGNORE INTO `lightning_task_info`\\.conflict_error_v3.*").
+	mockDB.ExpectExec("INSERT INTO `lightning_task_info`\\.conflict_error_v3.*").
 		WithArgs(0, "a", nil, nil, data5RowKey, data5RowValue, 2,
 			0, "a", nil, nil, data2RowKey, data2RowValue, 2,
 			0, "a", nil, nil, data4RowKey, data4RowValue, 2).


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57578

Problem Summary:

### What changed and how does it work?

https://github.com/pingcap/tidb/pull/55477 change the behavior of null value insert. To adapt to this change, some `NOT NULL` constraints have to be removed.

Previous PR just wrongly change `INSERT INTO` to `INSERT IGNORE INTO`, which may case data correctness.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
