### PR TITLE
planner: provide a system view `cluster_tidb_plan_cache` to allow users to see the cluster's Plan Cache Info

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2279,6 +2279,7 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) exec.Ex
 			strings.ToLower(infoschema.TableKeywords),
 			strings.ToLower(infoschema.TableTiDBIndexUsage),
 			strings.ToLower(infoschema.TableTiDBPlanCache),
+			strings.ToLower(infoschema.ClusterTableTiDBPlanCache),
 			strings.ToLower(infoschema.ClusterTableTiDBIndexUsage):
 			memTracker := memory.NewTracker(v.ID(), -1)
 			memTracker.AttachTo(b.ctx.GetSessionVars().StmtCtx.MemTracker)

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -54,6 +54,8 @@ const (
 	ClusterTableMemoryUsageOpsHistory = "CLUSTER_MEMORY_USAGE_OPS_HISTORY"
 	// ClusterTableTiDBIndexUsage is a table to show the usage stats of indexes across the whole cluster.
 	ClusterTableTiDBIndexUsage = "CLUSTER_TIDB_INDEX_USAGE"
+	// ClusterTableTiDBPlanCache is the plan cache status of tidb cluster.
+	ClusterTableTiDBPlanCache = "CLUSTER_TIDB_PLAN_CACHE"
 )
 
 // memTableToAllTiDBClusterTables means add memory table to cluster table that will send cop request to all TiDB nodes.
@@ -69,6 +71,7 @@ var memTableToAllTiDBClusterTables = map[string]string{
 	TableMemoryUsage:              ClusterTableMemoryUsage,
 	TableMemoryUsageOpsHistory:    ClusterTableMemoryUsageOpsHistory,
 	TableTiDBIndexUsage:           ClusterTableTiDBIndexUsage,
+	TableTiDBPlanCache:            ClusterTableTiDBPlanCache,
 }
 
 // memTableToDDLOwnerClusterTables means add memory table to cluster table that will send cop request to DDL owner node.

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -341,6 +341,7 @@ var tableIDMap = map[string]int64{
 	ClusterTableTiDBIndexUsage:           autoid.InformationSchemaDBID + 94,
 	TableTiFlashIndexes:                  autoid.InformationSchemaDBID + 95,
 	TableTiDBPlanCache:                   autoid.InformationSchemaDBID + 96,
+	ClusterTableTiDBPlanCache:            autoid.InformationSchemaDBID + 97,
 }
 
 // columnInfo represents the basic column information of all kinds of INFORMATION_SCHEMA tables


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54057

Problem Summary: planner: provide a system view `cluster_tidb_plan_cache` to allow users to see the cluster's Plan Cache Info

### What changed and how does it work?

```
mysql> select * from information_schema.cluster_tidb_plan_cache\G
*************************** 1. row ***************************
        INSTANCE: 127.0.0.1:10080
      SQL_DIGEST: e5796985ccafe2f71126ed6c0ac939ffa015a8c0744a24b7aee6d587103fd2f7
        SQL_TEXT: select * from t
       STMT_TYPE: Select
      PARSE_USER: root
     PLAN_DIGEST: ccb0d7dbb386cbf97a7007105f4b9f48d79db972766c84bfba32e55df7ffede8
     BINARY_PLAN: wAFYCr0BCg1UYWJsZVJlYWRlcl81EmoKD1QBEVBGdWxsU2Nhbl80IQEAAAA4DU9BKQABAdiIw0A4AkACSgsKCQoEVEVTVBIBdFIea2VlcCBvcmRlcjpmYWxzZSwgc3RhdHM6cHNldWRvcP//DQIEAXgNCSj//wEhVVVVVZUjEx1ZKAFAAVIUZGF0YTpUNoUAAHAZNyh4////////////AQ==
         BINDING: 
         OPT_ENV: fa40491c2d37f137ecaefe68699bc30e649245edfe999a81729f84f9cdd5d2e7
    PARSE_VALUES: 
        MEM_SIZE: 4998
      EXECUTIONS: 2
  PROCESSED_KEYS: 0
      TOTAL_KEYS: 2
     SUM_LATENCY: 7365876
       LOAD_TIME: 2024-11-28 14:18:08
LAST_ACTIVE_TIME: 2024-11-28 14:18:08
*************************** 2. row ***************************
        INSTANCE: 127.0.0.1:10081
      SQL_DIGEST: e5796985ccafe2f71126ed6c0ac939ffa015a8c0744a24b7aee6d587103fd2f7
        SQL_TEXT: select * from t
       STMT_TYPE: Select
      PARSE_USER: root
     PLAN_DIGEST: ccb0d7dbb386cbf97a7007105f4b9f48d79db972766c84bfba32e55df7ffede8
     BINARY_PLAN: wAFYCr0BCg1UYWJsZVJlYWRlcl81EmoKD1QBEVBGdWxsU2Nhbl80IQEAAAA4DU9BKQABAdiIw0A4AkACSgsKCQoEdGVzdBIBdFIea2VlcCBvcmRlcjpmYWxzZSwgc3RhdHM6cHNldWRvcP//DQIEAXgNCSj//wEhVVVVVZUjEx1ZNAFAAVIUZGF0YTpUYWJsHYUAcBk3KHj///////////8B
         BINDING: 
         OPT_ENV: e869fe7b8a196b0ef75453c9b92d3f67cf4b1f638bab22eb8ba26a16160d3577
    PARSE_VALUES: 
        MEM_SIZE: 4998
      EXECUTIONS: 2
  PROCESSED_KEYS: 0
      TOTAL_KEYS: 2
     SUM_LATENCY: 6261791
       LOAD_TIME: 2024-11-28 14:17:30
LAST_ACTIVE_TIME: 2024-11-28 14:17:31
2 rows in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
