### PR TITLE
statistics: do not record historical stats meta if the table is locked

### DIFF
--- a/pkg/statistics/handle/handletest/lockstats/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/lockstats/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//pkg/statistics",
         "//pkg/testkit",
         "//pkg/testkit/testsetup",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],

--- a/pkg/statistics/handle/usage/BUILD.bazel
+++ b/pkg/statistics/handle/usage/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/util/intest",
         "//pkg/util/sqlescape",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
     ],
 )
 

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
@@ -129,8 +130,13 @@ func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool) error {
 // For a partitioned table, we will update its global-stats as well.
 func (s *statsUsageImpl) dumpTableStatCountToKV(is infoschema.InfoSchema, physicalTableID int64, delta variable.TableDelta) (updated bool, err error) {
 	statsVersion := uint64(0)
+	isLocked := false
 	defer func() {
-		if err == nil && statsVersion != 0 {
+		// Only record the historical stats meta when the table is not locked because all stats meta are stored in the locked table.
+		if err == nil && statsVersion != 0 && !isLocked {
+			failpoint.Inject("panic-when-record-historical-stats-meta", func() {
+				panic("panic when record historical stats meta")
+			})
 			s.statsHandle.RecordHistoricalStatsMeta(physicalTableID, statsVersion, "flush stats", false)
 		}
 	}()
@@ -171,6 +177,7 @@ func (s *statsUsageImpl) dumpTableStatCountToKV(is infoschema.InfoSchema, physic
 				isPartitionLocked = true
 			}
 			tableOrPartitionLocked := isTableLocked || isPartitionLocked
+			isLocked = tableOrPartitionLocked
 			if err = storage.UpdateStatsMeta(utilstats.StatsCtx, sctx, statsVersion, delta,
 				physicalTableID, tableOrPartitionLocked); err != nil {
 				return err
@@ -201,6 +208,7 @@ func (s *statsUsageImpl) dumpTableStatCountToKV(is infoschema.InfoSchema, physic
 			if _, ok := lockedTables[physicalTableID]; ok {
 				isTableLocked = true
 			}
+			isLocked = isTableLocked
 			if err = storage.UpdateStatsMeta(utilstats.StatsCtx, sctx, statsVersion, delta,
 				physicalTableID, isTableLocked); err != nil {
 				return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57628

Problem Summary:

### What changed and how does it work?

We don't need to record the historical stats meta if the table is locked because all the information is stored in the locked tables.

So in this PR, we skip the record when the tables are locked.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复在 tidb_enable_historical_stats 开启并且锁定表统计信息的时候会出现的无效错误日志的问题
Fix the issue of invalid error logs that occur when `tidb_enable_historical_stats` is enabled and table statistics are locked
```
