### PR TITLE
planner: Prevent OR Expressions in IN Subquery Conversion to INNER JOIN to Avoid Data Duplication

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1221,16 +1221,16 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 			"NO_DECORRELATE() is inapplicable because there are no correlated columns.")
 		noDecorrelate = false
 	}
-	ifLexprReturnBoolean := false
+	ifLexprReturnBool := false
 	// if lexpr is a scalar function who will return 1 or 0, don't convert the sub-query to an inner-join.
 	if lexpr, ok := lexpr.(*expression.ScalarFunction); ok && lexpr.FuncName.L == "or" {
-		ifLexprReturnBoolean = true
+		ifLexprReturnBool = true
 	}
 	// If it's not the form of `not in (SUBQUERY)`,
 	// and has no correlated column from the current level plan(if the correlated column is from upper level,
 	// we can treat it as constant, because the upper LogicalApply cannot be eliminated since current node is a join node),
 	// and don't need to append a scalar value, we can rewrite it to inner join.
-	if planCtx.builder.ctx.GetSessionVars().GetAllowInSubqToJoinAndAgg() && !v.Not && !asScalar && len(corCols) == 0 && collFlag && !ifLexprReturnBoolean {
+	if planCtx.builder.ctx.GetSessionVars().GetAllowInSubqToJoinAndAgg() && !v.Not && !asScalar && len(corCols) == 0 && collFlag && !ifLexprReturnBool {
 		// We need to try to eliminate the agg and the projection produced by this operation.
 		planCtx.builder.optFlag |= rule.FlagEliminateAgg
 		planCtx.builder.optFlag |= rule.FlagEliminateProjection

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1208,7 +1208,6 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 		er.err = err
 		return v, true
 	}
-
 	// If the leftKey and the rightKey have different collations, don't convert the sub-query to an inner-join
 	// since when converting we will add a distinct-agg upon the right child and this distinct-agg doesn't have the right collation.
 	// To keep it simple, we forbid this converting if they have different collations.
@@ -1222,12 +1221,16 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, planCtx *exp
 			"NO_DECORRELATE() is inapplicable because there are no correlated columns.")
 		noDecorrelate = false
 	}
-
+	ifLexprReturnBoolean := false
+	// if lexpr is a scalar function who will return 1 or 0, don't convert the sub-query to an inner-join.
+	if lexpr, ok := lexpr.(*expression.ScalarFunction); ok && lexpr.FuncName.L == "or" {
+		ifLexprReturnBoolean = true
+	}
 	// If it's not the form of `not in (SUBQUERY)`,
 	// and has no correlated column from the current level plan(if the correlated column is from upper level,
 	// we can treat it as constant, because the upper LogicalApply cannot be eliminated since current node is a join node),
 	// and don't need to append a scalar value, we can rewrite it to inner join.
