### PR TITLE
planner/core: move all extra columns to the end in ExpandVirtualColumn

### DIFF
--- a/pkg/planner/core/casetest/partition/BUILD.bazel
+++ b/pkg/planner/core/casetest/partition/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 9,
+    shard_count = 10,
     deps = [
         "//pkg/config",
         "//pkg/planner/util/coretestsdk",

--- a/pkg/planner/core/casetest/partition/integration_partition_test.go
+++ b/pkg/planner/core/casetest/partition/integration_partition_test.go
@@ -247,3 +247,23 @@ func TestBatchPointGetPartitionForAccessObject(t *testing.T) {
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+// Issue 58475
+func TestGeneratedColumnWithPartition(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`
+		CREATE TABLE tp (
+			id int,
+			c1 int,
+			c2 int GENERATED ALWAYS AS (c1) VIRTUAL,
+			KEY idx (id)
+		) PARTITION BY RANGE (id)
+		(PARTITION p0 VALUES LESS THAN (0),
+		PARTITION p1 VALUES LESS THAN (10000))
+	`)
+	tk.MustExec(`INSERT INTO tp (id, c1) VALUES (0, 1)`)
+	tk.MustExec(`select /*+ FORCE_INDEX(tp, idx) */id from tp where c2 = 2 group by id having id in (0)`)
+}

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -2318,23 +2318,3 @@ func TestNestedVirtualGeneratedColumnUpdate(t *testing.T) {
 	tk.MustExec("UPDATE test1 SET col7 = '{\"col10\":\"DDDDD\",\"col9\":[\"abcdefg\"]}';\n")
 	tk.MustExec("DELETE FROM test1 WHERE col1 < 0;\n")
 }
-
-// Issue 58475
-func TestGeneratedColumnWithPartition(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-
-	tk.MustExec(`
-		CREATE TABLE tp (
-			id int,
-			c1 int,
-			c2 int GENERATED ALWAYS AS (c1) VIRTUAL,
-			KEY idx (id)
-		) PARTITION BY RANGE (id)
-		(PARTITION p0 VALUES LESS THAN (0),
-		PARTITION p1 VALUES LESS THAN (10000))
-	`)
-	tk.MustExec(`INSERT INTO tp (id, c1) VALUES (0, 1)`)
-	tk.MustExec(`select /*+ FORCE_INDEX(tp, idx) */id from tp where c2 = 2 group by id having id in (0)`)
-}

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1066,8 +1066,10 @@ func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
 	numExtraColumns := 0
 	for i := oldNumColumns - 1; i >= 0; i-- {
 		cid := schema.Columns[i].ID
-		// All columns with negative cid should be placed at last.
-		if cid >= 0 {
+		// Move extra columns to the end.
+		// ExtraRowChecksumID is ignored here since it's treated as an ordinary column.
+		// https://github.com/pingcap/tidb/blob/3c407312a986327bc4876920e70fdd6841b8365f/pkg/util/rowcodec/decoder.go#L206-L222
+		if cid != model.ExtraHandleID && cid != model.ExtraPhysTblID {
 			break
 		}
 		numExtraColumns++

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1067,7 +1067,7 @@ func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
 	for i := oldNumColumns - 1; i >= 0; i-- {
 		cid := schema.Columns[i].ID
 		// All columns with negative cid should be placed at last.
-		if cid < 0 {
+		if cid >= 0 {
 			break
 		}
 		numExtraColumns++

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1059,8 +1059,8 @@ func (ts *PhysicalTableScan) ResolveCorrelatedColumns() ([]*ranger.Range, error)
 // ExpandVirtualColumn expands the virtual column's dependent columns to ts's schema and column.
 func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
 	colsInfo []*model.ColumnInfo) []*model.ColumnInfo {
-	copyColumn := make([]*model.ColumnInfo, len(columns))
-	copy(copyColumn, columns)
+	copyColumn := make([]*model.ColumnInfo, 0, len(columns))
+	copyColumn = append(copyColumn, columns...)
 
 	oldNumColumns := len(schema.Columns)
 	numExtraColumns := 0

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1061,14 +1061,26 @@ func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
 	colsInfo []*model.ColumnInfo) []*model.ColumnInfo {
 	copyColumn := make([]*model.ColumnInfo, len(columns))
 	copy(copyColumn, columns)
-	var extraColumn *expression.Column
-	var extraColumnModel *model.ColumnInfo
-	if schema.Columns[len(schema.Columns)-1].ID == model.ExtraHandleID {
-		extraColumn = schema.Columns[len(schema.Columns)-1]
-		extraColumnModel = copyColumn[len(copyColumn)-1]
-		schema.Columns = schema.Columns[:len(schema.Columns)-1]
-		copyColumn = copyColumn[:len(copyColumn)-1]
+
+	oldNumColumns := len(schema.Columns)
+	numExtraColumns := 0
+	for i := oldNumColumns - 1; i >= 0; i-- {
+		cid := schema.Columns[i].ID
+		// All columns with negative cid should be placed at last.
+		if cid < 0 {
+			break
+		}
+		numExtraColumns++
 	}
+
+	extraColumns := make([]*expression.Column, numExtraColumns)
+	copy(extraColumns, schema.Columns[oldNumColumns-numExtraColumns:])
+	schema.Columns = schema.Columns[:oldNumColumns-numExtraColumns]
+
+	extraColumnModels := make([]*model.ColumnInfo, numExtraColumns)
+	copy(extraColumnModels, copyColumn[len(copyColumn)-numExtraColumns:])
+	copyColumn = copyColumn[:len(copyColumn)-numExtraColumns]
+
 	schemaColumns := schema.Columns
 	for _, col := range schemaColumns {
 		if col.VirtualExpr == nil {
@@ -1083,10 +1095,9 @@ func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
 			}
 		}
 	}
-	if extraColumn != nil {
-		schema.Columns = append(schema.Columns, extraColumn)
-		copyColumn = append(copyColumn, extraColumnModel) // nozero
-	}
+
+	schema.Columns = append(schema.Columns, extraColumns...)
+	copyColumn = append(copyColumn, extraColumnModels...)
 	return copyColumn
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58475, close https://github.com/pingcap/tidb/issues/56013

Problem Summary:

### What changed and how does it work?

As title. Previously we only move column with id `ExtraHandleID` to the end, but we forgot some other extra columns.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
