### PR TITLE
workloadrepo: add admin create workload snapshot stmt

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
         "update.go",
         "utils.go",
         "window.go",
+        "workloadrepo.go",
         "write.go",
     ],
     importpath = "github.com/pingcap/tidb/pkg/executor",

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -321,6 +321,8 @@ func (b *executorBuilder) build(p base.Plan) exec.Executor {
 		return b.buildExpand(v)
 	case *plannercore.RecommendIndexPlan:
 		return b.buildRecommendIndex(v)
+	case *plannercore.WorkloadRepoCreate:
+		return b.buildWorkloadRepoCreate(v)
 	default:
 		if mp, ok := p.(testutil.MockPhysicalPlan); ok {
 			return mp.GetExecutor()
@@ -5759,4 +5761,9 @@ func (b *executorBuilder) buildRecommendIndex(v *plannercore.RecommendIndexPlan)
 		AdviseID:     v.AdviseID,
 		Options:      v.Options,
 	}
+}
+
+func (b *executorBuilder) buildWorkloadRepoCreate(_ *plannercore.WorkloadRepoCreate) exec.Executor {
+	base := exec.NewBaseExecutor(b.ctx, nil, 0)
+	return &WorkloadRepoCreateExec{base}
 }

--- a/pkg/executor/workloadrepo.go
+++ b/pkg/executor/workloadrepo.go
@@ -1,0 +1,38 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/util/chunk"
+)
+
+// TakeSnapshot is a hook from workload repo that may trigger manual snapshot.
+var TakeSnapshot func() error = nil
+
+// WorkloadRepoCreateExec indicates WorkloadRepoCreate executor.
+type WorkloadRepoCreateExec struct {
+	exec.BaseExecutor
+}
+
+// Next implements the Executor Next interface.
+func (*WorkloadRepoCreateExec) Next(context.Context, *chunk.Chunk) error {
+	if TakeSnapshot != nil {
+		return TakeSnapshot()
+	}
+	return nil
+}

--- a/pkg/executor/workloadrepo.go
+++ b/pkg/executor/workloadrepo.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TakeSnapshot is a hook from workload repo that may trigger manual snapshot.
-var TakeSnapshot func() error = nil
+var TakeSnapshot func() error
 
 // WorkloadRepoCreateExec indicates WorkloadRepoCreate executor.
 type WorkloadRepoCreateExec struct {

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -2577,6 +2577,7 @@ const (
 	AdminShowBDRRole
 	AdminUnsetBDRRole
 	AdminAlterDDLJob
+	AdminWorkloadRepoCreate
 )
 
 // HandleRange represents a range where handle value >= Begin and < End.
@@ -2877,6 +2878,8 @@ func (n *AdminStmt) Restore(ctx *format.RestoreCtx) error {
 				return errors.Annotatef(err, "An error occurred while restore AdminStmt.AlterJobOptions[%d]", i)
 			}
 		}
+	case AdminWorkloadRepoCreate:
+		ctx.WriteKeyWord("CREATE WORKLOAD SNAPSHOT")
 	default:
 		return errors.New("Unsupported AdminStmt type")
 	}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -11239,6 +11239,10 @@ AdminStmt:
 			Index:  string($5),
 		}
 	}
