### PR TITLE
executor: Fix the parse problematic slow log panic issue due to empty value string

### DIFF
--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -594,6 +594,10 @@ func splitByColon(line string) (fields []string, values []string) {
 			fields = append(fields, line[start:current])
 			parseKey = false
 			current += 2 // bypass ": "
+			if current >= lineLength {
+				// last empty value
+				values = append(values, "")
+			}
 		} else {
 			start = current
 			if current < lineLength && (line[current] == '{' || line[current] == '[') {
@@ -607,6 +611,13 @@ func splitByColon(line string) (fields []string, values []string) {
 				for current < lineLength && line[current] != ' ' {
 					current++
 				}
+				// Meet empty value cases: "Key: Key:"
+				if current > 0 && line[current-1] == ':' {
+					values = append(values, "")
+					current = start
+					parseKey = true
+					continue
+				}
 			}
 			values = append(values, line[start:min(current, len(line))])
 			parseKey = true
@@ -614,6 +625,10 @@ func splitByColon(line string) (fields []string, values []string) {
 	}
 	if len(errMsg) > 0 {
 		logutil.BgLogger().Warn("slow query parse slow log error", zap.String("Error", errMsg), zap.String("Log", line))
+		return nil, nil
+	}
+	if len(fields) != len(values) {
+		logutil.BgLogger().Warn("slow query parse slow log error", zap.Int("field_count", len(fields)), zap.Int("value_count", len(values)), zap.String("Log", line))
 		return nil, nil
 	}
 	return fields, values

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -540,7 +540,7 @@ func TestSplitbyColon(t *testing.T) {
 		{
 			"123a",
 			[]string{"123a"},
-			[]string{},
+			[]string{""},
 		},
 		{
 			"1a: 2b",
@@ -593,9 +593,16 @@ func TestSplitbyColon(t *testing.T) {
 			[]string{"Time"},
 			[]string{"2021-09-08T14:39:54.506967433+08:00"},
 		},
+		{
+
+			"Cop_proc_avg: 0 Cop_proc_addr: Cop_proc_max: Cop_proc_min: ",
+			[]string{"Cop_proc_avg", "Cop_proc_addr", "Cop_proc_max", "Cop_proc_min"},
+			[]string{"0", "", "", ""},
+		},
 	}
 	for _, c := range cases {
 		resFields, resValues := splitByColon(c.line)
+		logutil.BgLogger().Info(c.line)
 		require.Equal(t, c.fields, resFields)
 		require.Equal(t, c.values, resValues)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58147 

Problem Summary:
Handle uncommon empty value string case in slow log, still not sure why empty copr addr appeared.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that queries for slow log may fail when some item's value is empty. 
```
