### PR TITLE
executor,sessionctx: handle last_insert_id(0) like MySQL

### DIFF
--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -1160,11 +1160,12 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	if priority := mysql.PriorityEnum(atomic.LoadInt32(&variable.ForcePriority)); priority != mysql.NoPriority {
 		sc.Priority = priority
 	}
-	if vars.StmtCtx.LastInsertID > 0 {
+	if vars.StmtCtx.LastInsertIDSet {
 		sc.PrevLastInsertID = vars.StmtCtx.LastInsertID
 	} else {
 		sc.PrevLastInsertID = vars.StmtCtx.PrevLastInsertID
 	}
+	sc.LastInsertIDSet = false
 	sc.PrevAffectedRows = 0
 	if vars.StmtCtx.InUpdateStmt || vars.StmtCtx.InDeleteStmt || vars.StmtCtx.InInsertStmt || vars.StmtCtx.InSetSessionStatesStmt {
 		sc.PrevAffectedRows = int64(vars.StmtCtx.AffectedRows())

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -245,6 +245,8 @@ type StatementContext struct {
 	PrevLastInsertID uint64
 	// LastInsertID is the auto-generated ID in the current statement.
 	LastInsertID uint64
+	// LastInsertIDSet is true if the LastInsertId was set
+	LastInsertIDSet bool
 	// InsertID is the given insert ID of an auto_increment column.
 	InsertID uint64
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2441,6 +2441,7 @@ func (s *SessionVars) SetStringUserVar(name string, strVal string, collation str
 // SetLastInsertID saves the last insert id to the session context.
 // TODO: we may store the result for last_insert_id sys var later.
 func (s *SessionVars) SetLastInsertID(insertID uint64) {
+	s.StmtCtx.LastInsertIDSet = true
 	s.StmtCtx.LastInsertID = insertID
 }
 

--- a/tests/integrationtest/r/session/session.result
+++ b/tests/integrationtest/r/session/session.result
@@ -189,3 +189,12 @@ deallocate prepare stmt1;
 select c1 from t where c2 = 20;
 c1
 3
+select last_insert_id(1);
+last_insert_id(1)
+1
+select last_insert_id(0);
+last_insert_id(0)
+0
+select last_insert_id();
+last_insert_id()
+0

--- a/tests/integrationtest/t/session/session.test
+++ b/tests/integrationtest/t/session/session.test
@@ -127,4 +127,7 @@ execute stmt1 using @v2;
 deallocate prepare stmt1;
 select c1 from t where c2 = 20;
 
-
+# https://github.com/pingcap/tidb/issues/58201
+select last_insert_id(1);
+select last_insert_id(0);
+select last_insert_id();


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58201

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Handling of `last_insert_id(0)` was changed to be compatible with MySQL
```
