### PR TITLE
planner: prevent FIELD() function from being incorrectly recognized as a NULL-Rejected condition in ConvertOuterToInnerJoin

### DIFF
--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -134,3 +134,17 @@ func TestIssue53175(t *testing.T) {
 	tk.MustQuery(`select * from t group by null`)
 	tk.MustQuery(`select * from v`)
 }
+
+func TestIssue51523(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t0, t1`)
+	tk.MustExec(`CREATE TABLE t0(c0 INT UNSIGNED, c1 INT UNSIGNED, c2 BOOL)`)
+	tk.MustExec(`CREATE TABLE t1 LIKE t0`)
+	tk.MustExec(`INSERT IGNORE INTO t0 VALUES (1, -2, true)`)
+	res1 := tk.MustQuery(`SELECT FIELD(t0.c1, '', t1.c1, 2) FROM t0 LEFT JOIN t1 ON t0.c0`)
+	res2 := tk.MustQuery(`SELECT * FROM t0 LEFT JOIN t1 ON t0.c0 WHERE FIELD(t0.c1, '', t1.c1, 2)`)
+	require.Equal(t, 1, len(res1.Rows()))
+	require.Equal(t, 1, len(res2.Rows()))
+}

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -87,6 +87,8 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1])
 		} else if expr.FuncName.L == ast.In {
 			return isNullRejectedInList(ctx, expr, innerSchema)
+		} else if expr.FuncName.L == ast.Field {
+			return false
 		} else {
 			return isNullRejectedSimpleExpr(ctx, innerSchema, expr)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #51523 

Problem Summary:

### What changed and how does it work?
During the `convert_outer_to_inner_joins` phase, TiDB checks if` FIELD()` is a `NULL-rejected condition` for t1. If it is treated as `NULL-rejected`, TiDB will rewriter `LEFT JOIN` as `INNER JOIN`.

https://github.com/pingcap/tidb/blob/6e22b8cb1314b539dec40623c17d0df577cc7af4/pkg/planner/core/operator/logicalop/logical_join.go#L669-L675

The logic behind this determination involves replacing the `t1`' columns with `NULL` and `t0`'s columns with `constant 1`.

If after evaluation, the function returns `NULL or 0`, it will be considered as `NULL-rejected condition`.
https://github.com/pingcap/tidb/blob/6e22b8cb1314b539dec40623c17d0df577cc7af4/pkg/expression/constant_fold.go#L191-L208

`FIELD(t0.c1, '', t1.c1, 2)` is transformed into `FIELD(1, 0, NULL, 2)`

The result of this evaluation is `0`, so `LEFT JOIN` is rewritten as `INNER JOIN` by mistake.

I added a special check in `IsNullRejected()` to make it `return false `when the function's name is `field()`.

https://github.com/dash12653/tidb/blob/e4f542ae751f0526911446a174efec8b11228233/pkg/planner/util/null_misc.go#L90-L91

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
