### PR TITLE
ttl: set the job history status to `cancelled` if it's removed in GC and it's still running

### DIFF
--- a/pkg/ttl/ttlworker/job_manager_test.go
+++ b/pkg/ttl/ttlworker/job_manager_test.go
@@ -215,6 +215,11 @@ func (m *JobManager) ID() string {
 	return m.id
 }
 
+// CheckNotOwnJob is an exported version of checkNotOwnJob
+func (m *JobManager) CheckNotOwnJob() {
+	m.checkNotOwnJob()
+}
+
 // CheckFinishedJob is an exported version of checkFinishedJob
 func (m *JobManager) CheckFinishedJob(se session.Session) {
 	m.checkFinishedJob(se)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58510

Problem Summary:

The job history is not updated after removing the table status. Therefore, the timer adapter will still believe there is a job running for it.

### What changed and how does it work?

Update the status to `cancelled` after removing the table status.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
None
```
