### PR TITLE
planner: Fix expression rewriting and method signature mismatch in plan cache

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1591,7 +1591,10 @@ func RemoveMutableConst(ctx BuildContext, exprs ...Expression) (err error) {
 			}
 			v.DeferredExpr = nil // do nothing since v.Value has already been evaluated in this case.
 		case *ScalarFunction:
-			return RemoveMutableConst(ctx, v.GetArgs()...)
+			err := RemoveMutableConst(ctx, v.GetArgs()...)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -3308,3 +3308,12 @@ select * from t_date where dt in ('2023-01-01', '2023-01-01', '2023-01-02');
 dt
 2023-01-01
 2023-01-02
+drop table if exists lrr_test;
+create table lrr_test( `COL1` tinyint(16),`COL3` bigint(20) DEFAULT NULL,KEY `UM_COL` (`COL1`,`COL3`));
+insert into lrr_test(col3) values(-825024501864323944);
+insert into lrr_test values(-2,2295421130981788987);
+prepare stmt from 'select * from lrr_test t1 join lrr_test t2 on t1.col1 = t2.col1 where t1. col1 + 10 > ? + 10 or t2. col1 + 10 >= ? + 10;';
+set @a=NULL, @b=-2;
+execute stmt using @a,@b;
+COL1	COL3	COL1	COL3
+-2	2295421130981788987	-2	2295421130981788987

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -2236,3 +2236,12 @@ select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
 select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
 select * from t where a in (1, NULL, NULL, NULL, 2);
 select * from t_date where dt in ('2023-01-01', '2023-01-01', '2023-01-02');
+
+# TestIssue56772
+drop table if exists lrr_test;
+create table lrr_test( `COL1` tinyint(16),`COL3` bigint(20) DEFAULT NULL,KEY `UM_COL` (`COL1`,`COL3`));
+insert into lrr_test(col3) values(-825024501864323944);
+insert into lrr_test values(-2,2295421130981788987);
+prepare stmt from 'select * from lrr_test t1 join lrr_test t2 on t1.col1 = t2.col1 where t1. col1 + 10 > ? + 10 or t2. col1 + 10 >= ? + 10;';
+set @a=NULL, @b=-2;
+execute stmt using @a,@b;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56772

Problem Summary:

### What changed and how does it work?
In the `expression rewriting` process, when constructing the condition `t1.col1 + 10 > ? + 10`, the argument `? + 10` will go through `argument refinement`, and the final result is set to` NULL`. The type of NULL is determined as `int.` 
Then, the method signature for` t1.col1 + 10 > ? + 10` is set to `builtinArithmeticPlusIntSig`. But the `DeferredExpr` for the expression `plus(NULL, 10)` is not removed, which results in a conflict method signature of `builtinArithmeticPlusRealSig`, 
which cannot handle int types. This leads to an error during execution.

`RemoveMutableConst():` will not traverse all the expressions.
https://github.com/pingcap/tidb/blob/8ecdb54c51a156a40ad1c84215af424dc55add41/pkg/expression/util.go#L1583-L1602

I modified the code to ensure that all expressions are properly traversed and DeferredExpr would be removed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
