### PR TITLE
planner: fix hash partition prune with `is null` condition

### DIFF
--- a/pkg/planner/core/casetest/partition/partition_pruner_test.go
+++ b/pkg/planner/core/casetest/partition/partition_pruner_test.go
@@ -49,7 +49,7 @@ func TestHashPartitionPruner(t *testing.T) {
 	tk.MustExec("create table t8(a int, b int) partition by hash(a) partitions 6;")
 	tk.MustExec("create table t9(a bit(1) default null, b int(11) default null) partition by hash(a) partitions 3;") //issue #22619
 	tk.MustExec("create table t10(a bigint unsigned) partition BY hash (a);")
-	tk.MustExec("create table t11(a int, b int) partition by hash(a + a + b) partitions 5")
+	tk.MustExec("create table t11(a int, b int) partition by hash(a + a + a + b) partitions 5")
 
 	var input []string
 	var output []struct {

--- a/pkg/planner/core/casetest/partition/partition_pruner_test.go
+++ b/pkg/planner/core/casetest/partition/partition_pruner_test.go
@@ -49,6 +49,7 @@ func TestHashPartitionPruner(t *testing.T) {
 	tk.MustExec("create table t8(a int, b int) partition by hash(a) partitions 6;")
 	tk.MustExec("create table t9(a bit(1) default null, b int(11) default null) partition by hash(a) partitions 3;") //issue #22619
 	tk.MustExec("create table t10(a bigint unsigned) partition BY hash (a);")
+	tk.MustExec("create table t11(a int, b int) partition by hash(a + a + b) partitions 5")
 
 	var input []string
 	var output []struct {

--- a/pkg/planner/core/casetest/partition/testdata/partition_pruner_in.json
+++ b/pkg/planner/core/casetest/partition/testdata/partition_pruner_in.json
@@ -32,7 +32,8 @@
       "explain format = 'brief' select * from t9",
       "explain format = 'brief' select * from t10 where a between 0 AND 15218001646226433652",
       "explain format = 'brief' select * from t11 where a is null",
-      "explain format = 'brief' select * from t11 where a is null and b = 2"
+      "explain format = 'brief' select * from t11 where a is null and b = 2",
+      "explain format = 'brief' select * from t11 where a = 1 and b = 2"
     ]
   },
   {

--- a/pkg/planner/core/casetest/partition/testdata/partition_pruner_in.json
+++ b/pkg/planner/core/casetest/partition/testdata/partition_pruner_in.json
@@ -30,7 +30,9 @@
       "explain format = 'brief' select * from t8 where (a <= 10 and a >= 8) or (a <= 13 and a >= 11) or (a <= 16 and a >= 14)",
       "explain format = 'brief' select * from t8 where a < 12 and a > 9",
       "explain format = 'brief' select * from t9",
-      "explain format = 'brief' select * from t10 where a between 0 AND 15218001646226433652"
+      "explain format = 'brief' select * from t10 where a between 0 AND 15218001646226433652",
+      "explain format = 'brief' select * from t11 where a is null",
+      "explain format = 'brief' select * from t11 where a is null and b = 2"
     ]
   },
   {

--- a/pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -215,6 +215,22 @@
           "└─Selection 250.00 cop[tikv]  ge(test_partition.t10.a, 0), le(test_partition.t10.a, 15218001646226433652)",
           "  └─TableFullScan 10000.00 cop[tikv] table:t10 keep order:false, stats:pseudo"
         ]
+      },
+      {
+        "SQL": "explain format = 'brief' select * from t11 where a is null",
+        "Result": [
+          "TableReader 10.00 root partition:all data:Selection",
+          "└─Selection 10.00 cop[tikv]  isnull(test_partition.t11.a)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t11 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select * from t11 where a is null and b = 2",
+        "Result": [
+          "TableReader 0.01 root partition:all data:Selection",
+          "└─Selection 0.01 cop[tikv]  eq(test_partition.t11.b, 2), isnull(test_partition.t11.a)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t11 keep order:false, stats:pseudo"
+        ]
       }
     ]
   },

--- a/pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
+++ b/pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
@@ -227,8 +227,16 @@
       {
         "SQL": "explain format = 'brief' select * from t11 where a is null and b = 2",
         "Result": [
-          "TableReader 0.01 root partition:all data:Selection",
+          "TableReader 0.01 root partition:p0 data:Selection",
           "└─Selection 0.01 cop[tikv]  eq(test_partition.t11.b, 2), isnull(test_partition.t11.a)",
+          "  └─TableFullScan 10000.00 cop[tikv] table:t11 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain format = 'brief' select * from t11 where a = 1 and b = 2",
+        "Result": [
+          "TableReader 0.01 root partition:p0 data:Selection",
+          "└─Selection 0.01 cop[tikv]  eq(test_partition.t11.a, 1), eq(test_partition.t11.b, 2)",
           "  └─TableFullScan 10000.00 cop[tikv] table:t11 keep order:false, stats:pseudo"
         ]
       }

--- a/pkg/planner/core/rule_partition_processor.go
+++ b/pkg/planner/core/rule_partition_processor.go
@@ -248,8 +248,9 @@ func (s *PartitionProcessor) getUsedHashPartitions(ctx base.PlanContext,
 			break
 		}
 
-		// TODO: now we can't process condition such as
-		// `partition by hash(a + a + b)`, when accompanied by specific conditions like `where a = 1 and b = 2`.
+		// It's the range is a point condition.
+		// If len(r.HighVal) != len(partCols), we couldn't caculate the result of `hashExpr(r.HighVal...)`
+		// TODO: now we can't prune partition table such as `partition by hash(a + a + b)`.
 		if len(r.HighVal) != len(partCols) {
 			used = []int{FullRange}
 			break


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58374

Problem Summary: Let codes in `getUsedHashPartitions` same as `getUsedKeyPartitions`.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
