### PR TITLE
expression: resolve bug caused by CAST during expression rewriting in compare subquery

### DIFF
--- a/tests/integrationtest/r/planner/core/expression_rewriter.result
+++ b/tests/integrationtest/r/planner/core/expression_rewriter.result
@@ -433,3 +433,20 @@ select collation(_utf8mb4'@a' collate utf8mb4_general_ci);
 collation(_utf8mb4'@a' collate utf8mb4_general_ci)
 utf8mb4_general_ci
 set @@session.default_collation_for_utf8mb4=default;
+drop table if exists table_3_utf8_undef, table_7_utf8_undef;
+create table table_3_utf8_undef (`col_char(20)_key_signed` char(20));
+insert into table_3_utf8_undef values ('1');
+insert into table_3_utf8_undef values ('3');
+insert into table_3_utf8_undef values (' ');
+insert into table_3_utf8_undef values ('w');
+create table table_7_utf8_undef (`col_double_key_signed` double);
+insert into table_7_utf8_undef values (0.0001);
+insert into table_7_utf8_undef values (0);
+insert into table_7_utf8_undef values (2);
+insert into table_7_utf8_undef values (-1);
+SELECT `col_double_key_signed`  FROM `table_7_utf8_undef`  WHERE( (-col_double_key_signed) <=ANY(SELECT `col_char(20)_key_signed` FROM `table_3_utf8_undef`)) ;
+col_double_key_signed
+0.0001
+0
+2
+-1

--- a/tests/integrationtest/t/planner/core/expression_rewriter.test
+++ b/tests/integrationtest/t/planner/core/expression_rewriter.test
@@ -272,3 +272,16 @@ select collation(_utf8mb4'@a' collate utf8mb4_general_ci);
 
 set @@session.default_collation_for_utf8mb4=default;
 
+# TestIssue50785
+drop table if exists table_3_utf8_undef, table_7_utf8_undef;
+create table table_3_utf8_undef (`col_char(20)_key_signed` char(20));
+insert into table_3_utf8_undef values ('1');
+insert into table_3_utf8_undef values ('3');
+insert into table_3_utf8_undef values (' ');
+insert into table_3_utf8_undef values ('w');
+create table table_7_utf8_undef (`col_double_key_signed` double);
+insert into table_7_utf8_undef values (0.0001);
+insert into table_7_utf8_undef values (0);
+insert into table_7_utf8_undef values (2);
+insert into table_7_utf8_undef values (-1);
+SELECT `col_double_key_signed`  FROM `table_7_utf8_undef`  WHERE( (-col_double_key_signed) <=ANY(SELECT `col_char(20)_key_signed` FROM `table_3_utf8_undef`)) ;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50785

Problem Summary:

### What changed and how does it work?
Update `rexpr` when a `cast function` is necessary before building `compare condition`. 
As discussed in #50785.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
