### PR TITLE
metrics: add col/idx name(s) for BackfillProgressGauge and BackfillTotalCounter

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -745,10 +745,6 @@ func NewIndexIngestOperator(
 				writers = append(writers, writer)
 			}
 
-			indexIDs := make([]int64, len(indexes))
-			for i := 0; i < len(indexes); i++ {
-				indexIDs[i] = indexes[i].Meta().ID
-			}
 			return &indexIngestLocalWorker{
 				indexIngestBaseWorker: indexIngestBaseWorker{
 					ctx:     ctx,
@@ -762,7 +758,6 @@ func NewIndexIngestOperator(
 					srcChunkPool: srcChunkPool,
 					reorgMeta:    reorgMeta,
 				},
-				indexIDs:       indexIDs,
 				backendCtx:     backendCtx,
 				rowCntListener: rowCntListener,
 				cpMgr:          cpMgr,
@@ -793,7 +788,6 @@ func (w *indexIngestExternalWorker) HandleTask(ck IndexRecordChunk, send func(In
 
 type indexIngestLocalWorker struct {
 	indexIngestBaseWorker
-	indexIDs       []int64
 	backendCtx     ingest.BackendCtx
 	rowCntListener RowCountListener
 	cpMgr          *ingest.CheckpointManager

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -225,14 +225,14 @@ func (r *readIndexExecutor) buildLocalStorePipeline(
 	d := r.d
 	indexIDs := make([]int64, 0, len(r.indexes))
 	uniques := make([]bool, 0, len(r.indexes))
-	var indexNames strings.Builder
+	var idxNames strings.Builder
 	for _, index := range r.indexes {
 		indexIDs = append(indexIDs, index.ID)
 		uniques = append(uniques, index.Unique)
-		if indexNames.Len() > 0 {
-			indexNames.WriteByte('+')
+		if idxNames.Len() > 0 {
+			idxNames.WriteByte('+')
 		}
-		indexNames.WriteString(index.Name.O)
+		idxNames.WriteString(index.Name.O)
 	}
 	engines, err := r.bc.Register(indexIDs, uniques, r.ptbl)
 	if err != nil {
@@ -242,7 +242,7 @@ func (r *readIndexExecutor) buildLocalStorePipeline(
 			zap.Int64s("index IDs", indexIDs))
 		return nil, err
 	}
-	rowCntListener := newDistTaskRowCntListener(r.curRowCount, r.job.SchemaName, tbl.Meta().Name.O, indexNames.String())
+	rowCntListener := newDistTaskRowCntListener(r.curRowCount, r.job.SchemaName, tbl.Meta().Name.O, idxNames.String())
 	return NewAddIndexIngestPipeline(
 		opCtx,
 		d.store,

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -224,9 +225,14 @@ func (r *readIndexExecutor) buildLocalStorePipeline(
 	d := r.d
 	indexIDs := make([]int64, 0, len(r.indexes))
 	uniques := make([]bool, 0, len(r.indexes))
+	var indexNames strings.Builder
 	for _, index := range r.indexes {
 		indexIDs = append(indexIDs, index.ID)
 		uniques = append(uniques, index.Unique)
+		if indexNames.Len() > 0 {
+			indexNames.WriteByte('+')
+		}
+		indexNames.WriteString(index.Name.O)
 	}
 	engines, err := r.bc.Register(indexIDs, uniques, r.ptbl)
 	if err != nil {
@@ -236,7 +242,7 @@ func (r *readIndexExecutor) buildLocalStorePipeline(
 			zap.Int64s("index IDs", indexIDs))
 		return nil, err
 	}
-	rowCntListener := newDistTaskRowCntListener(r.curRowCount, r.job.SchemaName, tbl.Meta().Name.O)
+	rowCntListener := newDistTaskRowCntListener(r.curRowCount, r.job.SchemaName, tbl.Meta().Name.O, indexNames.String())
 	return NewAddIndexIngestPipeline(
 		opCtx,
 		d.store,
@@ -280,7 +286,14 @@ func (r *readIndexExecutor) buildExternalStorePipeline(
 		kvMeta.MergeSummary(summary)
 		s.mu.Unlock()
 	}
-	rowCntListener := newDistTaskRowCntListener(r.curRowCount, r.job.SchemaName, tbl.Meta().Name.O)
+	var idxNames strings.Builder
+	for _, idx := range r.indexes {
+		if idxNames.Len() > 0 {
+			idxNames.WriteByte('+')
+		}
+		idxNames.WriteString(idx.Name.O)
+	}
+	rowCntListener := newDistTaskRowCntListener(r.curRowCount, r.job.SchemaName, tbl.Meta().Name.O, idxNames.String())
 	return NewWriteIndexToExternalStoragePipeline(
 		opCtx,
 		d.store,
@@ -307,9 +320,8 @@ type distTaskRowCntListener struct {
 	counter       prometheus.Counter
 }
 
-func newDistTaskRowCntListener(totalRowCnt *atomic.Int64, dbName, tblName string) *distTaskRowCntListener {
-	counter := metrics.BackfillTotalCounter.WithLabelValues(
-		metrics.GenerateReorgLabel("add_idx_rate", dbName, tblName))
+func newDistTaskRowCntListener(totalRowCnt *atomic.Int64, dbName, tblName, idxName string) *distTaskRowCntListener {
+	counter := metrics.GetBackfillTotalByLabel(metrics.LblAddIdxRate, dbName, tblName, idxName)
 	return &distTaskRowCntListener{
 		totalRowCount: totalRowCnt,
 		counter:       counter,

--- a/pkg/ddl/backfilling_scheduler.go
+++ b/pkg/ddl/backfilling_scheduler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/errctx"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/resourcegroup"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
@@ -271,7 +272,7 @@ func (b *txnBackfillScheduler) adjustWorkerSize() error {
 		)
 		switch b.tp {
 		case typeAddIndexWorker:
-			backfillCtx, err := newBackfillCtx(i, reorgInfo, job.SchemaName, b.tbl, jc, "add_idx_rate", false, false)
+			backfillCtx, err := newBackfillCtx(i, reorgInfo, job.SchemaName, b.tbl, jc, metrics.LblAddIdxRate, false, false)
 			if err != nil {
 				return err
 			}
@@ -284,7 +285,7 @@ func (b *txnBackfillScheduler) adjustWorkerSize() error {
 			runner = newBackfillWorker(b.ctx, idxWorker)
 			worker = idxWorker
 		case typeAddIndexMergeTmpWorker:
-			backfillCtx, err := newBackfillCtx(i, reorgInfo, job.SchemaName, b.tbl, jc, "merge_tmp_idx_rate", false, false)
+			backfillCtx, err := newBackfillCtx(i, reorgInfo, job.SchemaName, b.tbl, jc, metrics.LblMergeTmpIdxRate, false, false)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -609,8 +610,19 @@ type updateColumnWorker struct {
 	checksumNeeded bool
 }
 
+func getOldAndNewColumnsForUpdateColumn(t table.Table, currElementID int64) (oldCol, newCol *model.ColumnInfo) {
+	for _, col := range t.WritableCols() {
+		if col.ID == currElementID {
+			newCol = col.ColumnInfo
+			oldCol = table.FindCol(t.Cols(), getChangingColumnOriginName(newCol)).ColumnInfo
+			return
+		}
+	}
+	return
+}
+
 func newUpdateColumnWorker(id int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*updateColumnWorker, error) {
-	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, "update_col_rate", false, true)
+	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, metrics.LblUpdateColRate, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -620,14 +632,7 @@ func newUpdateColumnWorker(id int, t table.PhysicalTable, decodeColMap map[int64
 			zap.Stringer("reorgInfo", reorgInfo))
 		return nil, nil
 	}
-	var oldCol, newCol *model.ColumnInfo
-	for _, col := range t.WritableCols() {
-		if col.ID == reorgInfo.currElement.ID {
-			newCol = col.ColumnInfo
-			oldCol = table.FindCol(t.Cols(), getChangingColumnOriginName(newCol)).ColumnInfo
-			break
-		}
-	}
+	oldCol, newCol := getOldAndNewColumnsForUpdateColumn(t, reorgInfo.currElement.ID)
 	rowDecoder := decoder.NewRowDecoder(t, t.WritableCols(), decodeColMap)
 	failpoint.Inject("forceRowLevelChecksumOnUpdateColumnBackfill", func() {
 		orig := variable.EnableRowLevelChecksum.Load()

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -613,9 +613,12 @@ type updateColumnWorker struct {
 func getOldAndNewColumnsForUpdateColumn(t table.Table, currElementID int64) (oldCol, newCol *model.ColumnInfo) {
 	for _, col := range t.WritableCols() {
 		if col.ID == currElementID {
-			newCol = col.ColumnInfo
-			oldCol = table.FindCol(t.Cols(), getChangingColumnOriginName(newCol)).ColumnInfo
-			return
+			changeColumnOrigName := table.FindCol(t.Cols(), getChangingColumnOriginName(col.ColumnInfo))
+			if changeColumnOrigName != nil {
+				newCol = col.ColumnInfo
+				oldCol = changeColumnOrigName.ColumnInfo
+				return
+			}
 		}
 	}
 	return

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2921,7 +2921,7 @@ type cleanUpIndexWorker struct {
 }
 
 func newCleanUpIndexWorker(id int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*cleanUpIndexWorker, error) {
-	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, "cleanup_idx_rate", false, false)
+	bCtx, err := newBackfillCtx(id, reorgInfo, reorgInfo.SchemaName, t, jc, metrics.LblCleanupIdxRate, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -502,7 +502,7 @@ func (w *worker) doModifyColumnTypeWithData(
 		// Make sure job args change after `updateVersionAndTableInfoWithCheck`, otherwise, the job args will
 		// be updated in `updateDDLJob` even if it meets an error in `updateVersionAndTableInfoWithCheck`.
 		job.SchemaState = model.StateDeleteOnly
-		metrics.GetBackfillProgressByLabel(metrics.LblModifyColumn, job.SchemaName, tblInfo.Name.String()).Set(0)
+		metrics.GetBackfillProgressByLabel(metrics.LblModifyColumn, job.SchemaName, tblInfo.Name.String(), args.OldColumnName.O).Set(0)
 		args.ChangingColumn = changingCol
 		args.ChangingIdxs = changingIdxs
 		failpoint.InjectCall("modifyColumnTypeWithData", job, args)

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -3334,7 +3334,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, job *model.Job) (ver 
 		}
 
 		// Assume we cannot have more than MaxUint64 rows, set the progress to 1/10 of that.
-		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String()).Set(0.1 / float64(math.MaxUint64))
+		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String(), "").Set(0.1 / float64(math.MaxUint64))
 		job.SchemaState = model.StateDeleteOnly
 		tblInfo.Partition.DDLState = job.SchemaState
 		ver, err = updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, true)
@@ -3398,7 +3398,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, job *model.Job) (ver 
 			}
 		}
 		tblInfo.Partition.DDLState = model.StateWriteOnly
-		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String()).Set(0.2 / float64(math.MaxUint64))
+		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String(), "").Set(0.2 / float64(math.MaxUint64))
 		failpoint.Inject("reorgPartRollback2", func(val failpoint.Value) {
 			if val.(bool) {
 				err = errors.New("Injected error by reorgPartRollback2")
@@ -3419,7 +3419,7 @@ func (w *worker) onReorganizePartition(jobCtx *jobContext, job *model.Job) (ver 
 		}
 		job.SchemaState = model.StateWriteReorganization
 		tblInfo.Partition.DDLState = job.SchemaState
-		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String()).Set(0.3 / float64(math.MaxUint64))
+		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, job.SchemaName, tblInfo.Name.String(), "").Set(0.3 / float64(math.MaxUint64))
 		ver, err = updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 	case model.StateWriteReorganization:
 		physicalTableIDs := getPartitionIDsFromDefinitions(tblInfo.Partition.DroppingDefinitions)
@@ -3813,7 +3813,7 @@ type reorgPartitionWorker struct {
 }
 
 func newReorgPartitionWorker(i int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*reorgPartitionWorker, error) {
-	bCtx, err := newBackfillCtx(i, reorgInfo, reorgInfo.SchemaName, t, jc, "reorg_partition_rate", false, false)
+	bCtx, err := newBackfillCtx(i, reorgInfo, reorgInfo.SchemaName, t, jc, metrics.LblReorgPartitionRate, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -511,11 +511,20 @@ func updateBackfillProgress(w *worker, reorgInfo *reorgInfo, tblInfo *model.Tabl
 		} else {
 			label = metrics.LblAddIndex
 		}
-		idxNames := getIdxNamesFromArgs(reorgInfo.jobCtx.jobArgs)
+		idxNames := ""
+		args, err := model.GetModifyIndexArgs(reorgInfo.Job)
+		if err != nil {
+			logutil.DDLLogger().Error("Fail to get ModifyIndexArgs", zap.Error(err))
+		} else {
+			idxNames = getIdxNamesFromArgs(args)
+		}
 		metrics.GetBackfillProgressByLabel(label, reorgInfo.SchemaName, tblInfo.Name.String(), idxNames).Set(progress * 100)
 	case model.ActionModifyColumn:
 		colName := ""
-		if args, ok := reorgInfo.jobCtx.jobArgs.(*model.ModifyColumnArgs); ok {
+		args, err := model.GetModifyColumnArgs(reorgInfo.Job)
+		if err != nil {
+			logutil.DDLLogger().Error("Fail to get ModifyColumnArgs", zap.Error(err))
+		} else {
 			colName = args.OldColumnName.O
 		}
 		metrics.GetBackfillProgressByLabel(metrics.LblModifyColumn, reorgInfo.SchemaName, tblInfo.Name.String(), colName).Set(progress * 100)

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -511,12 +511,17 @@ func updateBackfillProgress(w *worker, reorgInfo *reorgInfo, tblInfo *model.Tabl
 		} else {
 			label = metrics.LblAddIndex
 		}
-		metrics.GetBackfillProgressByLabel(label, reorgInfo.SchemaName, tblInfo.Name.String()).Set(progress * 100)
+		idxNames := getIdxNamesFromArgs(reorgInfo.jobCtx.jobArgs)
+		metrics.GetBackfillProgressByLabel(label, reorgInfo.SchemaName, tblInfo.Name.String(), idxNames).Set(progress * 100)
 	case model.ActionModifyColumn:
-		metrics.GetBackfillProgressByLabel(metrics.LblModifyColumn, reorgInfo.SchemaName, tblInfo.Name.String()).Set(progress * 100)
+		colName := ""
+		if args, ok := reorgInfo.jobCtx.jobArgs.(*model.ModifyColumnArgs); ok {
+			colName = args.OldColumnName.O
+		}
+		metrics.GetBackfillProgressByLabel(metrics.LblModifyColumn, reorgInfo.SchemaName, tblInfo.Name.String(), colName).Set(progress * 100)
 	case model.ActionReorganizePartition, model.ActionRemovePartitioning,
 		model.ActionAlterTablePartitioning:
-		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, reorgInfo.SchemaName, tblInfo.Name.String()).Set(progress * 100)
+		metrics.GetBackfillProgressByLabel(metrics.LblReorgPartition, reorgInfo.SchemaName, tblInfo.Name.String(), "").Set(progress * 100)
 	}
 }
 

--- a/pkg/metrics/ddl.go
+++ b/pkg/metrics/ddl.go
@@ -204,12 +204,12 @@ func generateReorgLabel(label, schemaName, tableName, colOrIdxNames string) stri
 		stringBuilder.Grow(len(label) + len(schemaName) + len(tableName) + len(colOrIdxNames) + 3)
 	}
 	stringBuilder.WriteString(label)
-	stringBuilder.WriteString("_")
+	stringBuilder.WriteString("-")
 	stringBuilder.WriteString(schemaName)
-	stringBuilder.WriteString("_")
+	stringBuilder.WriteString("-")
 	stringBuilder.WriteString(tableName)
 	if len(colOrIdxNames) > 0 {
-		stringBuilder.WriteString("_")
+		stringBuilder.WriteString("-")
 		stringBuilder.WriteString(colOrIdxNames)
 	}
 	return stringBuilder.String()

--- a/pkg/metrics/ddl.go
+++ b/pkg/metrics/ddl.go
@@ -180,26 +180,47 @@ func InitDDLMetrics() {
 const (
 	LblAction = "action"
 
-	LblAddIndex      = "add_index"
-	LblAddIndexMerge = "add_index_merge_tmp"
-	LblModifyColumn  = "modify_column"
-
+	// Used by BackfillProgressGauge
+	LblAddIndex       = "add_index"
+	LblAddIndexMerge  = "add_index_merge_tmp"
+	LblModifyColumn   = "modify_column"
 	LblReorgPartition = "reorganize_partition"
+
+	// Used by BackfillTotalCounter
+	LblAddIdxRate         = "add_idx_rate"
+	LblMergeTmpIdxRate    = "merge_tmp_idx_rate"
+	LblCleanupIdxRate     = "cleanup_idx_rate"
+	LblUpdateColRate      = "update_col_rate"
+	LblReorgPartitionRate = "reorg_partition_rate"
 )
 
-// GenerateReorgLabel returns the label with schema name and table name.
-func GenerateReorgLabel(label string, schemaName string, tableName string) string {
+// generateReorgLabel returns the label with schema name, table name and optional column/index names.
+// Multiple columns/indexes can be concatenated with "+".
+func generateReorgLabel(label, schemaName, tableName, colOrIdxNames string) string {
 	var stringBuilder strings.Builder
-	stringBuilder.Grow(len(label) + len(schemaName) + len(tableName) + 2)
+	if len(colOrIdxNames) == 0 {
+		stringBuilder.Grow(len(label) + len(schemaName) + len(tableName) + 2)
+	} else {
+		stringBuilder.Grow(len(label) + len(schemaName) + len(tableName) + len(colOrIdxNames) + 3)
+	}
 	stringBuilder.WriteString(label)
 	stringBuilder.WriteString("_")
 	stringBuilder.WriteString(schemaName)
 	stringBuilder.WriteString("_")
 	stringBuilder.WriteString(tableName)
+	if len(colOrIdxNames) > 0 {
+		stringBuilder.WriteString("_")
+		stringBuilder.WriteString(colOrIdxNames)
+	}
 	return stringBuilder.String()
 }
 
+// GetBackfillTotalByLabel returns the Counter showing the speed of backfilling for the given type label.
+func GetBackfillTotalByLabel(label, schemaName, tableName, optionalColOrIdxName string) prometheus.Counter {
+	return BackfillTotalCounter.WithLabelValues(generateReorgLabel(label, schemaName, tableName, optionalColOrIdxName))
+}
+
 // GetBackfillProgressByLabel returns the Gauge showing the percentage progress for the given type label.
-func GetBackfillProgressByLabel(label string, schemaName string, tableName string) prometheus.Gauge {
-	return BackfillProgressGauge.WithLabelValues(GenerateReorgLabel(label, schemaName, tableName))
+func GetBackfillProgressByLabel(label, schemaName, tableName, optionalColOrIdxName string) prometheus.Gauge {
+	return BackfillProgressGauge.WithLabelValues(generateReorgLabel(label, schemaName, tableName, optionalColOrIdxName))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58114

Problem Summary:

For BackfillProgressGauge and BackfillTotalCounter, tidb only shows the database name and table name in the metrics. If we add multiple indexes on a single table, it would be difficult to know the rate and progress of each index.

### What changed and how does it work?

* Add column names and index names for metrics.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test script:
```bash
mysql -h 127.0.0.1 -P4000 -uroot -e'create database test1; create database test2;'

sysbench oltp_read_write prepare --db-driver=mysql --mysql-host=127.0.0.1 --mysql-port=4000 --mysql-user=root --mysql-db=test1 --threads=16 --tables=2 --table-size=1000000
sysbench oltp_read_write prepare --db-driver=mysql --mysql-host=127.0.0.1 --mysql-port=4000 --mysql-user=root --mysql-db=test2 --threads=16 --tables=2 --table-size=1000000

# Add Index
mysql -h 127.0.0.1 -P4000 -uroot -e'create index k_pad on test1.sbtest1(pad); alter table test1.sbtest2 add index k_pad(pad), add index k_comp(c, pad);'
mysql -h 127.0.0.1 -P4000 -uroot -e'create index k_pad on test2.sbtest1(pad); alter table test2.sbtest2 add index k_pad(pad), add index k_comp(c, pad);'

# Modify Column
mysql -h 127.0.0.1 -P4000 -uroot -e'alter table test1.sbtest1 change column k k varchar(64); alter table test1.sbtest2 change column k k varchar(64);'
mysql -h 127.0.0.1 -P4000 -uroot -e'alter table test2.sbtest1 change column k k varchar(64); alter table test2.sbtest2 change column k k varchar(64);'
```

<img width="1826" alt="image" src="https://github.com/user-attachments/assets/d9158958-7e08-44ae-b481-1a7fc9e57ef5" />


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
