### PR TITLE
executor: reduce overhead of copystack in idxlookup workers

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -643,8 +643,9 @@ func (e *IndexLookUpExecutor) startWorkers(ctx context.Context, initBatchSize in
 	// so fetching index and getting table data can run concurrently.
 	e.workerCtx, e.cancelFunc = context.WithCancel(ctx)
 	e.pool = &workerPool{
-		TolerablePendingTasks: 1,
-		MaxWorkers:            int32(max(1, e.indexLookupConcurrency)),
+		spawn: func(workers, tasks uint32) bool {
+			return workers < uint32(e.indexLookupConcurrency) && tasks > 1
+		},
 	}
 	if err := e.startIndexWorker(ctx, initBatchSize); err != nil {
 		return err
@@ -732,6 +733,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 	e.idxWorkerWg.Add(1)
 	e.pool.submit(func() {
 		defer trace.StartRegion(ctx, "IndexLookUpIndexTask").End()
+		growWorkerStack16K()
 		worker := &indexWorker{
 			idxLookup:       e,
 			finished:        e.finished,
@@ -1090,6 +1092,7 @@ func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.Select
 				case <-e.finished:
 					return
 				default:
+					growWorkerStack16K()
 					execTableTask(e, task)
 				}
 			})

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -643,7 +643,7 @@ func (e *IndexLookUpExecutor) startWorkers(ctx context.Context, initBatchSize in
 	// so fetching index and getting table data can run concurrently.
 	e.workerCtx, e.cancelFunc = context.WithCancel(ctx)
 	e.pool = &workerPool{
-		spawn: func(workers, tasks uint32) bool {
+		needSpawn: func(workers, tasks uint32) bool {
 			return workers < uint32(e.indexLookupConcurrency) && tasks > 1
 		},
 	}

--- a/pkg/executor/utils.go
+++ b/pkg/executor/utils.go
@@ -174,9 +174,8 @@ func (p *workerPool) run() {
 			p.workers--
 			p.lock.Unlock()
 			return
-		} else {
-			task, p.head = p.head, p.head.next
 		}
+		task, p.head = p.head, p.head.next
 		p.tasks--
 		p.lock.Unlock()
 

--- a/pkg/executor/utils.go
+++ b/pkg/executor/utils.go
@@ -136,9 +136,9 @@ type workerPool struct {
 	head *workerTask
 	tail *workerTask
 
-	tasks   uint32
-	workers uint32
-	spawn   func(workers, tasks uint32) bool
+	tasks     uint32
+	workers   uint32
+	needSpawn func(workers, tasks uint32) bool
 }
 
 func (p *workerPool) submit(f func()) {
@@ -154,7 +154,7 @@ func (p *workerPool) submit(f func()) {
 	}
 	p.tail = task
 	p.tasks++
-	if p.workers == 0 || p.spawn == nil || p.spawn(p.workers, p.tasks) {
+	if p.workers == 0 || p.needSpawn == nil || p.needSpawn(p.workers, p.tasks) {
 		p.workers++
 		spawn = true
 	}

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -199,7 +199,7 @@ func TestWorkerPool(t *testing.T) {
 	t.Run("SingleWorker", func(t *testing.T) {
 		clean()
 		pool := &workerPool{
-			spawn: func(workers, tasks uint32) bool {
+			needSpawn: func(workers, tasks uint32) bool {
 				return workers < 1 && tasks > 0
 			},
 		}
@@ -225,7 +225,7 @@ func TestWorkerPool(t *testing.T) {
 	t.Run("TwoWorkers", func(t *testing.T) {
 		clean()
 		pool := &workerPool{
-			spawn: func(workers, tasks uint32) bool {
+			needSpawn: func(workers, tasks uint32) bool {
 				return workers < 2 && tasks > 0
 			},
 		}
@@ -251,7 +251,7 @@ func TestWorkerPool(t *testing.T) {
 	t.Run("TolerateOnePendingTask", func(t *testing.T) {
 		clean()
 		pool := &workerPool{
-			spawn: func(workers, tasks uint32) bool {
+			needSpawn: func(workers, tasks uint32) bool {
 				return workers < 2 && tasks > 1
 			},
 		}

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -180,7 +180,7 @@ func TestEncodePasswordWithPlugin(t *testing.T) {
 	require.Equal(t, "", pwd)
 }
 
-func TestGoPool(t *testing.T) {
+func TestWorkerPool(t *testing.T) {
 	var (
 		list []int
 		lock sync.Mutex
@@ -199,8 +199,9 @@ func TestGoPool(t *testing.T) {
 	t.Run("SingleWorker", func(t *testing.T) {
 		clean()
 		pool := &workerPool{
-			TolerablePendingTasks: 0,
-			MaxWorkers:            1,
+			spawn: func(workers, tasks uint32) bool {
+				return workers < 1 && tasks > 0
+			},
 		}
 		wg := sync.WaitGroup{}
 		wg.Add(1)
@@ -224,8 +225,9 @@ func TestGoPool(t *testing.T) {
 	t.Run("TwoWorkers", func(t *testing.T) {
 		clean()
 		pool := &workerPool{
-			TolerablePendingTasks: 0,
-			MaxWorkers:            2,
+			spawn: func(workers, tasks uint32) bool {
+				return workers < 2 && tasks > 0
+			},
 		}
 		wg := sync.WaitGroup{}
 		wg.Add(1)
@@ -249,8 +251,9 @@ func TestGoPool(t *testing.T) {
 	t.Run("TolerateOnePendingTask", func(t *testing.T) {
 		clean()
 		pool := &workerPool{
-			TolerablePendingTasks: 1,
-			MaxWorkers:            2,
+			spawn: func(workers, tasks uint32) bool {
+				return workers < 2 && tasks > 1
+			},
 		}
 		wg := sync.WaitGroup{}
 		wg.Add(1)


### PR DESCRIPTION
also refine the worker pool

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #56649

Problem Summary: copystack in index lookup workers consume a lot of cpu resources.

![image](https://github.com/user-attachments/assets/2c003c3e-fef8-4bee-8113-867a22f6298d)

### What changed and how does it work?

Growing the stack at the beginning of the worker goroutine. Also refine the implementation of the worker pool.

![image](https://github.com/user-attachments/assets/f074aae9-348a-44d5-8573-89c9c1639885)

And here are some benchmark results.

| Workload  | Threads | TPS (this PR) | TPS (baseline) | Diff |
| --------- | ------: | ------------: | -------------: | ---: |
| idxlookup |      32 |       2797.99 |        2708.88 | 3.3% |
| idxlookup |      64 |       3292.84 |        3123.35 | 5.4% |

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
