### PR TITLE
partition: set `AddRecordOpt.isUpdate = true` when update partition records

### DIFF
--- a/pkg/ddl/partition_test.go
+++ b/pkg/ddl/partition_test.go
@@ -256,18 +256,21 @@ func TestUpdateDuringAddColumn(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t1 (c1 int, c2 int) partition by hash (c1) partitions 16")
-	tk.MustExec("insert t1 values (1, 1), (2, 1)")
+	tk.MustExec("insert t1 values (1, 1), (2, 2)")
+	tk.MustExec("create table t2 (c1 int, c2 int) partition by hash (c1) partitions 16")
+	tk.MustExec("insert t2 values (1, 3), (2, 5)")
 	tk2 := testkit.NewTestKit(t, store)
 	tk2.MustExec("use test")
 
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobUpdated", func(job *model.Job) {
 		if job.SchemaState == model.StateWriteOnly {
-			tk2.MustExec("update t1 set t1.c1 = 8 where t1.c2 = 1")
-			tk2.MustQuery("select * from t1").Sort().Check(testkit.Rows("8 1", "8 1"))
+			tk2.MustExec("update t1, t2 set t1.c1 = 8, t2.c2 = 10 where t1.c2 = t2.c1")
+			tk2.MustQuery("select * from t1").Sort().Check(testkit.Rows("8 1", "8 2"))
+			tk2.MustQuery("select * from t2").Sort().Check(testkit.Rows("1 10", "2 10"))
 		}
 	})
 
 	tk.MustExec("alter table t1 add column c3 bigint default 9")
 
-	tk.MustQuery("select * from t1").Sort().Check(testkit.Rows("8 1 9", "8 1 9"))
+	tk.MustQuery("select * from t1").Sort().Check(testkit.Rows("8 1 9", "8 2 9"))
 }

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -202,7 +202,7 @@ func (opt *UpdateRecordOpt) SkipWriteUntouchedIndices() bool {
 
 // GetAddRecordOpt creates a AddRecordOpt.
 func (opt *UpdateRecordOpt) GetAddRecordOpt() *AddRecordOpt {
-	return &AddRecordOpt{commonMutateOpt: opt.commonMutateOpt}
+	return &AddRecordOpt{commonMutateOpt: opt.commonMutateOpt, isUpdate: true}
 }
 
 // GetCreateIdxOpt creates a CreateIdxOpt.

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -60,12 +60,12 @@ func TestOptions(t *testing.T) {
 	// NewUpdateRecordOpt without option
 	updateOpt := NewUpdateRecordOpt()
 	require.Equal(t, UpdateRecordOpt{}, *updateOpt)
-	require.Equal(t, AddRecordOpt{}, *(updateOpt.GetAddRecordOpt()))
+	require.Equal(t, AddRecordOpt{isUpdate: true}, *(updateOpt.GetAddRecordOpt()))
 	require.Equal(t, CreateIdxOpt{}, *(updateOpt.GetCreateIdxOpt()))
 	// NewUpdateRecordOpt with options
 	updateOpt = NewUpdateRecordOpt(WithCtx(ctx))
 	require.Equal(t, UpdateRecordOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *updateOpt)
-	require.Equal(t, AddRecordOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *(updateOpt.GetAddRecordOpt()))
+	require.Equal(t, AddRecordOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}, isUpdate: true}, *(updateOpt.GetAddRecordOpt()))
 	require.Equal(t, CreateIdxOpt{commonMutateOpt: commonMutateOpt{ctx: ctx}}, *(updateOpt.GetCreateIdxOpt()))
 	// NewCreateIdxOpt without option
 	createIdxOpt := NewCreateIdxOpt()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57588

Problem Summary: 

Didn't set `isUpdate = true` before, so it will use the last value in datum as `_tidb_rowid` which caused primary key duplicate.

If we don't do this during add columns, `len(r) == len(cols)` always equal to true, so it's safe.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
