### PR TITLE
ttl: retry the rows when del rate limiter returns error in delWorker

### DIFF
--- a/pkg/ttl/ttlworker/del.go
+++ b/pkg/ttl/ttlworker/del.go
@@ -41,22 +41,26 @@ const (
 	delRetryInterval   = time.Second * 5
 )
 
+type delRateLimiter interface {
+	WaitDelToken(ctx context.Context) error
+}
+
 var globalDelRateLimiter = newDelRateLimiter()
 
-type delRateLimiter struct {
+type defaultDelRateLimiter struct {
 	sync.Mutex
 	limiter *rate.Limiter
 	limit   atomic.Int64
 }
 
-func newDelRateLimiter() *delRateLimiter {
-	limiter := &delRateLimiter{}
+func newDelRateLimiter() delRateLimiter {
+	limiter := &defaultDelRateLimiter{}
 	limiter.limiter = rate.NewLimiter(0, 1)
 	limiter.limit.Store(0)
 	return limiter
 }
 
-func (l *delRateLimiter) Wait(ctx context.Context) error {
+func (l *defaultDelRateLimiter) WaitDelToken(ctx context.Context) error {
 	limit := l.limit.Load()
 	if variable.TTLDeleteRateLimit.Load() != limit {
 		limit = l.reset()
@@ -69,7 +73,7 @@ func (l *delRateLimiter) Wait(ctx context.Context) error {
 	return l.limiter.Wait(ctx)
 }
 
-func (l *delRateLimiter) reset() (newLimit int64) {
+func (l *defaultDelRateLimiter) reset() (newLimit int64) {
 	l.Lock()
 	defer l.Unlock()
 	newLimit = variable.TTLDeleteRateLimit.Load()
@@ -123,9 +127,15 @@ func (t *ttlDeleteTask) doDelete(ctx context.Context, rawSe session.Session) (re
 		}
 
 		tracer.EnterPhase(metrics.PhaseWaitToken)
-		if err = globalDelRateLimiter.Wait(ctx); err != nil {
-			t.statistics.IncErrorRows(len(delBatch))
-			return
+		if err = globalDelRateLimiter.WaitDelToken(ctx); err != nil {
+			tracer.EnterPhase(metrics.PhaseOther)
+			logutil.BgLogger().Info(
+				"wait TTL delete rate limiter interrupted",
+				zap.Error(err),
+				zap.Int("waitDelRowCnt", len(delBatch)),
+			)
+			retryRows = append(retryRows, delBatch...)
+			continue
 		}
 		tracer.EnterPhase(metrics.PhaseOther)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58205

### What changed and how does it work?

When `globalDelRateLimiter` returns an error, put the waiting rows to `retryRows`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
