### PR TITLE
workloadrepo: disable statement summary history when repository is enabled

### DIFF
--- a/pkg/util/stmtsummary/statement_summary.go
+++ b/pkg/util/stmtsummary/statement_summary.go
@@ -81,6 +81,7 @@ type stmtSummaryByDigestMap struct {
 	// These options are set by global system variables and are accessed concurrently.
 	optEnabled             *atomic2.Bool
 	optEnableInternalQuery *atomic2.Bool
+	optHistoryEnabled      *atomic2.Bool
 	optMaxStmtCount        *atomic2.Uint32
 	optRefreshInterval     *atomic2.Int64
 	optHistorySize         *atomic2.Int32
@@ -293,6 +294,7 @@ func newStmtSummaryByDigestMap() *stmtSummaryByDigestMap {
 		optMaxStmtCount:        atomic2.NewUint32(uint32(maxStmtCount)),
 		optEnabled:             atomic2.NewBool(true),
 		optEnableInternalQuery: atomic2.NewBool(false),
+		optHistoryEnabled:      atomic2.NewBool(true),
 		optRefreshInterval:     atomic2.NewInt64(1800),
 		optHistorySize:         atomic2.NewInt32(24),
 		optMaxSQLLength:        atomic2.NewInt32(4096),
@@ -322,7 +324,10 @@ func (ssMap *stmtSummaryByDigestMap) AddStatement(sei *StmtExecInfo) {
 	})
 
 	intervalSeconds := ssMap.refreshInterval()
-	historySize := ssMap.historySize()
+	historySize := 0
+	if ssMap.historyEnabled() {
+		historySize = ssMap.historySize()
+	}
 
 	key := &stmtSummaryByDigestKey{
 		schemaName:        sei.SchemaName,
@@ -395,6 +400,22 @@ func (ssMap *stmtSummaryByDigestMap) clearInternal() {
 		if summary.(*stmtSummaryByDigest).isInternal {
 			ssMap.summaryMap.Delete(key)
 		}
+	}
+}
+
+// clearHistory removes history for all statement summaries, leaving only the current interval.
+func (ssMap *stmtSummaryByDigestMap) clearHistory() {
+	ssMap.Lock()
+	values := ssMap.summaryMap.Values()
+	ssMap.Unlock()
+
+	for _, value := range values {
+		ssbd := value.(*stmtSummaryByDigest)
+		ssbd.Lock()
+		newHistory := list.New()
+		newHistory.PushFront(ssbd.history.Front().Value)
+		ssbd.history = newHistory
+		ssbd.Unlock()
 	}
 }
 
@@ -479,6 +500,21 @@ func (ssMap *stmtSummaryByDigestMap) SetEnabledInternalQuery(value bool) error {
 // EnabledInternal returns whether internal statement summary is enabled.
 func (ssMap *stmtSummaryByDigestMap) EnabledInternal() bool {
 	return ssMap.optEnableInternalQuery.Load()
+}
+
+// SetHistoryEnabled enables or disables maintaining the history of statement summary intervals.
+// When history is disabled, any existing history is cleared.
+func (ssMap *stmtSummaryByDigestMap) SetHistoryEnabled(value bool) error {
+	ssMap.optHistoryEnabled.Store(value)
+	if !value {
+		ssMap.clearHistory()
+	}
+	return nil
+}
+
+// historyEnabled returns whether the history of statement summary intervals is maintained.
+func (ssMap *stmtSummaryByDigestMap) historyEnabled() bool {
+	return ssMap.optHistoryEnabled.Load()
 }
 
 // SetRefreshInterval sets refreshing interval in ssMap.sysVars.

--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/slice",
         "//pkg/util/sqlescape",
         "//pkg/util/sqlexec",
+        "//pkg/util/stmtsummary",
         "@com_github_ngaut_pools//:pools",
         "@com_github_pingcap_errors//:errors",
         "@io_etcd_go_etcd_client_v3//:client",

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -335,7 +335,7 @@ func (w *worker) start() error {
 		return errors.New("etcd client required for workload repository")
 	}
 
-	stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(false)
+	_ = stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(false)
 	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	w.wg.RunWithRecover(w.startRepository(ctx), func(err any) {
@@ -354,7 +354,7 @@ func (w *worker) stop() {
 
 	w.cancel()
 	w.wg.Wait()
-	stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(true)
+	_ = stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(true)
 
 	if w.owner != nil {
 		w.owner.Close()

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"github.com/pingcap/tidb/pkg/util/stmtsummary"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
@@ -334,6 +335,7 @@ func (w *worker) start() error {
 		return errors.New("etcd client required for workload repository")
 	}
 
+	stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(false)
 	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	w.wg.RunWithRecover(w.startRepository(ctx), func(err any) {
@@ -352,6 +354,7 @@ func (w *worker) stop() {
 
 	w.cancel()
 	w.wg.Wait()
+	stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(true)
 
 	if w.owner != nil {
 		w.owner.Close()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #57147 

Problem Summary: When the workload repository is enabled, we only care about collecting cumulative metrics for SQL statements from the new `tidb_statements_stats` memory table, rather than from the interval-based statement summary tables. Since statement summary records are large, maintaining statement summary history adds unnecessary memory burden while the workload repository is active.

### What is changed and how it works?

* Add an option to enable/disable statement summary history that the repository worker controls by calling `SetHistoryEnabled()`.
* When statement summary history is disabled, any existing history is cleared.
* When we add statement execution info to a statement summary while history is disabled, pin the history size to 0.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
```
1. Started tidb-server.
2. Ran `set global tidb_stmt_summary_refresh_interval = 1;`.
3. For 5 seconds, repeatedly ran:
   `select summary_begin_time, summary_end_time, digest_text
      from statements_summary_history order by summary_end_time asc;`
4. Verified that a new row for each history interval was created.
5. Ran `set global tidb_workload_repository_dest = 'table';`.
6. Verified that only one row for that select query was in the statments_summary_history table.
7. Verified that that row was also in the statements_summary table, and a new interval was not created.
8. Repeated step 3, verifying that there was still only one row for that select query.
9. Ran `set global tidb_workload_repository_dest = 'off';`.
10. Repeated steps 3 and 4.
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```