### PR TITLE
planner: add parent GE refs of group and prepare the global GE map for detecting group merge case.

### DIFF
--- a/pkg/planner/cascades/memo/BUILD.bazel
+++ b/pkg/planner/cascades/memo/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     ],
     embed = [":memo"],
     flaky = True,
-    shard_count = 8,
+    shard_count = 10,
     deps = [
         "//pkg/expression",
         "//pkg/planner/cascades/base",

--- a/pkg/planner/cascades/memo/BUILD.bazel
+++ b/pkg/planner/cascades/memo/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     ],
     embed = [":memo"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 9,
     deps = [
         "//pkg/expression",
         "//pkg/planner/cascades/base",

--- a/pkg/planner/cascades/memo/BUILD.bazel
+++ b/pkg/planner/cascades/memo/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     ],
     embed = [":memo"],
     flaky = True,
-    shard_count = 7,
+    shard_count = 8,
     deps = [
         "//pkg/expression",
         "//pkg/planner/cascades/base",

--- a/pkg/planner/cascades/memo/group_and_expr_test.go
+++ b/pkg/planner/cascades/memo/group_and_expr_test.go
@@ -15,6 +15,9 @@
 package memo
 
 import (
+	"container/list"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -90,6 +93,50 @@ func TestGroupExpressionHashCollision(t *testing.T) {
 	require.Equal(t, res.Value.(*GroupExpression).Inputs[1].groupID, GroupID(1))
 }
 
+func TestGroupExpressionDelete(t *testing.T) {
+	hasher1 := base.NewHashEqualer()
+	hasher2 := base.NewHashEqualer()
+	child1 := &Group{groupID: 1}
+	child2 := &Group{groupID: 2}
+	a := &GroupExpression{
+		Inputs:      []*Group{child1, child2},
+		LogicalPlan: &logicalop.LogicalProjection{Exprs: []expression.Expression{expression.NewOne()}},
+	}
+	b := &GroupExpression{
+		// root group should change the hash.
+		Inputs:      []*Group{child2, child1},
+		LogicalPlan: &logicalop.LogicalProjection{Exprs: []expression.Expression{expression.NewOne()}},
+	}
+	a.Hash64(hasher1)
+	a.hash64 = hasher1.Sum64()
+	b.Hash64(hasher2)
+	b.hash64 = hasher2.Sum64()
+	root := NewGroup(nil)
+	root.groupID = 3
+	require.True(t, root.Insert(a))
+	require.True(t, root.Insert(b))
+	require.Equal(t, root.logicalExpressions.Len(), 2)
+
+	mock := &GroupExpression{
+		Inputs:      []*Group{child1},
+		LogicalPlan: &logicalop.LogicalProjection{Exprs: []expression.Expression{expression.NewOne()}},
+	}
+	hasher1.Reset()
+	mock.Hash64(hasher1)
+	mock.hash64 = hasher1.Sum64()
+
+	root.Delete(mock)
+	require.Equal(t, root.logicalExpressions.Len(), 2)
+
+	root.Delete(a)
+	require.Equal(t, root.logicalExpressions.Len(), 1)
+	require.Equal(t, root.GetLogicalExpressions().Front().Value.(*GroupExpression), b)
+
+	root.Delete(b)
+	require.Equal(t, root.logicalExpressions.Len(), 0)
+	require.Equal(t, root.GetLogicalExpressions().Len(), 0)
+}
+
 func TestGroupHashEquals(t *testing.T) {
 	hasher1 := base.NewHashEqualer()
 	hasher2 := base.NewHashEqualer()
@@ -140,4 +187,98 @@ func TestGroupExpressionHashEquals(t *testing.T) {
 	require.NotEqual(t, hasher1.Sum64(), hasher2.Sum64())
 	require.False(t, a.Equals(b))
 	require.False(t, a.Equals(&b))
+}
+
+func TestGroupParentGERefs(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/cascades/memo/MockPlanSkipMemoDeriveStats", `return(true)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/planner/cascades/memo/MockPlanSkipMemoDeriveStats"))
+	}()
+	col1 := &expression.Column{
+		UniqueID: 1,
+	}
+	col2 := &expression.Column{
+		UniqueID: 2,
+	}
+	ctx := mock.NewContext()
+	t1 := logicalop.DataSource{}.Init(ctx, 0)
+	t1.SetSchema(expression.NewSchema(col1))
+	t2 := logicalop.DataSource{}.Init(ctx, 0)
+	t2.SetSchema(expression.NewSchema(col2))
+	join := logicalop.LogicalJoin{}.Init(ctx, 0)
+	join.SetSchema(expression.NewSchema(col1, col2))
+	join.SetChildren(t1, t2)
+
+	mm := NewMemo()
+	mm.Init(join)
+	require.Equal(t, 3, mm.GetGroups().Len())
+	require.Equal(t, 3, len(mm.GetGroupID2Group()))
+
+	require.Equal(t, mm.rootGroup.hash2ParentGroupExpr.Size(), 0)
+	require.Equal(t, mm.rootGroup.hash2GroupExpr.Size(), 1)
+	var (
+		j, j1, j2 *GroupExpression
+		elem      *list.Element
+	)
+	mm.rootGroup.hash2GroupExpr.Each(func(key *GroupExpression, val *list.Element) {
+		j = key
+		elem = val
+	})
+	require.NotNil(t, elem)
+	require.NotNil(t, j)
+	require.Equal(t, elem.Value.(*GroupExpression), j)
+	require.Equal(t, mm.rootGroup.logicalExpressions.Len(), 1)
+	require.Equal(t, mm.rootGroup.logicalExpressions.Front(), elem)
+	require.True(t, j.LogicalPlan.Equals(join))
+
+	// left child group
+	leftGroup := j.Inputs[0]
+	require.Equal(t, leftGroup.hash2ParentGroupExpr.Size(), 1)
+	ge, ok := leftGroup.hash2ParentGroupExpr.Get(j)
+	require.True(t, ok)
+	require.NotNil(t, ge)
+	require.Equal(t, leftGroup.hash2GroupExpr.Size(), 1)
+	leftGroup.hash2GroupExpr.Each(func(key *GroupExpression, val *list.Element) {
+		j1 = key
+		elem = val
+	})
+	require.NotNil(t, elem)
+	require.NotNil(t, j1)
+	require.Equal(t, elem.Value.(*GroupExpression), j1)
+	require.True(t, j1.LogicalPlan.Equals(t1))
+
+	// right child group
+	rightGroup := j.Inputs[1]
+	require.Equal(t, rightGroup.hash2ParentGroupExpr.Size(), 1)
+	ge, ok = rightGroup.hash2ParentGroupExpr.Get(j)
+	require.True(t, ok)
+	require.NotNil(t, ge)
+	require.Equal(t, rightGroup.hash2GroupExpr.Size(), 1)
+	rightGroup.hash2GroupExpr.Each(func(key *GroupExpression, val *list.Element) {
+		j2 = key
+		elem = val
+	})
+	require.NotNil(t, elem)
+	require.NotNil(t, j2)
+	require.Equal(t, elem.Value.(*GroupExpression), j2)
+	require.True(t, j2.LogicalPlan.Equals(t2))
+
+	// assert global memo
+	require.Equal(t, mm.groups.Len(), 3)
+	require.Equal(t, mm.hash2GlobalGroupExpr.Size(), 3)
+	found := [3]bool{}
+	mm.hash2GlobalGroupExpr.Each(func(key *GroupExpression, val *GroupExpression) {
+		if key.Equals(j) {
+			found[0] = true
+		}
+		if key.Equals(j1) {
+			found[1] = true
+		}
+		if key.Equals(j2) {
+			found[2] = true
+		}
+	})
+	require.True(t, found[0])
+	require.True(t, found[1])
+	require.True(t, found[2])
 }

--- a/pkg/planner/cascades/memo/group_and_expr_test.go
+++ b/pkg/planner/cascades/memo/group_and_expr_test.go
@@ -16,13 +16,13 @@ package memo
 
 import (
 	"container/list"
-	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/pkg/util/mock"
 	"testing"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/cascades/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
+	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/zyedidia/generic/hashmap"
 )

--- a/pkg/planner/cascades/memo/group_expr.go
+++ b/pkg/planner/cascades/memo/group_expr.go
@@ -120,23 +120,6 @@ func (e *GroupExpression) Equals(other any) bool {
 	return true
 }
 
-// NewGroupExpression creates a new GroupExpression with the given logical plan and children.
-func NewGroupExpression(lp base.LogicalPlan, inputs []*Group) *GroupExpression {
-	ge := &GroupExpression{
-		group:       nil,
-		Inputs:      inputs,
-		LogicalPlan: lp,
-		hash64:      0,
-		// todo: add rule set length
-		mask: bitset.New(1),
-	}
-	// maintain the parentGE refs.
-	for _, childG := range inputs {
-		childG.addParentGEs(ge)
-	}
-	return ge
-}
-
 // Init initializes the GroupExpression with the given group and hasher.
 func (e *GroupExpression) Init(h base2.Hasher) {
 	e.Hash64(h)

--- a/pkg/planner/cascades/memo/group_expr.go
+++ b/pkg/planner/cascades/memo/group_expr.go
@@ -122,7 +122,7 @@ func (e *GroupExpression) Equals(other any) bool {
 
 // NewGroupExpression creates a new GroupExpression with the given logical plan and children.
 func NewGroupExpression(lp base.LogicalPlan, inputs []*Group) *GroupExpression {
-	return &GroupExpression{
+	ge := &GroupExpression{
 		group:       nil,
 		Inputs:      inputs,
 		LogicalPlan: lp,
@@ -130,6 +130,11 @@ func NewGroupExpression(lp base.LogicalPlan, inputs []*Group) *GroupExpression {
 		// todo: add rule set length
 		mask: bitset.New(1),
 	}
+	// maintain the parentGE refs.
+	for _, childG := range inputs {
+		childG.addParentGEs(ge)
+	}
+	return ge
 }
 
 // Init initializes the GroupExpression with the given group and hasher.

--- a/pkg/planner/cascades/memo/memo.go
+++ b/pkg/planner/cascades/memo/memo.go
@@ -114,10 +114,16 @@ func (mm *Memo) CopyIn(target *Group, lp base.LogicalPlan) (*GroupExpression, er
 		intest.Assert(currentChildG != target)
 		childGroups = append(childGroups, currentChildG)
 	}
-	hasher := mm.GetHasher()
-	groupExpr := NewGroupExpression(lp, childGroups)
-	groupExpr.Init(hasher)
-	if _, ok := mm.InsertGroupExpression(groupExpr, target); ok && target == nil {
+	var (
+		ok        bool
+		h         base2.Hasher
+		groupExpr *GroupExpression
+	)
+	h = mm.GetHasher()
+	groupExpr = NewGroupExpression(lp, childGroups)
+	groupExpr.Init(h)
+	groupExpr, ok = mm.InsertGroupExpression(groupExpr, target)
+	if ok && target == nil {
 		// derive logical property for new group.
 		err := groupExpr.DeriveLogicalProp()
 		if err != nil {

--- a/pkg/planner/cascades/memo/memo.go
+++ b/pkg/planner/cascades/memo/memo.go
@@ -227,6 +227,6 @@ func (mm *Memo) NewGroupExpression(lp base.LogicalPlan, inputs []*Group) *GroupE
 // 3: this two GEs has the same operator info.
 // from the 3 above, we could say this two group expression are equivalent,
 // and their groups are equivalent as well from the equivalent transitive rule.
-func (mm *Memo) mergeGroup(src, dst *Group) {
+func (mm *Memo) mergeGroup(_, _ *Group) {
 	// todo: in next pull request
 }

--- a/pkg/planner/cascades/memo/memo.go
+++ b/pkg/planner/cascades/memo/memo.go
@@ -16,8 +16,8 @@ package memo
 
 import (
 	"container/list"
-	"github.com/bits-and-blooms/bitset"
 
+	"github.com/bits-and-blooms/bitset"
 	base2 "github.com/pingcap/tidb/pkg/planner/cascades/base"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/util/intest"

--- a/pkg/planner/cascades/memo/memo.go
+++ b/pkg/planner/cascades/memo/memo.go
@@ -227,6 +227,6 @@ func (mm *Memo) NewGroupExpression(lp base.LogicalPlan, inputs []*Group) *GroupE
 // 3: this two GEs has the same operator info.
 // from the 3 above, we could say this two group expression are equivalent,
 // and their groups are equivalent as well from the equivalent transitive rule.
-func (mm *Memo) mergeGroup(_, _ *Group) {
+func (*Memo) mergeGroup(_, _ *Group) {
 	// todo: in next pull request
 }

--- a/pkg/planner/cascades/memo/memo_test.go
+++ b/pkg/planner/cascades/memo/memo_test.go
@@ -15,8 +15,6 @@
 package memo
 
 import (
-	"container/list"
-	"fmt"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -24,17 +22,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func Test1(t *testing.T) {
-	hash2ParentGroupExpr := map[uint64][]*GroupExpression{}
-	GE := &GroupExpression{hash64: 1}
-	hash2ParentGroupExpr[1] = append(hash2ParentGroupExpr[1], GE)
-	fmt.Println(hash2ParentGroupExpr)
-
-	l := list.New()
-	elem := l.PushBack(GE)
-	l.Remove(elem)
-}
 
 func TestMemo(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/cascades/memo/MockPlanSkipMemoDeriveStats", `return(true)`))

--- a/pkg/planner/cascades/memo/memo_test.go
+++ b/pkg/planner/cascades/memo/memo_test.go
@@ -82,7 +82,7 @@ func TestInsertGE(t *testing.T) {
 	limit := logicalop.LogicalLimit{}.Init(ctx, 0)
 	limit.SetID(-4)
 	hasher := mm.GetHasher()
-	groupExpr := NewGroupExpression(limit, []*Group{mm.GetRootGroup()})
+	groupExpr := mm.NewGroupExpression(limit, []*Group{mm.GetRootGroup()})
 	groupExpr.Init(hasher)
 
 	// Insert a new group with a new expression.

--- a/pkg/planner/cascades/memo/memo_test.go
+++ b/pkg/planner/cascades/memo/memo_test.go
@@ -15,6 +15,8 @@
 package memo
 
 import (
+	"container/list"
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -22,6 +24,17 @@ import (
 	"github.com/pingcap/tidb/pkg/util/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func Test1(t *testing.T) {
+	hash2ParentGroupExpr := map[uint64][]*GroupExpression{}
+	GE := &GroupExpression{hash64: 1}
+	hash2ParentGroupExpr[1] = append(hash2ParentGroupExpr[1], GE)
+	fmt.Println(hash2ParentGroupExpr)
+
+	l := list.New()
+	elem := l.PushBack(GE)
+	l.Remove(elem)
+}
 
 func TestMemo(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/planner/cascades/memo/MockPlanSkipMemoDeriveStats", `return(true)`))

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -967,6 +968,9 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 	var err error
 	var againRuleList []base.LogicalOptRule
 	for i, rule := range optRuleList {
+		if strings.Contains(logic.SCtx().GetSessionVars().StmtCtx.OriginalSQL, "intersect") && i == 12 {
+			fmt.Println(1)
+		}
 		// The order of flags is same as the order of optRule in the list.
 		// We use a bitmask to record which opt rules should be used. If the i-th bit is 1, it means we should
 		// apply i-th optimizing rule.

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -968,9 +967,6 @@ func logicalOptimize(ctx context.Context, flag uint64, logic base.LogicalPlan) (
 	var err error
 	var againRuleList []base.LogicalOptRule
 	for i, rule := range optRuleList {
-		if strings.Contains(logic.SCtx().GetSessionVars().StmtCtx.OriginalSQL, "intersect") && i == 12 {
-			fmt.Println(1)
-		}
 		// The order of flags is same as the order of optRule in the list.
 		// We use a bitmask to record which opt rules should be used. If the i-th bit is 1, it means we should
 		// apply i-th optimizing rule.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/51664

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
