### PR TITLE
lightning: replace information_schema query when importing table schema with separate show create table

### DIFF
--- a/lightning/tests/lightning_character_sets/run.sh
+++ b/lightning/tests/lightning_character_sets/run.sh
@@ -81,7 +81,7 @@ check_contains 's: 5291'
 # test local backend
 run_lightning --config "$CUR/greek.toml" -d "$CUR/greek" 2>&1 | grep -q "Unknown character set: 'greek'"
 # check TiDB does not receive the DDL
-check_not_contains "greek" $TEST_DIR/tidb.log
+check_not_contains "CHARSET=greek" $TEST_DIR/tidb.log
 run_sql 'DROP DATABASE IF EXISTS charsets;'
 run_sql 'CREATE DATABASE charsets;'
 run_sql 'CREATE TABLE charsets.greek (c VARCHAR(20) PRIMARY KEY);'

--- a/lightning/tests/lightning_no_schema/data/noschema.invalid-schema.sql
+++ b/lightning/tests/lightning_no_schema/data/noschema.invalid-schema.sql
@@ -1,0 +1,1 @@
+this is a invalid schema;

--- a/lightning/tests/lightning_no_schema/data/noschema.invalid.sql
+++ b/lightning/tests/lightning_no_schema/data/noschema.invalid.sql
@@ -1,0 +1,1 @@
+insert into t values (1);

--- a/lightning/tests/lightning_no_schema/run.sh
+++ b/lightning/tests/lightning_no_schema/run.sh
@@ -20,9 +20,12 @@ set -eu
 run_sql "DROP DATABASE IF EXISTS noschema;"
 run_sql "create database noschema;"
 run_sql "create table noschema.t (x int primary key);"
+run_sql "create table noschema.invalid (x int primary key);"
 
 # Starting importing
 run_lightning --no-schema=1
 
 run_sql "SELECT sum(x) FROM noschema.t;"
 check_contains 'sum(x): 120'
+run_sql "SELECT sum(x) FROM noschema.invalid;"
+check_contains 'sum(x): 1'

--- a/lightning/tests/lightning_no_schema/run.sh
+++ b/lightning/tests/lightning_no_schema/run.sh
@@ -19,10 +19,16 @@ set -eu
 # keep this test for check the compatibility of noschema config.
 run_sql "DROP DATABASE IF EXISTS noschema;"
 run_sql "create database noschema;"
-run_sql "create table noschema.t (x int primary key);"
 run_sql "create table noschema.invalid (x int primary key);"
+! run_lightning --no-schema=1
+grep -Fq 'schema not found' $TEST_DIR/lightning.log
 
-# Starting importing
+run_sql "drop table noschema.invalid;"
+run_sql "create table noschema.t (x int primary key);"
+! run_lightning --no-schema=1
+grep -Fq 'invalid schema statement:' $TEST_DIR/lightning.log
+
+run_sql "create table noschema.invalid (x int primary key);"
 run_lightning --no-schema=1
 
 run_sql "SELECT sum(x) FROM noschema.t;"

--- a/pkg/lightning/mydump/BUILD.bazel
+++ b/pkg/lightning/mydump/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//br/pkg/storage",
         "//pkg/config",
+        "//pkg/errno",
         "//pkg/lightning/common",
         "//pkg/lightning/config",
         "//pkg/lightning/log",
