### PR TITLE
compacted restore: fix the wrong initial configrations

### DIFF
--- a/br/pkg/checkpoint/checkpoint_test.go
+++ b/br/pkg/checkpoint/checkpoint_test.go
@@ -628,6 +628,9 @@ func TestCheckpointCompactedRestoreRunner(t *testing.T) {
 		respCount++
 	}
 
+	exists := checkpoint.ExistsSstRestoreCheckpoint(ctx, s.Mock.Domain, checkpoint.CustomSSTRestoreCheckpointDatabaseName)
+	require.True(t, exists)
+
 	_, err = checkpoint.LoadCheckpointDataForSstRestore(ctx, se.GetSessionCtx().GetRestrictedSQLExecutor(), checkpoint.CustomSSTRestoreCheckpointDatabaseName, checker)
 	require.NoError(t, err)
 	require.Equal(t, 3, respCount)
@@ -635,7 +638,7 @@ func TestCheckpointCompactedRestoreRunner(t *testing.T) {
 	err = checkpoint.RemoveCheckpointDataForSstRestore(ctx, s.Mock.Domain, se, checkpoint.CustomSSTRestoreCheckpointDatabaseName)
 	require.NoError(t, err)
 
-	exists := checkpoint.ExistsSstRestoreCheckpoint(ctx, s.Mock.Domain, checkpoint.CustomSSTRestoreCheckpointDatabaseName)
+	exists = checkpoint.ExistsSstRestoreCheckpoint(ctx, s.Mock.Domain, checkpoint.CustomSSTRestoreCheckpointDatabaseName)
 	require.False(t, exists)
 	exists = s.Mock.Domain.InfoSchema().SchemaExists(pmodel.NewCIStr(checkpoint.CustomSSTRestoreCheckpointDatabaseName))
 	require.False(t, exists)

--- a/br/pkg/checkpoint/restore.go
+++ b/br/pkg/checkpoint/restore.go
@@ -170,8 +170,10 @@ func ExistsSstRestoreCheckpoint(
 	dom *domain.Domain,
 	dbName string,
 ) bool {
+	// we only check the existence of the checkpoint data table
+	// because the checkpoint metadata is not used for restore
 	return dom.InfoSchema().
-		TableExists(pmodel.NewCIStr(dbName), pmodel.NewCIStr(checkpointMetaTableName))
+		TableExists(pmodel.NewCIStr(dbName), pmodel.NewCIStr(checkpointDataTableName))
 }
 
 func RemoveCheckpointDataForSstRestore(ctx context.Context, dom *domain.Domain, se glue.Session, dbName string) error {

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -445,17 +445,10 @@ func (rc *LogClient) InitCheckpointMetadataForCompactedSstRestore(
 	sstCheckpointSets := make(map[string]struct{})
 
 	if checkpoint.ExistsSstRestoreCheckpoint(ctx, rc.dom, checkpoint.CustomSSTRestoreCheckpointDatabaseName) {
-		// get sst checkpoint to skip repeated files
-		checkpointSetWithTableID := make(map[int64]map[string]struct{})
 		// we need to load the checkpoint data for the following restore
 		execCtx := rc.unsafeSession.GetSessionCtx().GetRestrictedSQLExecutor()
 		_, err := checkpoint.LoadCheckpointDataForSstRestore(ctx, execCtx, checkpoint.CustomSSTRestoreCheckpointDatabaseName, func(tableID int64, v checkpoint.RestoreValueType) {
-			checkpointSet, exists := checkpointSetWithTableID[tableID]
-			if !exists {
-				checkpointSet = make(map[string]struct{})
-				checkpointSetWithTableID[tableID] = checkpointSet
-			}
-			checkpointSet[v.Name] = struct{}{}
+			sstCheckpointSets[v.Name] = struct{}{}
 		})
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/br/pkg/restore/restorer.go
+++ b/br/pkg/restore/restorer.go
@@ -359,7 +359,6 @@ func (p *PipelineRestorerWrapper[T]) WithSplit(ctx context.Context, i iter.TryNe
 
 			// Check if the accumulated items meet the criteria for splitting.
 			if strategy.ShouldSplit() {
-				log.Info("Trying to start region split with accumulations")
 				startTime := time.Now()
 
 				// Execute the split operation on the accumulated items.

--- a/br/pkg/restore/snap_client/BUILD.bazel
+++ b/br/pkg/restore/snap_client/BUILD.bazel
@@ -82,7 +82,7 @@ go_test(
     ],
     embed = [":snap_client"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/glue",

--- a/br/pkg/restore/snap_client/import.go
+++ b/br/pkg/restore/snap_client/import.go
@@ -183,6 +183,7 @@ func NewSnapFileImporterOptions(
 		metaClient:          metaClient,
 		importClient:        importClient,
 		backend:             backend,
+		rewriteMode:         rewriteMode,
 		tikvStores:          tikvStores,
 		concurrencyPerStore: concurrencyPerStore,
 		createCallBacks:     createCallbacks,

--- a/br/pkg/restore/snap_client/import.go
+++ b/br/pkg/restore/snap_client/import.go
@@ -183,7 +183,6 @@ func NewSnapFileImporterOptions(
 		metaClient:          metaClient,
 		importClient:        importClient,
 		backend:             backend,
-		rewriteMode:         rewriteMode,
 		tikvStores:          tikvStores,
 		concurrencyPerStore: concurrencyPerStore,
 		createCallBacks:     createCallbacks,
@@ -213,6 +212,9 @@ func NewSnapFileImporter(
 	kvMode KvMode,
 	options *SnapFileImporterOptions,
 ) (*SnapFileImporter, error) {
+	if options.concurrencyPerStore == 0 {
+		return nil, errors.New("concurrencyPerStore must be greater than 0")
+	}
 	fileImporter := &SnapFileImporter{
 		apiVersion: apiVersion,
 		kvMode:     kvMode,

--- a/br/pkg/restore/snap_client/import_test.go
+++ b/br/pkg/restore/snap_client/import_test.go
@@ -155,6 +155,13 @@ func (client *fakeImporterClient) MultiIngest(
 	return &import_sstpb.IngestResponse{}, nil
 }
 
+func TestUnproperConfigSnapImporter(t *testing.T) {
+	ctx := context.Background()
+	opt := snapclient.NewSnapFileImporterOptionsForTest(nil, nil, nil, snapclient.RewriteModeKeyspace, 0)
+	_, err := snapclient.NewSnapFileImporter(ctx, kvrpcpb.APIVersion_V1, snapclient.TiDBFull, opt)
+	require.Error(t, err)
+}
+
 func TestSnapImporter(t *testing.T) {
 	ctx := context.Background()
 	splitClient := split.NewFakeSplitClient()

--- a/br/tests/br_pitr/run.sh
+++ b/br/tests/br_pitr/run.sh
@@ -107,6 +107,7 @@ fi
 # PITR restore
 echo "run pitr"
 run_sql "DROP DATABASE __TiDB_BR_Temporary_Log_Restore_Checkpoint;"
+run_sql "DROP DATABASE __TiDB_BR_Temporary_Custom_SST_Restore_Checkpoint;"
 run_br --pd $PD_ADDR restore point -s "local://$TEST_DIR/$PREFIX/log" --full-backup-storage "local://$TEST_DIR/$PREFIX/full" > $res_file 2>&1
 
 check_result


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:  ref https://github.com/pingcap/tidb/issues/56522
Problem Summary:
1. the initial config concurrencyPerStore of snapclient is not right. which make the compacted restore blocked. This PR try to fix it.
2. the initial checkpoint for compacted restore is not complete. this PR fix it.

### What changed and how does it work?
set the correct config. and add a config check when initialize 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