+|	"ADMIN" "CREATE" "WORKLOAD" "SNAPSHOT"
+	{
+		$$ = &ast.AdminStmt{Tp: ast.AdminWorkloadRepoCreate}
+	}
 |	"ADMIN" "CLEANUP" "INDEX" TableName Identifier
 	{
 		$$ = &ast.AdminStmt{

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -498,6 +498,7 @@ func TestAdminStmt(t *testing.T) {
 		{"admin show ddl job queries limit 3 offset 2", true, "ADMIN SHOW DDL JOB QUERIES LIMIT 2, 3"},
 		{"admin show ddl job queries limit 22 offset 0", true, "ADMIN SHOW DDL JOB QUERIES LIMIT 0, 22"},
 		{"admin show t1 next_row_id", true, "ADMIN SHOW `t1` NEXT_ROW_ID"},
+		{"admin create workload snapshot;", true, "ADMIN CREATE WORKLOAD SNAPSHOT"},
 		{"admin check table t1, t2;", true, "ADMIN CHECK TABLE `t1`, `t2`"},
 		{"admin check index tableName idxName;", true, "ADMIN CHECK INDEX `tableName` idxName"},
 		{"admin check index tableName idxName (1, 2), (4, 5);", true, "ADMIN CHECK INDEX `tableName` idxName (1,2), (4,5)"},

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -177,6 +177,11 @@ type AlterDDLJob struct {
 	Options []*AlterDDLJobOpt
 }
 
+// WorkloadRepoCreate is the plan of admin create workload snapshot.
+type WorkloadRepoCreate struct {
+	baseSchemaProducer
+}
+
 // ReloadExprPushdownBlacklist reloads the data from expr_pushdown_blacklist table.
 type ReloadExprPushdownBlacklist struct {
 	baseSchemaProducer

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1584,6 +1584,8 @@ func (b *PlanBuilder) buildAdmin(ctx context.Context, as *ast.AdminStmt) (base.P
 		if err != nil {
 			return nil, err
 		}
+	case ast.AdminWorkloadRepoCreate:
+		return &WorkloadRepoCreate{}, nil
 	default:
 		return nil, plannererrors.ErrUnsupportedType.GenWithStack("Unsupported ast.AdminStmt(%T) for buildAdmin", as)
 	}

--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/domain",
         "//pkg/domain/infosync",
+        "//pkg/executor",
         "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/meta/model",

--- a/pkg/util/workloadrepo/const.go
+++ b/pkg/util/workloadrepo/const.go
@@ -25,7 +25,8 @@ const (
 	promptKey = "workloadrepo"
 	snapIDKey = "/tidb/workloadrepo/snap_id"
 
-	etcdOpTimeout = 5 * time.Second
+	etcdOpTimeout   = 5 * time.Second
+	snapshotRetries = 5
 
 	defSamplingInterval = 5
 	defSnapshotInterval = 3600

--- a/pkg/util/workloadrepo/const.go
+++ b/pkg/util/workloadrepo/const.go
@@ -21,9 +21,12 @@ import (
 )
 
 const (
-	ownerKey  = "/tidb/workloadrepo/owner"
-	promptKey = "workloadrepo"
-	snapIDKey = "/tidb/workloadrepo/snap_id"
+	ownerKey       = "/tidb/workloadrepo/owner"
+	promptKey      = "workloadrepo"
+	snapIDKey      = "/tidb/workloadrepo/snap_id"
+	snapCommandKey = "/tidb/workloadrepo/snap_command"
+
+	snapCommandTake = "take_snapshot"
 
 	etcdOpTimeout   = 5 * time.Second
 	snapshotRetries = 5

--- a/pkg/util/workloadrepo/sampling.go
+++ b/pkg/util/workloadrepo/sampling.go
@@ -38,7 +38,7 @@ func (w *worker) samplingTable(ctx context.Context, rt *repositoryTable) {
 	}
 
 	if _, err := runQuery(ctx, sess, rt.insertStmt, w.instanceID); err != nil {
-		logutil.BgLogger().Info("workload repository sampling failed: could not run insert statement", zap.String("tbl", rt.destTable), zap.NamedError("err", err))
+		//logutil.BgLogger().Info("workload repository sampling failed: could not run insert statement", zap.String("tbl", rt.destTable), zap.NamedError("err", err))
 	}
 }
 

--- a/pkg/util/workloadrepo/sampling.go
+++ b/pkg/util/workloadrepo/sampling.go
@@ -38,7 +38,7 @@ func (w *worker) samplingTable(ctx context.Context, rt *repositoryTable) {
 	}
 
 	if _, err := runQuery(ctx, sess, rt.insertStmt, w.instanceID); err != nil {
-		//logutil.BgLogger().Info("workload repository sampling failed: could not run insert statement", zap.String("tbl", rt.destTable), zap.NamedError("err", err))
+		logutil.BgLogger().Info("workload repository sampling failed: could not run insert statement", zap.String("tbl", rt.destTable), zap.NamedError("err", err))
 	}
 }
 

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -35,7 +35,7 @@ func (w *worker) etcdCreate(ctx context.Context, key, val string) error {
 	defer cancel()
 	res, err := w.etcdClient.Txn(ctx).
 		If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
-		Then(clientv3.OpPut(snapIDKey, val)).
+		Then(clientv3.OpPut(key, val)).
 		Commit()
 	if err != nil {
 		return err
@@ -128,6 +128,53 @@ func (w *worker) snapshotTable(ctx context.Context, snapID uint64, rt *repositor
 	return nil
 }
 
+func (w *worker) takeSnapshot(ctx context.Context, sess sessionctx.Context, sendCommand bool) {
+	// coordination logic
+	if !w.owner.IsOwner() {
+		if sendCommand {
+			command, err := w.etcdGet(ctx, snapCommandKey, "")
+			if err != nil {
+				logutil.BgLogger().Info("workload repository cannot get current snapid to send", zap.NamedError("err", err))
+				return
+			}
+
+			if err = w.etcdCAS(ctx, snapCommandKey, command, snapCommandTake); err != nil {
+				logutil.BgLogger().Info("workload repository cannot send snapshot command", zap.NamedError("err", err))
+				return
+			}
+		}
+		return
+	}
+
+	for range snapshotRetries {
+		snapID, err := w.getSnapID(ctx)
+		if err != nil {
+			logutil.BgLogger().Info("workload repository cannot get current snapid", zap.NamedError("err", err))
+			continue
+		}
+		// Use UPSERT to ensure this SQL doesn't fail on duplicate snapID.
+		//
+		// NOTE: In a highly unlikely corner case, there could be two owners.
+		// This might occur if upsertHistSnapshot succeeds but updateSnapID fails
+		// due to another owner winning the etcd CAS loop.
+		// While undesirable, this scenario is acceptable since both owners would
+		// likely share similar datetime values and same cluster version.
+
+		if err := upsertHistSnapshot(ctx, sess, snapID+1); err != nil {
+			logutil.BgLogger().Info("workload repository could not insert into hist_snapshots", zap.NamedError("err", err))
+			continue
+		}
+		err = w.updateSnapID(ctx, snapID, snapID+1)
+		if err != nil {
+			logutil.BgLogger().Info("workload repository cannot update current snapid", zap.Uint64("new_id", snapID), zap.NamedError("err", err))
+			continue
+		}
+
+		logutil.BgLogger().Info("workload repository fired snapshot", zap.String("owner", w.instanceID), zap.Uint64("snapID", snapID+1))
+		break
+	}
+}
+
 func (w *worker) startSnapshot(_ctx context.Context) func() {
 	return func() {
 		w.Lock()
@@ -142,13 +189,25 @@ func (w *worker) startSnapshot(_ctx context.Context) func() {
 		// other wise wch won't be collected after the exit of this function
 		ctx, cancel := context.WithCancel(_ctx)
 		defer cancel()
-		wch := w.etcdClient.Watch(ctx, snapIDKey)
+		snapIDCh := w.etcdClient.Watch(ctx, snapIDKey)
+		snapCmdCh := w.etcdClient.Watch(ctx, snapCommandKey)
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case resp := <-wch:
+			case resp := <-snapCmdCh:
+				if len(resp.Events) < 1 {
+					continue
+				}
+
+				// same as snapID events
+				// we only catch the last event if possible
+				snapCommandStr := string(resp.Events[len(resp.Events)-1].Kv.Value)
+				if snapCommandStr == snapCommandTake {
+					w.takeSnapshot(ctx, sess, false)
+				}
+			case resp := <-snapIDCh:
 				if len(resp.Events) < 1 {
 					// since there is no event, we don't know the latest snapid either
 					// really should not happen except creation
@@ -187,43 +246,10 @@ func (w *worker) startSnapshot(_ctx context.Context) func() {
 				if err := updateHistSnapshot(ctx, sess, snapID, errs); err != nil {
 					logutil.BgLogger().Info("workload repository snapshot failed: could not update hist_snapshots", zap.NamedError("err", err))
 				}
-
-				continue
 			case <-w.snapshotChan:
+				w.takeSnapshot(ctx, sess, true)
 			case <-w.snapshotTicker.C:
-			}
-
-			// coordination logic
-			if !w.owner.IsOwner() {
-				continue
-			}
-
-			for range snapshotRetries {
-				snapID, err := w.getSnapID(ctx)
-				if err != nil {
-					logutil.BgLogger().Info("workload repository cannot get current snapid", zap.NamedError("err", err))
-					continue
-				}
-				// Use UPSERT to ensure this SQL doesn't fail on duplicate snapID.
-				//
-				// NOTE: In a highly unlikely corner case, there could be two owners.
-				// This might occur if upsertHistSnapshot succeeds but updateSnapID fails
-				// due to another owner winning the etcd CAS loop.
-				// While undesirable, this scenario is acceptable since both owners would
-				// likely share similar datetime values and same cluster version.
-
-				if err := upsertHistSnapshot(ctx, sess, snapID+1); err != nil {
-					logutil.BgLogger().Info("workload repository could not insert into hist_snapshots", zap.NamedError("err", err))
-					continue
-				}
-				err = w.updateSnapID(ctx, snapID, snapID+1)
-				if err != nil {
-					logutil.BgLogger().Info("workload repository cannot update current snapid", zap.Uint64("new_id", snapID), zap.NamedError("err", err))
-					continue
-				}
-
-				logutil.BgLogger().Info("workload repository fired snapshot", zap.String("owner", w.instanceID), zap.Uint64("snapID", snapID+1))
-				break
+				w.takeSnapshot(ctx, sess, false)
 			}
 		}
 	}

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -145,6 +145,7 @@ func (w *worker) createAllTables(ctx context.Context) error {
 	return createAllPartitions(ctx, sess, is)
 }
 
+// checkTablesExists will check if all tables are created and if the work is bootstrapped.
 func (w *worker) checkTablesExists(ctx context.Context) bool {
 	_sessctx := w.getSessionWithRetry()
 	sess := _sessctx.(sessionctx.Context)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58248

Problem Summary: as title, a new syntax to trigger snapshot manually.

### What changed and how does it work?

1. Minimal changes to parser/planner/executor
2. Due to cyclic imports, I must export some "internal" interfaces in workloadrepo

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
