### PR TITLE
executor,util: Stat inner/inter zone network traffic for MPP tasks

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -5906,13 +5906,13 @@ def go_deps():
         name = "com_github_pingcap_tipb",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/pingcap/tipb",
-        sha256 = "923efe448355ba420cfbd82e93df2f99b08c3fb36191b1f2cabdd3bf32904852",
-        strip_prefix = "github.com/pingcap/tipb@v0.0.0-20241105053214-f91fdb81a69e",
+        sha256 = "87ef3f28a30822c9e2a4966bfb573025ae332ac2a045be1026641e121fccb7e6",
+        strip_prefix = "github.com/pingcap/tipb@v0.0.0-20241212101007-246f91188357",
         urls = [
-            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241105053214-f91fdb81a69e.zip",
-            "http://ats.apps.svc/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241105053214-f91fdb81a69e.zip",
-            "https://cache.hawkingrei.com/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241105053214-f91fdb81a69e.zip",
-            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241105053214-f91fdb81a69e.zip",
+            "http://bazel-cache.pingcap.net:8080/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241212101007-246f91188357.zip",
+            "http://ats.apps.svc/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241212101007-246f91188357.zip",
+            "https://cache.hawkingrei.com/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241212101007-246f91188357.zip",
+            "https://storage.googleapis.com/pingcapmirror/gomod/github.com/pingcap/tipb/com_github_pingcap_tipb-v0.0.0-20241212101007-246f91188357.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -330,3 +330,5 @@ replace (
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/tipb => github.com/pingcap/tipb v0.0.0-20241212101007-246f91188357

--- a/go.mod
+++ b/go.mod
@@ -330,4 +330,3 @@ replace (
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/pingcap/log v1.1.1-0.20241212030209-7e3ff8601a2a
 	github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20211011031125-9b13dc409c5e
-	github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e
+	github.com/pingcap/tipb v0.0.0-20241212101007-246f91188357
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.61.0
@@ -331,4 +331,3 @@ replace (
 	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/tipb => github.com/pingcap/tipb v0.0.0-20241212101007-246f91188357

--- a/go.sum
+++ b/go.sum
@@ -684,8 +684,8 @@ github.com/pingcap/log v1.1.1-0.20241212030209-7e3ff8601a2a h1:WIhmJBlNGmnCWH6TL
 github.com/pingcap/log v1.1.1-0.20241212030209-7e3ff8601a2a/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeAhmOQHNPRRogMYxP13V7BkYw3ZsoSfE=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
-github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e h1:7DdrYVwWpYr4o1AyKl8T376B4h2RsMEjkmom8MxQuuM=
-github.com/pingcap/tipb v0.0.0-20241105053214-f91fdb81a69e/go.mod h1:zrnYy8vReNODg8G0OiYaX9OK+kpq+rK1jHmvd1DnIWw=
+github.com/pingcap/tipb v0.0.0-20241212101007-246f91188357 h1:s58UXyaWMNeaoeuVPZdrkm5Uk7NcODHqICGCUQ3A9s4=
+github.com/pingcap/tipb v0.0.0-20241212101007-246f91188357/go.mod h1:zrnYy8vReNODg8G0OiYaX9OK+kpq+rK1jHmvd1DnIWw=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1804,6 +1804,10 @@ func GetResultRowsCount(stmtCtx *stmtctx.StatementContext, p base.Plan) int64 {
 func (a *ExecStmt) updateMPPNetworkTraffic() {
 	sessVars := a.Ctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
+	runtimeStatsColl := stmtCtx.RuntimeStatsColl
+	if runtimeStatsColl == nil {
+		return
+	}
 	var tikvExecDetail util.ExecDetails
 	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
 	if tikvExecDetailRaw == nil {
@@ -1812,7 +1816,7 @@ func (a *ExecStmt) updateMPPNetworkTraffic() {
 	}
 
 	tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
-	tiflashNetworkStats := stmtCtx.RuntimeStatsColl.GetStmtCopRuntimeStats().TiflashNetworkStats
+	tiflashNetworkStats := runtimeStatsColl.GetStmtCopRuntimeStats().TiflashNetworkStats
 	if tiflashNetworkStats != nil {
 		tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
 	}

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1812,14 +1812,14 @@ func (a *ExecStmt) updateMPPNetworkTraffic() {
 	if tiflashNetworkStats == nil {
 		return
 	}
-	var tikvExecDetail util.ExecDetails
+	var tikvExecDetail *util.ExecDetails
 	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
 	if tikvExecDetailRaw == nil {
 		tikvExecDetailRaw = &util.ExecDetails{}
 		a.GoCtx = context.WithValue(a.GoCtx, util.ExecDetailsKey, tikvExecDetailRaw)
 	}
 
-	tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
+	tikvExecDetail = tikvExecDetailRaw.(*util.ExecDetails)
 	tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
 }
 

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1808,6 +1808,10 @@ func (a *ExecStmt) updateMPPNetworkTraffic() {
 	if runtimeStatsColl == nil {
 		return
 	}
+	tiflashNetworkStats := runtimeStatsColl.GetStmtCopRuntimeStats().TiflashNetworkStats
+	if tiflashNetworkStats == nil {
+		return
+	}
 	var tikvExecDetail util.ExecDetails
 	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
 	if tikvExecDetailRaw == nil {
@@ -1816,10 +1820,7 @@ func (a *ExecStmt) updateMPPNetworkTraffic() {
 	}
 
 	tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
-	tiflashNetworkStats := runtimeStatsColl.GetStmtCopRuntimeStats().TiflashNetworkStats
-	if tiflashNetworkStats != nil {
-		tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
-	}
+	tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
 }
 
 // getFlatPlan generates a FlatPhysicalPlan from the plan stored in stmtCtx.plan,

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1806,9 +1806,12 @@ func (a *ExecStmt) updateMPPNetworkTraffic() {
 	stmtCtx := sessVars.StmtCtx
 	var tikvExecDetail util.ExecDetails
 	tikvExecDetailRaw := a.GoCtx.Value(util.ExecDetailsKey)
-	if tikvExecDetailRaw != nil {
-		tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
+	if tikvExecDetailRaw == nil {
+		tikvExecDetailRaw = &util.ExecDetails{}
+		a.GoCtx = context.WithValue(a.GoCtx, util.ExecDetailsKey, tikvExecDetailRaw)
 	}
+
+	tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
 	tiflashNetworkStats := stmtCtx.RuntimeStatsColl.GetStmtCopRuntimeStats().TiflashNetworkStats
 	tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
 }

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1813,7 +1813,9 @@ func (a *ExecStmt) updateMPPNetworkTraffic() {
 
 	tikvExecDetail = *(tikvExecDetailRaw.(*util.ExecDetails))
 	tiflashNetworkStats := stmtCtx.RuntimeStatsColl.GetStmtCopRuntimeStats().TiflashNetworkStats
-	tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
+	if tiflashNetworkStats != nil {
+		tiflashNetworkStats.UpdateTiKVExecDetails(tikvExecDetail)
+	}
 }
 
 // getFlatPlan generates a FlatPhysicalPlan from the plan stored in stmtCtx.plan,

--- a/pkg/executor/internal/mpp/BUILD.bazel
+++ b/pkg/executor/internal/mpp/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//pkg/executor:__subpackages__"],
     deps = [
         "//pkg/config",
+        "//pkg/ddl/placement",
         "//pkg/distsql",
         "//pkg/executor/internal/builder",
         "//pkg/executor/internal/util",
@@ -25,6 +26,7 @@ go_library(
         "//pkg/store/copr",
         "//pkg/store/driver/backoff",
         "//pkg/store/driver/error",
+        "//pkg/store/helper",
         "//pkg/util",
         "//pkg/util/execdetails",
         "//pkg/util/logutil",
@@ -34,6 +36,7 @@ go_library(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/mpp",
         "@com_github_pingcap_tipb//go-tipb",
+        "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_zap//:zap",
     ],

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -441,7 +441,7 @@ func (h *taskZoneInfoHelper) fillSameZoneFlagForExchange(exec *tipb.Executor) {
 		logutil.BgLogger().Warn(fmt.Sprintf("unknown new tipb protocol %v %v", exec.ExecutorId, sameZoneFlags))
 		exec.ExchangeSender.SameZoneFlag = sameZoneFlags
 	case tipb.ExecType_TypeExchangeReceiver:
-		slots := len(exec.ExchangeSender.EncodedTaskMeta)
+		slots := len(exec.ExchangeReceiver.EncodedTaskMeta)
 		sameZoneFlags := make([]bool, 0, slots)
 		filled := false
 		if filled, sameZoneFlags = h.tryQuickFillWithUncertainZones(exec, slots, sameZoneFlags); filled {

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -432,7 +432,7 @@ func (h *taskZoneInfoHelper) fillSameZoneFlagForExchange(exec *tipb.Executor) {
 		}
 		zoneInfos, exist := h.exchangeZoneInfo[*exec.ExecutorId]
 		if !exist {
-			zoneInfos = h.inferSameZoneFlags(exec.ExchangeReceiver.EncodedTaskMeta, slots)
+			zoneInfos = h.inferSameZoneFlags(exec.ExchangeSender.EncodedTaskMeta, slots)
 			h.exchangeZoneInfo[*exec.ExecutorId] = zoneInfos
 		}
 		for i := 0; i < slots; i++ {

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -353,14 +353,11 @@ func (c *localMppCoordinator) fixTaskForCTEStorageAndReader(exec *tipb.Executor,
 
 // taskZoneInfoHelper used to help reset exchange executor's same zone flags
 type taskZoneInfoHelper struct {
-	isRoot             bool
+	allTiflashZoneInfo map[string]string
+	exchangeZoneInfo   map[string][]string
 	tidbZone           string
 	currentTaskZone    string
-	allTiflashZoneInfo map[string]string
-	// exchangeZoneInfo is used to cache one mpp task's zone info:
-	// key is executor id, value is zone_info array
-	// for ExchangeSender, it's target tiflash nodes' zone info; for ExchangeReceiver, it's source tiflash nodes' zone info
-	exchangeZoneInfo map[string][]string
+	isRoot             bool
 }
 
 func (h *taskZoneInfoHelper) init(store kv.Storage) {

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -398,6 +398,7 @@ func (c *localMppCoordinator) fillSameZoneFlagForExchange(exec *tipb.Executor, t
 			receiverZone, receiverExist := zoneMap[taskMeta.GetAddress()]
 			sameZoneFlags = append(sameZoneFlags, !receiverExist || taskZoneLabel == receiverZone)
 		}
+		logutil.BgLogger().Warn(fmt.Sprintf("unknown new tipb protocol %v %v", exec.ExecutorId, sameZoneFlags))
 		exec.ExchangeSender.SameZoneFlag = sameZoneFlags
 	case tipb.ExecType_TypeExchangeReceiver:
 		sameZoneFlags := make([]bool, 0, len(exec.ExchangeReceiver.EncodedTaskMeta))
@@ -418,6 +419,7 @@ func (c *localMppCoordinator) fillSameZoneFlagForExchange(exec *tipb.Executor, t
 			senderZone, senderExist := zoneMap[taskMeta.GetAddress()]
 			sameZoneFlags = append(sameZoneFlags, !senderExist || taskZoneLabel == senderZone)
 		}
+		logutil.BgLogger().Warn(fmt.Sprintf("unknown new tipb protocol %v %v", exec.ExecutorId, sameZoneFlags))
 		exec.ExchangeReceiver.SameZoneFlag = sameZoneFlags
 	case tipb.ExecType_TypeJoin:
 		children = append(children, exec.Join.Children...)

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -354,10 +354,13 @@ func (c *localMppCoordinator) fixTaskForCTEStorageAndReader(exec *tipb.Executor,
 // taskZoneInfoHelper used to help reset exchange executor's same zone flags
 type taskZoneInfoHelper struct {
 	allTiflashZoneInfo map[string]string
-	exchangeZoneInfo   map[string][]string
-	tidbZone           string
-	currentTaskZone    string
-	isRoot             bool
+	// exchangeZoneInfo is used to cache one mpp task's zone info:
+	// key is executor id, value is zone info array
+	// for ExchangeSender, it's target tiflash nodes' zone info; for ExchangeReceiver, it's source tiflash nodes' zone info
+	exchangeZoneInfo map[string][]string
+	tidbZone         string
+	currentTaskZone  string
+	isRoot           bool
 }
 
 func (h *taskZoneInfoHelper) init(store kv.Storage) {

--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -380,7 +380,7 @@ func (c *localMppCoordinator) fillSameZoneFlagForExchange(exec *tipb.Executor, t
 		children = append(children, exec.Limit.Child)
 	case tipb.ExecType_TypeExchangeSender:
 		children = append(children, exec.ExchangeSender.Child)
-		sameZoneFlags := make([]bool, len(exec.ExchangeSender.EncodedTaskMeta))
+		sameZoneFlags := make([]bool, 0, len(exec.ExchangeSender.EncodedTaskMeta))
 		if len(taskZoneLabel) == 0 {
 			for i := 0; i < len(exec.ExchangeSender.EncodedTaskMeta); i++ {
 				sameZoneFlags = append(sameZoneFlags, true)
@@ -400,7 +400,7 @@ func (c *localMppCoordinator) fillSameZoneFlagForExchange(exec *tipb.Executor, t
 		}
 		exec.ExchangeSender.SameZoneFlag = sameZoneFlags
 	case tipb.ExecType_TypeExchangeReceiver:
-		sameZoneFlags := make([]bool, len(exec.ExchangeReceiver.EncodedTaskMeta))
+		sameZoneFlags := make([]bool, 0, len(exec.ExchangeReceiver.EncodedTaskMeta))
 		if len(taskZoneLabel) == 0 {
 			for i := 0; i < len(exec.ExchangeReceiver.EncodedTaskMeta); i++ {
 				sameZoneFlags = append(sameZoneFlags, true)

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -53,3 +53,35 @@ func TestNeedReportExecutionSummary(t *testing.T) {
 	limitTIDB2.SetChildren(join)
 	require.True(t, needReportExecutionSummary(limitTIDB2, 10, false))
 }
+
+func TestZoneHelperTryQuickFill(t *testing.T) {
+	tableScan := &plannercore.PhysicalTableScan{}
+	limit := &plannercore.PhysicalLimit{}
+	passSender := &plannercore.PhysicalExchangeSender{
+		ExchangeType: tipb.ExchangeType_PassThrough,
+	}
+	passSender.SetID(10)
+	tableReader := &plannercore.PhysicalTableReader{}
+	tableReader.SetTablePlanForTest(passSender)
+	limitTIDB := &plannercore.PhysicalLimit{}
+	limitTIDB.SetChildren(tableReader)
+	passSender.SetChildren(limit)
+	limit.SetChildren(tableScan)
+
+	require.True(t, needReportExecutionSummary(limitTIDB, 10, false))
+	require.False(t, needReportExecutionSummary(limitTIDB, 11, false))
+
+	projection := &plannercore.PhysicalProjection{}
+	projection.SetChildren(tableReader)
+	require.False(t, needReportExecutionSummary(projection, 10, false))
+
+	join := &plannercore.PhysicalHashJoin{}
+	tableScan2 := &plannercore.PhysicalTableScan{}
+	tableScan2.SetID(20)
+	tableReader2 := &plannercore.PhysicalTableReader{}
+	tableReader2.SetTablePlanForTest(tableScan2)
+	join.SetChildren(tableReader2, projection)
+	limitTIDB2 := &plannercore.PhysicalLimit{}
+	limitTIDB2.SetChildren(join)
+	require.True(t, needReportExecutionSummary(limitTIDB2, 10, false))
+}

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -54,34 +54,91 @@ func TestNeedReportExecutionSummary(t *testing.T) {
 	require.True(t, needReportExecutionSummary(limitTIDB2, 10, false))
 }
 
-func TestZoneHelperTryQuickFill(t *testing.T) {
-	tableScan := &plannercore.PhysicalTableScan{}
-	limit := &plannercore.PhysicalLimit{}
-	passSender := &plannercore.PhysicalExchangeSender{
-		ExchangeType: tipb.ExchangeType_PassThrough,
+func mockTaskZoneInfoHelper(isRoot bool, taskZone string, tidbZone string, storeZoneMpp map[string]string, exchangeZoneInfo map[string][]string) taskZoneInfoHelper {
+	helper := taskZoneInfoHelper{
+		tidbZone:           tidbZone,
+		currentTaskZone:    taskZone,
+		isRoot:             isRoot,
+		allTiflashZoneInfo: storeZoneMpp,
+		exchangeZoneInfo:   exchangeZoneInfo,
 	}
-	passSender.SetID(10)
-	tableReader := &plannercore.PhysicalTableReader{}
-	tableReader.SetTablePlanForTest(passSender)
-	limitTIDB := &plannercore.PhysicalLimit{}
-	limitTIDB.SetChildren(tableReader)
-	passSender.SetChildren(limit)
-	limit.SetChildren(tableScan)
+	return helper
+}
 
-	require.True(t, needReportExecutionSummary(limitTIDB, 10, false))
-	require.False(t, needReportExecutionSummary(limitTIDB, 11, false))
+/*func (h *taskZoneInfoHelper) tryQuickFillWithUncertainZones(exec *tipb.Executor, slots int, sameZoneFlags []bool) (bool, []bool) {
+	if exec.ExecutorId == nil || len(h.currentTaskZone) == 0 {
+		for i := 0; i < slots; i++ {
+			sameZoneFlags = append(sameZoneFlags, true)
+		}
+		return true, sameZoneFlags
+	}
+	if h.isRoot && exec.Tp == tipb.ExecType_TypeExchangeSender {
+		sameZoneFlags = append(sameZoneFlags, len(h.tidbZone) == 0 || h.currentTaskZone == h.tidbZone)
+		return true, sameZoneFlags
+	}
+	return false, sameZoneFlags
+}*/
 
-	projection := &plannercore.PhysicalProjection{}
-	projection.SetChildren(tableReader)
-	require.False(t, needReportExecutionSummary(projection, 10, false))
+func TestZoneHelperTryQuickFill(t *testing.T) {
+	slots := 3
+	allTiflashZoneInfo := make(map[string]string, slots)
+	exchangeZoneInfo := make(map[string][]string, 2)
+	helper := mockTaskZoneInfoHelper(false, "", "east", allTiflashZoneInfo, exchangeZoneInfo)
+	exchangeSenderID := "ExchangeSender_1"
+	sender := &tipb.Executor{
+		ExecutorId: &exchangeSenderID,
+		Tp:         tipb.ExecType_TypeExchangeSender,
+	}
+	sameZoneFlags := make([]bool, 0, slots)
+	quickFill := false
+	// When task zone is empty, then the function returns true, and all sameZoneFlags are true
+	quickFill, sameZoneFlags = helper.tryQuickFillWithUncertainZones(sender, slots, sameZoneFlags)
+	require.True(t, quickFill)
+	require.Equal(t, slots, len(sameZoneFlags))
+	for i := 0; i < slots; i++ {
+		require.True(t, sameZoneFlags[i])
+	}
 
-	join := &plannercore.PhysicalHashJoin{}
-	tableScan2 := &plannercore.PhysicalTableScan{}
-	tableScan2.SetID(20)
-	tableReader2 := &plannercore.PhysicalTableReader{}
-	tableReader2.SetTablePlanForTest(tableScan2)
-	join.SetChildren(tableReader2, projection)
-	limitTIDB2 := &plannercore.PhysicalLimit{}
-	limitTIDB2.SetChildren(join)
-	require.True(t, needReportExecutionSummary(limitTIDB2, 10, false))
+	// When task is root task, and executor is exchangeSender then the function compares tidbZone with currentTaskZone
+	helper.isRoot = true
+	helper.currentTaskZone = "west"
+	slots = 1
+	sameZoneFlags = make([]bool, 0, slots)
+	quickFill, sameZoneFlags = helper.tryQuickFillWithUncertainZones(sender, slots, sameZoneFlags)
+	require.True(t, quickFill)
+	require.Equal(t, slots, len(sameZoneFlags))
+	for i := 0; i < slots; i++ {
+		require.False(t, sameZoneFlags[i])
+	}
+
+	helper.currentTaskZone = "east"
+	sameZoneFlags = make([]bool, 0, slots)
+	quickFill, sameZoneFlags = helper.tryQuickFillWithUncertainZones(sender, slots, sameZoneFlags)
+	require.True(t, quickFill)
+	require.Equal(t, slots, len(sameZoneFlags))
+	for i := 0; i < slots; i++ {
+		require.True(t, sameZoneFlags[i])
+	}
+
+	// When task is neither root exchange sender nor current task zone is empty, return false, and empty sameZoneFlags
+	helper.isRoot = false
+	helper.currentTaskZone = "west"
+	slots = 3
+	sameZoneFlags = make([]bool, 0, slots)
+	quickFill, sameZoneFlags = helper.tryQuickFillWithUncertainZones(sender, slots, sameZoneFlags)
+	require.False(t, quickFill)
+	require.Equal(t, 0, len(sameZoneFlags))
+
+	helper.isRoot = true
+	helper.currentTaskZone = "west"
+	slots = 3
+	sameZoneFlags = make([]bool, 0, slots)
+	exchangeReceiverID := "ExchangeReceiver_2"
+	receiver := &tipb.Executor{
+		ExecutorId: &exchangeReceiverID,
+		Tp:         tipb.ExecType_TypeExchangeReceiver,
+	}
+	quickFill, sameZoneFlags = helper.tryQuickFillWithUncertainZones(receiver, slots, sameZoneFlags)
+	require.False(t, quickFill)
+	require.Equal(t, 0, len(sameZoneFlags))
 }

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -65,20 +65,6 @@ func mockTaskZoneInfoHelper(isRoot bool, taskZone string, tidbZone string, store
 	return helper
 }
 
-/*func (h *taskZoneInfoHelper) tryQuickFillWithUncertainZones(exec *tipb.Executor, slots int, sameZoneFlags []bool) (bool, []bool) {
-	if exec.ExecutorId == nil || len(h.currentTaskZone) == 0 {
-		for i := 0; i < slots; i++ {
-			sameZoneFlags = append(sameZoneFlags, true)
-		}
-		return true, sameZoneFlags
-	}
-	if h.isRoot && exec.Tp == tipb.ExecType_TypeExchangeSender {
-		sameZoneFlags = append(sameZoneFlags, len(h.tidbZone) == 0 || h.currentTaskZone == h.tidbZone)
-		return true, sameZoneFlags
-	}
-	return false, sameZoneFlags
-}*/
-
 func TestZoneHelperTryQuickFill(t *testing.T) {
 	slots := 3
 	allTiflashZoneInfo := make(map[string]string, slots)

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -59,7 +59,7 @@ func mockTaskZoneInfoHelper(isRoot bool, taskZone string, tidbZone string, store
 		tidbZone:           tidbZone,
 		currentTaskZone:    taskZone,
 		isRoot:             isRoot,
-		allTiflashZoneInfo: storeZoneMpp,
+		allTiFlashZoneInfo: storeZoneMpp,
 		exchangeZoneInfo:   exchangeZoneInfo,
 	}
 	return helper

--- a/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator_test.go
@@ -74,6 +74,9 @@ func TestZoneHelperTryQuickFill(t *testing.T) {
 	sender := &tipb.Executor{
 		ExecutorId: &exchangeSenderID,
 		Tp:         tipb.ExecType_TypeExchangeSender,
+		ExchangeSender: &tipb.ExchangeSender{
+			UpstreamCteTaskMeta: nil,
+		},
 	}
 	sameZoneFlags := make([]bool, 0, slots)
 	quickFill := false
@@ -123,6 +126,9 @@ func TestZoneHelperTryQuickFill(t *testing.T) {
 	receiver := &tipb.Executor{
 		ExecutorId: &exchangeReceiverID,
 		Tp:         tipb.ExecType_TypeExchangeReceiver,
+		ExchangeReceiver: &tipb.ExchangeReceiver{
+			OriginalCtePrdocuerTaskMeta: nil,
+		},
 	}
 	quickFill, sameZoneFlags = helper.tryQuickFillWithUncertainZones(receiver, slots, sameZoneFlags)
 	require.False(t, quickFill)

--- a/pkg/planner/core/plan_to_pb.go
+++ b/pkg/planner/core/plan_to_pb.go
@@ -16,6 +16,9 @@ package core
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/ddl/placement"
+	"github.com/pingcap/tidb/pkg/store/helper"
 	"math"
 
 	"github.com/pingcap/errors"
@@ -31,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
+	"github.com/tikv/client-go/v2/tikv"
 )
 
 // ToPB implements PhysicalPlan ToPB interface.
@@ -375,14 +379,21 @@ func (e *PhysicalExchangeSender) ToPB(ctx *base.BuildPBContext, storeType kv.Sto
 
 	encodedTask := make([][]byte, 0, len(e.TargetTasks))
 
+	isTiDBLabelZoneSet, storeSameZoneMap := prepareZoneInfo(e.Plan.SCtx().GetStore())
+	sameZoneFlags := make([]bool, len(e.TargetTasks))
 	for _, task := range e.TargetTasks {
 		encodedStr, err := task.ToPB().Marshal()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		encodedTask = append(encodedTask, encodedStr)
+		sameZoneFlag := true
+		if isTiDBLabelZoneSet {
+			sameZone, exist := storeSameZoneMap[task.Meta.GetAddress()]
+			sameZoneFlag = !exist || sameZone
+		}
+		sameZoneFlags = append(sameZoneFlags, sameZoneFlag)
 	}
-
 	encodedUpstreamCTETask := make([]*tipb.EncodedBytesSlice, 0, len(e.TargetCTEReaderTasks))
 	for _, cteRTasks := range e.TargetCTEReaderTasks {
 		encodedTasksForOneCTEReader := &tipb.EncodedBytesSlice{
@@ -430,6 +441,7 @@ func (e *PhysicalExchangeSender) ToPB(ctx *base.BuildPBContext, storeType kv.Sto
 		AllFieldTypes:       allFieldTypes,
 		Compression:         e.CompressionMode.ToTipbCompressionMode(),
 		UpstreamCteTaskMeta: encodedUpstreamCTETask,
+		SameZoneFlag:        sameZoneFlags,
 	}
 	executorID := e.ExplainID().String()
 	return &tipb.Executor{
@@ -441,16 +453,48 @@ func (e *PhysicalExchangeSender) ToPB(ctx *base.BuildPBContext, storeType kv.Sto
 	}, nil
 }
 
+func prepareZoneInfo(store kv.Storage) (bool, map[string]bool) {
+	tidbZone, isTiDBLabelZoneSet := config.GetGlobalConfig().Labels[placement.DCLabelKey]
+	//logutil.BgLogger().Info(fmt.Sprintf("%v %v", tidbZone, isTiDBLabelZoneSet))
+	if !isTiDBLabelZoneSet {
+		return isTiDBLabelZoneSet, nil
+	}
+
+	storeSameZoneMap := make(map[string]bool)
+	tikvStore, ok := store.(helper.Storage)
+	if !ok {
+		return false, nil
+	} 
+	cache := tikvStore.GetRegionCache()
+	allTiFlashStores := cache.GetTiFlashStores(tikv.LabelFilterNoTiFlashWriteNode)
+	for _, tiflashStore := range allTiFlashStores {
+		tiflashStoreAddr := tiflashStore.GetAddr()
+		if tiflashZone, isSet := tiflashStore.GetLabelValue(placement.DCLabelKey); isSet {
+			storeSameZoneMap[tiflashStoreAddr] = tiflashZone == tidbZone
+		} else {
+			storeSameZoneMap[tiflashStoreAddr] = true
+		}
+	}
+	return isTiDBLabelZoneSet, storeSameZoneMap
+}
+
 // ToPB generates the pb structure.
 func (e *PhysicalExchangeReceiver) ToPB(ctx *base.BuildPBContext, _ kv.StoreType) (*tipb.Executor, error) {
 	encodedTask := make([][]byte, 0, len(e.Tasks))
-
+	isTiDBLabelZoneSet, storeSameZoneMap := prepareZoneInfo(e.Plan.SCtx().GetStore())
+	sameZoneFlags := make([]bool, len(e.Tasks))
 	for _, task := range e.Tasks {
 		encodedStr, err := task.ToPB().Marshal()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		encodedTask = append(encodedTask, encodedStr)
+		sameZoneFlag := true
+		if isTiDBLabelZoneSet {
+			sameZone, exist := storeSameZoneMap[task.Meta.GetAddress()]
+			sameZoneFlag = !exist || sameZone
+		}
+		sameZoneFlags = append(sameZoneFlags, sameZoneFlag)
 	}
 
 	fieldTypes := make([]*tipb.FieldType, 0, len(e.Schema().Columns))
@@ -464,6 +508,7 @@ func (e *PhysicalExchangeReceiver) ToPB(ctx *base.BuildPBContext, _ kv.StoreType
 	ecExec := &tipb.ExchangeReceiver{
 		EncodedTaskMeta: encodedTask,
 		FieldTypes:      fieldTypes,
+		SameZoneFlag:    sameZoneFlags,
 	}
 	if e.IsCTEReader {
 		encodedTaskShallowCopy := make([][]byte, len(e.Tasks))

--- a/pkg/planner/core/plan_to_pb.go
+++ b/pkg/planner/core/plan_to_pb.go
@@ -374,6 +374,7 @@ func (e *PhysicalExchangeSender) ToPB(ctx *base.BuildPBContext, storeType kv.Sto
 	}
 
 	encodedTask := make([][]byte, 0, len(e.TargetTasks))
+
 	for _, task := range e.TargetTasks {
 		encodedStr, err := task.ToPB().Marshal()
 		if err != nil {
@@ -381,6 +382,7 @@ func (e *PhysicalExchangeSender) ToPB(ctx *base.BuildPBContext, storeType kv.Sto
 		}
 		encodedTask = append(encodedTask, encodedStr)
 	}
+
 	encodedUpstreamCTETask := make([]*tipb.EncodedBytesSlice, 0, len(e.TargetCTEReaderTasks))
 	for _, cteRTasks := range e.TargetCTEReaderTasks {
 		encodedTasksForOneCTEReader := &tipb.EncodedBytesSlice{
@@ -442,6 +444,7 @@ func (e *PhysicalExchangeSender) ToPB(ctx *base.BuildPBContext, storeType kv.Sto
 // ToPB generates the pb structure.
 func (e *PhysicalExchangeReceiver) ToPB(ctx *base.BuildPBContext, _ kv.StoreType) (*tipb.Executor, error) {
 	encodedTask := make([][]byte, 0, len(e.Tasks))
+
 	for _, task := range e.Tasks {
 		encodedStr, err := task.ToPB().Marshal()
 		if err != nil {

--- a/pkg/planner/core/plan_to_pb.go
+++ b/pkg/planner/core/plan_to_pb.go
@@ -464,7 +464,7 @@ func prepareZoneInfo(store kv.Storage) (bool, map[string]bool) {
 	tikvStore, ok := store.(helper.Storage)
 	if !ok {
 		return false, nil
-	} 
+	}
 	cache := tikvStore.GetRegionCache()
 	allTiFlashStores := cache.GetTiFlashStores(tikv.LabelFilterNoTiFlashWriteNode)
 	for _, tiflashStore := range allTiFlashStores {

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1432,7 +1432,10 @@ type TiFlashNetworkTrafficSummary struct {
 }
 
 // UpdateTiKVExecDetails update tikvDetails with TiFlashNetworkTrafficSummary's values
-func (networkTraffic *TiFlashNetworkTrafficSummary) UpdateTiKVExecDetails(tikvDetails util.ExecDetails) {
+func (networkTraffic *TiFlashNetworkTrafficSummary) UpdateTiKVExecDetails(tikvDetails *util.ExecDetails) {
+	if tikvDetails == nil {
+		return
+	}
 	tikvDetails.UnpackedBytesSentMPPCrossZone += int64(networkTraffic.interZoneSendBytes)
 	tikvDetails.UnpackedBytesSentMPPTotal += int64(networkTraffic.interZoneSendBytes)
 	tikvDetails.UnpackedBytesSentMPPTotal += int64(networkTraffic.innerZoneSendBytes)

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -915,19 +915,16 @@ func (*basicCopRuntimeStats) Tp() int {
 }
 
 type StmtCopRuntimeStats struct {
-	TiflashNetworkStats TiFlashNetworkTrafficSummary
+	TiflashNetworkStats *TiFlashNetworkTrafficSummary
 }
 
 // mergeExecSummary merges ExecutorExecutionSummary into stmt cop runtime stats directly.
 func (e *StmtCopRuntimeStats) mergeExecSummary(summary *tipb.ExecutorExecutionSummary) {
 	if tiflashNetworkSummary := summary.GetTiflashNetworkSummary(); tiflashNetworkSummary != nil {
-		tmp := TiFlashNetworkTrafficSummary{
-			innerZoneSendBytes:    *tiflashNetworkSummary.InnerZoneSendBytes,
-			interZoneSendBytes:    *tiflashNetworkSummary.InterZoneSendBytes,
-			innerZoneReceiveBytes: *tiflashNetworkSummary.InnerZoneReceiveBytes,
-			interZoneReceiveBytes: *tiflashNetworkSummary.InterZoneReceiveBytes,
+		if e.TiflashNetworkStats == nil {
+			e.TiflashNetworkStats = &TiFlashNetworkTrafficSummary{}
 		}
-		e.TiflashNetworkStats.Merge(tmp)
+		e.TiflashNetworkStats.mergeExecSummary(tiflashNetworkSummary)
 	}
 }
 
@@ -1484,6 +1481,13 @@ func (networkTraffic *TiFlashNetworkTrafficSummary) Merge(other TiFlashNetworkTr
 	networkTraffic.interZoneSendBytes = other.interZoneSendBytes
 	networkTraffic.innerZoneReceiveBytes = other.innerZoneReceiveBytes
 	networkTraffic.interZoneReceiveBytes = other.interZoneReceiveBytes
+}
+
+func (networkTraffic *TiFlashNetworkTrafficSummary) mergeExecSummary(summary *tipb.TiFlashNetWorkSummary) {
+	networkTraffic.innerZoneSendBytes += *summary.InnerZoneSendBytes
+	networkTraffic.interZoneSendBytes += *summary.InterZoneSendBytes
+	networkTraffic.innerZoneReceiveBytes += *summary.InnerZoneReceiveBytes
+	networkTraffic.interZoneReceiveBytes += *summary.InterZoneReceiveBytes
 }
 
 // BasicRuntimeStats is the basic runtime stats.

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -847,6 +847,7 @@ func (*basicCopRuntimeStats) Tp() int {
 	return TpBasicCopRunTimeStats
 }
 
+// StmtCopRuntimeStats stores the cop runtime stats of the total statement
 type StmtCopRuntimeStats struct {
 	// TiflashNetworkStats stats all mpp tasks' network traffic info, nil if no any mpp tasks' network traffic
 	TiflashNetworkStats *TiFlashNetworkTrafficSummary

--- a/pkg/util/execdetails/execdetails_test.go
+++ b/pkg/util/execdetails/execdetails_test.go
@@ -179,7 +179,7 @@ func mockExecutorExecutionSummary(TimeProcessedNs, NumProducedRows, NumIteration
 		NumIterations: &NumIterations}
 }
 
-func mockExecutorExecutionSummaryForTiFlash(TimeProcessedNs, NumProducedRows, NumIterations, Concurrency, dmfileScannedRows, dmfileSkippedRows, totalDmfileRsCheckMs, totalDmfileReadTimeMs, totalBuildSnapshotMs, localRegions, remoteRegions, totalLearnerReadMs, disaggReadCacheHitBytes, disaggReadCacheMissBytes, minTSOWaitTime, pipelineBreakerWaitTime, pipelineQueueTime uint64, ExecutorID string) *tipb.ExecutorExecutionSummary {
+func mockExecutorExecutionSummaryForTiFlash(TimeProcessedNs, NumProducedRows, NumIterations, Concurrency, dmfileScannedRows, dmfileSkippedRows, totalDmfileRsCheckMs, totalDmfileReadTimeMs, totalBuildSnapshotMs, localRegions, remoteRegions, totalLearnerReadMs, disaggReadCacheHitBytes, disaggReadCacheMissBytes, minTSOWaitTime, pipelineBreakerWaitTime, pipelineQueueTime uint64, innerZoneSendBytes uint64, interZoneSendBytes uint64, innerZoneReceiveBytes uint64, interZoneReceiveBytes uint64, ExecutorID string) *tipb.ExecutorExecutionSummary {
 	tiflashScanContext := tipb.TiFlashScanContext{
 		DmfileDataScannedRows:    &dmfileScannedRows,
 		DmfileDataSkippedRows:    &dmfileSkippedRows,
@@ -197,8 +197,14 @@ func mockExecutorExecutionSummaryForTiFlash(TimeProcessedNs, NumProducedRows, Nu
 		PipelineQueueWaitNs:   &pipelineBreakerWaitTime,
 		PipelineBreakerWaitNs: &pipelineQueueTime,
 	}
+	tiflashNetworkSummary := tipb.TiFlashNetWorkSummary{
+		InnerZoneSendBytes:    &innerZoneSendBytes,
+		InterZoneSendBytes:    &interZoneSendBytes,
+		InnerZoneReceiveBytes: &innerZoneReceiveBytes,
+		InterZoneReceiveBytes: &interZoneReceiveBytes,
+	}
 	return &tipb.ExecutorExecutionSummary{TimeProcessedNs: &TimeProcessedNs, NumProducedRows: &NumProducedRows,
-		NumIterations: &NumIterations, Concurrency: &Concurrency, ExecutorId: &ExecutorID, DetailInfo: &tipb.ExecutorExecutionSummary_TiflashScanContext{TiflashScanContext: &tiflashScanContext}, TiflashWaitSummary: &tiflashWaitSummary}
+		NumIterations: &NumIterations, Concurrency: &Concurrency, ExecutorId: &ExecutorID, DetailInfo: &tipb.ExecutorExecutionSummary_TiflashScanContext{TiflashScanContext: &tiflashScanContext}, TiflashWaitSummary: &tiflashWaitSummary, TiflashNetworkSummary: &tiflashNetworkSummary}
 }
 
 func TestCopRuntimeStats(t *testing.T) {
@@ -255,10 +261,10 @@ func TestCopRuntimeStatsForTiFlash(t *testing.T) {
 	tableScanID := 1
 	aggID := 2
 	tableReaderID := 3
-	stats.RecordOneCopTask(tableScanID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(1, 1, 1, 1, 8192, 0, 15, 200, 40, 10, 4, 1, 100, 50, 30000000, 20000000, 10000000, "tablescan_"+strconv.Itoa(tableScanID)))
-	stats.RecordOneCopTask(tableScanID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(2, 2, 2, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 20000000, 10000000, 5000000, "tablescan_"+strconv.Itoa(tableScanID)))
-	stats.RecordOneCopTask(aggID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(3, 3, 3, 1, 12000, 6000, 60, 1000, 20, 5, 1, 0, 20, 0, 0, 0, 0, "aggregation_"+strconv.Itoa(aggID)))
-	stats.RecordOneCopTask(aggID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(4, 4, 4, 1, 8192, 80000, 40, 2000, 30, 1, 1, 0, 0, 0, 0, 0, 0, "aggregation_"+strconv.Itoa(aggID)))
+	stats.RecordOneCopTask(tableScanID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(1, 1, 1, 1, 8192, 0, 15, 200, 40, 10, 4, 1, 100, 50, 30000000, 20000000, 10000000, 1000, 2000, 3000, 4000, "tablescan_"+strconv.Itoa(tableScanID)))
+	stats.RecordOneCopTask(tableScanID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(2, 2, 2, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 20000000, 10000000, 5000000, 10000, 20000, 30000, 40000, "tablescan_"+strconv.Itoa(tableScanID)))
+	stats.RecordOneCopTask(aggID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(3, 3, 3, 1, 12000, 6000, 60, 1000, 20, 5, 1, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, "aggregation_"+strconv.Itoa(aggID)))
+	stats.RecordOneCopTask(aggID, kv.TiFlash, mockExecutorExecutionSummaryForTiFlash(4, 4, 4, 1, 8192, 80000, 40, 2000, 30, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "aggregation_"+strconv.Itoa(aggID)))
 	scanDetail := &util.ScanDetail{
 		TotalKeys:                 10,
 		ProcessedKeys:             10,
@@ -272,18 +278,24 @@ func TestCopRuntimeStatsForTiFlash(t *testing.T) {
 	require.True(t, stats.ExistsCopStats(tableScanID))
 
 	cop := stats.GetCopStats(tableScanID)
-	require.Equal(t, "tiflash_task:{proc max:2ns, min:1ns, avg: 1ns, p80:2ns, p95:2ns, iters:3, tasks:2, threads:2}, tiflash_wait: {minTSO_wait: 20ms, pipeline_breaker_wait: 5ms, pipeline_queue_wait: 10ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:10, remote_regions:4, tot_learner_read:1ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:40ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:8192, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:15ms, tot_read:202ms, disagg_cache_hit_bytes: 100, disagg_cache_miss_bytes: 50}}", cop.String())
+	require.Equal(t, "tiflash_task:{proc max:2ns, min:1ns, avg: 1ns, p80:2ns, p95:2ns, iters:3, tasks:2, threads:2}, tiflash_wait: {minTSO_wait: 20ms, pipeline_breaker_wait: 5ms, pipeline_queue_wait: 10ms}, tiflash_network: {inner_zone_send_bytes: 11000, inter_zone_send_bytes: 22000, inner_zone_receive_bytes: 33000, inter_zone_receive_bytes: 44000}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:10, remote_regions:4, tot_learner_read:1ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:40ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:8192, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:15ms, tot_read:202ms, disagg_cache_hit_bytes: 100, disagg_cache_miss_bytes: 50}}", cop.String())
 
 	copStats := cop.stats
 	require.NotNil(t, copStats)
 
-	require.Equal(t, "time:3ns, loops:3, threads:2, tiflash_wait: {minTSO_wait: 20ms, pipeline_breaker_wait: 5ms, pipeline_queue_wait: 10ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:10, remote_regions:4, tot_learner_read:1ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:40ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:8192, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:15ms, tot_read:202ms, disagg_cache_hit_bytes: 100, disagg_cache_miss_bytes: 50}}", copStats.String())
+	require.Equal(t, "time:3ns, loops:3, threads:2, tiflash_wait: {minTSO_wait: 20ms, pipeline_breaker_wait: 5ms, pipeline_queue_wait: 10ms}, tiflash_network: {inner_zone_send_bytes: 11000, inter_zone_send_bytes: 22000, inner_zone_receive_bytes: 33000, inter_zone_receive_bytes: 44000}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:10, remote_regions:4, tot_learner_read:1ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:40ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:8192, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:15ms, tot_read:202ms, disagg_cache_hit_bytes: 100, disagg_cache_miss_bytes: 50}}", copStats.String())
 	expected := "tiflash_task:{proc max:4ns, min:3ns, avg: 3ns, p80:4ns, p95:4ns, iters:7, tasks:2, threads:2}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:6, remote_regions:2, tot_learner_read:0ms, region_balance:none, delta_rows:0, delta_bytes:0, segments:0, stale_read_regions:0, tot_build_snapshot:50ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:0ms, max_local_stream:0ms, dtfile:{data_scanned_rows:20192, data_skipped_rows:86000, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:100ms, tot_read:3000ms, disagg_cache_hit_bytes: 20, disagg_cache_miss_bytes: 0}}"
 	require.Equal(t, expected, stats.GetCopStats(aggID).String())
 
 	rootStats := stats.GetRootStats(tableReaderID)
 	require.NotNil(t, rootStats)
 	require.True(t, stats.ExistsRootStats(tableReaderID))
+
+	stmtNetworkStats := stats.GetStmtCopRuntimeStats().TiflashNetworkStats
+	require.Equal(t, stmtNetworkStats.innerZoneSendBytes, uint64(11000))
+	require.Equal(t, stmtNetworkStats.interZoneSendBytes, uint64(22000))
+	require.Equal(t, stmtNetworkStats.innerZoneReceiveBytes, uint64(33000))
+	require.Equal(t, stmtNetworkStats.interZoneReceiveBytes, uint64(44000))
 }
 
 func TestVectorSearchStats(t *testing.T) {
@@ -291,7 +303,7 @@ func TestVectorSearchStats(t *testing.T) {
 
 	var v uint64 = 1
 
-	execSummary := mockExecutorExecutionSummaryForTiFlash(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "")
+	execSummary := mockExecutorExecutionSummaryForTiFlash(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "")
 	execSummary.DetailInfo.(*tipb.ExecutorExecutionSummary_TiflashScanContext).TiflashScanContext.TotalVectorIdxLoadFromS3 = &v
 	stats.RecordOneCopTask(1, kv.TiFlash, execSummary)
 	s := stats.GetCopStats(1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58682 

Problem Summary:

### What changed and how does it work?
1. Refine the execution summary merging code for tiflash to reduce heap allocation
2. Encode sameZoneFlags for mpp exchange senders/receivers
3. Parse new added network traffic info in tiflash execution summary, and finally set to tikv exec details

### Manual tests
Slow Log Test will be done in https://github.com/pingcap/tidb/pull/59041 
Execution Summary Test: 3 TiFlash Nodes, zone labels: [east, east, west]
TPCH-10, Q1
## Tidb Zone east ##
```
For ExchangeSender_51, all data are sent to one east tiflash node
+--------------------------------------------+-------------+----------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| id                                         | estRows     | actRows  | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | memory  | disk    |
+--------------------------------------------+-------------+----------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| Sort_6                                     | 2.94        | 4        | root         |                | time:2.5s, open:2.69ms, close:10µs, loops:2, RU:126048.87                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 11.5 KB | 0 Bytes |
| └─TableReader_54                           | 2.94        | 4        | root         |                | time:2.5s, open:2.68ms, close:8.74µs, loops:2, cop_task: {num: 4, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 1.79 KB | N/A     |
|   └─ExchangeSender_53                      | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.47s, min:2.45s, avg: 2.46s, p80:2.47s, p95:2.47s, iters:1, tasks:3, threads:3}, tiflash_network: {inner_zone_send_bytes: 1331}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A     | N/A     |
|     └─Projection_9                         | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.47s, min:2.45s, avg: 2.46s, p80:2.47s, p95:2.47s, iters:1, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | test.lineitem.l_returnflag, test.lineitem.l_linestatus, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24                                                                                                                                                                                                                                                                                                                                                                                                                                                                | N/A     | N/A     |
|       └─Projection_49                      | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.47s, min:2.45s, avg: 2.46s, p80:2.47s, p95:2.47s, iters:1, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Column#17, Column#18, Column#19, Column#20, div(Column#21, cast(case(eq(Column#73, 0), 1, Column#73), decimal(20,0) BINARY))->Column#21, div(Column#22, cast(case(eq(Column#74, 0), 1, Column#74), decimal(20,0) BINARY))->Column#22, div(Column#23, cast(case(eq(Column#75, 0), 1, Column#75), decimal(20,0) BINARY))->Column#23, Column#24, test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                          | N/A     | N/A     |
|         └─HashAgg_50                       | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.46s, min:2.45s, avg: 2.46s, p80:2.46s, p95:2.46s, iters:1, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | group by:test.lineitem.l_linestatus, test.lineitem.l_returnflag, funcs:sum(Column#76)->Column#17, funcs:sum(Column#77)->Column#18, funcs:sum(Column#78)->Column#19, funcs:sum(Column#79)->Column#20, funcs:sum(Column#80)->Column#73, funcs:sum(Column#81)->Column#21, funcs:sum(Column#82)->Column#74, funcs:sum(Column#83)->Column#22, funcs:sum(Column#84)->Column#75, funcs:sum(Column#85)->Column#23, funcs:sum(Column#86)->Column#24, funcs:firstrow(test.lineitem.l_returnflag)->test.lineitem.l_returnflag, funcs:firstrow(test.lineitem.l_linestatus)->test.lineitem.l_linestatus                    | N/A     | N/A     |
|           └─ExchangeReceiver_52            | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:2.43s, min:2.39s, avg: 2.4s, p80:2.43s, p95:2.43s, iters:3, tasks:3, threads:216}, tiflash_wait: {pipeline_queue_wait: 2ms}, tiflash_network: {inner_zone_receive_bytes: 849, inter_zone_receive_bytes: 848}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A     | N/A     |
|             └─ExchangeSender_51            | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:2.29s, min:0s, avg: 763.9ms, p80:2.29s, p95:2.29s, iters:3, tasks:3, threads:3}, tiflash_network: {inner_zone_send_bytes: 849, inter_zone_send_bytes: 848}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_returnflag, collate: utf8mb4_bin], [name: test.lineitem.l_linestatus, collate: utf8mb4_bin]                                                                                                                                                                                                                                                                                                                                                                                                                                 | N/A     | N/A     |
|               └─HashAgg_47                 | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:2.29s, min:0s, avg: 762.9ms, p80:2.29s, p95:2.29s, iters:3, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | group by:Column#100, Column#99, funcs:sum(Column#89)->Column#76, funcs:sum(Column#90)->Column#77, funcs:sum(Column#91)->Column#78, funcs:sum(Column#92)->Column#79, funcs:count(Column#93)->Column#80, funcs:sum(Column#94)->Column#81, funcs:count(Column#95)->Column#82, funcs:sum(Column#96)->Column#83, funcs:count(Column#97)->Column#84, funcs:sum(Column#98)->Column#85, funcs:count(1)->Column#86                                                                                                                                                                                                     | N/A     | N/A     |
|                 └─Projection_57            | 58794654.01 | 58773499 | mpp[tiflash] |                | tiflash_task:{proc max:1.7s, min:0s, avg: 567.6ms, p80:1.7s, p95:1.7s, iters:970, tasks:3, threads:216}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | test.lineitem.l_quantity->Column#89, test.lineitem.l_extendedprice->Column#90, mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount))->Column#91, mul(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), plus(1, test.lineitem.l_tax))->Column#92, test.lineitem.l_quantity->Column#93, test.lineitem.l_quantity->Column#94, test.lineitem.l_extendedprice->Column#95, test.lineitem.l_extendedprice->Column#96, test.lineitem.l_discount->Column#97, test.lineitem.l_discount->Column#98, test.lineitem.l_returnflag->Column#99, test.lineitem.l_linestatus->Column#100 | N/A     | N/A     |
|                   └─Selection_36           | 58794654.01 | 58773499 | mpp[tiflash] |                | tiflash_task:{proc max:1.11s, min:0s, avg: 368.9ms, p80:1.11s, p95:1.11s, iters:970, tasks:3, threads:216}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | le(test.lineitem.l_shipdate, 1998-08-15 00:00:00.000000)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | N/A     | N/A     |
|                     └─TableFullScan_35     | 59986052.00 | 59986052 | mpp[tiflash] | table:lineitem | tiflash_task:{proc max:962.8ms, min:0s, avg: 320.9ms, p80:962.8ms, p95:962.8ms, iters:970, tasks:3, threads:216}, tiflash_wait: {pipeline_queue_wait: 21ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:49, remote_regions:0, tot_learner_read:38ms, region_balance:{instance_num: 3, max/min: 17/16=1.062500}, delta_rows:0, delta_bytes:0, segments:98, stale_read_regions:0, tot_build_snapshot:7ms, tot_build_bitmap:25ms, tot_build_inputstream:5199ms, min_local_stream:43ms, max_local_stream:817ms, dtfile:{data_scanned_rows:59986052, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:554ms, tot_read:53977ms}} | pushed down filter:empty, keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | N/A     | N/A     |
+--------------------------------------------+-------------+----------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
```

## Tidb Zone west ##
For ExchangeSender_51, all data are sent to one west tiflash node
```
+--------------------------------------------+-------------+----------+--------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| id                                         | estRows     | actRows  | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | memory  | disk    |
+--------------------------------------------+-------------+----------+--------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| Sort_6                                     | 2.94        | 4        | root         |                | time:3.03s, open:5.07ms, close:11µs, loops:2, RU:143284.20                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 11.5 KB | 0 Bytes |
| └─TableReader_54                           | 2.94        | 4        | root         |                | time:3.03s, open:5.05ms, close:9.25µs, loops:2, cop_task: {num: 4, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 1.79 KB | N/A     |
|   └─ExchangeSender_53                      | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.98s, min:2.94s, avg: 2.96s, p80:2.98s, p95:2.98s, iters:1, tasks:3, threads:3}, tiflash_network: {inner_zone_send_bytes: 1331}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A     | N/A     |
|     └─Projection_9                         | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.98s, min:2.94s, avg: 2.96s, p80:2.98s, p95:2.98s, iters:1, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | test.lineitem.l_returnflag, test.lineitem.l_linestatus, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24                                                                                                                                                                                                                                                                                                                                                                                                                                                                | N/A     | N/A     |
|       └─Projection_49                      | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.98s, min:2.94s, avg: 2.96s, p80:2.98s, p95:2.98s, iters:1, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Column#17, Column#18, Column#19, Column#20, div(Column#21, cast(case(eq(Column#73, 0), 1, Column#73), decimal(20,0) BINARY))->Column#21, div(Column#22, cast(case(eq(Column#74, 0), 1, Column#74), decimal(20,0) BINARY))->Column#22, div(Column#23, cast(case(eq(Column#75, 0), 1, Column#75), decimal(20,0) BINARY))->Column#23, Column#24, test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                          | N/A     | N/A     |
|         └─HashAgg_50                       | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:2.98s, min:2.94s, avg: 2.96s, p80:2.98s, p95:2.98s, iters:1, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | group by:test.lineitem.l_linestatus, test.lineitem.l_returnflag, funcs:sum(Column#76)->Column#17, funcs:sum(Column#77)->Column#18, funcs:sum(Column#78)->Column#19, funcs:sum(Column#79)->Column#20, funcs:sum(Column#80)->Column#73, funcs:sum(Column#81)->Column#21, funcs:sum(Column#82)->Column#74, funcs:sum(Column#83)->Column#22, funcs:sum(Column#84)->Column#75, funcs:sum(Column#85)->Column#23, funcs:sum(Column#86)->Column#24, funcs:firstrow(test.lineitem.l_returnflag)->test.lineitem.l_returnflag, funcs:firstrow(test.lineitem.l_linestatus)->test.lineitem.l_linestatus                    | N/A     | N/A     |
|           └─ExchangeReceiver_52            | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:2.94s, min:2.85s, avg: 2.89s, p80:2.94s, p95:2.94s, iters:3, tasks:3, threads:216}, tiflash_wait: {pipeline_queue_wait: 2ms}, tiflash_network: {inter_zone_receive_bytes: 1699}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A     | N/A     |
|             └─ExchangeSender_51            | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:2.75s, min:0s, avg: 917.2ms, p80:2.75s, p95:2.75s, iters:3, tasks:3, threads:3}, tiflash_network: {inter_zone_send_bytes: 1699}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_returnflag, collate: utf8mb4_bin], [name: test.lineitem.l_linestatus, collate: utf8mb4_bin]                                                                                                                                                                                                                                                                                                                                                                                                                                 | N/A     | N/A     |
|               └─HashAgg_47                 | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:2.75s, min:0s, avg: 915.2ms, p80:2.75s, p95:2.75s, iters:3, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | group by:Column#100, Column#99, funcs:sum(Column#89)->Column#76, funcs:sum(Column#90)->Column#77, funcs:sum(Column#91)->Column#78, funcs:sum(Column#92)->Column#79, funcs:count(Column#93)->Column#80, funcs:sum(Column#94)->Column#81, funcs:count(Column#95)->Column#82, funcs:sum(Column#96)->Column#83, funcs:count(Column#97)->Column#84, funcs:sum(Column#98)->Column#85, funcs:count(1)->Column#86                                                                                                                                                                                                     | N/A     | N/A     |
|                 └─Projection_57            | 58794654.01 | 58773499 | mpp[tiflash] |                | tiflash_task:{proc max:2.2s, min:0s, avg: 734.8ms, p80:2.2s, p95:2.2s, iters:970, tasks:3, threads:216}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | test.lineitem.l_quantity->Column#89, test.lineitem.l_extendedprice->Column#90, mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount))->Column#91, mul(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), plus(1, test.lineitem.l_tax))->Column#92, test.lineitem.l_quantity->Column#93, test.lineitem.l_quantity->Column#94, test.lineitem.l_extendedprice->Column#95, test.lineitem.l_extendedprice->Column#96, test.lineitem.l_discount->Column#97, test.lineitem.l_discount->Column#98, test.lineitem.l_returnflag->Column#99, test.lineitem.l_linestatus->Column#100 | N/A     | N/A     |
|                   └─Selection_36           | 58794654.01 | 58773499 | mpp[tiflash] |                | tiflash_task:{proc max:1.59s, min:0s, avg: 531.2ms, p80:1.59s, p95:1.59s, iters:970, tasks:3, threads:216}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | le(test.lineitem.l_shipdate, 1998-08-15 00:00:00.000000)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | N/A     | N/A     |
|                     └─TableFullScan_35     | 59986052.00 | 59986052 | mpp[tiflash] | table:lineitem | tiflash_task:{proc max:1.37s, min:0s, avg: 456.2ms, p80:1.37s, p95:1.37s, iters:970, tasks:3, threads:216}, tiflash_wait: {pipeline_queue_wait: 9ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:49, remote_regions:0, tot_learner_read:40ms, region_balance:{instance_num: 3, max/min: 17/16=1.062500}, delta_rows:0, delta_bytes:0, segments:98, stale_read_regions:0, tot_build_snapshot:8ms, tot_build_bitmap:24ms, tot_build_inputstream:7337ms, min_local_stream:60ms, max_local_stream:1182ms, dtfile:{data_scanned_rows:59986052, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:1463ms, tot_read:69838ms}} | pushed down filter:empty, keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | N/A     | N/A     |
+--------------------------------------------+-------------+----------+--------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
```

## Tidb Zone west, fine grained count = 8  ##
For ExchangeSender_51, all data are sent to one west tiflash node
```
+--------------------------------------------+-------------+----------+--------------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| id                                         | estRows     | actRows  | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | operator info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | memory  | disk    |
+--------------------------------------------+-------------+----------+--------------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
| Sort_6                                     | 2.94        | 4        | root         |                | time:1.61s, open:15.4ms, close:12.7µs, loops:2, RU:115859.54                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 11.5 KB | 0 Bytes |
| └─TableReader_54                           | 2.94        | 4        | root         |                | time:1.61s, open:15.4ms, close:10.3µs, loops:2, cop_task: {num: 7, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | MppVersion: 2, data:ExchangeSender_53                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 1.79 KB | N/A     |
|   └─ExchangeSender_53                      | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:1.39s, min:1.37s, avg: 1.38s, p80:1.39s, p95:1.39s, iters:4, tasks:3, threads:24}, tiflash_network: {inner_zone_send_bytes: 1652}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | ExchangeType: PassThrough                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | N/A     | N/A     |
|     └─Projection_9                         | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:1.38s, min:1.37s, avg: 1.38s, p80:1.38s, p95:1.38s, iters:4, tasks:3, threads:24}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | test.lineitem.l_returnflag, test.lineitem.l_linestatus, Column#17, Column#18, Column#19, Column#20, Column#21, Column#22, Column#23, Column#24                                                                                                                                                                                                                                                                                                                                                                                                                                                                | N/A     | N/A     |
|       └─Projection_49                      | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:1.38s, min:1.37s, avg: 1.38s, p80:1.38s, p95:1.38s, iters:4, tasks:3, threads:24}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Column#17, Column#18, Column#19, Column#20, div(Column#21, cast(case(eq(Column#73, 0), 1, Column#73), decimal(20,0) BINARY))->Column#21, div(Column#22, cast(case(eq(Column#74, 0), 1, Column#74), decimal(20,0) BINARY))->Column#22, div(Column#23, cast(case(eq(Column#75, 0), 1, Column#75), decimal(20,0) BINARY))->Column#23, Column#24, test.lineitem.l_returnflag, test.lineitem.l_linestatus                                                                                                                                                                                                          | N/A     | N/A     |
|         └─HashAgg_50                       | 2.94        | 4        | mpp[tiflash] |                | tiflash_task:{proc max:1.38s, min:1.37s, avg: 1.38s, p80:1.38s, p95:1.38s, iters:4, tasks:3, threads:24}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | group by:test.lineitem.l_linestatus, test.lineitem.l_returnflag, funcs:sum(Column#76)->Column#17, funcs:sum(Column#77)->Column#18, funcs:sum(Column#78)->Column#19, funcs:sum(Column#79)->Column#20, funcs:sum(Column#80)->Column#73, funcs:sum(Column#81)->Column#21, funcs:sum(Column#82)->Column#74, funcs:sum(Column#83)->Column#22, funcs:sum(Column#84)->Column#75, funcs:sum(Column#85)->Column#23, funcs:sum(Column#86)->Column#24, funcs:firstrow(test.lineitem.l_returnflag)->test.lineitem.l_returnflag, funcs:firstrow(test.lineitem.l_linestatus)->test.lineitem.l_linestatus, stream_count: 8   | N/A     | N/A     |
|           └─ExchangeReceiver_52            | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:1.38s, min:1.37s, avg: 1.37s, p80:1.38s, p95:1.38s, iters:4, tasks:3, threads:24}, tiflash_wait: {pipeline_queue_wait: 1ms}, tiflash_network: {inter_zone_receive_bytes: 4018}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | stream_count: 8                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | N/A     | N/A     |
|             └─ExchangeSender_51            | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:1.29s, min:0s, avg: 431.6ms, p80:1.29s, p95:1.29s, iters:3, tasks:3, threads:3}, tiflash_network: {inter_zone_send_bytes: 4018}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_returnflag, collate: utf8mb4_bin], [name: test.lineitem.l_linestatus, collate: utf8mb4_bin], stream_count: 8                                                                                                                                                                                                                                                                                                                                                                                                                | N/A     | N/A     |
|               └─HashAgg_47                 | 2.94        | 12       | mpp[tiflash] |                | tiflash_task:{proc max:1.27s, min:0s, avg: 425ms, p80:1.27s, p95:1.27s, iters:3, tasks:3, threads:3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | group by:Column#100, Column#99, funcs:sum(Column#89)->Column#76, funcs:sum(Column#90)->Column#77, funcs:sum(Column#91)->Column#78, funcs:sum(Column#92)->Column#79, funcs:count(Column#93)->Column#80, funcs:sum(Column#94)->Column#81, funcs:count(Column#95)->Column#82, funcs:sum(Column#96)->Column#83, funcs:count(Column#97)->Column#84, funcs:sum(Column#98)->Column#85, funcs:count(1)->Column#86                                                                                                                                                                                                     | N/A     | N/A     |
|                 └─Projection_57            | 58794654.01 | 58773499 | mpp[tiflash] |                | tiflash_task:{proc max:915.9ms, min:0s, avg: 305.3ms, p80:915.9ms, p95:915.9ms, iters:970, tasks:3, threads:216}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | test.lineitem.l_quantity->Column#89, test.lineitem.l_extendedprice->Column#90, mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount))->Column#91, mul(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), plus(1, test.lineitem.l_tax))->Column#92, test.lineitem.l_quantity->Column#93, test.lineitem.l_quantity->Column#94, test.lineitem.l_extendedprice->Column#95, test.lineitem.l_extendedprice->Column#96, test.lineitem.l_discount->Column#97, test.lineitem.l_discount->Column#98, test.lineitem.l_returnflag->Column#99, test.lineitem.l_linestatus->Column#100 | N/A     | N/A     |
|                   └─Selection_36           | 58794654.01 | 58773499 | mpp[tiflash] |                | tiflash_task:{proc max:529.9ms, min:0s, avg: 176.6ms, p80:529.9ms, p95:529.9ms, iters:970, tasks:3, threads:216}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | le(test.lineitem.l_shipdate, 1998-08-15 00:00:00.000000)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | N/A     | N/A     |
|                     └─TableFullScan_35     | 59986052.00 | 59986052 | mpp[tiflash] | table:lineitem | tiflash_task:{proc max:308.9ms, min:0s, avg: 103ms, p80:308.9ms, p95:308.9ms, iters:970, tasks:3, threads:216}, tiflash_wait: {pipeline_queue_wait: 4ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:49, remote_regions:0, tot_learner_read:16ms, region_balance:{instance_num: 3, max/min: 17/16=1.062500}, delta_rows:0, delta_bytes:0, segments:98, stale_read_regions:0, tot_build_snapshot:5ms, tot_build_bitmap:208ms, tot_build_inputstream:4226ms, min_local_stream:58ms, max_local_stream:214ms, dtfile:{data_scanned_rows:59986052, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:1002ms, tot_read:41763ms}} | pushed down filter:empty, keep order:false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | N/A     | N/A     |
+--------------------------------------------+-------------+----------+--------------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+---------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
