### PR TITLE
br: fix flaky test `TestConcurrentLock`

### DIFF
--- a/br/pkg/storage/azblob.go
+++ b/br/pkg/storage/azblob.go
@@ -326,6 +326,10 @@ type AzureBlobStorage struct {
 	cpkInfo  *blob.CPKInfo
 }
 
+func (*AzureBlobStorage) MarkStrongConsistency() {
+	// See https://github.com/MicrosoftDocs/azure-docs/issues/105331#issuecomment-1450252384
+}
+
 func newAzureBlobStorage(ctx context.Context, options *backuppb.AzureBlobStorage, opts *ExternalStorageOptions) (*AzureBlobStorage, error) {
 	clientBuilder, err := getAzureServiceClientBuilder(options, opts)
 	if err != nil {

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -113,6 +113,10 @@ type GCSStorage struct {
 	clients []*storage.Client
 }
 
+func (s *GCSStorage) MarkStrongConsistency() {
+	// See https://cloud.google.com/storage/docs/consistency#strongly_consistent_operations
+}
+
 // GetBucketHandle gets the handle to the GCS API on the bucket.
 func (s *GCSStorage) GetBucketHandle() *storage.BucketHandle {
 	i := s.idx.Inc() % int64(len(s.handles))

--- a/br/pkg/storage/local.go
+++ b/br/pkg/storage/local.go
@@ -262,7 +262,9 @@ func (l *LocalStorage) Rename(_ context.Context, oldFileName, newFileName string
 }
 
 // Close implements ExternalStorage interface.
-func (*LocalStorage) Close() {}
+func (l *LocalStorage) Close() {
+	_ = l.baseFD.Close()
+}
 
 func pathExists(_path string) (bool, error) {
 	_, err := os.Stat(_path)

--- a/br/pkg/storage/local.go
+++ b/br/pkg/storage/local.go
@@ -289,6 +289,10 @@ func NewLocalStorage(base string) (*LocalStorage, error) {
 			return nil, errors.Trace(err)
 		}
 	}
+
+	// Here the path targets to a directory and we will only call `Sync` over it.
+	// Disable the G304 warning which focus on relative path injection like "../../import_stuff".
+	//nolint: gosec
 	baseFD, err := os.Open(base)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/br/pkg/storage/locking.go
+++ b/br/pkg/storage/locking.go
@@ -82,7 +82,7 @@ func (w conditionalPut) CommitTo(ctx context.Context, s ExternalStorage) (uuid.U
 	if err := checkConflict(); err != nil {
 		return uuid.UUID{}, errors.Annotate(err, "during initial check")
 	}
-	failpoint.Inject("exclusive-write-commit-to-1", func() {})
+	failpoint.InjectCall("exclusive-write-commit-to-1")
 
 	if err := s.WriteFile(cx, intentFileName, []byte{}); err != nil {
 		return uuid.UUID{}, errors.Annotate(err, "during writing intention file")
@@ -97,7 +97,7 @@ func (w conditionalPut) CommitTo(ctx context.Context, s ExternalStorage) (uuid.U
 	if err := checkConflict(); err != nil {
 		return uuid.UUID{}, errors.Annotate(err, "during checking whether there are other intentions")
 	}
-	failpoint.Inject("exclusive-write-commit-to-2", func() {})
+	failpoint.InjectCall("exclusive-write-commit-to-2")
 
 	return txnID, s.WriteFile(cx, w.Target, w.Content(txnID))
 }
@@ -106,6 +106,7 @@ func (w conditionalPut) CommitTo(ctx context.Context, s ExternalStorage) (uuid.U
 func (cx VerifyWriteContext) assertNoOtherOfPrefixExpect(pfx string, expect string) error {
 	fileName := path.Base(pfx)
 	dirName := path.Dir(pfx)
+
 	return cx.Storage.WalkDir(cx, &WalkOption{
 		SubDir:    dirName,
 		ObjPrefix: fileName,

--- a/br/pkg/storage/locking.go
+++ b/br/pkg/storage/locking.go
@@ -114,8 +114,8 @@ func (cx VerifyWriteContext) assertNoOtherOfPrefixExpect(pfx string, expect stri
 	dirName := path.Dir(pfx)
 
 	return cx.Storage.WalkDir(cx, &WalkOption{
-		SubDir:           dirName,
-		ObjPrefix:        fileName,
+		SubDir:    dirName,
+		ObjPrefix: fileName,
 		// We'd better read a deleted intention...
 		IncludeTombstone: true,
 	}, func(path string, size int64) error {

--- a/br/pkg/storage/locking_test.go
+++ b/br/pkg/storage/locking_test.go
@@ -93,8 +93,8 @@ func TestConcurrentLock(t *testing.T) {
 			ch <- struct{}{}
 		}
 	}
-	// sync.OnceFunc holds a `Mutex` during executing `f`...
-	onceFunc := func(f func()) func() {
+
+	asyncOnceFunc := func(f func()) func() {
 		run := new(atomic.Bool)
 		return func() {
 			if run.CompareAndSwap(false, true) {
@@ -103,9 +103,9 @@ func TestConcurrentLock(t *testing.T) {
 		}
 	}
 	chA := make(chan struct{})
-	onceA := onceFunc(waitRecvTwice(chA))
+	onceA := asyncOnceFunc(waitRecvTwice(chA))
 	chB := make(chan struct{})
-	onceB := onceFunc(waitRecvTwice(chB))
+	onceB := asyncOnceFunc(waitRecvTwice(chB))
 
 	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-1", onceA))
 	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-2", onceB))

--- a/br/pkg/storage/locking_test.go
+++ b/br/pkg/storage/locking_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -86,8 +87,28 @@ func TestConcurrentLock(t *testing.T) {
 	errChA := make(chan error, 1)
 	errChB := make(chan error, 1)
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-1", "1*pause"))
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-2", "1*pause"))
+	waitRecvTwice := func(ch chan<- struct{}) func() {
+		return func() {
+			ch <- struct{}{}
+			ch <- struct{}{}
+		}
+	}
+	// sync.OnceFunc holds a `Mutex` during executing `f`...
+	onceFunc := func(f func()) func() {
+		run := new(atomic.Bool)
+		return func() {
+			if run.CompareAndSwap(false, true) {
+				f()
+			}
+		}
+	}
+	chA := make(chan struct{})
+	onceA := onceFunc(waitRecvTwice(chA))
+	chB := make(chan struct{})
+	onceB := onceFunc(waitRecvTwice(chB))
+
+	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-1", onceA))
+	require.NoError(t, failpoint.EnableCall("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-2", onceB))
 
 	go func() {
 		_, err := storage.TryLockRemote(ctx, strg, "test.lock", "I wanna read it, but I hesitated before send my intention!")
@@ -99,8 +120,11 @@ func TestConcurrentLock(t *testing.T) {
 		errChB <- err
 	}()
 
-	failpoint.Disable("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-1")
-	failpoint.Disable("github.com/pingcap/tidb/br/pkg/storage/exclusive-write-commit-to-2")
+	<-chA
+	<-chB
+
+	<-chB
+	<-chA
 
 	// There is exactly one error.
 	errA := <-errChA
@@ -108,7 +132,7 @@ func TestConcurrentLock(t *testing.T) {
 	if errA == nil {
 		require.Error(t, errB)
 	} else {
-		require.NoError(t, errB)
+		require.NoError(t, errB, "%s", errA)
 	}
 
 	requireFileExists(t, filepath.Join(path, "test.lock"))

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -83,6 +83,10 @@ type S3Storage struct {
 	options *backuppb.S3
 }
 
+func (*S3Storage) MarkStrongConsistency() {
+	// See https://aws.amazon.com/cn/s3/consistency/
+}
+
 // GetS3APIHandle gets the handle to the S3 API.
 func (rs *S3Storage) GetS3APIHandle() s3iface.S3API {
 	return rs.svc

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -18,6 +18,12 @@ import (
 // Permission represents the permission we need to check in create storage.
 type Permission string
 
+// StrongConsistency is a marker interface that indicates the storage is strong consistent
+// over its `Read`, `Write` and `WalkDir` APIs.
+type StrongConsisency interface {
+	MarkStrongConsistency()
+}
+
 const (
 	// AccessBuckets represents bucket access permission
 	// it replace the origin skip-check-path.
@@ -33,7 +39,8 @@ const (
 	// we cannot check DeleteObject permission alone, so we use PutAndDeleteObject instead.
 	PutAndDeleteObject Permission = "PutAndDeleteObject"
 
-	DefaultRequestConcurrency uint = 128
+	DefaultRequestConcurrency uint  = 128
+	TombstoneSize             int64 = -1
 )
 
 // WalkOption is the option of storage.WalkDir.
@@ -62,6 +69,14 @@ type WalkOption struct {
 	// to reduce the possibility of timeout on an extremely slow connection, or
 	// perform testing.
 	ListCount int64
+	// IncludeTombstone will allow `Walk` to emit removed files during walking.
+	//
+	// In most cases, `Walk` runs over a snapshot, if a file in the snapshot
+	// was deleted during walking, the file will be ignored. Set this to `true`
+	// will make them be sent to the callback.
+	//
+	// The size of a deleted file should be `TombstoneSize`.
+	IncludeTombstone bool
 }
 
 // ReadSeekCloser is the interface that groups the basic Read, Seek and Close methods.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/56523

close https://github.com/pingcap/tidb/issues/57755

Problem Summary:
The test case `TestConcurrentLock` isn't stable enough.

### What changed and how does it work?
Make it more stable by stronger syncing.
```console
# go test -count 2000 -run '^TestConcurrentLock$' github.com/pingcap/tidb/br/pkg/storage
ok      github.com/pingcap/tidb/br/pkg/storage  9.397s
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > It is a test.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
