### PR TITLE
lightning: allow long dbname printed in 1 line for error summary

### DIFF
--- a/pkg/lightning/errormanager/errormanager.go
+++ b/pkg/lightning/errormanager/errormanager.go
@@ -1107,10 +1107,10 @@ func (em *ErrorManager) Output() string {
 	t := table.NewWriter()
 	t.AppendHeader(table.Row{"#", "Error Type", "Error Count", "Error Data Table"})
 	t.SetColumnConfigs([]table.ColumnConfig{
-		{Name: "#", WidthMax: 6},
-		{Name: "Error Type", WidthMax: 20},
-		{Name: "Error Count", WidthMax: 12},
-		{Name: "Error Data Table", WidthMax: 42},
+		{Name: "#"},
+		{Name: "Error Type"},
+		{Name: "Error Count"},
+		{Name: "Error Data Table"},
 	})
 	t.SetRowPainter(func(table.Row) text.Colors {
 		return text.Colors{text.FgRed}

--- a/pkg/lightning/errormanager/errormanager_test.go
+++ b/pkg/lightning/errormanager/errormanager_test.go
@@ -707,4 +707,18 @@ func TestErrorMgrErrorOutput(t *testing.T) {
 		"|\x1b[31m 4 \x1b[0m|\x1b[31m Unique Key Conflict \x1b[0m|\x1b[31m         100 \x1b[0m|\x1b[31m `error_info`.`conflict_view`   \x1b[0m|\n" +
 		"+---+---------------------+-------------+--------------------------------+\n"
 	require.Equal(t, expected, output)
+
+	em.schema = "long_long_long_long_long_long_long_long_dbname"
+	output = em.Output()
+	expected = "\n" +
+		"Import Data Error Summary: \n" +
+		"+---+---------------------+-------------+--------------------------------------------------------------------+\n" +
+		"| # | ERROR TYPE          | ERROR COUNT | ERROR DATA TABLE                                                   |\n" +
+		"+---+---------------------+-------------+--------------------------------------------------------------------+\n" +
+		"|\x1b[31m 1 \x1b[0m|\x1b[31m Data Type           \x1b[0m|\x1b[31m         100 \x1b[0m|\x1b[31m `long_long_long_long_long_long_long_long_dbname`.`type_error_v2`   \x1b[0m|\n" +
+		"|\x1b[31m 2 \x1b[0m|\x1b[31m Data Syntax         \x1b[0m|\x1b[31m         100 \x1b[0m|\x1b[31m `long_long_long_long_long_long_long_long_dbname`.`syntax_error_v2` \x1b[0m|\n" +
+		"|\x1b[31m 3 \x1b[0m|\x1b[31m Charset Error       \x1b[0m|\x1b[31m         100 \x1b[0m|\x1b[31m                                                                    \x1b[0m|\n" +
+		"|\x1b[31m 4 \x1b[0m|\x1b[31m Unique Key Conflict \x1b[0m|\x1b[31m         100 \x1b[0m|\x1b[31m `long_long_long_long_long_long_long_long_dbname`.`conflict_view`   \x1b[0m|\n" +
+		"+---+---------------------+-------------+--------------------------------------------------------------------+\n"
+	require.Equal(t, expected, output)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58085

Problem Summary:

### What changed and how does it work?

the database name is configurated by user, and it can be up to 64 bytes. Displaying the database name and table name in one line makes user easy to copy and paste.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
