### PR TITLE
statistics: stats cache set default quota as 20% 

### DIFF
--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -75,14 +75,14 @@ func NewLFU(totalMemCost int64) (*LFU, error) {
 }
 
 // adjustMemCost adjusts the memory cost according to the total memory cost.
-// When the total memory cost is 0, the memory cost is set to half of the total memory.
+// When the total memory cost is 0, the memory cost is set to 15% of the total memory.
 func adjustMemCost(totalMemCost int64) (result int64, err error) {
 	if totalMemCost == 0 {
 		memTotal, err := memory.MemTotal()
 		if err != nil {
 			return 0, err
 		}
-		return int64(memTotal / 2), nil
+		return int64(memTotal * 20 / 100), nil
 	}
 	return totalMemCost, nil
 }

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -75,7 +75,7 @@ func NewLFU(totalMemCost int64) (*LFU, error) {
 }
 
 // adjustMemCost adjusts the memory cost according to the total memory cost.
-// When the total memory cost is 0, the memory cost is set to 15% of the total memory.
+// When the total memory cost is 0, the memory cost is set to 20% of the total memory.
 func adjustMemCost(totalMemCost int64) (result int64, err error) {
 	if totalMemCost == 0 {
 		memTotal, err := memory.MemTotal()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/58014

Problem Summary:

### What changed and how does it work?

stats cache set default quota as 20%

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note 
stats cache set default quota as 20%

state cache 的默认阈值为 20%
```
