### PR TITLE
restore: set tidb_scatter_region to global before tables creation

### DIFF
--- a/br/pkg/restore/internal/prealloc_db/db.go
+++ b/br/pkg/restore/internal/prealloc_db/db.go
@@ -45,6 +45,12 @@ func NewDB(g glue.Glue, store kv.Storage, policyMode string) (*DB, bool, error) 
 		return nil, false, errors.Trace(err)
 	}
 
+	err = se.Execute(context.Background(), "set @@tidb_scatter_region = 'global'")
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
+	log.Debug("set tidb_scatter_region to global success")
+
 	supportPolicy := false
 	if len(policyMode) != 0 {
 		// Set placement mode for handle placement policy.
@@ -56,7 +62,7 @@ func NewDB(g glue.Glue, store kv.Storage, policyMode string) (*DB, bool, error) 
 			// not support placement policy, just ignore it
 			log.Warn("target tidb not support tidb_placement_mode, ignore create policies", zap.Error(err))
 		} else {
-			log.Info("set tidb_placement_mode success", zap.String("mode", policyMode))
+			log.Debug("set tidb_placement_mode success", zap.String("mode", policyMode))
 			supportPolicy = true
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57596

Problem Summary:
Empty tables cannot scatter after table creations during restore.
### What changed and how does it work?
After v8.4 we can set `tidb_scatter_region` to global to trigger the scatter regions after table created.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support scatter empty tables after restore.
```
