### PR TITLE
br/backup: make the error rightly checked

### DIFF
--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -69,9 +69,10 @@ go_test(
     embed = [":backup"],
     flaky = True,
     race = "on",
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//br/pkg/conn",
+        "//br/pkg/errors",
         "//br/pkg/gluetidb",
         "//br/pkg/metautil",
         "//br/pkg/mock",
@@ -84,6 +85,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "//pkg/util/table-filter",
         "@com_github_golang_protobuf//proto",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
@@ -96,5 +98,6 @@ go_test(
         "@com_github_tikv_pd_client//:client",
         "@io_opencensus_go//stats/view",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_multierr//:multierr",
     ],
 )

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -100,11 +100,12 @@ func (e *StoreBasedErr) Cause() error {
 // Errors implements errors.ErrorGroup.
 // For now `WalkDeep` cannot walk "subtree"s like:
 /* 1 - 2 - 5
-   |
-   + 3 - 4
-*/
+ *   |
+ *   + 3 - 4
+ */
 // It stops after walking `1` and then gave up.
 // This is a bug: see https://github.com/pingcap/errors/issues/72
+// We manually make this a multierr to workaround this...
 func (e *StoreBasedErr) Errors() []error {
 	return multierr.Errors(e.err)
 }

--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -50,7 +50,6 @@ import (
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
 	pd "github.com/tikv/pd/client"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
@@ -107,7 +106,10 @@ func (e *StoreBasedErr) Cause() error {
 // This is a bug: see https://github.com/pingcap/errors/issues/72
 // We manually make this a multierr to workaround this...
 func (e *StoreBasedErr) Errors() []error {
-	return multierr.Errors(e.err)
+	if errs, ok := e.err.(errors.ErrorGroup); ok {
+		return errs.Errors()
+	}
+	return nil
 }
 
 const (

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/tidb/br/pkg/backup"
 	"github.com/pingcap/tidb/br/pkg/conn"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/gluetidb"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/mock"
@@ -32,8 +33,6 @@ import (
 	pd "github.com/tikv/pd/client"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/multierr"
-
-	berrors "github.com/pingcap/tidb/br/pkg/errors"
 )
 
 type testBackup struct {

--- a/br/pkg/backup/client_test.go
+++ b/br/pkg/backup/client_test.go
@@ -375,4 +375,5 @@ func TestErr(t *testing.T) {
 		errors.Annotate(berrors.ErrFailedToConnect, "oops"),
 		berrors.ErrFailedToConnect.GenWithStack("whoa")))
 	require.True(t, berrors.Is(serr, berrors.ErrFailedToConnect))
+	require.False(t, berrors.Is(serr, berrors.ErrUnknown))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58340

Problem Summary:
We gave up too early when there is a `StoreErr` returns because the `errors` package cannot properly get the inner error and soonly give up retry then.

### What changed and how does it work?
Make the `StoreErr` can be rightly unwraped by `pingcap/errors`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
