### PR TITLE
keyspace: Add UT for the auto ID in the keyspace scenario

### DIFF
--- a/pkg/autoid_service/BUILD.bazel
+++ b/pkg/autoid_service/BUILD.bazel
@@ -35,8 +35,10 @@ go_test(
     shard_count = 3,
     deps = [
         "//pkg/parser/model",
+        "//pkg/store/mockstore",
         "//pkg/testkit",
         "@com_github_pingcap_kvproto//pkg/autoid",
+        "@com_github_pingcap_kvproto//pkg/keyspacepb",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//tikv",
         "@io_etcd_go_etcd_tests_v3//integration",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/58210

Problem Summary:

### What changed and how does it work?

In the TestAPI, when it is necessary to send an autoid.AutoIDRequest:

1. Non-keyspace scenario: KeyspaceID: uint32(tikv.NullspaceID)
2. Keyspace scenario: Construct the store through keyspaceMeta, and pass keyspaceMeta.Id in the AutoIDRequest. The service side will check whether the keyspace ID in the store is consistent with the one in the request.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
keyspace: Add UT for the auto ID in the keyspace scenario
```
