### PR TITLE
owner: fix bug of owner manager hang

### DIFF
--- a/pkg/owner/BUILD.bazel
+++ b/pkg/owner/BUILD.bazel
@@ -37,7 +37,7 @@ go_test(
     ],
     embed = [":owner"],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/parser/terror",
         "//pkg/testkit/testfailpoint",

--- a/pkg/util/etcd.go
+++ b/pkg/util/etcd.go
@@ -68,6 +68,13 @@ func NewSession(ctx context.Context, logPrefix string, etcdCli *clientv3.Client,
 			}
 		})
 
+		failpoint.Inject("waitCancelCtx", func(val failpoint.Value) {
+			if val.(bool) {
+				<-ctx.Done()
+				ctx = context.Background()
+			}
+		})
+
 		startTime := time.Now()
 		etcdSession, err = concurrency.NewSession(etcdCli,
 			concurrency.WithTTL(ttl), concurrency.WithContext(ctx))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58620

Problem Summary:

### What changed and how does it work?

The owner compaign loop use wrong ctx for refressSession, so `owner.Close()` may hang sometimes.

Before the fix, the behavior is:

```
ctx := context.Background()
m := NewOwnerManager(ctx, ...)
m.Close()  // no, this cannot make m exit
```

Call `Close()` may hang, unless we pass a `ctx` to `NewOwnerManager` and cancel that ctx:

```
ctx, cancel := context.WithCancel(context.Background())
m := NewOwnerManager(ctx, ...)
m.Close() // no, this cannot make m exit
cancel()  // ok, this can make m exit
```

This is not what I expected. Close() should not hang!

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
