### PR TITLE
executor: Fix unstable test TestTiKVClientReadTimeout

### DIFF
--- a/pkg/executor/executor_failpoint_test.go
+++ b/pkg/executor/executor_failpoint_test.go
@@ -17,7 +17,6 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"github.com/tikv/client-go/v2/oracle"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -38,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/deadlockhistory"
 	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 )
 
 func TestTiDBLastTxnInfoCommitMode(t *testing.T) {

--- a/pkg/executor/executor_failpoint_test.go
+++ b/pkg/executor/executor_failpoint_test.go
@@ -17,6 +17,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"github.com/tikv/client-go/v2/oracle"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -594,6 +595,26 @@ func TestTiKVClientReadTimeout(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/store/mockstore/unistore/unistoreRPCDeadlineExceeded"))
 	}()
+
+	waitUntilReadTSSafe := func(tk *testkit.TestKit, readTime string) {
+		unixTime, err := strconv.ParseFloat(tk.MustQuery("select unix_timestamp(" + readTime + ")").Rows()[0][0].(string), 64)
+		require.NoError(t, err)
+		expectedPhysical := int64(unixTime*1000) + 1
+		expectedTS := oracle.ComposeTS(expectedPhysical, 0)
+		for {
+			tk.MustExec("begin")
+			currentTS, err := strconv.ParseUint(tk.MustQuery("select @@tidb_current_ts").Rows()[0][0].(string), 10, 64)
+			require.NoError(t, err)
+			tk.MustExec("rollback")
+
+			if currentTS >= expectedTS {
+				return
+			}
+
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
 	// Test for point_get request
 	rows := tk.MustQuery("explain analyze select /*+ set_var(tikv_client_read_timeout=1) */ * from t where a = 1").Rows()
 	require.Len(t, rows, 1)
@@ -614,6 +635,7 @@ func TestTiKVClientReadTimeout(t *testing.T) {
 
 	// Test for stale read.
 	tk.MustExec("set @a=now(6);")
+	waitUntilReadTSSafe(tk, "@a")
 	tk.MustExec("set @@tidb_replica_read='closest-replicas';")
 	rows = tk.MustQuery("explain analyze select /*+ set_var(tikv_client_read_timeout=1) */ * from t as of timestamp(@a) where b > 1").Rows()
 	require.Len(t, rows, 3)
@@ -642,6 +664,7 @@ func TestTiKVClientReadTimeout(t *testing.T) {
 
 	// Test for stale read.
 	tk.MustExec("set @a=now(6);")
+	waitUntilReadTSSafe(tk, "@a")
 	tk.MustExec("set @@tidb_replica_read='closest-replicas';")
 	rows = tk.MustQuery("explain analyze select * from t as of timestamp(@a) where b > 1").Rows()
 	require.Len(t, rows, 3)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57348

Problem Summary:

### What changed and how does it work?

After #57050 , the safety check on stale read ts is made strict, making sure that the stale read ts never exceeds that PD has allocated.

However there seems still exists some test code that have some unsafe usage of stale read (such as reading at `now`). For these usages, the read ts has chance to exceed PD's max allocated ts, causing the ts validation failed.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
