### PR TITLE
server: return error on ping when in graceful shutdown

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -2936,6 +2936,11 @@ error = '''
 Access denied for user '%-.48s'@'%-.255s' (using password: %s)
 '''
 
+["server:1053"]
+error = '''
+Server shutdown in progress
+'''
+
 ["server:1148"]
 error = '''
 The used command is not allowed with this MySQL version

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1390,7 +1390,10 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 		return cc.writeStats(ctx)
 	// ComProcessInfo, ComConnect, ComProcessKill, ComDebug
 	case mysql.ComPing:
-		return cc.writeOK(ctx)
+		if cc.server.health.Load() {
+			return cc.writeOK(ctx)
+		}
+		return errors.New("ping refused, because unhealthy (shutting down?)")
 	case mysql.ComChangeUser:
 		return cc.handleChangeUser(ctx, data)
 	// ComBinlogDump, ComTableDump, ComConnectOut, ComRegisterSlave

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -1393,7 +1393,7 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 		if cc.server.health.Load() {
 			return cc.writeOK(ctx)
 		}
-		return errors.New("ping refused, because unhealthy (shutting down?)")
+		return servererr.ErrServerShutdown
 	case mysql.ComChangeUser:
 		return cc.handleChangeUser(ctx, data)
 	// ComBinlogDump, ComTableDump, ComConnectOut, ComRegisterSlave

--- a/pkg/server/conn_test.go
+++ b/pkg/server/conn_test.go
@@ -613,6 +613,11 @@ func testDispatch(t *testing.T, inputs []dispatchInput, capability uint32) {
 	cfg.Status.ReportStatus = false
 	server, err := NewServer(cfg, tidbdrv)
 	require.NoError(t, err)
+
+	// Set healthy. This is used by graceful shutdown
+	// and is used in the response for ComPing and the
+	// /status HTTP endpoint
+	server.health.Store(true)
 	defer server.Close()
 
 	cc := &clientConn{

--- a/pkg/server/err/error.go
+++ b/pkg/server/err/error.go
@@ -44,4 +44,6 @@ var (
 	ErrNetPacketTooLarge = dbterror.ClassServer.NewStd(errno.ErrNetPacketTooLarge)
 	// ErrMustChangePassword is returned when the user must change the password.
 	ErrMustChangePassword = dbterror.ClassServer.NewStd(errno.ErrMustChangePassword)
+	// ErrServerShutdown is returned when the server is shutting down.
+	ErrServerShutdown = dbterror.ClassServer.NewStd(errno.ErrServerShutdown)
 )


### PR DESCRIPTION
Issue Number: ref #58007 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
TiDB now returns errors for COM_PING commands when in shutdown
```


From ProxySQL:
```
mysql-5.5.30> select * from monitor.mysql_server_ping_log order by time_start_us desc limit 15;
+-----------+------+------------------+----------------------+--------------------------------------------------+
| hostname  | port | time_start_us    | ping_success_time_us | ping_error                                       |
+-----------+------+------------------+----------------------+--------------------------------------------------+
| 127.0.0.1 | 4000 | 1733385305164128 | 0                    | ping refused, because unhealthy (shutting down?) |
| 127.0.0.1 | 4000 | 1733385295163107 | 452                  | NULL                                             |
| 127.0.0.1 | 4000 | 1733385285162817 | 66                   | NULL                                             |
| 127.0.0.1 | 4000 | 1733385275162347 | 0                    | Can't connect to server on '127.0.0.1' (115)     |
```