@@ -39,6 +40,7 @@ go_library(
         "//pkg/util/sqlescape",
         "//pkg/util/table-filter",
         "//pkg/util/zeropool",
+        "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_spkg_bom//:bom",
@@ -80,6 +82,7 @@ go_test(
     deps = [
         "//br/pkg/mock/storage",
         "//br/pkg/storage",
+        "//pkg/errno",
         "//pkg/lightning/common",
         "//pkg/lightning/config",
         "//pkg/lightning/log",
@@ -92,6 +95,7 @@ go_test(
         "//pkg/util/table-filter",
         "//pkg/util/table-router",
         "@com_github_data_dog_go_sqlmock//:go-sqlmock",
+        "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/lightning/mydump/schema_import.go
+++ b/pkg/lightning/mydump/schema_import.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"strings"
 
+	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	tmysql "github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -158,6 +160,20 @@ func (si *SchemaImporter) importTables(ctx context.Context, dbMetas []*MDDatabas
 			p := parser.New()
 			p.SetSQLMode(si.sqlMode)
 			for tableMeta := range ch {
+				if tableMeta.SchemaFile.FileMeta.Path == "" {
+					exist, err := si.isTableExist(egCtx, tableMeta.DB, tableMeta.Name)
+					if err != nil {
+						return err
+					}
+					if exist {
+						// we already has this table in TiDB.
+						// we should skip ddl job and let SchemaValid check.
+						si.logger.Info("table already exists in downstream, skip",
+							zap.String("db", tableMeta.DB), zap.String("table", tableMeta.Name))
+						continue
+					}
+					return common.ErrSchemaNotExists.GenWithStackByArgs(tableMeta.DB, tableMeta.Name)
+				}
 				sqlStr, err := tableMeta.GetSchema(egCtx, si.store)
 				if err != nil {
 					return err
@@ -180,24 +196,8 @@ func (si *SchemaImporter) importTables(ctx context.Context, dbMetas []*MDDatabas
 			if len(dbMeta.Tables) == 0 {
 				continue
 			}
-			tables, err := si.getExistingTables(egCtx, dbMeta.Name)
-			if err != nil {
-				return err
-			}
 			for i := range dbMeta.Tables {
 				tblMeta := dbMeta.Tables[i]
-				if tables.Exist(strings.ToLower(tblMeta.Name)) {
-					// we already has this table in TiDB.
-					// we should skip ddl job and let SchemaValid check.
-					si.logger.Info("table already exists in downstream, skip",
-						zap.String("db", dbMeta.Name),
-						zap.String("table", tblMeta.Name),
-					)
-					continue
-				} else if tblMeta.SchemaFile.FileMeta.Path == "" {
-					return common.ErrSchemaNotExists.GenWithStackByArgs(dbMeta.Name, tblMeta.Name)
-				}
-
 				select {
 				case ch <- tblMeta:
 				case <-egCtx.Done():
@@ -259,6 +259,19 @@ func (si *SchemaImporter) importViews(ctx context.Context, dbMetas []*MDDatabase
 func (si *SchemaImporter) runJob(ctx context.Context, p *parser.Parser, job *schemaJob) error {
 	stmts, err := createIfNotExistsStmt(p, job.sqlStr, job.dbName, job.tblName)
 	if err != nil {
+		// if the schema supplied by the user is un-parsable by TiDB, we allow
+		// user to create the table by themselves, then import data.
+		exist, err2 := si.isTableExist(ctx, job.dbName, job.tblName)
+		if err2 != nil {
+			return err2
+		}
+		if exist {
+			// we already has this table in TiDB.
+			// we should skip ddl job and let SchemaValid check.
+			si.logger.Info("table already exists in downstream, skip",
+				zap.String("db", job.dbName), zap.String("table", job.tblName))
+			return nil
+		}
 		return errors.Trace(err)
 	}
 	conn, err := si.db.Conn(ctx)
@@ -290,11 +303,22 @@ func (si *SchemaImporter) getExistingDatabases(ctx context.Context) (set.StringS
 	return si.getExistingSchemas(ctx, `SELECT SCHEMA_NAME FROM information_schema.SCHEMATA`)
 }
 
-// the result contains views too, but as table and view share the same name space, it's ok.
-func (si *SchemaImporter) getExistingTables(ctx context.Context, dbName string) (set.StringSet, error) {
+// isTableExist checks whether the table exists in the downstream database, it
+// works for view too.
+func (si *SchemaImporter) isTableExist(ctx context.Context, dbName, tableName string) (bool, error) {
 	sb := new(strings.Builder)
-	sqlescape.MustFormatSQL(sb, `SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = %?`, dbName)
-	return si.getExistingSchemas(ctx, sb.String())
+	sqlescape.MustFormatSQL(sb, `SHOW CREATE TABLE %n.%n`, dbName, tableName)
+	_, err := si.getExistingSchemas(ctx, sb.String())
+	if err != nil {
+		cause := errors.Cause(err)
+		if driverErr, ok := cause.(*dmysql.MySQLError); ok && driverErr.Number == tmysql.ErrNoSuchTable {
+			return false, nil
+		}
+		return false, err
+	}
+	// show create table always return the table if no error, so no need to check
+	// the result row count.
+	return true, nil
 }
 
 func (si *SchemaImporter) getExistingViews(ctx context.Context, dbName string) (set.StringSet, error) {

--- a/pkg/lightning/mydump/schema_import.go
+++ b/pkg/lightning/mydump/schema_import.go
@@ -23,7 +23,7 @@ import (
 	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/storage"
-	tmysql "github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -333,7 +333,7 @@ func (si *SchemaImporter) isTableExist(ctx context.Context, dbName, tableName st
 	_, err := si.getExistingSchemas(ctx, sb.String())
 	if err != nil {
 		cause := errors.Cause(err)
-		if driverErr, ok := cause.(*dmysql.MySQLError); ok && driverErr.Number == tmysql.ErrNoSuchTable {
+		if driverErr, ok := cause.(*dmysql.MySQLError); ok && driverErr.Number == errno.ErrNoSuchTable {
 			return false, nil
 		}
 		return false, err

--- a/pkg/lightning/mydump/schema_import_test.go
+++ b/pkg/lightning/mydump/schema_import_test.go
@@ -22,8 +22,10 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	dmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	tmysql "github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/lightning/common"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -101,18 +103,27 @@ func TestSchemaImporter(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	t.Run("table: get existing schema err", func(t *testing.T) {
+	t.Run("table: no schema file for the table", func(t *testing.T) {
 		mock.ExpectQuery(`information_schema.SCHEMATA`).WillReturnRows(
 			sqlmock.NewRows([]string{"SCHEMA_NAME"}).
 				AddRow("test01").AddRow("test02").AddRow("test03").
 				AddRow("test04").AddRow("test05"))
-		mock.ExpectQuery("TABLES WHERE TABLE_SCHEMA = 'test02'").
-			WillReturnError(errors.New("non retryable error"))
+		mock.ExpectQuery("SHOW CREATE TABLE `test02`.`t`").
+			WillReturnError(&dmysql.MySQLError{Number: tmysql.ErrNoSuchTable})
 		dbMetas := []*MDDatabaseMeta{
 			{Name: "test01"},
 			{Name: "test02", Tables: []*MDTableMeta{{DB: "test02", Name: "t"}}},
 		}
-		require.ErrorContains(t, importer.Run(ctx, dbMetas), "non retryable error")
+		require.ErrorContains(t, importer.Run(ctx, dbMetas), "schema not found")
+		require.NoError(t, mock.ExpectationsWereMet())
+
+		mock.ExpectQuery(`information_schema.SCHEMATA`).WillReturnRows(
+			sqlmock.NewRows([]string{"SCHEMA_NAME"}).
+				AddRow("test01").AddRow("test02").AddRow("test03").
+				AddRow("test04").AddRow("test05"))
+		mock.ExpectQuery("SHOW CREATE TABLE `test02`.`t`").
+			WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t", "CREATE TABLE `t` (a int);"))
+		require.NoError(t, importer.Run(ctx, dbMetas))
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -121,8 +132,10 @@ func TestSchemaImporter(t *testing.T) {
 			sqlmock.NewRows([]string{"SCHEMA_NAME"}).
 				AddRow("test01").AddRow("test02").AddRow("test03").
 				AddRow("test04").AddRow("test05"))
-		mock.ExpectQuery("TABLES WHERE TABLE_SCHEMA = 'test01'").
-			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("t1"))
+		mock.ExpectQuery("SHOW CREATE TABLE `test01`.`t1`").
+			WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t1", "CREATE TABLE `t1` (a int);"))
+		mock.ExpectQuery("SHOW CREATE TABLE `test01`.`T2`").
+			WillReturnError(&dmysql.MySQLError{Number: tmysql.ErrNoSuchTable})
 		fileName := "t2-invalid-schema.sql"
 		require.NoError(t, os.WriteFile(path.Join(tempDir, fileName), []byte("CREATE table t2 whatever;"), 0o644))
 		dbMetas := []*MDDatabaseMeta{
@@ -140,8 +153,10 @@ func TestSchemaImporter(t *testing.T) {
 			sqlmock.NewRows([]string{"SCHEMA_NAME"}).
 				AddRow("test01").AddRow("test02").AddRow("test03").
 				AddRow("test04").AddRow("test05"))
-		mock.ExpectQuery("TABLES WHERE TABLE_SCHEMA = 'test01'").
-			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("t1").AddRow("t2"))
+		mock.ExpectQuery("SHOW CREATE TABLE `test01`.`t1`").
+			WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t1", "CREATE TABLE `t1` (a int);"))
+		mock.ExpectQuery("SHOW CREATE TABLE `test01`.`T2`").
+			WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("T2", "CREATE TABLE `t2` (a int);"))
 		require.NoError(t, importer.Run(ctx, dbMetas))
 		require.NoError(t, mock.ExpectationsWereMet())
 		require.NoError(t, os.Remove(path.Join(tempDir, fileName)))
@@ -163,8 +178,6 @@ func TestSchemaImporter(t *testing.T) {
 				{DB: "test01", Name: "t2", charSet: "auto", SchemaFile: FileInfo{FileMeta: SourceFileMeta{Path: fileNameT2}}},
 			}},
 		}
-		mock.ExpectQuery("TABLES WHERE TABLE_SCHEMA = 'test01'").
-			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}))
 		mock.ExpectExec("CREATE TABLE IF NOT EXISTS `test01`.`t1`").
 			WillReturnError(errors.New("non retryable create table error"))
 		require.ErrorContains(t, importer2.Run(ctx, dbMetas), "non retryable create table error")
@@ -247,8 +260,6 @@ func TestSchemaImporterManyTables(t *testing.T) {
 		dbMeta := &MDDatabaseMeta{Name: dbName, Tables: make([]*MDTableMeta, 0, 100)}
 		mock.ExpectExec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", dbName)).
 			WillReturnResult(sqlmock.NewResult(0, 0))
-		mock.ExpectQuery(fmt.Sprintf("TABLES WHERE TABLE_SCHEMA = '%s'", dbName)).
-			WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}))
 		for j := 0; j < 50; j++ {
 			tblName := fmt.Sprintf("t%03d", j)
 			fileName := fmt.Sprintf("%s.%s-schema.sql", dbName, tblName)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58141

Problem Summary:

### What changed and how does it work?
info schema V2 only store one copy of schema object in memory, so read/write need to lock, if we read too much and takes too long, it affects write, i.e. schema reloading during DDL execution, we can mitigate this by using finer-grained lock, but we cannot avoid it completely with current strategy. so in lightning, we remove related queries, and avoid create table twice by `IF NOT EXIST`, and check table existence on error by `SHOW CREATE TABLE`, to make schema import part faster

we also found that the query to `information_schema.tables` is getting slower over time, and cause lightning dispatch jobs slower, we can fix it too by replace the query.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

import 100K DB and total 200K tables, time reduced from 55m27 -> 19m20

before
![image](https://github.com/user-attachments/assets/28a0fbfc-2627-4db9-b66c-b5059fdbc2b1)
after
![image](https://github.com/user-attachments/assets/494c9d98-b343-4bea-b1b9-79ff725055ef)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
