### PR TITLE
statistics: enhance dumpStatsDeltaToKV to return updated batch updates and ensure proper sorting

### DIFF
--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -183,7 +183,6 @@ func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool) error {
 
 			// Update deltaMap after the batch is successfully dumped.
 			for _, update := range batchUpdates {
-				UpdateTableDeltaMap(deltaMap, update.TableID, -update.Delta.Delta, -update.Delta.Count)
 				delete(deltaMap, update.TableID)
 			}
 
@@ -311,12 +310,6 @@ func (s *statsUsageImpl) dumpStatsDeltaToKV(
 		}
 	}
 	intest.Assert(len(updates) >= beforeLen, "updates can only be appended")
-	if len(updates) > beforeLen {
-		// Resort updates after appending new updates.
-		slices.SortFunc(updates, func(i, j *storage.DeltaUpdate) int {
-			return cmp.Compare(i.TableID, j.TableID)
-		})
-	}
 
 	// Batch update stats meta.
 	if err = storage.UpdateStatsMeta(utilstats.StatsCtx, sctx, statsVersion, updates...); err != nil {

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -166,12 +166,16 @@ func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool) error {
 			}
 
 			// Process all updates in the batch with a single transaction.
-			// Note: batchUpdates may be modified in dumpStatsDeltaToKV.
-			startTs, err := s.dumpStatsDeltaToKV(is, sctx, batchUpdates)
+			// Note: batchUpdates may be modified in dumpStatsDeltaToKV. (e.g. sorting, updating IsLocked)
+			startTs, updated, err := s.dumpStatsDeltaToKV(is, sctx, batchUpdates)
 			if err != nil {
 				return errors.Trace(err)
 			}
 			statsVersion = startTs
+			// Note: Ensure we use the updated slice after dumpStatsDeltaToKV,
+			// because dumpStatsDeltaToKV may modify the underlying array of batchUpdates.
+			// For example, dumpStatsDeltaToKV may sort the array.
+			batchUpdates = updated
 			intest.AssertFunc(
 				func() bool {
 					return slices.IsSortedFunc(batchUpdates, func(i, j *storage.DeltaUpdate) int {
@@ -233,14 +237,14 @@ func (s *statsUsageImpl) dumpStatsDeltaToKV(
 	is infoschema.InfoSchema,
 	sctx sessionctx.Context,
 	updates []*storage.DeltaUpdate,
-) (statsVersion uint64, err error) {
+) (statsVersion uint64, updated []*storage.DeltaUpdate, err error) {
 	if len(updates) == 0 {
-		return 0, nil
+		return 0, nil, nil
 	}
 	beforeLen := len(updates)
 	statsVersion, err = utilstats.GetStartTS(sctx)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, nil, errors.Trace(err)
 	}
 
 	// Collect all table IDs that need lock checking.
@@ -261,7 +265,7 @@ func (s *statsUsageImpl) dumpStatsDeltaToKV(
 	// Batch get lock status for all tables.
 	lockedTables, err := s.statsHandle.GetLockedTables(allTableIDs...)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, nil, errors.Trace(err)
 	}
 
 	// Prepare batch updates
@@ -310,13 +314,21 @@ func (s *statsUsageImpl) dumpStatsDeltaToKV(
 		}
 	}
 	intest.Assert(len(updates) >= beforeLen, "updates can only be appended")
+	if len(updates) > beforeLen {
+		// Resort updates after appending new updates.
+		slices.SortFunc(updates, func(i, j *storage.DeltaUpdate) int {
+			return cmp.Compare(i.TableID, j.TableID)
+		})
+	}
 
 	// Batch update stats meta.
 	if err = storage.UpdateStatsMeta(utilstats.StatsCtx, sctx, statsVersion, updates...); err != nil {
-		return 0, errors.Trace(err)
+		return 0, nil, errors.Trace(err)
 	}
 
-	return statsVersion, nil
+	// Because we may sort the updates, we need to return the updated slice.
+	// Otherwise the caller may use the original slice and get wrong results.
+	return statsVersion, updates, nil
 }
 
 // DumpColStatsUsageToKV sweeps the whole list, updates the column stats usage map and dumps it to KV.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/57869

Problem Summary:

### What changed and how does it work?

1. Remove useless map update. 
2. Make sure we use the right slice to update the delta map and record the historical stats meta.
~~3. I also updated it to use `SELECT FOR UPDATE NOWAIT` to avoid the deadlock in the first place.~~


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/58929#issuecomment-2592179266)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
