### PR TITLE
ttl: don't GC running TTL jobs

### DIFF
--- a/pkg/ttl/ttlworker/job.go
+++ b/pkg/ttl/ttlworker/job.go
@@ -112,7 +112,11 @@ type ttlJob struct {
 	createTime    time.Time
 	ttlExpireTime time.Time
 
-	tbl *cache.PhysicalTable
+	// assignTime is the time when the job is assigned to the current manager.
+	// The `assignTime` may be greater than `createTime` if the job is reassigned to another manager.
+	assignTime time.Time
+
+	tableID int64
 
 	// status is the only field which should be protected by a mutex, as `Cancel` may be called at any time, and will
 	// change the status
@@ -127,7 +131,7 @@ func (job *ttlJob) finish(se session.Session, now time.Time, summary *TTLSummary
 	// at this time, the job.ctx may have been canceled (to cancel this job)
 	// even when it's canceled, we'll need to update the states, so use another context
 	err := se.RunInTxn(context.TODO(), func() error {
-		sql, args := finishJobSQL(job.tbl.ID, now, summary.SummaryText, job.id)
+		sql, args := finishJobSQL(job.tableID, now, summary.SummaryText, job.id)
 		_, err := se.ExecuteSQL(context.TODO(), sql, args...)
 		if err != nil {
 			return errors.Wrapf(err, "execute sql: %s", sql)

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -64,12 +64,9 @@ const taskGCTemplate = `DELETE task FROM
 	WHERE job.table_id IS NULL`
 
 const ttlJobHistoryGCTemplate = `DELETE FROM mysql.tidb_ttl_job_history WHERE create_time < CURDATE() - INTERVAL 90 DAY`
-const ttlTableStatusGCWithoutIDTemplate = `DELETE FROM mysql.tidb_ttl_table_status WHERE (current_job_status IS NULL OR current_job_owner_hb_time < %?)`
 
-// don't remove the rows for non-exist tables directly. Instead, set them to cancelled. In some special situations, the TTL job may still be able
-// to finish correctly. If that happen, the status will be updated from 'cancelled' to 'finished' in `(*ttlJob).finish`
-const ttlJobHistoryGCNonExistTableTemplate = `UPDATE mysql.tidb_ttl_job_history SET status = 'cancelled'
-	WHERE table_id NOT IN (SELECT table_id FROM mysql.tidb_ttl_table_status) AND status = 'running'`
+// don't need to consider heartbeat timeout now, because the job will only be GCed when there is no owner and no job running
+const ttlTableStatusGCWithoutIDTemplate = `DELETE FROM mysql.tidb_ttl_table_status WHERE current_job_status IS NULL`
 
 var timeFormat = time.DateTime
 
@@ -85,18 +82,16 @@ func updateHeartBeatSQL(tableID int64, now time.Time, id string) (string, []any)
 	return updateHeartBeatTemplate, []any{now.Format(timeFormat), tableID, id}
 }
 
-func gcTTLTableStatusGCSQL(existIDs []int64, now time.Time) (string, []any) {
+func gcTTLTableStatusGCSQL(existIDs []int64) string {
 	existIDStrs := make([]string, 0, len(existIDs))
 	for _, id := range existIDs {
 		existIDStrs = append(existIDStrs, strconv.Itoa(int(id)))
 	}
 
-	hbExpireTime := now.Add(-getHeartbeatInterval() * 2)
-	args := []any{hbExpireTime.Format(timeFormat)}
 	if len(existIDStrs) > 0 {
-		return ttlTableStatusGCWithoutIDTemplate + fmt.Sprintf(` AND table_id NOT IN (%s)`, strings.Join(existIDStrs, ",")), args
+		return ttlTableStatusGCWithoutIDTemplate + fmt.Sprintf(` AND table_id NOT IN (%s)`, strings.Join(existIDStrs, ","))
 	}
-	return ttlTableStatusGCWithoutIDTemplate, args
+	return ttlTableStatusGCWithoutIDTemplate
 }
 
 // JobManager schedules and manages the ttl jobs on this instance
@@ -521,7 +516,7 @@ func (m *JobManager) checkNotOwnJob() {
 	for i := len(m.runningJobs) - 1; i >= 0; i-- {
 		job := m.runningJobs[i]
 
-		tableStatus := m.tableStatusCache.Tables[job.tbl.ID]
+		tableStatus := m.tableStatusCache.Tables[job.tableID]
 		if tableStatus == nil || tableStatus.CurrentJobOwnerID != m.id {
 			logger := logutil.Logger(m.ctx).With(zap.String("jobID", job.id))
 			if tableStatus != nil {
@@ -565,11 +560,8 @@ j:
 		}
 
 		if allFinished {
-			logger := logutil.Logger(m.ctx).With(
-				zap.String("jobID", job.id),
-				zap.Int64("tableID", job.tbl.ID),
-				zap.String("table", job.tbl.FullName()),
-			)
+			logger := m.jobLogger(job)
+			logger.Info("job has finished")
 			summary, err := summarizeTaskResult(allTasks)
 			if err != nil {
 				logger.Info("fail to summarize job", zap.Error(err))
@@ -596,11 +588,10 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 	// when the heart beat is not sent
 	for _, table := range jobTables {
 		logger := logutil.Logger(m.ctx).With(
-			zap.Int64("tableID", table.ID),
-			zap.String("table", table.FullName()),
+			zap.Int64("tableID", table.TableID),
 		)
 		logger.Info("try lock new job")
-		if _, err := m.lockHBTimeoutJob(m.ctx, se, table, now); err != nil {
+		if _, err := m.lockHBTimeoutJob(m.ctx, se, table.TableID, table.ParentTableID, now); err != nil {
 			logger.Warn("failed to lock heartbeat timeout job", zap.Error(err))
 		}
 	}
@@ -622,11 +613,7 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 			for i := len(m.runningJobs) - 1; i >= 0; i-- {
 				job := m.runningJobs[i]
 
-				logger := logutil.Logger(m.ctx).With(
-					zap.String("jobID", job.id),
-					zap.Int64("tableID", job.tbl.ID),
-					zap.String("table", job.tbl.FullName()),
-				)
+				logger := m.jobLogger(job)
 				logger.Info(fmt.Sprintf("cancel job because %s", cancelReason))
 				summary, err := summarizeErr(errors.New(cancelReason))
 				if err != nil {
@@ -648,17 +635,13 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 	for i := len(m.runningJobs) - 1; i >= 0; i-- {
 		job := m.runningJobs[i]
 
-		_, ok := m.infoSchemaCache.Tables[job.tbl.ID]
+		_, ok := m.infoSchemaCache.Tables[job.tableID]
 		if ok {
 			continue
 		}
 
 		// when the job is locked, it can be found in `infoSchemaCache`. Therefore, it must have been dropped.
-		logger := logutil.Logger(m.ctx).With(
-			zap.String("jobID", job.id),
-			zap.Int64("tableID", job.tbl.ID),
-			zap.String("table", job.tbl.FullName()),
-		)
+		logger := m.jobLogger(job)
 		logger.Info("cancel job because the table has been dropped or it's no longer TTL table")
 		summary, err := summarizeErr(errors.New("TTL table has been removed or the TTL on this table has been stopped"))
 		if err != nil {
@@ -676,7 +659,7 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 func (m *JobManager) localJobs() []*ttlJob {
 	jobs := make([]*ttlJob, 0, len(m.runningJobs))
 	for _, job := range m.runningJobs {
-		status := m.tableStatusCache.Tables[job.tbl.ID]
+		status := m.tableStatusCache.Tables[job.tableID]
 		if status == nil || status.CurrentJobOwnerID != m.id {
 			// these jobs will be removed in `checkNotOwnJob`
 			continue
@@ -688,63 +671,58 @@ func (m *JobManager) localJobs() []*ttlJob {
 }
 
 // readyForLockHBTimeoutJobTables returns all tables whose job is timeout and should be taken over
-func (m *JobManager) readyForLockHBTimeoutJobTables(now time.Time) []*cache.PhysicalTable {
-	tables := make([]*cache.PhysicalTable, 0, len(m.infoSchemaCache.Tables))
+func (m *JobManager) readyForLockHBTimeoutJobTables(now time.Time) []*cache.TableStatus {
+	tables := make([]*cache.TableStatus, 0, len(m.infoSchemaCache.Tables))
 tblLoop:
-	for _, table := range m.infoSchemaCache.Tables {
+	for _, status := range m.tableStatusCache.Tables {
 		// If this node already has a job for this table, just ignore.
 		// Actually, the logic should ensure this condition never meet, we still add the check here to keep safety
 		// (especially when the content of the status table is incorrect)
 		for _, job := range m.runningJobs {
-			if job.tbl.ID == table.ID {
+			if job.tableID == status.TableID {
 				continue tblLoop
 			}
 		}
 
-		status := m.tableStatusCache.Tables[table.ID]
-		if m.couldLockJob(status, table, now, false, false) {
-			tables = append(tables, table)
+		if m.couldLockJobForExistJob(status, now) {
+			tables = append(tables, status)
 		}
 	}
 
 	return tables
 }
 
-// couldLockJob returns whether a table should be tried to run TTL
-func (m *JobManager) couldLockJob(tableStatus *cache.TableStatus, table *cache.PhysicalTable, now time.Time, isCreate bool, checkScheduleInterval bool) bool {
-	if table == nil {
-		// if the table is not recorded in info schema, return false
+// couldLockJobForCreate returns whether a table should be tried to create a new TTL job
+func (m *JobManager) couldLockJobForCreate(tableStatus *cache.TableStatus, table *cache.PhysicalTable, now time.Time, checkScheduleInterval bool) bool {
+	if tableStatus == nil {
+		return true
+	}
+
+	if tableStatus.CurrentJobID != "" {
 		return false
 	}
 
-	if isCreate {
-		if tableStatus == nil {
-			return true
-		}
-
-		if tableStatus.CurrentJobID != "" {
-			return false
-		}
-
-		if !checkScheduleInterval {
-			return true
-		}
-
-		startTime := tableStatus.LastJobStartTime
-
-		interval, err := table.TTLInfo.GetJobInterval()
-		if err != nil {
-			logutil.Logger(m.ctx).Warn(
-				"illegal job interval",
-				zap.Error(err),
-				zap.Int64("tableID", table.ID),
-				zap.String("table", table.FullName()),
-			)
-			return false
-		}
-		return startTime.Add(interval).Before(now)
+	if !checkScheduleInterval {
+		return true
 	}
 
+	startTime := tableStatus.LastJobStartTime
+
+	interval, err := table.TTLInfo.GetJobInterval()
+	if err != nil {
+		logutil.Logger(m.ctx).Warn(
+			"illegal job interval",
+			zap.Error(err),
+			zap.Int64("tableID", table.ID),
+			zap.String("table", table.FullName()),
+		)
+		return false
+	}
+	return startTime.Add(interval).Before(now)
+}
+
+// couldLockJob returns whether a job for a table should be taken over.
+func (m *JobManager) couldLockJobForExistJob(tableStatus *cache.TableStatus, now time.Time) bool {
 	// if isCreate is false, it means to take over an exist job
 	if tableStatus == nil || tableStatus.CurrentJobID == "" {
 		return false
@@ -764,8 +742,7 @@ func (m *JobManager) couldLockJob(tableStatus *cache.TableStatus, table *cache.P
 		if hbTime.Add(hbTimeout).Before(now) {
 			logutil.Logger(m.ctx).Info("job heartbeat has stopped",
 				zap.String("jobID", tableStatus.CurrentJobID),
-				zap.Int64("tableID", table.ID),
-				zap.String("table", table.FullName()),
+				zap.Int64("tableID", tableStatus.TableID),
 				zap.Time("hbTime", hbTime),
 				zap.Time("now", now),
 			)
@@ -776,25 +753,25 @@ func (m *JobManager) couldLockJob(tableStatus *cache.TableStatus, table *cache.P
 	return true
 }
 
-func (m *JobManager) lockHBTimeoutJob(ctx context.Context, se session.Session, table *cache.PhysicalTable, now time.Time) (*ttlJob, error) {
+func (m *JobManager) lockHBTimeoutJob(ctx context.Context, se session.Session, tableID int64, parentTableID int64, now time.Time) (*ttlJob, error) {
 	var jobID string
 	var jobStart time.Time
 	var expireTime time.Time
 	err := se.RunInTxn(ctx, func() error {
-		tableStatus, err := m.getTableStatusForUpdateNotWait(ctx, se, table.ID, table.TableInfo.ID, false)
+		tableStatus, err := m.getTableStatusForUpdateNotWait(ctx, se, tableID, parentTableID, false)
 		if err != nil {
 			return err
 		}
 
-		if tableStatus == nil || !m.couldLockJob(tableStatus, m.infoSchemaCache.Tables[tableStatus.TableID], now, false, false) {
-			return errors.Errorf("couldn't lock timeout TTL job for table id '%d'", table.ID)
+		if tableStatus == nil || !m.couldLockJobForExistJob(tableStatus, now) {
+			return errors.Errorf("couldn't lock timeout TTL job for table id '%d'", tableID)
 		}
 
 		jobID = tableStatus.CurrentJobID
 		jobStart = tableStatus.CurrentJobStartTime
 		expireTime = tableStatus.CurrentJobTTLExpire
 		intest.Assert(se.GetSessionVars().TimeZone.String() == now.Location().String())
-		sql, args := setTableStatusOwnerSQL(tableStatus.CurrentJobID, table.ID, jobStart, now, expireTime, m.id)
+		sql, args := setTableStatusOwnerSQL(tableStatus.CurrentJobID, tableID, jobStart, now, expireTime, m.id)
 		if _, err = se.ExecuteSQL(ctx, sql, args...); err != nil {
 			return errors.Wrapf(err, "execute sql: %s", sql)
 		}
@@ -805,7 +782,7 @@ func (m *JobManager) lockHBTimeoutJob(ctx context.Context, se session.Session, t
 		return nil, err
 	}
 
-	return m.appendLockedJob(jobID, se, jobStart, expireTime, table)
+	return m.appendLockedJob(jobID, se, jobStart, expireTime, tableID)
 }
 
 // lockNewJob locks a new job
@@ -817,7 +794,7 @@ func (m *JobManager) lockNewJob(ctx context.Context, se session.Session, table *
 			return err
 		}
 
-		if !m.couldLockJob(tableStatus, m.infoSchemaCache.Tables[tableStatus.TableID], now, true, checkScheduleInterval) {
+		if !m.couldLockJobForCreate(tableStatus, m.infoSchemaCache.Tables[tableStatus.TableID], now, checkScheduleInterval) {
 			return errors.New("couldn't schedule ttl job")
 		}
 
@@ -862,7 +839,7 @@ func (m *JobManager) lockNewJob(ctx context.Context, se session.Session, table *
 		return nil, err
 	}
 
-	return m.appendLockedJob(jobID, se, now, expireTime, table)
+	return m.appendLockedJob(jobID, se, now, expireTime, table.ID)
 }
 
 func (m *JobManager) getTableStatusForUpdateNotWait(ctx context.Context, se session.Session, physicalID int64, parentTableID int64, createIfNotExist bool) (*cache.TableStatus, error) {
@@ -901,7 +878,7 @@ func (m *JobManager) getTableStatusForUpdateNotWait(ctx context.Context, se sess
 	return cache.RowToTableStatus(se, rows[0])
 }
 
-func (m *JobManager) appendLockedJob(id string, se session.Session, createTime time.Time, expireTime time.Time, table *cache.PhysicalTable) (*ttlJob, error) {
+func (m *JobManager) appendLockedJob(id string, se session.Session, createTime time.Time, expireTime time.Time, tableID int64) (*ttlJob, error) {
 	// successfully update the table status, will need to refresh the cache.
 	err := m.updateInfoSchemaCache(se)
 	if err != nil {
@@ -914,8 +891,7 @@ func (m *JobManager) appendLockedJob(id string, se session.Session, createTime t
 
 	logger := logutil.Logger(m.ctx).With(
 		zap.String("jobID", id),
-		zap.Int64("tableID", table.ID),
-		zap.String("table", table.FullName()),
+		zap.Int64("tableID", tableID),
 	)
 
 	// job is created, notify every scan managers to fetch new tasks
@@ -929,13 +905,13 @@ func (m *JobManager) appendLockedJob(id string, se session.Session, createTime t
 		ownerID: m.id,
 
 		createTime:    createTime,
+		assignTime:    time.Now(),
 		ttlExpireTime: expireTime,
-		// at least, the info schema cache and table status cache are consistent in table id, so it's safe to get table
-		// information from schema cache directly
-		tbl: table,
+		tableID:       tableID,
 
 		status: cache.JobStatusRunning,
 	}
+	logger = m.jobLogger(job)
 
 	logger.Info("append new running job")
 	m.appendJob(job)
@@ -948,23 +924,15 @@ func (m *JobManager) updateHeartBeat(ctx context.Context, se session.Session, no
 	for _, job := range m.localJobs() {
 		err := m.updateHeartBeatForJob(ctx, se, now, job)
 		if err != nil {
-			logutil.Logger(m.ctx).Warn("fail to update heartbeat for job",
-				zap.Error(err),
-				zap.String("jobID", job.id),
-				zap.Int64("tableID", job.tbl.ID),
-				zap.String("table", job.tbl.FullName()),
-			)
+			m.jobLogger(job).Warn("fail to update heartbeat for job",
+				zap.Error(err))
 		}
 	}
 }
 
 func (m *JobManager) updateHeartBeatForJob(ctx context.Context, se session.Session, now time.Time, job *ttlJob) error {
 	if job.createTime.Add(ttlJobTimeout).Before(now) {
-		logutil.Logger(m.ctx).Info("job is timeout",
-			zap.String("jobID", job.id),
-			zap.Int64("tableID", job.tbl.ID),
-			zap.String("table", job.tbl.FullName()),
-		)
+		m.jobLogger(job).Info("job is timeout")
 		summary, err := summarizeErr(errors.New("job is timeout"))
 		if err != nil {
 			return errors.Wrapf(err, "fail to summarize job")
@@ -978,7 +946,7 @@ func (m *JobManager) updateHeartBeatForJob(ctx context.Context, se session.Sessi
 	}
 
 	intest.Assert(se.GetSessionVars().TimeZone.String() == now.Location().String())
-	sql, args := updateHeartBeatSQL(job.tbl.ID, now, m.id)
+	sql, args := updateHeartBeatSQL(job.tableID, now, m.id)
 	_, err := se.ExecuteSQL(ctx, sql, args...)
 	if err != nil {
 		return errors.Wrapf(err, "execute sql: %s", sql)
@@ -1101,8 +1069,8 @@ func (m *JobManager) DoGC(ctx context.Context, se session.Session, now time.Time
 		for id := range m.infoSchemaCache.Tables {
 			existIDs = append(existIDs, id)
 		}
-		sql, args := gcTTLTableStatusGCSQL(existIDs, now)
-		if _, err := se.ExecuteSQL(ctx, sql, args...); err != nil {
+		sql := gcTTLTableStatusGCSQL(existIDs)
+		if _, err := se.ExecuteSQL(ctx, sql); err != nil {
 			logutil.Logger(ctx).Warn("fail to gc ttl table status", zap.Error(err))
 		}
 	} else {
@@ -1115,10 +1083,6 @@ func (m *JobManager) DoGC(ctx context.Context, se session.Session, now time.Time
 
 	if _, err := se.ExecuteSQL(ctx, ttlJobHistoryGCTemplate); err != nil {
 		logutil.Logger(ctx).Warn("fail to gc ttl job history", zap.Error(err))
-	}
-
-	if _, err := se.ExecuteSQL(ctx, ttlJobHistoryGCNonExistTableTemplate); err != nil {
-		logutil.Logger(ctx).Warn("fail to gc ttl job history for non-exist table", zap.Error(err))
 	}
 }
 
@@ -1398,4 +1362,18 @@ func (a *managerJobAdapter) Now() (time.Time, error) {
 	}
 
 	return se.Now().In(tz), nil
+}
+
+func (m *JobManager) jobLogger(job *ttlJob) *zap.Logger {
+	logger := logutil.Logger(m.ctx)
+
+	logger = logger.With(zap.String("jobID", job.id))
+	logger = logger.With(zap.Int64("tableID", job.tableID))
+	if tbl, ok := m.infoSchemaCache.Tables[job.tableID]; ok {
+		logger = logger.With(zap.String("tableName", tbl.FullName()))
+	} else {
+		logger = logger.With(zap.String("tableName", "unknown"))
+	}
+
+	return logger
 }

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -197,11 +197,12 @@ func TestFinishJob(t *testing.T) {
 
 	expireTime, err := testTable.EvalExpireTime(context.Background(), se, startTime)
 	require.NoError(t, err)
+	tkTZ := tk.Session().GetSessionVars().Location()
 	tk.MustQuery("select * from mysql.tidb_ttl_job_history").Check(testkit.Rows(strings.Join([]string{
 		job.ID(), "2", "1", "db1", "t1", "<nil>",
-		startTime.Format(timeFormat),
+		startTime.In(tkTZ).Format(timeFormat),
 		time.Unix(1, 0).Format(timeFormat),
-		expireTime.Format(timeFormat),
+		expireTime.In(tkTZ).Format(timeFormat),
 		"<nil>", "<nil>", "<nil>", "<nil>",
 		"running",
 	}, " ")))
@@ -222,7 +223,7 @@ func TestFinishJob(t *testing.T) {
 	tk.MustQuery("select * from mysql.tidb_ttl_task").Check(testkit.Rows())
 	expectedRow := []string{
 		job.ID(), "2", "1", "db1", "t1", "<nil>",
-		startTime.Format(timeFormat), endTime.Format(timeFormat), expireTime.Format(timeFormat),
+		startTime.In(tkTZ).Format(timeFormat), endTime.In(tkTZ).Format(timeFormat), expireTime.In(tkTZ).Format(timeFormat),
 		summary.SummaryText, "128", "120", "8", "finished",
 	}
 	tk.MustQuery("select * from mysql.tidb_ttl_job_history").Check(testkit.Rows(strings.Join(expectedRow, " ")))
@@ -1553,8 +1554,8 @@ func TestDisableTTLAfterLoseHeartbeat(t *testing.T) {
 		require.NoError(t, m2.TableStatusCache().Update(ctx, se))
 		m2.RescheduleJobs(se, now)
 
-		// the job cannot be cancelled, because it doesn't exist in the infoschema cache.
-		tk.MustQuery("select current_job_status from mysql.tidb_ttl_table_status").Check(testkit.Rows("running"))
+		// the job will be cancelled, because it doesn't exist in the infoschema cache.
+		tk.MustQuery("select current_job_status from mysql.tidb_ttl_table_status").Check(testkit.Rows("<nil>"))
 
 		// run GC
 		m2.DoGC(ctx, se, now)
@@ -1583,8 +1584,8 @@ func TestDisableTTLAfterLoseHeartbeat(t *testing.T) {
 		require.NoError(t, m2.TableStatusCache().Update(ctx, se))
 		m2.RescheduleJobs(se, now)
 
-		// the job cannot be cancelled, because it doesn't exist in the infoschema cache.
-		tk.MustQuery("select current_job_status from mysql.tidb_ttl_table_status").Check(testkit.Rows("running"))
+		// the job will be cancelled, because it doesn't exist in the infoschema cache.
+		tk.MustQuery("select current_job_status from mysql.tidb_ttl_table_status").Check(testkit.Rows("<nil>"))
 
 		// run GC
 		m2.DoGC(ctx, se, now)
@@ -1880,7 +1881,8 @@ func TestTimerJobAfterDropTable(t *testing.T) {
 	tk.MustExec("create table t (created_at datetime) TTL = created_at + INTERVAL 1 HOUR")
 	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
-	m := ttlworker.NewJobManager("test-job-manager", pool, store, nil, func() bool { return true })
+	m1 := ttlworker.NewJobManager("test-job-manager-1", pool, store, nil, func() bool { return true })
+	m2 := ttlworker.NewJobManager("test-job-manager-2", pool, store, nil, func() bool { return true })
 
 	se, err := ttlworker.GetSessionForTest(pool)
 	require.NoError(t, err)
@@ -1889,8 +1891,8 @@ func TestTimerJobAfterDropTable(t *testing.T) {
 	// First, schedule the job. The row in the `tidb_ttl_table_status` and `tidb_ttl_job_history` will be created
 	jobID := "test-job-id"
 
-	require.NoError(t, m.InfoSchemaCache().Update(se))
-	err = m.SubmitJob(se, tbl.Meta().ID, tbl.Meta().ID, jobID)
+	require.NoError(t, m1.InfoSchemaCache().Update(se))
+	err = m1.SubmitJob(se, tbl.Meta().ID, tbl.Meta().ID, jobID)
 	require.NoError(t, err)
 	now := se.Now()
 	tk.MustQuery("select count(*) from mysql.tidb_ttl_table_status").Check(testkit.Rows("1"))
@@ -1900,14 +1902,28 @@ func TestTimerJobAfterDropTable(t *testing.T) {
 	tk.MustExec("drop table t")
 
 	now = now.Add(time.Hour * 2)
-	m.DoGC(context.Background(), se, now)
-	tk.MustQuery("select count(*) from mysql.tidb_ttl_table_status").Check(testkit.Rows("0"))
-	tk.MustQuery("select status from mysql.tidb_ttl_job_history").Check(testkit.Rows("cancelled"))
+	m1.DoGC(context.Background(), se, now)
+	tk.MustQuery("select count(*) from mysql.tidb_ttl_table_status").Check(testkit.Rows("1"))
+	tk.MustQuery("select status from mysql.tidb_ttl_job_history").Check(testkit.Rows("running"))
 
-	require.NoError(t, m.TableStatusCache().Update(context.Background(), se))
-	require.NoError(t, m.InfoSchemaCache().Update(se))
-	m.CheckNotOwnJob()
-	require.Len(t, m.RunningJobs(), 0)
+	// Another job manager should be able to reschedule the job
+	require.NoError(t, m2.TableStatusCache().Update(context.Background(), se))
+	require.NoError(t, m2.InfoSchemaCache().Update(se))
+	m2.RescheduleJobs(se, now)
+
+	// The job should have been removed
+	tk.MustQuery("select current_job_owner_id from mysql.tidb_ttl_table_status").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("select status from mysql.tidb_ttl_job_history").Check(testkit.Rows("finished"))
+
+	// Then it'll be removed by GC
+	m2.DoGC(context.Background(), se, now)
+	tk.MustQuery("select count(*) from mysql.tidb_ttl_table_status").Check(testkit.Rows("0"))
+
+	// When m1 is online again, it will remove this job
+	require.NoError(t, m1.TableStatusCache().Update(context.Background(), se))
+	require.NoError(t, m1.InfoSchemaCache().Update(se))
+	m1.CheckNotOwnJob()
+	require.Len(t, m1.RunningJobs(), 0)
 
 	// The adapter should not return the job
 	adapter := ttlworker.NewManagerJobAdapter(store, pool, nil)

--- a/pkg/ttl/ttlworker/job_manager_test.go
+++ b/pkg/ttl/ttlworker/job_manager_test.go
@@ -154,7 +154,7 @@ func GetSessionForTest(pool util.SessionPool) (session.Session, error) {
 // LockJob is an exported version of lockNewJob for test
 func (m *JobManager) LockJob(ctx context.Context, se session.Session, table *cache.PhysicalTable, now time.Time, createJobID string, checkInterval bool) (*TTLJob, error) {
 	if createJobID == "" {
-		return m.lockHBTimeoutJob(ctx, se, table, now)
+		return m.lockHBTimeoutJob(ctx, se, table.ID, table.TableInfo.ID, now)
 	}
 	return m.lockNewJob(ctx, se, table, now, createJobID, checkInterval)
 }
@@ -279,8 +279,8 @@ func TestReadyForLockHBTimeoutJobTables(t *testing.T) {
 			tables := m.readyForLockHBTimeoutJobTables(se.Now())
 			if c.shouldSchedule {
 				assert.Len(t, tables, 1)
-				assert.Equal(t, tbl.ID, tables[0].ID)
-				assert.Equal(t, tbl.ID, tables[0].TableInfo.ID)
+				assert.Equal(t, tbl.ID, tables[0].TableID)
+				assert.Equal(t, tbl.ID, tables[0].ParentTableID)
 			} else {
 				assert.Len(t, tables, 0)
 			}
@@ -632,7 +632,7 @@ func TestLockTable(t *testing.T) {
 			if c.isCreate {
 				job, err = m.lockNewJob(context.Background(), se, c.table, now, "new-job-id", c.checkInterval)
 			} else {
-				job, err = m.lockHBTimeoutJob(context.Background(), se, c.table, now)
+				job, err = m.lockHBTimeoutJob(context.Background(), se, c.table.ID, c.table.TableInfo.ID, now)
 			}
 			require.Equal(t, len(c.sqls), sqlCounter)
 			if c.hasError {
@@ -643,8 +643,8 @@ func TestLockTable(t *testing.T) {
 				assert.NotNil(t, job)
 				assert.Equal(t, "test-id", job.ownerID)
 				assert.Equal(t, cache.JobStatusRunning, job.status)
-				assert.NotNil(t, job.tbl)
-				assert.Same(t, c.table, job.tbl)
+				assert.NotEmpty(t, job.tableID)
+				assert.Equal(t, c.table.ID, job.tableID)
 				if c.isCreate {
 					assert.Equal(t, "new-job-id", job.id)
 					assert.Equal(t, now, job.createTime)
@@ -669,7 +669,7 @@ func TestLocalJobs(t *testing.T) {
 	m := NewJobManager("test-id", nil, nil, nil, nil)
 	m.sessPool = newMockSessionPool(t, tbl1, tbl2)
 
-	m.runningJobs = []*ttlJob{{tbl: tbl1, id: "1"}, {tbl: tbl2, id: "2"}}
+	m.runningJobs = []*ttlJob{{tableID: tbl1.ID, id: "1"}, {tableID: tbl2.ID, id: "2"}}
 	m.tableStatusCache.Tables = map[int64]*cache.TableStatus{
 		tbl1.ID: {
 			CurrentJobOwnerID: m.id,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58642

Problem Summary:

### What changed and how does it work?

As mentioned in https://github.com/pingcap/tidb/pull/58539, a better solution to #58510 is to not remove running TTL jobs in GC, but let the owner to finish the job.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
