### PR TITLE
infoschema: simplify size calculation for array

### DIFF
--- a/pkg/infoschema/internal/sizer.go
+++ b/pkg/infoschema/internal/sizer.go
@@ -41,7 +41,7 @@ func sizeOf(v reflect.Value, cache map[uintptr]bool) int {
 			}
 			sum += s
 		}
-		return sum + (v.Cap()-v.Len())*int(v.Type().Elem().Size())
+		return sum
 	case reflect.Slice:
 		// return 0 if this node has been visited already
 		if cache[v.Pointer()] {

--- a/pkg/infoschema/internal/sizer_test.go
+++ b/pkg/infoschema/internal/sizer_test.go
@@ -19,6 +19,9 @@ import (
 )
 
 func TestSize(t *testing.T) {
+	stringSlice := make([]string, 2, 5)
+	stringSlice[0] = "AAAAAAAAAA"
+	stringSlice[1] = "BBBBBBBBBBBB"
 	tests := []struct {
 		name string
 		v    any
@@ -30,9 +33,19 @@ func TestSize(t *testing.T) {
 			want: 12,
 		},
 		{
+			name: "Array 2",
+			v:    [5]string{}, // 5 * 16  = 80
+			want: 80,
+		},
+		{
 			name: "Slice",
 			v:    make([]int64, 2, 5), // 5 * 8 + 24 = 64
 			want: 64,
+		},
+		{
+			name: "string Slice",
+			v:    stringSlice, // 5 * 16 + 10 + 12 + 24 = 126
+			want: 126,
 		},
 		{
 			name: "String",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #50959

Problem Summary:

### What changed and how does it work?
for array, `v.Cap()` always equals `v.Len()`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
