### PR TITLE
executor: Optimize statements summary by using buffer pool

### DIFF
--- a/pkg/util/stmtsummary/BUILD.bazel
+++ b/pkg/util/stmtsummary/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/execdetails",
+        "//pkg/util/hack",
         "//pkg/util/plancodec",
         "//pkg/util/ppcpuusage",
         "@com_github_pingcap_log//:log",

--- a/pkg/util/stmtsummary/evicted.go
+++ b/pkg/util/stmtsummary/evicted.go
@@ -70,7 +70,7 @@ func newStmtSummaryByDigestEvictedElement(beginTime int64, endTime int64) *stmtS
 }
 
 // AddEvicted is used add an evicted record to stmtSummaryByDigestEvicted
-func (ssbde *stmtSummaryByDigestEvicted) AddEvicted(evictedKey *stmtSummaryByDigestKey, evictedValue *stmtSummaryByDigest, historySize int) {
+func (ssbde *stmtSummaryByDigestEvicted) AddEvicted(evictedKey *StmtDigestKey, evictedValue *stmtSummaryByDigest, historySize int) {
 	if evictedValue == nil {
 		return
 	}
@@ -152,7 +152,7 @@ func (ssbde *stmtSummaryByDigestEvicted) Clear() {
 }
 
 // add an evicted record to stmtSummaryByDigestEvictedElement
-func (seElement *stmtSummaryByDigestEvictedElement) addEvicted(digestKey *stmtSummaryByDigestKey, digestValue *stmtSummaryByDigestElement) {
+func (seElement *stmtSummaryByDigestEvictedElement) addEvicted(digestKey *StmtDigestKey, digestValue *stmtSummaryByDigestElement) {
 	if digestKey != nil {
 		seElement.count++
 		addInfo(seElement.otherSummary, digestValue)
@@ -169,7 +169,7 @@ const (
 // if matches, it will add the digest and return enum match
 // if digest too old, it will return enum tooOld and do nothing
 // if digest too young, it will return enum tooYoung and do nothing
-func (seElement *stmtSummaryByDigestEvictedElement) matchAndAdd(digestKey *stmtSummaryByDigestKey, digestValue *stmtSummaryByDigestElement) (statement int) {
+func (seElement *stmtSummaryByDigestEvictedElement) matchAndAdd(digestKey *StmtDigestKey, digestValue *stmtSummaryByDigestElement) (statement int) {
 	if seElement == nil || digestValue == nil {
 		return isTooYoung
 	}

--- a/pkg/util/stmtsummary/evicted_test.go
+++ b/pkg/util/stmtsummary/evicted_test.go
@@ -49,9 +49,9 @@ func newInduceSsbde(beginTime int64, endTime int64) *stmtSummaryByDigestElement 
 	return newSsbde
 }
 
-// generate new stmtSummaryByDigestKey and stmtSummaryByDigest
-func generateStmtSummaryByDigestKeyValue(schema string, beginTime int64, endTime int64) (*stmtSummaryByDigestKey, *stmtSummaryByDigest) {
-	key := &stmtSummaryByDigestKey{
+// generate new StmtDigestKey and stmtSummaryByDigest
+func generateStmtSummaryByDigestKeyValue(schema string, beginTime int64, endTime int64) (*StmtDigestKey, *stmtSummaryByDigest) {
+	key := &StmtDigestKey{
 		schemaName: schema,
 	}
 	value := newInduceSsbd(beginTime, endTime)
@@ -191,7 +191,7 @@ func TestSimpleStmtSummaryByDigestEvicted(t *testing.T) {
 	ssbde.AddEvicted(evictedKey, evictedValue, 3)
 	require.Equal(t, "{begin: 8, end: 9, count: 1}, {begin: 5, end: 6, count: 1}, {begin: 2, end: 3, count: 1}", getAllEvicted(ssbde))
 
-	evictedKey = &stmtSummaryByDigestKey{schemaName: "b"}
+	evictedKey = &StmtDigestKey{schemaName: "b"}
 	ssbde.AddEvicted(evictedKey, evictedValue, 4)
 	require.Equal(t, "{begin: 8, end: 9, count: 2}, {begin: 5, end: 6, count: 2}, {begin: 2, end: 3, count: 2}, {begin: 1, end: 2, count: 1}", getAllEvicted(ssbde))
 
@@ -307,7 +307,7 @@ func TestEvictedCountDetailed(t *testing.T) {
 	ssMap.Clear()
 	other := ssMap.other
 	// test poisoning with empty-history digestValue
-	other.AddEvicted(new(stmtSummaryByDigestKey), new(stmtSummaryByDigest), 100)
+	other.AddEvicted(new(StmtDigestKey), new(stmtSummaryByDigest), 100)
 	require.Equal(t, 0, other.history.Len())
 }
 

--- a/pkg/util/stmtsummary/evicted_test.go
+++ b/pkg/util/stmtsummary/evicted_test.go
@@ -51,9 +51,8 @@ func newInduceSsbde(beginTime int64, endTime int64) *stmtSummaryByDigestElement 
 
 // generate new StmtDigestKey and stmtSummaryByDigest
 func generateStmtSummaryByDigestKeyValue(schema string, beginTime int64, endTime int64) (*StmtDigestKey, *stmtSummaryByDigest) {
-	key := &StmtDigestKey{
-		schemaName: schema,
-	}
+	key := &StmtDigestKey{}
+	key.Init(schema, "", "", "", "")
 	value := newInduceSsbd(beginTime, endTime)
 	return key, value
 }
@@ -191,7 +190,8 @@ func TestSimpleStmtSummaryByDigestEvicted(t *testing.T) {
 	ssbde.AddEvicted(evictedKey, evictedValue, 3)
 	require.Equal(t, "{begin: 8, end: 9, count: 1}, {begin: 5, end: 6, count: 1}, {begin: 2, end: 3, count: 1}", getAllEvicted(ssbde))
 
-	evictedKey = &StmtDigestKey{schemaName: "b"}
+	evictedKey = &StmtDigestKey{}
+	evictedKey.Init("b", "", "", "", "")
 	ssbde.AddEvicted(evictedKey, evictedValue, 4)
 	require.Equal(t, "{begin: 8, end: 9, count: 2}, {begin: 5, end: 6, count: 2}, {begin: 2, end: 3, count: 2}, {begin: 1, end: 2, count: 1}", getAllEvicted(ssbde))
 

--- a/pkg/util/stmtsummary/statement_summary.go
+++ b/pkg/util/stmtsummary/statement_summary.go
@@ -53,6 +53,7 @@ type StmtDigestKey struct {
 	hash []byte
 }
 
+// Init initialize the hash key.
 func (key *StmtDigestKey) Init(schemaName, digest, prevDigest, planDigest, resourceGroupName string) {
 	length := len(schemaName) + len(digest) + len(prevDigest) + len(planDigest) + len(resourceGroupName)
 	if cap(key.hash) < length {

--- a/pkg/util/stmtsummary/statement_summary.go
+++ b/pkg/util/stmtsummary/statement_summary.go
@@ -42,7 +42,7 @@ import (
 
 // StmtDigestKeyPool is the pool for StmtDigestKey.
 var StmtDigestKeyPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &StmtDigestKey{}
 	},
 }

--- a/pkg/util/stmtsummary/statement_summary_test.go
+++ b/pkg/util/stmtsummary/statement_summary_test.go
@@ -15,6 +15,7 @@
 package stmtsummary
 
 import (
+	"bytes"
 	"container/list"
 	"fmt"
 	"strings"
@@ -30,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
+	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/ppcpuusage"
 	"github.com/stretchr/testify/require"
@@ -75,12 +77,8 @@ func TestAddStatement(t *testing.T) {
 	// first statement
 	stmtExecInfo1 := generateAnyExecInfo()
 	stmtExecInfo1.ExecDetail.CommitDetail.Mu.PrewriteBackoffTypes = make([]string, 0)
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        stmtExecInfo1.PlanDigest,
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, "", stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 	samplePlan, _, _ := stmtExecInfo1.LazyInfo.GetEncodedPlan()
 	stmtExecInfo1.ExecDetail.CommitDetail.Mu.Lock()
 	expectedSummaryElement := stmtSummaryByDigestElement{
@@ -454,12 +452,8 @@ func TestAddStatement(t *testing.T) {
 	stmtExecInfo4 := stmtExecInfo1
 	stmtExecInfo4.SchemaName = "schema2"
 	stmtExecInfo4.ExecDetail.CommitDetail = nil
-	key = &StmtDigestKey{
-		schemaName:        stmtExecInfo4.SchemaName,
-		digest:            stmtExecInfo4.Digest,
-		planDigest:        stmtExecInfo4.PlanDigest,
-		resourceGroupName: stmtExecInfo4.ResourceGroupName,
-	}
+	key = &StmtDigestKey{}
+	key.Init(stmtExecInfo4.SchemaName, stmtExecInfo4.Digest, "", stmtExecInfo4.PlanDigest, stmtExecInfo4.ResourceGroupName)
 	ssMap.AddStatement(stmtExecInfo4)
 	require.Equal(t, 2, ssMap.summaryMap.Size())
 	_, ok = ssMap.summaryMap.Get(key)
@@ -468,12 +462,8 @@ func TestAddStatement(t *testing.T) {
 	// Fifth statement has a different digest.
 	stmtExecInfo5 := stmtExecInfo1
 	stmtExecInfo5.Digest = "digest2"
-	key = &StmtDigestKey{
-		schemaName:        stmtExecInfo5.SchemaName,
-		digest:            stmtExecInfo5.Digest,
-		planDigest:        stmtExecInfo4.PlanDigest,
-		resourceGroupName: stmtExecInfo5.ResourceGroupName,
-	}
+	key = &StmtDigestKey{}
+	key.Init(stmtExecInfo5.SchemaName, stmtExecInfo5.Digest, "", stmtExecInfo5.PlanDigest, stmtExecInfo5.ResourceGroupName)
 	ssMap.AddStatement(stmtExecInfo5)
 	require.Equal(t, 3, ssMap.summaryMap.Size())
 	_, ok = ssMap.summaryMap.Get(key)
@@ -482,12 +472,8 @@ func TestAddStatement(t *testing.T) {
 	// Sixth statement has a different plan digest.
 	stmtExecInfo6 := stmtExecInfo1
 	stmtExecInfo6.PlanDigest = "plan_digest2"
-	key = &StmtDigestKey{
-		schemaName:        stmtExecInfo6.SchemaName,
-		digest:            stmtExecInfo6.Digest,
-		planDigest:        stmtExecInfo6.PlanDigest,
-		resourceGroupName: stmtExecInfo6.ResourceGroupName,
-	}
+	key = &StmtDigestKey{}
+	key.Init(stmtExecInfo6.SchemaName, stmtExecInfo6.Digest, "", stmtExecInfo6.PlanDigest, stmtExecInfo6.ResourceGroupName)
 	ssMap.AddStatement(stmtExecInfo6)
 	require.Equal(t, 4, ssMap.summaryMap.Size())
 	_, ok = ssMap.summaryMap.Get(key)
@@ -507,18 +493,16 @@ func TestAddStatement(t *testing.T) {
 		binPlan:     "",
 		planDigest:  "",
 	}
-	key = &StmtDigestKey{
-		schemaName:        stmtExecInfo7.SchemaName,
-		digest:            stmtExecInfo7.Digest,
-		planDigest:        stmtExecInfo7.PlanDigest,
-		resourceGroupName: stmtExecInfo7.ResourceGroupName,
-	}
+	key = &StmtDigestKey{}
+	key.Init(stmtExecInfo7.SchemaName, stmtExecInfo7.Digest, "", stmtExecInfo7.PlanDigest, stmtExecInfo7.ResourceGroupName)
 	ssMap.AddStatement(stmtExecInfo7)
 	require.Equal(t, 5, ssMap.summaryMap.Size())
 	v, ok := ssMap.summaryMap.Get(key)
 	require.True(t, ok)
 	stmt := v.(*stmtSummaryByDigest)
-	require.Equal(t, key.digest, stmt.digest)
+	require.True(t, bytes.Contains(key.Hash(), hack.Slice(stmt.schemaName)))
+	require.True(t, bytes.Contains(key.Hash(), hack.Slice(stmt.digest)))
+	require.True(t, bytes.Contains(key.Hash(), hack.Slice(stmt.planDigest)))
 	e := stmt.history.Back()
 	ssElement := e.Value.(*stmtSummaryByDigestElement)
 	require.Equal(t, plancodec.PlanDiscardedEncoded, ssElement.samplePlan)
@@ -1044,12 +1028,8 @@ func TestMaxStmtCount(t *testing.T) {
 
 	// LRU cache should work.
 	for i := loops - 10; i < loops; i++ {
-		key := &StmtDigestKey{
-			schemaName:        stmtExecInfo1.SchemaName,
-			digest:            fmt.Sprintf("digest%d", i),
-			planDigest:        stmtExecInfo1.PlanDigest,
-			resourceGroupName: stmtExecInfo1.ResourceGroupName,
-		}
+		key := &StmtDigestKey{}
+		key.Init(stmtExecInfo1.SchemaName, fmt.Sprintf("digest%d", i), "", stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 		key.Hash()
 		_, ok := sm.Get(key)
 		require.True(t, ok)
@@ -1092,13 +1072,8 @@ func TestMaxSQLLength(t *testing.T) {
 	stmtExecInfo1.NormalizedSQL = str
 	ssMap.AddStatement(stmtExecInfo1)
 
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        stmtExecInfo1.PlanDigest,
-		prevDigest:        stmtExecInfo1.PrevSQLDigest,
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, "", stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 	value, ok := ssMap.summaryMap.Get(key)
 	require.True(t, ok)
 
@@ -1301,12 +1276,8 @@ func TestRefreshCurrentSummary(t *testing.T) {
 
 	ssMap.beginTimeForCurInterval = now + 10
 	stmtExecInfo1 := generateAnyExecInfo()
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        stmtExecInfo1.PlanDigest,
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, "", stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 	ssMap.AddStatement(stmtExecInfo1)
 	require.Equal(t, 1, ssMap.summaryMap.Size())
 	value, ok := ssMap.summaryMap.Get(key)
@@ -1352,12 +1323,8 @@ func TestSummaryHistory(t *testing.T) {
 	}()
 
 	stmtExecInfo1 := generateAnyExecInfo()
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        stmtExecInfo1.PlanDigest,
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, "", stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 	for i := range 11 {
 		ssMap.beginTimeForCurInterval = now + int64(i+1)*10
 		ssMap.AddStatement(stmtExecInfo1)
@@ -1425,13 +1392,8 @@ func TestPrevSQL(t *testing.T) {
 	stmtExecInfo1.PrevSQL = "prevSQL"
 	stmtExecInfo1.PrevSQLDigest = "prevSQLDigest"
 	ssMap.AddStatement(stmtExecInfo1)
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        stmtExecInfo1.PlanDigest,
-		prevDigest:        stmtExecInfo1.PrevSQLDigest,
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, stmtExecInfo1.PrevSQLDigest, stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 	require.Equal(t, 1, ssMap.summaryMap.Size())
 	_, ok := ssMap.summaryMap.Get(key)
 	require.True(t, ok)
@@ -1444,9 +1406,9 @@ func TestPrevSQL(t *testing.T) {
 	stmtExecInfo2 := stmtExecInfo1
 	stmtExecInfo2.PrevSQL = "prevSQL1"
 	stmtExecInfo2.PrevSQLDigest = "prevSQLDigest1"
-	key.prevDigest = stmtExecInfo2.PrevSQLDigest
 	ssMap.AddStatement(stmtExecInfo2)
 	require.Equal(t, 2, ssMap.summaryMap.Size())
+	key.Init(stmtExecInfo2.SchemaName, stmtExecInfo2.Digest, stmtExecInfo2.PrevSQLDigest, stmtExecInfo2.PlanDigest, stmtExecInfo2.ResourceGroupName)
 	_, ok = ssMap.summaryMap.Get(key)
 	require.True(t, ok)
 }
@@ -1458,12 +1420,8 @@ func TestEndTime(t *testing.T) {
 
 	stmtExecInfo1 := generateAnyExecInfo()
 	ssMap.AddStatement(stmtExecInfo1)
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        stmtExecInfo1.PlanDigest,
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, "", stmtExecInfo1.PlanDigest, stmtExecInfo1.ResourceGroupName)
 	require.Equal(t, 1, ssMap.summaryMap.Size())
 	value, ok := ssMap.summaryMap.Get(key)
 	require.True(t, ok)
@@ -1508,12 +1466,8 @@ func TestPointGet(t *testing.T) {
 	stmtExecInfo1.PlanDigest = ""
 	stmtExecInfo1.LazyInfo.(*mockLazyInfo).plan = fakePlanDigestGenerator()
 	ssMap.AddStatement(stmtExecInfo1)
-	key := &StmtDigestKey{
-		schemaName:        stmtExecInfo1.SchemaName,
-		digest:            stmtExecInfo1.Digest,
-		planDigest:        "",
-		resourceGroupName: stmtExecInfo1.ResourceGroupName,
-	}
+	key := &StmtDigestKey{}
+	key.Init(stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, "", "", stmtExecInfo1.ResourceGroupName)
 	require.Equal(t, 1, ssMap.summaryMap.Size())
 	value, ok := ssMap.summaryMap.Get(key)
 	require.True(t, ok)

--- a/pkg/util/stmtsummary/statement_summary_test.go
+++ b/pkg/util/stmtsummary/statement_summary_test.go
@@ -75,7 +75,7 @@ func TestAddStatement(t *testing.T) {
 	// first statement
 	stmtExecInfo1 := generateAnyExecInfo()
 	stmtExecInfo1.ExecDetail.CommitDetail.Mu.PrewriteBackoffTypes = make([]string, 0)
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        stmtExecInfo1.PlanDigest,
@@ -454,7 +454,7 @@ func TestAddStatement(t *testing.T) {
 	stmtExecInfo4 := stmtExecInfo1
 	stmtExecInfo4.SchemaName = "schema2"
 	stmtExecInfo4.ExecDetail.CommitDetail = nil
-	key = &stmtSummaryByDigestKey{
+	key = &StmtDigestKey{
 		schemaName:        stmtExecInfo4.SchemaName,
 		digest:            stmtExecInfo4.Digest,
 		planDigest:        stmtExecInfo4.PlanDigest,
@@ -468,7 +468,7 @@ func TestAddStatement(t *testing.T) {
 	// Fifth statement has a different digest.
 	stmtExecInfo5 := stmtExecInfo1
 	stmtExecInfo5.Digest = "digest2"
-	key = &stmtSummaryByDigestKey{
+	key = &StmtDigestKey{
 		schemaName:        stmtExecInfo5.SchemaName,
 		digest:            stmtExecInfo5.Digest,
 		planDigest:        stmtExecInfo4.PlanDigest,
@@ -482,7 +482,7 @@ func TestAddStatement(t *testing.T) {
 	// Sixth statement has a different plan digest.
 	stmtExecInfo6 := stmtExecInfo1
 	stmtExecInfo6.PlanDigest = "plan_digest2"
-	key = &stmtSummaryByDigestKey{
+	key = &StmtDigestKey{
 		schemaName:        stmtExecInfo6.SchemaName,
 		digest:            stmtExecInfo6.Digest,
 		planDigest:        stmtExecInfo6.PlanDigest,
@@ -507,7 +507,7 @@ func TestAddStatement(t *testing.T) {
 		binPlan:     "",
 		planDigest:  "",
 	}
-	key = &stmtSummaryByDigestKey{
+	key = &StmtDigestKey{
 		schemaName:        stmtExecInfo7.SchemaName,
 		digest:            stmtExecInfo7.Digest,
 		planDigest:        stmtExecInfo7.PlanDigest,
@@ -1044,7 +1044,7 @@ func TestMaxStmtCount(t *testing.T) {
 
 	// LRU cache should work.
 	for i := loops - 10; i < loops; i++ {
-		key := &stmtSummaryByDigestKey{
+		key := &StmtDigestKey{
 			schemaName:        stmtExecInfo1.SchemaName,
 			digest:            fmt.Sprintf("digest%d", i),
 			planDigest:        stmtExecInfo1.PlanDigest,
@@ -1092,7 +1092,7 @@ func TestMaxSQLLength(t *testing.T) {
 	stmtExecInfo1.NormalizedSQL = str
 	ssMap.AddStatement(stmtExecInfo1)
 
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        stmtExecInfo1.PlanDigest,
@@ -1301,7 +1301,7 @@ func TestRefreshCurrentSummary(t *testing.T) {
 
 	ssMap.beginTimeForCurInterval = now + 10
 	stmtExecInfo1 := generateAnyExecInfo()
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        stmtExecInfo1.PlanDigest,
@@ -1352,7 +1352,7 @@ func TestSummaryHistory(t *testing.T) {
 	}()
 
 	stmtExecInfo1 := generateAnyExecInfo()
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        stmtExecInfo1.PlanDigest,
@@ -1425,7 +1425,7 @@ func TestPrevSQL(t *testing.T) {
 	stmtExecInfo1.PrevSQL = "prevSQL"
 	stmtExecInfo1.PrevSQLDigest = "prevSQLDigest"
 	ssMap.AddStatement(stmtExecInfo1)
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        stmtExecInfo1.PlanDigest,
@@ -1458,7 +1458,7 @@ func TestEndTime(t *testing.T) {
 
 	stmtExecInfo1 := generateAnyExecInfo()
 	ssMap.AddStatement(stmtExecInfo1)
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        stmtExecInfo1.PlanDigest,
@@ -1508,7 +1508,7 @@ func TestPointGet(t *testing.T) {
 	stmtExecInfo1.PlanDigest = ""
 	stmtExecInfo1.LazyInfo.(*mockLazyInfo).plan = fakePlanDigestGenerator()
 	ssMap.AddStatement(stmtExecInfo1)
-	key := &stmtSummaryByDigestKey{
+	key := &StmtDigestKey{
 		schemaName:        stmtExecInfo1.SchemaName,
 		digest:            stmtExecInfo1.Digest,
 		planDigest:        "",

--- a/pkg/util/stmtsummary/v2/BUILD.bazel
+++ b/pkg/util/stmtsummary/v2/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/execdetails",
-        "//pkg/util/hack",
         "//pkg/util/kvcache",
         "//pkg/util/logutil",
         "//pkg/util/plancodec",

--- a/pkg/util/stmtsummary/v2/stmtsummary.go
+++ b/pkg/util/stmtsummary/v2/stmtsummary.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/kvcache"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/stmtsummary"
@@ -416,7 +415,7 @@ func (s *StmtSummary) rotate(now time.Time) {
 // into stmtEvicted.
 type stmtWindow struct {
 	begin   time.Time
-	lru     *kvcache.SimpleLRUCache // *stmtKey => *lockedStmtRecord
+	lru     *kvcache.SimpleLRUCache // *StmtDigestKey => *lockedStmtRecord
 	evicted *stmtEvicted
 }
 
@@ -430,7 +429,7 @@ func newStmtWindow(begin time.Time, capacity uint) *stmtWindow {
 		r := v.(*lockedStmtRecord)
 		r.Lock()
 		defer r.Unlock()
-		w.evicted.add(k.(*stmtKey), r.StmtRecord)
+		w.evicted.add(k.(*stmtsummary.StmtDigestKey), r.StmtRecord)
 	})
 	return w
 }
@@ -443,36 +442,6 @@ func (w *stmtWindow) clear() {
 type stmtStorage interface {
 	persist(w *stmtWindow, end time.Time)
 	sync() error
-}
-
-// stmtKey defines key for stmtElement.
-type stmtKey struct {
-	// Same statements may appear in different schema, but they refer to different tables.
-	schemaName string
-	digest     string
-	// The digest of the previous statement.
-	prevDigest string
-	// The digest of the plan of this SQL.
-	planDigest string
-	// `resourceGroupName` is the resource group's name of this statement is bind to.
-	resourceGroupName string
-	// `hash` is the hash value of this object.
-	hash []byte
-}
-
-// Hash implements SimpleLRUCache.Key.
-// Only when current SQL is `commit` do we record `prevSQL`. Otherwise, `prevSQL` is empty.
-// `prevSQL` is included in the key To distinguish different transactions.
-func (k *stmtKey) Hash() []byte {
-	if len(k.hash) == 0 {
-		k.hash = make([]byte, 0, len(k.schemaName)+len(k.digest)+len(k.prevDigest)+len(k.planDigest)+len(k.resourceGroupName))
-		k.hash = append(k.hash, hack.Slice(k.digest)...)
-		k.hash = append(k.hash, hack.Slice(k.schemaName)...)
-		k.hash = append(k.hash, hack.Slice(k.prevDigest)...)
-		k.hash = append(k.hash, hack.Slice(k.planDigest)...)
-		k.hash = append(k.hash, hack.Slice(k.resourceGroupName)...)
-	}
-	return k.hash
 }
 
 type stmtEvicted struct {
@@ -493,7 +462,7 @@ func newStmtEvicted() *stmtEvicted {
 	}
 }
 
-func (e *stmtEvicted) add(key *stmtKey, record *StmtRecord) {
+func (e *stmtEvicted) add(key *stmtsummary.StmtDigestKey, record *StmtRecord) {
 	if key == nil || record == nil {
 		return
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #56649

Problem Summary: Optimize statements summary by using buffer pool
### What changed and how does it work?


Before:

<img width="3005" alt="image" src="https://github.com/user-attachments/assets/5095b1e3-1e7f-4ff8-bd28-798801c17abf" />


This PR:


<img width="3007" alt="image" src="https://github.com/user-attachments/assets/216e05e2-3367-4859-a910-172190eb01c8" />


version | workload | thread | QPS | 
-- | -- | -- | -- 
master | oltp_point_select | 100 | 83498 |  
This PR | oltp_point_select | 100 | 83800 | 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
