### PR TITLE
executor, session: store utf8 string in `sessionctx`

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -258,8 +258,6 @@ type ExecStmt struct {
 	InfoSchema infoschema.InfoSchema
 	// Plan stores a reference to the final physical plan.
 	Plan base.Plan
-	// Text represents the origin query text.
-	Text string
 
 	StmtNode ast.StmtNode
 
@@ -379,6 +377,11 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 // OriginText returns original statement as a string.
 func (a *ExecStmt) OriginText() string {
 	return a.StmtNode.OriginalText()
+}
+
+// Text returns utf8 encoded statement as a string.
+func (a *ExecStmt) Text() string {
+	return a.StmtNode.Text()
 }
 
 // IsPrepared returns true if stmt is a prepare statement.

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -296,7 +296,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 	r, ctx := tracing.StartRegionEx(ctx, "ExecStmt.PointGet")
 	defer r.End()
 	if r.Span != nil {
-		r.Span.LogKV("sql", a.OriginText())
+		r.Span.LogKV("sql", a.Text())
 	}
 
 	failpoint.Inject("assertTxnManagerInShortPointGetPlan", func() {
@@ -357,7 +357,7 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 	var pi processinfoSetter
 	if raw, ok := sctx.(processinfoSetter); ok {
 		pi = raw
-		sql := a.OriginText()
+		sql := a.Text()
 		maxExecutionTime := sctx.GetSessionVars().GetMaxExecutionTime()
 		// Update processinfo, ShowProcess() will use it.
 		pi.SetProcessInfo(sql, time.Now(), cmd, maxExecutionTime)
@@ -644,7 +644,7 @@ func (a *ExecStmt) inheritContextFromExecuteStmt() {
 }
 
 func (a *ExecStmt) getSQLForProcessInfo() string {
-	sql := a.OriginText()
+	sql := a.Text()
 	if simple, ok := a.Plan.(*plannercore.Simple); ok && simple.Statement != nil {
 		if ss, ok := simple.Statement.(ast.SensitiveStmtNode); ok {
 			// Use SecureText to avoid leak password information.
@@ -1038,7 +1038,7 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e exec.Executor) (e
 			// If it's not a retryable error, rollback current transaction instead of rolling back current statement like
 			// in normal transactions, because we cannot locate and rollback the statement that leads to the lock error.
 			// This is too strict, but since the feature is not for everyone, it's the easiest way to guarantee safety.
-			stmtText := parser.Normalize(a.OriginText(), sctx.GetSessionVars().EnableRedactLog)
+			stmtText := parser.Normalize(a.Text(), sctx.GetSessionVars().EnableRedactLog)
 			logutil.Logger(ctx).Info("Transaction abort for the safety of lazy uniqueness check. "+
 				"Note this may not be a uniqueness violation.",
 				zap.Error(err),

--- a/pkg/executor/compiler.go
+++ b/pkg/executor/compiler.go
@@ -122,7 +122,6 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (_ *ExecS
 		InfoSchema:    is,
 		Plan:          finalPlan,
 		LowerPriority: lowerPriority,
-		Text:          stmtNode.Text(),
 		StmtNode:      stmtNode,
 		Ctx:           c.Ctx,
 		OutputNames:   names,

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -1972,6 +1972,14 @@ func TestAdapterStatement(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "select 1", stmt.OriginText())
 
+	gbkSQL := "select '\xb1\xed1'"
+	stmts, _, err := s.ParseSQL(gbkSQL, parser.CharsetClient("gbk"))
+	require.NoError(t, err)
+	stmt, err = compiler.Compile(context.TODO(), stmts[0])
+	require.NoError(t, err)
+	require.Equal(t, "select '表1'", stmt.Text())
+	require.Equal(t, gbkSQL, stmt.OriginText())
+
 	stmtNode, err = s.ParseOneStmt("create table test.t (a int)", "", "")
 	require.NoError(t, err)
 	stmt, err = compiler.Compile(context.TODO(), stmtNode)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2259,10 +2259,10 @@ func runStmt(ctx context.Context, se *session, s sqlexec.Statement) (rs sqlexec.
 	r, ctx := tracing.StartRegionEx(ctx, "session.runStmt")
 	defer r.End()
 	if r.Span != nil {
-		r.Span.LogKV("sql", s.OriginText())
+		r.Span.LogKV("sql", s.Text())
 	}
 
-	se.SetValue(sessionctx.QueryString, s.OriginText())
+	se.SetValue(sessionctx.QueryString, s.Text())
 	if _, ok := s.(*executor.ExecStmt).StmtNode.(ast.DDLNode); ok {
 		se.SetValue(sessionctx.LastExecuteDDL, true)
 	} else {
@@ -4148,7 +4148,7 @@ func logGeneralQuery(execStmt *executor.ExecStmt, s *session, isPrepared bool) {
 			zap.String("sessionTxnMode", vars.GetReadableTxnMode()),
 			zap.String("sql", query),
 		}
-		if ot := execStmt.OriginText(); ot != execStmt.Text {
+		if ot := execStmt.OriginText(); ot != execStmt.Text() {
 			fields = append(fields, zap.String("originText", strconv.Quote(ot)))
 		}
 		logutil.GeneralLogger.Info("GENERAL_LOG", fields...)

--- a/pkg/util/sqlexec/restricted_sql_executor.go
+++ b/pkg/util/sqlexec/restricted_sql_executor.go
@@ -165,6 +165,9 @@ type Statement interface {
 	// OriginText gets the origin SQL text.
 	OriginText() string
 
+	// Text gets the utf8 encoded SQL text.
+	Text() string
+
 	// GetTextToLog gets the desensitization SQL text for logging.
 	GetTextToLog(keepHint bool) string
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57646

Problem Summary:

TiCDC relies on DDL Statements from `mysql.tidb_ddl_history` table to do replication in downstream database, and these DDL statements are obtained through the `OriginText()` function.

https://github.com/pingcap/tidb/blob/6e22b8cb1314b539dec40623c17d0df577cc7af4/pkg/session/session.go#L2265

https://github.com/pingcap/tidb/blob/6e22b8cb1314b539dec40623c17d0df577cc7af4/pkg/executor/adapter.go#L379-L380

Before PR #57393, `OriginText` mistakenly return UTF-8 encoded queries. However, after that PR, this function returns the original queries, which may lead to different results in the upstream and downstream.

For example, in the failed CI,  DDLs use GBK encoding. Therefore, you can see the following results in the log:

```
An error occured while initializing diff: from upstream: please make sure the filter is correct.: the target has no table to be compared. source-table is ``test`.`表2``, please check log info in /tmp/tidb_cdc_test/kafka_simple_basic/output/sync_diff.log for full details

An error occured while initializing diff: from upstream: please make sure the filter is correct.: the source has no table to be compared. target-table is ``test`.`��2``, please check log info in /tmp/tidb_cdc_test/kafka_simple_basic/output/sync_diff.log for full details
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
