### PR TITLE
planner, executor: support `show traffic jobs`

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1150,7 +1150,7 @@ func (b *executorBuilder) buildTraffic(traffic *plannercore.Traffic) exec.Execut
 	switch traffic.OpType {
 	case ast.TrafficOpCapture:
 		exec := &TrafficCaptureExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
 			Args: map[string]string{
 				"output": traffic.Dir,
 			},
@@ -1168,7 +1168,7 @@ func (b *executorBuilder) buildTraffic(traffic *plannercore.Traffic) exec.Execut
 		return exec
 	case ast.TrafficOpReplay:
 		exec := &TrafficReplayExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
 			Args: map[string]string{
 				"input": traffic.Dir,
 			},
@@ -1192,11 +1192,11 @@ func (b *executorBuilder) buildTraffic(traffic *plannercore.Traffic) exec.Execut
 		return exec
 	case ast.TrafficOpCancel:
 		return &TrafficCancelExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
 		}
 	case ast.TrafficOpShow:
 		return &TrafficShowExec{
-			BaseExecutor: exec.NewBaseExecutor(b.ctx, nil, 0),
+			BaseExecutor: exec.NewBaseExecutor(b.ctx, traffic.Schema(), traffic.ID()),
 		}
 	}
 	// impossible here

--- a/pkg/executor/traffic.go
+++ b/pkg/executor/traffic.go
@@ -16,17 +16,22 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -38,6 +43,20 @@ type tiproxyAddrKeyType struct{}
 
 var tiproxyAddrKey tiproxyAddrKeyType
 
