### PR TITLE
lightning: adjust TS assertion range between TiDB and PD

### DIFF
--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -440,14 +440,14 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) error {
 	intest.AssertFunc(func() bool {
 		timeOfTS := oracle.GetTimeFromTS(dataCommitTS)
 		now := time.Now()
-		if timeOfTS.After(now) {
+		if timeOfTS.Sub(now) > time.Hour {
 			return false
 		}
 		if now.Sub(timeOfTS) > 24*time.Hour {
 			return false
 		}
 		return true
-	}, "TS used in import should in [now-1d, now], but got %d", dataCommitTS)
+	}, "TS used in import should in [now-1d, now+1h], but got %d", dataCommitTS)
 	if dataCommitTS == 0 {
 		return errors.New("data commitTS is 0")
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58449
Problem Summary:

Timestamp assertion was flaky due to minor clock drift between TiDB and PD.



### What changed and how does it work?

Expanded the range to tolerate minor differences, allowing timestamps up to 1 hour in the future and 24 hours in the past.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I’d greatly appreciate it if you could suggest a good place to add tests, if needed!

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix flaky assert by adjusting the TS range
```
