### PR TITLE
session: add resource group name in stmt context (retrofit from 7.5 into 7.1)

### DIFF
--- a/ddl/resourcegrouptest/resource_group_test.go
+++ b/ddl/resourcegrouptest/resource_group_test.go
@@ -207,9 +207,9 @@ func TestResourceGroupHint(t *testing.T) {
 	tk.MustQuery("select /*+ resource_group(rg1) resource_group(default) */ * from t1")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 RESOURCE_GROUP() is defined more than once, only the last definition takes effect: RESOURCE_GROUP(default)"))
 	tk.MustQuery("select /*+ resource_group(rg1) */ DB, RESOURCE_GROUP from information_schema.processlist").Check(testkit.Rows("test rg1"))
-	tk.MustQuery("select DB, RESOURCE_GROUP from information_schema.processlist").Check(testkit.Rows("test "))
+	tk.MustQuery("select DB, RESOURCE_GROUP from information_schema.processlist").Check(testkit.Rows("test default"))
 	tk.MustExec("set global tidb_enable_resource_control='off'")
-	tk.MustQuery("select /*+ resource_group(rg1) */ DB, RESOURCE_GROUP from information_schema.processlist").Check(testkit.Rows("test "))
+	tk.MustQuery("select /*+ resource_group(rg1) */ DB, RESOURCE_GROUP from information_schema.processlist").Check(testkit.Rows("test default"))
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 8250 Resource control feature is disabled. Run `SET GLOBAL tidb_enable_resource_control='on'` to enable the feature"))
 }
 
@@ -361,8 +361,9 @@ func TestBindHints(t *testing.T) {
 	tk.MustExec("create global binding for select * from t using select /*+ resource_group(rg1) */ * from t")
 	tk.MustQuery("select * from t")
 	re.Equal("rg1", tk.Session().GetSessionVars().StmtCtx.ResourceGroup)
-	re.Equal("", tk.Session().GetSessionVars().ResourceGroupName)
+	re.Equal("rg1", tk.Session().GetSessionVars().ResourceGroupName)
+	re.Equal("default", tk.Session().GetSessionVars().ResourceGroupName)
 	tk.MustQuery("select a, b from t")
-	re.Equal("", tk.Session().GetSessionVars().StmtCtx.ResourceGroup)
-	re.Equal("", tk.Session().GetSessionVars().ResourceGroupName)
+	re.Equal("default", tk.Session().GetSessionVars().StmtCtx.ResourceGroup)
+	re.Equal("default", tk.Session().GetSessionVars().ResourceGroupName)
 }

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -335,7 +335,7 @@ func (builder *RequestBuilder) SetFromSessionVars(sv *variable.SessionVars) *Req
 	builder.RequestSource.RequestSourceInternal = sv.InRestrictedSQL
 	builder.RequestSource.RequestSourceType = sv.RequestSourceType
 	builder.StoreBatchSize = sv.StoreBatchSize
-	builder.Request.ResourceGroupName = sv.ResourceGroupName
+	builder.Request.ResourceGroupName = sv.StmtCtx.ResourceGroupName
 	builder.Request.StoreBusyThreshold = sv.LoadBasedReplicaReadThreshold
 	return builder
 }

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -265,15 +265,16 @@ func TestRequestBuilder1(t *testing.T) {
 				EndKey:   kv.Key{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x23},
 			},
 		}),
-		Cacheable:        true,
-		KeepOrder:        false,
-		Desc:             false,
-		Concurrency:      variable.DefDistSQLScanConcurrency,
-		IsolationLevel:   0,
-		Priority:         0,
-		NotFillCache:     false,
-		ReplicaRead:      kv.ReplicaReadLeader,
-		ReadReplicaScope: kv.GlobalReplicaScope,
+		Cacheable:         true,
+		KeepOrder:         false,
+		Desc:              false,
+		Concurrency:       variable.DefDistSQLScanConcurrency,
+		IsolationLevel:    0,
+		Priority:          0,
+		NotFillCache:      false,
+		ReplicaRead:       kv.ReplicaReadLeader,
+		ReadReplicaScope:  kv.GlobalReplicaScope,
+		ResourceGroupName: "default",
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
 	expect.Paging.MaxPagingSize = paging.MaxPagingSize
