### PR TITLE
planner: add test for logical topN and logical tableDual's hash64 and equals

### DIFF
--- a/pkg/planner/core/operator/logicalop/logicalop_test/BUILD.bazel
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "logical_mem_table_predicate_extractor_test.go",
     ],
     flaky = True,
-    shard_count = 31,
+    shard_count = 33,
     deps = [
         "//pkg/domain",
         "//pkg/expression",

--- a/pkg/planner/core/operator/logicalop/logicalop_test/hash64_equals_test.go
+++ b/pkg/planner/core/operator/logicalop/logicalop_test/hash64_equals_test.go
@@ -33,6 +33,128 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLogicalTopNHash64Equals(t *testing.T) {
+	col1 := &expression.Column{
+		ID:      1,
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	col2 := &expression.Column{
+		ID:      2,
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	ctx := mock.NewContext()
+	p1 := logicalop.LogicalTopN{}.Init(ctx, 1)
+	p1.ByItems = []*util.ByItems{{Expr: col1, Desc: true}}
+	p1.PartitionBy = []property.SortItem{{Col: col1, Desc: true}}
+	p2 := logicalop.LogicalTopN{}.Init(ctx, 1)
+	p2.ByItems = []*util.ByItems{{Expr: col1, Desc: true}}
+	p2.PartitionBy = []property.SortItem{{Col: col1, Desc: true}}
+	hasher1 := base.NewHashEqualer()
+	hasher2 := base.NewHashEqualer()
+	p1.Hash64(hasher1)
+	p2.Hash64(hasher2)
+	require.Equal(t, hasher1.Sum64(), hasher2.Sum64())
+	require.True(t, p1.Equals(p2))
+
+	p2.ByItems = []*util.ByItems{{Expr: col2, Desc: true}}
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.ByItems = []*util.ByItems{{Expr: col1, Desc: false}}
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.ByItems = []*util.ByItems{{Expr: col1, Desc: true}}
+	p2.PartitionBy = []property.SortItem{{Col: col1, Desc: false}}
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.PartitionBy = []property.SortItem{{Col: col2, Desc: true}}
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.PartitionBy = []property.SortItem{{Col: col1, Desc: true}}
+	p2.Offset = 2
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.Offset = 0
+	p2.Count = 1
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.Count = 0
+	p2.PreferLimitToCop = true
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.PreferLimitToCop = false
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.Equal(t, hasher1.Sum64(), hasher2.Sum64())
+	require.True(t, p1.Equals(p2))
+}
+
+func TestLogicalTableDualHash64Equals(t *testing.T) {
+	col1 := &expression.Column{
+		ID:      1,
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	col2 := &expression.Column{
+		ID:      2,
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	ctx := mock.NewContext()
+	p1 := logicalop.LogicalTableDual{}.Init(ctx, 1)
+	p1.LogicalSchemaProducer.SetSchema(&expression.Schema{Columns: []*expression.Column{col1}})
+	p2 := logicalop.LogicalTableDual{}.Init(ctx, 1)
+	p2.LogicalSchemaProducer.SetSchema(&expression.Schema{Columns: []*expression.Column{col1}})
+	hasher1 := base.NewHashEqualer()
+	hasher2 := base.NewHashEqualer()
+	p1.Hash64(hasher1)
+	p2.Hash64(hasher2)
+	require.Equal(t, hasher1.Sum64(), hasher2.Sum64())
+	require.True(t, p1.Equals(p2))
+
+	p2.LogicalSchemaProducer.SetSchema(&expression.Schema{Columns: []*expression.Column{col2}})
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.LogicalSchemaProducer.SetSchema(&expression.Schema{Columns: []*expression.Column{col1}})
+	p2.RowCount = 2
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
+	require.False(t, p1.Equals(p2))
+
+	p2.LogicalSchemaProducer.SetSchema(&expression.Schema{Columns: []*expression.Column{col1}})
+	p2.RowCount = 0
+	hasher2.Reset()
+	p2.Hash64(hasher2)
+	require.Equal(t, hasher1.Sum64(), hasher2.Sum64())
+	require.True(t, p1.Equals(p2))
+}
+
 func TestLogicalSortHash64Equals(t *testing.T) {
 	col1 := &expression.Column{
 		ID:      1,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/51664

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
