### PR TITLE
br: add chaos testing for advancer owner

### DIFF
--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -90,8 +90,8 @@ func (c *CheckpointAdvancer) HasTask() bool {
 	return c.task != nil
 }
 
-// HasSubscriber returns whether the advancer is associated with a subscriber.
-func (c *CheckpointAdvancer) HasSubscribion() bool {
+// HasSubscriptions returns whether the advancer is associated with a subscriber.
+func (c *CheckpointAdvancer) HasSubscriptions() bool {
 	c.subscriberMu.Lock()
 	defer c.subscriberMu.Unlock()
 
@@ -117,7 +117,7 @@ func newCheckpointWithTS(ts uint64) *checkpoint {
 	}
 }
 
-func NewCheckpointWithSpan(s spans.Valued) *checkpoint {
+func newCheckpointWithSpan(s spans.Valued) *checkpoint {
 	return &checkpoint{
 		StartKey:        s.Key.StartKey,
 		EndKey:          s.Key.EndKey,
@@ -268,11 +268,6 @@ func (c *CheckpointAdvancer) WithCheckpoints(f func(*spans.ValueSortedFull)) {
 	defer c.checkpointsMu.Unlock()
 
 	f(c.checkpoints)
-}
-
-// only used for test
-func (c *CheckpointAdvancer) NewCheckpoints(cps *spans.ValueSortedFull) {
-	c.checkpoints = cps
 }
 
 func (c *CheckpointAdvancer) fetchRegionHint(ctx context.Context, startKey []byte) string {
@@ -473,7 +468,7 @@ func (c *CheckpointAdvancer) onTaskEvent(ctx context.Context, e TaskEvent) error
 }
 
 func (c *CheckpointAdvancer) setCheckpoint(s spans.Valued) bool {
-	cp := NewCheckpointWithSpan(s)
+	cp := newCheckpointWithSpan(s)
 	if cp.TS < c.lastCheckpoint.TS {
 		log.Warn("failed to update global checkpoint: stale",
 			zap.Uint64("old", c.lastCheckpoint.TS), zap.Uint64("new", cp.TS))

--- a/br/pkg/streamhelper/advancer_test.go
+++ b/br/pkg/streamhelper/advancer_test.go
@@ -475,7 +475,7 @@ func TestRemoveTaskAndFlush(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/streamhelper/subscription-handler-loop"))
 	require.Eventually(t, func() bool {
-		return !adv.HasSubscribion()
+		return !adv.HasSubscriptions()
 	}, 10*time.Second, 100*time.Millisecond)
 }
 

--- a/br/pkg/streamhelper/config/advancer_conf.go
+++ b/br/pkg/streamhelper/config/advancer_conf.go
@@ -61,6 +61,9 @@ func DefineFlagsForCheckpointAdvancerConfig(f *pflag.FlagSet) {
 	// used for chaos testing
 	f.Duration(flagOwnershipCycleInterval, DefaultOwnershipCycleInterval,
 		"The interval that the owner will retire itself")
+
+	// mark hidden
+	_ = f.MarkHidden(flagOwnershipCycleInterval)
 }
 
 func Default() Config {

--- a/br/pkg/streamhelper/config/advancer_conf.go
+++ b/br/pkg/streamhelper/config/advancer_conf.go
@@ -11,18 +11,19 @@ import (
 const (
 	flagBackoffTime         = "backoff-time"
 	flagTickInterval        = "tick-interval"
-	flagFullScanDiffTick    = "full-scan-tick"
-	flagAdvancingByCache    = "advancing-by-cache"
 	flagTryAdvanceThreshold = "try-advance-threshold"
 	flagCheckPointLagLimit  = "check-point-lag-limit"
 
-	DefaultConsistencyCheckTick = 5
-	DefaultTryAdvanceThreshold  = 4 * time.Minute
-	DefaultCheckPointLagLimit   = 48 * time.Hour
-	DefaultBackOffTime          = 5 * time.Second
-	DefaultTickInterval         = 12 * time.Second
-	DefaultFullScanTick         = 4
-	DefaultAdvanceByCache       = true
+	// used for chaos testing
+	flagOwnerRetireInterval = "advance-owner-resign-interval"
+
+	DefaultTryAdvanceThreshold = 4 * time.Minute
+	DefaultCheckPointLagLimit  = 48 * time.Hour
+	DefaultBackOffTime         = 5 * time.Second
+	DefaultTickInterval        = 12 * time.Second
+
+	// used for chaos testing, default to disable
+	DefaultAdvancerOwnerRetireInterval = 0
 )
 
 var (
@@ -38,6 +39,11 @@ type Config struct {
 	TryAdvanceThreshold time.Duration `toml:"try-advance-threshold" json:"try-advance-threshold"`
 	// The maximum lag could be tolerated for the checkpoint lag.
 	CheckPointLagLimit time.Duration `toml:"check-point-lag-limit" json:"check-point-lag-limit"`
+
+	// Following configs are used in chaos testings, better not to enable in prod
+	//
+	// used to periodically retire advancer owner for chaos testing
+	AdvancerOwnerRetireInterval time.Duration `toml:"advancer-owner-retire-interval" json:"advancer-owner-retire-interval"`
 }
 
 func DefineFlagsForCheckpointAdvancerConfig(f *pflag.FlagSet) {
@@ -49,6 +55,10 @@ func DefineFlagsForCheckpointAdvancerConfig(f *pflag.FlagSet) {
 		"If the checkpoint lag is greater than how long, we would try to poll TiKV for checkpoints.")
 	f.Duration(flagCheckPointLagLimit, DefaultCheckPointLagLimit,
 		"The maximum lag could be tolerated for the checkpoint lag.")
+
+	// used for chaos testing
+	f.Duration(flagOwnerRetireInterval, DefaultAdvancerOwnerRetireInterval,
+		"The interval that the owner will retire itself")
 }
 
 func Default() Config {

--- a/br/pkg/streamhelper/daemon/owner_daemon.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon.go
@@ -24,20 +24,14 @@ type OwnerDaemon struct {
 
 	// When not `nil`, implies the daemon is running.
 	cancel context.CancelFunc
-
-	// leader retire internal, used for chaos testing, suggest not to enable in prod
-	// default to 0 to disable
-	retireInterval time.Duration
-	ownerStartTime time.Time
 }
 
 // New creates a new owner daemon.
-func New(daemon Interface, manager owner.Manager, tickInterval time.Duration, retireInternal time.Duration) *OwnerDaemon {
+func New(daemon Interface, manager owner.Manager, tickInterval time.Duration) *OwnerDaemon {
 	return &OwnerDaemon{
-		daemon:         daemon,
-		manager:        manager,
-		tickInterval:   tickInterval,
-		retireInterval: retireInternal,
+		daemon:       daemon,
+		manager:      manager,
+		tickInterval: tickInterval,
 	}
 }
 
@@ -62,15 +56,11 @@ func (od *OwnerDaemon) ownerTick(ctx context.Context) {
 		log.Info("daemon became owner", zap.String("id", od.manager.ID()), zap.String("daemon-id", od.daemon.Name()))
 		// Note: maybe save the context so we can cancel the tick when we are not owner?
 		od.daemon.OnBecomeOwner(cx)
-		od.ownerStartTime = time.Now()
 	}
 
 	// Tick anyway.
 	if err := od.daemon.OnTick(ctx); err != nil {
 		log.Warn("failed on tick", logutil.ShortError(err))
-	}
-	if od.retireInterval != 0 && time.Now().Sub(od.ownerStartTime) > od.retireInterval {
-		od.manager.RetireOwner()
 	}
 }
 
@@ -111,4 +101,12 @@ func (od *OwnerDaemon) Begin(ctx context.Context) (func(), error) {
 		}
 	}
 	return loop, nil
+}
+
+func (od *OwnerDaemon) ForceToBeOwner(ctx context.Context) error {
+	return od.manager.ForceToBeOwner(ctx)
+}
+
+func (od *OwnerDaemon) RetireIfOwner() {
+	od.manager.RetireOwner()
 }

--- a/br/pkg/streamhelper/daemon/owner_daemon_test.go
+++ b/br/pkg/streamhelper/daemon/owner_daemon_test.go
@@ -137,7 +137,7 @@ func TestDaemon(t *testing.T) {
 	req := require.New(t)
 	app := newTestApp(t)
 	ow := owner.NewMockManager(ctx, "owner_daemon_test", nil, "owner_key")
-	d := daemon.New(app, ow, 100*time.Millisecond)
+	d := daemon.New(app, ow, 100*time.Millisecond, 0)
 
 	app.AssertService(req, false)
 	f, err := d.Begin(ctx)
@@ -149,10 +149,44 @@ func TestDaemon(t *testing.T) {
 	ow.RetireOwner()
 	req.False(ow.IsOwner())
 	app.AssertNotRunning(1 * time.Second)
-	ow.CampaignOwner()
 	req.Eventually(func() bool {
 		return ow.IsOwner()
 	}, 1*time.Second, 100*time.Millisecond)
 	app.AssertStart(1 * time.Second)
 	app.AssertTick(1 * time.Second)
+
+	// make sure chaos did not kick in so never retires
+	req.Neverf(func() bool {
+		return !ow.IsOwner()
+	}, 5*time.Second, 100*time.Millisecond, "should never retire")
+}
+
+func TestDaemonWithChaos(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := require.New(t)
+	app := newTestApp(t)
+	ow := owner.NewMockManager(ctx, "owner_daemon_test", nil, "owner_key")
+	d := daemon.New(app, ow, 100*time.Millisecond, 2*time.Second)
+
+	app.AssertService(req, false)
+	f, err := d.Begin(ctx)
+	req.NoError(err)
+	app.AssertService(req, true)
+	go f()
+
+	// wait for it to become owner
+	req.Eventually(func() bool {
+		return ow.IsOwner()
+	}, 1*time.Second, 100*time.Millisecond)
+
+	// wait for chaos test to kick in to auto retire
+	req.Eventually(func() bool {
+		return !ow.IsOwner()
+	}, 3*time.Second, 500*time.Millisecond)
+
+	// sanity check it will try to become leader in background again
+	req.Eventually(func() bool {
+		return ow.IsOwner()
+	}, 2*time.Second, 500*time.Millisecond)
 }

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -948,19 +948,18 @@ func RunStreamAdvancer(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 		if err != nil {
 			return err
 		}
-		log.Info("this advancerd forced to be the owner")
-		go runOwnershipCycle(ctx, advancerd, cfg.AdvancerCfg.OwnershipCycleInterval)
+		log.Info("command line advancer forced to be the owner")
+		go runOwnershipCycle(ctx, advancerd, cfg.AdvancerCfg.OwnershipCycleInterval, true)
 	}
 	loop()
 	return nil
 }
 
 // runOwnershipCycle handles the periodic cycling of ownership for the advancer
-func runOwnershipCycle(ctx context.Context, advancerd *daemon.OwnerDaemon, cycleDuration time.Duration) {
+func runOwnershipCycle(ctx context.Context, advancerd *daemon.OwnerDaemon, cycleDuration time.Duration, isOwner bool) {
 	ticker := time.NewTicker(cycleDuration)
 	defer ticker.Stop()
 
-	isOwner := false
 	for {
 		select {
 		case <-ctx.Done():
@@ -969,15 +968,15 @@ func runOwnershipCycle(ctx context.Context, advancerd *daemon.OwnerDaemon, cycle
 			if !isOwner {
 				// try to become owner
 				if err := advancerd.ForceToBeOwner(ctx); err != nil {
-					log.Error("failed to force ownership", zap.Error(err))
+					log.Error("command line advancer failed to force ownership", zap.Error(err))
 					continue
 				}
-				log.Info("advancer forced to be the owner")
+				log.Info("command line advancer forced to be the owner")
 				isOwner = true
 			} else {
 				// retire from being owner
 				advancerd.RetireIfOwner()
-				log.Info("advancer retired from being owner")
+				log.Info("command line advancer retired from being owner")
 				isOwner = false
 			}
 		}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -936,7 +936,7 @@ func RunStreamAdvancer(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	defer func() {
 		ownerMgr.Close()
 	}()
-	advancerd := daemon.New(advancer, ownerMgr, cfg.AdvancerCfg.TickDuration)
+	advancerd := daemon.New(advancer, ownerMgr, cfg.AdvancerCfg.TickDuration, cfg.AdvancerCfg.AdvancerOwnerRetireInterval)
 	loop, err := advancerd.Begin(ctx)
 	if err != nil {
 		return err

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/config",
     visibility = ["//visibility:public"],
     deps = [
-        "//br/pkg/streamhelper/config",
         "//pkg/parser/terror",
         "//pkg/util/logutil",
         "//pkg/util/tiflashcompute",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
 	zaplog "github.com/pingcap/log"
-	logbackupconf "github.com/pingcap/tidb/br/pkg/streamhelper/config"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/tiflashcompute"
@@ -456,13 +455,6 @@ func (b *AtomicBool) UnmarshalText(text []byte) error {
 		return errors.New("Invalid value for bool type: " + str)
 	}
 	return nil
-}
-
-// LogBackup is the config for log backup service.
-// For now, it includes the embed advancer.
-type LogBackup struct {
-	Advancer logbackupconf.Config `toml:"advancer" json:"advancer"`
-	Enabled  bool                 `toml:"enabled" json:"enabled"`
 }
 
 // Log is the log section of config.

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1512,7 +1512,7 @@ func (do *Domain) Start(startMode ddl.StartMode) error {
 		}, "closestReplicaReadCheckLoop")
 	}
 
-	err = do.initLogBackupAdvancer(do.ctx, pdCli)
+	err = do.initLogBackup(do.ctx, pdCli)
 	if err != nil {
 		return err
 	}
@@ -1540,7 +1540,7 @@ func (do *Domain) SetOnClose(onClose func()) {
 	do.onClose = onClose
 }
 
-func (do *Domain) initLogBackupAdvancer(ctx context.Context, pdClient pd.Client) error {
+func (do *Domain) initLogBackup(ctx context.Context, pdClient pd.Client) error {
 	cfg := config.GetGlobalConfig()
 	if pdClient == nil || do.etcdClient == nil {
 		log.Warn("pd / etcd client not provided, won't begin Advancer.")

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1512,7 +1512,7 @@ func (do *Domain) Start(startMode ddl.StartMode) error {
 		}, "closestReplicaReadCheckLoop")
 	}
 
-	err = do.initLogBackup(do.ctx, pdCli)
+	err = do.initLogBackupAdvancer(do.ctx, pdCli)
 	if err != nil {
 		return err
 	}
@@ -1540,7 +1540,7 @@ func (do *Domain) SetOnClose(onClose func()) {
 	do.onClose = onClose
 }
 
-func (do *Domain) initLogBackup(ctx context.Context, pdClient pd.Client) error {
+func (do *Domain) initLogBackupAdvancer(ctx context.Context, pdClient pd.Client) error {
 	cfg := config.GetGlobalConfig()
 	if pdClient == nil || do.etcdClient == nil {
 		log.Warn("pd / etcd client not provided, won't begin Advancer.")
@@ -1557,7 +1557,7 @@ func (do *Domain) initLogBackup(ctx context.Context, pdClient pd.Client) error {
 	}
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	do.brOwnerMgr = streamhelper.OwnerManagerForLogBackup(ctx, do.etcdClient)
-	do.logBackupAdvancer = daemon.New(adv, do.brOwnerMgr, adv.Config().TickDuration, adv.Config().AdvancerOwnerRetireInterval)
+	do.logBackupAdvancer = daemon.New(adv, do.brOwnerMgr, adv.Config().TickDuration)
 	loop, err := do.logBackupAdvancer.Begin(ctx)
 	if err != nil {
 		return err

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1557,7 +1557,7 @@ func (do *Domain) initLogBackup(ctx context.Context, pdClient pd.Client) error {
 	}
 	adv := streamhelper.NewCheckpointAdvancer(env)
 	do.brOwnerMgr = streamhelper.OwnerManagerForLogBackup(ctx, do.etcdClient)
-	do.logBackupAdvancer = daemon.New(adv, do.brOwnerMgr, adv.Config().TickDuration)
+	do.logBackupAdvancer = daemon.New(adv, do.brOwnerMgr, adv.Config().TickDuration, adv.Config().AdvancerOwnerRetireInterval)
 	loop, err := do.logBackupAdvancer.Begin(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50458

Problem Summary:

### What changed and how does it work?
Add a cycle to force to be owner and retire when using `log advancer` cmd. In the test we can start this debugging command and it will do this cycle repeatedly until exits. It creates a chaos scenario for advancer testing. 
Also all the parameters in the advancer are exposed to the cmd already which is convenient. The advancer daemon running on TiDB domain will not be affected by any of these configs since they use default and cannot be configured.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