-	if planCtx.builder.ctx.GetSessionVars().GetAllowInSubqToJoinAndAgg() && !v.Not && !asScalar && len(corCols) == 0 && collFlag {
+	if planCtx.builder.ctx.GetSessionVars().GetAllowInSubqToJoinAndAgg() && !v.Not && !asScalar && len(corCols) == 0 && collFlag && !ifLexprReturnBoolean {
 		// We need to try to eliminate the agg and the projection produced by this operation.
 		planCtx.builder.optFlag |= rule.FlagEliminateAgg
 		planCtx.builder.optFlag |= rule.FlagEliminateProjection

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -134,3 +134,20 @@ func TestIssue53175(t *testing.T) {
 	tk.MustQuery(`select * from t group by null`)
 	tk.MustQuery(`select * from v`)
 }
+
+func TestIssue57390(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("DROP TABLE IF EXISTS t0, t1")
+	tk.MustExec("CREATE TABLE t0 (c0 FLOAT, c1 VARBINARY(11))")
+	tk.MustExec("INSERT INTO t0 (c0, c1) VALUES (8.416507379856948e+37, 0xBD18FF9DA18)")
+	tk.MustExec("INSERT INTO t0 (c0, c1) VALUES (-8.039100705145107e+36, 0x751F7D92AF2)")
+	tk.MustExec("INSERT INTO t0 (c0, c1) VALUES (-3.2141114349670245e+37, 0x22693D9BBE4)")
+	tk.MustExec("INSERT INTO t0 (c0, c1) VALUES (-1.972829282794721e+35, 0x9C0F3D7E886)")
+	tk.MustExec("INSERT INTO t0 (c0, c1) VALUES (4.535289015159612e+37, 0x2BA66016016)")
+	tk.MustExec("CREATE TABLE t1 (c0 double , c1 VARBINARY(11))")
+	tk.MustExec("INSERT INTO t1 SELECT (AVG(c0)), c1 FROM t0 GROUP BY c1")
+	res := tk.MustQuery("SELECT c0, c1 FROM t1 WHERE (c1 OR c1) IN (SELECT c1 FROM t1 WHERE (c1 <= (0x991D3FA2F9C))) AND ((c0 AND 8.98447659672538e+29))")
+	require.Equal(t, 5, len(res.Rows()))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57390

Problem Summary:

### What changed and how does it work?
This is the plan: 

```sql
tidb> explain 
SELECT c0, c1 
FROM t1 
WHERE (c1 OR c1) IN (SELECT c1 FROM t1 WHERE (c1 <= (0x991D3FA2F9C))) AND ((c0 AND 8.98447659672538e+29));
+--------------------------------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| id                             | estRows | task      | access object | operator info                                                                                                                                                                       |
+--------------------------------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| HashJoin_11                    | 2.66    | root      |               | semi join, equal:[eq(Column#7, Column#8)]                                                                                                                                           |
| ├─Projection_16(Build)         | 1.66    | root      |               | cast(fix_57390.t1.c1, double BINARY)->Column#8                                                                                                                                      |
| │ └─TableReader_19             | 1.66    | root      |               | data:Selection_18                                                                                                                                                                   |
| │   └─Selection_18             | 1.66    | cop[tikv] |               | le(fix_57390.t1.c1, "0x0991d3fa2f9c")                                                                                                                                               |
| │     └─TableFullScan_17       | 5.00    | cop[tikv] | table:t1      | keep order:false, stats:pseudo                                                                                                                                                      |
| └─Projection_12(Probe)         | 3.33    | root      |               | fix_57390.t1.c0, fix_57390.t1.c1, cast(or(istrue_with_null(cast(fix_57390.t1.c1, double BINARY)), istrue_with_null(cast(fix_57390.t1.c1, double BINARY))), double BINARY)->Column#7 |
|   └─TableReader_15             | 3.33    | root      |               | data:Selection_14                                                                                                                                                                   |
|     └─Selection_14             | 3.33    | cop[tikv] |               | fix_57390.t1.c0                                                                                                                                                                     |
|       └─TableFullScan_13       | 5.00    | cop[tikv] | table:t1      | keep order:false, stats:pseudo                                                                                                                                                      |
+--------------------------------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

When tidb encounters an `IN subquery`, it tries to rewrite the outer table and subquery as `INNER JOIN`.

https://github.com/pingcap/tidb/blob/c091dba89718599dc1b3d3e45f9b0308a8d49ef0/pkg/planner/core/expression_rewriter.go#L1226-L1242

When rewriting `OR expressions` (e.g., (c1 OR c1)), the kernel will convert the type of c1 to `DOUBLE`.

https://github.com/pingcap/tidb/blob/c091dba89718599dc1b3d3e45f9b0308a8d49ef0/pkg/expression/builtin_cast.go#L2556-L2568

The join's condition is `(c1 OR c1) = c1`.

We can check the output of the join condition for the left and right tables after converting INNER JOIN.

left output：
```sql
tidb> select (c1 or c1) from t1;
+------------+
| (c1 or c1) |
+------------+
|          0 |
|          0 |
|          0 |
|          0 |
|          0 |
+------------+
5 rows in set, 10 warnings (0.00 sec)
```

right output:
```sql
tidb> SELECT cast(c1 as double) FROM t1 WHERE (c1 <= (0x991D3FA2F9C)) group by c1;
+--------------------+
| cast(c1 as double) |
+--------------------+
|                  0 |
|                  0 |
|                  0 |
+--------------------+
3 rows in set, 3 warnings (0.01 sec)

tidb> 

```
After the `DISTINCT` operation, `CAST(c1 AS DOUBLE) `actually causes data duplication, which will lead to unexpected results for `in operation`.

To address this, I add a restriction who will check if the left expression is or function in the conditions for converting to an INNER JOIN.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
