### PR TITLE
domain,infoschema: make infoschema activity block GC safepoint advancing

### DIFF
--- a/pkg/ddl/attributes_sql_test.go
+++ b/pkg/ddl/attributes_sql_test.go
@@ -252,7 +252,7 @@ PARTITION BY RANGE (c) (
 func TestFlashbackTable(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 
-	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true)
+	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true, dom.InfoCache())
 	require.NoError(t, err)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -310,7 +310,7 @@ PARTITION BY RANGE (c) (
 func TestDropTable(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 
-	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true)
+	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true, dom.InfoCache())
 	require.NoError(t, err)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -363,7 +363,7 @@ PARTITION BY RANGE (c) (
 func TestCreateWithSameName(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 
-	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true)
+	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true, dom.InfoCache())
 	require.NoError(t, err)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -427,7 +427,7 @@ PARTITION BY RANGE (c) (
 func TestPartition(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 
-	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true)
+	_, err := infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true, dom.InfoCache())
 	require.NoError(t, err)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/pkg/ddl/main_test.go
+++ b/pkg/ddl/main_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		conf.Experimental.AllowsExpressionIndex = true
 	})
 
-	_, err := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true)
+	_, err := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true, nil)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ddl: infosync.GlobalInfoSyncerInit: %v\n", err)
 		os.Exit(1)

--- a/pkg/ddl/tests/serial/main_test.go
+++ b/pkg/ddl/tests/serial/main_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 		conf.Experimental.AllowsExpressionIndex = true
 	})
 
-	_, err := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true)
+	_, err := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true, nil)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ddl: infosync.GlobalInfoSyncerInit: %v\n", err)
 		os.Exit(1)

--- a/pkg/domain/db_test.go
+++ b/pkg/domain/db_test.go
@@ -80,7 +80,7 @@ func TestNormalSessionPool(t *testing.T) {
 	domain, err := session.BootstrapSession(store)
 	require.NoError(t, err)
 	defer domain.Close()
-	info, err1 := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true)
+	info, err1 := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true, domain.InfoCache())
 	require.NoError(t, err1)
 	conf := config.GetGlobalConfig()
 	conf.Socket = ""
@@ -113,7 +113,7 @@ func TestAbnormalSessionPool(t *testing.T) {
 	domain, err := session.BootstrapSession(store)
 	require.NoError(t, err)
 	defer domain.Close()
-	info, err1 := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true)
+	info, err1 := infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, true, domain.InfoCache())
 	require.NoError(t, err1)
 	conf := config.GetGlobalConfig()
 	conf.Socket = ""

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1405,7 +1405,7 @@ func (do *Domain) Init(
 	skipRegisterToDashboard := config.GetGlobalConfig().SkipRegisterToDashboard
 	do.info, err = infosync.GlobalInfoSyncerInit(ctx, do.ddl.GetID(), do.ServerID,
 		do.etcdClient, do.unprefixedEtcdCli, pdCli, pdHTTPCli,
-		do.Store().GetCodec(), skipRegisterToDashboard)
+		do.Store().GetCodec(), skipRegisterToDashboard, do.infoCache)
 	if err != nil {
 		return err
 	}

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -808,10 +808,12 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 		}
 	}
 
-	schemaTS := is.infoCache.GetAndResetRecentInfoSchemaTS(currentVer.Ver)
-	logutil.BgLogger().Debug("ReportMinStartTS", zap.Uint64("InfoSchema Recent StartTS", schemaTS))
-	if schemaTS > startTSLowerLimit && schemaTS < minStartTS {
-		minStartTS = schemaTS
+	if is.infoCache != nil {
+		schemaTS := is.infoCache.GetAndResetRecentInfoSchemaTS(currentVer.Ver)
+		logutil.BgLogger().Debug("ReportMinStartTS", zap.Uint64("InfoSchema Recent StartTS", schemaTS))
+		if schemaTS > startTSLowerLimit && schemaTS < minStartTS {
+			minStartTS = schemaTS
+		}
 	}
 
 	is.minStartTS = kv.GetMinInnerTxnStartTS(now, startTSLowerLimit, minStartTS)

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -126,6 +126,7 @@ type InfoSyncer struct {
 	scheduleManager       ScheduleManager
 	tiflashReplicaManager TiFlashReplicaManager
 	resourceManagerClient pd.ResourceManagerClient
+	infoCache             infoschemaMinTS
 }
 
 // ServerInfo is server static information.
@@ -202,6 +203,10 @@ func SetPDHttpCliForTest(cli pdhttp.Client) func() {
 	}
 }
 