+type trafficJob struct {
+	Instance  string `json:"-"` // not passed from TiProxy
+	Type      string `json:"type"`
+	Status    string `json:"status"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time,omitempty"`
+	Progress  string `json:"progress"`
+	Err       string `json:"error,omitempty"`
+}
+
+const (
+	startTimeKey = "start-time"
+)
+
 // TrafficCaptureExec sends capture traffic requests to TiProxy.
 type TrafficCaptureExec struct {
 	exec.BaseExecutor
@@ -46,8 +65,10 @@ type TrafficCaptureExec struct {
 
 // Next implements the Executor Next interface.
 func (e *TrafficCaptureExec) Next(ctx context.Context, _ *chunk.Chunk) error {
+	e.Args[startTimeKey] = time.Now().Format(time.RFC3339)
 	form := getForm(e.Args)
-	return request(ctx, e.BaseExecutor, strings.NewReader(form), http.MethodPost, "api/traffic/capture")
+	_, err := request(ctx, e.BaseExecutor, strings.NewReader(form), http.MethodPost, "api/traffic/capture")
+	return err
 }
 
 // TrafficReplayExec sends replay traffic requests to TiProxy.
@@ -58,8 +79,10 @@ type TrafficReplayExec struct {
 
 // Next implements the Executor Next interface.
 func (e *TrafficReplayExec) Next(ctx context.Context, _ *chunk.Chunk) error {
+	e.Args[startTimeKey] = time.Now().Format(time.RFC3339)
 	form := getForm(e.Args)
-	return request(ctx, e.BaseExecutor, strings.NewReader(form), http.MethodPost, "api/traffic/replay")
+	_, err := request(ctx, e.BaseExecutor, strings.NewReader(form), http.MethodPost, "api/traffic/replay")
+	return err
 }
 
 // TrafficCancelExec sends cancel traffic job requests to TiProxy.
@@ -69,39 +92,92 @@ type TrafficCancelExec struct {
 
 // Next implements the Executor Next interface.
 func (e *TrafficCancelExec) Next(ctx context.Context, _ *chunk.Chunk) error {
-	return request(ctx, e.BaseExecutor, nil, http.MethodPost, "api/traffic/cancel")
+	_, err := request(ctx, e.BaseExecutor, nil, http.MethodPost, "api/traffic/cancel")
+	return err
 }
 
 // TrafficShowExec sends show traffic job requests to TiProxy.
 type TrafficShowExec struct {
 	exec.BaseExecutor
+	jobs   []trafficJob
+	cursor int
 }
 
-// Next implements the Executor Next interface.
-func (e *TrafficShowExec) Next(ctx context.Context, _ *chunk.Chunk) error {
-	return request(ctx, e.BaseExecutor, nil, http.MethodGet, "api/traffic/show")
-}
-
-func request(ctx context.Context, exec exec.BaseExecutor, reader io.Reader, method, path string) error {
-	addrs, err := getTiProxyAddrs(ctx)
+// Open implements the Executor Open interface.
+func (e *TrafficShowExec) Open(ctx context.Context) error {
+	if err := e.BaseExecutor.Open(ctx); err != nil {
+		return err
+	}
+	resps, err := request(ctx, e.BaseExecutor, nil, http.MethodGet, "api/traffic/show")
 	if err != nil {
 		return err
 	}
+	var allJobs []trafficJob
+	for addr, resp := range resps {
+		var jobs []trafficJob
+		if err := json.Unmarshal([]byte(resp), &jobs); err != nil {
+			logutil.Logger(ctx).Error("unmarshal traffic job failed", zap.String("addr", addr), zap.String("jobs", resp), zap.Error(err))
+			return err
+		}
+		for i := range len(jobs) {
+			jobs[i].Instance = addr
+		}
+		allJobs = append(allJobs, jobs...)
+	}
+	sort.Slice(allJobs, func(i, j int) bool {
+		if allJobs[i].StartTime > allJobs[j].StartTime {
+			return true
+		} else if allJobs[i].StartTime < allJobs[j].StartTime {
+			return false
+		}
+		return allJobs[i].Instance < allJobs[j].Instance
+	})
+	e.jobs = allJobs
+	return nil
+}
+
+// Next implements the Executor Next interface.
+func (e *TrafficShowExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	batchSize := min(e.MaxChunkSize(), len(e.jobs)-e.cursor)
+	req.GrowAndReset(batchSize)
+	for i := 0; i < batchSize; i++ {
+		job := e.jobs[e.cursor]
+		e.cursor++
+		req.AppendTime(0, parseTime(ctx, e.BaseExecutor, job.StartTime))
+		req.AppendTime(1, parseTime(ctx, e.BaseExecutor, job.EndTime))
+		req.AppendString(2, job.Instance)
+		req.AppendString(3, job.Type)
+		req.AppendString(4, job.Progress)
+		req.AppendString(5, job.Status)
+		req.AppendString(6, job.Err)
+	}
+	return nil
+}
+
+func request(ctx context.Context, exec exec.BaseExecutor, reader io.Reader, method, path string) (map[string]string, error) {
+	addrs, err := getTiProxyAddrs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resps := make(map[string]string, len(addrs))
 	for _, addr := range addrs {
 		resp, requestErr := requestOne(method, addr, path, reader)
 		if requestErr != nil {
+			// Let's send requests to all the instances even if some fail.
 			exec.Ctx().GetSessionVars().StmtCtx.AppendError(requestErr)
 			logutil.Logger(ctx).Error("traffic request to tiproxy failed", zap.String("method", method),
 				zap.String("path", path), zap.String("addr", addr), zap.String("resp", resp), zap.Error(requestErr))
 			if err == nil {
 				err = requestErr
 			}
+		} else {
+			resps[addr] = resp
 		}
 	}
 	if err == nil {
 		logutil.Logger(ctx).Info("traffic request to tiproxy succeeds", zap.Any("addrs", addrs), zap.String("path", path))
 	}
-	return err
+	return resps, err
 }
 
 func getTiProxyAddrs(ctx context.Context) ([]string, error) {
@@ -156,4 +232,13 @@ func getForm(m map[string]string) string {
 		form.Add(key, value)
 	}
 	return form.Encode()
+}
+
+func parseTime(ctx context.Context, exec exec.BaseExecutor, timeStr string) types.Time {
+	t, err := time.Parse(time.RFC3339, timeStr)
+	if err != nil {
+		exec.Ctx().GetSessionVars().StmtCtx.AppendError(err)
+		logutil.Logger(ctx).Error("parse time failed", zap.String("time", timeStr), zap.Error(err))
+	}
+	return types.NewTime(types.FromGoTime(t), mysql.TypeDatetime, types.MaxFsp)
 }

--- a/pkg/executor/traffic.go
+++ b/pkg/executor/traffic.go
@@ -112,7 +112,7 @@ func (e *TrafficShowExec) Open(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	var allJobs []trafficJob
+	allJobs := make([]trafficJob, 0, len(resps))
 	for addr, resp := range resps {
 		var jobs []trafficJob
 		if err := json.Unmarshal([]byte(resp), &jobs); err != nil {

--- a/pkg/executor/traffic_test.go
+++ b/pkg/executor/traffic_test.go
@@ -25,11 +25,15 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/executor/internal/exec"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/hint"
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
@@ -37,10 +41,11 @@ import (
 
 func TestTrafficForm(t *testing.T) {
 	tests := []struct {
-		sql    string
-		method string
-		path   string
-		form   url.Values
+		sql          string
+		method       string
+		path         string
+		form         url.Values
+		hasStartTime bool
 	}{
 		{
 			sql:    "traffic capture to '/tmp' duration='1s' encryption_method='aes' compress=false",
@@ -52,6 +57,7 @@ func TestTrafficForm(t *testing.T) {
 				"encrypt-method": []string{"aes"},
 				"compress":       []string{"false"},
 			},
+			hasStartTime: true,
 		},
 		{
 			sql:    "traffic capture to '/tmp' duration='1s'",
@@ -61,6 +67,7 @@ func TestTrafficForm(t *testing.T) {
 				"output":   []string{"/tmp"},
 				"duration": []string{"1s"},
 			},
+			hasStartTime: true,
 		},
 		{
 			sql:    "traffic replay from '/tmp' user='root' password='123456' speed=1.0 read_only=true",
@@ -73,6 +80,7 @@ func TestTrafficForm(t *testing.T) {
 				"speed":    []string{"1.0"},
 				"readonly": []string{"true"},
 			},
+			hasStartTime: true,
 		},
 		{
 			sql:    "traffic replay from '/tmp' user='root'",
@@ -82,6 +90,7 @@ func TestTrafficForm(t *testing.T) {
 				"input":    []string{"/tmp"},
 				"username": []string{"root"},
 			},
+			hasStartTime: true,
 		},
 		{
 			sql:    "cancel traffic jobs",
@@ -97,42 +106,32 @@ func TestTrafficForm(t *testing.T) {
 		},
 	}
 
-	parser := parser.New()
-	sctx := mock.NewContext()
+	suite := newTrafficTestSuite(t, 10)
 	ctx := context.TODO()
-	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable(), plannercore.MockUnsignedTable()})
-	builder, _ := plannercore.NewPlanBuilder().Init(sctx, nil, hint.NewQBHintHandler(nil))
 	httpHandler := &mockHTTPHandler{t: t, httpOK: true}
 	server, port := runServer(t, httpHandler)
 	defer server.Close()
 	ctx = fillCtxWithTiProxyAddr(ctx, []int{port})
-	for _, test := range tests {
-		stmt, err := parser.ParseOneStmt(test.sql, "", "")
-		require.NoError(t, err)
-		p, err := builder.Build(ctx, resolve.NewNodeW(stmt))
-		require.NoError(t, err)
-		executorBuilder := NewMockExecutorBuilderForTest(sctx, is)
-		exec := executorBuilder.build(p)
-		require.NotEmpty(t, exec)
-		require.NoError(t, exec.Next(ctx, nil))
-		require.Equal(t, test.method, httpHandler.getMethod())
-		require.Equal(t, test.path, httpHandler.getPath())
-		require.Equal(t, test.form, httpHandler.getForm())
+	for i, test := range tests {
+		executor := suite.build(ctx, test.sql)
+		require.NoError(t, executor.Open(ctx))
+		chk := exec.NewFirstChunk(executor)
+		require.NoError(t, executor.Next(ctx, chk), "case %d", i)
+		require.Equal(t, test.method, httpHandler.getMethod(), "case %d", i)
+		require.Equal(t, test.path, httpHandler.getPath(), "case %d", i)
+		actualForm := httpHandler.getForm()
+		if test.hasStartTime {
+			require.NotEmpty(t, actualForm.Get("start-time"), "case %d", i)
+			test.form.Add("start-time", actualForm.Get("start-time"))
+		}
+		require.Equal(t, test.form, actualForm, "case %d", i)
 	}
 }
 
 func TestTrafficError(t *testing.T) {
-	sctx := mock.NewContext()
+	suite := newTrafficTestSuite(t, 10)
 	ctx := context.TODO()
-	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable(), plannercore.MockUnsignedTable()})
-	builder, _ := plannercore.NewPlanBuilder().Init(sctx, nil, hint.NewQBHintHandler(nil))
-	stmt, err := parser.New().ParseOneStmt("cancel traffic jobs", "", "")
-	require.NoError(t, err)
-	p, err := builder.Build(ctx, resolve.NewNodeW(stmt))
-	require.NoError(t, err)
-	executorBuilder := NewMockExecutorBuilderForTest(sctx, is)
-	exec := executorBuilder.build(p)
-	require.NotEmpty(t, exec)
+	exec := suite.build(ctx, "cancel traffic jobs")
 
 	// no tiproxy
 	m := make(map[string]*infosync.TiProxyServerInfo)
@@ -151,13 +150,129 @@ func TestTrafficError(t *testing.T) {
 	require.ErrorContains(t, exec.Next(tempCtx, nil), "500 Internal Server Error")
 }
 
+func TestTrafficShow(t *testing.T) {
+	suite := newTrafficTestSuite(t, 2)
+	ctx := context.TODO()
+	fields := trafficJobFields()
+
+	handlers := make([]*mockHTTPHandler, 0, 2)
+	servers := make([]*http.Server, 0, 2)
+	ports := make([]int, 0, 2)
+	for i := 0; i < 2; i++ {
+		httpHandler := &mockHTTPHandler{t: t, httpOK: true}
+		handlers = append(handlers, httpHandler)
+		server, port := runServer(t, httpHandler)
+		servers = append(servers, server)
+		ports = append(ports, port)
+	}
+	defer func() {
+		for _, server := range servers {
+			server.Close()
+		}
+	}()
+	if strconv.Itoa(ports[0]) > strconv.Itoa(ports[1]) {
+		ports[0], ports[1] = ports[1], ports[0]
+		handlers[0], handlers[1] = handlers[1], handlers[0]
+	}
+	ctx = fillCtxWithTiProxyAddr(ctx, ports)
+
+	marshaledTime1, marshaledTime2 := "2020-01-01T00:00:00Z", "2020-01-01T01:00:00Z"
+	marshaledJob := `{
+		"type": "capture",
+		"status": "canceled",
+		"start_time": "%s",
+		"end_time": "2020-01-01T02:01:01Z",
+		"progress": "50%%",
+		"error": "mock error"
+	}`
+	showTime1, showTime2 := "2020-01-01 00:00:00.000000", "2020-01-01 01:00:00.000000"
+	showResult := "%s, 2020-01-01 02:01:01.000000, 127.0.0.1:%d, capture, 50%%, canceled, mock error\n"
+	tests := []struct {
+		resp []string
+		chks []string
+	}{
+		{
+			resp: []string{"[]", "[]"},
+			chks: []string{},
+		},
+		{
+			resp: []string{fmt.Sprintf("[%s]", fmt.Sprintf(marshaledJob, marshaledTime1)), "[]"},
+			chks: []string{fmt.Sprintf(showResult, showTime1, ports[0])},
+		},
+		{
+			resp: []string{fmt.Sprintf("[%s]", fmt.Sprintf(marshaledJob, marshaledTime1)), fmt.Sprintf("[%s]", fmt.Sprintf(marshaledJob, marshaledTime1))},
+			chks: []string{fmt.Sprintf("%s%s", fmt.Sprintf(showResult, showTime1, ports[0]), fmt.Sprintf(showResult, showTime1, ports[1]))},
+		},
+		{
+			resp: []string{fmt.Sprintf("[%s,%s]", fmt.Sprintf(marshaledJob, marshaledTime1), fmt.Sprintf(marshaledJob, marshaledTime2)),
+				fmt.Sprintf("[%s,%s]", fmt.Sprintf(marshaledJob, marshaledTime1), fmt.Sprintf(marshaledJob, marshaledTime2))},
+			chks: []string{fmt.Sprintf("%s%s", fmt.Sprintf(showResult, showTime2, ports[0]), fmt.Sprintf(showResult, showTime2, ports[1])),
+				fmt.Sprintf("%s%s", fmt.Sprintf(showResult, showTime1, ports[0]), fmt.Sprintf(showResult, showTime1, ports[1]))},
+		},
+	}
+
+	for _, test := range tests {
+		for j := range test.resp {
+			handlers[j].setResponse(test.resp[j])
+		}
+		executor := suite.build(ctx, "show traffic jobs")
+		require.NoError(t, executor.Open(ctx))
+		chk := chunk.New(fields, 2, 2)
+		for j := 0; j < len(test.chks); j++ {
+			require.NoError(t, executor.Next(ctx, chk))
+			require.Equal(t, test.chks[j], chk.ToString(fields))
+		}
+		require.NoError(t, executor.Next(ctx, chk))
+		require.Equal(t, 0, chk.NumRows())
+	}
+}
+
+type trafficTestSuite struct {
+	t           *testing.T
+	parser      *parser.Parser
+	planBuilder *plannercore.PlanBuilder
+	execBuilder *MockExecutorBuilder
+}
+
+func newTrafficTestSuite(t *testing.T, chunkSize int) *trafficTestSuite {
+	parser := parser.New()
+	sctx := mock.NewContext()
+	sctx.GetSessionVars().MaxChunkSize = chunkSize
+	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable(), plannercore.MockUnsignedTable()})
+	planBuilder, _ := plannercore.NewPlanBuilder().Init(sctx, nil, hint.NewQBHintHandler(nil))
+	execBuilder := NewMockExecutorBuilderForTest(sctx, is)
+	return &trafficTestSuite{
+		t:           t,
+		parser:      parser,
+		planBuilder: planBuilder,
+		execBuilder: execBuilder,
+	}
+}
+
+func (suite *trafficTestSuite) build(ctx context.Context, sql string) exec.Executor {
+	stmt, err := suite.parser.ParseOneStmt(sql, "", "")
+	require.NoError(suite.t, err)
+	p, err := suite.planBuilder.Build(ctx, resolve.NewNodeW(stmt))
+	require.NoError(suite.t, err)
+	executor := suite.execBuilder.build(p)
+	require.NotEmpty(suite.t, executor)
+	return executor
+}
+
 type mockHTTPHandler struct {
 	t *testing.T
 	sync.Mutex
 	form   url.Values
 	method string
 	path   string
+	resp   string
 	httpOK bool
+}
+
+func (handler *mockHTTPHandler) setResponse(resp string) {
+	handler.Lock()
+	defer handler.Unlock()
+	handler.resp = resp
 }
 
 func (handler *mockHTTPHandler) getForm() url.Values {
@@ -185,6 +300,8 @@ func (handler *mockHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	handler.path = r.URL.Path
 	require.NoError(handler.t, r.ParseForm())
 	handler.form = r.PostForm
+	_, err := w.Write([]byte(handler.resp))
+	require.NoError(handler.t, err)
 	if handler.httpOK {
 		w.WriteHeader(http.StatusOK)
 	} else {
@@ -207,4 +324,16 @@ func fillCtxWithTiProxyAddr(ctx context.Context, ports []int) context.Context {
 		m[addr] = &infosync.TiProxyServerInfo{IP: "127.0.0.1", StatusPort: strconv.Itoa(port)}
 	}
 	return context.WithValue(ctx, tiproxyAddrKey, m)
+}
+
+func trafficJobFields() []*types.FieldType {
+	return []*types.FieldType{
+		types.NewFieldType(mysql.TypeDate),
+		types.NewFieldType(mysql.TypeDate),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeString),
+	}
 }

--- a/pkg/executor/traffic_test.go
+++ b/pkg/executor/traffic_test.go
@@ -300,10 +300,14 @@ func (handler *mockHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	handler.path = r.URL.Path
 	require.NoError(handler.t, r.ParseForm())
 	handler.form = r.PostForm
-	_, err := w.Write([]byte(handler.resp))
-	require.NoError(handler.t, err)
 	if handler.httpOK {
 		w.WriteHeader(http.StatusOK)
+		resp := handler.resp
+		if len(resp) == 0 && r.Method == http.MethodGet {
+			resp = "[]"
+		}
+		_, err := w.Write([]byte(resp))
+		require.NoError(handler.t, err)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3331,6 +3331,19 @@ func buildAddQueryWatchSchema() (*expression.Schema, types.NameSlice) {
 	return cols.col2Schema(), cols.names
 }
 
+func buildShowTrafficJobsSchema() (*expression.Schema, types.NameSlice) {
+	schema := newColumnsWithNames(7)
+	schema.Append(buildColumnWithName("", "START_TIME", mysql.TypeDatetime, 19))
+	schema.Append(buildColumnWithName("", "END_TIME", mysql.TypeDatetime, 19))
+	schema.Append(buildColumnWithName("", "INSTANCE", mysql.TypeVarchar, 256))
+	schema.Append(buildColumnWithName("", "TYPE", mysql.TypeVarchar, 32))
+	schema.Append(buildColumnWithName("", "PROGRESS", mysql.TypeVarchar, 32))
+	schema.Append(buildColumnWithName("", "STATUS", mysql.TypeVarchar, 32))
+	schema.Append(buildColumnWithName("", "FAIL_REASON", mysql.TypeVarchar, 256))
+
+	return schema.col2Schema(), schema.names
+}
+
 func buildColumnWithName(tableName, name string, tp byte, size int) (*expression.Column, *types.FieldName) {
 	cs, cl := types.DefaultCharsetForType(tp)
 	flag := mysql.UnsignedFlag
@@ -5830,11 +5843,15 @@ func findStmtAsViewSchema(stmt ast.Node) *ast.SelectStmt {
 }
 
 func (*PlanBuilder) buildTraffic(pc *ast.TrafficStmt) base.Plan {
-	return &Traffic{
+	p := &Traffic{
 		OpType:  pc.OpType,
 		Options: pc.Options,
 		Dir:     pc.Dir,
 	}
+	if pc.OpType == ast.TrafficOpShow {
+		p.setSchemaAndNames(buildShowTrafficJobsSchema())
+	}
+	return p
 }
 
 // buildCompactTable builds a plan for the "ALTER TABLE [NAME] COMPACT ..." statement.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58319 

Problem Summary:
Support `show traffic jobs`, which fetches traffic jobs from TiProxy and outputs them.

### What changed and how does it work?
- `Open()` fetches all traffic jobs
- `Next()` outputs the traffic jobs

The privileges will be checked in another PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```sql
mysql> traffic capture to "/tmp/traffic" duration="1m";
Query OK, 0 rows affected (0.01 sec)

mysql> traffic replay from "/tmp/traffic" user="root";
Query OK, 0 rows affected (1.60 sec)

mysql> show traffic jobs;
+----------------------------+----------------------------+----------------+---------+----------+--------+-------------+
| START_TIME                 | END_TIME                   | INSTANCE       | TYPE    | PROGRESS | STATUS | FAIL_REASON |
+----------------------------+----------------------------+----------------+---------+----------+--------+-------------+
| 2024-12-17 10:54:41.000000 | 2024-12-17 10:54:43.000000 | 127.0.0.1:3080 | replay  | 0%       | done   |             |
| 2024-12-17 10:39:36.000000 | 2024-12-17 10:40:36.000000 | 127.0.0.1:3080 | capture | 100%     | done   |             |
+----------------------------+----------------------------+----------------+---------+----------+--------+-------------+
2 rows in set (0.01 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
