### PR TITLE
DXF: check the cause of `subtaskCtx` to decide the subtask state

### DIFF
--- a/pkg/disttask/framework/integrationtests/framework_test.go
+++ b/pkg/disttask/framework/integrationtests/framework_test.go
@@ -161,7 +161,7 @@ func TestFrameworkCancelTask(t *testing.T) {
 	registerExampleTask(t, c.MockCtrl, testutil.GetMockBasicSchedulerExt(c.MockCtrl), c.TestContext, nil)
 	var counter atomic.Int32
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterRunSubtask",
-		func(e taskexecutor.TaskExecutor, _ *error) {
+		func(e taskexecutor.TaskExecutor, _ *error, _ context.Context) {
 			if counter.Add(1) == 1 {
 				require.NoError(t, c.TaskMgr.CancelTask(c.Ctx, e.GetTaskBase().ID))
 			}
@@ -245,7 +245,7 @@ func TestFrameworkRunSubtaskCancelOrFailed(t *testing.T) {
 	t.Run("meet cancel on run subtask", func(t *testing.T) {
 		var counter atomic.Int32
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterRunSubtask",
-			func(e taskexecutor.TaskExecutor, errP *error) {
+			func(e taskexecutor.TaskExecutor, errP *error, _ context.Context) {
 				if counter.Add(1) == 1 {
 					e.CancelRunningSubtask()
 					*errP = taskexecutor.ErrCancelSubtask
@@ -259,7 +259,7 @@ func TestFrameworkRunSubtaskCancelOrFailed(t *testing.T) {
 	t.Run("meet some error on run subtask", func(t *testing.T) {
 		var counter atomic.Int32
 		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterRunSubtask",
-			func(_ taskexecutor.TaskExecutor, errP *error) {
+			func(_ taskexecutor.TaskExecutor, errP *error, _ context.Context) {
 				if counter.Add(1) == 1 {
 					*errP = errors.New("MockExecutorRunErr")
 				}

--- a/pkg/disttask/framework/scheduler/balancer.go
+++ b/pkg/disttask/framework/scheduler/balancer.go
@@ -74,7 +74,7 @@ func (b *balancer) balanceLoop(ctx context.Context, sm *Manager) {
 func (b *balancer) balance(ctx context.Context, sm *Manager) {
 	// we will use currUsedSlots to calculate adjusted eligible nodes during balance,
 	// it's initial value depends on the managed nodes, to have a consistent view,
-	// DO NOT call getManagedNodes twice during 1 balance.
+	// DO NOT call getNodes twice during 1 balance.
 	managedNodes := b.nodeMgr.getNodes()
 	b.currUsedSlots = make(map[string]int, len(managedNodes))
 	for _, n := range managedNodes {

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -471,7 +471,7 @@ func (e *BaseTaskExecutor) runSubtask(subtask *proto.Subtask) (resErr error) {
 		return subtaskErr
 	}
 
-	err := e.finishSubtask(subtaskCtx, subtask)
+	err := e.finishSubtask(e.stepCtx, subtask)
 	failpoint.InjectCall("syncAfterSubtaskFinish")
 	return err
 }

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -465,7 +465,7 @@ func (e *BaseTaskExecutor) runSubtask(subtask *proto.Subtask) (resErr error) {
 	defer func() {
 		subtaskCancel()
 	}()
-	failpoint.InjectCall("afterRunSubtask", e, &subtaskErr)
+	failpoint.InjectCall("afterRunSubtask", e, &subtaskErr, subtaskCtx)
 	logTask.End2(zap.InfoLevel, subtaskErr)
 
 	failpoint.InjectCall("mockTiDBShutdown", e, e.execID, e.GetTaskBase())

--- a/pkg/disttask/framework/taskexecutor/task_executor_test.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor_test.go
@@ -341,7 +341,6 @@ func TestTaskExecutorRun(t *testing.T) {
 			<-ctx.Done()
 			return ctx.Err()
 		})
-		e.taskExecExt.EXPECT().IsRetryableError(gomock.Any()).Return(true)
 		// keep running next subtask
 		nextSubtask := &proto.Subtask{SubtaskBase: proto.SubtaskBase{
 			ID: 2, Type: e.task1.Type, Step: proto.StepOne, State: proto.SubtaskStatePending, ExecID: "id"}}

--- a/tests/realtikvtest/addindextest1/disttask_test.go
+++ b/tests/realtikvtest/addindextest1/disttask_test.go
@@ -433,14 +433,12 @@ func TestAddIndexScheduleAway(t *testing.T) {
 			tk1.MustExec(updateExecID)
 		})
 	})
-	var subtaskCtx context.Context
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterRunSubtask",
 		func(_ taskexecutor.TaskExecutor, _ *error, ctx context.Context) {
-			subtaskCtx = ctx
+			require.Error(t, ctx.Err())
+			require.Equal(t, context.Canceled, context.Cause(ctx))
 		},
 	)
 	tk.MustExec("alter table t add index idx(b);")
 	require.NotEqual(t, int64(0), jobID.Load())
-	require.Error(t, subtaskCtx.Err())
-	require.Equal(t, context.Canceled, context.Cause(subtaskCtx))
 }

--- a/tests/realtikvtest/addindextest1/disttask_test.go
+++ b/tests/realtikvtest/addindextest1/disttask_test.go
@@ -99,7 +99,7 @@ func TestAddIndexDistBasic(t *testing.T) {
 
 	var counter atomic.Int32
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterRunSubtask",
-		func(e taskexecutor.TaskExecutor, errP *error) {
+		func(e taskexecutor.TaskExecutor, errP *error, _ context.Context) {
 			if counter.Add(1) == 1 {
 				*errP = context.Canceled
 			}
@@ -433,6 +433,14 @@ func TestAddIndexScheduleAway(t *testing.T) {
 			tk1.MustExec(updateExecID)
 		})
 	})
+	var subtaskCtx context.Context
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterRunSubtask",
+		func(_ taskexecutor.TaskExecutor, _ *error, ctx context.Context) {
+			subtaskCtx = ctx
+		},
+	)
 	tk.MustExec("alter table t add index idx(b);")
 	require.NotEqual(t, int64(0), jobID.Load())
+	require.Error(t, subtaskCtx.Err())
+	require.Equal(t, context.Canceled, context.Cause(subtaskCtx))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58827

Problem Summary:

See https://github.com/pingcap/tidb/issues/58827#issuecomment-2582290429

### What changed and how does it work?

1. check `subtaskCtx` instead of `stepCtx` in `markSubTaskCanceledOrFailed`
2. ~~remove `checkCtx` since we introduced `subtaskCtx`~~

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