+type infoschemaMinTS interface {
+	GetAndResetRecentInfoSchemaTS(now uint64) uint64
+}
+
 // GlobalInfoSyncerInit return a new InfoSyncer. It is exported for testing.
 func GlobalInfoSyncerInit(
 	ctx context.Context,
@@ -211,6 +216,7 @@ func GlobalInfoSyncerInit(
 	pdCli pd.Client, pdHTTPCli pdhttp.Client,
 	codec tikv.Codec,
 	skipRegisterToDashBoard bool,
+	infoCache infoschemaMinTS,
 ) (*InfoSyncer, error) {
 	if pdHTTPCli != nil {
 		pdHTTPCli = pdHTTPCli.
@@ -224,6 +230,7 @@ func GlobalInfoSyncerInit(
 		info:              getServerInfo(id, serverIDGetter),
 		serverInfoPath:    fmt.Sprintf("%s/%s", ServerInformationPath, id),
 		minStartTSPath:    fmt.Sprintf("%s/%s", ServerMinStartTSPath, id),
+		infoCache:         infoCache,
 	}
 	err := is.init(ctx, skipRegisterToDashBoard)
 	if err != nil {
@@ -799,6 +806,12 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 		if innerTS > startTSLowerLimit && innerTS < minStartTS {
 			minStartTS = innerTS
 		}
+	}
+
+	schemaTS := is.infoCache.GetAndResetRecentInfoSchemaTS(currentVer.Ver)
+	logutil.BgLogger().Debug("ReportMinStartTS", zap.Uint64("InfoSchema Recent StartTS", schemaTS))
+	if schemaTS > startTSLowerLimit && schemaTS < minStartTS {
+		minStartTS = schemaTS
 	}
 
 	is.minStartTS = kv.GetMinInnerTxnStartTS(now, startTSLowerLimit, minStartTS)

--- a/pkg/domain/infosync/info_test.go
+++ b/pkg/domain/infosync/info_test.go
@@ -71,7 +71,7 @@ func TestTopology(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	info, err := GlobalInfoSyncerInit(ctx, currentID, func() uint64 { return 1 }, client, client, nil, nil, keyspace.CodecV1, false)
+	info, err := GlobalInfoSyncerInit(ctx, currentID, func() uint64 { return 1 }, client, client, nil, nil, keyspace.CodecV1, false, nil)
 	require.NoError(t, err)
 
 	err = info.newTopologySessionAndStoreServerInfo(ctx, util2.NewSessionDefaultRetryCnt)

--- a/pkg/domain/infosync/info_test.go
+++ b/pkg/domain/infosync/info_test.go
@@ -156,7 +156,7 @@ func (is *InfoSyncer) ttlKeyExists(ctx context.Context) (bool, error) {
 }
 
 func TestPutBundlesRetry(t *testing.T) {
-	_, err := GlobalInfoSyncerInit(context.TODO(), "test", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, false)
+	_, err := GlobalInfoSyncerInit(context.TODO(), "test", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, false, nil)
 	require.NoError(t, err)
 
 	bundle, err := placement.NewBundleFromOptions(&model.PlacementSettings{PrimaryRegion: "r1", Regions: "r1,r2"})
@@ -220,7 +220,7 @@ func TestPutBundlesRetry(t *testing.T) {
 
 func TestTiFlashManager(t *testing.T) {
 	ctx := context.Background()
-	_, err := GlobalInfoSyncerInit(ctx, "test", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, false)
+	_, err := GlobalInfoSyncerInit(ctx, "test", func() uint64 { return 1 }, nil, nil, nil, nil, keyspace.CodecV1, false, nil)
 	tiflash := NewMockTiFlash()
 	SetMockTiFlash(tiflash)
 

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -17,6 +17,7 @@ package infoschema
 import (
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	infoschema_metrics "github.com/pingcap/tidb/pkg/infoschema/metrics"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
@@ -57,6 +58,13 @@ func NewCache(r autoid.Requirement, capacity int) *InfoCache {
 		r:                   r,
 		Data:                infoData,
 	}
+}
+
+// GetAndResetRecentInfoSchemaTS provides the min start ts for infosync.InfoSyncer.
+func (h *InfoCache) GetAndResetRecentInfoSchemaTS(now uint64) uint64 {
+	ret := atomic.LoadUint64(&h.Data.recentMinTS)
+	atomic.StoreUint64(&h.Data.recentMinTS, now)
+	return ret
 }
 
 // ReSize re-size the cache.

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -60,6 +60,18 @@ func NewCache(r autoid.Requirement, capacity int) *InfoCache {
 }
 
 // GetAndResetRecentInfoSchemaTS provides the min start ts for infosync.InfoSyncer.
+// It works like this:
+//
+//	There is a background infosync worker calling ReportMinStartTS() function periodically.
+//	At the beginning of each round, the Data.recentMinTS here is reset to current TS.
+//	If InfoSchemaV2 APIs are called, there is an internal keepAlive() function will also be called.
+//	The keepAlive() function will compare the InfoSchemaV2's ts with Data.recentMinTS, and
+//	update the Data.recentMinTS to smaller one.
+//
+// In a nutshell, every round of ReportMinStartTS(), the minimal known TS used be InfoSchemaV2 APIs will be reported.
+// Some corner cases might happen: the caller take an InfoSchemaV2 instance and not use it immediately.
+// Seveval rounds later, that InfoSchema is used and its TS is reported to block GC safepoint advancing.
+// But that's too late, the GC has been done, "GC life time is shorter than transaction duration" error still happen.
 func (h *InfoCache) GetAndResetRecentInfoSchemaTS(now uint64) uint64 {
 	ret := h.Data.recentMinTS.Load()
 	h.Data.recentMinTS.Store(now)

--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -17,7 +17,6 @@ package infoschema
 import (
 	"sort"
 	"sync"
-	"sync/atomic"
 
 	infoschema_metrics "github.com/pingcap/tidb/pkg/infoschema/metrics"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
@@ -62,8 +61,8 @@ func NewCache(r autoid.Requirement, capacity int) *InfoCache {
 
 // GetAndResetRecentInfoSchemaTS provides the min start ts for infosync.InfoSyncer.
 func (h *InfoCache) GetAndResetRecentInfoSchemaTS(now uint64) uint64 {
-	ret := atomic.LoadUint64(&h.Data.recentMinTS)
-	atomic.StoreUint64(&h.Data.recentMinTS, now)
+	ret := h.Data.recentMinTS.Load()
+	h.Data.recentMinTS.Store(now)
 	return ret
 }
 

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -125,7 +125,7 @@ type Data struct {
 	tableInfoResident *btree.BTreeG[tableInfoItem]
 
 	// the minimum ts of the recent used infoschema
-	recentMinTS uint64
+	recentMinTS atomic.Uint64
 }
 
 type tableInfoItem struct {
@@ -829,11 +829,11 @@ func (is *infoschemaV2) TableInfoByID(id int64) (*model.TableInfo, bool) {
 // reports the min TS to info.InfoSyncer.
 func (is *infoschemaV2) keepAlive() {
 	for {
-		v := atomic.LoadUint64(&is.Data.recentMinTS)
+		v := is.Data.recentMinTS.Load()
 		if v <= is.ts {
 			break
 		}
-		succ := atomic.CompareAndSwapUint64(&is.Data.recentMinTS, v, is.ts)
+		succ := is.Data.recentMinTS.CompareAndSwap(v, is.ts)
 		if succ {
 			break
 		}

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ngaut/pools"
@@ -122,6 +123,9 @@ type Data struct {
 	//     TTLInfo, TiFlashReplica
 	// PlacementPolicyRef, Partition might be added later, and also ForeignKeys, TableLock etc
 	tableInfoResident *btree.BTreeG[tableInfoItem]
+
+	// the minimum ts of the recent used infoschema
+	recentMinTS uint64
 }
 
 type tableInfoItem struct {
@@ -608,6 +612,7 @@ func (is *infoschemaV2) TableByID(ctx context.Context, id int64) (val table.Tabl
 		return
 	}
 
+	is.keepAlive()
 	itm, ok := is.searchTableItemByID(id)
 	if !ok {
 		return nil, false
@@ -769,8 +774,8 @@ func (is *infoschemaV2) TableByName(ctx context.Context, schema, tbl pmodel.CISt
 		return nil, ErrTableNotExists.FastGenByArgs(schema, tbl)
 	}
 
+	is.keepAlive()
 	start := time.Now()
-
 	var h tableByNameHelper
 	h.end = tableItem{dbName: schema, tableName: tbl, schemaVersion: math.MaxInt64}
 	h.schemaVersion = is.infoSchema.schemaMetaVersion
@@ -819,6 +824,22 @@ func (is *infoschemaV2) TableInfoByID(id int64) (*model.TableInfo, bool) {
 	return getTableInfo(tbl), ok
 }
 
+// keepAlive prevents the "GC life time is shorter than transaction duration" error on infoschema v2.
+// It works by collecting the min TS of the during infoschem v2 API calls, and
+// reports the min TS to info.InfoSyncer.
+func (is *infoschemaV2) keepAlive() {
+	for {
+		v := atomic.LoadUint64(&is.Data.recentMinTS)
+		if v <= is.ts {
+			break
+		}
+		succ := atomic.CompareAndSwapUint64(&is.Data.recentMinTS, v, is.ts)
+		if succ {
+			break
+		}
+	}
+}
+
 // SchemaTableInfos implements MetaOnlyInfoSchema.
 func (is *infoschemaV2) SchemaTableInfos(ctx context.Context, schema pmodel.CIStr) ([]*model.TableInfo, error) {
 	if IsSpecialDB(schema.L) {
@@ -834,6 +855,7 @@ func (is *infoschemaV2) SchemaTableInfos(ctx context.Context, schema pmodel.CISt
 		return nil, nil // something wrong?
 	}
 
+	is.keepAlive()
 retry:
 	dbInfo, ok := is.SchemaByName(schema)
 	if !ok {

--- a/pkg/infoschema/test/infoschemav2test/BUILD.bazel
+++ b/pkg/infoschema/test/infoschemav2test/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "v2_test.go",
     ],
     flaky = True,
-    shard_count = 12,
+    shard_count = 13,
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",

--- a/pkg/server/stat_test.go
+++ b/pkg/server/stat_test.go
@@ -50,7 +50,7 @@ func TestUptime(t *testing.T) {
 	}()
 	require.NoError(t, err)
 
-	_, err = infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true)
+	_, err = infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), dom.GetEtcdClient(), dom.GetPDClient(), dom.GetPDHTTPClient(), keyspace.CodecV1, true, dom.InfoCache())
 	require.NoError(t, err)
 
 	tidbdrv := NewTiDBDriver(store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57952

Problem Summary:

### What changed and how does it work?

Currently, when we get a infoschema v2 instance, it's lifetime is in range [ts, ts + 10min)
If the caller hold a infoschema, and use it some time later, it might get error "GC lifetime is shorter than transaction duration" error. That's because infoschema v2 internally use meta package API, while the meta API does not block the GC safepoint advancing.

In this commit, I add a `keepAlive()`  call to the infoschema API,
that `keepAlive()` function will keep the minimal start ts of active infoschema API calls.

The infosync.Syncer call `ReportMinStartTS()` periodically, amd now it will take the active infoschema ts into consideration, which is updated by the `keepAlive()` function.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
