### PR TITLE
br: add status field for log status with json

### DIFF
--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -98,6 +98,16 @@ func (t *TaskStatus) colorfulStatusString() string {
 	return statusOK("NORMAL")
 }
 
+func (t *TaskStatus) statusString() string {
+	if t.paused && len(t.LastErrors) > 0 {
+		return "ERROR"
+	}
+	if t.paused {
+		return "PAUSE"
+	}
+	return "NORMAL"
+}
+
 // GetCheckpoint calculates the checkpoint of the task.
 func (t TaskStatus) GetMinStoreCheckpoint() Checkpoint {
 	initialized := false
@@ -195,6 +205,7 @@ func (p *printByJSON) PrintTasks() {
 		Name         string           `json:"name"`
 		StartTS      uint64           `json:"start_ts,omitempty"`
 		EndTS        uint64           `json:"end_ts,omitempty"`
+		Status       string           `json:"status"`
 		TableFilter  []string         `json:"table_filter"`
 		Progress     []storeProgress  `json:"progress"`
 		Storage      string           `json:"storage"`
@@ -224,6 +235,7 @@ func (p *printByJSON) PrintTasks() {
 			Name:         t.Info.GetName(),
 			StartTS:      t.Info.GetStartTs(),
 			EndTS:        t.Info.GetEndTs(),
+			Status:       t.statusString(),
 			TableFilter:  t.Info.GetTableFilter(),
 			Progress:     sp,
 			Storage:      s.String(),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #57959

Problem Summary:
log task status is not reported in the json format output
### What changed and how does it work?
report log task status in the json format output
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

```
$ ./br log status --task-name pitr -u 127.0.0.1:2379
● Total 1 Tasks.
> #1 <
              name: pitr
            status: ● NORMAL
             start: 2024-12-23 14:30:34.62 +0800
               end: 2090-11-18 22:07:45.624 +0800
           storage: local:///root/backups/test9/log
       speed(est.): 0.00 ops/s
checkpoint[global]: 2024-12-23 14:30:34.62 +0800; gap=22s

$ ./br log status --task-name pitr -u 127.0.0.1:2379 --json
[{"name":"pitr","start_ts":454802914573025282,"end_ts":999999999999999999,"status":"NORMAL","table_filter":["*.*"],"progress":[],"storage":"local:///root/backups/test9/log","checkpoint":454802914573025282,"estimate_qps":0,"last_errors":[]}]
```

```
$ ./br log status --task-name pitr -u 127.0.0.1:2379
● Total 1 Tasks.
> #1 <
              name: pitr
            status: ● PAUSE
             start: 2024-12-23 14:30:34.62 +0800
               end: 2090-11-18 22:07:45.624 +0800
           storage: local:///root/backups/test9/log
       speed(est.): 0.00 ops/s
checkpoint[global]: 2024-12-23 14:33:02.07 +0800; gap=3m10s

$ ./br log status --task-name pitr -u 127.0.0.1:2379 --json
[{"name":"pitr","start_ts":454802914573025282,"end_ts":999999999999999999,"status":"PAUSE","table_filter":["*.*"],"progress":[],"storage":"local:///root/backups/test9/log","checkpoint":454802953226158082,"estimate_qps":0,"last_errors":[]}]
```

```
$ ./br log status --task-name pitr -u 127.0.0.1:2379
● Total 1 Tasks.
> #1 <
                    name: pitr
                  status: ○ ERROR
                   start: 2024-12-23 14:30:34.62 +0800
                     end: 2090-11-18 22:07:45.624 +0800
                 storage: local:///root/backups/test9/log
             speed(est.): 0.00 ops/s
      checkpoint[global]: 2024-12-23 14:33:02.07 +0800; gap=14m37s
          error[store=1]: KV:LogBackup:Io
error-happen-at[store=1]: 2024-12-23 14:46:22.055 +0800; gap=1m17s
  error-message[store=1]: I/O Error: No such file or directory (os error 2)
          error[store=2]: KV:LogBackup:Io
error-happen-at[store=2]: 2024-12-23 14:46:22.056 +0800; gap=1m17s
  error-message[store=2]: I/O Error: No such file or directory (os error 2)
          error[store=3]: KV:LogBackup:Io
error-happen-at[store=3]: 2024-12-23 14:46:22.057 +0800; gap=1m17s
  error-message[store=3]: I/O Error: No such file or directory (os error 2)

$ ./br log status --task-name pitr -u 127.0.0.1:2379 --json
[{"name":"pitr","start_ts":454802914573025282,"end_ts":999999999999999999,"status":"ERROR","table_filter":["*.*"],"progress":[],"storage":"local:///root/backups/test9/log","checkpoint":454802953226158082,"estimate_qps":0,"last_errors":[{"store_id":1,"last_error":{"happen_at":1734936382055,"error_code":"KV:LogBackup:Io","error_message":"I/O Error: No such file or directory (os error 2)","store_id":1}},{"store_id":2,"last_error":{"happen_at":1734936382056,"error_code":"KV:LogBackup:Io","error_message":"I/O Error: No such file or directory (os error 2)","store_id":2}},{"store_id":3,"last_error":{"happen_at":1734936382057,"error_code":"KV:LogBackup:Io","error_message":"I/O Error: No such file or directory (os error 2)","store_id":3}}]}]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
