### PR TITLE
infoschema: avoid panic when updating infoschema v2 btree conflicts

### DIFF
--- a/pkg/infoschema/test/infoschemav2test/v2_test.go
+++ b/pkg/infoschema/test/infoschemav2test/v2_test.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58712

Problem Summary:

### What changed and how does it work?

I check the code again.
If Reload() is thread-safe, the possible write conflict should come from `GCOldVersion()`

In this commit, I avoid the panic and add more logs for it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [X] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

This kind of case is really difficult to test, this is a *guess* at the best of my effort.


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```