### PR TITLE
ttl, test: scale TTL workers during the fault tests

### DIFF
--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -1728,8 +1728,6 @@ func TestJobManagerWithFault(t *testing.T) {
 	}
 
 	stopTestCh := make(chan struct{})
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
 
 	fault := newFaultWithFilter(func(sql string) bool {
 		// skip some local only sql, ref `getSession()` in `session.go`
@@ -1740,6 +1738,10 @@ func TestJobManagerWithFault(t *testing.T) {
 
 		return true
 	}, newFaultWithProbability(faultPercent))
+
+	wg := &sync.WaitGroup{}
+	// start the goroutine to inject fault to managers randomly
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
@@ -1772,6 +1774,38 @@ func TestJobManagerWithFault(t *testing.T) {
 					logutil.BgLogger().Info("inject fault", zap.String("id", m.m.ID()))
 					m.pool.(*faultSessionPool).setFault(fault)
 				}
+			}
+		}
+	}()
+
+	// start the goroutine to randomly scale the worker count
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		maxScanWorkerCount := variable.DefTiDBTTLScanWorkerCount * 2
+		minScanWorkerCount := variable.DefTiDBTTLScanWorkerCount / 2
+
+		maxDelWorkerCount := variable.DefTiDBTTLDeleteWorkerCount * 2
+		minDelWorkerCount := variable.DefTiDBTTLDeleteWorkerCount / 2
+		faultTicker := time.NewTicker(time.Second)
+
+		tk := testkit.NewTestKit(t, store)
+		for {
+			select {
+			case <-stopTestCh:
+				// Recover to the default count
+				tk.MustExec("set @@global.tidb_ttl_scan_worker_count = ?", variable.DefTiDBTTLScanWorkerCount)
+				tk.MustExec("set @@global.tidb_ttl_delete_worker_count = ?", variable.DefTiDBTTLDeleteWorkerCount)
+
+				return
+			case <-faultTicker.C:
+				scanWorkerCount := rand.Int()%(maxScanWorkerCount-minScanWorkerCount) + minScanWorkerCount
+				delWorkerCount := rand.Int()%(maxDelWorkerCount-minDelWorkerCount) + minDelWorkerCount
+
+				logutil.BgLogger().Info("scale worker count", zap.Int("scanWorkerCount", scanWorkerCount), zap.Int("delWorkerCount", delWorkerCount))
+				tk.MustExec("set @@global.tidb_ttl_scan_worker_count = ?", scanWorkerCount)
+				tk.MustExec("set @@global.tidb_ttl_delete_worker_count = ?", delWorkerCount)
 			}
 		}
 	}()
@@ -1826,7 +1860,6 @@ func TestJobManagerWithFault(t *testing.T) {
 	}
 
 	logutil.BgLogger().Info("test finished")
-	stopTestCh <- struct{}{}
 	close(stopTestCh)
 
 	wg.Wait()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58745

Problem Summary:

### What changed and how does it work?

Modify the test to also scale workers during fault tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
