### PR TITLE
statistics: speed up table iteration during PQ initialization

### DIFF
--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -70,10 +70,6 @@ func (g Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	se, err := g.createTypesSession(store)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	dom, err := session.GetDomain(store)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -84,7 +80,7 @@ func (g Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
 			return nil, err
 		}
 		// create stats handler for backup and restore.
-		err = dom.UpdateTableStatsLoop(se, initStatsSe)
+		err = dom.UpdateTableStatsLoop(initStatsSe)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2440,7 +2440,7 @@ func (do *Domain) StatsHandle() *handle.Handle {
 }
 
 // CreateStatsHandle is used only for test.
-func (do *Domain) CreateStatsHandle(ctx, initStatsCtx sessionctx.Context) error {
+func (do *Domain) CreateStatsHandle(ctx context.Context, initStatsCtx sessionctx.Context) error {
 	h, err := handle.NewHandle(
 		ctx,
 		initStatsCtx,
@@ -2475,20 +2475,19 @@ func (do *Domain) SetStatsUpdating(val bool) {
 
 // LoadAndUpdateStatsLoop loads and updates stats info.
 func (do *Domain) LoadAndUpdateStatsLoop(ctxs []sessionctx.Context, initStatsCtx sessionctx.Context) error {
-	if err := do.UpdateTableStatsLoop(ctxs[0], initStatsCtx); err != nil {
+	if err := do.UpdateTableStatsLoop(initStatsCtx); err != nil {
 		return err
 	}
-	do.StartLoadStatsSubWorkers(ctxs[1:])
+	do.StartLoadStatsSubWorkers(ctxs)
 	return nil
 }
 
 // UpdateTableStatsLoop creates a goroutine loads stats info and updates stats info in a loop.
 // It will also start a goroutine to analyze tables automatically.
 // It should be called only once in BootstrapSession.
-func (do *Domain) UpdateTableStatsLoop(ctx, initStatsCtx sessionctx.Context) error {
-	ctx.GetSessionVars().InRestrictedSQL = true
+func (do *Domain) UpdateTableStatsLoop(initStatsCtx sessionctx.Context) error {
 	statsHandle, err := handle.NewHandle(
-		ctx,
+		do.ctx,
 		initStatsCtx,
 		do.statsLease,
 		do.sysSessionPool,

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -114,7 +114,7 @@ func createPlannerSuite() (s *plannerSuite) {
 	}
 	ctx.GetSessionVars().CurrentDB = "test"
 	do := domain.NewMockDomain()
-	if err := do.CreateStatsHandle(ctx, initStatsCtx); err != nil {
+	if err := do.CreateStatsHandle(context.Background(), initStatsCtx); err != nil {
 		panic(fmt.Sprintf("create mock context panic: %+v", err))
 	}
 	ctx.BindDomain(do)

--- a/pkg/planner/core/mock.go
+++ b/pkg/planner/core/mock.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pingcap/tidb/pkg/domain"
@@ -426,7 +427,7 @@ func MockContext() *mock.Context {
 	ctx.GetSessionVars().CurrentDB = "test"
 	ctx.GetSessionVars().DivPrecisionIncrement = vardef.DefDivPrecisionIncrement
 	do := domain.NewMockDomain()
-	if err := do.CreateStatsHandle(ctx, initStatsCtx); err != nil {
+	if err := do.CreateStatsHandle(context.Background(), initStatsCtx); err != nil {
 		panic(fmt.Sprintf("create mock context panic: %+v", err))
 	}
 	ctx.BindDomain(do)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3611,14 +3611,12 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 			failToLoadOrParseSQLFile = true
 		}
 	}
-	// A sub context for update table stats, and other contexts for concurrent stats loading.
-	cnt := 1 + concurrency
-	syncStatsCtxs, err := createSessions(store, cnt)
+	syncStatsCtxs, err := createSessions(store, concurrency)
 	if err != nil {
 		return nil, err
 	}
-	subCtxs := make([]sessionctx.Context, cnt)
-	for i := 0; i < cnt; i++ {
+	subCtxs := make([]sessionctx.Context, concurrency)
+	for i := 0; i < concurrency; i++ {
 		subCtxs[i] = sessionctx.Context(syncStatsCtxs[i])
 	}
 

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -64,13 +64,14 @@ type statsAnalyze struct {
 
 // NewStatsAnalyze creates a new StatsAnalyze.
 func NewStatsAnalyze(
+	ctx context.Context,
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sysproctrack.Tracker,
 	ddlNotifier *notifier.DDLNotifier,
 ) statstypes.StatsAnalyze {
 	// Usually, we should only create the refresher when auto-analyze priority queue is enabled.
 	// But to allow users to enable auto-analyze priority queue on the fly, we need to create the refresher here.
-	r := refresher.NewRefresher(statsHandle, sysProcTracker, ddlNotifier)
+	r := refresher.NewRefresher(ctx, statsHandle, sysProcTracker, ddlNotifier)
 	return &statsAnalyze{
 		statsHandle:    statsHandle,
 		sysProcTracker: sysProcTracker,

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/ddl/notifier",
         "//pkg/infoschema",
+        "//pkg/meta",
         "//pkg/meta/model",
         "//pkg/sessionctx",
         "//pkg/sessionctx/sysproctrack",

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -16,12 +16,14 @@ package priorityqueue
 
 import (
 	"context"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
@@ -131,7 +133,7 @@ func (pq *AnalysisPriorityQueue) IsInitialized() bool {
 
 // Initialize initializes the priority queue.
 // Note: This function is thread-safe.
-func (pq *AnalysisPriorityQueue) Initialize() error {
+func (pq *AnalysisPriorityQueue) Initialize(ctx context.Context) error {
 	pq.syncFields.mu.Lock()
 	if pq.syncFields.initialized {
 		statslogutil.StatsLogger().Warn("Priority queue already initialized")
@@ -146,13 +148,12 @@ func (pq *AnalysisPriorityQueue) Initialize() error {
 	}()
 
 	pq.syncFields.mu.Lock()
-	if err := pq.rebuildWithoutLock(); err != nil {
+	if err := pq.rebuildWithoutLock(ctx); err != nil {
 		pq.syncFields.mu.Unlock()
 		pq.Close()
 		return errors.Trace(err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	pq.ctx = ctx
 	pq.syncFields.cancel = cancel
 	pq.syncFields.runningJobs = make(map[int64]struct{})
@@ -175,12 +176,12 @@ func (pq *AnalysisPriorityQueue) Rebuild() error {
 		return errors.New(notInitializedErrMsg)
 	}
 
-	return pq.rebuildWithoutLock()
+	return pq.rebuildWithoutLock(pq.ctx)
 }
 
 // rebuildWithoutLock rebuilds the priority queue without holding the lock.
 // Note: Please hold the lock before calling this function.
-func (pq *AnalysisPriorityQueue) rebuildWithoutLock() error {
+func (pq *AnalysisPriorityQueue) rebuildWithoutLock(ctx context.Context) error {
 	pq.syncFields.inner = newHeap()
 
 	// We need to fetch the next check version with offset before fetching all tables and building analysis jobs.
@@ -189,7 +190,7 @@ func (pq *AnalysisPriorityQueue) rebuildWithoutLock() error {
 	// This will guarantee that we will not miss any DML changes. But it may cause some DML changes to be processed twice.
 	// It is acceptable since the DML changes operation is idempotent.
 	nextCheckVersionWithOffset := pq.statsHandle.GetNextCheckVersionWithOffset()
-	err := pq.fetchAllTablesAndBuildAnalysisJobs()
+	err := pq.fetchAllTablesAndBuildAnalysisJobs(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -201,93 +202,123 @@ func (pq *AnalysisPriorityQueue) rebuildWithoutLock() error {
 
 // fetchAllTablesAndBuildAnalysisJobs builds analysis jobs for all eligible tables and partitions.
 // Note: Please hold the lock before calling this function.
-func (pq *AnalysisPriorityQueue) fetchAllTablesAndBuildAnalysisJobs() error {
+func (pq *AnalysisPriorityQueue) fetchAllTablesAndBuildAnalysisJobs(ctx context.Context) error {
 	return statsutil.CallWithSCtx(pq.statsHandle.SPool(), func(sctx sessionctx.Context) error {
 		parameters := exec.GetAutoAnalyzeParameters(sctx)
 		autoAnalyzeRatio := exec.ParseAutoAnalyzeRatio(parameters[vardef.TiDBAutoAnalyzeRatio])
 		pruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
-		is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 		// Query locked tables once to minimize overhead.
 		// Outdated lock info is acceptable as we verify table lock status pre-analysis.
 		lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
 		if err != nil {
 			return err
 		}
+
+		is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
 		// Get current timestamp from the session context.
 		currentTs, err := statsutil.GetStartTS(sctx)
 		if err != nil {
 			return err
 		}
-
 		jobFactory := NewAnalysisJobFactory(sctx, autoAnalyzeRatio, currentTs)
 
-		dbs := is.AllSchemaNames()
-		for _, db := range dbs {
-			// Ignore the memory and system database.
-			if util.IsMemOrSysDB(db.L) {
+		// Get all schemas except the memory and system database.
+		tbls := make([]*model.TableInfo, 0, 512)
+		// This only occurs during priority queue initialization which is infrequent.
+		halfCPUNum := runtime.NumCPU() / 2
+		start := time.Now()
+		if err := meta.IterAllTables(
+			ctx,
+			sctx.GetStore(),
+			currentTs,
+			halfCPUNum,
+			// Make sure this function is thread-safe.
+			func(info *model.TableInfo) error {
+				// Ignore the memory and system database.
+				db, ok := is.SchemaByID(info.DBID)
+				if !ok || util.IsMemOrSysDB(db.Name.L) {
+					return nil
+				}
+				tbls = append(tbls, info)
+				return nil
+			}); err != nil {
+			return errors.Trace(err)
+		}
+		statslogutil.StatsLogger().Info("Fetched all tables", zap.Int("tableCount", len(tbls)), zap.Duration("duration", time.Since(start)))
+		// Add assertion to verify we've collected all tables by comparing with two different methods.
+		// The below one is way slower than the above one, so we only use it for verification.
+		intest.AssertFunc(func() bool {
+			dbs := is.AllSchemaNames()
+			verifyTbls := make([]*model.TableInfo, 0, 512)
+			for _, db := range dbs {
+				// Ignore the memory and system database.
+				if util.IsMemOrSysDB(db.L) {
+					continue
+				}
+
+				tbls, err := is.SchemaTableInfos(context.Background(), db)
+				if err != nil {
+					panic(err)
+				}
+				verifyTbls = append(verifyTbls, tbls...)
+			}
+			return len(verifyTbls) == len(tbls)
+		})
+
+		// We need to check every partition of every table to see if it needs to be analyzed.
+		for _, tblInfo := range tbls {
+			// If table locked, skip analyze all partitions of the table.
+			if _, ok := lockedTables[tblInfo.ID]; ok {
 				continue
 			}
 
-			tbls, err := is.SchemaTableInfos(context.Background(), db)
-			if err != nil {
-				return err
+			if tblInfo.IsView() {
+				continue
 			}
 
-			// We need to check every partition of every table to see if it needs to be analyzed.
-			for _, tblInfo := range tbls {
-				// If table locked, skip analyze all partitions of the table.
-				if _, ok := lockedTables[tblInfo.ID]; ok {
-					continue
+			pi := tblInfo.GetPartitionInfo()
+			if pi == nil {
+				job := jobFactory.CreateNonPartitionedTableAnalysisJob(
+					tblInfo,
+					pq.statsHandle.GetTableStatsForAutoAnalyze(tblInfo),
+				)
+				err := pq.pushWithoutLock(job)
+				if err != nil {
+					return err
 				}
+				continue
+			}
 
-				if tblInfo.IsView() {
-					continue
+			// Only analyze the partition that has not been locked.
+			partitionDefs := make([]model.PartitionDefinition, 0, len(pi.Definitions))
+			for _, def := range pi.Definitions {
+				if _, ok := lockedTables[def.ID]; !ok {
+					partitionDefs = append(partitionDefs, def)
 				}
-
-				pi := tblInfo.GetPartitionInfo()
-				if pi == nil {
-					job := jobFactory.CreateNonPartitionedTableAnalysisJob(
+			}
+			partitionStats := GetPartitionStats(pq.statsHandle, tblInfo, partitionDefs)
+			// If the prune mode is static, we need to analyze every partition as a separate table.
+			if pruneMode == variable.Static {
+				for pIDAndName, stats := range partitionStats {
+					job := jobFactory.CreateStaticPartitionAnalysisJob(
 						tblInfo,
-						pq.statsHandle.GetTableStatsForAutoAnalyze(tblInfo),
+						pIDAndName.ID,
+						stats,
 					)
 					err := pq.pushWithoutLock(job)
 					if err != nil {
 						return err
 					}
-					continue
 				}
-
-				// Only analyze the partition that has not been locked.
-				partitionDefs := make([]model.PartitionDefinition, 0, len(pi.Definitions))
-				for _, def := range pi.Definitions {
-					if _, ok := lockedTables[def.ID]; !ok {
-						partitionDefs = append(partitionDefs, def)
-					}
-				}
-				partitionStats := GetPartitionStats(pq.statsHandle, tblInfo, partitionDefs)
-				// If the prune mode is static, we need to analyze every partition as a separate table.
-				if pruneMode == variable.Static {
-					for pIDAndName, stats := range partitionStats {
-						job := jobFactory.CreateStaticPartitionAnalysisJob(
-							tblInfo,
-							pIDAndName.ID,
-							stats,
-						)
-						err := pq.pushWithoutLock(job)
-						if err != nil {
-							return err
-						}
-					}
-				} else {
-					job := jobFactory.CreateDynamicPartitionedTableAnalysisJob(
-						tblInfo,
-						pq.statsHandle.GetPartitionStatsForAutoAnalyze(tblInfo, tblInfo.ID),
-						partitionStats,
-					)
-					err := pq.pushWithoutLock(job)
-					if err != nil {
-						return err
-					}
+			} else {
+				job := jobFactory.CreateDynamicPartitionedTableAnalysisJob(
+					tblInfo,
+					pq.statsHandle.GetPartitionStatsForAutoAnalyze(tblInfo, tblInfo.ID),
+					partitionStats,
+				)
+				err := pq.pushWithoutLock(job)
+				if err != nil {
+					return err
 				}
 			}
 		}

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler_test.go
@@ -85,7 +85,7 @@ func TestHandleDDLEventsWithRunningJobs(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(ctx))
 
 	// Check there are no running jobs.
 	runningJobs := pq.GetRunningJobs()
@@ -188,7 +188,8 @@ func TestTruncateTable(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -206,7 +207,6 @@ func TestTruncateTable(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, truncateTableEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	sctx := testKit.Session().(sessionctx.Context)
 	// Handle the truncate table event in priority queue.
 	require.NoError(t, pq.HandleDDLEvent(ctx, sctx, truncateTableEvent))
@@ -253,7 +253,8 @@ func testTruncatePartitionedTable(
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -268,7 +269,6 @@ func testTruncatePartitionedTable(
 	err = statstestutil.HandleDDLEventWithTxn(h, truncateTableEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	sctx := testKit.Session().(sessionctx.Context)
 	// Handle the truncate table event in priority queue.
 	require.NoError(t, pq.HandleDDLEvent(ctx, sctx, truncateTableEvent))
@@ -302,7 +302,8 @@ func TestDropTable(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -320,7 +321,6 @@ func TestDropTable(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, dropTableEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	sctx := testKit.Session().(sessionctx.Context)
 	// Handle the drop table event in priority queue.
 	require.NoError(t, pq.HandleDDLEvent(ctx, sctx, dropTableEvent))
@@ -367,7 +367,8 @@ func testDropPartitionedTable(
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -382,7 +383,6 @@ func testDropPartitionedTable(
 	err = statstestutil.HandleDDLEventWithTxn(h, dropTableEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	sctx := testKit.Session().(sessionctx.Context)
 	// Handle the drop table event in priority queue.
 	require.NoError(t, pq.HandleDDLEvent(ctx, sctx, dropTableEvent))
@@ -418,7 +418,8 @@ func TestTruncateTablePartition(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -436,7 +437,6 @@ func TestTruncateTablePartition(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, truncateTablePartitionEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -477,7 +477,8 @@ func TestDropTablePartition(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -495,7 +496,6 @@ func TestDropTablePartition(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, dropTablePartitionEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -542,7 +542,8 @@ func TestExchangeTablePartition(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -560,7 +561,6 @@ func TestExchangeTablePartition(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, exchangeTablePartitionEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -604,7 +604,8 @@ func TestReorganizeTablePartition(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -622,7 +623,6 @@ func TestReorganizeTablePartition(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, reorganizeTablePartitionEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -663,7 +663,8 @@ func TestAlterTablePartitioning(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -681,7 +682,6 @@ func TestAlterTablePartitioning(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, alterTablePartitioningEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -722,7 +722,8 @@ func TestRemovePartitioning(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -740,7 +741,6 @@ func TestRemovePartitioning(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, removePartitioningEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -789,7 +789,8 @@ func TestDropSchemaEventWithDynamicPartition(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -811,7 +812,6 @@ func TestDropSchemaEventWithDynamicPartition(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, dropSchemaEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -846,7 +846,8 @@ func TestDropSchemaEventWithStaticPartition(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	ctx := context.Background()
+	require.NoError(t, pq.Initialize(ctx))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)
@@ -865,7 +866,6 @@ func TestDropSchemaEventWithStaticPartition(t *testing.T) {
 	err = statstestutil.HandleDDLEventWithTxn(h, dropSchemaEvent)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	require.NoError(t, statsutil.CallWithSCtx(
 		h.SPool(),
 		func(sctx sessionctx.Context) error {
@@ -910,7 +910,7 @@ func TestVectorIndexTriggerAutoAnalyze(t *testing.T) {
 	tk.MustExec("alter table t set tiflash replica 1;")
 	testkit.SetTiFlashReplica(t, dom, "test", "t")
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.True(t, isEmpty)
@@ -951,7 +951,7 @@ func TestAddIndexTriggerAutoAnalyzeWithStatsVersion1(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(h)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 	isEmpty, err := pq.IsEmpty()
 	require.NoError(t, err)
 	require.False(t, isEmpty)

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_test.go
@@ -88,12 +88,19 @@ func TestAnalysisPriorityQueue(t *testing.T) {
 	defer pq.Close()
 
 	t.Run("Initialize", func(t *testing.T) {
-		err := pq.Initialize()
+		// With timeout context
+		cancellableContext, cancel := context.WithTimeout(ctx, 100*time.Second)
+		// Cancel the context to test the error handling
+		cancel()
+		err := pq.Initialize(cancellableContext)
+		require.ErrorIs(t, err, context.Canceled)
+
+		err = pq.Initialize(ctx)
 		require.NoError(t, err)
 		require.True(t, pq.IsInitialized())
 
 		// Test double initialization
-		err = pq.Initialize()
+		err = pq.Initialize(ctx)
 		require.NoError(t, err)
 	})
 
@@ -140,7 +147,7 @@ func TestRefreshLastAnalysisDuration(t *testing.T) {
 	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(ctx))
 
 	// Check current jobs
 	isEmpty, err := pq.IsEmpty()
@@ -218,7 +225,7 @@ func testProcessDMLChanges(t *testing.T, partitioned bool) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(ctx))
 
 	// Check current jobs.
 	job1, err := pq.Pop()
@@ -310,7 +317,7 @@ func TestProcessDMLChangesWithRunningJobs(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(ctx))
 
 	// Check there are no running jobs.
 	runningJobs := pq.GetRunningJobs()
@@ -393,7 +400,7 @@ func TestRequeueMustRetryJobs(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 
 	job, err := pq.Pop()
 	require.NoError(t, err)
@@ -442,7 +449,7 @@ func TestProcessDMLChangesWithLockedTables(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 
 	schema := ast.NewCIStr("test")
 	tbl1, err := dom.InfoSchema().TableByName(ctx, schema, ast.NewCIStr("t1"))
@@ -505,7 +512,7 @@ func TestProcessDMLChangesWithLockedPartitionsAndDynamicPruneMode(t *testing.T) 
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 
 	schema := ast.NewCIStr("test")
 	tbl, err := dom.InfoSchema().TableByName(ctx, schema, ast.NewCIStr("t1"))
@@ -572,7 +579,7 @@ func TestProcessDMLChangesWithLockedPartitionsAndStaticPruneMode(t *testing.T) {
 
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(ctx))
 
 	// Check current jobs.
 	job, err := pq.Peek()
@@ -611,7 +618,7 @@ func TestPQCanBeClosedAndReInitialized(t *testing.T) {
 	handle := dom.StatsHandle()
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 
 	// Close the priority queue.
 	pq.Close()
@@ -620,7 +627,7 @@ func TestPQCanBeClosedAndReInitialized(t *testing.T) {
 	require.False(t, pq.IsInitialized())
 
 	// Re-initialize the priority queue.
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(context.Background()))
 
 	// Check if the priority queue is initialized.
 	require.True(t, pq.IsInitialized())
@@ -645,7 +652,7 @@ func TestPQHandlesTableDeletionGracefully(t *testing.T) {
 	require.NoError(t, handle.Update(ctx, dom.InfoSchema()))
 	pq := priorityqueue.NewAnalysisPriorityQueue(handle)
 	defer pq.Close()
-	require.NoError(t, pq.Initialize())
+	require.NoError(t, pq.Initialize(ctx))
 
 	// Check the priority queue is not empty.
 	l, err := pq.Len()

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -15,6 +15,7 @@
 package refresher
 
 import (
+	"context"
 	stderrors "errors"
 	"time"
 
@@ -35,6 +36,8 @@ import (
 // Refresher provides methods to refresh stats info.
 // NOTE: Refresher is not thread-safe.
 type Refresher struct {
+	// This context is used to cancel background tasks when the domain exits.
+	ctx context.Context
 	// This will be refreshed every time we rebuild the priority queue.
 	autoAnalysisTimeWindow priorityqueue.AutoAnalysisTimeWindow
 
@@ -58,12 +61,14 @@ type Refresher struct {
 
 // NewRefresher creates a new Refresher and starts the goroutine.
 func NewRefresher(
+	ctx context.Context,
 	statsHandle statstypes.StatsHandle,
 	sysProcTracker sysproctrack.Tracker,
 	ddlNotifier *notifier.DDLNotifier,
 ) *Refresher {
 	maxConcurrency := int(vardef.AutoAnalyzeConcurrency.Load())
 	r := &Refresher{
+		ctx:            ctx,
 		statsHandle:    statsHandle,
 		sysProcTracker: sysProcTracker,
 		jobs:           priorityqueue.NewAnalysisPriorityQueue(statsHandle),
@@ -98,7 +103,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	currentAutoAnalyzeRatio := exec.ParseAutoAnalyzeRatio(parameters[vardef.TiDBAutoAnalyzeRatio])
 	currentPruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	if !r.jobs.IsInitialized() {
-		if err := r.jobs.Initialize(); err != nil {
+		if err := r.jobs.Initialize(r.ctx); err != nil {
 			statslogutil.StatsLogger().Error("Failed to initialize the queue", zap.Error(err))
 			return false
 		}

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -43,7 +43,7 @@ func TestChangePruneMode(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	tk.MustExec("analyze table t1")
-	r := refresher.NewRefresher(handle, dom.SysProcTracker(), dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, dom.SysProcTracker(), dom.DDLNotifier())
 	defer r.Close()
 
 	// Insert more data to each partition.
@@ -119,7 +119,7 @@ func TestSkipAnalyzeTableWhenAutoAnalyzeRatioIsZero(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 	// No jobs are added.
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
@@ -152,7 +152,7 @@ func TestIgnoreNilOrPseudoStatsOfPartitionedTable(t *testing.T) {
 	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
 	handle := dom.StatsHandle()
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
 		require.False(t, r.AnalyzeHighestPriorityTables(sctx))
@@ -176,7 +176,7 @@ func TestIgnoreNilOrPseudoStatsOfNonPartitionedTable(t *testing.T) {
 	tk.MustExec("insert into t2 values (1, 1), (2, 2), (3, 3)")
 	handle := dom.StatsHandle()
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
 		require.False(t, r.AnalyzeHighestPriorityTables(sctx))
@@ -224,7 +224,7 @@ func TestIgnoreTinyTable(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
 		require.True(t, r.AnalyzeHighestPriorityTables(sctx))
@@ -262,7 +262,7 @@ func TestAnalyzeHighestPriorityTables(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 	// Analyze t1 first.
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
@@ -331,7 +331,7 @@ func TestAnalyzeHighestPriorityTablesConcurrently(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 	// Analyze tables concurrently.
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
@@ -395,7 +395,7 @@ func TestDoNotRetryTableNotExistJob(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
@@ -452,7 +452,7 @@ func TestAnalyzeHighestPriorityTablesWithFailedAnalysis(t *testing.T) {
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(handle, sysProcTracker, dom.DDLNotifier())
+	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
 	defer r.Close()
 
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -15,6 +15,7 @@
 package handle
 
 import (
+	"context"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
@@ -111,7 +112,7 @@ func (h *Handle) Clear() {
 
 // NewHandle creates a Handle for update stats.
 func NewHandle(
-	_, /* ctx, keep it for feature usage */
+	ctx context.Context,
 	initStatsCtx sessionctx.Context,
 	lease time.Duration,
 	pool pkgutil.DestroyableSessionPool,
@@ -139,7 +140,7 @@ func NewHandle(
 	handle.StatsCache = statsCache
 	handle.StatsHistory = history.NewStatsHistory(handle)
 	handle.StatsUsage = usage.NewStatsUsageImpl(handle)
-	handle.StatsAnalyze = autoanalyze.NewStatsAnalyze(handle, tracker, ddlNotifier)
+	handle.StatsAnalyze = autoanalyze.NewStatsAnalyze(ctx, handle, tracker, ddlNotifier)
 	handle.StatsSyncLoad = syncload.NewStatsSyncLoad(handle)
 	handle.StatsGlobal = globalstats.NewStatsGlobal(handle)
 	handle.DDL = ddl.NewDDLHandler(

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -120,7 +120,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 	tableInfo1 := tbl1.Meta()
 	h, err := handle.NewHandle(
-		testKit.Session(),
+		context.Background(),
 		testKit2.Session(),
 		time.Millisecond,
 		do.SysSessionPool(),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/57960

Problem Summary:

### What changed and how does it work?

In this PR, we used the new API to speed up table iteration during PQ initialization. The duration was reduced from 23 minutes to 1 minute for 3 million tables.

It will use more goroutines to get the table info from TiKV. The concurrency is half of the CPU cores.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/58825#issuecomment-2664867551)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Accelerating TiDB's initialization of the auto-analyze queue
加速 TiDB 初始化自动分析队列的过程
```
