### PR TITLE
types: MySQL compatible JSON object

### DIFF
--- a/pkg/types/json_binary.go
+++ b/pkg/types/json_binary.go
@@ -25,6 +25,7 @@ import (
 	"math/bits"
 	"reflect"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -377,16 +378,29 @@ func (bj BinaryJSON) marshalArrayTo(buf []byte) ([]byte, error) {
 }
 
 func (bj BinaryJSON) marshalObjTo(buf []byte) ([]byte, error) {
+	keynrs := make(map[string]int, 0)
+	keys := make([]string, 0)
+
 	elemCount := int(jsonEndian.Uint32(bj.Value))
-	buf = append(buf, '{')
 	for i := 0; i < elemCount; i++ {
+		key := string(bj.objectGetKey(i))
+		keys = append(keys, key)
+		keynrs[key] = i
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) < len(keys[j])
+	})
+
+	buf = append(buf, '{')
+	for i, key := range keys {
 		if i != 0 {
 			buf = append(buf, ", "...)
 		}
-		buf = jsonMarshalStringTo(buf, bj.objectGetKey(i))
+		buf = jsonMarshalStringTo(buf, []byte(key))
 		buf = append(buf, ": "...)
 		var err error
-		buf, err = bj.objectGetVal(i).marshalTo(buf)
+		buf, err = bj.objectGetVal(keynrs[key]).marshalTo(buf)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
By changing how we order keys in a JSON object we can make TiDB more compatible with MySQL

```sql
create table t1 (id int primary key auto_increment, j JSON);
insert into t1(j) values ('{"aaa":1, "b": 1, "aa": 1}');
SELECT j, MD5(j) FROM t1;
```

MySQL:

```
mysql-9.1.0> SELECT j, MD5(j) FROM t1;
+-----------------------------+----------------------------------+
| j                           | MD5(j)                           |
+-----------------------------+----------------------------------+
| {"b": 1, "aa": 1, "aaa": 1} | bebcc335a94996f7b47af552fb432d93 |
+-----------------------------+----------------------------------+
1 row in set (0.00 sec)
```

TiDB, Without this PR:

```
mysql-8.0.11-TiDB-v8.5.0-alpha-210-gec8b81b98e> SELECT j, MD5(j) FROM t1;
+-----------------------------+----------------------------------+
| j                           | MD5(j)                           |
+-----------------------------+----------------------------------+
| {"aa": 1, "aaa": 1, "b": 1} | 34e9c9a9f71006cbe28ab9af018c830a |
+-----------------------------+----------------------------------+
1 row in set (0.00 sec)
```

TiDB, With this PR:

```
mysql-8.0.11-TiDB-v8.5.0-alpha-210-gec8b81b98e-dirty> SELECT j, MD5(j) FROM t1;
+-----------------------------+----------------------------------+
| j                           | MD5(j)                           |
+-----------------------------+----------------------------------+
| {"b": 1, "aa": 1, "aaa": 1} | bebcc335a94996f7b47af552fb432d93 |
+-----------------------------+----------------------------------+
1 row in set (0.00 sec)
```





<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57842 

Problem Summary:

See also https://github.com/pingcap/tidb-tools/issues/830

For `sync-diff-inspector` it currently fails table checks for most slightly more complex JSON data as the checksums don't match. Then  when `export-fix-sql` is set to `true` it will compare the actual data by doing a unmarshal/marshal on the JSON data so that comparing works as expected.

This PR makes it so that the checksum would match in a much larger set of cases, avoiding the need for comparing the values which takes more memory, CPU and network bandwidth.

The drawback of this is that this now takes more resources when outputting JSON objects. We could put this new behavior behind a variable if needed.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The way JSON objects are handled is made to more closely resemble the way that MySQL does this.
```