@@ -348,15 +349,16 @@ func TestRequestBuilder2(t *testing.T) {
 				EndKey:   kv.Key{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf, 0x3, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x23},
 			},
 		}),
-		Cacheable:        true,
-		KeepOrder:        false,
-		Desc:             false,
-		Concurrency:      variable.DefDistSQLScanConcurrency,
-		IsolationLevel:   0,
-		Priority:         0,
-		NotFillCache:     false,
-		ReplicaRead:      kv.ReplicaReadLeader,
-		ReadReplicaScope: kv.GlobalReplicaScope,
+		Cacheable:         true,
+		KeepOrder:         false,
+		Desc:              false,
+		Concurrency:       variable.DefDistSQLScanConcurrency,
+		IsolationLevel:    0,
+		Priority:          0,
+		NotFillCache:      false,
+		ReplicaRead:       kv.ReplicaReadLeader,
+		ReadReplicaScope:  kv.GlobalReplicaScope,
+		ResourceGroupName: "default",
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
 	expect.Paging.MaxPagingSize = paging.MaxPagingSize
@@ -397,15 +399,16 @@ func TestRequestBuilder3(t *testing.T) {
 				EndKey:   kv.Key{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x65},
 			},
 		}, []int{1, 4, 2, 1}),
-		Cacheable:        true,
-		KeepOrder:        false,
-		Desc:             false,
-		Concurrency:      variable.DefDistSQLScanConcurrency,
-		IsolationLevel:   0,
-		Priority:         0,
-		NotFillCache:     false,
-		ReplicaRead:      kv.ReplicaReadLeader,
-		ReadReplicaScope: kv.GlobalReplicaScope,
+		Cacheable:         true,
+		KeepOrder:         false,
+		Desc:              false,
+		Concurrency:       variable.DefDistSQLScanConcurrency,
+		IsolationLevel:    0,
+		Priority:          0,
+		NotFillCache:      false,
+		ReplicaRead:       kv.ReplicaReadLeader,
+		ReadReplicaScope:  kv.GlobalReplicaScope,
+		ResourceGroupName: "default",
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
 	expect.Paging.MaxPagingSize = paging.MaxPagingSize
