### PR TITLE
[DNM] push index lookup down

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,3 +334,5 @@ replace (
 	sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/tipb => github.com/crazycs520/tipb v0.0.0-20240722065543-dc5e149075ff

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/crazycs520/tipb v0.0.0-20240722065543-dc5e149075ff h1:n8F0E2CG5EtnC0LSgtX187DBZaIg7ailbsNhvndbUrM=
+github.com/crazycs520/tipb v0.0.0-20240722065543-dc5e149075ff/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
@@ -703,8 +705,6 @@ github.com/pingcap/log v1.1.1-0.20240314023424-862ccc32f18d h1:y3EueKVfVykdpTyfU
 github.com/pingcap/log v1.1.1-0.20240314023424-862ccc32f18d/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5 h1:T4pXRhBflzDeAhmOQHNPRRogMYxP13V7BkYw3ZsoSfE=
 github.com/pingcap/sysutil v1.0.1-0.20240311050922-ae81ee01f3a5/go.mod h1:rlimy0GcTvjiJqvD5mXTRr8O2eNZPBrcUgiWVYp9530=
-github.com/pingcap/tipb v0.0.0-20240703084358-e46e4632bd2b h1:tySAGYw21A3Xa8CcA9jBTfrgAB3+KQWyqyW7fUyokzk=
-github.com/pingcap/tipb v0.0.0-20240703084358-e46e4632bd2b/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkg/distsql/distsql.go
+++ b/pkg/distsql/distsql.go
@@ -154,6 +154,19 @@ func SelectWithRuntimeStats(ctx context.Context, dctx *distsqlctx.DistSQLContext
 	return sr, nil
 }
 
+func ExtractExtraChunks(result SelectResult) []*tipb.Chunk {
+	if selectResult, ok := result.(*selectResult); ok {
+		chks := selectResult.extraChunks
+		selectResult.extraChunks = nil
+		if selectResult.selectResp != nil && len(selectResult.selectResp.ExtraChunks) > 0 {
+			chks = append(chks, selectResult.selectResp.ExtraChunks...)
+			selectResult.selectResp.ExtraChunks = nil
+		}
+		return chks
+	}
+	return nil
+}
+
 // Analyze do a analyze request.
 func Analyze(ctx context.Context, client kv.Client, kvReq *kv.Request, vars any,
 	isRestrict bool, dctx *distsqlctx.DistSQLContext) (SelectResult, error) {

--- a/pkg/executor/admin.go
+++ b/pkg/executor/admin.go
@@ -824,7 +824,6 @@ func (e *CleanupIndexExec) buildIndexScan(ctx context.Context, txn kv.Transactio
 		return nil, err
 	}
 
-	kvReq.Concurrency = 1
 	result, err := distsql.Select(ctx, e.Ctx().GetDistSQLCtx(), kvReq, e.getIdxColTypes())
 	if err != nil {
 		return nil, err

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3985,10 +3985,12 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plannercore.PhysicalIn
 	if err != nil {
 		return nil, err
 	}
-	tableId := tableReq.Executors[0].TblScan.TableId
-	indexReq.ExtraTableId = &tableId
-	indexReq.ExtraExecutors = tableReq.Executors
-	indexReq.ExtraOutputOffsets = tableReq.OutputOffsets
+	if is.Table.GetPartitionInfo() == nil && is.Table.IsCommonHandle == false {
+		tableId := tableReq.Executors[0].TblScan.TableId
+		indexReq.ExtraTableId = &tableId
+		indexReq.ExtraExecutors = tableReq.Executors
+		indexReq.ExtraOutputOffsets = tableReq.OutputOffsets
+	}
 	ts := v.TablePlans[0].(*plannercore.PhysicalTableScan)
 	startTS, err := b.getSnapshotTS()
 	if err != nil {

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3985,6 +3985,10 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plannercore.PhysicalIn
 	if err != nil {
 		return nil, err
 	}
+	tableId := tableReq.Executors[0].TblScan.TableId
+	indexReq.ExtraTableId = &tableId
+	indexReq.ExtraExecutors = tableReq.Executors
+	indexReq.ExtraOutputOffsets = tableReq.OutputOffsets
 	ts := v.TablePlans[0].(*plannercore.PhysicalTableScan)
 	startTS, err := b.getSnapshotTS()
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

Related TiKV PR: https://github.com/tikv/tikv/pull/18226

Following is a demo, the `local_row_can=10` in the plan indicates 10 rows that are fetch locally in TiKV, and the `actRows` of `TableRowIDScan_6` is 0  indicates TiDB did not send any additional `TableRowIDScan` requests

```sql
test> create table t (id bigint, b int, unique index(id));
Query OK, 0 rows affected
Time: 0.144s
test> insert into t values (1,1), (2,2), (3,3), (4,4), (5,5),(6,6),(7,7),(8,8),(9,9),(10,10)
Query OK, 10 rows affected
Time: 0.019s
test> explain analyze select * from t use index(id) where id>=1;
+---------------------------+---------+---------+-----------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------+---------+------+
| id                        | estRows | actRows | task      | access object         | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | operator info                                  | memory  | disk |
+---------------------------+---------+---------+-----------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------+---------+------+
| IndexLookUp_7             | 3333.33 | 10      | root      |                       | time:2.8ms, loops:2, RU:0.548811, index_task: {total_time: 2.64ms, fetch_handle: 2.63ms, build: 833ns, wait: 4.38µs, local_row_can: 10}, table_task: {total_time: 77.4µs, num: 1, concurrency: 5}, next: {wait_index: 2.71ms, wait_table_lookup_build: 29µs, wait_table_lookup_resp: 45.6µs}                                                                                                                                                                                                                         |                                                | 65.0 KB | N/A  |
| ├─IndexRangeScan_5(Build) | 3333.33 | 10      | cop[tikv] | table:t, index:id(id) | time:2.62ms, loops:2, cop_task: {num: 1, max: 2.57ms, proc_keys: 10, tot_proc: 201.3µs, tot_wait: 293.5µs, copr_cache_hit_ratio: 0.00, build_task_duration: 15.2µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:2.56ms}}, tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 10, total_process_keys_size: 440, total_keys: 11, get_snapshot_time: 191.1µs, rocksdb: {key_skipped_count: 10, block: {}}}, time_detail: {total_process_time: 201.3µs, total_wait_time: 293.5µs, ... | range:[1,+inf], keep order:false, stats:pseudo | N/A     | N/A  |
| └─TableRowIDScan_6(Probe) | 3333.33 | 0       | cop[tikv] | table:t               | time:28.4µs, loops:1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | keep order:false, stats:pseudo                 | N/A     | N/A  |
+---------------------------+---------+---------+-----------+-----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------+---------+------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
