### PR TITLE
ttl: make the default value of `ttl_job_interval` to `24h`

### DIFF
--- a/pkg/ddl/tests/serial/serial_test.go
+++ b/pkg/ddl/tests/serial/serial_test.go
@@ -500,20 +500,20 @@ func TestRecoverTableWithTTL(t *testing.T) {
 	tk.MustExec("create table t_recover1 (t timestamp) TTL=`t`+INTERVAL 1 DAY")
 	tk.MustExec("drop table t_recover1")
 	tk.MustExec("recover table t_recover1")
-	tk.MustQuery("show create table t_recover1").Check(testkit.Rows("t_recover1 CREATE TABLE `t_recover1` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */"))
+	tk.MustQuery("show create table t_recover1").Check(testkit.Rows("t_recover1 CREATE TABLE `t_recover1` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */"))
 
 	// recover table with job id
 	tk.MustExec("create table t_recover2 (t timestamp) TTL=`t`+INTERVAL 1 DAY")
 	tk.MustExec("drop table t_recover2")
 	jobID := getDDLJobID("t_recover2", "drop table")
 	tk.MustExec(fmt.Sprintf("recover table BY JOB %d", jobID))
-	tk.MustQuery("show create table t_recover2").Check(testkit.Rows("t_recover2 CREATE TABLE `t_recover2` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */"))
+	tk.MustQuery("show create table t_recover2").Check(testkit.Rows("t_recover2 CREATE TABLE `t_recover2` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */"))
 
 	// flashback table
 	tk.MustExec("create table t_recover3 (t timestamp) TTL=`t`+INTERVAL 1 DAY")
 	tk.MustExec("drop table t_recover3")
 	tk.MustExec("flashback table t_recover3")
-	tk.MustQuery("show create table t_recover3").Check(testkit.Rows("t_recover3 CREATE TABLE `t_recover3` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */"))
+	tk.MustQuery("show create table t_recover3").Check(testkit.Rows("t_recover3 CREATE TABLE `t_recover3` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */"))
 
 	// flashback database
 	tk.MustExec("create database if not exists test_recover2")
@@ -521,8 +521,8 @@ func TestRecoverTableWithTTL(t *testing.T) {
 	tk.MustExec("create table test_recover2.t2 (t timestamp) TTL=`t`+INTERVAL 1 DAY")
 	tk.MustExec("drop database test_recover2")
 	tk.MustExec("flashback database test_recover2")
-	tk.MustQuery("show create table test_recover2.t1").Check(testkit.Rows("t1 CREATE TABLE `t1` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */"))
-	tk.MustQuery("show create table test_recover2.t2").Check(testkit.Rows("t2 CREATE TABLE `t2` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */"))
+	tk.MustQuery("show create table test_recover2.t1").Check(testkit.Rows("t1 CREATE TABLE `t1` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */"))
+	tk.MustQuery("show create table test_recover2.t2").Check(testkit.Rows("t2 CREATE TABLE `t2` (\n  `t` timestamp NULL DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`t` + INTERVAL 1 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */"))
 }
 
 func TestRecoverTableByJobID(t *testing.T) {

--- a/pkg/ddl/ttl.go
+++ b/pkg/ddl/ttl.go
@@ -30,9 +30,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 )
 
-// DefaultTTLJobInterval is the default value for ttl job interval.
-const DefaultTTLJobInterval = "1h"
-
 func onTTLInfoRemove(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
 	tblInfo, err := GetTableInfoAndCancelFaultJob(jobCtx.metaMut, job, job.SchemaID)
 	if err != nil {
@@ -195,7 +192,7 @@ func getTTLInfoInOptions(options []*ast.TableOption) (ttlInfo *model.TTLInfo, tt
 				IntervalExprStr:  intervalExpr,
 				IntervalTimeUnit: int(op.TimeUnitValue.Unit),
 				Enable:           true,
-				JobInterval:      DefaultTTLJobInterval,
+				JobInterval:      model.DefaultTTLJobInterval,
 			}
 		case ast.TableOptionTTLEnable:
 			ttlEnable = &op.BoolValue

--- a/pkg/ddl/ttl_test.go
+++ b/pkg/ddl/ttl_test.go
@@ -26,7 +26,7 @@ import (
 func Test_getTTLInfoInOptions(t *testing.T) {
 	falseValue := false
 	trueValue := true
-	twentyFourHours := "24h"
+	twentyFiveHours := "25h"
 
 	cases := []struct {
 		options            []*ast.TableOption
@@ -56,7 +56,7 @@ func Test_getTTLInfoInOptions(t *testing.T) {
 				IntervalExprStr:  "5",
 				IntervalTimeUnit: int(ast.TimeUnitYear),
 				Enable:           true,
-				JobInterval:      DefaultTTLJobInterval,
+				JobInterval:      model.DefaultTTLJobInterval,
 			},
 			nil,
 			nil,
@@ -80,7 +80,7 @@ func Test_getTTLInfoInOptions(t *testing.T) {
 				IntervalExprStr:  "5",
 				IntervalTimeUnit: int(ast.TimeUnitYear),
 				Enable:           false,
-				JobInterval:      DefaultTTLJobInterval,
+				JobInterval:      model.DefaultTTLJobInterval,
 			},
 			&falseValue,
 			nil,
@@ -108,7 +108,7 @@ func Test_getTTLInfoInOptions(t *testing.T) {
 				IntervalExprStr:  "5",
 				IntervalTimeUnit: int(ast.TimeUnitYear),
 				Enable:           true,
-				JobInterval:      DefaultTTLJobInterval,
+				JobInterval:      model.DefaultTTLJobInterval,
 			},
 			&trueValue,
 			nil,
@@ -124,7 +124,7 @@ func Test_getTTLInfoInOptions(t *testing.T) {
 				},
 				{
 					Tp:       ast.TableOptionTTLJobInterval,
-					StrValue: "24h",
+					StrValue: "25h",
 				},
 			},
 			&model.TTLInfo{
@@ -132,10 +132,10 @@ func Test_getTTLInfoInOptions(t *testing.T) {
 				IntervalExprStr:  "5",
 				IntervalTimeUnit: int(ast.TimeUnitYear),
 				Enable:           true,
-				JobInterval:      "24h",
+				JobInterval:      "25h",
 			},
 			nil,
-			&twentyFourHours,
+			&twentyFiveHours,
 			nil,
 		},
 	}

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1429,7 +1429,10 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *pmodel.CIS
 			restoreCtx.WriteKeyWord("TTL_JOB_INTERVAL")
 			restoreCtx.WritePlain("=")
 			if len(tableInfo.TTLInfo.JobInterval) == 0 {
-				restoreCtx.WriteString(model.DefaultJobIntervalStr)
+				// This only happens when the table is created from 6.5 in which the `tidb_job_interval` is not introduced yet.
+				// We use `OldDefaultTTLJobInterval` as the return value to ensure a consistent behavior for the
+				// upgrades: v6.5 -> v8.5(or previous version) -> newer version than v8.5.
+				restoreCtx.WriteString(model.OldDefaultTTLJobInterval)
 			} else {
 				restoreCtx.WriteString(tableInfo.TTLInfo.JobInterval)
 			}

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -1320,11 +1320,12 @@ func (s WindowRepeatType) String() string {
 	}
 }
 
-// DefaultJobInterval sets the default interval between TTL jobs
-const DefaultJobInterval = time.Hour
+// DefaultTTLJobInterval is the default interval of TTL jobs.
+const DefaultTTLJobInterval = "24h"
 
-// DefaultJobIntervalStr is the string representation of DefaultJobInterval
-const DefaultJobIntervalStr = "1h"
+// OldDefaultTTLJobInterval is the default interval of TTL jobs in v8.5 and the previous versions.
+// It is used by some codes to keep compatible with the previous versions.
+const OldDefaultTTLJobInterval = "1h"
 
 // TTLInfo records the TTL config
 type TTLInfo struct {
@@ -1351,7 +1352,10 @@ func (t *TTLInfo) Clone() *TTLInfo {
 // and could avoid bugs blocking users from upgrading or bootstrapping the cluster.
 func (t *TTLInfo) GetJobInterval() (time.Duration, error) {
 	if len(t.JobInterval) == 0 {
-		return DefaultJobInterval, nil
+		// This only happens when the table is created from 6.5 in which the `tidb_job_interval` is not introduced yet.
+		// We use `OldDefaultTTLJobInterval` as the return value to ensure a consistent behavior for the
+		// upgrades: v6.5 -> v8.5(or previous version) -> newer version than v8.5.
+		return duration.ParseDuration(OldDefaultTTLJobInterval)
 	}
 
 	return duration.ParseDuration(t.JobInterval)

--- a/pkg/meta/model/table_test.go
+++ b/pkg/meta/model/table_test.go
@@ -238,8 +238,12 @@ func TestClearReorgIntermediateInfo(t *testing.T) {
 }
 
 func TestTTLDefaultJobInterval(t *testing.T) {
-	// test const `DefaultJobIntervalStr` and `DefaultJobInterval` are consistent.
-	d, err := duration.ParseDuration(DefaultJobIntervalStr)
+	// test default value of `DefaultTTLJobInterval` is valid.
+	d, err := duration.ParseDuration(DefaultTTLJobInterval)
 	require.NoError(t, err)
-	require.Equal(t, DefaultJobInterval, d)
+	require.Equal(t, 24*time.Hour, d)
+	// test default value of `OldDefaultTTLJobInterval` is valid.
+	d, err = duration.ParseDuration(OldDefaultTTLJobInterval)
+	require.NoError(t, err)
+	require.Equal(t, time.Hour, d)
 }

--- a/pkg/ttl/ttlworker/timer_sync.go
+++ b/pkg/ttl/ttlworker/timer_sync.go
@@ -414,7 +414,9 @@ func getTTLSchedulePolicy(info *model.TTLInfo) (timerapi.SchedPolicyType, string
 	interval := info.JobInterval
 	if interval == "" {
 		// This only happens when the table is created from 6.5 in which the `tidb_job_interval` is not introduced yet.
-		interval = model.DefaultJobIntervalStr
+		// We use `OldDefaultTTLJobInterval` as the return value to ensure a consistent behavior for the
+		// upgrades: v6.5 -> v8.5(or previous version) -> newer version than v8.5.
+		interval = model.OldDefaultTTLJobInterval
 	}
 	return timerapi.SchedEventInterval, interval
 }

--- a/pkg/ttl/ttlworker/timer_test.go
+++ b/pkg/ttl/ttlworker/timer_test.go
@@ -584,7 +584,7 @@ func TestGetTTLSchedulePolicy(t *testing.T) {
 		JobInterval: "",
 	})
 	require.Equal(t, timerapi.SchedEventInterval, tp)
-	require.Equal(t, model.DefaultJobIntervalStr, expr)
+	require.Equal(t, model.OldDefaultTTLJobInterval, expr)
 	_, err = timerapi.CreateSchedEventPolicy(tp, expr)
 	require.NoError(t, err)
 }

--- a/tests/integrationtest/r/executor/ddl.result
+++ b/tests/integrationtest/r/executor/ddl.result
@@ -179,7 +179,7 @@ SHOW CREATE TABLE t;
 Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 5 DAY */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 5 DAY */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 DROP TABLE t;
 CREATE TABLE t (id int) TTL = `id` + INTERVAL 5 DAY;
 Error 8148 (HY000): Field 'id' is of a not supported type for TTL config, expect DATETIME, DATE or TIMESTAMP
@@ -199,7 +199,7 @@ SHOW CREATE TABLE t;
 Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 3 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 3 DAY */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 DROP TABLE t;
 drop table if exists t;
 CREATE TABLE t (created_at datetime, updated_at datetime, wrong_type int) TTL = `created_at` + INTERVAL 5 DAY;
@@ -210,7 +210,7 @@ t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `wrong_type` int DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`updated_at` + INTERVAL 2 YEAR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`updated_at` + INTERVAL 2 YEAR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 ALTER TABLE t TTL_ENABLE = 'OFF';
 SHOW CREATE TABLE t;
 Table	Create Table
@@ -218,7 +218,7 @@ t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `wrong_type` int DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`updated_at` + INTERVAL 2 YEAR */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`updated_at` + INTERVAL 2 YEAR */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 ALTER TABLE t TTL_JOB_INTERVAL = '1d';
 SHOW CREATE TABLE t;
 Table	Create Table

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -116,28 +116,28 @@ show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 100 YEAR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 100 YEAR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 drop table if exists t;
 create table t(created_at datetime) ttl = `created_at` + INTERVAL 100 YEAR ttl_enable = 'OFF';
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 100 YEAR */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 100 YEAR */ /*T![ttl] TTL_ENABLE='OFF' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 drop table if exists t;
 create table t (created_at datetime) TTL = created_at + INTERVAL 3.14159 HOUR_MINUTE;
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 3.14159 HOUR_MINUTE */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL 3.14159 HOUR_MINUTE */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 drop table if exists t;
 create table t (created_at datetime) TTL = created_at + INTERVAL "15:20" HOUR_MINUTE;
 show create table t;
 Table	Create Table
 t	CREATE TABLE `t` (
   `created_at` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL _utf8mb4'15:20' HOUR_MINUTE */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='1h' */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_at` + INTERVAL _utf8mb4'15:20' HOUR_MINUTE */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
 drop table if exists t;
 create table t (created_at datetime) TTL = created_at + INTERVAL 100 YEAR TTL_JOB_INTERVAL = '1d';
 show create table t;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57757

### What changed and how does it work?

The default value of `ttl_job_interval` changed from `1h` to `24h`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
ttl: The default value of `ttl_job_interval` changed from `1h` to `24h`
```
