### PR TITLE
executor, indexusage: don't load stats for point get index usage reporter

### DIFF
--- a/pkg/executor/internal/exec/indexusage_test.go
+++ b/pkg/executor/internal/exec/indexusage_test.go
@@ -269,7 +269,8 @@ func TestIndexUsageReporterWithRealData(t *testing.T) {
 			"select * from t where id_1 = 1",
 			"Point_Get",
 			[]indexStatsExpect{
-				{tableID, idx1ID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 100)}},
+				// The point get will always use smallest bucket.
+				{tableID, idx1ID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 1000)}},
 			},
 		},
 		{
@@ -339,7 +340,7 @@ partition p3 values less than MAXVALUE)`)
 			"select * from t where id_1 = 1",
 			"Point_Get",
 			[]indexStatsExpect{
-				{table.Meta().ID, idx1ID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 10)}},
+				{table.Meta().ID, idx1ID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 1000)}},
 			},
 		},
 		// BatchPointGet in a partition
@@ -389,7 +390,7 @@ partition p3 values less than MAXVALUE)`)
 			"select * from t use index(idx_1) where id_1 = 1",
 			"Point_Get",
 			[]indexStatsExpect{
-				{table.Meta().ID, idx1ID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 100)}},
+				{table.Meta().ID, idx1ID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 1000)}},
 			},
 		},
 		// BatchPointGet on global index
@@ -519,13 +520,15 @@ func TestIndexUsageReporterWithClusterIndex(t *testing.T) {
 		{
 			"select * from t0 where id = 1",
 			"Point_Get",
-			[]indexStatsExpect{{testTableInfos[0].tableID, testTableInfos[0].pkID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 100)}}},
+			// The point get will always use smallest bucket.
+			[]indexStatsExpect{{testTableInfos[0].tableID, testTableInfos[0].pkID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 1000)}}},
 		},
 		// PointGet on CommonHandle
 		{
 			"select * from t1 where id = \"1\"",
 			"Point_Get",
-			[]indexStatsExpect{{testTableInfos[1].tableID, testTableInfos[1].pkID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 100)}}},
+			// The point get will always use smallest bucket.
+			[]indexStatsExpect{{testTableInfos[1].tableID, testTableInfos[1].pkID, []indexusage.Sample{indexusage.NewSample(1, 1, 1, 1000)}}},
 		},
 		// BatchPointGet on PKAsHandle
 		{

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -73,7 +73,7 @@ func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) exec.Execut
 
 	e := &PointGetExecutor{
 		BaseExecutor:       exec.NewBaseExecutor(b.ctx, p.Schema(), p.ID()),
-		indexUsageReporter: b.buildIndexUsageReporter(p),
+		indexUsageReporter: b.buildIndexUsageReporter(p, false),
 		txnScope:           b.txnScope,
 		readReplicaScope:   b.readReplicaScope,
 		isStaleness:        b.isStaleness,
@@ -204,7 +204,7 @@ func (e *PointGetExecutor) Recreated(p *plannercore.PointGetPlan) {
 	// It's necessary to at least reset the `runtimeStats` of the `BaseExecutor`.
 	// As the `StmtCtx` may have changed, a new index usage reporter should also be created.
 	e.BaseExecutor = exec.NewBaseExecutor(e.Ctx(), p.Schema(), p.ID())
-	e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p)
+	e.indexUsageReporter = buildIndexUsageReporter(e.Ctx(), p, false)
 }
 
 // Init set fields needed for PointGetExecutor reuse, this does NOT change baseExecutor field


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58477

Problem Summary:

As described in the issue, maybe load stats is too slow for point get requests.

### What changed and how does it work?

1. Don't load stats for point get requests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

It has been covered by existing tests.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
