### PR TITLE
statistics: temporarily skip handling errors for DDL events

### DIFF
--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 21,
     deps = [
         ":ddl",
         "//pkg/ddl/notifier",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -21,9 +21,11 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+	"go.uber.org/zap"
 )
 
 type ddlHandlerImpl struct {
@@ -48,7 +50,16 @@ func NewDDLHandler(
 
 // HandleDDLEvent begins to process a ddl task.
 func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Context, s *notifier.SchemaChangeEvent) error {
-	return h.sub.handle(ctx, sctx, s)
+	// Ideally, we shouldn't allow any errors to be ignored, but for now, some queries can fail.
+	// Temporarily ignore the error and we need to check all queries to ensure they are correct.
+	if err := h.sub.handle(ctx, sctx, s); err != nil {
+		statslogutil.StatsLogger().Warn(
+			"failed to handle DDL event",
+			zap.String("event", s.String()),
+			zap.Error(err),
+		)
+	}
+	return nil
 }
 
 // DDLEventCh returns ddl events channel in handle.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/58545

Problem Summary:

### What changed and how does it work?

In this PR, I just temporarily ignore this error and make sure the ddl notfier can proceed. I will spend more time figuring out how to avoid this kind of bug altogether.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
