### PR TITLE
ttl: rollback the scan trasnaction even if the `BEGIN` failed.

### DIFF
--- a/pkg/ttl/ttlworker/BUILD.bazel
+++ b/pkg/ttl/ttlworker/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "del_test.go",
         "job_manager_integration_test.go",
         "job_manager_test.go",
+        "scan_integration_test.go",
         "scan_test.go",
         "session_integration_test.go",
         "session_test.go",

--- a/pkg/ttl/ttlworker/scan_integration_test.go
+++ b/pkg/ttl/ttlworker/scan_integration_test.go
@@ -1,0 +1,99 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttlworker_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testflag"
+	"github.com/pingcap/tidb/pkg/ttl/cache"
+	"github.com/pingcap/tidb/pkg/ttl/ttlworker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelWhileScan(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("create table test.t (id int, created_at datetime) TTL= created_at + interval 1 hour")
+	testTable, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	for i := 0; i < 10000; i++ {
+		tk.MustExec(fmt.Sprintf("insert into test.t values (%d, NOW() - INTERVAL 24 HOUR)", i))
+	}
+	testPhysicalTableCache, err := cache.NewPhysicalTable(ast.NewCIStr("test"), testTable.Meta(), ast.NewCIStr(""))
+	require.NoError(t, err)
+
+	delCh := make(chan *ttlworker.TTLDeleteTask)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range delCh {
+			// do nothing
+		}
+	}()
+
+	testStart := time.Now()
+	testDuration := time.Second
+	if testflag.Long() {
+		testDuration = time.Minute
+	}
+	for time.Since(testStart) < testDuration {
+		ctx, cancel := context.WithCancel(context.Background())
+		ttlTask := ttlworker.NewTTLScanTask(ctx, testPhysicalTableCache, &cache.TTLTask{
+			JobID:            "test",
+			TableID:          1,
+			ScanID:           1,
+			ScanRangeStart:   nil,
+			ScanRangeEnd:     nil,
+			ExpireTime:       time.Now().Add(-12 * time.Hour),
+			OwnerID:          "test",
+			OwnerAddr:        "test",
+			OwnerHBTime:      time.Now(),
+			Status:           cache.TaskStatusRunning,
+			StatusUpdateTime: time.Now(),
+			State:            &cache.TTLTaskState{},
+			CreatedTime:      time.Now(),
+		})
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ttlTask.DoScan(ctx, delCh, dom.SysSessionPool())
+		}()
+
+		// randomly sleep for a while and cancel the scan
+		time.Sleep(time.Duration(rand.Int() % int(time.Millisecond*10)))
+		startCancel := time.Now()
+		cancel()
+
+		wg.Wait()
+		// make sure the scan is canceled in time
+		require.Less(t, time.Since(startCancel), time.Second)
+	}
+
+	close(delCh)
+	wg.Wait()
+}

--- a/pkg/ttl/ttlworker/scan_test.go
+++ b/pkg/ttl/ttlworker/scan_test.go
@@ -554,3 +554,21 @@ func TestScanTaskCancelStmt(t *testing.T) {
 	task.ctx, cancel = context.WithCancel(context.Background())
 	testCancel(context.Background(), cancel)
 }
+
+// NewTTLScanTask creates a new TTL scan task for test.
+func NewTTLScanTask(ctx context.Context, tbl *cache.PhysicalTable, ttlTask *cache.TTLTask) *ttlScanTask {
+	return &ttlScanTask{
+		ctx:        ctx,
+		tbl:        tbl,
+		TTLTask:    ttlTask,
+		statistics: &ttlStatistics{},
+	}
+}
+
+// DoScan is an exported version of `doScan` for test.
+func (t *ttlScanTask) DoScan(ctx context.Context, delCh chan<- *TTLDeleteTask, sessPool util.SessionPool) *ttlScanTaskExecResult {
+	return t.doScan(ctx, delCh, sessPool)
+}
+
+// TTLDeleteTask is an exported version of `ttlDeleteTask` for test.
+type TTLDeleteTask = ttlDeleteTask


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #58900

Problem Summary:

Previously, the `RunInTxn` will only rollback the transaction after the `BEGIN` runs successfully. However, if the `BEGIN` is killed after setting the transaction status, it can still leave a valid transaction. We'll need to also `ROLLBACK` it.

The effect is that when we are cancelling a TTL task (scaling the workers, stepping out of the TTL window, stopping the TTL function...), a session with valid transaction may pollute the session pool.

### What changed and how does it work?

Move the `defer ... ROLLBACK` logic to the top of the `RunInTxn` function.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

```release-note
Fix the issue that canceling a TTL task may return a polluted session to global session pool.
```
