### PR TITLE
stmtsummary: check authUsers using the polymorphic stmtSummaryStats

### DIFF
--- a/pkg/util/stmtsummary/reader.go
+++ b/pkg/util/stmtsummary/reader.go
@@ -139,10 +139,10 @@ func (ssr *stmtSummaryReader) SetChecker(checker *stmtSummaryChecker) {
 	ssr.checker = checker
 }
 
-func (ssr *stmtSummaryReader) isAuthed(ssbd *stmtSummaryByDigest) bool {
+func (ssr *stmtSummaryReader) isAuthed(ssStats *stmtSummaryStats) bool {
 	isAuthed := true
 	if ssr.user != nil && !ssr.hasProcessPriv {
-		_, isAuthed = ssbd.cumulative.authUsers[ssr.user.Username]
+		_, isAuthed = ssStats.authUsers[ssr.user.Username]
 	}
 	return isAuthed
 }
@@ -150,7 +150,7 @@ func (ssr *stmtSummaryReader) isAuthed(ssbd *stmtSummaryByDigest) bool {
 func (ssr *stmtSummaryReader) getStmtByDigestCumulativeRow(ssbd *stmtSummaryByDigest) []types.Datum {
 	ssbd.Lock()
 	defer ssbd.Unlock()
-	if !ssr.isAuthed(ssbd) {
+	if !ssr.isAuthed(&ssbd.cumulative) {
 		return nil
 	}
 
@@ -181,7 +181,7 @@ func (ssr *stmtSummaryReader) getStmtByDigestRow(ssbd *stmtSummaryByDigest, begi
 func (ssr *stmtSummaryReader) getStmtByDigestElementRow(ssElement *stmtSummaryByDigestElement, ssbd *stmtSummaryByDigest) []types.Datum {
 	ssElement.Lock()
 	defer ssElement.Unlock()
-	if !ssr.isAuthed(ssbd) {
+	if !ssr.isAuthed(&ssElement.stmtSummaryStats) {
 		return nil
 	}
 

--- a/pkg/util/stmtsummary/statement_summary_test.go
+++ b/pkg/util/stmtsummary/statement_summary_test.go
@@ -1505,4 +1505,32 @@ func TestAccessPrivilege(t *testing.T) {
 	reader.hasProcessPriv = true
 	datums = reader.GetStmtSummaryHistoryRows()
 	require.Len(t, datums, loops)
+
+	// Test the same query digests, but run as a different user in a new statement
+	// summary interval. The old user should not be able to access the rows generated
+	// for the new user.
+	ssMap.beginTimeForCurInterval = time.Now().Unix()
+	stmtExecInfo2 := generateAnyExecInfo()
+	stmtExecInfo2.User = "new_user"
+
+	for i := range loops {
+		stmtExecInfo2.Digest = fmt.Sprintf("digest%d", i)
+		ssMap.AddStatement(stmtExecInfo2)
+	}
+
+	oldUser := user
+	newUser := &auth.UserIdentity{Username: "new_user"}
+
+	reader.user = newUser
+	reader.hasProcessPriv = false
+	datums = reader.GetStmtSummaryCurrentRows()
+	require.Len(t, datums, loops)
+	reader.user = oldUser
+	reader.hasProcessPriv = false
+	datums = reader.GetStmtSummaryCurrentRows()
+	require.Len(t, datums, 0)
+	reader.user = oldUser
+	reader.hasProcessPriv = true
+	datums = reader.GetStmtSummaryCurrentRows()
+	require.Len(t, datums, loops)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58403

Problem Summary:

`isAuthed` was factored out of `getStmtByDigestElementRow` so it could be shared with `getStmtByDigestCumulativeRow`, but the logic was hardcoded to use the cumulative statement stats, breaking the auth checks for the original interval-based statement summary tables.

### What changed and how does it work?

* In `isAuthed`, check `ssStats.authUsers` rather than checking `ssbd.cumulative.authUsers`.
* Extend `TestAccessPrivilege` to test the same query digests as before, but run as a different user in a new statement summary interval (which should not be able to access rows generated for the old user).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```Reverted the fix and confirmed that the modified TestAccessPrivilege test fails.```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
