### PR TITLE
executor: skip execution when build query for VIEW in I_S (#58203)

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -842,7 +842,7 @@ func (e *hugeMemTableRetriever) dataForColumnsInTable(ctx context.Context, sctx 
 			// Build plan is not thread safe, there will be concurrency on sessionctx.
 			if err := runWithSystemSession(internalCtx, sctx, func(s sessionctx.Context) error {
 				is := sessiontxn.GetTxnManager(s).GetTxnInfoSchema()
-				planBuilder, _ := plannercore.NewPlanBuilder().Init(s, is, &hint.BlockHintProcessor{})
+				planBuilder, _ := plannercore.NewPlanBuilder(plannercore.PlanBuilderOptNoExecution{}).Init(s, is, &hint.BlockHintProcessor{})
 				var err error
 				viewLogicalPlan, err = planBuilder.BuildDataSourceFromView(ctx, schema.Name, tbl, nil, nil)
 				return errors.Trace(err)
@@ -1003,27 +1003,27 @@ ForColumnsTag:
 			}
 		}
 		record := types.MakeDatums(
-			infoschema.CatalogVal, // TABLE_CATALOG
-			schema.Name.O,         // TABLE_SCHEMA
-			tbl.Name.O,            // TABLE_NAME
-			col.Name.O,            // COLUMN_NAME
-			i,                     // ORDINAL_POSITION
-			columnDefault,         // COLUMN_DEFAULT
-			columnDesc.Null,       // IS_NULLABLE
-			types.TypeToStr(ft.GetType(), ft.GetCharset()), // DATA_TYPE
-			charMaxLen,           // CHARACTER_MAXIMUM_LENGTH
-			charOctLen,           // CHARACTER_OCTET_LENGTH
-			numericPrecision,     // NUMERIC_PRECISION
-			numericScale,         // NUMERIC_SCALE
-			datetimePrecision,    // DATETIME_PRECISION
-			columnDesc.Charset,   // CHARACTER_SET_NAME
-			columnDesc.Collation, // COLLATION_NAME
-			columnType,           // COLUMN_TYPE
-			columnDesc.Key,       // COLUMN_KEY
-			columnDesc.Extra,     // EXTRA
+			infoschema.CatalogVal,                                                                // TABLE_CATALOG
+			schema.Name.O,                                                                        // TABLE_SCHEMA
+			tbl.Name.O,                                                                           // TABLE_NAME
+			col.Name.O,                                                                           // COLUMN_NAME
+			i,                                                                                    // ORDINAL_POSITION
+			columnDefault,                                                                        // COLUMN_DEFAULT
+			columnDesc.Null,                                                                      // IS_NULLABLE
+			types.TypeToStr(ft.GetType(), ft.GetCharset()),                                       // DATA_TYPE
+			charMaxLen,                                                                           // CHARACTER_MAXIMUM_LENGTH
+			charOctLen,                                                                           // CHARACTER_OCTET_LENGTH
+			numericPrecision,                                                                     // NUMERIC_PRECISION
+			numericScale,                                                                         // NUMERIC_SCALE
+			datetimePrecision,                                                                    // DATETIME_PRECISION
+			columnDesc.Charset,                                                                   // CHARACTER_SET_NAME
+			columnDesc.Collation,                                                                 // COLLATION_NAME
+			columnType,                                                                           // COLUMN_TYPE
+			columnDesc.Key,                                                                       // COLUMN_KEY
+			columnDesc.Extra,                                                                     // EXTRA
 			strings.ToLower(privileges.PrivToString(priv, mysql.AllColumnPrivs, mysql.Priv2Str)), // PRIVILEGES
-			columnDesc.Comment,      // COLUMN_COMMENT
-			col.GeneratedExprString, // GENERATION_EXPRESSION
+			columnDesc.Comment,                                                                   // COLUMN_COMMENT
+			col.GeneratedExprString,                                                              // GENERATION_EXPRESSION
 		)
 		e.rows = append(e.rows, record)
 		i++
@@ -1460,12 +1460,12 @@ func (e *memtableRetriever) setDataFromEngines() {
 	var rows [][]types.Datum
 	rows = append(rows,
 		types.MakeDatums(
-			"InnoDB",  // Engine
-			"DEFAULT", // Support
+			"InnoDB",                                                     // Engine
+			"DEFAULT",                                                    // Support
 			"Supports transactions, row-level locking, and foreign keys", // Comment
-			"YES", // Transactions
-			"YES", // XA
-			"YES", // Savepoints
+			"YES",                                                        // Transactions
+			"YES",                                                        // XA
+			"YES",                                                        // Savepoints
 		),
 	)
 	e.rows = rows
@@ -2229,14 +2229,14 @@ func (e *memtableRetriever) setDataForServersInfo(ctx sessionctx.Context) error 
 	rows := make([][]types.Datum, 0, len(serversInfo))
 	for _, info := range serversInfo {
 		row := types.MakeDatums(
-			info.ID,              // DDL_ID
-			info.IP,              // IP
-			int(info.Port),       // PORT
-			int(info.StatusPort), // STATUS_PORT
-			info.Lease,           // LEASE
-			info.Version,         // VERSION
-			info.GitHash,         // GIT_HASH
-			info.BinlogStatus,    // BINLOG_STATUS
+			info.ID,                                       // DDL_ID
+			info.IP,                                       // IP
+			int(info.Port),                                // PORT
+			int(info.StatusPort),                          // STATUS_PORT
+			info.Lease,                                    // LEASE
+			info.Version,                                  // VERSION
+			info.GitHash,                                  // GIT_HASH
+			info.BinlogStatus,                             // BINLOG_STATUS
 			stringutil.BuildStringFromLabels(info.Labels), // LABELS
 		)
 		if sem.IsEnabled() {
@@ -2314,10 +2314,10 @@ func (e *memtableRetriever) dataForTableTiFlashReplica(ctx sessionctx.Context, s
 			progressString := types.TruncateFloatToString(progress, 2)
 			progress, _ = strconv.ParseFloat(progressString, 64)
 			record := types.MakeDatums(
-				schema.Name.O,                   // TABLE_SCHEMA
-				tbl.Name.O,                      // TABLE_NAME
-				tbl.ID,                          // TABLE_ID
-				int64(tbl.TiFlashReplica.Count), // REPLICA_COUNT
+				schema.Name.O,                                        // TABLE_SCHEMA
+				tbl.Name.O,                                           // TABLE_NAME
+				tbl.ID,                                               // TABLE_ID
+				int64(tbl.TiFlashReplica.Count),                      // REPLICA_COUNT
 				strings.Join(tbl.TiFlashReplica.LocationLabels, ","), // LOCATION_LABELS
 				tbl.TiFlashReplica.Available,                         // AVAILABLE
 				progress,                                             // PROGRESS

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1003,27 +1003,27 @@ ForColumnsTag:
 			}
 		}
 		record := types.MakeDatums(
-			infoschema.CatalogVal,                                                                // TABLE_CATALOG
-			schema.Name.O,                                                                        // TABLE_SCHEMA
-			tbl.Name.O,                                                                           // TABLE_NAME
-			col.Name.O,                                                                           // COLUMN_NAME
-			i,                                                                                    // ORDINAL_POSITION
-			columnDefault,                                                                        // COLUMN_DEFAULT
-			columnDesc.Null,                                                                      // IS_NULLABLE
-			types.TypeToStr(ft.GetType(), ft.GetCharset()),                                       // DATA_TYPE
-			charMaxLen,                                                                           // CHARACTER_MAXIMUM_LENGTH
-			charOctLen,                                                                           // CHARACTER_OCTET_LENGTH
-			numericPrecision,                                                                     // NUMERIC_PRECISION
-			numericScale,                                                                         // NUMERIC_SCALE
-			datetimePrecision,                                                                    // DATETIME_PRECISION
-			columnDesc.Charset,                                                                   // CHARACTER_SET_NAME
-			columnDesc.Collation,                                                                 // COLLATION_NAME
-			columnType,                                                                           // COLUMN_TYPE
-			columnDesc.Key,                                                                       // COLUMN_KEY
-			columnDesc.Extra,                                                                     // EXTRA
+			infoschema.CatalogVal, // TABLE_CATALOG
+			schema.Name.O,         // TABLE_SCHEMA
+			tbl.Name.O,            // TABLE_NAME
+			col.Name.O,            // COLUMN_NAME
+			i,                     // ORDINAL_POSITION
+			columnDefault,         // COLUMN_DEFAULT
+			columnDesc.Null,       // IS_NULLABLE
+			types.TypeToStr(ft.GetType(), ft.GetCharset()), // DATA_TYPE
+			charMaxLen,           // CHARACTER_MAXIMUM_LENGTH
+			charOctLen,           // CHARACTER_OCTET_LENGTH
+			numericPrecision,     // NUMERIC_PRECISION
+			numericScale,         // NUMERIC_SCALE
+			datetimePrecision,    // DATETIME_PRECISION
+			columnDesc.Charset,   // CHARACTER_SET_NAME
+			columnDesc.Collation, // COLLATION_NAME
+			columnType,           // COLUMN_TYPE
+			columnDesc.Key,       // COLUMN_KEY
+			columnDesc.Extra,     // EXTRA
 			strings.ToLower(privileges.PrivToString(priv, mysql.AllColumnPrivs, mysql.Priv2Str)), // PRIVILEGES
-			columnDesc.Comment,                                                                   // COLUMN_COMMENT
-			col.GeneratedExprString,                                                              // GENERATION_EXPRESSION
+			columnDesc.Comment,      // COLUMN_COMMENT
+			col.GeneratedExprString, // GENERATION_EXPRESSION
 		)
 		e.rows = append(e.rows, record)
 		i++
@@ -1460,12 +1460,12 @@ func (e *memtableRetriever) setDataFromEngines() {
 	var rows [][]types.Datum
 	rows = append(rows,
 		types.MakeDatums(
-			"InnoDB",                                                     // Engine
-			"DEFAULT",                                                    // Support
+			"InnoDB",  // Engine
+			"DEFAULT", // Support
 			"Supports transactions, row-level locking, and foreign keys", // Comment
-			"YES",                                                        // Transactions
-			"YES",                                                        // XA
-			"YES",                                                        // Savepoints
+			"YES", // Transactions
+			"YES", // XA
+			"YES", // Savepoints
 		),
 	)
 	e.rows = rows
@@ -2229,14 +2229,14 @@ func (e *memtableRetriever) setDataForServersInfo(ctx sessionctx.Context) error 
 	rows := make([][]types.Datum, 0, len(serversInfo))
 	for _, info := range serversInfo {
 		row := types.MakeDatums(
-			info.ID,                                       // DDL_ID
-			info.IP,                                       // IP
-			int(info.Port),                                // PORT
-			int(info.StatusPort),                          // STATUS_PORT
-			info.Lease,                                    // LEASE
-			info.Version,                                  // VERSION
-			info.GitHash,                                  // GIT_HASH
-			info.BinlogStatus,                             // BINLOG_STATUS
+			info.ID,              // DDL_ID
+			info.IP,              // IP
+			int(info.Port),       // PORT
+			int(info.StatusPort), // STATUS_PORT
+			info.Lease,           // LEASE
+			info.Version,         // VERSION
+			info.GitHash,         // GIT_HASH
+			info.BinlogStatus,    // BINLOG_STATUS
 			stringutil.BuildStringFromLabels(info.Labels), // LABELS
 		)
 		if sem.IsEnabled() {
@@ -2314,10 +2314,10 @@ func (e *memtableRetriever) dataForTableTiFlashReplica(ctx sessionctx.Context, s
 			progressString := types.TruncateFloatToString(progress, 2)
 			progress, _ = strconv.ParseFloat(progressString, 64)
 			record := types.MakeDatums(
-				schema.Name.O,                                        // TABLE_SCHEMA
-				tbl.Name.O,                                           // TABLE_NAME
-				tbl.ID,                                               // TABLE_ID
-				int64(tbl.TiFlashReplica.Count),                      // REPLICA_COUNT
+				schema.Name.O,                   // TABLE_SCHEMA
+				tbl.Name.O,                      // TABLE_NAME
+				tbl.ID,                          // TABLE_ID
+				int64(tbl.TiFlashReplica.Count), // REPLICA_COUNT
 				strings.Join(tbl.TiFlashReplica.LocationLabels, ","), // LOCATION_LABELS
 				tbl.TiFlashReplica.Available,                         // AVAILABLE
 				progress,                                             // PROGRESS

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -855,11 +855,14 @@ func TestShowColumnsWithSubQueryView(t *testing.T) {
 	tk.MustExec("create view temp_view as (select * from `added` where id > (select max(id) from `incremental`));")
 	// Show columns should not send coprocessor request to the storage.
 	require.NoError(t, failpoint.Enable("tikvclient/tikvStoreSendReqResult", `return("timeout")`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/BuildDataSourceFailed", "panic"))
 	tk.MustQuery("show columns from temp_view;").Check(testkit.Rows(
 		"id int(11) YES  <nil> ",
 		"name text YES  <nil> ",
 		"some_date timestamp YES  <nil> "))
+	tk.MustQuery("select COLUMN_NAME from information_schema.columns where table_name = 'temp_view';").Check(testkit.Rows("id", "name", "some_date"))
 	require.NoError(t, failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/BuildDataSourceFailed"))
 }
 
 func TestNullColumns(t *testing.T) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -5324,6 +5324,7 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName model.
 			terror.ErrorNotEqual(err, ErrNotSupportedYet) {
 			err = ErrViewInvalid.GenWithStackByArgs(dbName.O, tableInfo.Name.O)
 		}
+		failpoint.Inject("BuildDataSourceFailed", func() {})
 		return nil, err
 	}
 	pm := privilege.GetPrivilegeManager(b.ctx)

--- a/tools/check/check-bazel-prepare.sh
+++ b/tools/check/check-bazel-prepare.sh
@@ -19,6 +19,7 @@
 #  -o pipefail: sets the exit code of a pipeline to that of the rightmost command to exit with a non-zero status,
 #       or to zero if all commands of the pipeline exit successfully.
 set -euo pipefail
+rm -rf /home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d
 
 before_checksum=`find . -type f \( -name '*.bazel' -o -name '*.bzl' \) -exec md5sum {} \;| sort -k 2`
 make bazel_prepare


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58184

Problem Summary:

### What changed and how does it work?

use `PlanBuilderOptNoExecution` to skip unnecessary execution. This should be the same behaviour with `SHOW COLUMNS`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