@@ -441,19 +444,20 @@ func TestRequestBuilder4(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 	expect := &kv.Request{
-		Tp:               103,
-		StartTs:          0x0,
-		Data:             []uint8{0x18, 0x0, 0x20, 0x0, 0x40, 0x0, 0x5a, 0x0},
-		KeyRanges:        kv.NewNonParitionedKeyRanges(keyRanges),
-		Cacheable:        true,
-		KeepOrder:        false,
-		Desc:             false,
-		Concurrency:      variable.DefDistSQLScanConcurrency,
-		IsolationLevel:   0,
-		Priority:         0,
-		NotFillCache:     false,
-		ReplicaRead:      kv.ReplicaReadLeader,
-		ReadReplicaScope: kv.GlobalReplicaScope,
+		Tp:                103,
+		StartTs:           0x0,
+		Data:              []uint8{0x18, 0x0, 0x20, 0x0, 0x40, 0x0, 0x5a, 0x0},
+		KeyRanges:         kv.NewNonParitionedKeyRanges(keyRanges),
+		Cacheable:         true,
+		KeepOrder:         false,
+		Desc:              false,
+		Concurrency:       variable.DefDistSQLScanConcurrency,
+		IsolationLevel:    0,
+		Priority:          0,
+		NotFillCache:      false,
+		ReplicaRead:       kv.ReplicaReadLeader,
+		ReadReplicaScope:  kv.GlobalReplicaScope,
+		ResourceGroupName: "default",
 	}
 	expect.Paging.MinPagingSize = paging.MinPagingSize
 	expect.Paging.MaxPagingSize = paging.MaxPagingSize
@@ -554,17 +558,18 @@ func TestRequestBuilder7(t *testing.T) {
 				Build()
 			require.NoError(t, err)
 			expect := &kv.Request{
-				Tp:               0,
-				StartTs:          0x0,
-				KeepOrder:        false,
-				KeyRanges:        kv.NewNonParitionedKeyRanges(nil),
-				Desc:             false,
-				Concurrency:      concurrency,
-				IsolationLevel:   0,
-				Priority:         0,
-				NotFillCache:     false,
-				ReplicaRead:      replicaRead.replicaReadType,
-				ReadReplicaScope: kv.GlobalReplicaScope,
+				Tp:                0,
+				StartTs:           0x0,
+				KeepOrder:         false,
+				KeyRanges:         kv.NewNonParitionedKeyRanges(nil),
+				Desc:              false,
+				Concurrency:       concurrency,
+				IsolationLevel:    0,
+				Priority:          0,
+				NotFillCache:      false,
+				ReplicaRead:       replicaRead.replicaReadType,
+				ReadReplicaScope:  kv.GlobalReplicaScope,
+				ResourceGroupName: "default",
 			}
 			expect.Paging.MinPagingSize = paging.MinPagingSize
 			expect.Paging.MaxPagingSize = paging.MaxPagingSize
@@ -576,7 +581,7 @@ func TestRequestBuilder7(t *testing.T) {
 
 func TestRequestBuilder8(t *testing.T) {
 	sv := variable.NewSessionVars(nil)
-	sv.ResourceGroupName = "test"
+	sv.StmtCtx.ResourceGroupName = "test"
 	actual, err := (&RequestBuilder{}).
 		SetFromSessionVars(sv).
 		Build()

--- a/executor/analyze_col.go
+++ b/executor/analyze_col.go
@@ -124,7 +124,7 @@ func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.Range) (distsql.SelectRe
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
 		SetMemTracker(e.memTracker).
-		SetResourceGroupName(e.ctx.GetSessionVars().ResourceGroupName).
+		SetResourceGroupName(e.ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		Build()
 	if err != nil {
 		return nil, err

--- a/executor/analyze_fast.go
+++ b/executor/analyze_fast.go
@@ -398,7 +398,7 @@ func (e *AnalyzeFastExec) handleScanTasks(bo *tikv.Backoffer) (keysSize int, err
 		snapshot.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
 	}
 	setOptionForTopSQL(e.ctx.GetSessionVars().StmtCtx, snapshot)
-	snapshot.SetOption(kv.ResourceGroupName, e.ctx.GetSessionVars().ResourceGroupName)
+	snapshot.SetOption(kv.ResourceGroupName, e.ctx.GetSessionVars().StmtCtx.ResourceGroupName)
 	for _, t := range e.scanTasks {
 		iter, err := snapshot.Iter(kv.Key(t.StartKey), kv.Key(t.EndKey))
 		if err != nil {
@@ -425,7 +425,7 @@ func (e *AnalyzeFastExec) handleSampTasks(workID int, step uint32, err *error) {
 	}
 	snapshot.SetOption(kv.NotFillCache, true)
 	snapshot.SetOption(kv.Priority, kv.PriorityLow)
-	snapshot.SetOption(kv.ResourceGroupName, e.ctx.GetSessionVars().ResourceGroupName)
+	snapshot.SetOption(kv.ResourceGroupName, e.ctx.GetSessionVars().StmtCtx.ResourceGroupName)
 	setOptionForTopSQL(e.ctx.GetSessionVars().StmtCtx, snapshot)
 	readReplicaType := e.ctx.GetSessionVars().GetReplicaRead()
 	if readReplicaType.IsFollowerRead() {

--- a/executor/analyze_idx.go
+++ b/executor/analyze_idx.go
@@ -156,7 +156,7 @@ func (e *AnalyzeIndexExec) fetchAnalyzeResult(ranges []*ranger.Range, isNullRang
 		SetStartTS(startTS).
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
-		SetResourceGroupName(e.ctx.GetSessionVars().ResourceGroupName).
+		SetResourceGroupName(e.ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		Build()
 	if err != nil {
 		return err

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1241,7 +1241,7 @@ func (b *executorBuilder) buildExplain(v *plannercore.Explain) Executor {
 		}
 		// If the resource group name is not empty, we could collect and display the RU
 		// runtime stats for analyze executor.
-		resourceGroupName := b.ctx.GetSessionVars().ResourceGroupName
+		resourceGroupName := b.ctx.GetSessionVars().StmtCtx.ResourceGroupName
 		// Try to register the RU runtime stats for analyze executor.
 		if store, ok := b.ctx.GetStore().(interface {
 			CreateRURuntimeStats(uint64) *clientutil.RURuntimeStats
@@ -5148,7 +5148,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 	if e.ctx.GetSessionVars().IsReplicaReadClosestAdaptive() {
 		e.snapshot.SetOption(kv.ReplicaReadAdjuster, newReplicaReadAdjuster(e.ctx, plan.GetAvgRowSize()))
 	}
-	e.snapshot.SetOption(kv.ResourceGroupName, b.ctx.GetSessionVars().ResourceGroupName)
+	e.snapshot.SetOption(kv.ResourceGroupName, b.ctx.GetSessionVars().StmtCtx.ResourceGroupName)
 	if e.runtimeStats != nil {
 		snapshotStats := &txnsnapshot.SnapshotRuntimeStats{}
 		e.stats = &runtimeStatsWithSnapshot{

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -246,7 +246,7 @@ func (c *checksumContext) buildTableRequest(ctx sessionctx.Context, tableID int6
 		SetChecksumRequest(checksum).
 		SetStartTS(c.StartTs).
 		SetConcurrency(ctx.GetSessionVars().DistSQLScanConcurrency()).
-		SetResourceGroupName(ctx.GetSessionVars().ResourceGroupName).
+		SetResourceGroupName(ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		Build()
 }
 
@@ -264,7 +264,7 @@ func (c *checksumContext) buildIndexRequest(ctx sessionctx.Context, tableID int6
 		SetChecksumRequest(checksum).
 		SetStartTS(c.StartTs).
 		SetConcurrency(ctx.GetSessionVars().DistSQLScanConcurrency()).
-		SetResourceGroupName(ctx.GetSessionVars().ResourceGroupName).
+		SetResourceGroupName(ctx.GetSessionVars().StmtCtx.ResourceGroupName).
 		Build()
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2058,6 +2058,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	sc.OptimizerCETrace = nil
 	sc.IsSyncStatsFailed = false
 	sc.IsExplainAnalyzeDML = false
+	sc.ResourceGroupName = vars.ResourceGroupName
 	// Firstly we assume that UseDynamicPruneMode can be enabled according session variable, then we will check other conditions
 	// in PlanBuilder.buildDataSource
 	if ctx.GetSessionVars().IsDynamicPartitionPruneEnabled() {

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -74,7 +74,7 @@ func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {
 	if b.ctx.GetSessionVars().IsReplicaReadClosestAdaptive() {
 		e.snapshot.SetOption(kv.ReplicaReadAdjuster, newReplicaReadAdjuster(e.ctx, p.GetAvgRowSize()))
 	}
-	e.snapshot.SetOption(kv.ResourceGroupName, b.ctx.GetSessionVars().ResourceGroupName)
+	e.snapshot.SetOption(kv.ResourceGroupName, b.ctx.GetSessionVars().StmtCtx.ResourceGroupName)
 	if e.runtimeStats != nil {
 		snapshotStats := &txnsnapshot.SnapshotRuntimeStats{}
 		e.stats = &runtimeStatsWithSnapshot{

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -2864,6 +2864,9 @@ func (e *SimpleExec) executeSetResourceGroupName(s *ast.SetResourceGroupStmt) er
 		if _, ok := e.is.ResourceGroupByName(s.Name); !ok {
 			return infoschema.ErrResourceGroupNotExists.GenWithStackByArgs(s.Name.O)
 		}
+		e.ctx.GetSessionVars().ResourceGroupName = s.Name.L
+	} else {
+		e.ctx.GetSessionVars().ResourceGroupName = "default"
 	}
 
 	e.ctx.GetSessionVars().ResourceGroupName = s.Name.L

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -2868,7 +2868,5 @@ func (e *SimpleExec) executeSetResourceGroupName(s *ast.SetResourceGroupStmt) er
 	} else {
 		e.ctx.GetSessionVars().ResourceGroupName = "default"
 	}
-
-	e.ctx.GetSessionVars().ResourceGroupName = s.Name.L
 	return nil
 }

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -145,7 +145,7 @@ func TestSetResourceGroup(t *testing.T) {
 
 	tk.MustExec("CREATE RESOURCE GROUP rg1 ru_per_sec = 100")
 	tk.MustExec("ALTER USER `root` RESOURCE GROUP `rg1`")
-	tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows(""))
+	tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows("default"))
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
 	tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows("rg1"))
 
@@ -157,7 +157,7 @@ func TestSetResourceGroup(t *testing.T) {
 	tk.MustExec("SET RESOURCE GROUP `rg2`")
 	tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows("rg2"))
 	tk.MustExec("SET RESOURCE GROUP ``")
-	tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows(""))
+	tk.MustQuery("SELECT CURRENT_RESOURCE_GROUP()").Check(testkit.Rows("default"))
 
 	tk.RefreshSession()
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))

--- a/expression/builtin_info_test.go
+++ b/expression/builtin_info_test.go
@@ -99,7 +99,7 @@ func TestCurrentUser(t *testing.T) {
 func TestCurrentResourceGroup(t *testing.T) {
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
-	sessionVars.ResourceGroupName = "rg1"
+	sessionVars.StmtCtx.ResourceGroupName = "rg1"
 
 	fc := funcs[ast.CurrentResourceGroup]
 	f, err := fc.getFunction(ctx, nil)

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -130,8 +130,9 @@ func (b *builtinCurrentResourceGroupSig) vecEvalString(input *chunk.Chunk, resul
 	}
 	n := input.NumRows()
 	result.ReserveString(n)
+	groupName := getHintResourceGroupName(data)
 	for i := 0; i < n; i++ {
-		result.AppendString(data.ResourceGroupName)
+		result.AppendString(groupName)
 	}
 	return nil
 }

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -182,11 +182,11 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 		// TODO: we didn't check the existence of the hinted resource group now to save the cost per query
 		if retErr == nil && sessVars.StmtCtx.StmtHints.HasResourceGroup {
 			if variable.EnableResourceControl.Load() {
-				sessVars.ResourceGroupName = sessVars.StmtCtx.StmtHints.ResourceGroup
+				sessVars.StmtCtx.ResourceGroupName = sessVars.StmtCtx.StmtHints.ResourceGroup
 				// if we are in a txn, should update the txn resource name to let the txn
 				// commit with the hint resource group.
 				if txn, err := sctx.Txn(false); err == nil && txn != nil && txn.Valid() {
-					txn.SetOption(kv.ResourceGroupName, sessVars.ResourceGroupName)
+					txn.SetOption(kv.ResourceGroupName, sessVars.StmtCtx.ResourceGroupName)
 				}
 			} else {
 				err := infoschema.ErrResourceGroupSupportDisabled

--- a/session/txn.go
+++ b/session/txn.go
@@ -308,7 +308,7 @@ func (txn *LazyTxn) changePendingToValid(ctx context.Context, sctx sessionctx.Co
 		txn.mu.TxnInfo.AllSQLDigests)
 
 	// set resource group name for kv request such as lock pessimistic keys.
-	txn.SetOption(kv.ResourceGroupName, sctx.GetSessionVars().ResourceGroupName)
+	txn.SetOption(kv.ResourceGroupName, sctx.GetSessionVars().StmtCtx.ResourceGroupName)
 
 	return nil
 }

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -244,18 +244,19 @@ type StatementContext struct {
 	MaxRowID  int64
 
 	// Copied from SessionVars.TimeZone.
-	TimeZone         *time.Location
-	Priority         mysql.PriorityEnum
-	NotFillCache     bool
-	MemTracker       *memory.Tracker
-	DiskTracker      *disk.Tracker
-	IsTiFlash        atomic2.Bool
-	RuntimeStatsColl *execdetails.RuntimeStatsColl
-	TableIDs         []int64
-	IndexNames       []string
-	StmtType         string
-	OriginalSQL      string
-	digestMemo       struct {
+	TimeZone          *time.Location
+	Priority          mysql.PriorityEnum
+	NotFillCache      bool
+	MemTracker        *memory.Tracker
+	DiskTracker       *disk.Tracker
+	ResourceGroupName string
+	IsTiFlash         atomic2.Bool
+	RuntimeStatsColl  *execdetails.RuntimeStatsColl
+	TableIDs          []int64
+	IndexNames        []string
+	StmtType          string
+	OriginalSQL       string
+	digestMemo        struct {
 		sync.Once
 		normalized string
 		digest     *parser.Digest

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1974,8 +1974,10 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		EnableLateMaterialization:     DefTiDBOptEnableLateMaterialization,
 		TiFlashComputeDispatchPolicy:  tiflashcompute.DispatchPolicyConsistentHash,
 		EnableWindowFunction:          DefEnableWindowFunction,
+		ResourceGroupName:             "default",
 	}
 	vars.KVVars = tikvstore.NewVariables(&vars.Killed)
+	vars.StmtCtx.ResourceGroupName = "default"
 	vars.Concurrency = Concurrency{
 		indexLookupConcurrency:            DefIndexLookupConcurrency,
 		indexSerialScanConcurrency:        DefIndexSerialScanConcurrency,

--- a/util/plancodec/binary_plan_decode.go
+++ b/util/plancodec/binary_plan_decode.go
@@ -149,7 +149,7 @@ func decodeBinaryOperator(op *tipb.ExplainOperator, indent string, isLastChild, 
 	if hasRuntimeStats {
 		actRows = strconv.FormatInt(int64(op.ActRows), 10)
 		execInfo = op.RootBasicExecInfo
-		groupExecInfo := strings.Join(op.RootGroupExecInfo, ",")
+		groupExecInfo := strings.Join(op.RootGroupExecInfo, ", ")
 		if len(groupExecInfo) > 0 {
 			if len(execInfo) > 0 {
 				execInfo += ", "


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: [close #xxx](https://github.com/pingcap/tidb/issues/49318)

Problem Summary:
When I run a simple select in any 7.1* release with subquery I see it's still uses (or reports) default group

e.g
```js
  const sql = `SELECT ${common.maxExecutionTimeHint} id `
    + `FROM Event `
    + `WHERE id IN ( `
    + `    SELECT event `
    + `    FROM EventRoleAssignment `
    + `    WHERE assignee = ?) `
    + `LIMIT 1000 `;
```

![resource_group_default_still_used](https://github.com/user-attachments/assets/bfe160ae-02a2-4909-8f3c-c96637859af6)

I tried to run all 7.1 and 7.5 versions. and saw that this starts working correctly in 7.5.1 branch. with this 
https://github.com/pingcap/tidb/commit/eeef0ee112ef70d7400c6a2e0b94f81a87a2e23d#diff-cedde52f04eef8a5117a506a088e41a878c00e147d529fcda309d834c966a010R173

(https://github.com/pingcap/tidb/pull/49422)

the commit doesn't merge cleanly with 7.1 as many things are different.


### What changed and how does it work?
backporting commit 
https://github.com/pingcap/tidb/commit/eeef0ee112ef70d7400c6a2e0b94f81a87a2e23d#diff-cedde52f04eef8a5117a506a088e41a878c00e147d529fcda309d834c966a010R173


the summary is:
* use `sessionVars.StmtCtx` instead of sessionVars to fetch current resource group.
* initialize `stmtCtx.resourceGroupName` with session's `resourceGroupName`
* remove code that was overriding sessionVar with hint value
* remove defer that was switching back to original value.
* update tests

after the change I verified that resource groups are accurately reported:

![Screenshot 2024-12-02 at 11 40 50 AM](https://github.com/user-attachments/assets/50169fb6-183b-4644-a054-c8d9c48fb2af)

and default as well
![Screenshot 2024-12-02 at 11 44 50 AM](https://github.com/user-attachments/assets/635dffe6-4ab8-4812-ae33-951f4b3440a1)


### Check List

Tests <!-- At least one of them must be included. -->

- [x ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
