### PR TITLE
importinto/lightning: fix negative value cast to upper bound in non strict sql mode

### DIFF
--- a/pkg/lightning/backend/kv/BUILD.bazel
+++ b/pkg/lightning/backend/kv/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/table/tblctx",
         "//pkg/tablecodec",
         "//pkg/types",
+        "//pkg/util",
         "//pkg/util/chunk",
         "//pkg/util/codec",
         "//pkg/util/context",

--- a/pkg/lightning/backend/kv/context.go
+++ b/pkg/lightning/backend/kv/context.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tblctx"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util"
 	contextutil "github.com/pingcap/tidb/pkg/util/context"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/timeutil"
@@ -48,11 +49,7 @@ type litExprContext struct {
 
 // NewExpressionContext creates a new `*ExprContext` for lightning import.
 func newLitExprContext(sqlMode mysql.SQLMode, sysVars map[string]string, timestamp int64) (*litExprContext, error) {
-	flags := types.DefaultStmtFlags.
-		WithTruncateAsWarning(!sqlMode.HasStrictMode()).
-		WithIgnoreInvalidDateErr(sqlMode.HasAllowInvalidDatesMode()).
-		WithIgnoreZeroInDate(!sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode() ||
-			!sqlMode.HasNoZeroInDateMode() || !sqlMode.HasNoZeroDateMode())
+	flags := util.GetTypeFlagsForImportInto(types.DefaultStmtFlags, sqlMode)
 
 	errLevels := stmtctx.DefaultStmtErrLevels
 	errLevels[errctx.ErrGroupTruncate] = errctx.ResolveErrLevel(flags.IgnoreTruncateErr(), flags.TruncateAsWarning())

--- a/pkg/lightning/backend/kv/context_test.go
+++ b/pkg/lightning/backend/kv/context_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestLitExprContext(t *testing.T) {
+	baseFlags := types.DefaultStmtFlags &^ types.FlagAllowNegativeToUnsigned
 	cases := []struct {
 		sqlMode       mysql.SQLMode
 		sysVars       map[string]string
@@ -47,7 +48,7 @@ func TestLitExprContext(t *testing.T) {
 		{
 			sqlMode:    mysql.ModeNone,
 			timestamp:  1234567,
-			checkFlags: types.DefaultStmtFlags | types.FlagTruncateAsWarning | types.FlagIgnoreZeroInDateErr,
+			checkFlags: baseFlags | types.FlagTruncateAsWarning | types.FlagIgnoreZeroInDateErr,
 			checkErrLevel: func() errctx.LevelMap {
 				m := stmtctx.DefaultStmtErrLevels
 				m[errctx.ErrGroupTruncate] = errctx.LevelWarn
@@ -68,7 +69,7 @@ func TestLitExprContext(t *testing.T) {
 		{
 			sqlMode: mysql.ModeStrictTransTables | mysql.ModeNoZeroDate | mysql.ModeNoZeroInDate |
 				mysql.ModeErrorForDivisionByZero,
-			checkFlags: types.DefaultStmtFlags,
+			checkFlags: baseFlags,
 			checkErrLevel: func() errctx.LevelMap {
 				m := stmtctx.DefaultStmtErrLevels
 				m[errctx.ErrGroupTruncate] = errctx.LevelError
@@ -80,7 +81,7 @@ func TestLitExprContext(t *testing.T) {
 		},
 		{
 			sqlMode:    mysql.ModeNoZeroDate | mysql.ModeNoZeroInDate | mysql.ModeErrorForDivisionByZero,
-			checkFlags: types.DefaultStmtFlags | types.FlagTruncateAsWarning | types.FlagIgnoreZeroInDateErr,
+			checkFlags: baseFlags | types.FlagTruncateAsWarning | types.FlagIgnoreZeroInDateErr,
 			checkErrLevel: func() errctx.LevelMap {
 				m := stmtctx.DefaultStmtErrLevels
 				m[errctx.ErrGroupTruncate] = errctx.LevelWarn
@@ -92,7 +93,7 @@ func TestLitExprContext(t *testing.T) {
 		},
 		{
 			sqlMode:    mysql.ModeStrictTransTables | mysql.ModeNoZeroInDate,
-			checkFlags: types.DefaultStmtFlags | types.FlagIgnoreZeroInDateErr,
+			checkFlags: baseFlags | types.FlagIgnoreZeroInDateErr,
 			checkErrLevel: func() errctx.LevelMap {
 				m := stmtctx.DefaultStmtErrLevels
 				m[errctx.ErrGroupTruncate] = errctx.LevelError
@@ -104,7 +105,7 @@ func TestLitExprContext(t *testing.T) {
 		},
 		{
 			sqlMode:    mysql.ModeStrictTransTables | mysql.ModeNoZeroDate,
-			checkFlags: types.DefaultStmtFlags | types.FlagIgnoreZeroInDateErr,
+			checkFlags: baseFlags | types.FlagIgnoreZeroInDateErr,
 			checkErrLevel: func() errctx.LevelMap {
 				m := stmtctx.DefaultStmtErrLevels
 				m[errctx.ErrGroupTruncate] = errctx.LevelError
@@ -116,7 +117,7 @@ func TestLitExprContext(t *testing.T) {
 		},
 		{
 			sqlMode:    mysql.ModeStrictTransTables | mysql.ModeAllowInvalidDates,
-			checkFlags: types.DefaultStmtFlags | types.FlagIgnoreZeroInDateErr | types.FlagIgnoreInvalidDateErr,
+			checkFlags: baseFlags | types.FlagIgnoreZeroInDateErr | types.FlagIgnoreInvalidDateErr,
 			checkErrLevel: func() errctx.LevelMap {
 				m := stmtctx.DefaultStmtErrLevels
 				m[errctx.ErrGroupTruncate] = errctx.LevelError

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -698,12 +698,14 @@ func createTLSCertificates(certpath string, keypath string, rsaKeySize int) erro
 // GetTypeFlagsForInsert gets the type flags for insert statement.
 func GetTypeFlagsForInsert(baseFlags types.Flags, sqlMode mysql.SQLMode, ignoreErr bool) types.Flags {
 	strictSQLMode := sqlMode.HasStrictMode()
+	// see comments in ResetContextOfStmt for WithAllowNegativeToUnsigned part.
 	return baseFlags.
 		WithTruncateAsWarning(!strictSQLMode || ignoreErr).
 		WithIgnoreInvalidDateErr(sqlMode.HasAllowInvalidDatesMode()).
 		WithIgnoreZeroInDate(!sqlMode.HasNoZeroInDateMode() ||
 			!sqlMode.HasNoZeroDateMode() || !strictSQLMode || ignoreErr ||
-			sqlMode.HasAllowInvalidDatesMode())
+			sqlMode.HasAllowInvalidDatesMode()).
+		WithAllowNegativeToUnsigned(false)
 }
 
 // GetTypeFlagsForImportInto gets the type flags for import into statement which

--- a/tests/realtikvtest/importintotest2/from_select_test.go
+++ b/tests/realtikvtest/importintotest2/from_select_test.go
@@ -155,3 +155,12 @@ func (s *mockGCSSuite) TestImportFromSelectStaleRead() {
 	s.tk.MustExec("import into dst from " + staleReadSQL)
 	s.tk.MustQuery("select * from dst").Check(testkit.Rows("1 a", "2 b"))
 }
+
+func (s *mockGCSSuite) TestCastNegativeToUnsigned() {
+	s.prepareAndUseDB("from_select")
+	s.tk.MustExec("create table dt(id int unsigned)")
+	s.ErrorContains(s.tk.ExecToErr("import into dt from select -1"), "constant -1 overflows int")
+	s.tk.MustExec("set sql_mode=''")
+	s.tk.MustExec("import into dt from select -1")
+	s.tk.MustQuery("select * from dt").Check(testkit.Rows("0"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58613

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
