### PR TITLE
planner: improve comments and clean up function for OR type IndexMerge logic

### DIFF
--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -133,59 +133,30 @@ func generateIndexMergePath(ds *logicalop.DataSource) error {
 	return nil
 }
 
-func generateNormalIndexPartialPaths4DNF(
+func generateNormalIndexPartialPath(
 	ds *logicalop.DataSource,
-	dnfItems []expression.Expression,
-	candidatePaths []*util.AccessPath,
-) (paths []*util.AccessPath, needSelection bool, usedMap []bool) {
-	paths = make([]*util.AccessPath, 0, len(dnfItems))
-	usedMap = make([]bool, len(dnfItems))
+	item expression.Expression,
+	candidatePath *util.AccessPath,
+) (paths *util.AccessPath, needSelection bool) {
 	pushDownCtx := util.GetPushDownCtx(ds.SCtx())
-	for offset, item := range dnfItems {
-		cnfItems := expression.SplitCNFItems(item)
-		pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
-		for _, cnfItem := range cnfItems {
-			if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
-				pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
-			} else {
-				needSelection = true
-			}
-		}
-		itemPaths := accessPathsForConds(ds, pushedDownCNFItems, candidatePaths)
-		if len(itemPaths) == 0 {
-			// for this dnf item, we couldn't generate an index merge partial path.
-			// (1 member of (a)) or (3 member of (b)) or d=1; if one dnf item like d=1 here could walk index path,
-			// the entire index merge is not valid anymore.
-			return nil, false, usedMap
-		}
-		partialPath := buildIndexMergePartialPath(itemPaths)
-		if partialPath == nil {
-			// for this dnf item, we couldn't generate an index merge partial path.
-			// (1 member of (a)) or (3 member of (b)) or d=1; if one dnf item like d=1 here could walk index path,
-			// the entire index merge is not valid anymore.
-			return nil, false, usedMap
-		}
-
-		// identify whether all pushedDownCNFItems are fully used.
-		// If any partial path contains table filters, we need to keep the whole DNF filter in the Selection.
-		if len(partialPath.TableFilters) > 0 {
-			needSelection = true
-			partialPath.TableFilters = nil
-		}
-		// If any partial path's index filter cannot be pushed to TiKV, we should keep the whole DNF filter.
-		if len(partialPath.IndexFilters) != 0 && !expression.CanExprsPushDown(pushDownCtx, partialPath.IndexFilters, kv.TiKV) {
-			needSelection = true
-			// Clear IndexFilter, the whole filter will be put in indexMergePath.TableFilters.
-			partialPath.IndexFilters = nil
-		}
-		// Keep this filter as a part of table filters for safety if it has any parameter.
-		if expression.MaybeOverOptimized4PlanCache(ds.SCtx().GetExprCtx(), cnfItems) {
+	cnfItems := expression.SplitCNFItems(item)
+	pushedDownCNFItems := make([]expression.Expression, 0, len(cnfItems))
+	for _, cnfItem := range cnfItems {
+		if expression.CanExprsPushDown(pushDownCtx, []expression.Expression{cnfItem}, kv.TiKV) {
+			pushedDownCNFItems = append(pushedDownCNFItems, cnfItem)
+		} else {
 			needSelection = true
 		}
-		usedMap[offset] = true
-		paths = append(paths, partialPath)
 	}
-	return paths, needSelection, usedMap
+	partialPath := accessPathsForConds(ds, pushedDownCNFItems,  []*util.AccessPath{candidatePath})
+	if len(partialPath) != 1 {
+		// for this dnf item, we couldn't generate an index merge partial path.
+		// (1 member of (a)) or (3 member of (b)) or d=1; if one dnf item like d=1 here could walk index path,
+		// the entire index merge is not valid anymore.
+		return nil, false
+	}
+
+	return partialPath[0], needSelection
 }
 
 // getIndexMergeOrPath generates all possible IndexMergeOrPaths.
@@ -789,12 +760,12 @@ func generateIndexMergeOnDNF4MVIndex(ds *logicalop.DataSource, normalPathCnt int
 			}
 			dnfFilters := expression.SplitDNFItems(sf) // [(1 member of (a) and b=1), (2 member of (a) and b=2)]
 
-			unfinishedIndexMergePath := generateUnfinishedIndexMergePathFromORList(
+			unfinishedIndexMergePath := genUnfinishedPathFromORList(
 				ds,
 				dnfFilters,
 				[]*util.AccessPath{ds.PossibleAccessPaths[idx]},
 			)
-			finishedIndexMergePath := handleTopLevelANDListAndGenFinishedPath(
+			finishedIndexMergePath := handleTopLevelANDList(
 				ds,
 				filters,
 				current,
@@ -909,12 +880,12 @@ func generateIndexMerge4ComposedIndex(ds *logicalop.DataSource, normalPathCnt in
 		}
 		dnfFilters := expression.SplitDNFItems(sf)
 
-		unfinishedIndexMergePath := generateUnfinishedIndexMergePathFromORList(
+		unfinishedIndexMergePath := genUnfinishedPathFromORList(
 			ds,
 			dnfFilters,
 			candidateAccessPaths,
 		)
-		finishedIndexMergePath := handleTopLevelANDListAndGenFinishedPath(
+		finishedIndexMergePath := handleTopLevelANDList(
 			ds,
 			indexMergeConds,
 			current,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #58361

### What changed and how does it work?

- The argument of the two slice parameter of `generateNormalIndexPartialPath()` always has 1 length, so I directly changed the parameter type.
- Try to make it more clear and easier to understand by renaming some variable/function names and cleaning up some comments.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
