### PR TITLE
br: redact secret strings when logging arguments

### DIFF
--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -32,13 +32,69 @@ func (f fakeValue) Type() string {
 }
 
 func TestUrlNoQuery(t *testing.T) {
-	flag := &pflag.Flag{
-		Name:  flagStorage,
-		Value: fakeValue("s3://some/what?secret=a123456789&key=987654321"),
+	testCases := []struct {
+		inputName     string
+		expectedName  string
+		inputValue    string
+		expectedValue string
+	}{
+		{
+			inputName:     flagSendCreds,
+			expectedName:  "send-credentials-to-tikv",
+			inputValue:    "true",
+			expectedValue: "true",
+		},
+		{
+			inputName:     flagStorage,
+			expectedName:  "storage",
+			inputValue:    "s3://some/what?secret=a123456789&key=987654321",
+			expectedValue: "s3://some/what",
+		},
+		{
+			inputName:     FlagStreamFullBackupStorage,
+			expectedName:  "full-backup-storage",
+			inputValue:    "s3://bucket/prefix/?access-key=1&secret-key=2",
+			expectedValue: "s3://bucket/prefix/",
+		},
+		{
+			inputName:     flagFullBackupCipherKey,
+			expectedName:  "crypter.key",
+			inputValue:    "537570657253656372657456616C7565",
+			expectedValue: "<redacted>",
+		},
+		{
+			inputName:     flagLogBackupCipherKey,
+			expectedName:  "log.crypter.key",
+			inputValue:    "537570657253656372657456616C7565",
+			expectedValue: "<redacted>",
+		},
+		{
+			inputName:     "azblob.encryption-key",
+			expectedName:  "azblob.encryption-key",
+			inputValue:    "SUPERSECRET_AZURE_ENCRYPTION_KEY",
+			expectedValue: "<redacted>",
+		},
+		{
+			inputName:     flagMasterKeyConfig,
+			expectedName:  "master-key",
+			inputValue:    "local:///path/abcd,aws-kms:///abcd?AWS_ACCESS_KEY_ID=SECRET1&AWS_SECRET_ACCESS_KEY=SECRET2&REGION=us-east-1,azure-kms:///abcd/v1?AZURE_TENANT_ID=tenant-id&AZURE_CLIENT_ID=client-id&AZURE_CLIENT_SECRET=client-secret&AZURE_VAULT_NAME=vault-name",
+			expectedValue: "<redacted>",
+			// expectedValue: "local:///path/abcd,aws-kms:///abcd,azure-kms:///abcd/v1"
+		},
 	}
-	field := flagToZapField(flag)
-	require.Equal(t, flagStorage, field.Key)
-	require.Equal(t, "s3://some/what", field.Interface.(fmt.Stringer).String())
+
+	for _, tc := range testCases {
+		flag := pflag.Flag{
+			Name:  tc.inputName,
+			Value: fakeValue(tc.inputValue),
+		}
+		field := flagToZapField(&flag)
+		require.Equal(t, tc.expectedName, field.Key, `test-case [%s="%s"]`, tc.expectedName, tc.expectedValue)
+		if stringer, ok := field.Interface.(fmt.Stringer); ok {
+			field.String = stringer.String()
+		}
+		require.Equal(t, tc.expectedValue, field.String, `test-case [%s="%s"]`, tc.expectedName, tc.expectedValue)
+	}
 }
 
 func TestTiDBConfigUnchanged(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57585

Problem Summary: Some values from the command line are not properly redacted.

### What changed and how does it work?

In additional to the existing handling for `--storage`, we also apply redaction to the following parameters:

* `--full-backup-storage`
* `--crypter.key`
* `--log.crypter.key`
* `--azblob.encryption-key`
* `--master-key` (the current implementation of this may be too conservative)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When invoking BR in command line with secret keys passed directly from arguments, they are no longer printed as plaintext in the log.
```
