### PR TITLE
planner: fix the issue that Update on partition tables can't hit the Instance Plan Cache

### DIFF
--- a/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "others_test.go",
     ],
     flaky = True,
-    shard_count = 38,
+    shard_count = 40,
     deps = [
         "//pkg/domain",
         "//pkg/parser/auth",

--- a/pkg/planner/core/casetest/instanceplancache/dml_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/dml_test.go
@@ -309,3 +309,139 @@ func TestInstancePlanCacheDMLBasic(t *testing.T) {
 		checkResult()
 	}
 }
+
+func TestInstancePlanCacheUpdateSpecifiedPartition(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
+	tk.MustExec(`create table t1 (a int, b int) partition by range (a) (
+    		partition p0 values less than (10),
+    		partition p1 values less than (20),
+    		partition p2 values less than (30),
+    		partition p3 values less than (40))`)
+	tk.MustExec(`create table t2 (a int, b int) partition by range (a) (
+    		partition p0 values less than (10),
+    		partition p1 values less than (20),
+    		partition p2 values less than (30),
+    		partition p3 values less than (40))`)
+	for i := 0; i < 40; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t1 values (%d, %d)", i, i))
+		tk.MustExec(fmt.Sprintf("insert into t2 values (%d, %d)", i, i))
+	}
+	tk.MustExec(`set @v=1`)
+	for i := 0; i < 100; i++ {
+		pIdx := rand.Intn(5)
+		if pIdx < 4 { // update a specified partition
+			tk.MustExec(fmt.Sprintf(`prepare st from 'update t1 partition(p%v) set b = b + ?'`, pIdx))
+			tk.MustExec(`execute st using @v`)
+			tk.MustExec(`execute st using @v`)
+			tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // can hit the cache
+			tk.MustExec(fmt.Sprintf(`update t2 partition(p%v) set b = b + 2`, pIdx))
+		} else { // no specified partition
+			tk.MustExec(`prepare st from 'update t1 set b = b + ?'`)
+			tk.MustExec(`execute st using @v`)
+			tk.MustExec(`execute st using @v`)
+			tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // can hit the cache
+			tk.MustExec(`update t2 set b = b + 2`)
+		}
+		tk.MustQuery(`select * from t1`).Sort().Check(tk.MustQuery(`select * from t2`).Sort().Rows())
+	}
+}
+
+func TestInstancePlanCacheDMLPartitioning(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
+	tk.MustExec(`create table t1 (a int, b int) partition by range (a) (
+    		partition p0 values less than (10),
+    		partition p1 values less than (20),
+    		partition p2 values less than (30),
+    		partition p3 values less than (40))`)
+	tk.MustExec(`create table t2 (a int, b int) partition by hash(a) partitions 4`)
+	tk.MustExec(`create table t3 (a int, b int) partition by list columns (a) (
+    		partition p0 values in (0, 1, 2),
+    		partition p1 values in (3, 4, 5),
+    		partition p2 values in (6, 7, 8),
+    		partition p3 values in (9, 10, 11))`)
+
+	for _, tbl := range []string{"t1", "t2", "t3"} {
+		// insert
+		tk.MustExec(fmt.Sprintf("prepare st from 'insert into %v values (?, ?)'", tbl))
+		tk.MustExec("set @a = 1, @b = 2")
+		tk.MustExec("execute st using @a, @b")
+		tk.MustExec("execute st using @b, @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'insert into %v (a, b) values (?, ?)'", tbl))
+		tk.MustExec("set @a = 1, @b = 2")
+		tk.MustExec("execute st using @a, @b")
+		tk.MustExec("execute st using @b, @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		// delete
+		tk.MustExec(fmt.Sprintf("prepare st from 'delete from %v'", tbl))
+		tk.MustExec("execute st")
+		tk.MustExec("execute st")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'delete from %v where a = ?'", tbl))
+		tk.MustExec("set @a = 1")
+		tk.MustExec("execute st using @a")
+		tk.MustExec("execute st using @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'delete from %v where a = ? and b = ?'", tbl))
+		tk.MustExec("set @a = 1, @b = 2")
+		tk.MustExec("execute st using @a, @b")
+		tk.MustExec("execute st using @b, @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		// update
+		tk.MustExec(fmt.Sprintf("prepare st from 'update %v set b = 1'", tbl))
+		tk.MustExec("execute st")
+		tk.MustExec("execute st")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'update %v set b = 1 where a = ?'", tbl))
+		tk.MustExec("set @a = 1")
+		tk.MustExec("execute st using @a")
+		tk.MustExec("execute st using @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'update %v set b = 1 where a = ? and b = ?'", tbl))
+		tk.MustExec("set @a = 1, @b = 2")
+		tk.MustExec("execute st using @a, @b")
+		tk.MustExec("execute st using @b, @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'update %v partition(p0) set b = 1'", tbl))
+		tk.MustExec("execute st")
+		tk.MustExec("execute st")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'update %v partition(p0, p1) set b = 1'", tbl))
+		tk.MustExec("execute st")
+		tk.MustExec("execute st")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'update %v partition(p0, p1, p2) set b = 1'", tbl))
+		tk.MustExec("execute st")
+		tk.MustExec("execute st")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		// replace
+		tk.MustExec(fmt.Sprintf("prepare st from 'replace into %v values (?, ?)'", tbl))
+		tk.MustExec("set @a = 1, @b = 2")
+		tk.MustExec("execute st using @a, @b")
+		tk.MustExec("execute st using @b, @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+		tk.MustExec(fmt.Sprintf("prepare st from 'replace into %v (a, b) values (?, ?)'", tbl))
+		tk.MustExec("set @a = 1, @b = 2")
+		tk.MustExec("execute st using @a, @b")
+		tk.MustExec("execute st using @b, @a")
+		tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+	}
+}

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -496,7 +496,7 @@ type Update struct {
 
 	// Used when partition sets are given.
 	// e.g. update t partition(p0) set a = 1;
-	PartitionedTable []table.PartitionedTable `plan-cache-clone:"must-nil"`
+	PartitionedTable []table.PartitionedTable `plan-cache-clone:"shallow"`
 
 	// tblID2Table stores related tables' info of this Update statement.
 	tblID2Table map[int64]table.Table `plan-cache-clone:"shallow"`

--- a/pkg/planner/core/plan_clone_generated.go
+++ b/pkg/planner/core/plan_clone_generated.go
@@ -429,9 +429,6 @@ func (op *Update) CloneForPlanCache(newCtx base.PlanContext) (base.Plan, bool) {
 		}
 		cloned.SelectPlan = SelectPlan.(base.PhysicalPlan)
 	}
-	if op.PartitionedTable != nil {
-		return nil, false
-	}
 	if op.FKChecks != nil {
 		return nil, false
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57726, ref #54057

Problem Summary: planner: fix the issue that Update on partition tables can't hit the Instance Plan Cache

### What changed and how does it work?

planner: fix the issue that Update on partition tables can't hit the Instance Plan Cache

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
