### PR TITLE
infoschema: remove domain init reload when reload time greater than half of schemaLease

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1482,24 +1482,8 @@ func (do *Domain) Init(
 		return err
 	}
 
-	startReloadTime := time.Now()
 	// step 3: domain reload the infoSchema.
-	err = do.Reload()
-	if err != nil {
-		return err
-	}
-
-	sub := time.Since(startReloadTime)
-	// The reload(in step 2) operation takes more than ddlLease and a new reload operation was not performed,
-	// the next query will respond by ErrInfoSchemaExpired error. So we do a new reload to update schemaValidator.latestSchemaExpire.
-	if sub > (do.schemaLease / 2) {
-		logutil.BgLogger().Warn("loading schema and starting ddl take a long time, we do a new reload", zap.Duration("take time", sub))
-		err = do.Reload()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return do.Reload()
 }
 
 // Start starts the domain. After start, DDLs can be executed using session, see


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/58821 

Problem Summary:

### What changed and how does it work?
- we have check schema version in domain reload after https://github.com/pingcap/tidb/issues/58095, so no need to reload twice when domain init
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
restart tidb with millions of tables
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
