### PR TITLE
statistics: fix flaky test TestSyncLoadOnObjectWhichCanNotFoundInStorage

### DIFF
--- a/pkg/statistics/handle/syncload/stats_syncload_test.go
+++ b/pkg/statistics/handle/syncload/stats_syncload_test.go
@@ -448,8 +448,11 @@ func TestSyncLoadOnObjectWhichCanNotFoundInStorage(t *testing.T) {
 
 	// Try sync load.
 	tk.MustExec("select * from t where a >= 1 and b = 2 and c = 3 and d = 4")
-	statsTbl, ok = h.Get(tblInfo.ID)
-	require.True(t, ok)
+	require.Eventually(t, func() bool {
+		statsTbl, ok = h.Get(tblInfo.ID)
+		require.True(t, ok)
+		return statsTbl.ColNum() == 3
+	}, 5*time.Second, 100*time.Millisecond)
 	require.True(t, statsTbl.GetCol(tblInfo.Columns[0].ID).IsFullLoad())
 	require.True(t, statsTbl.GetCol(tblInfo.Columns[1].ID).IsFullLoad())
 	require.True(t, statsTbl.GetCol(tblInfo.Columns[3].ID).IsFullLoad())
@@ -463,8 +466,11 @@ func TestSyncLoadOnObjectWhichCanNotFoundInStorage(t *testing.T) {
 	tk.MustExec("analyze table t columns a, b, c")
 	require.NoError(t, h.InitStatsLite(context.TODO()))
 	tk.MustExec("select * from t where a >= 1 and b = 2 and c = 3 and d = 4")
-	statsTbl, ok = h.Get(tblInfo.ID)
-	require.True(t, ok)
+	require.Eventually(t, func() bool {
+		statsTbl, ok = h.Get(tblInfo.ID)
+		require.True(t, ok)
+		return statsTbl.ColNum() == 4
+	}, 5*time.Second, 100*time.Millisecond)
 	// a, b, d's status is not changed.
 	require.True(t, statsTbl.GetCol(tblInfo.Columns[0].ID).IsFullLoad())
 	require.True(t, statsTbl.GetCol(tblInfo.Columns[1].ID).IsFullLoad())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58162

Problem Summary:

### What changed and how does it work?

sync load is running on the background. so we need to create the checkpoint which wait for the sync load's completing working. then we can check the result.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
