### PR TITLE
json: add json fuzz test for `json_extract` function and fix several bugs found by it | tidb-test=pr/2467

### DIFF
--- a/pkg/types/BUILD.bazel
+++ b/pkg/types/BUILD.bazel
@@ -113,6 +113,7 @@ go_test(
         "//pkg/util/collate",
         "//pkg/util/context",
         "//pkg/util/hack",
+        "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/types/json_binary_functions.go
+++ b/pkg/types/json_binary_functions.go
@@ -165,9 +165,13 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 	return
 }
 
-// quoteJSONString escapes interior quote and other characters for JSON_QUOTE
-// https://dev.mysql.com/doc/refman/5.7/en/json-creation-functions.html#function_json-quote
-// TODO: add JSON_QUOTE builtin
+// quoteJSONString escapes interior quote and other characters for json functions.
+//
+// The implementation of `JSON_QUOTE` doesn't use this function. The `JSON_QUOTE` used `goJSON` to encode the string
+// directly. Therefore, this function is not compatible with `JSON_QUOTE` function for the convience of internal usage.
+//
+// This function will add extra quotes to the string if it contains special characters which needs to escape, or it's not
+// a valid ECMAScript identifier.
 func quoteJSONString(s string) string {
 	var escapeByteMap = map[byte]string{
 		'\\': "\\\\",

--- a/pkg/types/json_path_expr_test.go
+++ b/pkg/types/json_path_expr_test.go
@@ -73,6 +73,12 @@ func TestValidatePathExpr(t *testing.T) {
 		{`$[`, false, 0},
 		{`$a.***[3]`, false, 0},
 		{`$1a`, false, 0},
+		{`$.ѿ`, false, 0},
+		{`$."ѿ"`, true, 1},
+		{"$.\"\\0\\", false, 0},
+		{`$.Ѡ`, false, 0}, // This test case is special, because Ѡ is 0xD1 0xA0 in UTF-8, and 0xA0 is a space character.
+		{`$."Ѡ"`, true, 1},
+		{`$.µ`, true, 1},
 	}
 
 	for _, test := range tests {

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -1541,7 +1541,7 @@ null
 NULL
 true
 3
-4
+4.0
 "string"
 select json_type(a) from test_json tj order by tj.id;
 json_type(a)
@@ -1557,7 +1557,7 @@ a
 3
 select a from test_json tj where a = 4.0;
 a
-4
+4.0
 select a from test_json tj where a = true;
 a
 true
@@ -1592,7 +1592,7 @@ a	count(1)
 NULL	1
 null	1
 3	1
-4	1
+4.0	1
 "string"	1
 {"a": [1, "2", {"aa": "bb"}, 4], "b": true}	1
 true	1

--- a/tests/integrationtest/r/expression/builtin.result
+++ b/tests/integrationtest/r/expression/builtin.result
@@ -713,7 +713,7 @@ create table tb5(a json, b bigint unsigned);
 insert into tb5 (a, b) values ('184467440737095516160', 18446744073709551615);
 select * from tb5 where cast(a as unsigned int)=b;
 a	b
-184467440737095500000	18446744073709551615
+1.844674407370955e20	18446744073709551615
 select * from tb5 where cast(b as unsigned int)=0;
 a	b
 drop table tb5;

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -838,7 +838,7 @@ j
 {"test": 3}
 {"test": 0}
 {"test": "0"}
-{"test": 0}
+{"test": 0.0}
 {"test": "aaabbb"}
 {"test": 3.1415}
 {"test": []}
@@ -881,7 +881,7 @@ j
 {"test": 3}
 {"test": 0}
 {"test": "0"}
-{"test": 0}
+{"test": 0.0}
 {"test": "aaabbb"}
 {"test": 3.1415}
 {"test": []}

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -817,3 +817,18 @@ set @a=1;
 execute stmt using @a, @a;
 json_object(?, ?)
 {"1": 1}
+select json_extract("0.0", "$");
+json_extract("0.0", "$")
+0.0
+select json_extract("[1E17]", "$");
+json_extract("[1E17]", "$")
+[1e17]
+select json_extract('[1E27]', '$');
+json_extract('[1E27]', '$')
+[1e27]
+select json_extract("{\"\\b\":\"\"}", "$");
+json_extract("{\"\\b\":\"\"}", "$")
+{"\b": ""}
+select json_extract("{\"\\f\":\"\"}", "$");
+json_extract("{\"\\f\":\"\"}", "$")
+{"\f": ""}

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -856,6 +856,7 @@ insert into tx2 values (json_array(922337203685477581)),(json_array(922337203685
 #
 # ordering by a JSON col is not supported in MySQL, and the order is a bit questionable in TiDB.
 # sort by count for test result stability.
+-- replace_regex /\[3\.0\]/[3]/
 select col, count(1) c from tx2 group by col order by c desc;
 
 

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -538,3 +538,14 @@ SELECT JSON_SCHEMA_VALID(b2, '{}') FROM t1;
 prepare stmt from 'select json_object(?, ?)';
 set @a=1;
 execute stmt using @a, @a;
+
+# TestIssue58888
+select json_extract("0.0", "$");
+select json_extract("[1E17]", "$");
+
+# TestIssue58894
+select json_extract('[1E27]', '$');
+
+# TestIssue58897
+select json_extract("{\"\\b\":\"\"}", "$");
+select json_extract("{\"\\f\":\"\"}", "$");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58897, close #58896, close #58895, close #58894, close #58888, close #37806

Problem Summary:

This PR adds a fuzz test for `json_extract` function and fix several bugs found by it.

### What changed and how does it work?

1. Add a fuzz test for `json_extract`.
2. Modify the behavior of `jsonMarshalStringTo` to specially handle the `\b` and `\f`.
3. Fix the json path parser by using `[]rune` to make sure we have correct unicode behavior.
4. Fix the scientific notation of float value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
