### PR TITLE
dupdetect: gRPC cancel should trigger retry

### DIFF
--- a/pkg/lightning/backend/local/duplicate.go
+++ b/pkg/lightning/backend/local/duplicate.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"math"
@@ -940,6 +941,7 @@ func (m *dupeDetector) processRemoteDupTaskOnce(
 				logutil.Key("dupDetectStartKey", kr.StartKey),
 				logutil.Key("dupDetectEndKey", kr.EndKey),
 			)
+			// TODO(lance6716): retry
 			err := func() error {
 				stream, err := NewRemoteDupKVStream(ctx, region, kr, importClientFactory, m.resourceGroupName, m.taskType, m.minCommitTS)
 				if err != nil {
@@ -997,7 +999,7 @@ func (m *dupeDetector) processRemoteDupTask(
 			}
 			return nil
 		}
-		if log.IsContextCanceledError(err) {
+		if stderrors.Is(err, context.Canceled) {
 			return errors.Trace(err)
 		}
 		if !madeProgress {

--- a/pkg/lightning/backend/local/duplicate.go
+++ b/pkg/lightning/backend/local/duplicate.go
@@ -941,7 +941,6 @@ func (m *dupeDetector) processRemoteDupTaskOnce(
 				logutil.Key("dupDetectStartKey", kr.StartKey),
 				logutil.Key("dupDetectEndKey", kr.EndKey),
 			)
-			// TODO(lance6716): retry
 			err := func() error {
 				stream, err := NewRemoteDupKVStream(ctx, region, kr, importClientFactory, m.resourceGroupName, m.taskType, m.minCommitTS)
 				if err != nil {

--- a/pkg/lightning/backend/local/duplicate.go
+++ b/pkg/lightning/backend/local/duplicate.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	stderrors "errors"
 	"fmt"
 	"io"
 	"math"
@@ -998,8 +997,9 @@ func (m *dupeDetector) processRemoteDupTask(
 			}
 			return nil
 		}
-		if stderrors.Is(err, context.Canceled) {
-			return errors.Trace(err)
+		if err2 := ctx.Err(); err2 != nil {
+			// stop retry when user cancel the context
+			return errors.Trace(err2)
 		}
 		if !madeProgress {
 			_, isRegionErr := errors.Cause(err).(regionError)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58523

Problem Summary:

### What changed and how does it work?

gRPC "canceled" error may be caused by network problems, for example the server thinks the client is gone so it cancels the RPC, and then the client receives canceled error, because streaming RPC has 2 connections independently for C->S and S->C. In lightning use case, we only want to break the retry when the user cancels it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
