### PR TITLE
infoschema: change sieve Get() function Mutex to RWMutex

### DIFF
--- a/pkg/infoschema/sieve_test.go
+++ b/pkg/infoschema/sieve_test.go
@@ -15,8 +15,8 @@
 package infoschema
 
 import (
-	"math/rand"
 	"context"
+	"math/rand"
 	"sync/atomic"
 	"testing"
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58227

Problem Summary:

### What changed and how does it work?

Change Mutex to RWMutex

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test

If there is not lock contention, 

```
go test -bench BenchmarkSieveGet -run XX -benchmem
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/infoschema
cpu: AMD Ryzen 7 PRO 4750G with Radeon Graphics
BenchmarkSieveGet-16            52371621                21.79 ns/op            0 B/op          0 allocs/op
--- BENCH: BenchmarkSieveGet-16
    sieve_test.go:178: 1: hit 1, miss 0, ratio 1.00
    sieve_test.go:178: 100: hit 100, miss 0, ratio 1.00
    sieve_test.go:178: 10000: hit 353, miss 9647, ratio 0.04
    sieve_test.go:178: 1000000: hit 9820, miss 990180, ratio 0.01
    sieve_test.go:178: 52371621: hit 474198, miss 51897423, ratio 0.01
PASS
ok      github.com/pingcap/tidb/pkg/infoschema  25.550s
```

With a goroutine calling `Set`, before vs after:

```
go test -bench BenchmarkSieveGet -run XX -benchmem
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/infoschema
cpu: AMD Ryzen 7 PRO 4750G with Radeon Graphics
BenchmarkSieveGet-16             1000000              1329 ns/op             298 B/op         10 allocs/op
--- BENCH: BenchmarkSieveGet-16
    sieve_test.go:178: 1: hit 1, miss 0, ratio 1.00
    sieve_test.go:178: 100: hit 100, miss 0, ratio 1.00
    sieve_test.go:178: 10000: hit 260, miss 9740, ratio 0.03
    sieve_test.go:178: 1000000: hit 9520, miss 990480, ratio 0.01
PASS
ok      github.com/pingcap/tidb/pkg/infoschema  1.879s



go test -bench BenchmarkSieveGet -run XX -benchmem
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/infoschema
cpu: AMD Ryzen 7 PRO 4750G with Radeon Graphics
BenchmarkSieveGet-16             1000000              1019 ns/op             108 B/op          3 allocs/op
--- BENCH: BenchmarkSieveGet-16
    sieve_test.go:178: 1: hit 1, miss 0, ratio 1.00
    sieve_test.go:178: 100: hit 100, miss 0, ratio 1.00
    sieve_test.go:178: 10000: hit 236, miss 9764, ratio 0.02
    sieve_test.go:178: 1000000: hit 9578, miss 990422, ratio 0.01
PASS
ok      github.com/pingcap/tidb/pkg/infoschema  1.575s
```

- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
