### PR TITLE
statstics: trigger evict by the timer

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2682,6 +2682,7 @@ func (do *Domain) updateStatsWorker(_ sessionctx.Context) {
 			}
 		case <-readMemTicker.C:
 			memory.ForceReadMemStats()
+			do.StatsHandle().StatsCache.TriggerEvict()
 		case <-updateStatsHealthyTicker.C:
 			statsHandle.UpdateStatsHealthyMetrics()
 		}

--- a/pkg/statistics/handle/cache/internal/inner.go
+++ b/pkg/statistics/handle/cache/internal/inner.go
@@ -41,4 +41,6 @@ type StatsCacheInner interface {
 	SetCapacity(int64)
 	// Close stops the cache
 	Close()
+	// TriggerEvict triggers the cache to evict some items
+	TriggerEvict()
 }

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -254,3 +254,8 @@ func (s *LFU) addCost(v int64) {
 	newv := s.cost.Add(v)
 	metrics.CostGauge.Set(float64(newv))
 }
+
+// TriggerEvict implements statsCacheInner
+func (s *LFU) TriggerEvict() {
+	s.triggerEvict()
+}

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -93,9 +93,6 @@ func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	if !ok {
 		return s.resultKeySet.Get(tid)
 	}
-	if tid%5 == 0 {
-		s.triggerEvict()
-	}
 	return result.(*statistics.Table), ok
 }
 

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -93,6 +93,9 @@ func (s *LFU) Get(tid int64) (*statistics.Table, bool) {
 	if !ok {
 		return s.resultKeySet.Get(tid)
 	}
+	if tid%5 == 0 {
+		s.triggerEvict()
+	}
 	return result.(*statistics.Table), ok
 }
 

--- a/pkg/statistics/handle/cache/internal/mapcache/map_cache.go
+++ b/pkg/statistics/handle/cache/internal/mapcache/map_cache.go
@@ -131,3 +131,6 @@ func (*MapCache) SetCapacity(int64) {}
 
 // Close implements StatsCacheInner
 func (*MapCache) Close() {}
+
+// TriggerEvict implements statsCacheInner
+func (*MapCache) TriggerEvict() {}

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -259,6 +259,11 @@ func (s *StatsCacheImpl) Put(id int64, t *statistics.Table) {
 	s.Load().put(id, t)
 }
 
+// TriggerEvict triggers the cache to evict some items.
+func (s *StatsCacheImpl) TriggerEvict() {
+	s.Load().TriggerEvict()
+}
+
 // MaxTableStatsVersion returns the version of the current cache, which is defined as
 // the max table stats version the cache has in its lifecycle.
 func (s *StatsCacheImpl) MaxTableStatsVersion() uint64 {

--- a/pkg/statistics/handle/cache/statscacheinner.go
+++ b/pkg/statistics/handle/cache/statscacheinner.go
@@ -183,3 +183,8 @@ func (sc *StatsCache) Update(tables []*statistics.Table, deletedIDs []int64, ski
 		}
 	}
 }
+
+// TriggerEvict triggers the cache to evict some items.
+func (sc *StatsCache) TriggerEvict() {
+	sc.c.TriggerEvict()
+}

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -260,6 +260,9 @@ type StatsCache interface {
 
 	// UpdateStatsHealthyMetrics updates stats healthy distribution metrics according to stats cache.
 	UpdateStatsHealthyMetrics()
+
+	// TriggerEvict triggers the cache to evict some items
+	TriggerEvict()
 }
 
 // StatsLockTable is the table info of which will be locked.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58052

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

after it. we can create a cluster with many table. stop the workload and waiting for no update/insert the stats cache. then you change the stats cache capacity. you will see the stats cache and evict more quick.

before:

![image](https://github.com/user-attachments/assets/a4262e19-0e01-455f-92a0-ff9ab2a29cbb)


after:

![image](https://github.com/user-attachments/assets/618490a4-3c60-4b78-8b74-53d3dfb670cb)



- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
