### PR TITLE
infoschema: avoid mem allocs when searching table items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,6 +367,7 @@ bench-daily:
 	go test github.com/pingcap/tidb/pkg/executor -run TestBenchDaily -bench Ignore --outfile bench_daily.json
 	go test github.com/pingcap/tidb/pkg/executor/test/splittest -run TestBenchDaily -bench Ignore --outfile bench_daily.json
 	go test github.com/pingcap/tidb/pkg/expression -run TestBenchDaily -bench Ignore --outfile bench_daily.json
+	go test github.com/pingcap/tidb/pkg/infoschema -run TestBenchDaily -bench Ignore --outfile bench_daily.json
 	go test github.com/pingcap/tidb/pkg/planner/core/tests/partition -run TestBenchDaily -bench Ignore --outfile bench_daily.json
 	go test github.com/pingcap/tidb/pkg/session -run TestBenchDaily -bench Ignore --outfile bench_daily.json
 	go test github.com/pingcap/tidb/pkg/statistics -run TestBenchDaily -bench Ignore --outfile bench_daily.json

--- a/pkg/infoschema/BUILD.bazel
+++ b/pkg/infoschema/BUILD.bazel
@@ -93,7 +93,7 @@ go_test(
     ],
     embed = [":infoschema"],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         "//pkg/ddl/placement",
         "//pkg/domain",
@@ -113,6 +113,7 @@ go_test(
         "//pkg/testkit/testutil",
         "//pkg/types",
         "//pkg/util",
+        "//pkg/util/benchdaily",
         "//pkg/util/logutil",
         "//pkg/util/set",
         "//pkg/util/size",

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -549,12 +549,12 @@ func NewInfoSchemaV2(r autoid.Requirement, factory func() (pools.Resource, error
 	}
 }
 
-func search(bt *btree.BTreeG[tableItem], schemaVersion int64, end tableItem, matchFn func(a, b *tableItem) bool) (tableItem, bool) {
+func search(bt *btree.BTreeG[tableItem], schemaVersion int64, end tableItem, matchFn func(a, b tableItem) bool) (tableItem, bool) {
 	var ok bool
 	var target tableItem
 	// Iterate through the btree, find the query item whose schema version is the largest one (latest).
 	bt.Descend(end, func(item tableItem) bool {
-		if !matchFn(&end, &item) {
+		if !matchFn(end, item) {
 			return false
 		}
 		if item.schemaVersion > schemaVersion {
@@ -591,7 +591,7 @@ func (is *infoschemaV2) CloneAndUpdateTS(startTS uint64) *infoschemaV2 {
 }
 
 func (is *infoschemaV2) searchTableItemByID(tableID int64) (tableItem, bool) {
-	eq := func(a, b *tableItem) bool { return a.tableID == b.tableID }
+	eq := func(a, b tableItem) bool { return a.tableID == b.tableID }
 	return search(
 		is.byID,
 		is.infoSchema.schemaMetaVersion,
@@ -725,7 +725,7 @@ func IsSpecialDB(dbName string) bool {
 
 // EvictTable is exported for testing only.
 func (is *infoschemaV2) EvictTable(schema, tbl pmodel.CIStr) {
-	eq := func(a, b *tableItem) bool { return a.dbName == b.dbName && a.tableName == b.tableName }
+	eq := func(a, b tableItem) bool { return a.dbName == b.dbName && a.tableName == b.tableName }
 	itm, ok := search(is.byName, is.infoSchema.schemaMetaVersion, tableItem{dbName: schema, tableName: tbl, schemaVersion: math.MaxInt64}, eq)
 	if !ok {
 		return

--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
+	"github.com/pingcap/tidb/pkg/util/benchdaily"
 	"github.com/stretchr/testify/require"
 )
 
@@ -741,6 +742,14 @@ func TestDataStructFieldsCorrectnessInSchemaChange(t *testing.T) {
 	dbItem, ok = v2.Data.schemaMap.Get(schemaItem{schemaVersion: 6, dbInfo: &model.DBInfo{Name: dbInfo.Name}})
 	require.True(t, ok)
 	require.True(t, dbItem.tomb)
+}
+
+func TestBenchDaily(t *testing.T) {
+	benchdaily.Run(
+		BenchmarkSearchByID_100,
+		BenchmarkSearchByID_1000,
+		BenchmarkSearchByID_10000,
+	)
 }
 
 func BenchmarkSearchByID_100(b *testing.B) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54047

Problem Summary: avoid mem allocs when searching table items

### What changed and how does it work?

Passing `tableItem` pointer to the `matchFn` introduces mem allocs on heap. Plan cache now calls `TableByID` for each related table (ref the following flamegraph of a point-get workload), which makes `searchTableItemByID` a hot path, thus extra mem allocs should be avoid.

![image](https://github.com/user-attachments/assets/2db1bea7-06c2-4254-8a13-7a63ee049fff)

We can simply optimize it by changing the signature of `matchFn` and here is the micro-benchmark results:

```
# Baseline
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/infoschema
cpu: Intel(R) Xeon(R) Gold 5220R CPU @ 2.20GHz
BenchmarkSearchByID_100
BenchmarkSearchByID_100-32               1898032               648.4 ns/op           288 B/op          3 allocs/op
BenchmarkSearchByID_1000
BenchmarkSearchByID_1000-32              1763356               714.4 ns/op           288 B/op          3 allocs/op
BenchmarkSearchByID_10000
BenchmarkSearchByID_10000-32             1657314               756.6 ns/op           288 B/op          3 allocs/op

# This PR
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/infoschema
cpu: Intel(R) Xeon(R) Gold 5220R CPU @ 2.20GHz
BenchmarkSearchByID_100
BenchmarkSearchByID_100-44               3701288               297.9 ns/op             0 B/op          0 allocs/op
BenchmarkSearchByID_1000
BenchmarkSearchByID_1000-44              3440937               306.4 ns/op             0 B/op          0 allocs/op
BenchmarkSearchByID_10000
BenchmarkSearchByID_10000-44             3548060               423.7 ns/op             0 B/op          0 allocs/op
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
