### PR TITLE
executor: fix prepared protocol charset

### DIFF
--- a/pkg/executor/prepared.go
+++ b/pkg/executor/prepared.go
@@ -97,11 +97,11 @@ func (e *PrepareExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	if e.needReset {
 		params = vars.GetParseParams()
 	} else {
-		var params_arr [2]parser.ParseParam
+		var paramsArr [2]parser.ParseParam
 		charset, collation := vars.GetCharsetInfo()
-		params_arr[0] = parser.CharsetConnection(charset)
-		params_arr[1] = parser.CollationConnection(collation)
-		params = params_arr[:]
+		paramsArr[0] = parser.CharsetConnection(charset)
+		paramsArr[1] = parser.CollationConnection(collation)
+		params = paramsArr[:]
 	}
 	if sqlParser, ok := e.Ctx().(sqlexec.SQLParser); ok {
 		// FIXME: ok... yet another parse API, may need some api interface clean.

--- a/pkg/executor/prepared.go
+++ b/pkg/executor/prepared.go
@@ -62,6 +62,8 @@ type PrepareExec struct {
 	// If it's generated from executing "prepare stmt from '...'", the process is parse -> plan -> executor
 	// If it's generated from the prepare protocol, the process is session.PrepareStmt -> NewPrepareExec
 	// They both generate a PrepareExec struct, but the second case needs to reset the statement context while the first already do that.
+	// Also, the second case need charset_client param since SQL is directly passed from clients.
+	// While the text-prepare already transformed charset by parser.
 	needReset bool
 }
 
@@ -87,23 +89,28 @@ func (e *PrepareExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 			return nil
 		}
 	}
-	charset, collation := vars.GetCharsetInfo()
 	var (
 		stmts []ast.StmtNode
 		err   error
 	)
+	var params []parser.ParseParam
+	if e.needReset {
+		params = vars.GetParseParams()
+	} else {
+		var params_arr [2]parser.ParseParam
+		charset, collation := vars.GetCharsetInfo()
+		params_arr[0] = parser.CharsetConnection(charset)
+		params_arr[1] = parser.CollationConnection(collation)
+		params = params_arr[:]
+	}
 	if sqlParser, ok := e.Ctx().(sqlexec.SQLParser); ok {
 		// FIXME: ok... yet another parse API, may need some api interface clean.
-		stmts, _, err = sqlParser.ParseSQL(ctx, e.sqlText,
-			parser.CharsetConnection(charset),
-			parser.CollationConnection(collation))
+		stmts, _, err = sqlParser.ParseSQL(ctx, e.sqlText, params...)
 	} else {
 		p := parser.New()
 		p.SetParserConfig(vars.BuildParserConfig())
 		var warns []error
-		stmts, warns, err = p.ParseSQL(e.sqlText,
-			parser.CharsetConnection(charset),
-			parser.CollationConnection(collation))
+		stmts, warns, err = p.ParseSQL(e.sqlText, params...)
 		for _, warn := range warns {
 			e.Ctx().GetSessionVars().StmtCtx.AppendWarning(util.SyntaxWarn(warn))
 		}

--- a/pkg/executor/prepared_test.go
+++ b/pkg/executor/prepared_test.go
@@ -1193,3 +1193,26 @@ func TestExecuteWithWrongType(t *testing.T) {
 	tk.MustExec(`set @i0 = 0.0, @i1 = 0.0`)
 	tk.MustExec(`execute p2 using @i0, @i1`)
 }
+
+func TestIssue58870(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("set names GBK")
+	tk.MustExec(`CREATE TABLE tsecurity  (
+  security_id int(11) NOT NULL DEFAULT 0,
+  mkt_id smallint(6) NOT NULL DEFAULT 0,
+  security_code varchar(64) CHARACTER SET gbk COLLATE gbk_bin NOT NULL DEFAULT ' ',
+  security_name varchar(128) CHARACTER SET gbk COLLATE gbk_bin NOT NULL DEFAULT ' ',
+  PRIMARY KEY (security_id) USING BTREE
+) ENGINE = InnoDB CHARACTER SET = gbk COLLATE = gbk_bin ROW_FORMAT = Compact;`)
+	tk.MustExec("INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (1, '1', 1 ,'\xB2\xE2')")
+	tk.MustExec("PREPARE a FROM 'INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (2, 2, 2 ,\"\xB2\xE2\")'")
+	tk.MustExec("EXECUTE a")
+	stmt, _, _, err  := tk.Session().PrepareStmt("INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (3, 3, 3 ,\"\xB2\xE2\")")
+	require.Nil(t, err)
+	rs, err := tk.Session().ExecutePreparedStmt(context.TODO(), stmt, nil)
+	require.Nil(t, err)
+	require.Nil(t, rs)
+}

--- a/pkg/executor/prepared_test.go
+++ b/pkg/executor/prepared_test.go
@@ -1210,7 +1210,7 @@ func TestIssue58870(t *testing.T) {
 	tk.MustExec("INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (1, '1', 1 ,'\xB2\xE2')")
 	tk.MustExec("PREPARE a FROM 'INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (2, 2, 2 ,\"\xB2\xE2\")'")
 	tk.MustExec("EXECUTE a")
-	stmt, _, _, err  := tk.Session().PrepareStmt("INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (3, 3, 3 ,\"\xB2\xE2\")")
+	stmt, _, _, err := tk.Session().PrepareStmt("INSERT INTO tsecurity (security_id, security_code, mkt_id, security_name) VALUES (3, 3, 3 ,\"\xB2\xE2\")")
 	require.Nil(t, err)
 	rs, err := tk.Session().ExecutePreparedStmt(context.TODO(), stmt, nil)
 	require.Nil(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58870

Problem Summary:

When it is text-prepare, SQL will be parsed twice. The first time, it is already transformed to utf8 due to `charset_client`. Thus when it comes to executor, only the other two parameters need to set.

But if it is coming from prepare protocol, SQL have not been parsed before. We also need to set `charset_client` to transform it to utf8.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix broken prepare protocol when charset_client is not UTF8
```
