### PR TITLE
br: better systable precheck in full restore

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -45,16 +45,16 @@ var statsTables = map[string]map[string]struct{}{
 }
 
 // tables in this map is restored when fullClusterRestore=true
-var sysPrivilegeTableMap = map[string]string{
-	"user":          "(user = '%s' and host = '%%')",       // since v1.0.0
-	"db":            "(user = '%s' and host = '%%')",       // since v1.0.0
-	"tables_priv":   "(user = '%s' and host = '%%')",       // since v1.0.0
-	"columns_priv":  "(user = '%s' and host = '%%')",       // since v1.0.0
-	"default_roles": "(user = '%s' and host = '%%')",       // since v3.0.0
-	"role_edges":    "(to_user = '%s' and to_host = '%%')", // since v3.0.0
-	"global_priv":   "(user = '%s' and host = '%%')",       // since v3.0.8
-	"global_grants": "(user = '%s' and host = '%%')",       // since v5.0.3
-	"bind_info":     "(user = '%s' and host = '%%')",       // since v7.6.0
+var sysPrivilegeTableMap = map[string]struct{}{
+	"user":          {}, // since v1.0.0
+	"db":            {}, // since v1.0.0
+	"tables_priv":   {}, // since v1.0.0
+	"columns_priv":  {}, // since v1.0.0
+	"default_roles": {}, // since v3.0.0
+	"role_edges":    {}, // since v3.0.0
+	"global_priv":   {}, // since v3.0.8
+	"global_grants": {}, // since v5.0.3
+	"bind_info":     {}, // since v7.6.0
 }
 
 var unRecoverableTable = map[string]map[string]struct{}{

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -276,10 +276,9 @@ func (rc *SnapClient) replaceTemporaryTableToSystable(ctx context.Context, ti *m
 	}
 
 	if db.ExistingTables[tableName] != nil {
-		log.Info("replace existing table",
+		log.Info("replace into existing table",
 			zap.String("table", tableName),
 			zap.Stringer("schema", db.Name))
-
 		// target column order may different with source cluster
 		columnNames := make([]string, 0, len(ti.Columns))
 		for _, col := range ti.Columns {
@@ -287,24 +286,10 @@ func (rc *SnapClient) replaceTemporaryTableToSystable(ctx context.Context, ti *m
 		}
 		colListStr := strings.Join(columnNames, ",")
 		replaceIntoSQL := fmt.Sprintf("REPLACE INTO %s(%s) SELECT %s FROM %s;",
-			utils.EncloseDBAndTable(db.TemporaryName.L, tableName),
-			colListStr, colListStr,
-			utils.EncloseDBAndTable(db.Name.L, tableName))
-		if err := execSQL(replaceIntoSQL); err != nil {
-			return err
-		}
-
-		renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s;",
 			utils.EncloseDBAndTable(db.Name.L, tableName),
-			utils.EncloseDBAndTable(db.TemporaryName.L, tableName+"__replaced__"))
-		if err := execSQL(renameSQL); err != nil {
-			return err
-		}
-
-		renameSQL = fmt.Sprintf("RENAME TABLE %s TO %s;",
-			utils.EncloseDBAndTable(db.TemporaryName.L, tableName),
-			utils.EncloseDBAndTable(db.Name.L, tableName))
-		return execSQL(renameSQL)
+			colListStr, colListStr,
+			utils.EncloseDBAndTable(db.TemporaryName.L, tableName))
+		return execSQL(replaceIntoSQL)
 	}
 
 	renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s;",

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -54,6 +54,7 @@ var sysPrivilegeTableMap = map[string]string{
 	"role_edges":    "(to_user = '%s' and to_host = '%%')", // since v3.0.0
 	"global_priv":   "(user = '%s' and host = '%%')",       // since v3.0.8
 	"global_grants": "(user = '%s' and host = '%%')",       // since v5.0.3
+	"bind_info":     "(user = '%s' and host = '%%')",       // since v7.6.0
 }
 
 var unRecoverableTable = map[string]map[string]struct{}{

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -289,21 +289,21 @@ func (rc *SnapClient) replaceTemporaryTableToSystable(ctx context.Context, ti *m
 		replaceIntoSQL := fmt.Sprintf("REPLACE INTO %s(%s) SELECT %s FROM %s;",
 			utils.EncloseDBAndTable(db.TemporaryName.L, tableName),
 			colListStr, colListStr,
-			utils.EncloseDBAndTable(db.Name.L, tableName),)
+			utils.EncloseDBAndTable(db.Name.L, tableName))
 		if err := execSQL(replaceIntoSQL); err != nil {
 			return err
 		}
 
 		renameSQL := fmt.Sprintf("RENAME TABLE %s TO %s;",
-		utils.EncloseDBAndTable(db.Name.L, tableName),
-		utils.EncloseDBAndTable(db.TemporaryName.L, tableName+"__replaced__"),)
+			utils.EncloseDBAndTable(db.Name.L, tableName),
+			utils.EncloseDBAndTable(db.TemporaryName.L, tableName+"__replaced__"))
 		if err := execSQL(renameSQL); err != nil {
 			return err
 		}
-		
+
 		renameSQL = fmt.Sprintf("RENAME TABLE %s TO %s;",
 			utils.EncloseDBAndTable(db.TemporaryName.L, tableName),
-			utils.EncloseDBAndTable(db.Name.L, tableName),)
+			utils.EncloseDBAndTable(db.Name.L, tableName))
 		return execSQL(renameSQL)
 	}
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1417,6 +1417,9 @@ func filterRestoreFiles(
 		dbName := db.Info.Name.O
 		if name, ok := utils.GetSysDBName(db.Info.Name); utils.IsSysDB(name) && ok {
 			dbName = name
+			if !cfg.WithSysTable {
+				continue
+			}
 		}
 		if checkpoint.IsCheckpointDB(db.Info.Name) {
 			continue


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:   close https://github.com/pingcap/tidb/issues/58663

Problem Summary:

Restore doesn't check the compatibility of `mysql.bind_info`

### What changed and how does it work?

Add `mysql.bind_info` into check list
Avoid some unused table restore

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
