### PR TITLE
dumpling: use I_S to get table list for TiDB and add database to WHERE

### DIFF
--- a/dumpling/export/sql.go
+++ b/dumpling/export/sql.go
@@ -368,10 +368,10 @@ func ListAllDatabasesTables(tctx *tcontext.Context, db *sql.Conn, databaseNames 
 	listType listTableType, tableTypes ...TableType) (DatabaseTables, error) { // revive:disable-line:flag-parameter
 	dbTables := DatabaseTables{}
 	var (
-		schema, table, tableTypeStr string
-		tableType                   TableType
-		avgRowLength                uint64
-		err                         error
+		table, tableTypeStr string
+		tableType           TableType
+		avgRowLength        uint64
+		err                 error
 	)
 
 	tableTypeConditions := make([]string, len(tableTypes))
@@ -380,38 +380,35 @@ func ListAllDatabasesTables(tctx *tcontext.Context, db *sql.Conn, databaseNames 
 	}
 	switch listType {
 	case listTableByInfoSchema:
-		query := fmt.Sprintf("SELECT TABLE_SCHEMA,TABLE_NAME,TABLE_TYPE,AVG_ROW_LENGTH FROM INFORMATION_SCHEMA.TABLES WHERE %s", strings.Join(tableTypeConditions, " OR "))
 		for _, schema := range databaseNames {
+			query := fmt.Sprintf("SELECT TABLE_NAME,TABLE_TYPE,AVG_ROW_LENGTH FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=? AND %s", strings.Join(tableTypeConditions, " OR "))
 			dbTables[schema] = make([]*TableInfo, 0)
-		}
-		if err = simpleQueryWithArgs(tctx, db, func(rows *sql.Rows) error {
-			var (
-				sqlAvgRowLength sql.NullInt64
-				err2            error
-			)
-			if err2 = rows.Scan(&schema, &table, &tableTypeStr, &sqlAvgRowLength); err != nil {
-				return errors.Trace(err2)
-			}
-			tableType, err2 = ParseTableType(tableTypeStr)
-			if err2 != nil {
-				return errors.Trace(err2)
-			}
+			if err = simpleQueryWithArgs(tctx, db, func(rows *sql.Rows) error {
+				var (
+					sqlAvgRowLength sql.NullInt64
+					err2            error
+				)
+				if err2 = rows.Scan(&table, &tableTypeStr, &sqlAvgRowLength); err != nil {
+					return errors.Trace(err2)
+				}
+				tableType, err2 = ParseTableType(tableTypeStr)
+				if err2 != nil {
+					return errors.Trace(err2)
+				}
 
-			if sqlAvgRowLength.Valid {
-				avgRowLength = uint64(sqlAvgRowLength.Int64)
-			} else {
-				avgRowLength = 0
-			}
-			// only append tables to schemas in databaseNames
-			if _, ok := dbTables[schema]; ok {
+				if sqlAvgRowLength.Valid {
+					avgRowLength = uint64(sqlAvgRowLength.Int64)
+				} else {
+					avgRowLength = 0
+				}
 				dbTables[schema] = append(dbTables[schema], &TableInfo{table, avgRowLength, tableType})
+				return nil
+			}, query, schema); err != nil {
+				return nil, errors.Annotatef(err, "sql: %s", query)
 			}
-			return nil
-		}, query); err != nil {
-			return nil, errors.Annotatef(err, "sql: %s", query)
 		}
 	case listTableByShowFullTables:
-		for _, schema = range databaseNames {
+		for _, schema := range databaseNames {
 			dbTables[schema] = make([]*TableInfo, 0)
 			query := fmt.Sprintf("SHOW FULL TABLES FROM `%s` WHERE %s",
 				escapeString(schema), strings.Join(tableTypeConditions, " OR "))
@@ -437,7 +434,7 @@ func ListAllDatabasesTables(tctx *tcontext.Context, db *sql.Conn, databaseNames 
 		for _, tableType = range tableTypes {
 			selectedTableType[tableType] = struct{}{}
 		}
-		for _, schema = range databaseNames {
+		for _, schema := range databaseNames {
 			dbTables[schema] = make([]*TableInfo, 0)
 			query := fmt.Sprintf(queryTemplate, escapeString(schema))
 			rows, err := db.QueryContext(tctx, query)

--- a/dumpling/export/sql.go
+++ b/dumpling/export/sql.go
@@ -922,8 +922,8 @@ func CheckTiDBWithTiKV(db *sql.DB) (bool, error) {
 	return count > 0, nil
 }
 
-// CheckIfSeqExists use sql to check whether sequence exists
-func CheckIfSeqExists(db *sql.Conn) (bool, error) {
+// checkIfSeqExists use sql to check whether sequence exists
+func checkIfSeqExists(db *sql.Conn) (bool, error) {
 	var count int
 	const query = "SELECT COUNT(1) as c FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='SEQUENCE'"
 	row := db.QueryRowContext(context.Background(), query)

--- a/dumpling/export/sql.go
+++ b/dumpling/export/sql.go
@@ -381,7 +381,7 @@ func ListAllDatabasesTables(tctx *tcontext.Context, db *sql.Conn, databaseNames 
 	switch listType {
 	case listTableByInfoSchema:
 		for _, schema := range databaseNames {
-			query := fmt.Sprintf("SELECT TABLE_NAME,TABLE_TYPE,AVG_ROW_LENGTH FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=? AND %s", strings.Join(tableTypeConditions, " OR "))
+			query := fmt.Sprintf("SELECT TABLE_NAME,TABLE_TYPE,AVG_ROW_LENGTH FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=? AND (%s)", strings.Join(tableTypeConditions, " OR "))
 			dbTables[schema] = make([]*TableInfo, 0)
 			if err = simpleQueryWithArgs(tctx, db, func(rows *sql.Rows) error {
 				var (

--- a/dumpling/export/sql_test.go
+++ b/dumpling/export/sql_test.go
@@ -1815,7 +1815,7 @@ func TestCheckIfSeqExists(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"c"}).
 			AddRow("1"))
 
-	exists, err := CheckIfSeqExists(conn)
+	exists, err := checkIfSeqExists(conn)
 	require.NoError(t, err)
 	require.Equal(t, true, exists)
 
@@ -1823,7 +1823,7 @@ func TestCheckIfSeqExists(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"c"}).
 			AddRow("0"))
 
-	exists, err = CheckIfSeqExists(conn)
+	exists, err = checkIfSeqExists(conn)
 	require.NoError(t, err)
 	require.Equal(t, false, exists)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57902

Problem Summary:

### What changed and how does it work?

by copilot

dumpling/export/dump.go: The logic for preparing the table list to dump has been updated to optimize the performance of reading INFORMATION_SCHEMA.TABLES for TiDB. It includes conditional checks and refactored code.
dumpling/export/sql.go: The function ListAllDatabasesTables has been refactored for improved readability and efficiency, particularly when querying INFORMATION_SCHEMA.TABLES. The function CheckIfSeqExists has been renamed to checkIfSeqExists.
dumpling/export/sql_test.go: Corresponding test cases have been updated to reflect the renaming of the function CheckIfSeqExists to checkIfSeqExists.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->


```
/dumpling-patch -u root -P 4000 -h xxx --filetype csv -t 16 -r 200000 -F 256MiB --database sb10wnormal1 --loglevel debug
[2024/12/02 10:50:39.356 +00:00] [INFO] [versions.go:54] ["Welcome to dumpling"]...
...
[2024/12/02 10:50:41.123 +00:00] [INFO] [main.go:82] ["dump data successfully, dumpling will exit now"]

root@benchtoolset2-0:/# ll export-2024-12-02T10\:50\:39Z/
total 3832
drwxrwxrwx 2 root root    4096 Dec  2 10:50 ./
drwxr-xr-x 1 root root    4096 Dec  2 10:50 ../
-rw-r--r-- 1 root root     150 Dec  2 10:50 metadata
-rw-r--r-- 1 root root     140 Dec  2 10:50 sb10wnormal1-schema-create.sql
-rw-r--r-- 1 root root     391 Dec  2 10:50 sb10wnormal1.sbtest1-schema.sql
-rw-r--r-- 1 root root 1947727 Dec  2 10:50 sb10wnormal1.sbtest1.0000000010000.csv
-rw-r--r-- 1 root root     391 Dec  2 10:50 sb10wnormal1.sbtest2-schema.sql
-rw-r--r-- 1 root root 1947783 Dec  2 10:50 sb10wnormal1.sbtest2.0000000010000.csv
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
