### PR TITLE
br: fix go leak when nothing to restore 

### DIFF
--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1042,9 +1042,7 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	// nothing to restore, maybe only ddl changes in incremental restore
 	if len(dbs) == 0 && len(tables) == 0 {
 		log.Info("nothing to restore, all databases and tables are filtered out")
-		// even nothing to restore, we show a success message since there is no failure.
-		markRestoreSuccess(&schedulersRemovable)
-		return nil
+		// go through rest of the process, need to clean up some resources
 	}
 
 	if err = client.CreateDatabases(ctx, dbs); err != nil {

--- a/br/tests/br_table_filter/run.sh
+++ b/br/tests/br_table_filter/run.sh
@@ -119,3 +119,13 @@ run_sql "select c from $DB.FIVE;"
 ! run_sql 'select c from '"$DB"'.`the,special,table`;'
 
 run_sql "drop schema $DB;"
+
+echo "test filter out everything"
+run_br restore full -f "${DB}_nothing.*" -s "local://$TEST_DIR/$DB/full" --pd $PD_ADDR
+! run_sql "select c from $DB.one;"
+! run_sql "select c from $DB.two;"
+! run_sql "select c from $DB.three;"
+! run_sql "select c from $DB.four;"
+! run_sql "select c from $DB.FIVE;"
+! run_sql "select c from $DB.TEN;"
+! run_sql 'select c from '"$DB"'.`the,special,table`;'


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58624

Problem Summary:

### What changed and how does it work?
Remove the early return, found 2 issues related to it, so better go through the entire restore process to avoid future surprises.
1. recent change makes the ctx in `GoSwitchToImportMode` not inherit from the main ctx, thus when main ctx cancelled, the go routine won't end, and the manual cleanup logic wasn't called when restoring an empty backup, leading to a go routine leak found in int test
2. recent change creates connection in `NewSnapFileImporter` and store it into a closure `rc.getRestorerFn`, early return didn't call the closure so couldn't free up the connection, causing another go leak.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
