### PR TITLE
lightning: fix lightning-ctl dump checkpoint file name

### DIFF
--- a/lightning/cmd/tidb-lightning-ctl/main.go
+++ b/lightning/cmd/tidb-lightning-ctl/main.go
@@ -70,7 +70,7 @@ func run() error {
 		cpRemove = fs.String("checkpoint-remove", "", "remove the checkpoint associated with the given table (value can be 'all' or '`db`.`table`')")
 		cpErrIgnore = fs.String("checkpoint-error-ignore", "", "ignore errors encoutered previously on the given table (value can be 'all' or '`db`.`table`'); may corrupt this table if used incorrectly")
 		cpErrDestroy = fs.String("checkpoint-error-destroy", "", "deletes imported data with table which has an error before (value can be 'all' or '`db`.`table`')")
-		cpDump = fs.String("checkpoint-dump", "", "dump the checkpoint information as two CSV files in the given folder")
+		cpDump = fs.String("checkpoint-dump", "", "dump the checkpoint information as three CSV files in the given folder")
 
 		localStoringTables = fs.Bool("check-local-storage", false, "show tables that are missing local intermediate files (value can be 'all' or '`db`.`table`')")
 
@@ -252,7 +252,7 @@ func checkpointDump(ctx context.Context, cfg *config.Config, dumpFolder string) 
 	defer tablesFile.Close()
 
 	enginesFileName := filepath.Join(dumpFolder, "engines.csv")
-	enginesFile, err := os.Create(tablesFileName)
+	enginesFile, err := os.Create(enginesFileName)
 	if err != nil {
 		return errors.Annotatef(err, "failed to create %s", enginesFileName)
 	}

--- a/lightning/tests/lightning_local_backend/run.sh
+++ b/lightning/tests/lightning_local_backend/run.sh
@@ -140,9 +140,14 @@ for ckpt in mysql file; do
   run_lightning_ctl --check-local-storage \
     --backend local \
     --enable-checkpoint=1 \
-    --checkpoint-dump $TEST_DIR \
     --config=$CUR/$ckpt.toml >$TEST_DIR/lightning_ctl.output 2>&1
   grep -Fq "No table has lost intermediate files according to given config" $TEST_DIR/lightning_ctl.output
+
+  run_lightning_ctl \
+    --backend local \
+    --enable-checkpoint=1 \
+    --checkpoint-dump $TEST_DIR \
+    --config=$CUR/$ckpt.toml >$TEST_DIR/lightning_ctl.output 2>&1
   # --checkpoint-dump option in lightning-ctl will dump checkpoint table as csv files to $TEST_DIR
   for file in engines.csv chunks.csv tables.csv; do
     if [ ! -f "$TEST_DIR/$file" ]; then

--- a/lightning/tests/lightning_local_backend/run.sh
+++ b/lightning/tests/lightning_local_backend/run.sh
@@ -142,18 +142,17 @@ for ckpt in mysql file; do
     --enable-checkpoint=1 \
     --config=$CUR/$ckpt.toml >$TEST_DIR/lightning_ctl.output 2>&1
   grep -Fq "No table has lost intermediate files according to given config" $TEST_DIR/lightning_ctl.output
-
-  run_lightning_ctl \
-    --backend local \
-    --enable-checkpoint=1 \
-    --checkpoint-dump $TEST_DIR \
-    --config=$CUR/$ckpt.toml >$TEST_DIR/lightning_ctl.output 2>&1
-  # --checkpoint-dump option in lightning-ctl will dump checkpoint table as csv files to $TEST_DIR
-  for file in engines.csv chunks.csv tables.csv; do
-    if [ ! -f "$TEST_DIR/$file" ]; then
-      echo "$file does not exist in $TEST_DIR"
-      exit 1
-    fi
-  done
+done
+run_lightning_ctl \
+  --backend local \
+  --enable-checkpoint=1 \
+  --checkpoint-dump $TEST_DIR \
+  --config=$CUR/mysql.toml >$TEST_DIR/lightning_ctl.output 2>&1
+# --checkpoint-dump option in lightning-ctl will dump checkpoint table as csv files to $TEST_DIR
+for file in engines.csv chunks.csv tables.csv; do
+  if [ ! -f "$TEST_DIR/$file" ]; then
+    echo "$file does not exist in $TEST_DIR"
+    exit 1
+  fi
 done
 rm -r $TEST_DIR/$TEST_NAME.sorted

--- a/lightning/tests/lightning_local_backend/run.sh
+++ b/lightning/tests/lightning_local_backend/run.sh
@@ -140,7 +140,15 @@ for ckpt in mysql file; do
   run_lightning_ctl --check-local-storage \
     --backend local \
     --enable-checkpoint=1 \
+    --checkpoint-dump $TEST_DIR \
     --config=$CUR/$ckpt.toml >$TEST_DIR/lightning_ctl.output 2>&1
+  # --checkpoint-dump option in lightning-ctl will dump checkpoint table as csv files to $TEST_DIR
+  for file in engines.csv chunks.csv tables.csv; do
+    if [ ! -f "$TEST_DIR/$file" ]; then
+      echo "$file does not exist in $TEST_DIR"
+      exit 1
+    fi
+  done
   grep -Fq "No table has lost intermediate files according to given config" $TEST_DIR/lightning_ctl.output
 done
 rm -r $TEST_DIR/$TEST_NAME.sorted

--- a/lightning/tests/lightning_local_backend/run.sh
+++ b/lightning/tests/lightning_local_backend/run.sh
@@ -142,6 +142,7 @@ for ckpt in mysql file; do
     --enable-checkpoint=1 \
     --checkpoint-dump $TEST_DIR \
     --config=$CUR/$ckpt.toml >$TEST_DIR/lightning_ctl.output 2>&1
+  grep -Fq "No table has lost intermediate files according to given config" $TEST_DIR/lightning_ctl.output
   # --checkpoint-dump option in lightning-ctl will dump checkpoint table as csv files to $TEST_DIR
   for file in engines.csv chunks.csv tables.csv; do
     if [ ! -f "$TEST_DIR/$file" ]; then
@@ -149,6 +150,5 @@ for ckpt in mysql file; do
       exit 1
     fi
   done
-  grep -Fq "No table has lost intermediate files according to given config" $TEST_DIR/lightning_ctl.output
 done
 rm -r $TEST_DIR/$TEST_NAME.sorted


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57402

Problem Summary: `checkpointDump()` use incorrect file name.

### What changed and how does it work?
`checkpointDump()` use correct file name.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
