### PR TITLE
expression: prevent building plan for `execute` statement with wrong type

### DIFF
--- a/pkg/executor/prepared_test.go
+++ b/pkg/executor/prepared_test.go
@@ -1172,3 +1172,24 @@ func TestPrepareProtocolWorkWithForeignKey(t *testing.T) {
 	// As schema version increased, the plan cache should be invalidated.
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
+
+func TestExecuteWithWrongType(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`set tidb_enable_prepared_plan_cache=1`)
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE t3 (c1 int, c2 decimal(32, 30))")
+
+	tk.MustExec(`prepare p1 from "update t3 set c1 = 2 where c2 in (?, ?)"`)
+	tk.MustExec(`set @i0 = 0.0, @i1 = 0.0`)
+	tk.MustExec(`execute p1 using @i0, @i1`)
+	tk.MustExec(`set @i0 = 0.0, @i1 = 'aa'`)
+	tk.MustExecToErr(`execute p1 using @i0, @i1`)
+
+	tk.MustExec(`prepare p2 from "update t3 set c1 = 2 where c2 in (?, ?)"`)
+	tk.MustExec(`set @i0 = 0.0, @i1 = 'aa'`)
+	tk.MustExecToErr(`execute p2 using @i0, @i1`)
+	tk.MustExec(`set @i0 = 0.0, @i1 = 0.0`)
+	tk.MustExec(`execute p2 using @i0, @i1`)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58053

Problem Summary:

### What changed and how does it work?

As mentioned in https://github.com/pingcap/tidb/issues/58053#issuecomment-2522362546, sometimes we can generate and cache some incorrect execution plans, such as those involving invalid type conversions. These erroneous plans may be pushed down to TiKV, and TiKV side can't handle them properly.

This PR serves as a workaround to mitigate this problem by preventing the generation of potentially wrong plans on the TiDB side.
- For `prepare` statement, the input args are `ConstStrict`, so this PR won't affect `prepare`.
- For `execute` statement whose args are `ConstOnlyInContext`, we try to evaluate it in advance to make sure we can get a correct plan. So the behavior is consistent with the result of directly executing these queries.
﻿
### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
