### PR TITLE
statistics: skip non-exicted table when to init stats

### DIFF
--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -164,6 +164,12 @@ func (*Handle) initStatsHistograms4ChunkLite(cache statstypes.StatsCache, iter *
 }
 
 func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache statstypes.StatsCache, iter *chunk.Iterator4Chunk, isCacheFull bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			logutil.BgLogger().Error("panic when initStatsHistograms4Chunk", zap.Any("r", r),
+				zap.Stack("stack"))
+		}
+	}()
 	var table *statistics.Table
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		tblID, statsVer := row.GetInt64(0), row.GetInt64(8)

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -193,6 +193,7 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		lastAnalyzePos := row.GetDatum(11, types.NewFieldType(mysql.TypeBlob))
 		tbl, ok := h.TableInfoByID(is, table.PhysicalID)
 		if !ok {
+			// this table has been dropped. but stats meta still exists and wait for being deleted.
 			logutil.BgLogger().Warn("cannot find this table when to init stats", zap.Int64("tableID", table.PhysicalID))
 			continue
 		}

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -185,7 +185,11 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 		}
 		id, ndv, nullCount, version, totColSize := row.GetInt64(2), row.GetInt64(3), row.GetInt64(5), row.GetUint64(4), row.GetInt64(7)
 		lastAnalyzePos := row.GetDatum(11, types.NewFieldType(mysql.TypeBlob))
-		tbl, _ := h.TableInfoByID(is, table.PhysicalID)
+		tbl, ok := h.TableInfoByID(is, table.PhysicalID)
+		if !ok {
+			logutil.BgLogger().Warn("cannot find this table when to init stats", zap.Int64("tableID", table.PhysicalID))
+			continue
+		}
 		if row.GetInt64(1) > 0 {
 			var idxInfo *model.IndexInfo
 			for _, idx := range tbl.Meta().Indices {

--- a/pkg/statistics/handle/handletest/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/initstats/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/parser/model",

--- a/pkg/statistics/handle/handletest/initstats/load_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/load_stats_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConcurrentlyInitStats(t *testing.T) {
+func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {

--- a/pkg/statistics/handle/handletest/initstats/load_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/load_stats_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
+func TestConcurrentlyInitStats(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
@@ -103,7 +103,27 @@ func testConcurrentlyInitStats(t *testing.T) {
 	require.Equal(t, int64(126), handle.GetMaxTidRecordForTest())
 }
 
-func TestIssue58371(t *testing.T) {
+func TestDropTableBeforeConcurrentlyInitStats(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.LiteInitStats = false
+		conf.Performance.ConcurrentlyInitStats = true
+	})
+	testDropTableBeforeInitStats(t)
+}
+
+func TestDropTableBeforeNonLiteInitStats(t *testing.T) {
+	restore := config.RestoreFunc()
+	defer restore()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.LiteInitStats = false
+		conf.Performance.ConcurrentlyInitStats = false
+	})
+	testDropTableBeforeInitStats(t)
+}
+
+func testDropTableBeforeInitStats(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test;")

--- a/pkg/statistics/handle/handletest/initstats/load_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/load_stats_test.go
@@ -102,3 +102,20 @@ func testConcurrentlyInitStats(t *testing.T) {
 	}
 	require.Equal(t, int64(126), handle.GetMaxTidRecordForTest())
 }
+
+func TestIssue58371(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t( id int, a int, b int, index idx(id, a));")
+	tk.MustExec("insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5);")
+	tk.MustExec("insert into t select * from t where id<>2;")
+	tk.MustExec("insert into t select * from t where id<>2;")
+	tk.MustExec("insert into t select * from t where id<>2;")
+	tk.MustExec("insert into t select * from t where id<>2;")
+	tk.MustExec("analyze table t all columns;")
+	tk.MustExec("drop table t")
+	h := dom.StatsHandle()
+	is := dom.InfoSchema()
+	require.NoError(t, h.InitStats(context.Background(), is))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58378

Problem Summary:

### What changed and how does it work?

a table is dropped. but it's stats will still be in the system table. but when to init stats, we should skip this non-exicted table to avoid the nill point from the ```tableByID```. it will happen to panic.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
