### PR TITLE
Backup: remove improper memory usage during full backup

### DIFF
--- a/br/pkg/rtree/rtree.go
+++ b/br/pkg/rtree/rtree.go
@@ -278,7 +278,9 @@ func (rangeTree *RangeTree) GetIncompleteRange(
 	if len(startKey) != 0 && bytes.Equal(startKey, endKey) {
 		return []Range{}
 	}
-	incomplete := make([]Range, 0, 64)
+	// Don't use a large buffer, because it will cause memory issue.
+	// And the number of missing ranges is usually small.
+	incomplete := make([]Range, 0, 1)
 	requestRange := Range{StartKey: startKey, EndKey: endKey}
 	lastEndKey := startKey
 	pviot := &Range{StartKey: startKey}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/58587
Problem Summary:
When performing a full backup on millions of tables, the default incomplete range buffer grows significantly due to the large number of ranges. Since most ranges are complete, a lower buffer value should be used to optimize memory usage.
### What changed and how does it work?
Set default incomplete to a lower value.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Manually Backup millions of tables
Before this PR, the inuse memory consume 4GB with GetIncompleteRanges
![image](https://github.com/user-attachments/assets/87ae16da-500f-4ca5-b76b-f9a643268276)

After the memory usage reduced.
![image](https://github.com/user-attachments/assets/557cf522-3366-4cb3-a19f-d6abc0469709)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
