### PR TITLE
workloadrepo: Add unit testing for the Workload Repository.

### DIFF
--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -41,7 +41,7 @@ go_library(
 
 go_test(
     name = "workloadrepo_test",
-    timeout = "short",
+    timeout = "long",
     srcs = ["worker_test.go"],
     embed = [":workloadrepo"],
     flaky = True,

--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -47,9 +47,11 @@ go_test(
     flaky = True,
     deps = [
         "//pkg/domain",
+        "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/owner",
         "//pkg/parser/ast",
+        "//pkg/sessionctx",
         "//pkg/testkit",
         "@com_github_stretchr_testify//require",
         "@io_etcd_go_etcd_client_v3//:client",

--- a/pkg/util/workloadrepo/housekeeper.go
+++ b/pkg/util/workloadrepo/housekeeper.go
@@ -84,7 +84,7 @@ func dropOldPartition(ctx context.Context, is infoschema.InfoSchema,
 		return fmt.Errorf("workload repository could not load information for '%s'", tbl.destTable)
 	}
 	pi := tbInfo.GetPartitionInfo()
-	if pi == nil {
+	if pi == nil || pi.Definitions == nil {
 		return fmt.Errorf("workload repository could not load partition information for '%s'", tbl.destTable)
 	}
 	for _, pt := range pi.Definitions {

--- a/pkg/util/workloadrepo/housekeeper.go
+++ b/pkg/util/workloadrepo/housekeeper.go
@@ -103,7 +103,7 @@ func (w *worker) dropOldPartitions(ctx context.Context, sess sessionctx.Context,
 				continue
 			}
 			sb.Reset()
-			sqlescape.MustFormatSQL(sb, "ALTER TABLE %s.%s DROP PARTITION %s",
+			sqlescape.MustFormatSQL(sb, "ALTER TABLE %n.%n DROP PARTITION %n",
 				WorkloadSchema, tbl.destTable, pt.Name.L)
 			_, err = execRetry(ctx, sess, sb.String())
 			if err != nil {
@@ -147,10 +147,6 @@ func (w *worker) startHouseKeeper(ctx context.Context) func() {
 					continue
 				}
 
-				// reschedule, drain channel first
-				if !timer.Stop() {
-					<-timer.C
-				}
 				timer.Reset(calcNextTick(now))
 			}
 		}

--- a/pkg/util/workloadrepo/sampling.go
+++ b/pkg/util/workloadrepo/sampling.go
@@ -44,9 +44,7 @@ func (w *worker) samplingTable(ctx context.Context, rt *repositoryTable) {
 
 func (w *worker) startSample(ctx context.Context) func() {
 	return func() {
-		w.Lock()
-		w.samplingTicker = time.NewTicker(time.Duration(w.samplingInterval) * time.Second)
-		w.Unlock()
+		w.resetSamplingInterval(w.samplingInterval)
 
 		for {
 			select {
@@ -73,10 +71,6 @@ func (w *worker) startSample(ctx context.Context) func() {
 }
 
 func (w *worker) resetSamplingInterval(newRate int32) {
-	if w.samplingTicker == nil {
-		return
-	}
-
 	if newRate == 0 {
 		w.samplingTicker.Stop()
 	} else {
@@ -95,7 +89,9 @@ func (w *worker) changeSamplingInterval(_ context.Context, d string) error {
 
 	if int32(n) != w.samplingInterval {
 		w.samplingInterval = int32(n)
-		w.resetSamplingInterval(w.samplingInterval)
+		if w.samplingTicker != nil {
+			w.resetSamplingInterval(w.samplingInterval)
+		}
 	}
 
 	return nil

--- a/pkg/util/workloadrepo/sampling.go
+++ b/pkg/util/workloadrepo/sampling.go
@@ -56,8 +56,8 @@ func (w *worker) startSample(ctx context.Context) func() {
 				// sample thread
 				var wg util.WaitGroupWrapper
 
-				for rtIdx := range workloadTables {
-					rt := &workloadTables[rtIdx]
+				for rtIdx := range w.workloadTables {
+					rt := &w.workloadTables[rtIdx]
 					if rt.tableType != samplingTable {
 						continue
 					}

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -246,11 +246,11 @@ func (w *worker) startSnapshot(_ctx context.Context) func() {
 					continue
 				}
 
-				errs := make([]error, len(workloadTables))
+				errs := make([]error, len(w.workloadTables))
 				var wg util.WaitGroupWrapper
 				cnt := 0
-				for rtIdx := range workloadTables {
-					rt := &workloadTables[rtIdx]
+				for rtIdx := range w.workloadTables {
+					rt := &w.workloadTables[rtIdx]
 					if rt.tableType != snapshotTable {
 						continue
 					}

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -46,7 +46,7 @@ func (w *worker) etcdCreate(ctx context.Context, key, val string) error {
 	return nil
 }
 
-func (w *worker) etcdGet(_ctx context.Context, key, defval string) (string, error) {
+func (w *worker) etcdGet(_ctx context.Context, key string) (string, error) {
 	ctx, cancel := context.WithTimeout(_ctx, etcdOpTimeout)
 	defer cancel()
 	res, err := w.etcdClient.Get(ctx, key)
@@ -54,9 +54,8 @@ func (w *worker) etcdGet(_ctx context.Context, key, defval string) (string, erro
 		return "", err
 	}
 	if len(res.Kvs) == 0 {
-		// nonexistent, create it atomically
-		// otherwise etcdCAS will fail
-		return defval, w.etcdCreate(_ctx, key, defval)
+		// key does not exist, just return an empty string
+		return "", nil
 	}
 	return string(res.Kvs[len(res.Kvs)-1].Value), nil
 }
@@ -78,9 +77,13 @@ func (w *worker) etcdCAS(ctx context.Context, key, oval, nval string) error {
 }
 
 func (w *worker) getSnapID(ctx context.Context) (uint64, error) {
-	snapIDStr, err := w.etcdGet(ctx, snapIDKey, "0")
+	snapIDStr, err := w.etcdGet(ctx, snapIDKey)
 	if err != nil {
 		return 0, err
+	}
+	if snapIDStr == "" {
+		// return zero when the key does not exist
+		return 0, nil
 	}
 	return strconv.ParseUint(snapIDStr, 10, 64)
 }
@@ -89,6 +92,10 @@ func (w *worker) updateSnapID(ctx context.Context, oid, nid uint64) error {
 	return w.etcdCAS(ctx, snapIDKey,
 		strconv.FormatUint(oid, 10),
 		strconv.FormatUint(nid, 10))
+}
+
+func (w *worker) createSnapID(ctx context.Context, nid uint64) error {
+	return w.etcdCreate(ctx, snapIDKey, strconv.FormatUint(nid, 10))
 }
 
 func upsertHistSnapshot(ctx context.Context, sctx sessionctx.Context, snapID uint64) error {
@@ -132,13 +139,19 @@ func (w *worker) takeSnapshot(ctx context.Context, sess sessionctx.Context, send
 	// coordination logic
 	if !w.owner.IsOwner() {
 		if sendCommand {
-			command, err := w.etcdGet(ctx, snapCommandKey, "")
+			command, err := w.etcdGet(ctx, snapCommandKey)
 			if err != nil {
-				logutil.BgLogger().Info("workload repository cannot get current snapid to send", zap.NamedError("err", err))
+				logutil.BgLogger().Info("workload repository cannot get current snap command value", zap.NamedError("err", err))
 				return
 			}
 
-			if err = w.etcdCAS(ctx, snapCommandKey, command, snapCommandTake); err != nil {
+			if command == "" {
+				err = w.etcdCreate(ctx, snapCommandKey, snapCommandTake)
+			} else {
+				err = w.etcdCAS(ctx, snapCommandKey, command, snapCommandTake)
+			}
+
+			if err != nil {
 				logutil.BgLogger().Info("workload repository cannot send snapshot command", zap.NamedError("err", err))
 				return
 			}
@@ -152,6 +165,7 @@ func (w *worker) takeSnapshot(ctx context.Context, sess sessionctx.Context, send
 			logutil.BgLogger().Info("workload repository cannot get current snapid", zap.NamedError("err", err))
 			continue
 		}
+
 		// Use UPSERT to ensure this SQL doesn't fail on duplicate snapID.
 		//
 		// NOTE: In a highly unlikely corner case, there could be two owners.
@@ -159,12 +173,17 @@ func (w *worker) takeSnapshot(ctx context.Context, sess sessionctx.Context, send
 		// due to another owner winning the etcd CAS loop.
 		// While undesirable, this scenario is acceptable since both owners would
 		// likely share similar datetime values and same cluster version.
-
 		if err := upsertHistSnapshot(ctx, sess, snapID+1); err != nil {
 			logutil.BgLogger().Info("workload repository could not insert into hist_snapshots", zap.NamedError("err", err))
 			continue
 		}
-		err = w.updateSnapID(ctx, snapID, snapID+1)
+
+		if snapID == 0 {
+			err = w.createSnapID(ctx, snapID+1)
+		} else {
+			err = w.updateSnapID(ctx, snapID, snapID+1)
+		}
+
 		if err != nil {
 			logutil.BgLogger().Info("workload repository cannot update current snapid", zap.Uint64("new_id", snapID), zap.NamedError("err", err))
 			continue

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -111,7 +111,7 @@ func (w *worker) createAllTables(ctx context.Context, now time.Time) error {
 		}
 	}
 
-	for _, tbl := range workloadTables {
+	for _, tbl := range w.workloadTables {
 		if checkTableExistsByIS(ctx, is, tbl.destTable, zeroTime) {
 			continue
 		}
@@ -143,7 +143,7 @@ func (w *worker) createAllTables(ctx context.Context, now time.Time) error {
 	}
 
 	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
-	return createAllPartitions(ctx, sess, is, now)
+	return w.createAllPartitions(ctx, sess, is, now)
 }
 
 func (w *worker) checkTablesExists(ctx context.Context, now time.Time) bool {
@@ -151,8 +151,8 @@ func (w *worker) checkTablesExists(ctx context.Context, now time.Time) bool {
 	sess := _sessctx.(sessionctx.Context)
 	defer w.sesspool.Put(_sessctx)
 	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
-	return slice.AllOf(workloadTables, func(i int) bool {
-		return checkTableExistsByIS(ctx, is, workloadTables[i].destTable, now)
+	return slice.AllOf(w.workloadTables, func(i int) bool {
+		return checkTableExistsByIS(ctx, is, w.workloadTables[i].destTable, now)
 	})
 }
 

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -172,7 +172,11 @@ func checkTableExistsByIS(ctx context.Context, is infoschema.InfoSchema, tblName
 	for i := range 2 {
 		newPtTime := now.AddDate(0, 0, i+1)
 		newPtName := "p" + newPtTime.Format("20060102")
-		ptInfos := tbInfo.GetPartitionInfo().Definitions
+		pi := tbInfo.GetPartitionInfo()
+		if pi == nil {
+			return false
+		}
+		ptInfos := pi.Definitions
 		if slice.NoneOf(ptInfos, func(i int) bool {
 			return ptInfos[i].Name.L == newPtName
 		}) {

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -142,6 +142,7 @@ func (w *worker) createAllTables(ctx context.Context, now time.Time) error {
 		}
 	}
 
+	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
 	return createAllPartitions(ctx, sess, is, now)
 }
 

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -173,7 +173,7 @@ func checkTableExistsByIS(ctx context.Context, is infoschema.InfoSchema, tblName
 		return false
 	}
 	pi := tbInfo.GetPartitionInfo()
-	if pi == nil {
+	if pi == nil || pi.Definitions == nil || len(pi.Definitions) == 0 {
 		return false
 	}
 	ptInfos := pi.Definitions

--- a/pkg/util/workloadrepo/utils.go
+++ b/pkg/util/workloadrepo/utils.go
@@ -41,7 +41,7 @@ func parsePartitionName(part string) (time.Time, error) {
 }
 
 func generatePartitionRanges(sb *strings.Builder, tbInfo *model.TableInfo, now time.Time) (bool, error) {
-	// Set lastPart to the lastest partition found in table or the date for
+	// Set lastPart to the latest partition found in table or the date for
 	// yesterday's partition if none is found. Note: The partition named for
 	// today's date holds yesterday's data.
 	lastPart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)

--- a/pkg/util/workloadrepo/utils.go
+++ b/pkg/util/workloadrepo/utils.go
@@ -25,10 +25,10 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 )
 
-func generatePartitionDef(sb *strings.Builder, col string) {
+func generatePartitionDef(sb *strings.Builder, col string, now time.Time) {
 	fmt.Fprintf(sb, " PARTITION BY RANGE( TO_DAYS(%s) ) (", col)
 	// tbInfo is nil, retval must be false
-	_, _ = generatePartitionRanges(sb, nil)
+	_, _ = generatePartitionRanges(sb, nil, now)
 	fmt.Fprintf(sb, ")")
 }
 
@@ -40,8 +40,7 @@ func parsePartitionName(part string) (time.Time, error) {
 	return time.ParseInLocation("p20060102", part, time.Local)
 }
 
-func generatePartitionRanges(sb *strings.Builder, tbInfo *model.TableInfo) (bool, error) {
-	now := time.Now()
+func generatePartitionRanges(sb *strings.Builder, tbInfo *model.TableInfo, now time.Time) (bool, error) {
 	firstPart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
 	if tbInfo != nil {
 		pi := tbInfo.GetPartitionInfo()

--- a/pkg/util/workloadrepo/utils.go
+++ b/pkg/util/workloadrepo/utils.go
@@ -44,7 +44,7 @@ func generatePartitionRanges(sb *strings.Builder, tbInfo *model.TableInfo, now t
 	firstPart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
 	if tbInfo != nil {
 		pi := tbInfo.GetPartitionInfo()
-		if pi != nil {
+		if pi != nil && pi.Definitions != nil && len(pi.Definitions) > 0 {
 			ptInfos := pi.Definitions
 			lastPartDate, err := parsePartitionName(ptInfos[len(ptInfos)-1].Name.L)
 			if err != nil {

--- a/pkg/util/workloadrepo/utils.go
+++ b/pkg/util/workloadrepo/utils.go
@@ -43,9 +43,9 @@ func generatePartitionRanges(sb *strings.Builder, tbInfo *model.TableInfo) bool 
 		newPtTime := now.AddDate(0, 0, i+1)
 		newPtName := "p" + newPtTime.Format("20060102")
 		if tbInfo != nil {
-			ptInfos := tbInfo.GetPartitionInfo().Definitions
-			if slice.AnyOf(ptInfos, func(i int) bool {
-				return ptInfos[i].Name.L == newPtName
+			pi := tbInfo.GetPartitionInfo()
+			if pi != nil && slice.AnyOf(pi.Definitions, func(i int) bool {
+				return pi.Definitions[i].Name.L == newPtName
 			}) {
 				continue
 			}

--- a/pkg/util/workloadrepo/utils.go
+++ b/pkg/util/workloadrepo/utils.go
@@ -16,6 +16,7 @@ package workloadrepo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -87,5 +88,9 @@ func (w *worker) setRetentionDays(_ context.Context, d string) error {
 
 func validateDest(orig string) (string, error) {
 	// validate S3 URL, etc...
-	return strings.ToLower(orig), nil
+	orig = strings.ToLower(orig)
+	if orig != "" && orig != "table" {
+		return "", errors.New("invalid repository destination")
+	}
+	return orig, nil
 }

--- a/pkg/util/workloadrepo/utils.go
+++ b/pkg/util/workloadrepo/utils.go
@@ -62,7 +62,7 @@ func generatePartitionRanges(sb *strings.Builder, tbInfo *model.TableInfo, now t
 		newPtTime := firstPart.AddDate(0, 0, 1)
 		newPtName := generatePartitionName(newPtTime)
 
-		if allExisted == false {
+		if !allExisted {
 			fmt.Fprintf(sb, ", ")
 		}
 		fmt.Fprintf(sb, "PARTITION %s VALUES LESS THAN (TO_DAYS('%s'))", newPtName, newPtTime.Format("2006-01-02"))

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -124,11 +124,7 @@ type worker struct {
 	retentionDays    int32
 }
 
-var workerCtx = worker{
-	samplingInterval: defSamplingInterval,
-	snapshotInterval: defSnapshotInterval,
-	retentionDays:    defRententionDays,
-}
+var workerCtx = worker{}
 
 func takeSnapshot() error {
 	if workerCtx.snapshotChan == nil {
@@ -193,6 +189,9 @@ func initializeWorker(w *worker, etcdCli *clientv3.Client, newOwner func(string,
 	w.sesspool = sesspool
 	w.newOwner = newOwner
 	w.workloadTables = workloadTables
+	w.samplingInterval = defSamplingInterval
+	w.snapshotInterval = defSnapshotInterval
+	w.retentionDays = defRententionDays
 
 	w.snapshotTicker = time.NewTicker(time.Second)
 	w.snapshotTicker.Stop()

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -79,7 +79,7 @@ var workloadTables = []repositoryTable{
 			ERROR TEXT DEFAULT NULL COMMENT 'extra messages are written if anything happens to block that snapshots.')`, WorkloadSchema, histSnapshotsTable),
 		"",
 	},
-	//{"INFORMATION_SCHEMA", "TIDB_INDEX_USAGE", snapshotTable, "", "", "", ""},
+	{"INFORMATION_SCHEMA", "TIDB_INDEX_USAGE", snapshotTable, "", "", "", ""},
 	//{"INFORMATION_SCHEMA", "TIDB_STATEMENTS_STATS", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_BY_HOST", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_BY_USER", snapshotTable, "", "", "", ""},

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -304,12 +304,12 @@ func (w *worker) startRepository(ctx context.Context) func() {
 			case <-ticker.C:
 				if w.owner.IsOwner() {
 					logutil.BgLogger().Info("repository has owner!")
-					if err := w.createAllTables(ctx); err != nil {
+					if err := w.createAllTables(ctx, time.Now()); err != nil {
 						logutil.BgLogger().Error("workload repository cannot create tables", zap.NamedError("err", err))
 					}
 				}
 
-				if !w.checkTablesExists(ctx) {
+				if !w.checkTablesExists(ctx, time.Now()) {
 					continue
 				}
 

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -274,6 +274,17 @@ func (w *worker) readInstanceID() error {
 	return nil
 }
 
+func fillInTableNames() {
+	for rtIdx := range workloadTables {
+		rt := &workloadTables[rtIdx]
+		if rt.table != "" {
+			if rt.destTable == "" {
+				rt.destTable = "HIST_" + rt.table
+			}
+		}
+	}
+}
+
 func (w *worker) startRepository(ctx context.Context) func() {
 	// TODO: add another txn type
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnOthers)
@@ -284,14 +295,7 @@ func (w *worker) startRepository(ctx context.Context) func() {
 		}
 		ticker := time.NewTicker(time.Second)
 
-		for rtIdx := range workloadTables {
-			rt := &workloadTables[rtIdx]
-			if rt.table != "" {
-				if rt.destTable == "" {
-					rt.destTable = "HIST_" + rt.table
-				}
-			}
-		}
+		fillInTableNames()
 
 		for {
 			select {

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -80,7 +80,7 @@ var workloadTables = []repositoryTable{
 		"",
 	},
 	{"INFORMATION_SCHEMA", "TIDB_INDEX_USAGE", snapshotTable, "", "", "", ""},
-	//{"INFORMATION_SCHEMA", "TIDB_STATEMENTS_STATS", snapshotTable, "", "", "", ""},
+	{"INFORMATION_SCHEMA", "TIDB_STATEMENTS_STATS", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_BY_HOST", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_BY_USER", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_GLOBAL", snapshotTable, "", "", "", ""},

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -193,6 +193,12 @@ func initializeWorker(w *worker, etcdCli *clientv3.Client, newOwner func(string,
 	w.sesspool = sesspool
 	w.newOwner = newOwner
 	w.workloadTables = workloadTables
+
+	w.snapshotTicker = time.NewTicker(time.Second)
+	w.snapshotTicker.Stop()
+	w.samplingTicker = time.NewTicker(time.Second)
+	w.samplingTicker.Stop()
+
 	w.wg = util.NewWaitGroupEnhancedWrapper("workloadrepo", nil, false)
 }
 

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -36,8 +36,30 @@ import (
 )
 
 func setupWorkerForTest(ctx context.Context, etcdCli *clientv3.Client, dom *domain.Domain, id string, testWorker bool) *worker {
-	wrk := &worker{}
+	wrk := &worker{
+		samplingInterval: defSamplingInterval,
+		snapshotInterval: defSnapshotInterval,
+		retentionDays:    defRententionDays,
+	}
+
 	if !testWorker {
+		workerCtx.etcdClient = nil
+		workerCtx.sesspool = nil
+		workerCtx.cancel = nil
+		workerCtx.newOwner = nil
+		workerCtx.owner = nil
+		workerCtx.wg = nil
+		workerCtx.enabled = false
+		workerCtx.instanceID = ""
+		workerCtx.workloadTables = nil
+
+		workerCtx.samplingInterval = defSamplingInterval
+		workerCtx.samplingTicker = nil
+		workerCtx.snapshotInterval = defSnapshotInterval
+		workerCtx.snapshotTicker = nil
+		workerCtx.snapshotChan = nil
+		workerCtx.retentionDays = defRententionDays
+
 		wrk = &workerCtx
 	}
 	workloadTables2 := make([]repositoryTable, len(workloadTables))

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -655,7 +655,7 @@ func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
 
 func TestCreatePartition(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
-	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("create database WORKLOAD_SCHEMA")
@@ -731,7 +731,7 @@ func validatePartitionDrop(ctx context.Context, now time.Time, t *testing.T,
 
 func TestDropOldPartitions(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
-	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("create database WORKLOAD_SCHEMA")
@@ -808,7 +808,7 @@ func getNextTick(now time.Time) time.Duration {
 
 func TestHouseKeeperThread(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
-	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("create database WORKLOAD_SCHEMA")

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -36,32 +36,11 @@ import (
 )
 
 func setupWorkerForTest(ctx context.Context, etcdCli *clientv3.Client, dom *domain.Domain, id string, testWorker bool) *worker {
-	wrk := &worker{
-		samplingInterval: defSamplingInterval,
-		snapshotInterval: defSnapshotInterval,
-		retentionDays:    defRententionDays,
-	}
-
+	wrk := &worker{}
 	if !testWorker {
-		workerCtx.etcdClient = nil
-		workerCtx.sesspool = nil
-		workerCtx.cancel = nil
-		workerCtx.newOwner = nil
-		workerCtx.owner = nil
-		workerCtx.wg = nil
-		workerCtx.enabled = false
-		workerCtx.instanceID = ""
-		workerCtx.workloadTables = nil
-
-		workerCtx.samplingInterval = defSamplingInterval
-		workerCtx.samplingTicker = nil
-		workerCtx.snapshotInterval = defSnapshotInterval
-		workerCtx.snapshotTicker = nil
-		workerCtx.snapshotChan = nil
-		workerCtx.retentionDays = defRententionDays
-
 		wrk = &workerCtx
 	}
+
 	workloadTables2 := make([]repositoryTable, len(workloadTables))
 	copy(workloadTables2, workloadTables)
 

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -556,7 +556,7 @@ func validatePartitionsMatchExpected(ctx context.Context, t *testing.T,
 	require.NotNil(t, tbInfo)
 	pi := tbInfo.GetPartitionInfo()
 	tp := make(map[string]struct{})
-	if pi != nil {
+	if pi != nil && pi.Definitions != nil {
 		for _, p := range pi.Definitions {
 			tp[p.Name.L] = struct{}{}
 		}

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -643,8 +643,7 @@ func TestCreatePartition(t *testing.T) {
 
 	now := time.Now()
 
-	/* Tables without partitions are not currently supported.  This also does
-	   not test cases with partitions in the future beyond what will be created. */
+	/* Tables without partitions are not currently supported. */
 
 	// Should create one partition for today and tomorrow on a table with only old partitions before today.
 	partitions := []time.Time{now.AddDate(0, 0, -1)}
@@ -665,6 +664,16 @@ func TestCreatePartition(t *testing.T) {
 	partitions = []time.Time{now, now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
 	validatePartitionCreation(ctx, now, t, sess, tk, false, "MEMORY_USAGE", partitions, expectedParts)
+
+	// Should not create any partitions on a table with a partition for the day after tomorrow.
+	partitions = []time.Time{now.AddDate(0, 0, 2)}
+	expectedParts = []time.Time{now.AddDate(0, 0, 2)}
+	validatePartitionCreation(ctx, now, t, sess, tk, false, "CLUSTER_LOAD", partitions, expectedParts)
+
+	// Should not fill in missing partitions on a table with a partition for dates beyond tomorrow.
+	partitions = []time.Time{now, now.AddDate(0, 0, 3)}
+	expectedParts = []time.Time{now, now.AddDate(0, 0, 3)}
+	validatePartitionCreation(ctx, now, t, sess, tk, false, "TIDB_HOT_REGIONS", partitions, expectedParts)
 
 	// this table should be updated when the repository is enabled
 	partitions = []time.Time{now}

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -602,10 +602,10 @@ func buildPartitionString(partitions []time.Time) string {
 
 func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit, tbl *repositoryTable,
 	sess sessionctx.Context, partitions []time.Time) {
-	createSql, err := buildCreateQuery(ctx, sess, tbl)
+	createSQL, err := buildCreateQuery(ctx, sess, tbl)
 	require.NoError(t, err)
-	createSql += buildPartitionString(partitions)
-	tk.MustExec(createSql)
+	createSQL += buildPartitionString(partitions)
+	tk.MustExec(createSQL)
 	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
 }
 

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -112,10 +112,6 @@ func setupWorker(ctx context.Context, t *testing.T, addr string, dom *domain.Dom
 	return wrk
 }
 
-func sleep(secs time.Duration) {
-	time.Sleep(time.Second * secs)
-}
-
 func eventuallyWithLock(t *testing.T, wrk *worker, fn func() bool) {
 	require.Eventually(t, func() bool {
 		wrk.Lock()
@@ -230,10 +226,7 @@ func TestMultipleWorker(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		cnt := getMultipleWorkerCount(tk, "worker1")
-		if cnt >= cnt1 {
-			return true
-		}
-		return false
+		return cnt >= cnt1
 	}, time.Minute, time.Second)
 
 	// stop worker 2, worker 1 should become owner
@@ -249,10 +242,7 @@ func TestMultipleWorker(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		cnt := getMultipleWorkerCount(tk, "worker2")
-		if cnt >= cnt2 {
-			return true
-		}
-		return false
+		return cnt >= cnt2
 	}, time.Minute, time.Second)
 }
 
@@ -452,7 +442,7 @@ func TestStoppingAndRestartingWorker(t *testing.T) {
 	snapshotCnt := len(tk.MustQuery("select snap_id from workload_schema." + histSnapshotsTable).Rows())
 
 	// Wait for 5 seconds to make sure no new samples are taken
-	sleep(5)
+	time.Sleep(time.Second * 5)
 	require.True(t, len(tk.MustQuery("select instance_id from workload_schema.hist_memory_usage").Rows()) == samplingCnt)
 	require.True(t, len(tk.MustQuery("select snap_id from workload_schema."+histSnapshotsTable).Rows()) == snapshotCnt)
 

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -16,14 +16,19 @@ package workloadrepo
 
 import (
 	"context"
+	"fmt"
 	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/owner"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -50,7 +55,8 @@ func setupWorkerForTest(ctx context.Context, etcdCli *clientv3.Client, dom *doma
 
 func setupDomainAndContext(t *testing.T) (context.Context, kv.Storage, *domain.Domain, string) {
 	ctx := context.Background()
-	var cancel context.CancelFunc
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnOthers)
+	var cancel context.CancelFunc = nil
 	if ddl, ok := t.Deadline(); ok {
 		ctx, cancel = context.WithDeadline(ctx, ddl)
 	}
@@ -106,7 +112,31 @@ func setupWorker(ctx context.Context, t *testing.T, addr string, dom *domain.Dom
 	return wrk
 }
 
-func TestMultipleWorker(t *testing.T) {
+func sleep(secs time.Duration) {
+	time.Sleep(time.Second * secs)
+}
+
+func eventuallyWithLock(t *testing.T, wrk *worker, fn func() bool) {
+	require.Eventually(t, func() bool {
+		wrk.Lock()
+		defer wrk.Unlock()
+		return fn()
+	}, time.Minute, time.Second)
+}
+
+func trueWithLock(t *testing.T, wrk *worker, fn func() bool) {
+	wrk.Lock()
+	defer wrk.Unlock()
+	require.True(t, fn())
+}
+
+func waitForTables(ctx context.Context, t *testing.T, wrk *worker, now time.Time) {
+	require.Eventually(t, func() bool {
+		return wrk.checkTablesExists(ctx, now)
+	}, time.Minute, time.Second)
+}
+
+func TestRaceToCreateTablesWorker(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
 
 	_, ok := dom.InfoSchema().SchemaByName(ast.NewCIStr("workload_schema"))
@@ -116,11 +146,12 @@ func TestMultipleWorker(t *testing.T) {
 	wrk2 := setupWorker(ctx, t, addr, dom, "worker2", true)
 	wrk1.changeSnapshotInterval(nil, "3600")
 	wrk2.changeSnapshotInterval(nil, "3600")
+	now := time.Now()
 	require.NoError(t, wrk1.setRepositoryDest(ctx, "table"))
 	require.NoError(t, wrk2.setRepositoryDest(ctx, "table"))
 
 	require.Eventually(t, func() bool {
-		return wrk1.checkTablesExists(ctx) && wrk2.checkTablesExists(ctx)
+		return wrk1.checkTablesExists(ctx, now) && wrk2.checkTablesExists(ctx, now)
 	}, time.Minute, time.Second)
 
 	tk := testkit.NewTestKit(t, store)
@@ -149,6 +180,82 @@ func TestMultipleWorker(t *testing.T) {
 	}, time.Minute, time.Second)
 }
 
+func getMultipleWorkerCount(tk *testkit.TestKit, worker string) int {
+	res := tk.MustQuery("select count(*) from workload_schema.hist_memory_usage group by instance_id having instance_id = '" + worker + "'").Rows()
+	return len(res)
+}
+
+func TestMultipleWorker(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	tk := testkit.NewTestKit(t, store)
+
+	wrk1 := setupWorker(ctx, t, addr, dom, "worker1", true)
+	wrk1.changeSamplingInterval(ctx, "1")
+	wrk2 := setupWorker(ctx, t, addr, dom, "worker2", true)
+	wrk2.changeSamplingInterval(ctx, "1")
+
+	// start worker 1
+	now := time.Now()
+	require.NoError(t, wrk1.setRepositoryDest(ctx, "table"))
+	waitForTables(ctx, t, wrk1, now)
+	require.True(t, wrk1.owner.IsOwner())
+
+	require.Eventually(t, func() bool {
+		return getMultipleWorkerCount(tk, "worker1") >= 1
+	}, time.Minute, time.Second)
+
+	// start worker 2
+	require.NoError(t, wrk2.setRepositoryDest(ctx, "table"))
+	eventuallyWithLock(t, wrk2, func() bool { return wrk2.owner != nil })
+	require.True(t, !wrk2.owner.IsOwner())
+
+	require.Eventually(t, func() bool {
+		return getMultipleWorkerCount(tk, "worker2") >= 1
+	}, time.Minute, time.Second)
+
+	// stop worker 1, worker 2 should become owner
+	require.NoError(t, wrk1.setRepositoryDest(ctx, ""))
+	require.Eventually(t, func() bool {
+		return wrk2.owner.IsOwner()
+	}, time.Minute, time.Second)
+
+	// start worker 1 again
+	require.NoError(t, wrk1.setRepositoryDest(ctx, "table"))
+	eventuallyWithLock(t, wrk1, func() bool { return wrk1.owner != nil })
+	require.True(t, !wrk1.owner.IsOwner())
+
+	// get counts from tables for both workers
+	cnt1 := getMultipleWorkerCount(tk, "worker1")
+	cnt2 := getMultipleWorkerCount(tk, "worker2")
+
+	require.Eventually(t, func() bool {
+		cnt := getMultipleWorkerCount(tk, "worker1")
+		if cnt >= cnt1 {
+			return true
+		}
+		return false
+	}, time.Minute, time.Second)
+
+	// stop worker 2, worker 1 should become owner
+	require.NoError(t, wrk2.setRepositoryDest(ctx, ""))
+	require.Eventually(t, func() bool {
+		return wrk1.owner.IsOwner()
+	}, time.Minute, time.Second)
+
+	// start worker 2 again
+	require.NoError(t, wrk2.setRepositoryDest(ctx, "table"))
+	eventuallyWithLock(t, wrk2, func() bool { return wrk2.owner != nil })
+	require.True(t, !wrk2.owner.IsOwner())
+
+	require.Eventually(t, func() bool {
+		cnt := getMultipleWorkerCount(tk, "worker2")
+		if cnt >= cnt2 {
+			return true
+		}
+		return false
+	}, time.Minute, time.Second)
+}
+
 func TestGlobalWorker(t *testing.T) {
 	ctx, store, dom, addr := setupDomainAndContext(t)
 	tk := testkit.NewTestKit(t, store)
@@ -157,15 +264,14 @@ func TestGlobalWorker(t *testing.T) {
 	require.False(t, ok)
 
 	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	now := time.Now()
 	tk.MustExec("set @@global.tidb_workload_repository_dest='table'")
 
-	require.Eventually(t, func() bool {
-		return wrk.checkTablesExists(ctx)
-	}, time.Minute, time.Second)
+	waitForTables(ctx, t, wrk, now)
 
 	// sampling succeeded
 	require.Eventually(t, func() bool {
-		res := tk.MustQuery("select instance_id, count(*) from workload_schema.hist_memory_usage group by instance_id").Rows()
+		res := tk.MustQuery("select instance_id from workload_schema.hist_memory_usage").Rows()
 		return len(res) >= 1
 	}, time.Minute, time.Second)
 }
@@ -178,12 +284,13 @@ func TestAdminWorkloadRepo(t *testing.T) {
 	require.False(t, ok)
 
 	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	now := time.Now()
 	tk.MustExec("set @@global.tidb_workload_repository_snapshot_interval='5000'")
 	tk.MustExec("set @@global.tidb_workload_repository_active_sampling_interval='600'")
 	tk.MustExec("set @@global.tidb_workload_repository_dest='table'")
 
 	require.Eventually(t, func() bool {
-		return wrk.checkTablesExists(ctx)
+		return wrk.checkTablesExists(ctx, now)
 	}, time.Minute, time.Second)
 
 	// able to snapshot manually
@@ -196,4 +303,557 @@ func TestAdminWorkloadRepo(t *testing.T) {
 	// disable the worker and it will fail
 	tk.MustExec("set @@global.tidb_workload_repository_dest=''")
 	tk.MustExecToErr("admin create workload snapshot")
+}
+
+func getRows(t *testing.T, tk *testkit.TestKit, cnt int, maxSecs int, query string) [][]any {
+	var rows [][]any
+	require.Eventually(t, func() bool {
+		rows = tk.MustQuery(query).Rows()
+		return len(rows) == cnt
+	}, time.Second*time.Duration(maxSecs*cnt), time.Millisecond*100)
+	return rows
+}
+
+func validateDate(t *testing.T, row []any, idx int, lastRowTs time.Time, maxSecs int) time.Time {
+	loc := lastRowTs.Location()
+	actualTs, err := time.ParseInLocation("2006-01-02 15:04:05", row[idx].(string), loc)
+	require.NoError(t, err)
+	require.Greater(t, actualTs.Unix(), lastRowTs.Unix())                    // after last row
+	require.LessOrEqual(t, actualTs.Unix(), lastRowTs.Unix()+int64(maxSecs)) // within last maxSecs seconds of last row
+	return actualTs
+}
+
+func SamplingTimingWorker(t *testing.T, tk *testkit.TestKit, lastRowTs time.Time, cnt int, maxSecs int) time.Time {
+	rows := getRows(t, tk, cnt, maxSecs, "select instance_id, ts from "+WorkloadSchema+".hist_memory_usage where ts > '"+lastRowTs.Format("2006-01-02 15:04:05")+"' order by ts asc")
+
+	for _, row := range rows {
+		// check that the instance_id is correct
+		require.Equal(t, "worker", row[0]) // instance_id should match worker name
+
+		// check that each rows are the correct interval apart
+		lastRowTs = validateDate(t, row, 1, lastRowTs, maxSecs)
+	}
+
+	return lastRowTs
+}
+
+func TestSamplingTimingWorker(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	tk := testkit.NewTestKit(t, store)
+
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
+	wrk.changeSamplingInterval(ctx, "2")
+	now := time.Now()
+	wrk.setRepositoryDest(ctx, "table")
+
+	waitForTables(ctx, t, wrk, now)
+
+	lastRowTs := time.Now()
+	lastRowTs = SamplingTimingWorker(t, tk, lastRowTs, 3, 3)
+
+	// Change interval and verify new samples are taken at new interval
+	wrk.changeSamplingInterval(ctx, "5")
+
+	_ = SamplingTimingWorker(t, tk, lastRowTs, 3, 6)
+}
+
+func findMatchingRowForSnapshot(t *testing.T, rowidx int, snapRows [][]any, row []any, lastRowTs time.Time, maxSecs int) {
+	require.Less(t, rowidx, len(snapRows))
+	row2 := snapRows[rowidx]
+	require.Equal(t, row2[0], row[0])
+	require.Equal(t, row2[2], "worker")
+	validateDate(t, row2, 1, lastRowTs, maxSecs)
+}
+
+func SnapshotTimingWorker(t *testing.T, tk *testkit.TestKit, lastRowTs time.Time, lastSnapID int, cnt int, maxSecs int) (time.Time, int) {
+	rows := getRows(t, tk, cnt, maxSecs, "select snap_id, begin_time from "+WorkloadSchema+"."+histSnapshotsTable+" where begin_time > '"+lastRowTs.Format("2006-01-02 15:04:05")+"' order by begin_time asc")
+
+	// We want to get all rows if we are starting from 0.
+	snapWhere := ""
+	if lastSnapID > 0 {
+		snapWhere = " where snap_id > " + strconv.Itoa(lastSnapID)
+	}
+
+	rows2 := getRows(t, tk, cnt, maxSecs, "select snap_id, ts, instance_id from WORKLOAD_SCHEMA.HIST_MEMORY_USAGE2"+snapWhere+" order by snap_id asc")
+	rows3 := getRows(t, tk, cnt, maxSecs, "select snap_id, ts, instance_id from WORKLOAD_SCHEMA.HIST_MEMORY_USAGE3"+snapWhere+" order by snap_id asc")
+	rowidx := 0
+
+	for _, row := range rows {
+		snapID, err := strconv.Atoi(row[0].(string))
+		require.NoError(t, err)
+		require.Equal(t, lastSnapID+1, snapID)
+
+		actualTs := validateDate(t, row, 1, lastRowTs, maxSecs)
+
+		findMatchingRowForSnapshot(t, rowidx, rows2, row, lastRowTs, maxSecs)
+		findMatchingRowForSnapshot(t, rowidx, rows3, row, lastRowTs, maxSecs)
+		rowidx++
+
+		lastSnapID = snapID
+		lastRowTs = actualTs
+	}
+
+	return lastRowTs, lastSnapID
+}
+
+func TestSnapshotTimingWorker(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	tk := testkit.NewTestKit(t, store)
+
+	// MEMORY_USAGE will contain a single row.  Ideal for testing here.
+	workloadTables[1] = repositoryTable{
+		"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, "HIST_MEMORY_USAGE2", "", "", "",
+	}
+	workloadTables = append(workloadTables, repositoryTable{
+		"INFORMATION_SCHEMA", "MEMORY_USAGE", snapshotTable, "HIST_MEMORY_USAGE3", "", "", "",
+	})
+
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
+	wrk.changeSnapshotInterval(ctx, "2")
+	now := time.Now()
+	wrk.setRepositoryDest(ctx, "table")
+
+	waitForTables(ctx, t, wrk, now)
+
+	// Check that snapshots are taken at 2 second intervals
+	lastRowTs := time.Now()
+	lastSnapID := 0
+	lastRowTs, lastSnapID = SnapshotTimingWorker(t, tk, lastRowTs, lastSnapID, 3, 3)
+
+	// Change interval and verify new snapshots are taken at new interval
+	wrk.changeSnapshotInterval(ctx, "6")
+	_, _ = SnapshotTimingWorker(t, tk, lastRowTs, lastSnapID, 1, 7)
+}
+
+func TestStoppingAndRestartingWorker(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	tk := testkit.NewTestKit(t, store)
+
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
+	wrk.changeSamplingInterval(ctx, "1")
+	wrk.changeSnapshotInterval(ctx, "1")
+	now := time.Now()
+	wrk.setRepositoryDest(ctx, "table")
+
+	waitForTables(ctx, t, wrk, now)
+
+	// There should be one row every second.
+	require.Eventually(t, func() bool {
+		return len(tk.MustQuery("select instance_id from workload_schema.hist_memory_usage").Rows()) > 0
+	}, time.Minute, time.Second)
+	require.Eventually(t, func() bool {
+		return len(tk.MustQuery("select snap_id from workload_schema."+histSnapshotsTable).Rows()) > 0
+	}, time.Minute, time.Second)
+
+	// Stop worker and verify no new samples are taken
+	wrk.setRepositoryDest(ctx, "")
+	eventuallyWithLock(t, wrk, func() bool { return wrk.cancel == nil })
+	samplingCnt := len(tk.MustQuery("select instance_id from workload_schema.hist_memory_usage").Rows())
+	snapshotCnt := len(tk.MustQuery("select snap_id from workload_schema." + histSnapshotsTable).Rows())
+
+	// Wait for 5 seconds to make sure no new samples are taken
+	sleep(5)
+	require.True(t, len(tk.MustQuery("select instance_id from workload_schema.hist_memory_usage").Rows()) == samplingCnt)
+	require.True(t, len(tk.MustQuery("select snap_id from workload_schema."+histSnapshotsTable).Rows()) == snapshotCnt)
+
+	// Restart worker and verify new samples are taken
+	wrk.setRepositoryDest(ctx, "table")
+
+	require.Eventually(t, func() bool {
+		return len(tk.MustQuery("select instance_id from workload_schema.hist_memory_usage").Rows()) >= samplingCnt
+	}, time.Minute, time.Second)
+	require.Eventually(t, func() bool {
+		return len(tk.MustQuery("select snap_id from workload_schema."+histSnapshotsTable).Rows()) >= snapshotCnt
+	}, time.Minute, time.Second)
+}
+
+func TestSettingSQLVariables(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	tk := testkit.NewTestKit(t, store)
+
+	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+
+	/* Order of less than minimum, maximum, minimum, and greater than maximum
+	tests are not random. Because we need to know of the invalid values are
+	converted to the minimum or maximum. */
+
+	// Test values less than minimum
+	tk.MustExec("set @@global." + repositorySamplingInterval + " = -1")
+	tk.MustExec("set @@global." + repositorySnapshotInterval + " = 899")
+	tk.MustExec("set @@global." + repositoryRetentionDays + " = -1")
+	eventuallyWithLock(t, wrk, func() bool { return int32(0) == wrk.samplingInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(900) == wrk.snapshotInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(0) == wrk.retentionDays })
+
+	// Test maximum values
+	tk.MustExec("set @@global." + repositorySamplingInterval + " = 600")
+	tk.MustExec("set @@global." + repositorySnapshotInterval + " = 7200")
+	tk.MustExec("set @@global." + repositoryRetentionDays + " = 365")
+	eventuallyWithLock(t, wrk, func() bool { return int32(600) == wrk.samplingInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(7200) == wrk.snapshotInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(365) == wrk.retentionDays })
+
+	// Test minimum values
+	tk.MustExec("set @@global." + repositorySamplingInterval + " = 0")
+	tk.MustExec("set @@global." + repositorySnapshotInterval + " = 900")
+	tk.MustExec("set @@global." + repositoryRetentionDays + " = 0")
+	eventuallyWithLock(t, wrk, func() bool { return int32(0) == wrk.samplingInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(900) == wrk.snapshotInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(0) == wrk.retentionDays })
+
+	// Test values greater than maximum
+	tk.MustExec("set @@global." + repositorySamplingInterval + " = 601")
+	tk.MustExec("set @@global." + repositorySnapshotInterval + " = 7201")
+	tk.MustExec("set @@global." + repositoryRetentionDays + " = 366")
+	eventuallyWithLock(t, wrk, func() bool { return int32(600) == wrk.samplingInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(7200) == wrk.snapshotInterval })
+	eventuallyWithLock(t, wrk, func() bool { return int32(365) == wrk.retentionDays })
+
+	// Test invalid value for sampling interval
+	err := tk.ExecToErr("set @@global." + repositorySamplingInterval + " = 'invalid'")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Incorrect argument type")
+
+	err = tk.ExecToErr("set @@global." + repositorySnapshotInterval + " = 'invalid'")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Incorrect argument type")
+
+	err = tk.ExecToErr("set @@global." + repositoryRetentionDays + " = 'invalid'")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Incorrect argument type")
+
+	trueWithLock(t, wrk, func() bool { return int32(600) == wrk.samplingInterval })
+	trueWithLock(t, wrk, func() bool { return int32(7200) == wrk.snapshotInterval })
+	trueWithLock(t, wrk, func() bool { return int32(365) == wrk.retentionDays })
+
+	// Test setting repository destination
+	tk.MustExec("set @@global." + repositoryDest + " = 'table'")
+	eventuallyWithLock(t, wrk, func() bool { return wrk.enabled })
+
+	// Test disabling repository
+	tk.MustExec("set @@global." + repositoryDest + " = ''")
+	eventuallyWithLock(t, wrk, func() bool { return !wrk.enabled })
+
+	// Test invalid value for repository destination
+	err = tk.ExecToErr("set @@global." + repositoryDest + " = 'invalid'")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid repository destination")
+}
+
+func getTable(t *testing.T, tableName string) *repositoryTable {
+	var tbl *repositoryTable = nil
+	for _, nt := range workloadTables {
+		if nt.table == tableName {
+			tbl = &nt
+		}
+	}
+	require.NotNil(t, tbl)
+	return tbl
+}
+
+func validatePartitionsMatchExpected(ctx context.Context, t *testing.T,
+	sess sessionctx.Context, tbl *repositoryTable, partitions []time.Time) bool {
+	// validate that the partitions exactly match as expected
+	ep := make(map[string]struct{})
+	for _, p := range partitions {
+		ep[generatePartitionName(p.AddDate(0, 0, 1))] = struct{}{}
+	}
+
+	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	tbSchema, err := is.TableByName(ctx, workloadSchemaCIStr, ast.NewCIStr(tbl.destTable))
+	require.NoError(t, err)
+	tbInfo := tbSchema.Meta()
+	require.NotNil(t, tbInfo)
+	pi := tbInfo.GetPartitionInfo()
+	tp := make(map[string]struct{})
+	if pi != nil {
+		for _, p := range pi.Definitions {
+			tp[p.Name.L] = struct{}{}
+		}
+	}
+
+	if len(tp) != len(ep) {
+		return false
+	}
+
+	for p := range ep {
+		_, ok := tp[p]
+		if !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func buildPartitonRow(now time.Time) string {
+	newPtTime := now.AddDate(0, 0, 1)
+	newPtName := "p" + newPtTime.Format("20060102")
+	parttemp := `PARTITION %s VALUES LESS THAN (TO_DAYS('%s'))`
+	return fmt.Sprintf(parttemp, newPtName, newPtTime.Format("2006-01-02"))
+}
+
+func buildPartitionString(partitions []time.Time) string {
+	sb := &strings.Builder{}
+	if len(partitions) > 0 {
+		fmt.Fprint(sb, ` PARTITION BY RANGE (TO_DAYS(TS)) (`)
+		first := true
+		for _, p := range partitions {
+			if !first {
+				fmt.Fprint(sb, ", ")
+			}
+			fmt.Fprint(sb, buildPartitonRow(p))
+			first = false
+		}
+		fmt.Fprint(sb, `)`)
+	}
+	return sb.String()
+}
+
+func createTableWithParts(ctx context.Context, t *testing.T, tk *testkit.TestKit, tbl *repositoryTable,
+	sess sessionctx.Context, partitions []time.Time) {
+	createSql, err := buildCreateQuery(ctx, sess, tbl)
+	require.NoError(t, err)
+	createSql += buildPartitionString(partitions)
+	tk.MustExec(createSql)
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
+}
+
+func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
+	sess sessionctx.Context, tk *testkit.TestKit,
+	firstTestFails bool, tableName string, partitions []time.Time, expectedParts []time.Time,
+) {
+	tbl := getTable(t, tableName)
+	createTableWithParts(ctx, t, tk, tbl, sess, partitions)
+
+	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	require.False(t, firstTestFails == checkTableExistsByIS(ctx, is, tbl.destTable, now))
+
+	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	require.NoError(t, createPartition(ctx, is, tbl, sess, now))
+
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, expectedParts))
+
+	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	require.True(t, checkTableExistsByIS(ctx, is, tbl.destTable, now))
+}
+
+func TestCreatePartition(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("create database WORKLOAD_SCHEMA")
+	tk.MustExec("use WORKLOAD_SCHEMA")
+
+	_sessctx := wrk.getSessionWithRetry()
+	sess := _sessctx.(sessionctx.Context)
+
+	fillInTableNames()
+
+	now := time.Now()
+
+	/* Tables without partitions are not currently supported.  This also does
+	   not test cases with partitions in the future beyond what will be created. */
+
+	// Should create one partition for today and tomorrow on a table with only old partitions before today.
+	partitions := []time.Time{now.AddDate(0, 0, -1)}
+	expectedParts := []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	validatePartitionCreation(ctx, now, t, sess, tk, true, "PROCESSLIST", partitions, expectedParts)
+
+	// Should create one partition for tomorrow on a table with only a partition for today.
+	partitions = []time.Time{now}
+	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
+	validatePartitionCreation(ctx, now, t, sess, tk, true, "DATA_LOCK_WAITS", partitions, expectedParts)
+
+	// Should not create any partitions on a table with only a partition for tomorrow.
+	partitions = []time.Time{now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now.AddDate(0, 0, 1)}
+	validatePartitionCreation(ctx, now, t, sess, tk, false, "TIDB_TRX", partitions, expectedParts)
+
+	// Should not create any partitions on a table with only a partitions for both today and tomorrow.
+	partitions = []time.Time{now, now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
+	validatePartitionCreation(ctx, now, t, sess, tk, false, "MEMORY_USAGE", partitions, expectedParts)
+
+	// this table should be updated when the repository is enabled
+	partitions = []time.Time{now}
+	createTableWithParts(ctx, t, tk, getTable(t, "DEADLOCKS"), sess, partitions)
+
+	// turn on the repository and see if it creates the remaining tables
+	now = time.Now()
+	wrk.setRepositoryDest(ctx, "table")
+	waitForTables(ctx, t, wrk, now)
+}
+
+func validatePartitionDrop(ctx context.Context, now time.Time, t *testing.T,
+	sess sessionctx.Context, tk *testkit.TestKit,
+	tableName string, partitions []time.Time, retention int, shouldErr bool, expectedParts []time.Time) {
+	tbl := getTable(t, tableName)
+	createTableWithParts(ctx, t, tk, tbl, sess, partitions)
+
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
+
+	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	err := dropOldPartition(ctx, is, tbl, now, retention, sess)
+	if shouldErr {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+	}
+
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, expectedParts))
+}
+
+func TestDropOldPartitions(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("create database WORKLOAD_SCHEMA")
+	tk.MustExec("use WORKLOAD_SCHEMA")
+
+	_sessctx := wrk.getSessionWithRetry()
+	sess := _sessctx.(sessionctx.Context)
+
+	fillInTableNames()
+
+	now := time.Now()
+
+	var partitions []time.Time
+	var expectedParts []time.Time
+	// Zero retention days disabled the partition deletion code.  So we will not test it here.
+
+	// Should not trim any partitions
+	partitions = []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "PROCESSLIST", partitions, 1, false, expectedParts)
+
+	// Test trimming a single partition more than one date before retention date.
+	partitions = []time.Time{now.AddDate(0, 0, -2), now, now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "DATA_LOCK_WAITS", partitions, 1, false, expectedParts)
+
+	// Check that multiple partitions can be removed.
+	partitions = []time.Time{now.AddDate(0, 0, -3), now.AddDate(0, 0, -2), now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "TIDB_TRX", partitions, 1, false, expectedParts)
+
+	// should trim nothing
+	partitions = []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "MEMORY_USAGE", partitions, 2, false, expectedParts)
+
+	// should one partition
+	partitions = []time.Time{now.AddDate(0, 0, -3), now.AddDate(0, 0, -2), now.AddDate(0, 0, 1)}
+	expectedParts = []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, 1)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "CLUSTER_LOAD", partitions, 2, false, expectedParts)
+
+	// validate that it works when not dropping any partitions
+	partitions = []time.Time{now.AddDate(0, 0, -1)}
+	expectedParts = []time.Time{now.AddDate(0, 0, -1)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "TIDB_HOT_REGIONS", partitions, 2, false, expectedParts)
+
+	// there must be partitions, so this should error
+	partitions = []time.Time{now.AddDate(0, 0, -2)}
+	expectedParts = []time.Time{now.AddDate(0, 0, -2)}
+	validatePartitionDrop(ctx, now, t, sess, tk, "TIKV_STORE_STATUS", partitions, 1, true, expectedParts)
+}
+
+func TestAddNewPartitionsOnStart(t *testing.T) {
+	ctx, _, dom, addr := setupDomainAndContext(t)
+	//tk := testkit.NewTestKit(t, store)
+
+	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
+	fillInTableNames()
+	now := time.Now()
+	require.NoError(t, wrk.createAllTables(ctx, now))
+	require.True(t, wrk.checkTablesExists(ctx, now))
+
+	_sessctx := wrk.getSessionWithRetry()
+	sess := _sessctx.(sessionctx.Context)
+	expectedParts := []time.Time{now, now.AddDate(0, 0, 1)}
+	for _, tbl := range workloadTables {
+		// check for now and now + 1 partitions
+		require.True(t, validatePartitionsMatchExpected(ctx, t, sess, &tbl, expectedParts))
+	}
+}
+
+func getNextTick(now time.Time) time.Duration {
+	return time.Second
+}
+
+func TestHouseKeeperThread(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("create database WORKLOAD_SCHEMA")
+	tk.MustExec("use WORKLOAD_SCHEMA")
+
+	_sessctx := wrk.getSessionWithRetry()
+	sess := _sessctx.(sessionctx.Context)
+
+	workloadTables = []repositoryTable{
+		{"INFORMATION_SCHEMA", "PROCESSLIST", samplingTable, "", "", "", ""},
+		{"INFORMATION_SCHEMA", "DATA_LOCK_WAITS", samplingTable, "", "", "", ""},
+	}
+	fillInTableNames()
+
+	now := time.Now()
+	var parts []time.Time
+
+	// This will have a partiton added for tomorrow.
+	parts = []time.Time{now.AddDate(0, 0, -1), now}
+	plTbl := getTable(t, "PROCESSLIST")
+	createTableWithParts(ctx, t, tk, plTbl, sess, parts)
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, plTbl, parts))
+
+	// This will have partitions removed.   -3 will be removed when retention is 2, and -2 will be removed at 1.
+	parts = []time.Time{now.AddDate(0, 0, -3), now.AddDate(0, 0, -2), now.AddDate(0, 0, -1), now}
+	dlwTbl := getTable(t, "DATA_LOCK_WAITS")
+	createTableWithParts(ctx, t, tk, dlwTbl, sess, parts)
+	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, dlwTbl, parts))
+
+	// start the thread
+	wrk.owner = wrk.newOwner(ownerKey, promptKey)
+	require.NoError(t, wrk.owner.CampaignOwner())
+	require.Eventually(t, func() bool {
+		return wrk.owner.IsOwner()
+	}, time.Second*10, time.Second)
+
+	// build remaining tables and start housekeeper
+	wrk.retentionDays = 2
+	fn := wrk.getHouseKeeper(ctx, getNextTick)
+	go fn()
+
+	// check paritions
+	require.Eventually(t, func() bool {
+		return validatePartitionsMatchExpected(ctx, t, sess, plTbl, []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)})
+	}, time.Second*10, time.Second)
+	require.Eventually(t, func() bool {
+		return validatePartitionsMatchExpected(ctx, t, sess, dlwTbl, []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)})
+	}, time.Second*10, time.Second)
+
+	// Change the retention value.  We just want to see that it is still running.
+	wrk.Lock()
+	wrk.retentionDays = 1
+	wrk.Unlock()
+
+	// check partitions
+	time.Sleep(time.Second * 10)
+	require.Eventually(t, func() bool {
+		return validatePartitionsMatchExpected(ctx, t, sess, plTbl, []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)})
+	}, time.Second*10, time.Second)
+	require.Eventually(t, func() bool {
+		return validatePartitionsMatchExpected(ctx, t, sess, dlwTbl, []time.Time{now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)})
+	}, time.Second*10, time.Second)
+}
+
+func TestCalcNextTick(t *testing.T) {
+	loc := time.Now().Location()
+	require.True(t, calcNextTick(time.Date(2024, 12, 6, 23, 59, 59, 999999999, loc)) == time.Hour*2+time.Nanosecond)
+	require.True(t, calcNextTick(time.Date(2024, 12, 7, 0, 0, 0, 0, loc)) == time.Hour*2)
+	require.True(t, calcNextTick(time.Date(2024, 12, 7, 2, 0, 0, 1, loc)) == time.Hour*24-time.Nanosecond)
+	require.True(t, calcNextTick(time.Date(2024, 12, 7, 1, 59, 59, 999999999, loc)) == time.Nanosecond)
 }

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -194,6 +194,6 @@ func TestAdminWorkloadRepo(t *testing.T) {
 	}, time.Minute, time.Second)
 
 	// disable the worker and it will fail
-	tk.MustExec("set @@global.tidb_workload_repository_dest='ble'")
+	tk.MustExec("set @@global.tidb_workload_repository_dest=''")
 	tk.MustExecToErr("admin create workload snapshot")
 }

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -464,7 +464,7 @@ func TestSettingSQLVariables(t *testing.T) {
 	wrk := setupWorker(ctx, t, addr, dom, "worker", false)
 
 	/* Order of less than minimum, maximum, minimum, and greater than maximum
-	tests are not random. Because we need to know of the invalid values are
+	tests are not random. Because we need to know if the invalid values are
 	converted to the minimum or maximum. */
 
 	// Test values less than minimum
@@ -576,7 +576,7 @@ func validatePartitionsMatchExpected(ctx context.Context, t *testing.T,
 	return true
 }
 
-func buildPartitonRow(now time.Time) string {
+func buildPartitionRow(now time.Time) string {
 	newPtTime := now.AddDate(0, 0, 1)
 	newPtName := "p" + newPtTime.Format("20060102")
 	parttemp := `PARTITION %s VALUES LESS THAN (TO_DAYS('%s'))`
@@ -592,7 +592,7 @@ func buildPartitionString(partitions []time.Time) string {
 			if !first {
 				fmt.Fprint(sb, ", ")
 			}
-			fmt.Fprint(sb, buildPartitonRow(p))
+			fmt.Fprint(sb, buildPartitionRow(p))
 			first = false
 		}
 		fmt.Fprint(sb, `)`)
@@ -660,7 +660,7 @@ func TestCreatePartition(t *testing.T) {
 	expectedParts = []time.Time{now.AddDate(0, 0, 1)}
 	validatePartitionCreation(ctx, now, t, sess, tk, false, "TIDB_TRX", partitions, expectedParts)
 
-	// Should not create any partitions on a table with only a partitions for both today and tomorrow.
+	// Should not create any partitions on a table with only partitions for both today and tomorrow.
 	partitions = []time.Time{now, now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 1)}
 	validatePartitionCreation(ctx, now, t, sess, tk, false, "MEMORY_USAGE", partitions, expectedParts)
@@ -743,7 +743,7 @@ func TestDropOldPartitions(t *testing.T) {
 	expectedParts = []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, -1), now, now.AddDate(0, 0, 1)}
 	validatePartitionDrop(ctx, now, t, sess, tk, "MEMORY_USAGE", partitions, 2, false, expectedParts)
 
-	// should one partition
+	// should trim one partition
 	partitions = []time.Time{now.AddDate(0, 0, -3), now.AddDate(0, 0, -2), now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, 1)}
 	validatePartitionDrop(ctx, now, t, sess, tk, "CLUSTER_LOAD", partitions, 2, false, expectedParts)
@@ -761,7 +761,6 @@ func TestDropOldPartitions(t *testing.T) {
 
 func TestAddNewPartitionsOnStart(t *testing.T) {
 	ctx, _, dom, addr := setupDomainAndContext(t)
-	//tk := testkit.NewTestKit(t, store)
 
 	wrk := setupWorker(ctx, t, addr, dom, "worker", true)
 	fillInTableNames()
@@ -802,7 +801,7 @@ func TestHouseKeeperThread(t *testing.T) {
 	now := time.Now()
 	var parts []time.Time
 
-	// This will have a partiton added for tomorrow.
+	// This will have a partition added for tomorrow.
 	parts = []time.Time{now.AddDate(0, 0, -1), now}
 	plTbl := getTable(t, "PROCESSLIST")
 	createTableWithParts(ctx, t, tk, plTbl, sess, parts)


### PR DESCRIPTION
Issue Number: ref #58247

Problem Summary:

This pull request adds unit testing for the Workload Repository code.  It also fixes a few issues and refactors some code. Specific changes include:

* Create the etcd snap id key the first actual value instead of zero.
* Enable snapshot collection for the TIDB_INDEX_USAGE.
* Add checks for nil to a few places in the partition handling code.
* Partition validation code will only check that partitions cover today and tomorrow.
* It will only generate new partitions if no partition covers the current day and the next day.
* Validate that the value assigned to tidb_workload_repository_dest is either an empty string or 'table.'
* Fix a couple of bugs in the housing keeping process.
* Factor out fillInTableNames(), createPartition() and dropOldPartition() for testing purposes.
* Pass the current time into createAllTables() and createPartition() so that testing can be deterministic
* Reread the information schema in createAllTables() before running code to create missing partitions.
* Add unit tests for the Workload Repository.

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
