### PR TITLE
ddl: fix ExistsTableRow and add tests for skip reorg checks

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/generatedexpr"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	tidblogutil "github.com/pingcap/tidb/pkg/util/logutil"
 	decoder "github.com/pingcap/tidb/pkg/util/rowDecoder"
 	"github.com/pingcap/tidb/pkg/util/size"
@@ -1156,7 +1157,8 @@ func checkIfPhysicalTableIsEmpty(
 	store kv.Storage,
 	tbl table.PhysicalTable,
 ) bool {
-	hasRecord, err := ExistsTableRow(ctx, store, math.MaxUint64, tbl)
+	hasRecord, err := existsTableRow(ctx, store, tbl)
+	intest.Assert(err == nil)
 	if err != nil {
 		logutil.DDLLogger().Info("check if table is empty failed", zap.Error(err))
 		return false
@@ -1231,6 +1233,7 @@ func checkIfTempIndexIsEmptyForPhysicalTable(
 			foundKey = true
 			return false, nil
 		})
+	intest.Assert(err == nil)
 	if err != nil {
 		logutil.DDLLogger().Info("check if temp index is empty failed", zap.Error(err))
 		return false

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"slices"
 	"strings"
@@ -1129,11 +1128,13 @@ func checkIfTableReorgWorkCanSkip(
 		return false
 	}
 	txn, err := sessCtx.Txn(false)
-	intest.Assert(err == nil)
-	var startTS uint64 = math.MaxUint64
-	if txn != nil && txn.Valid() {
-		startTS = txn.StartTS()
+	validTxn := err == nil && txn != nil && txn.Valid()
+	intest.Assert(validTxn)
+	if !validTxn {
+		logutil.DDLLogger().Warn("check if table is empty failed", zap.Error(err))
+		return false
 	}
+	startTS := txn.StartTS()
 	ctx := NewReorgContext()
 	ctx.resourceGroupName = job.ReorgMeta.ResourceGroupName
 	ctx.setDDLLabelForTopSQL(job.Query)
@@ -1192,11 +1193,13 @@ func checkIfTempIndexReorgWorkCanSkip(
 		return false
 	}
 	txn, err := sessCtx.Txn(false)
-	intest.Assert(err == nil)
-	var startTS uint64 = math.MaxUint64
-	if txn != nil && txn.Valid() {
-		startTS = txn.StartTS()
+	validTxn := err == nil && txn != nil && txn.Valid()
+	intest.Assert(validTxn)
+	if !validTxn {
+		logutil.DDLLogger().Warn("check if temp index is empty failed", zap.Error(err))
+		return false
 	}
+	startTS := txn.StartTS()
 	ctx := NewReorgContext()
 	ctx.resourceGroupName = job.ReorgMeta.ResourceGroupName
 	ctx.setDDLLabelForTopSQL(job.Query)

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1156,7 +1156,7 @@ func checkIfPhysicalTableIsEmpty(
 	store kv.Storage,
 	tbl table.PhysicalTable,
 ) bool {
-	hasRecord, err := ExistsTableRow(ctx, store, math.MaxInt64, tbl)
+	hasRecord, err := ExistsTableRow(ctx, store, math.MaxUint64, tbl)
 	if err != nil {
 		logutil.DDLLogger().Info("check if table is empty failed", zap.Error(err))
 		return false
@@ -1337,6 +1337,7 @@ func doReorgWorkForCreateIndex(
 				return false, ver, errors.Trace(err)
 			}
 		} else {
+			failpoint.InjectCall("afterCheckTableReorgCanSkip")
 			logutil.DDLLogger().Info("table is empty, skipping reorg work",
 				zap.Int64("jobID", job.ID),
 				zap.String("table", tbl.Meta().Name.O))
@@ -1374,6 +1375,7 @@ func doReorgWorkForCreateIndex(
 				return false, ver, err
 			}
 		} else {
+			failpoint.InjectCall("afterCheckTempIndexReorgCanSkip")
 			logutil.DDLLogger().Info("temp index is empty, skipping reorg work",
 				zap.Int64("jobID", job.ID),
 				zap.String("table", tbl.Meta().Name.O))

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"math"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -770,9 +769,9 @@ func GetTableMaxHandle(ctx *ReorgContext, store kv.Storage, startTS uint64, tbl 
 
 // existsTableRow checks if there is at least one row in the specified table.
 // In case of an error during the operation, it returns false along with the error.
-func existsTableRow(ctx *ReorgContext, store kv.Storage, tbl table.PhysicalTable) (bool, error) {
+func existsTableRow(ctx *ReorgContext, store kv.Storage, tbl table.PhysicalTable, startTS uint64) (bool, error) {
 	found := false
-	err := iterateSnapshotKeys(ctx, store, kv.PriorityLow, tbl.RecordPrefix(), math.MaxUint64, nil, nil,
+	err := iterateSnapshotKeys(ctx, store, kv.PriorityLow, tbl.RecordPrefix(), startTS, nil, nil,
 		func(_ kv.Handle, _ kv.Key, _ []byte) (bool, error) {
 			found = true
 			return false, nil

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -773,7 +773,7 @@ func GetTableMaxHandle(ctx *ReorgContext, store kv.Storage, startTS uint64, tbl 
 func existsTableRow(ctx *ReorgContext, store kv.Storage, tbl table.PhysicalTable) (bool, error) {
 	found := false
 	err := iterateSnapshotKeys(ctx, store, kv.PriorityLow, tbl.RecordPrefix(), math.MaxUint64, nil, nil,
-		func(_ kv.Handle, rowKey kv.Key, _ []byte) (bool, error) {
+		func(_ kv.Handle, _ kv.Key, _ []byte) (bool, error) {
 			found = true
 			return false, nil
 		})

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -767,11 +768,11 @@ func GetTableMaxHandle(ctx *ReorgContext, store kv.Storage, startTS uint64, tbl 
 	return kv.IntHandle(row.GetInt64(0)), false, nil
 }
 
-// ExistsTableRow checks if there is at least one row in the specified table.
+// existsTableRow checks if there is at least one row in the specified table.
 // In case of an error during the operation, it returns false along with the error.
-func ExistsTableRow(ctx *ReorgContext, store kv.Storage, startTS uint64, tbl table.PhysicalTable) (bool, error) {
+func existsTableRow(ctx *ReorgContext, store kv.Storage, tbl table.PhysicalTable) (bool, error) {
 	found := false
-	err := iterateSnapshotKeys(ctx, store, kv.PriorityLow, tbl.RecordPrefix(), startTS, nil, nil,
+	err := iterateSnapshotKeys(ctx, store, kv.PriorityLow, tbl.RecordPrefix(), math.MaxUint64, nil, nil,
 		func(_ kv.Handle, rowKey kv.Key, _ []byte) (bool, error) {
 			found = true
 			return false, nil

--- a/pkg/ddl/tests/indexmerge/BUILD.bazel
+++ b/pkg/ddl/tests/indexmerge/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 21,
+    shard_count = 23,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/ddl/tests/indexmerge/merge_test.go
+++ b/pkg/ddl/tests/indexmerge/merge_test.go
@@ -910,28 +910,24 @@ func TestAddIndexInsertAfterReorgSkipCheck(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (a int);")
-	err := failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip", func() {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip", func() {
 		tk2 := testkit.NewTestKit(t, store)
 		tk2.MustExec("use test")
 		tk2.MustExec("insert into t values (1);")
 	})
-	require.NoError(t, err)
 	tk.MustExec("alter table t add index idx(a);")
 	tk.MustQuery("select * from t;").Check(testkit.Rows("1"))
 	tk.MustExec("admin check table t;")
-	err = failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip")
+	err := failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip")
 	require.NoError(t, err)
 
 	tk.MustExec("truncate table t;")
-	err = failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/afterCheckTempIndexReorgCanSkip", func() {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterCheckTempIndexReorgCanSkip", func() {
 		tk2 := testkit.NewTestKit(t, store)
 		tk2.MustExec("use test")
 		tk2.MustExec("insert into t values (2);")
 	})
-	require.NoError(t, err)
 	tk.MustExec("alter table t add index idx2(a);")
 	tk.MustQuery("select * from t;").Check(testkit.Rows("2"))
 	tk.MustExec("admin check table t;")
-	err = failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/afterCheckTempIndexReorgCanSkip")
-	require.NoError(t, err)
 }

--- a/pkg/ddl/tests/indexmerge/merge_test.go
+++ b/pkg/ddl/tests/indexmerge/merge_test.go
@@ -901,6 +901,8 @@ func TestAddIndexSkipReorgCheck(t *testing.T) {
 	tk.MustExec("alter table t add index idx3(a);")
 	require.False(t, skipTableReorg)
 	require.False(t, skipTempIdxReorg)
+	tk.MustQuery("select * from t;").Check(testkit.Rows("1", "2"))
+	tk.MustExec("admin check table t;")
 }
 
 func TestAddIndexInsertAfterReorgSkipCheck(t *testing.T) {

--- a/pkg/ddl/tests/indexmerge/merge_test.go
+++ b/pkg/ddl/tests/indexmerge/merge_test.go
@@ -857,3 +857,79 @@ func TestAddUniqueIndexFalsePositiveDuplicate(t *testing.T) {
 	tk.MustExec("alter table t add unique index idx(b);")
 	tk.MustExec("admin check table t;")
 }
+
+func TestAddIndexSkipReorgCheck(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int);")
+
+	skipTableReorg := false
+	skipTempIdxReorg := false
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip", func() {
+		skipTableReorg = true
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterCheckTempIndexReorgCanSkip", func() {
+		skipTempIdxReorg = true
+	})
+	tk.MustExec("alter table t add index idx1(a);")
+	require.True(t, skipTableReorg)
+	require.True(t, skipTempIdxReorg)
+
+	skipTableReorg = false
+	skipTempIdxReorg = false
+	tk.MustExec("insert into t values (1);")
+	tk.MustExec("alter table t add index idx2(a);")
+	require.False(t, skipTableReorg)
+	require.True(t, skipTempIdxReorg)
+
+	skipTableReorg = false
+	skipTempIdxReorg = false
+	var runDML bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onJobRunAfter", func(job *model.Job) {
+		if t.Failed() || runDML {
+			return
+		}
+		switch job.SchemaState {
+		case model.StateWriteReorganization:
+			tk2 := testkit.NewTestKit(t, store)
+			tk2.MustExec("use test")
+			tk2.MustExec("insert into t values (2);")
+			runDML = true
+		}
+	})
+	tk.MustExec("alter table t add index idx3(a);")
+	require.False(t, skipTableReorg)
+	require.False(t, skipTempIdxReorg)
+}
+
+func TestAddIndexInsertAfterReorgSkipCheck(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int);")
+	err := failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip", func() {
+		tk2 := testkit.NewTestKit(t, store)
+		tk2.MustExec("use test")
+		tk2.MustExec("insert into t values (1);")
+	})
+	require.NoError(t, err)
+	tk.MustExec("alter table t add index idx(a);")
+	tk.MustQuery("select * from t;").Check(testkit.Rows("1"))
+	tk.MustExec("admin check table t;")
+	err = failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/afterCheckTableReorgCanSkip")
+	require.NoError(t, err)
+
+	tk.MustExec("truncate table t;")
+	err = failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/afterCheckTempIndexReorgCanSkip", func() {
+		tk2 := testkit.NewTestKit(t, store)
+		tk2.MustExec("use test")
+		tk2.MustExec("insert into t values (2);")
+	})
+	require.NoError(t, err)
+	tk.MustExec("alter table t add index idx2(a);")
+	tk.MustQuery("select * from t;").Check(testkit.Rows("2"))
+	tk.MustExec("admin check table t;")
+	err = failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/afterCheckTempIndexReorgCanSkip")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57769

Problem Summary:

> The cause is the PR(https://github.com/pingcap/tidb/pull/56406/files#diff-45ad039a8b87835b475a52615355c444538d3a1f31a84d7b3ac94e15b1ce8721R1159), which uses the user specified timestamp math.MaxInt64 to read directly with DAG interfaces.

### What changed and how does it work?

Use the transaction key-value interface instead to check if a table is empty.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
