### PR TITLE
*: activate txn for query on infoschema tables

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -116,12 +116,25 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 	// Cache the ret full rows in schemataRetriever
 	if !e.initialized {
 		var err error
+		// InTxn() should be true in most of the cases.
+		// Because the transaction should have been activated in MemTableReaderExec Open().
+		// Why not just activate the txn here (sctx.Txn(true)) and do it in Open() instead?
+		// Because it could DATA RACE here and in Open() it's safe.
 		if sctx.GetSessionVars().InTxn() {
 			e.is, err = domain.GetDomain(sctx).GetSnapshotInfoSchema(sctx.GetSessionVars().TxnCtx.StartTS)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 		} else {
+			// When the excutor is built from tidb coprocessor request, the transaction is not valid.
+			// Then InTxn() is false.
+			//
+			// What's the difference between using latest infoschema and using snapshot infoschema?
+			// A query *should* use the infoschema of the txn start ts, but it's still safe to use the latest.
+			// If now it's 12:00:00, the ts of the latest infoschema might be 11:59:30 or 11:52:12 or anything.
+			// Say, default GC interval is 10min, the ts of the latest infoschema is 11:52:12.
+			// Then the valid lifetime range on infoschema API become [11:52:12, 12:12:12) using latest infoschema,
+			// but it should be [12:00:00, 12:10:00) if using the snapshot infoschema.
 			e.is = sctx.GetInfoSchema().(infoschema.InfoSchema)
 		}
 

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -115,7 +115,6 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 
 	// Cache the ret full rows in schemataRetriever
 	if !e.initialized {
-
 		// Activate the transaction, otherwise SELECT .. FROM INFORMATION_SCHEMA.XX .. does not block GC worker.
 		// And if the query last too long (10min), it causes error "GC life time is shorter than transaction duration"
 		txn, err := sctx.Txn(true)

--- a/pkg/executor/memtable_reader.go
+++ b/pkg/executor/memtable_reader.go
@@ -102,8 +102,8 @@ func (e *MemTableReaderExec) Open(ctx context.Context) error {
 
 	// Activate the transaction, otherwise SELECT .. FROM INFORMATION_SCHEMA.XX .. does not block GC worker.
 	// And if the query last too long (10min), it causes error "GC life time is shorter than transaction duration"
-	if !strings.HasPrefix(e.table.Name.L, "cluster_") {
-		// Skip cluster_ tables because it could be a tidb coprocessor request and txn is not prepared.
+	if txn, err1 := e.Ctx().Txn(false); err1 == nil && txn != nil && txn.Valid() {
+		// Call e.Ctx().Txn(true) may panic, it's too difficult to debug all the callers.
 		_, err = e.Ctx().Txn(true)
 	}
 	return err

--- a/pkg/executor/memtable_reader.go
+++ b/pkg/executor/memtable_reader.go
@@ -93,7 +93,7 @@ func (*MemTableReaderExec) isInspectionCacheableTable(tblName string) bool {
 	}
 }
 
-// Open implements the Executor Next interface.
+// Open implements the Executor Open interface.
 func (e *MemTableReaderExec) Open(ctx context.Context) error {
 	err := e.BaseExecutor.Open(ctx)
 	if err != nil {

--- a/pkg/executor/memtable_reader.go
+++ b/pkg/executor/memtable_reader.go
@@ -93,19 +93,6 @@ func (*MemTableReaderExec) isInspectionCacheableTable(tblName string) bool {
 	}
 }
 
-// Open implements the Executor Open interface.
-func (e *MemTableReaderExec) Open(ctx context.Context) error {
-	err := e.BaseExecutor.Open(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Activate the transaction, otherwise SELECT .. FROM INFORMATION_SCHEMA.XX .. does not block GC worker.
-	// And if the query last too long (10min), it causes error "GC life time is shorter than transaction duration"
-	_, err = e.Ctx().Txn(true)
-	return err
-}
-
 // Next implements the Executor Next interface.
 func (e *MemTableReaderExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57874

Problem Summary:

The GC should be blocked by query.

### What changed and how does it work?

There are two places that the transaction should blcok GC:

- The query "SELECT COUNT(1) as c FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='SEQUENCE'" itself
- The internal transaction `meta.ListTables` invoked by `SchemaTableInfos()` API

This commit just fix the first one. It should be enough to fix issue 57874.
The root cause is that whe we query on infoschema tables, the transaction is not activated.
So the session process info would not be collected to block GC.

The second issue is caused by the fact that the meta API call does not block GC.
I don't take investigation on it further more, meta API is limited used.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Modify the code and build tidb, check no more "GC life time is shorter than transaction duration" error.

```
diff --git a/pkg/planner/core/memtable_infoschema_extractor.go b/pkg/planner/core/memtable_infoschema_extractor.go
index c527dde968..34cabb3677 100644
--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+       "time"
        "bytes"
        "context"
        "fmt"
@@ -184,6 +185,7 @@ func (e *InfoSchemaBaseExtractor) ListSchemasAndTables(
                return findTableAndSchemaByName(ctx, is, schemas, tableNames)
        }
        schemas := e.ListSchemas(is)
+       time.Sleep(12 * time.Minute)
        return listTablesForEachSchema(ctx, e, is, schemas)
 }
```

```
mysql> set @@tidb_mem_quota_query = 12*1024*1024*1024;
Query OK, 0 rows affected (0.00 sec)

mysql> select count(tidb_table_id) from information_schema.tables where table_name != 'test';
+----------------------+
| count(tidb_table_id) |
+----------------------+
|              1000818 |
+----------------------+
1 row in set (12 min 28.84 sec)
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
