### PR TITLE
types: throw error when input exceeds the range of float32 in vector

### DIFF
--- a/pkg/expression/integration_test/integration_test.go
+++ b/pkg/expression/integration_test/integration_test.go
@@ -890,9 +890,12 @@ func TestVectorArithmatic(t *testing.T) {
 	tk.MustQueryToErr(`SELECT VEC_FROM_TEXT('[1]') + 2;`)
 	tk.MustQueryToErr(`SELECT VEC_FROM_TEXT('[1]') + '2';`)
 
+	// Input outside the float32 value range will result in an error.
 	tk.MustQueryToErr(`SELECT VEC_FROM_TEXT('[3e38]') + '[3e38]';`)
 	tk.MustQuery(`SELECT VEC_FROM_TEXT('[1,2,3]') * '[4,5,6]';`).Check(testkit.Rows("[4,10,18]"))
 	tk.MustQueryToErr(`SELECT VEC_FROM_TEXT('[1e37]') * '[1e37]';`)
+	tk.MustQueryToErr("select VEC_L2_NORM('[1e39]') + 1")
+	tk.MustQueryToErr("select VEC_L2_NORM('[1e39]')*0 + 1")
 }
 
 func TestVectorFunctions(t *testing.T) {

--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -233,6 +233,11 @@ func ParseVectorFloat32(s string) (VectorFloat32, error) {
 			valueError = errors.Errorf("infinite value not allowed in vector")
 			return false
 		}
+		// Check if the value can be safely converted to float32
+		if v < -math.MaxFloat32 || v > math.MaxFloat32 {
+			valueError = errors.Errorf("value %v out of range for float32", v)
+			return false
+		}
 		values = append(values, float32(v))
 		return true
 	})

--- a/pkg/types/vector_test.go
+++ b/pkg/types/vector_test.go
@@ -101,6 +101,9 @@ func TestVectorParse(t *testing.T) {
 	require.False(t, v.IsZeroValue())
 	require.Equal(t, 1, v.Compare(types.ZeroVectorFloat32))
 	require.Equal(t, -1, types.ZeroVectorFloat32.Compare(v))
+
+	v, err = types.ParseVectorFloat32(`[-1e39, 1e39]`)
+	require.EqualError(t, err, "value -1e+39 out of range for float32")
 }
 
 func TestVectorDatum(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58379

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
