### PR TITLE
executor: fix issue that query slow_query table return wrong result  | tidb-test=345b2782950dafda7b4a938c84bffb7f46834add 

### DIFF
--- a/pkg/executor/cluster_table_test.go
+++ b/pkg/executor/cluster_table_test.go
@@ -131,15 +131,23 @@ select 7;`
 		},
 		{
 			sql:    "select count(*),min(time),max(time) from %s",
-			result: []string{"1|2020-05-14 19:03:54.314615|2020-05-14 19:03:54.314615"},
+			result: []string{"7|2020-02-15 18:00:01.000000|2020-05-14 19:03:54.314615"},
 		},
 		{
-			sql:    "select count(*),min(time) from %s where time > '2020-02-16 20:00:00'",
-			result: []string{"1|2020-02-17 18:00:05.000000"},
+			sql:    "select count(*),min(time),max(time) from %s where time > '2020-02-16 20:00:00'",
+			result: []string{"2|2020-02-17 18:00:05.000000|2020-05-14 19:03:54.314615"},
 		},
 		{
 			sql:    "select count(*) from %s where time > '2020-02-17 20:00:00'",
-			result: []string{"0"},
+			result: []string{"1"},
+		},
+		{
+			sql:    "select count(*) from %s where time > '1980-01-11 00:00:00'",
+			result: []string{"7"},
+		},
+		{
+			sql:    "select count(*) from %s where time < '2024-01-01 00:00:00'",
+			result: []string{"7"},
 		},
 		{
 			sql:    "select query from %s where time > '2019-01-26 21:51:00' and time < now()",

--- a/pkg/executor/slow_query.go
+++ b/pkg/executor/slow_query.go
@@ -842,18 +842,6 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 			e.stats.totalFileNum = totalFileNum
 		}()
 	}
-	if e.extractor == nil || !e.extractor.Enable {
-		totalFileNum = 1
-		//nolint: gosec
-		file, err := os.Open(logFilePath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		return []logFile{{file: file}}, nil
-	}
 	var logFiles []logFile
 	logDir := filepath.Dir(logFilePath)
 	ext := filepath.Ext(logFilePath)
@@ -897,15 +885,17 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 			return handleErr(err)
 		}
 		start := types.NewTime(types.FromGoTime(fileStartTime), mysql.TypeDatetime, types.MaxFsp)
-		notInAllTimeRanges := true
-		for _, tr := range e.checker.timeRanges {
-			if start.Compare(tr.endTime) <= 0 {
-				notInAllTimeRanges = false
-				break
+		if e.checker.enableTimeCheck {
+			notInAllTimeRanges := true
+			for _, tr := range e.checker.timeRanges {
+				if start.Compare(tr.endTime) <= 0 {
+					notInAllTimeRanges = false
+					break
+				}
 			}
-		}
-		if notInAllTimeRanges {
-			return nil
+			if notInAllTimeRanges {
+				return nil
+			}
 		}
 
 		// Get the file end time.
@@ -913,16 +903,18 @@ func (e *slowQueryRetriever) getAllFiles(ctx context.Context, sctx sessionctx.Co
 		if err != nil {
 			return handleErr(err)
 		}
-		end := types.NewTime(types.FromGoTime(fileEndTime), mysql.TypeDatetime, types.MaxFsp)
-		inTimeRanges := false
-		for _, tr := range e.checker.timeRanges {
-			if !(start.Compare(tr.endTime) > 0 || end.Compare(tr.startTime) < 0) {
-				inTimeRanges = true
-				break
+		if e.checker.enableTimeCheck {
+			end := types.NewTime(types.FromGoTime(fileEndTime), mysql.TypeDatetime, types.MaxFsp)
+			inTimeRanges := false
+			for _, tr := range e.checker.timeRanges {
+				if !(start.Compare(tr.endTime) > 0 || end.Compare(tr.startTime) < 0) {
+					inTimeRanges = true
+					break
+				}
 			}
-		}
-		if !inTimeRanges {
-			return nil
+			if !inTimeRanges {
+				return nil
+			}
 		}
 		_, err = file.Seek(0, io.SeekStart)
 		if err != nil {

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -439,8 +439,12 @@ select 7;`
 		{
 			startTime: "",
 			endTime:   "",
-			files:     []string{fileName3},
+			files:     []string{fileName1, fileName2, fileName3},
 			querys: []string{
+				"select 1;",
+				"select 2;",
+				"select 3;",
+				"select 4;",
 				"select 5;",
 				"select 6;",
 				"select 7;",

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -257,7 +257,7 @@ func TestSelectClusterTable(t *testing.T) {
 	tk.MustQuery("select query_time, conn_id, session_alias from `CLUSTER_SLOW_QUERY` order by time desc limit 1").Check(testkit.Rows("25.571605962 40507 alias123"))
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("1", "1"))
 	tk.MustQuery("select digest, count(*) from `CLUSTER_SLOW_QUERY` group by digest order by digest").Check(testkit.Rows("124acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc 1", "42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772 1"))
-	tk.MustQuery(`select length(query) as l,time from information_schema.cluster_slow_query where time > "2019-02-12 19:33:56" order by abs(l) desc limit 10;`).Check(testkit.Rows("21 2019-02-12 19:33:56.571953"))
+	tk.MustQuery(`select length(query) as l,time from information_schema.cluster_slow_query where time > "2019-02-12 19:33:56" order by abs(l) desc limit 10;`).Check(testkit.Rows("21 2019-02-12 19:33:56.571953", "16 2021-09-08 14:39:54.506967"))
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` where time > now() group by digest").Check(testkit.Rows())
 	re := tk.MustQuery("select * from `CLUSTER_statements_summary`")
 	require.NotNil(t, re)

--- a/pkg/planner/core/memtable_predicate_extractor.go
+++ b/pkg/planner/core/memtable_predicate_extractor.go
@@ -1191,22 +1191,19 @@ func (e *SlowQueryExtractor) Extract(
 }
 
 func (e *SlowQueryExtractor) setTimeRange(start, end int64) {
-	const defaultSlowQueryDuration = 24 * time.Hour
-	var startTime, endTime time.Time
 	if start == 0 && end == 0 {
 		return
 	}
+	var startTime, endTime time.Time
 	if start != 0 {
 		startTime = e.convertToTime(start)
+	} else {
+		startTime, _ = types.MinDatetime.GoTime(time.UTC)
 	}
 	if end != 0 {
 		endTime = e.convertToTime(end)
-	}
-	if start == 0 {
-		startTime = endTime.Add(-defaultSlowQueryDuration)
-	}
-	if end == 0 {
-		endTime = startTime.Add(defaultSlowQueryDuration)
+	} else {
+		endTime, _ = types.MaxDatetime.GoTime(time.UTC)
 	}
 	timeRange := &TimeRange{
 		StartTime: startTime,


### PR DESCRIPTION
This is an hotfix of #56356

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #56100

Problem Summary: fix issue that query slow_query table return wrong result

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
