### PR TITLE
executor: fix the issue that the int primary key doesn't show in the index usage

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -514,6 +514,7 @@ go_test(
         "@org_golang_google_grpc//:grpc",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",
     ],
 )

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3910,7 +3910,7 @@ func (e *memtableRetriever) setDataFromIndexUsage(ctx context.Context, sctx sess
 			usage := dom.StatsHandle().GetIndexUsage(tbl.ID, idx.ID)
 			row = append(row, types.NewStringDatum(schema.O))
 			row = append(row, types.NewStringDatum(tbl.Name.O))
-			row = append(row, types.NewStringDatum(idx.Name.O))
+			row = append(row, types.NewStringDatum(idx.Name))
 			row = append(row, types.NewIntDatum(int64(usage.QueryTotal)))
 			row = append(row, types.NewIntDatum(int64(usage.KvReqTotal)))
 			row = append(row, types.NewIntDatum(int64(usage.RowAccessTotal)))

--- a/pkg/executor/internal/exec/indexusage.go
+++ b/pkg/executor/internal/exec/indexusage.go
@@ -70,7 +70,6 @@ func (e *IndexUsageReporter) ReportCopIndexUsageForTable(tbl table.Table, indexI
 func (e *IndexUsageReporter) ReportCopIndexUsage(tableID int64, physicalTableID int64, indexID int64, planID int) {
 	tableRowCount, ok := e.getTableRowCount(physicalTableID)
 	if !ok {
-		// skip if the table is empty or the stats is not valid
 		return
 	}
 

--- a/tests/integrationtest/r/infoschema/infoschema.result
+++ b/tests/integrationtest/r/infoschema/infoschema.result
@@ -314,14 +314,17 @@ TABLE_SCHEMA	TABLE_NAME	INDEX_NAME
 indexusage	idt1	idx_1
 indexusage	idt1	idx_2
 indexusage	idt1	idx_3
+indexusage	idt1	primary
 indexusage	idt2	idx_1
 indexusage	idt2	idx_2
 indexusage	idt2	idx_4
+indexusage	idt2	primary
 select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage where TABLE_NAME = 'idt1';
 TABLE_SCHEMA	TABLE_NAME	INDEX_NAME
 indexusage	idt1	idx_1
 indexusage	idt1	idx_2
 indexusage	idt1	idx_3
+indexusage	idt1	primary
 select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage where INDEX_NAME = 'IDX_3';
 TABLE_SCHEMA	TABLE_NAME	INDEX_NAME
 indexusage	idt1	idx_3
@@ -330,6 +333,7 @@ TABLE_SCHEMA	TABLE_NAME	INDEX_NAME
 indexusage	idt1	idx_1
 indexusage	idt1	idx_2
 indexusage	idt1	idx_3
+indexusage	idt1	primary
 select TABLE_SCHEMA, TABLE_NAME, INDEX_NAME from information_schema.tidb_index_usage where TABLE_SCHEMA = 'indexusage' and INDEX_NAME = 'idx_2';
 TABLE_SCHEMA	TABLE_NAME	INDEX_NAME
 indexusage	idt1	idx_2


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58256

Problem Summary:

### What changed and how does it work?

If the table only has an integer primary key, add a fake index entry to the index usage extractor to get it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note


```release-note
None
```
