### PR TITLE
planner: fix index range intersection for in-list and other predicates 

### DIFF
--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -165,6 +165,8 @@ func TestRangeIntersection(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec(`set @@tidb_opt_fix_control = "54337:ON"`)
 	tk.MustExec("create table t1 (a1 int, b1 int, c1 int, key pkx (a1,b1));")
+
+	tk.MustExec("create table t_inlist_test(a1 int,b1 int,c1 varbinary(767) DEFAULT NULL, KEY twoColIndex (a1,b1));")
 	tk.MustExec("insert into t1 values (1,1,1);")
 	tk.MustExec("insert into t1 values (null,1,1);")
 	tk.MustExec("insert into t1 values (1,null,1);")

--- a/pkg/planner/core/casetest/index/testdata/index_range_in.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_in.json
@@ -44,6 +44,10 @@
 	"select /*+ USE_INDEX(tablename,PKK) */ count(*) from tablename where (primary_key,secondary_key,timestamp) >= ('1primary_key_start','3secondary_key_start','1707885658544000000') and (primary_key,secondary_key,timestamp) <= ('2primary_key_end','4secondary_key_end','2707885658544000000');",
 	"SELECT /*+ USE_INDEX(t,PK) */ a FROM tnull WHERE a IN (42) OR (a IS TRUE AND a IS NULL);",
 	"SELECT id7 FROM tkey_string WHERE id7 > 'large' AND id7 < 'x-small';",
+	// IN list and range intersection
+        "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (44, 70, 76) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
+        "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (44,45) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
+        "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (70, 73, 76) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
 	// Empty intersections.
 	"select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (0, 20)", 
 	"select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (2, 20) and b1 <5",

--- a/pkg/planner/core/casetest/index/testdata/index_range_out.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_out.json
@@ -388,6 +388,32 @@
         ]
       },
       {
+        "SQL": "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (44, 70, 76) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
+        "Plan": [
+          "Projection 43.33 root  1->Column#5",
+          "└─IndexReader 54.17 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 54.17 cop[tikv] table:t_inlist_test, index:twoColIndex(a1, b1) range:(70 41,70 +inf], [76,76], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (44,45) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
+        "Plan": [
+          "Projection 6.71 root  1->Column#5",
+          "└─TableDual 6.71 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (70, 73, 76) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
+        "Plan": [
+          "Projection 53.33 root  1->Column#5",
+          "└─IndexReader 53.33 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 53.33 cop[tikv] table:t_inlist_test, index:twoColIndex(a1, b1) range:(70 41,70 +inf], [73,73], [76,76], keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
         "SQL": "select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (0, 20)",
         "Plan": [
           "HashAgg 1.00 root  funcs:count(1)->Column#5",

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -362,6 +362,30 @@ func unionColumnValues(lhs, rhs []*valueInfo) []*valueInfo {
 	return lhs
 }
 
+// Check which detach result is more selective. This function is called to choose between point ranges and the best CNF ranges.
+// This is needed because sometimes the best CNF has full intersection and is more selective,
+// and other times it is not when the intersection is not applied.
+func chooseBetweenRangeAndPoint(sctx *rangerctx.RangerContext, r1 *DetachRangeResult, r2 *cnfItemRangeResult) {
+	if fixcontrol.GetBoolWithDefault(sctx.OptimizerFixControl, fixcontrol.Fix54337, false) {
+		if r1 != nil && len(r1.Ranges) > 0 && r2 != nil && r2.rangeResult != nil {
+			r1Minusr2 := removeConditions(sctx.ExprCtx.GetEvalCtx(), r1.AccessConds, r2.rangeResult.AccessConds)
+			r2Minusr1 := removeConditions(sctx.ExprCtx.GetEvalCtx(), r2.rangeResult.AccessConds, r1.AccessConds)
+			// r2 is considered more selective (and more useful) than r1 if its AccessConds are a superset of r1's AccessConds.
+			// This means that r1.AccessConds minus r2.AccessConds should result in an empty set.
+			// The function `removeConditions` is used to perform this subtraction.
+			// For example, if A = {t1.a1 IN (44, 70, 76)} and B = {t1.a1 IN (44, 70, 76), (t1.a1 > 70 OR (t1.a1 = 70 AND t1.b1 > 41))},
+			// then A-B is empty and therefore B is a superset of A.
+			// Avoid the case when both r1 and r2 have the same AccessConds (r2Minusr1 is not empty).
+			if len(r1Minusr2) == 0 && len(r2Minusr1) > 0 {
+				// Update final result and just update: Ranges, AccessConds and RemainedConds
+				r1.RemainedConds = removeConditions(sctx.ExprCtx.GetEvalCtx(), r1.RemainedConds, r2.rangeResult.AccessConds)
+				r1.Ranges = r2.rangeResult.Ranges
+				r1.AccessConds = r2.rangeResult.AccessConds
+			}
+		}
+	}
+}
+
 // detachCNFCondAndBuildRangeForIndex will detach the index filters from table filters. These conditions are connected with `and`
 // It will first find the point query column and then extract the range query column.
 // considerDNF is true means it will try to extract access conditions from the DNF expressions.
@@ -510,6 +534,10 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 				return res, nil
 			}
 			res.RemainedConds = append(res.RemainedConds, tailRes.RemainedConds...)
+			// Check if `bestCNFItemRes` is more selective than the ranges derived from the IN list.
+			// This can occur if `bestCNFItemRes` represents the intersection of the IN list values
+			// and additional conditions, resulting in a more restrictive filter.
+			chooseBetweenRangeAndPoint(d.sctx, res, bestCNFItemRes)
 			return res, nil
 		}
 		// `eqOrInCount` must be 0 when coming here.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57694

### Problem Summary:
This is a limitation for optimal multi-column index range derivation. It is similar to  https://github.com/pingcap/tidb/pull/54166 but different where point ranges are derived from IN list on the prefix column. A simple example is below where the range is based on "t1.a1 IN ( 44, 70, 76)" and not the full predicate  "t1.a1 IN ( 44, 70, 76) AND (t1.a1 > 70 OR (t1.a1 = 70 AND t1.b1 > 41))"

```
CREATE TABLE t1 (
  a1 int,
  b1 int,
  c1 varbinary(767) DEFAULT NULL,
  KEY twoColIndex (a1,b1)
)

EXPLAIN  format = brief
SELECT 1
     FROM t1 FORCE INDEX (twoColIndex)
     WHERE
       t1.a1 IN ( 44, 70, 76)
       AND (t1.a1 > 70 OR (t1.a1 = 70 AND t1.b1 > 41))
--------------

id      estRows task    access object   operator info
Projection      10.07   root            1->Column#5
└─IndexReader   10.10   root            index:Selection
  └─Selection   10.10   cop[tikv]               or(gt(test.t1.a1, 70), and(eq(test.t1.a1, 70), gt(test.t1.b1, 41)))
    └─IndexRangeScan    30.00   cop[tikv]       table:t1, index:twoColIndex(a1, b1)     range:[44,44], [70,70], [76,76]
```

The optimal solution is below where the range intersection of all predicates is: (70 41,70 +inf], [76,76]
```
id      estRows task    access object   operator info
Projection      43.33   root            1->Column#5
└─IndexReader   54.17   root            index:IndexRangeScan
  └─IndexRangeScan      54.17   cop[tikv]       table:t1, index:twoColIndex(a1, b1)     range:(70 41,70 +inf], [76,76]
```

We already have the logic of intersection through prior 54166 PR and it is computed for this case as well. The problem is that  we do not choose the intersection for this case. 

### What changed and how does it work?
The fix is to recognize this case by comparing the conjunctive normal form, or CNF result (applying all predicates) and IN list ranges and pick the most selective. The CNF result is more selective if the covers a superset of filters. In the above example, the CNF result access conditions is "t1.a1 IN ( 44, 45) AND (t1.a1 > 70 OR (t1.a1 = 70 AND t1.b1 > 41))" which is a superset of the IN list access conditions "

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
