### PR TITLE
ddl: Remove explicit exclude for "engine" notIn "tiflash"

### DIFF
--- a/pkg/ddl/placement/bundle.go
+++ b/pkg/ddl/placement/bundle.go
@@ -314,8 +314,8 @@ func (b *Bundle) String() string {
 
 // Tidy will post optimize Rules, trying to generate rules that suits PD.
 func (b *Bundle) Tidy() error {
-	// refer to #58633
-	// Note that does not explicitly set rule with label.key==EngineLabelKey, because the
+	// refer to tidb#58633
+	// Does not explicitly set exclude rule with label.key==EngineLabelKey, because the
 	// PD may wrongly add peer to the unexpected stores if that key is specified.
 	tempRules := b.Rules[:0]
 	id := 0

--- a/pkg/ddl/placement/bundle.go
+++ b/pkg/ddl/placement/bundle.go
@@ -314,23 +314,15 @@ func (b *Bundle) String() string {
 
 // Tidy will post optimize Rules, trying to generate rules that suits PD.
 func (b *Bundle) Tidy() error {
+	// refer to #58633
+	// Note that does not explicitly set rule with label.key==EngineLabelKey, because the
+	// PD may wrongly add peer to the unexpected stores if that key is specified.
 	tempRules := b.Rules[:0]
 	id := 0
 	for _, rule := range b.Rules {
 		// useless Rule
 		if rule.Count <= 0 {
 			continue
-		}
-		// refer to tidb#22065.
-		// add -engine=tiflash to every rule to avoid schedules to tiflash instances.
-		// placement rules in SQL is not compatible with `set tiflash replica` yet
-		err := AddConstraint(&rule.LabelConstraints, pd.LabelConstraint{
-			Op:     pd.NotIn,
-			Key:    EngineLabelKey,
-			Values: []string{EngineLabelTiFlash},
-		})
-		if err != nil {
-			return err
 		}
 		rule.ID = strconv.Itoa(id)
 		tempRules = append(tempRules, rule)

--- a/pkg/ddl/placement/bundle_test.go
+++ b/pkg/ddl/placement/bundle_test.go
@@ -347,9 +347,10 @@ func TestString(t *testing.T) {
 	require.NoError(t, err)
 	rules2, err := newRules(pd.Voter, 4, `["-zone=sh", "+zone=bj"]`)
 	require.NoError(t, err)
-	bundle.Rules = append(rules1, rules2...)
+	rules3, err := newRules(pd.Voter, 3, `["-engine=tiflash", "-engine=tiflash_compute"]`)
+	bundle.Rules = append(append(rules1, rules2...), rules3...)
 
-	require.Equal(t, "{\"group_id\":\"TiDB_DDL_1\",\"group_index\":0,\"group_override\":false,\"rules\":[{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":3,\"label_constraints\":[{\"key\":\"zone\",\"op\":\"in\",\"values\":[\"sh\"]}]},{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":4,\"label_constraints\":[{\"key\":\"zone\",\"op\":\"notIn\",\"values\":[\"sh\"]},{\"key\":\"zone\",\"op\":\"in\",\"values\":[\"bj\"]}]}]}", bundle.String())
+	require.Equal(t, "{\"group_id\":\"TiDB_DDL_1\",\"group_index\":0,\"group_override\":false,\"rules\":[{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":3,\"label_constraints\":[{\"key\":\"zone\",\"op\":\"in\",\"values\":[\"sh\"]}]},{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":4,\"label_constraints\":[{\"key\":\"zone\",\"op\":\"notIn\",\"values\":[\"sh\"]},{\"key\":\"zone\",\"op\":\"in\",\"values\":[\"bj\"]}]},{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":3,\"label_constraints\":[{\"key\":\"engine\",\"op\":\"notIn\",\"values\":[\"tiflash\"]},{\"key\":\"engine\",\"op\":\"notIn\",\"values\":[\"tiflash_compute\"]}]}]}", bundle.String())
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/placement/MockMarshalFailure", `return(true)`))
 	defer func() {
@@ -956,12 +957,7 @@ func TestTidy(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bundle.Rules, 1)
 	require.Equal(t, "0", bundle.Rules[0].ID)
-	require.Len(t, bundle.Rules[0].LabelConstraints, 3)
-	require.Equal(t, pd.LabelConstraint{
-		Op:     pd.NotIn,
-		Key:    EngineLabelKey,
-		Values: []string{EngineLabelTiFlash},
-	}, bundle.Rules[0].LabelConstraints[2])
+	require.Len(t, bundle.Rules[0].LabelConstraints, 2)
 
 	// merge
 	rules3, err := newRules(pd.Follower, 4, "")
@@ -986,13 +982,7 @@ func TestTidy(t *testing.T) {
 		require.Equal(t, "0", bundle.Rules[0].ID)
 		require.Equal(t, "1", bundle.Rules[1].ID)
 		require.Equal(t, 9, bundle.Rules[1].Count)
-		require.Equal(t, []pd.LabelConstraint{
-			{
-				Op:     pd.NotIn,
-				Key:    EngineLabelKey,
-				Values: []string{EngineLabelTiFlash},
-			},
-		}, bundle.Rules[1].LabelConstraints)
+		require.Equal(t, 0, len(bundle.Rules[1].LabelConstraints))
 		require.Equal(t, []string{"zone", "host"}, bundle.Rules[1].LocationLabels)
 	}
 	err = bundle.Tidy()
@@ -1009,13 +999,6 @@ func TestTidy(t *testing.T) {
 	err = bundle2.Tidy()
 	require.NoError(t, err)
 	require.Equal(t, bundle, bundle2)
-
-	bundle.Rules[1].LabelConstraints = append(bundle.Rules[1].LabelConstraints, pd.LabelConstraint{
-		Op:     pd.In,
-		Key:    EngineLabelKey,
-		Values: []string{EngineLabelTiFlash},
-	})
-	require.ErrorIs(t, bundle.Tidy(), ErrConflictingConstraints)
 }
 
 func TestTidy2(t *testing.T) {
@@ -1468,12 +1451,6 @@ func TestTidy2(t *testing.T) {
 
 			for i, rule := range tt.bundle.Rules {
 				expectedRule := tt.expected.Rules[i]
-				// Tiflash is always excluded from the constraints.
-				AddConstraint(&expectedRule.LabelConstraints, pd.LabelConstraint{
-					Op:     pd.NotIn,
-					Key:    EngineLabelKey,
-					Values: []string{EngineLabelTiFlash},
-				})
 				if !reflect.DeepEqual(rule, expectedRule) {
 					t.Errorf("unexpected rule at index %d:\nactual=%#v,\nexpected=%#v\n", i, rule, expectedRule)
 				}

--- a/pkg/ddl/placement/bundle_test.go
+++ b/pkg/ddl/placement/bundle_test.go
@@ -348,6 +348,7 @@ func TestString(t *testing.T) {
 	rules2, err := newRules(pd.Voter, 4, `["-zone=sh", "+zone=bj"]`)
 	require.NoError(t, err)
 	rules3, err := newRules(pd.Voter, 3, `["-engine=tiflash", "-engine=tiflash_compute"]`)
+	require.NoError(t, err)
 	bundle.Rules = append(append(rules1, rules2...), rules3...)
 
 	require.Equal(t, "{\"group_id\":\"TiDB_DDL_1\",\"group_index\":0,\"group_override\":false,\"rules\":[{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":3,\"label_constraints\":[{\"key\":\"zone\",\"op\":\"in\",\"values\":[\"sh\"]}]},{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":4,\"label_constraints\":[{\"key\":\"zone\",\"op\":\"notIn\",\"values\":[\"sh\"]},{\"key\":\"zone\",\"op\":\"in\",\"values\":[\"bj\"]}]},{\"group_id\":\"\",\"id\":\"\",\"start_key\":\"\",\"end_key\":\"\",\"role\":\"voter\",\"is_witness\":false,\"count\":3,\"label_constraints\":[{\"key\":\"engine\",\"op\":\"notIn\",\"values\":[\"tiflash\"]},{\"key\":\"engine\",\"op\":\"notIn\",\"values\":[\"tiflash_compute\"]}]}]}", bundle.String())

--- a/pkg/ddl/placement/constraint.go
+++ b/pkg/ddl/placement/constraint.go
@@ -54,6 +54,7 @@ func NewConstraint(label string) (pd.LabelConstraint, error) {
 		return r, fmt.Errorf("%w: %s", ErrInvalidConstraintFormat, label)
 	}
 
+	// Does not allow adding rule of tiflash.
 	if op == pd.In && key == EngineLabelKey && strings.ToLower(val) == EngineLabelTiFlash {
 		return r, fmt.Errorf("%w: %s", ErrUnsupportedConstraint, label)
 	}

--- a/pkg/ddl/placement/constraint_test.go
+++ b/pkg/ddl/placement/constraint_test.go
@@ -65,6 +65,15 @@ func TestNewConstraint(t *testing.T) {
 			},
 		},
 		{
+			name:  "not tiflash_compute",
+			input: "-engine  =  tiflash_compute  ",
+			label: pd.LabelConstraint{
+				Key:    "engine",
+				Op:     pd.NotIn,
+				Values: []string{"tiflash_compute"},
+			},
+		},
+		{
 			name:  "disallow tiflash",
 			input: "+engine=Tiflash",
 			err:   ErrUnsupportedConstraint,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/58633

Problem Summary:

When creating a placement policy through tidb, tidb will create a placement-rule with `"engine" notIn "tiflash"` https://github.com/pingcap/tidb/pull/22065
However, under tiflash disaggregated compute and storage arch, the compute node will register store with label `{"engine": "tiflash_compute"}`.

The logic in PD of choosing store for rule: [pkg/schedule/placement/label_constraint.go @ pd](https://github.com/tikv/pd/blob/7d33065019f78d9150a8c89ddb4593f81e6ff9b3/pkg/schedule/placement/label_constraint.go#L81-L95)

1. If the store's label.key is equal to "engine" (or "exclusive," or starts with '$'), and the rule's constraint does not contain a rule with the same label.key, then do not schedule the peer to this store.
2. Otherwise, further check if the rule's constraint matches the store's label. If it matches, schedule the peer to this store.

So the PD would pick tiflash compute node as target store to place the Region peer.

### What changed and how does it work?

Remove the explicit exclude rule `"engine" notIn "tiflash"` when generating rule

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

1. Deploy a cluster with tikv and disaggregated tiflash (1 tiflash compute node and 1 tiflash storage node)
2. Load TPC-H dataset into the cluster and create tiflash replica
3. Create placement policy
```
CREATE PLACEMENT POLICY evict_sata_dw CONSTRAINTS="[-disk=sata-new, -disk=dw-ssd]" SURVIVAL_PREFERENCES="[host]";
ALTER TABLE test.region PLACEMENT POLICY=evict_sata_dw;
ALTER RANGE global PLACEMENT POLICY evict_sata_dw;
```
4. Check the cluster status, no node crashes
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that after executing `ALTER TABLE ... PLACEMENT POLICY ...` Region peers may be unexpectedly added to the TiFlash Compute Node in the disaggregated storage and compute architecture
```
