### PR TITLE
planner: fix "invalid memory address or nil pointer dereference" when using Instance Plan Cache in some cases

### DIFF
--- a/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "instanceplancache_test",
-    timeout = "moderate",
+    timeout = "long",
     srcs = [
         "builtin_func_test.go",
         "concurrency_test.go",

--- a/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
+++ b/pkg/planner/core/casetest/instanceplancache/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 40,
+    shard_count = 42,
     deps = [
         "//pkg/domain",
         "//pkg/parser/auth",

--- a/pkg/planner/core/casetest/instanceplancache/others_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/others_test.go
@@ -637,3 +637,17 @@ func TestInstancePlanCacheView(t *testing.T) {
 		testkit.Rows("select a from t where a<=? Select root 1 3",
 			"select a from t where a=? and b=? Select root (1, 2) 3"))
 }
+
+func TestInstancePlanCacheIssue58395(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`set global tidb_enable_instance_plan_cache=1`)
+	tk.MustExec(`CREATE TABLE t3 (c datetime, PRIMARY KEY (c))`)
+	tk.MustExec(`prepare p4 from "select * from t3 where c in (?, ? , '2033-11-23')"`)
+	tk.MustExec(`set @i0 = '2027-12-17', @i1 = '1986-12-03'`)
+	tk.MustQuery(`execute p4 using @i0, @i1`) // no error
+
+	tk.MustExec(`set @i0 = 'a', @i1 = 'b'`)
+	tk.MustExec(`execute p4 using @i0, @i1`)
+}

--- a/pkg/planner/core/plan_clone_utils.go
+++ b/pkg/planner/core/plan_clone_utils.go
@@ -140,6 +140,9 @@ func cloneConstantsForPlanCache(constants, cloned []*expression.Constant) []*exp
 	}
 	allSafe := true
 	for _, c := range constants {
+		if c == nil {
+			continue
+		}
 		if !c.SafeToShareAcrossSession() {
 			allSafe = false
 			break


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58395

Problem Summary: planner: fix "invalid memory address or nil pointer dereference" when using Instance Plan Cache in some cases

### What changed and how does it work?

planner: fix "invalid memory address or nil pointer dereference" when using Instance Plan Cache in some cases

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
