### PR TITLE
statistics: copy stats when to update it for avoiding data race

### DIFF
--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -660,6 +660,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		// Otherwise, it will trigger the sync/async load again, even if the column has not been analyzed.
 		if loadNeeded && !analyzed {
 			fakeCol := statistics.EmptyColumn(tblInfo.ID, tblInfo.PKIsHandle, colInfo)
+			statsTbl = statsTbl.Copy()
 			statsTbl.SetCol(col.ID, fakeCol)
 			statsHandle.UpdateStatsCache(statstypes.CacheUpdate{
 				Updated: []*statistics.Table{statsTbl},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58074 

close https://github.com/pingcap/tidb/issues/57958

Problem Summary:

### What changed and how does it work?

I find this data race. we forget to copy stats when to update it.
```
==================
WARNING: DATA RACE
Write at 0x00c0114072c0 by goroutine 830:
  runtime.mapassign_fast64()
      /usr/local/go/src/runtime/map_fast64.go:113 +0x0
  github.com/pingcap/tidb/pkg/statistics.(*HistColl).SetCol()
      /tidb/pkg/statistics/table.go:294 +0x372
  github.com/pingcap/tidb/pkg/statistics/handle/storage.loadNeededColumnHistograms()
      /tidb/pkg/statistics/handle/storage/read.go:663 +0x32d
  github.com/pingcap/tidb/pkg/statistics/handle/storage.LoadNeededHistograms()
      /tidb/pkg/statistics/handle/storage/read.go:598 +0x15d
  github.com/pingcap/tidb/pkg/statistics/handle/storage.(*statsReadWriter).LoadNeededHistograms.func1()
      /tidb/pkg/statistics/handle/storage/stats_read_writer.go:265 +0xbc
  github.com/pingcap/tidb/pkg/statistics/handle/util.WrapTxn()
      /tidb/pkg/statistics/handle/util/util.go:201 +0x125
  github.com/pingcap/tidb/pkg/statistics/handle/util.CallWithSCtx()
      /tidb/pkg/statistics/handle/util/util.go:99 +0x324
  github.com/pingcap/tidb/pkg/statistics/handle/storage.(*statsReadWriter).LoadNeededHistograms()
      /tidb/pkg/statistics/handle/storage/stats_read_writer.go:263 +0x119
  github.com/pingcap/tidb/pkg/domain.(*Domain).loadStatsWorker()
      /tidb/pkg/domain/domain.go:2568 +0x667
  github.com/pingcap/tidb/pkg/domain.(*Domain).loadStatsWorker-fm()
      <autogenerated>:1 +0x33
  github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run.func1()
      /tidb/pkg/util/wait_group_wrapper.go:99 +0xba

Previous read at 0x00c0114072c0 by goroutine 63116:
  runtime.mapiterinit()
      /usr/local/go/src/runtime/map.go:877 +0x0
  github.com/pingcap/tidb/pkg/statistics.(*Table).IsInitialized()
      /tidb/pkg/statistics/table.go:884 +0xaef
  github.com/pingcap/tidb/pkg/planner/core.getStatsTable()
      /tidb/pkg/planner/core/logical_plan_builder.go:4126 +0xa99
  github.com/pingcap/tidb/pkg/planner/core.loadTableStats()
      /tidb/pkg/planner/core/stats.go:726 +0x116
  github.com/pingcap/tidb/pkg/planner/core.(*PhysicalIndexReader).LoadTableStats()
      /tidb/pkg/planner/core/physical_plans.go:451 +0xd6
  github.com/pingcap/tidb/pkg/executor.buildIndexUsageReporter()
      /tidb/pkg/executor/builder.go:4281 +0x124
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).buildIndexUsageReporter()
      /tidb/pkg/executor/builder.go:4293 +0x507
  github.com/pingcap/tidb/pkg/executor.buildNoRangeIndexReader()
      /tidb/pkg/executor/builder.go:3913 +0x6fd
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).buildIndexReader()
      /tidb/pkg/executor/builder.go:3950 +0x16b
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).build()
      /tidb/pkg/executor/builder.go:294 +0x3c8
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).buildProjection()
      /tidb/pkg/executor/builder.go:2085 +0xb4
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).build()
      /tidb/pkg/executor/builder.go:278 +0x11c8
  github.com/pingcap/tidb/pkg/executor.(*ExecStmt).buildExecutor()
      /tidb/pkg/executor/adapter.go:1230 +0x3be
  github.com/pingcap/tidb/pkg/executor.(*ExecStmt).Exec()
      /tidb/pkg/executor/adapter.go:571 +0x104c
  github.com/pingcap/tidb/pkg/session.runStmt()
      /tidb/pkg/session/session.go:2289 +0x56b
  github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt()
      /tidb/pkg/session/session.go:2151 +0x1c09
  github.com/pingcap/tidb/pkg/server.(*TiDBContext).ExecuteStmt()
      /tidb/pkg/server/driver_tidb.go:291 +0xee
  github.com/pingcap/tidb/pkg/server.(*clientConn).executePreparedStmtAndWriteResult()
      /tidb/pkg/server/conn_stmt.go:306 +0x82e
  github.com/pingcap/tidb/pkg/server.(*clientConn).executePlanCacheStmt()
      /tidb/pkg/server/conn_stmt.go:234 +0x229
  github.com/pingcap/tidb/pkg/server.(*clientConn).handleStmtExecute()
      /tidb/pkg/server/conn_stmt.go:225 +0xfd3
  github.com/pingcap/tidb/pkg/server.(*clientConn).dispatch()
      /tidb/pkg/server/conn.go:1405 +0x1bf4
  github.com/pingcap/tidb/pkg/server.(*clientConn).Run()
      /tidb/pkg/server/conn.go:1147 +0x804
  github.com/pingcap/tidb/pkg/server.(*Server).onConn()
      /tidb/pkg/server/server.go:741 +0x1564
  github.com/pingcap/tidb/pkg/server.(*Server).startNetworkListener.gowrap1()
      /tidb/pkg/server/server.go:560 +0x44

Goroutine 830 (running) created at:
  github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run()
      /tidb/pkg/util/wait_group_wrapper.go:94 +0x145
  github.com/pingcap/tidb/pkg/domain.(*Domain).UpdateTableStatsLoop()
      /tidb/pkg/domain/domain.go:2390 +0x432
  github.com/pingcap/tidb/pkg/domain.(*Domain).LoadAndUpdateStatsLoop()
      /tidb/pkg/domain/domain.go:2359 +0x75
  github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl()
      /tidb/pkg/session/session.go:3626 +0x1b57
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func217()
      /tidb/pkg/sessionctx/variable/sysvar.go:1148 +0x52
  github.com/pingcap/tidb/pkg/sessionctx/variable.(*SysVar).ValidateWithRelaxedValidation()
      /tidb/pkg/sessionctx/variable/variable.go:377 +0x242
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:142 +0x9c4
  github.com/pingcap/tidb/pkg/sessionctx/variable.parseSchemaCacheSize()
      /tidb/pkg/sessionctx/variable/varsutil.go:638 +0x17c
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func620()
      /tidb/pkg/sessionctx/variable/sysvar.go:3318 +0x67
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func619()
      /tidb/pkg/sessionctx/variable/sysvar.go:3310 +0x52
  github.com/pingcap/tidb/pkg/sessionctx/variable.(*SysVar).ValidateWithRelaxedValidation()
      /tidb/pkg/sessionctx/variable/variable.go:377 +0x242
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:142 +0x9c4
  fmt.Sscanf()
      /usr/local/go/src/fmt/scan.go:114 +0x18e
  github.com/pingcap/tidb/pkg/sessionctx/variable.parseByteSize()
      /tidb/pkg/sessionctx/variable/varsutil.go:406 +0x1d
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func261()
      /tidb/pkg/sessionctx/variable/sysvar.go:1419 +0x44
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/domain.(*Domain).LoadSysVarCacheLoop()
      /tidb/pkg/domain/domain.go:1923 +0x93
  github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl()
      /tidb/pkg/session/session.go:3537 +0x847
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func218()
      /tidb/pkg/sessionctx/variable/sysvar.go:1155 +0x56
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func217()
      /tidb/pkg/sessionctx/variable/sysvar.go:1148 +0x52
  github.com/pingcap/tidb/pkg/sessionctx/variable.(*SysVar).ValidateWithRelaxedValidation()
      /tidb/pkg/sessionctx/variable/variable.go:377 +0x242
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:142 +0x9c4
  fmt.Sscanf()
      /usr/local/go/src/fmt/scan.go:114 +0x18e
  github.com/pingcap/tidb/pkg/sessionctx/variable.parseByteSize()
      /tidb/pkg/sessionctx/variable/varsutil.go:406 +0x1d
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func261()
      /tidb/pkg/sessionctx/variable/sysvar.go:1419 +0x44
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCacheIfNeeded()
      /tidb/pkg/domain/sysvar_cache.go:50 +0x155
  github.com/pingcap/tidb/pkg/domain.(*Domain).GetSessionCache()
      /tidb/pkg/domain/sysvar_cache.go:61 +0x4a
  github.com/pingcap/tidb/pkg/session.(*session).loadCommonGlobalVariablesIfNeeded()
      /tidb/pkg/session/session.go:3945 +0x2ae
  github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt()
      /tidb/pkg/session/session.go:2013 +0x17a
  github.com/pingcap/tidb/pkg/session.(*session).ExecuteInternal()
      /tidb/pkg/session/session.go:1524 +0x3af
  github.com/pingcap/tidb/pkg/domain.(*Domain).LoadPrivilegeLoop()
      /tidb/pkg/domain/domain.go:1863 +0x102
  github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl()
      /tidb/pkg/session/session.go:3530 +0x7f4
  github.com/pingcap/tidb/pkg/session.BootstrapSession()
      /tidb/pkg/session/session.go:3406 +0x2f9
  main.createStoreDDLOwnerMgrAndDomain()
      /tidb/cmd/tidb-server/main.go:418 +0x2d5
  main.main()
      /tidb/cmd/tidb-server/main.go:321 +0x996

Goroutine 63116 (running) created at:
  github.com/pingcap/tidb/pkg/server.(*Server).startNetworkListener()
      /tidb/pkg/server/server.go:560 +0x84a
  github.com/pingcap/tidb/pkg/server.(*Server).Run.gowrap1()
      /tidb/pkg/server/server.go:460 +0x64
==================
==================
WARNING: DATA RACE
Write at 0x00c010b5c5a0 by goroutine 830:
  runtime.mapassign_fast64()
      /usr/local/go/src/runtime/map_fast64.go:113 +0x0
  github.com/pingcap/tidb/pkg/statistics.(*HistColl).SetCol()
      /tidb/pkg/statistics/table.go:294 +0x372
  github.com/pingcap/tidb/pkg/statistics/handle/storage.loadNeededColumnHistograms()
      /tidb/pkg/statistics/handle/storage/read.go:663 +0x32d
  github.com/pingcap/tidb/pkg/statistics/handle/storage.LoadNeededHistograms()
      /tidb/pkg/statistics/handle/storage/read.go:598 +0x15d
  github.com/pingcap/tidb/pkg/statistics/handle/storage.(*statsReadWriter).LoadNeededHistograms.func1()
      /tidb/pkg/statistics/handle/storage/stats_read_writer.go:265 +0xbc
  github.com/pingcap/tidb/pkg/statistics/handle/util.WrapTxn()
      /tidb/pkg/statistics/handle/util/util.go:201 +0x125
  github.com/pingcap/tidb/pkg/statistics/handle/util.CallWithSCtx()
      /tidb/pkg/statistics/handle/util/util.go:99 +0x324
  github.com/pingcap/tidb/pkg/statistics/handle/storage.(*statsReadWriter).LoadNeededHistograms()
      /tidb/pkg/statistics/handle/storage/stats_read_writer.go:263 +0x119
  github.com/pingcap/tidb/pkg/domain.(*Domain).loadStatsWorker()
      /tidb/pkg/domain/domain.go:2568 +0x667
  github.com/pingcap/tidb/pkg/domain.(*Domain).loadStatsWorker-fm()
      <autogenerated>:1 +0x33
  github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run.func1()
      /tidb/pkg/util/wait_group_wrapper.go:99 +0xba

Previous read at 0x00c010b5c5a0 by goroutine 63123:
  runtime.mapiterinit()
      /usr/local/go/src/runtime/map.go:877 +0x0
  github.com/pingcap/tidb/pkg/statistics.(*Table).IsInitialized()
      /tidb/pkg/statistics/table.go:884 +0xaef
  github.com/pingcap/tidb/pkg/planner/core.getStatsTable()
      /tidb/pkg/planner/core/logical_plan_builder.go:4126 +0xa99
  github.com/pingcap/tidb/pkg/planner/core.loadTableStats()
      /tidb/pkg/planner/core/stats.go:726 +0x116
  github.com/pingcap/tidb/pkg/planner/core.(*PointGetPlan).LoadTableStats()
      /tidb/pkg/planner/core/point_get_plan.go:340 +0x204
  github.com/pingcap/tidb/pkg/executor.buildIndexUsageReporter()
      /tidb/pkg/executor/builder.go:4281 +0x124
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).buildIndexUsageReporter()
      /tidb/pkg/executor/builder.go:4293 +0x50a
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).buildPointGet()
      /tidb/pkg/executor/point_get.go:76 +0x5d3
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).build()
      /tidb/pkg/executor/builder.go:196 +0x1b68
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).buildUpdate()
      /tidb/pkg/executor/builder.go:2707 +0x404
  github.com/pingcap/tidb/pkg/executor.(*executorBuilder).build()
      /tidb/pkg/executor/builder.go:258 +0x1d68
  github.com/pingcap/tidb/pkg/executor.(*ExecStmt).buildExecutor()
      /tidb/pkg/executor/adapter.go:1230 +0x3be
  github.com/pingcap/tidb/pkg/executor.(*ExecStmt).Exec()
      /tidb/pkg/executor/adapter.go:571 +0x104c
  github.com/pingcap/tidb/pkg/session.runStmt()
      /tidb/pkg/session/session.go:2289 +0x56b
  github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt()
      /tidb/pkg/session/session.go:2151 +0x1c09
  github.com/pingcap/tidb/pkg/server.(*TiDBContext).ExecuteStmt()
      /tidb/pkg/server/driver_tidb.go:291 +0xee
  github.com/pingcap/tidb/pkg/server.(*clientConn).executePreparedStmtAndWriteResult()
      /tidb/pkg/server/conn_stmt.go:306 +0x82e
  github.com/pingcap/tidb/pkg/server.(*clientConn).executePlanCacheStmt()
      /tidb/pkg/server/conn_stmt.go:234 +0x229
  github.com/pingcap/tidb/pkg/server.(*clientConn).handleStmtExecute()
      /tidb/pkg/server/conn_stmt.go:225 +0xfd3
  github.com/pingcap/tidb/pkg/server.(*clientConn).dispatch()
      /tidb/pkg/server/conn.go:1405 +0x1bf4
  github.com/pingcap/tidb/pkg/server.(*clientConn).Run()
      /tidb/pkg/server/conn.go:1147 +0x804
  github.com/pingcap/tidb/pkg/server.(*Server).onConn()
      /tidb/pkg/server/server.go:741 +0x1564
  github.com/pingcap/tidb/pkg/server.(*Server).startNetworkListener.gowrap1()
      /tidb/pkg/server/server.go:560 +0x44

Goroutine 830 (running) created at:
  github.com/pingcap/tidb/pkg/util.(*WaitGroupEnhancedWrapper).Run()
      /tidb/pkg/util/wait_group_wrapper.go:94 +0x145
  github.com/pingcap/tidb/pkg/domain.(*Domain).UpdateTableStatsLoop()
      /tidb/pkg/domain/domain.go:2390 +0x432
  github.com/pingcap/tidb/pkg/domain.(*Domain).LoadAndUpdateStatsLoop()
      /tidb/pkg/domain/domain.go:2359 +0x75
  github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl()
      /tidb/pkg/session/session.go:3626 +0x1b57
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func217()
      /tidb/pkg/sessionctx/variable/sysvar.go:1148 +0x52
  github.com/pingcap/tidb/pkg/sessionctx/variable.(*SysVar).ValidateWithRelaxedValidation()
      /tidb/pkg/sessionctx/variable/variable.go:377 +0x242
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:142 +0x9c4
  github.com/pingcap/tidb/pkg/sessionctx/variable.parseSchemaCacheSize()
      /tidb/pkg/sessionctx/variable/varsutil.go:638 +0x17c
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func620()
      /tidb/pkg/sessionctx/variable/sysvar.go:3318 +0x67
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func619()
      /tidb/pkg/sessionctx/variable/sysvar.go:3310 +0x52
  github.com/pingcap/tidb/pkg/sessionctx/variable.(*SysVar).ValidateWithRelaxedValidation()
      /tidb/pkg/sessionctx/variable/variable.go:377 +0x242
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:142 +0x9c4
  fmt.Sscanf()
      /usr/local/go/src/fmt/scan.go:114 +0x18e
  github.com/pingcap/tidb/pkg/sessionctx/variable.parseByteSize()
      /tidb/pkg/sessionctx/variable/varsutil.go:406 +0x1d
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func261()
      /tidb/pkg/sessionctx/variable/sysvar.go:1419 +0x44
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/domain.(*Domain).LoadSysVarCacheLoop()
      /tidb/pkg/domain/domain.go:1923 +0x93
  github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl()
      /tidb/pkg/session/session.go:3537 +0x847
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func218()
      /tidb/pkg/sessionctx/variable/sysvar.go:1155 +0x56
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func217()
      /tidb/pkg/sessionctx/variable/sysvar.go:1148 +0x52
  github.com/pingcap/tidb/pkg/sessionctx/variable.(*SysVar).ValidateWithRelaxedValidation()
      /tidb/pkg/sessionctx/variable/variable.go:377 +0x242
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:142 +0x9c4
  fmt.Sscanf()
      /usr/local/go/src/fmt/scan.go:114 +0x18e
  github.com/pingcap/tidb/pkg/sessionctx/variable.parseByteSize()
      /tidb/pkg/sessionctx/variable/varsutil.go:406 +0x1d
  github.com/pingcap/tidb/pkg/sessionctx/variable.init.func261()
      /tidb/pkg/sessionctx/variable/sysvar.go:1419 +0x44
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCache()
      /tidb/pkg/domain/sysvar_cache.go:143 +0xa34
  github.com/pingcap/tidb/pkg/domain.(*Domain).rebuildSysVarCacheIfNeeded()
      /tidb/pkg/domain/sysvar_cache.go:50 +0x155
  github.com/pingcap/tidb/pkg/domain.(*Domain).GetSessionCache()
      /tidb/pkg/domain/sysvar_cache.go:61 +0x4a
  github.com/pingcap/tidb/pkg/session.(*session).loadCommonGlobalVariablesIfNeeded()
      /tidb/pkg/session/session.go:3945 +0x2ae
  github.com/pingcap/tidb/pkg/session.(*session).ExecuteStmt()
      /tidb/pkg/session/session.go:2013 +0x17a
  github.com/pingcap/tidb/pkg/session.(*session).ExecuteInternal()
      /tidb/pkg/session/session.go:1524 +0x3af
  github.com/pingcap/tidb/pkg/domain.(*Domain).LoadPrivilegeLoop()
      /tidb/pkg/domain/domain.go:1863 +0x102
  github.com/pingcap/tidb/pkg/session.bootstrapSessionImpl()
      /tidb/pkg/session/session.go:3530 +0x7f4
  github.com/pingcap/tidb/pkg/session.BootstrapSession()
      /tidb/pkg/session/session.go:3406 +0x2f9
  main.createStoreDDLOwnerMgrAndDomain()
      /tidb/cmd/tidb-server/main.go:418 +0x2d5
  main.main()
      /tidb/cmd/tidb-server/main.go:321 +0x996

Goroutine 63123 (running) created at:
  github.com/pingcap/tidb/pkg/server.(*Server).startNetworkListener()
      /tidb/pkg/server/server.go:560 +0x84a
  github.com/pingcap/tidb/pkg/server.(*Server).Run.gowrap1()
      /tidb/pkg/server/server.go:460 +0x64
==================
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

it use this PR to run tpcc with race mod. it cannot raise the data race。

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
