### PR TITLE
br/backup: make the error rightly checked

### DIFF
--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -72,9 +72,10 @@ go_test(
     embed = [":backup"],
     flaky = True,
     race = "on",
-    shard_count = 13,
+    shard_count = 10,
     deps = [
         "//br/pkg/conn",
+        "//br/pkg/errors",
         "//br/pkg/gluetidb",
         "//br/pkg/metautil",
         "//br/pkg/mock",
@@ -91,6 +92,8 @@ go_test(
         "//pkg/util/codec",
         "//pkg/util/table-filter",
         "@com_github_golang_protobuf//proto",
+        "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
         "@com_github_pingcap_kvproto//pkg/errorpb",
@@ -103,5 +106,6 @@ go_test(
         "@io_opencensus_go//stats/view",
         "@org_golang_google_grpc//:grpc",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_multierr//:multierr",
     ],
 )

--- a/br/pkg/backup/BUILD.bazel
+++ b/br/pkg/backup/BUILD.bazel
@@ -72,7 +72,7 @@ go_test(
     embed = [":backup"],
     flaky = True,
     race = "on",
-    shard_count = 10,
+    shard_count = 14,
     deps = [
         "//br/pkg/conn",
         "//br/pkg/errors",
@@ -93,7 +93,6 @@ go_test(
         "//pkg/util/table-filter",
         "@com_github_golang_protobuf//proto",
         "@com_github_pingcap_errors//:errors",
-        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/encryptionpb",
         "@com_github_pingcap_kvproto//pkg/errorpb",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58340

Problem Summary:
We gave up too early when there is a `StoreErr` returns because the `errors` package cannot properly get the inner error and soonly give up retry then.

### What changed and how does it work?
Make the `StoreErr` can be rightly unwraped by `pingcap/errors`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
