### PR TITLE
lightning: handle full engine range after separate region split keys

### DIFF
--- a/pkg/lightning/common/engine.go
+++ b/pkg/lightning/common/engine.go
@@ -32,13 +32,15 @@ type Engine interface {
 	ID() string
 	// LoadIngestData sends DataAndRanges to outCh.
 	LoadIngestData(ctx context.Context, outCh chan<- DataAndRanges) error
-	// KVStatistics returns the total kv size and total kv count.
+	// KVStatistics returns the total kv size and total kv count. If the total KV
+	// size is 0, it means the engine is empty.
 	KVStatistics() (totalKVSize int64, totalKVCount int64)
 	// ImportedStatistics returns the imported kv size and imported kv count.
 	ImportedStatistics() (importedKVSize int64, importedKVCount int64)
 	// GetKeyRange returns the key range [startKey, endKey) of the engine. If the
 	// duplicate detection is enabled, the keys in engine are encoded by duplicate
 	// detection but the returned keys should not be encoded.
+	// TODO(lance6716): assert for startKey and endKey has non-zero length.
 	GetKeyRange() (startKey []byte, endKey []byte, err error)
 	// GetRegionSplitKeys checks the KV distribution of the Engine and returns the
 	// keys that can be used as region split keys. If the duplicate detection is


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58267

Problem Summary:

### What changed and how does it work?

after I separate region job's keys and region split keys in https://github.com/pingcap/tidb/pull/55759 , lightning's behaviour changed. Region split keys are the internal split points of a key range, so the first split key is larger than the key range start and the last split key is smaller. We should not use them to pause PD region scheduling or other things. Instead, we should use the full engine key range to do that.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
