### PR TITLE
session: skip creating indexes on the analyze_jobs table for older clusters

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -116,5 +116,5 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(241), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(240), session.CurrentBootstrapVersion)
 }

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -1236,17 +1236,13 @@ const (
 	// add modify_params to tidb_global_task and tidb_global_task_history.
 	version239 = 239
 
-	// version 240
-	// Add indexes to mysql.analyze_jobs to speed up the query.
-	version240 = 240
-
 	// Add index on user field for some mysql tables.
-	version241 = 241
+	version240 = 240
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version241
+var currentBootstrapVersion int64 = version240
 
 // DDL owner key's expired time is ManagerSessionTTL seconds, we should wait the time and give more time to have a chance to finish it.
 var internalSQLTimeout = owner.ManagerSessionTTL + 15
@@ -1422,7 +1418,6 @@ var (
 		upgradeToVer218,
 		upgradeToVer239,
 		upgradeToVer240,
-		upgradeToVer241,
 	}
 )
 
@@ -3334,26 +3329,8 @@ func upgradeToVer239(s sessiontypes.Session, ver int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.tidb_global_task_history ADD COLUMN modify_params json AFTER `error`;", infoschema.ErrColumnExists)
 }
 
-const (
-	// addAnalyzeJobsSchemaTableStateIndex is a DDL statement that adds an index on (table_schema, table_name, state)
-	// columns to mysql.analyze_jobs table. This index is currently unused since queries filter on partition_name='',
-	// even for non-partitioned tables. It is kept for potential future optimization where queries could use this
-	// simpler index directly for non-partitioned tables.
-	addAnalyzeJobsSchemaTableStateIndex = "ALTER TABLE mysql.analyze_jobs ADD INDEX idx_schema_table_state (table_schema, table_name, state)"
-	// addAnalyzeJobsSchemaTablePartitionStateIndex adds an index on (table_schema, table_name, partition_name, state) to mysql.analyze_jobs
-	addAnalyzeJobsSchemaTablePartitionStateIndex = "ALTER TABLE mysql.analyze_jobs ADD INDEX idx_schema_table_partition_state (table_schema, table_name, partition_name, state)"
-)
-
 func upgradeToVer240(s sessiontypes.Session, ver int64) {
 	if ver >= version240 {
-		return
-	}
-	doReentrantDDL(s, addAnalyzeJobsSchemaTableStateIndex, dbterror.ErrDupKeyName)
-	doReentrantDDL(s, addAnalyzeJobsSchemaTablePartitionStateIndex, dbterror.ErrDupKeyName)
-}
-
-func upgradeToVer241(s sessiontypes.Session, ver int64) {
-	if ver >= version241 {
 		return
 	}
 	doReentrantDDL(s, "ALTER TABLE mysql.user ADD INDEX i_user (user)", dbterror.ErrDupKeyName)

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2615,10 +2615,13 @@ func (mebd *mockEtcdBackend) TLSConfig() *tls.Config { return nil }
 
 func (mebd *mockEtcdBackend) StartGCWorker() error { return nil }
 
-func TestTiDBUpgradeToVer240(t *testing.T) {
+func TestAnalyzeJobsIndexes(t *testing.T) {
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
-	defer func() { require.NoError(t, store.Close()) }()
+	defer func() {
+		dom.Close()
+		require.NoError(t, store.Close())
+	}()
 
 	ver239 := version239
 	seV239 := CreateSessionAndSetID(t, store)
@@ -2635,24 +2638,6 @@ func TestTiDBUpgradeToVer240(t *testing.T) {
 	// Check if the required indexes already exist in mysql.analyze_jobs (they are created by default in new clusters)
 	res := MustExecToRecodeSet(t, seV239, "show create table mysql.analyze_jobs")
 	chk := res.NewChunk(nil)
-	err = res.Next(ctx, chk)
-	require.NoError(t, err)
-	require.Equal(t, 1, chk.NumRows())
-	require.Contains(t, string(chk.GetRow(0).GetBytes(1)), "idx_schema_table_state")
-	require.Contains(t, string(chk.GetRow(0).GetBytes(1)), "idx_schema_table_partition_state")
-
-	// Check that the indexes still exist after upgrading to the new version and that no errors occurred during the upgrade.
-	dom.Close()
-	domCurVer, err := BootstrapSession(store)
-	require.NoError(t, err)
-	defer domCurVer.Close()
-	seCurVer := CreateSessionAndSetID(t, store)
-	ver, err := getBootstrapVersion(seCurVer)
-	require.NoError(t, err)
-	require.Equal(t, currentBootstrapVersion, ver)
-
-	res = MustExecToRecodeSet(t, seCurVer, "show create table mysql.analyze_jobs")
-	chk = res.NewChunk(nil)
 	err = res.Next(ctx, chk)
 	require.NoError(t, err)
 	require.Equal(t, 1, chk.NumRows())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57996

Problem Summary:

### What changed and how does it work?

I test https://github.com/pingcap/tidb/pull/58134 again locally to evaluate the performance of creating indexes. For 100k rows, it takes 16 seconds to create the indexes, although it is not that slow, but it still takes some time. So I decided to undo part of this change. We will only create the new indexes for the new cluster. And we do not create the index for the old clusters during the upgrade process.

Normally, for the smaller cluster, this should not be a problem. But for some huge clusters, we can ask users to manually create it instead of blocking the upgrade process.


```sql
> ALTER TABLE mysql.analyze_jobs ADD INDEX `idx_schema_table_state` (`table_schema`, `table_name`, `state`)
[2024-12-30 14:17:40] completed in 5 s 755 ms
> ALTER TABLE mysql.analyze_jobs ADD INDEX `idx_schema_table_partition_state` (`table_schema`, `table_name`, `partition_name`, `state`)
[2024-12-30 14:17:52] completed in 11 s 860 ms
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
