### PR TITLE
planner: Handle _tidb_rowid correctly in batchPointGet Plan to avoid index out of range error

### DIFF
--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1063,15 +1063,17 @@ func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
 
 	oldNumColumns := len(schema.Columns)
 	numExtraColumns := 0
-	for i := oldNumColumns - 1; i >= 0; i-- {
-		cid := schema.Columns[i].ID
-		// Move extra columns to the end.
-		// ExtraRowChecksumID is ignored here since it's treated as an ordinary column.
-		// https://github.com/pingcap/tidb/blob/3c407312a986327bc4876920e70fdd6841b8365f/pkg/util/rowcodec/decoder.go#L206-L222
-		if cid != model.ExtraHandleID && cid != model.ExtraPhysTblID {
-			break
+	if oldNumColumns > 1 {
+		for i := oldNumColumns - 1; i >= 0; i-- {
+			cid := schema.Columns[i].ID
+			// Move extra columns to the end.
+			// ExtraRowChecksumID is ignored here since it's treated as an ordinary column.
+			// https://github.com/pingcap/tidb/blob/3c407312a986327bc4876920e70fdd6841b8365f/pkg/util/rowcodec/decoder.go#L206-L222
+			if cid != model.ExtraHandleID && cid != model.ExtraPhysTblID {
+				break
+			}
+			numExtraColumns++
 		}
-		numExtraColumns++
 	}
 
 	extraColumns := make([]*expression.Column, numExtraColumns)

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -765,3 +765,13 @@ KEY `idx_65` (`col_36`(5))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 with cte_192 ( col_1101,col_1102,col_1103,col_1104 ) AS ( select  /*+ use_index_merge( tl6e913fb9 ) */   replace( tl6e913fb9.col_36 , tl6e913fb9.col_36 , tl6e913fb9.col_36 ) as r0 , space( 0 ) as r1 , min( distinct  tl6e913fb9.col_36 ) as r2 , count( distinct  tl6e913fb9.col_36 ) as r3 from tl6e913fb9 where tl6e913fb9.col_36 between 'n92ok$B%W#UU%O' and '()c=KVQ=T%-vzGJ' and tl6e913fb9.col_36 in ( 'T+kf' ,'Lvluod2H' ,'3#Omx@pC^fFkeH' ,'=b$z' ) group by tl6e913fb9.col_36  having tl6e913fb9.col_36 = 'xjV@' or IsNull( tl6e913fb9.col_36 ) ) ( select 1,col_1101,col_1102,col_1103,col_1104 from cte_192 where not( IsNull( cte_192.col_1102 ) ) order by 1,2,3,4,5 limit 72850972 );
 1	col_1101	col_1102	col_1103	col_1104
+drop table if exists t;
+create table t (id int unique key, c int);
+insert into t values (1, 10);
+insert into t values (2, 20);
+insert into t values (3, 30);
+select _tidb_rowid from t where id in (1, 2, 3);
+_tidb_rowid
+1
+2
+3

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -534,3 +534,11 @@ CREATE TABLE `tl6e913fb9` (
   KEY `idx_65` (`col_36`(5))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 with cte_192 ( col_1101,col_1102,col_1103,col_1104 ) AS ( select  /*+ use_index_merge( tl6e913fb9 ) */   replace( tl6e913fb9.col_36 , tl6e913fb9.col_36 , tl6e913fb9.col_36 ) as r0 , space( 0 ) as r1 , min( distinct  tl6e913fb9.col_36 ) as r2 , count( distinct  tl6e913fb9.col_36 ) as r3 from tl6e913fb9 where tl6e913fb9.col_36 between 'n92ok$B%W#UU%O' and '()c=KVQ=T%-vzGJ' and tl6e913fb9.col_36 in ( 'T+kf' ,'Lvluod2H' ,'3#Omx@pC^fFkeH' ,'=b$z' ) group by tl6e913fb9.col_36  having tl6e913fb9.col_36 = 'xjV@' or IsNull( tl6e913fb9.col_36 ) ) ( select 1,col_1101,col_1102,col_1103,col_1104 from cte_192 where not( IsNull( cte_192.col_1102 ) ) order by 1,2,3,4,5 limit 72850972 );
+
+# TestIssue58581
+drop table if exists t;
+create table t (id int unique key, c int);
+insert into t values (1, 10);
+insert into t values (2, 20);
+insert into t values (3, 30);
+select _tidb_rowid from t where id in (1, 2, 3);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58581 

Problem Summary:

### What changed and how does it work?
If we only select `_tidb_rowid` in a `batchPointGet` Plan, `_tidb_rowid` would be treated as an `extra column` incorrectly, leading to panic when adjusting the schema.

I added a condition to make sure that the check for extra columns will only apply when there are multiple columns. 
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
