### PR TITLE
executor: skip execution when build query for VIEW in I_S

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -1062,7 +1062,7 @@ func (e *hugeMemTableRetriever) dataForColumnsInTable(
 			// Build plan is not thread safe, there will be concurrency on sessionctx.
 			if err := runWithSystemSession(internalCtx, sctx, func(s sessionctx.Context) error {
 				is := sessiontxn.GetTxnManager(s).GetTxnInfoSchema()
-				planBuilder, _ := plannercore.NewPlanBuilder().Init(s.GetPlanCtx(), is, hint.NewQBHintHandler(nil))
+				planBuilder, _ := plannercore.NewPlanBuilder(plannercore.PlanBuilderOptNoExecution{}).Init(s.GetPlanCtx(), is, hint.NewQBHintHandler(nil))
 				var err error
 				viewLogicalPlan, err = planBuilder.BuildDataSourceFromView(ctx, schema, tbl, nil, nil)
 				return errors.Trace(err)

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -746,21 +746,23 @@ func TestShowColumnsWithSubQueryView(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	if tk.MustQuery("select @@tidb_schema_cache_size > 0").Equal(testkit.Rows("1")) {
-		// infoschema v2 requires network, so it cannot be tested this way.
-		t.Skip()
-	}
+	tk.MustExec("set @@global.tidb_schema_cache_size = 0;")
+	t.Cleanup(func() {
+		tk.MustExec("set @@global.tidb_schema_cache_size = default;")
+	})
 
 	tk.MustExec("CREATE TABLE added (`id` int(11), `name` text, `some_date` timestamp);")
 	tk.MustExec("CREATE TABLE incremental (`id` int(11), `name`text, `some_date` timestamp);")
 	tk.MustExec("create view temp_view as (select * from `added` where id > (select max(id) from `incremental`));")
 	// Show columns should not send coprocessor request to the storage.
-	require.NoError(t, failpoint.Enable("tikvclient/tikvStoreSendReqResult", `return("timeout")`))
+	testfailpoint.Enable(t, "tikvclient/tikvStoreSendReqResult", `return("timeout")`)
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/planner/core/BuildDataSourceFailed", "panic")
+
 	tk.MustQuery("show columns from temp_view;").Check(testkit.Rows(
 		"id int(11) YES  <nil> ",
 		"name text YES  <nil> ",
 		"some_date timestamp YES  <nil> "))
-	require.NoError(t, failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+	tk.MustQuery("select COLUMN_NAME from information_schema.columns where table_name = 'temp_view';").Check(testkit.Rows("id", "name", "some_date"))
 }
 
 // Code below are helper utilities for the test cases.

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5000,6 +5000,7 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName pmodel
 			terror.ErrorNotEqual(err, plannererrors.ErrNotSupportedYet) {
 			err = plannererrors.ErrViewInvalid.GenWithStackByArgs(dbName.O, tableInfo.Name.O)
 		}
+		failpoint.Inject("BuildDataSourceFailed", func() {})
 		return nil, err
 	}
 	pm := privilege.GetPrivilegeManager(b.ctx)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58184

Problem Summary:

### What changed and how does it work?

use `PlanBuilderOptNoExecution` to skip unnecessary execution. This should be the same behaviour with `SHOW COLUMNS`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I tested the new `PlanBuilderOptNoExecution` based on release-6.5 with the reproduce steps in issue. Before this PR (which is v6.5.11)

```
mysql> select count(1) from INFORMATION_SCHEMA.columns;
+----------+
| count(1) |
+----------+
|     4635 |
+----------+
1 row in set (0.66 sec)

mysql> trace select count(1) from INFORMATION_SCHEMA.columns;
+-----------------------------------------------------------------------------+-----------------+-------------+
| operation                                                                   | startTS         | duration    |
+-----------------------------------------------------------------------------+-----------------+-------------+
| trace                                                                       | 15:19:40.955394 | 28.741875ms |
|   ├─session.ExecuteStmt                                                     | 15:19:40.955411 | 897.25µs    |
|   │ ├─executor.Compile                                                      | 15:19:40.955448 | 293.25µs    |
|   │ └─session.runStmt                                                       | 15:19:40.956066 | 196.333µs   |
|   ├─*executor.HashAggExec.Next                                              | 15:19:40.956323 | 27.783083ms |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.956367 | 5.175042ms  |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.961575 | 4.542083ms  |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.966134 | 4.1615ms    |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.970309 | 3.901959ms  |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.974224 | 9.777625ms  |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.977166 | 832.333µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.977198 | 62.292µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.977220 | 26.75µs     |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.977293 | 594.75µs    |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.977314 | 558.375µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.977316 | 195.75µs    |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.977316 | 41.708µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.977316 | 41.708µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.977273 | 714.667µs   |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.977275 | 703.458µs   |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.977276 | 691.042µs   |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.977281 | 649.375µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.977943 | 16.5µs      |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.977973 | 542ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.977983 | 542ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.978578 | 494.875µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.978592 | 26.541µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.978601 | 10.916µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.978640 | 362.875µs   |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.978648 | 347.334µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.978648 | 103.959µs   |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.978648 | 20.291µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.978648 | 20.291µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.978625 | 442.625µs   |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.978626 | 431.334µs   |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.978627 | 421.458µs   |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.978629 | 394.625µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.979033 | 9.958µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.979053 | 417ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.979062 | 334ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.979615 | 519.291µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.979634 | 27.583µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.979645 | 11.459µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.979682 | 358.625µs   |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.979689 | 344.542µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.979690 | 108.958µs   |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.979690 | 19.458µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.979690 | 19.458µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.979669 | 460.375µs   |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.979670 | 451.083µs   |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.979670 | 441.5µs     |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.979673 | 389.833µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.980092 | 12.75µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.980117 | 417ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.980125 | 333ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.980505 | 1.343084ms  |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.980519 | 34.292µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.980531 | 12.958µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.980573 | 339.75µs    |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.980582 | 321.542µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.980582 | 88.792µs    |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.980582 | 18.458µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.980582 | 18.458µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.980560 | 1.281041ms  |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.980561 | 1.272291ms  |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.980562 | 1.259083ms  |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.980564 | 367.958µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.980940 | 8.542µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.981829 | 833ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.981838 | 333ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.982310 | 398.042µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.982322 | 27.666µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.982331 | 13.875µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.982370 | 262.708µs   |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.982377 | 249.208µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.982377 | 77.459µs    |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.982377 | 17.458µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.982377 | 17.458µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.982356 | 346µs       |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.982357 | 325.5µs     |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.982358 | 316.625µs   |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.982361 | 290.833µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.982659 | 9.917µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.982679 | 416ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.982698 | 417ns       |
|   │ │ └─executor.EvalSubQuery                                               | 15:19:40.983042 | 401.166µs   |
|   │ │   ├─TableReaderExecutor.Open                                          | 15:19:40.983054 | 27.25µs     |
|   │ │   │ └─distsql.Select                                                  | 15:19:40.983062 | 13µs        |
|   │ │   │   └─regionRequest.SendReqCtx                                      | 15:19:40.983101 | 277.667µs   |
|   │ │   │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.983107 | 265.083µs   |
|   │ │   │       └─tikv.RPC                                                  | 15:19:40.983108 | 94.5µs      |
|   │ │   │         └─tikv.Wait                                               | 15:19:40.983108 | 22.083µs    |
|   │ │   │           └─tikv.GetSnapshot                                      | 15:19:40.983108 | 22.083µs    |
|   │ │   └─*executor.MaxOneRowExec.Next                                      | 15:19:40.983088 | 349.375µs   |
|   │ │     ├─*executor.StreamAggExec.Next                                    | 15:19:40.983089 | 340.459µs   |
|   │ │     │ ├─*executor.TopNExec.Next                                       | 15:19:40.983090 | 329.916µs   |
|   │ │     │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.983092 | 305.541µs   |
|   │ │     │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.983406 | 8.208µs     |
|   │ │     │ └─*executor.TopNExec.Next                                       | 15:19:40.983424 | 375ns       |
|   │ │     └─*executor.StreamAggExec.Next                                    | 15:19:40.983434 | 375ns       |
|   │ └─*executor.MemTableReaderExec.Next                                     | 15:19:40.984015 | 1.75µs      |
|   └─*executor.HashAggExec.Next                                              | 15:19:40.984115 | 750ns       |
+-----------------------------------------------------------------------------+-----------------+-------------+
102 rows in set (0.03 sec)
```

with this PR

```
mysql> select count(1) from INFORMATION_SCHEMA.columns;
+----------+
| count(1) |
+----------+
|     4635 |
+----------+
1 row in set (0.03 sec)

mysql> trace SELECT COUNT(1) FROM INFORMATION_SCHEMA.COLUMNS;
+-----------------------------------------------+-----------------+-------------+
| operation                                     | startTS         | duration    |
+-----------------------------------------------+-----------------+-------------+
| trace                                         | 15:17:33.199398 | 28.597792ms |
|   ├─session.ExecuteStmt                       | 15:17:33.199704 | 1.093833ms  |
|   │ ├─executor.Compile                        | 15:17:33.199750 | 317.875µs   |
|   │ └─session.runStmt                         | 15:17:33.200340 | 181.5µs     |
|   ├─*executor.HashAggExec.Next                | 15:17:33.200809 | 27.12125ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.200850 | 5.302125ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.206185 | 4.823458ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.211029 | 4.406417ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.215453 | 7.002666ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.222477 | 5.324958ms  |
|   │ └─*executor.MemTableReaderExec.Next       | 15:17:33.227816 | 1.667µs     |
|   └─*executor.HashAggExec.Next                | 15:17:33.227942 | 17.833µs    |
+-----------------------------------------------+-----------------+-------------+
12 rows in set (0.03 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
