### PR TITLE
ddl: avoid schema version without diff

### DIFF
--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -397,19 +397,7 @@ func (sv *schemaVersionManager) setSchemaVersion(jobCtx *jobContext, job *model.
 	if err != nil {
 		return schemaVersion, errors.Trace(err)
 	}
-	// TODO we can merge this txn into job transaction to avoid schema version
-	//  without differ.
-	start := time.Now()
-	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnDDL), sv.store, true, func(_ context.Context, txn kv.Transaction) error {
-		var err error
-		m := meta.NewMutator(txn)
-		schemaVersion, err = m.GenSchemaVersion()
-		return err
-	})
-	defer func() {
-		metrics.DDLIncrSchemaVerOpHist.Observe(time.Since(start).Seconds())
-	}()
-	return schemaVersion, err
+	return jobCtx.metaMut.GenSchemaVersion()
 }
 
 // lockSchemaVersion gets the lock to prevent the schema version from being updated.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58486, #58483

Problem Summary:

### What changed and how does it work?
- by put `incr schema version` and `set diff for the version` in one txn, there will be no version without diff, i.e. no hole, and diff will all be committed in version order, so this pr fix https://github.com/pingcap/tidb/issues/58483 too
- by removing the separate txn to incr schema version, we can also improve DDL performance a bit, will test it later

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

same step as in https://github.com/pingcap/tidb/issues/58486, now `tidb-server-5000` will fail the txn with `write conflict`, and `tidb-server-4000` will run it successfully, and all node can see the new table
```
[2024/12/26 15:16:55.611 +08:00] [INFO] [job_scheduler.go:597] ["handle ddl job failed"] [category=ddl] [jobID=111] [conn=2797600772] [error="[kv:9007]Write conflict
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
