### PR TITLE
ttl: fix the issue that `DROP TABLE` / `ALTER TABLE` will keep job running

### DIFF
--- a/pkg/ttl/ttlworker/config.go
+++ b/pkg/ttl/ttlworker/config.go
@@ -32,7 +32,7 @@ const ttlJobTimeout = 6 * time.Hour
 
 const taskManagerLoopTickerInterval = time.Minute
 const ttlTaskHeartBeatTickerInterval = time.Minute
-const ttlGCInterval = time.Hour
+const ttlGCInterval = 10 * time.Minute
 
 func getCheckJobInterval() time.Duration {
 	failpoint.Inject("check-job-interval", func(val failpoint.Value) time.Duration {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #57556, close #57702

Problem Summary:

If the TTL job owner restarts and the TTL table is disabled or dropped, it'll not be removed and will always keep running.

### What changed and how does it work?

1. Also remove the table even when it's current status is not NULL if its heartbeat has timeout.
2. Shorten the GC period to 10 minutes.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
