### PR TITLE
test: stabilize TestGetAndResetRecentInfoSchemaTS

### DIFF
--- a/pkg/infoschema/cache.go
+++ b/pkg/infoschema/cache.go
@@ -74,7 +74,7 @@ func NewCache(r autoid.Requirement, capacity int) *InfoCache {
 //	The keepAlive() function will compare the InfoSchemaV2's ts with Data.recentMinTS, and
 //	update the Data.recentMinTS to smaller one.
 //
-// In a nutshell, every round of ReportMinStartTS(), the minimal known TS used be InfoSchemaV2 APIs will be reported.
+// In a nutshell, every round of ReportMinStartTS(), the minimal known TS used by InfoSchemaV2 APIs will be reported.
 // Some corner cases might happen: the caller take an InfoSchemaV2 instance and not use it immediately.
 // Seveval rounds later, that InfoSchema is used and its TS is reported to block GC safepoint advancing.
 // But that's too late, the GC has been done, "GC life time is shorter than transaction duration" error still happen.

--- a/pkg/infoschema/test/infoschemav2test/v2_test.go
+++ b/pkg/infoschema/test/infoschemav2test/v2_test.go
@@ -563,6 +563,7 @@ func TestInfoSchemaCachedAutoIncrement(t *testing.T) {
 func TestGetAndResetRecentInfoSchemaTS(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@global.tidb_schema_cache_size = 1024 * 1024 * 1024")
 
 	// For mocktikv, safe point is not initialized, we manually insert it for snapshot to use.
 	timeSafe := time.Now().Add(-48 * 60 * 60 * time.Second).Format("20060102-15:04:05 -0700 MST")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58453

Problem Summary:

If infoschema cache v2 is not enabled, the TS is never updated:

https://github.com/pingcap/tidb/blob/b11cce72848142c279842061285ed457846340c0/pkg/domain/domain.go#L322-L329

As a result, `infocache.GetAndResetRecentInfoSchemaTS` is always MaxInt64 and we cannot get the changed TS.

### What changed and how does it work?

Enable infoschema cache v2.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
