### PR TITLE
br: make br help sync with the new checksum default value

### DIFF
--- a/br/cmd/br/backup.go
+++ b/br/cmd/br/backup.go
@@ -26,7 +26,6 @@ func runBackupCommand(command *cobra.Command, cmdName string) error {
 		command.SilenceUsage = false
 		return errors.Trace(err)
 	}
-	overrideDefaultBackupConfigIfNeeded(&cfg, command)
 
 	if err := metricsutil.RegisterMetricsForBR(cfg.PD, cfg.KeyspaceName); err != nil {
 		return errors.Trace(err)
@@ -216,11 +215,4 @@ func newTxnBackupCommand() *cobra.Command {
 
 	task.DefineTxnBackupFlags(command)
 	return command
-}
-
-func overrideDefaultBackupConfigIfNeeded(config *task.BackupConfig, cmd *cobra.Command) {
-	// override only if flag not set by user
-	if !cmd.Flags().Changed(task.FlagChecksum) {
-		config.Checksum = false
-	}
 }

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -88,6 +88,7 @@ type BackupConfig struct {
 	BackupTS         uint64            `json:"backup-ts" toml:"backup-ts"`
 	LastBackupTS     uint64            `json:"last-backup-ts" toml:"last-backup-ts"`
 	GCTTL            int64             `json:"gc-ttl" toml:"gc-ttl"`
+	Checksum         bool              `json:"checksum" toml:"checksum"`
 	RemoveSchedulers bool              `json:"remove-schedulers" toml:"remove-schedulers"`
 	IgnoreStats      bool              `json:"ignore-stats" toml:"ignore-stats"`
 	UseBackupMetaV2  bool              `json:"use-backupmeta-v2"`
@@ -181,6 +182,12 @@ func (cfg *BackupConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig b
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	cfg.Checksum, err = flags.GetBool(flagBackupChecksum)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	cfg.UseBackupMetaV2, err = flags.GetBool(flagUseBackupMetaV2)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -46,6 +46,7 @@ import (
 )
 
 const (
+	flagBackupChecksum   = "checksum"
 	flagBackupTimeago    = "timeago"
 	flagBackupTS         = "backupts"
 	flagLastBackupTS     = "lastbackupts"
@@ -110,6 +111,7 @@ func DefineBackupFlags(flags *pflag.FlagSet) {
 		flagBackupTimeago, 0,
 		"The history version of the backup task, e.g. 1m, 1h. Do not exceed GCSafePoint")
 
+	flags.Bool(flagBackupChecksum, false, "Run checksum at end of task")
 	// TODO: remove experimental tag if it's stable
 	flags.Uint64(flagLastBackupTS, 0, "(experimental) the last time backup ts,"+
 		" use for incremental backup, support TSO only")

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -357,9 +357,7 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 // HiddenFlagsForStream temporary hidden flags that stream cmd not support.
 func HiddenFlagsForStream(flags *pflag.FlagSet) {
-	_ = flags.MarkHidden(flagBackupChecksum)
 	_ = flags.MarkHidden(flagLoadStats)
-	_ = flags.MarkHidden(flagRestoreChecksum)
 	_ = flags.MarkHidden(flagChecksumConcurrency)
 	_ = flags.MarkHidden(flagRateLimit)
 	_ = flags.MarkHidden(flagRateLimitUnit)

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -773,11 +773,6 @@ func (cfg *Config) parseAndValidateMasterKeyInfo(hasPlaintextKey bool, flags *pf
 	return nil
 }
 
-// OverrideDefaultForBackup override common config for backup tasks
-func (cfg *Config) OverrideDefaultForBackup() {
-	cfg.Checksum = false
-}
-
 // NewMgr creates a new mgr at the given PD address.
 func NewMgr(ctx context.Context,
 	g glue.Glue, pds []string,

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -64,7 +64,6 @@ const (
 	flagRateLimit           = "ratelimit"
 	flagRateLimitUnit       = "ratelimit-unit"
 	flagConcurrency         = "concurrency"
-	FlagChecksum            = "checksum"
 	flagFilter              = "filter"
 	flagCaseSensitive       = "case-sensitive"
 	flagRemoveTiFlash       = "remove-tiflash"
@@ -297,7 +296,6 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 	flags.Uint(flagChecksumConcurrency, variable.DefChecksumTableConcurrency, "The concurrency of checksumming in one table")
 
 	flags.Uint64(flagRateLimit, unlimited, "The rate limit of the task, MB/s per node")
-	flags.Bool(FlagChecksum, true, "Run checksum at end of task")
 	flags.Bool(flagRemoveTiFlash, true,
 		"Remove TiFlash replicas before backup or restore, for unsupported versions of TiFlash")
 
@@ -359,8 +357,9 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 // HiddenFlagsForStream temporary hidden flags that stream cmd not support.
 func HiddenFlagsForStream(flags *pflag.FlagSet) {
-	_ = flags.MarkHidden(FlagChecksum)
+	_ = flags.MarkHidden(flagBackupChecksum)
 	_ = flags.MarkHidden(flagLoadStats)
+	_ = flags.MarkHidden(flagRestoreChecksum)
 	_ = flags.MarkHidden(flagChecksumConcurrency)
 	_ = flags.MarkHidden(flagRateLimit)
 	_ = flags.MarkHidden(flagRateLimitUnit)
@@ -609,9 +608,6 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 		return errors.Trace(err)
 	}
 
-	if cfg.Checksum, err = flags.GetBool(FlagChecksum); err != nil {
-		return errors.Trace(err)
-	}
 	if cfg.ChecksumConcurrency, err = flags.GetUint(flagChecksumConcurrency); err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -329,7 +329,6 @@ func TestDefault(t *testing.T) {
 
 func TestDefaultBackup(t *testing.T) {
 	commonConfig := DefaultConfig()
-	commonConfig.OverrideDefaultForBackup()
 	def := DefaultBackupConfig(commonConfig)
 	defaultConfig := expectedDefaultBackupConfig()
 	require.Equal(t, defaultConfig, def)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -52,6 +52,7 @@ import (
 )
 
 const (
+	flagRestoreChecksum          = "checksum"
 	flagOnline                   = "online"
 	flagNoSchema                 = "no-schema"
 	flagLoadStats                = "load-stats"
@@ -172,7 +173,7 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 	flags.Bool(flagWithSysTable, true, "whether restore system privilege tables on default setting")
 	flags.StringArrayP(FlagResetSysUsers, "", []string{"cloud_admin", "root"}, "whether reset these users after restoration")
 	flags.Bool(flagUseFSR, false, "whether enable FSR for AWS snapshots")
-
+	flags.Bool(flagRestoreChecksum, true, "Run checksum at end of task")
 	_ = flags.MarkHidden(FlagResetSysUsers)
 	_ = flags.MarkHidden(FlagMergeRegionSizeBytes)
 	_ = flags.MarkHidden(FlagMergeRegionKeyCount)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -231,6 +231,7 @@ type RestoreConfig struct {
 	Config
 	RestoreCommonConfig
 
+	Checksum           bool          `json:"checksum" toml:"checksum"`
 	NoSchema           bool          `json:"no-schema" toml:"no-schema"`
 	LoadStats          bool          `json:"load-stats" toml:"load-stats"`
 	PDConcurrency      uint          `json:"pd-concurrency" toml:"pd-concurrency"`
@@ -357,6 +358,11 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 		return errors.Trace(err)
 	}
 	cfg.LoadStats, err = flags.GetBool(flagLoadStats)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	cfg.Checksum, err = flags.GetBool(flagRestoreChecksum)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/executor/brie.go
+++ b/pkg/executor/brie.go
@@ -284,13 +284,7 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 	}
 	pds := strings.Split(tidbCfg.Path, ",")
 
-	// build common config and override for specific task if needed
 	cfg := task.DefaultConfig()
-	switch s.Kind {
-	case ast.BRIEKindBackup:
-		cfg.OverrideDefaultForBackup()
-	default:
-	}
 
 	cfg.PD = pds
 	cfg.TLS = tlsCfg


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58559 

Problem Summary:

### What changed and how does it work?

make the br output gives the correct `--checksum` default values for  `br backup --help` and `br restore --help` commands respetively.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
<img width="993" alt="image" src="https://github.com/user-attachments/assets/9f75c479-fc62-4105-8368-8e80c8c7344a" />

<img width="993" alt="image" src="https://github.com/user-attachments/assets/51d364f0-7950-47fb-85c6-8149aa8f89d3" />

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
