### PR TITLE
planner: quickly get total count from index/column

### DIFF
--- a/pkg/planner/cardinality/ndv.go
+++ b/pkg/planner/cardinality/ndv.go
@@ -51,13 +51,18 @@ func getTotalRowCount(statsTbl *statistics.Table, colHist *statistics.Column) in
 	}
 	// If colHist is not fully loaded, we may still get its total row count from other index/column stats.
 	totCount := int64(0)
+	stop := false
 	statsTbl.ForEachIndexImmutable(func(_ int64, idx *statistics.Index) bool {
 		if idx.IsFullLoad() && idx.LastUpdateVersion == colHist.LastUpdateVersion {
 			totCount = int64(idx.TotalRowCount())
+			stop = true
 			return true
 		}
 		return false
 	})
+	if stop {
+		return totCount
+	}
 	statsTbl.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
 		if col.IsFullLoad() && col.LastUpdateVersion == colHist.LastUpdateVersion {
 			totCount = int64(col.TotalRowCount())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/58366

Problem Summary:

### What changed and how does it work?

Recently, I found that the map iter time here has become significantly longer. 

<img width="934" alt="image" src="https://github.com/user-attachments/assets/a6bc4ed7-66e7-46b2-bb74-19214fbc5ecb" />

Compared with the older code, you will find that the current code will traverse the column statistics after traversing the index, which makes the time here longer.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
