### PR TITLE
*: fix tidb panic in (*memoryUsageAlarm).recordSQL

### DIFF
--- a/util/expensivequery/expensivequerey_test.go
+++ b/util/expensivequery/expensivequerey_test.go
@@ -94,19 +94,23 @@ func TestGetCurrentMemoryUsage(t *testing.T) {
 	assert.Equal(t, int64(0), getCurrentMemoryUsage(nil, stmtCtx))
 	// case 2, refCount is not nil
 	assert.Equal(t, memUsage, getCurrentMemoryUsage(&refCount, stmtCtx))
+	assert.Equal(t, stmtctx.ReferenceCount(0), refCount)
 	// case 3, panic inside getCurrentMemoryUsage
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/util/expensivequery/panicWhenGetCurrentMemoryUsage", `return`))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/util/expensivequery/panicWhenGetCurrentMemoryUsage"))
 	}()
 	assert.Equal(t, int64(0), getCurrentMemoryUsage(&refCount, stmtCtx))
+	assert.Equal(t, stmtctx.ReferenceCount(0), refCount)
 	// case 4, refCount is not nil, but refCount.TryIncrease() return false
 	assert.Equal(t, true, refCount.TryFreeze())
 	assert.Equal(t, int64(0), getCurrentMemoryUsage(&refCount, stmtCtx))
 	refCount.UnFreeze()
+	assert.Equal(t, stmtctx.ReferenceCount(0), refCount)
 	// case 5, stmtCtx is reset
 	assert.Equal(t, true, refCount.TryFreeze())
 	*stmtCtx = stmtctx.StatementContext{}
 	refCount.UnFreeze()
 	assert.Equal(t, int64(0), getCurrentMemoryUsage(&refCount, stmtCtx))
+	assert.Equal(t, stmtctx.ReferenceCount(0), refCount)
 }

--- a/util/expensivequery/memory_usage_alarm.go
+++ b/util/expensivequery/memory_usage_alarm.go
@@ -175,9 +175,7 @@ func getCurrentMemoryUsage(refCount *stmtctx.ReferenceCount, stmtCtx *stmtctx.St
 		}()
 		if tracker := stmtCtx.MemTracker; tracker != nil {
 			ret = tracker.MaxConsumed()
-			if _, _err_ := failpoint.Eval(_curpkg_("panicWhenGetCurrentMemoryUsage")); _err_ == nil {
-				panic("panic when get current memory usage")
-			}
+			failpoint.Inject("panicWhenGetCurrentMemoryUsage", func() { panic("panic when get current memory usage") })
 		}
 	}
 	return

--- a/util/expensivequery/memory_usage_alarm.go
+++ b/util/expensivequery/memory_usage_alarm.go
@@ -231,9 +231,9 @@ func (record *memoryUsageAlarm) recordSQL(sm util.SessionManager) {
 
 	_, err = f.WriteString("The 10 SQLs with the most memory usage for OOM analysis\n")
 	printTop10(func(i, j int) bool {
-		i_consume := getCurrentMemoryUsage(pinfo[i].RefCountOfStmtCtx, pinfo[i].StmtCtx)
-		j_consume := getCurrentMemoryUsage(pinfo[j].RefCountOfStmtCtx, pinfo[j].StmtCtx)
-		return i_consume > j_consume
+		iConsume := getCurrentMemoryUsage(pinfo[i].RefCountOfStmtCtx, pinfo[i].StmtCtx)
+		jConsume := getCurrentMemoryUsage(pinfo[j].RefCountOfStmtCtx, pinfo[j].StmtCtx)
+		return iConsume > jConsume
 	})
 
 	_, err = f.WriteString("The 10 SQLs with the most time usage for OOM analysis\n")

--- a/util/expensivequery/memory_usage_alarm.go
+++ b/util/expensivequery/memory_usage_alarm.go
@@ -175,7 +175,9 @@ func getCurrentMemoryUsage(refCount *stmtctx.ReferenceCount, stmtCtx *stmtctx.St
 		}()
 		if tracker := stmtCtx.MemTracker; tracker != nil {
 			ret = tracker.MaxConsumed()
-			failpoint.Inject("panicWhenGetCurrentMemoryUsage", func() { panic("panic when get current memory usage") })
+			if _, _err_ := failpoint.Eval(_curpkg_("panicWhenGetCurrentMemoryUsage")); _err_ == nil {
+				panic("panic when get current memory usage")
+			}
 		}
 	}
 	return

--- a/util/expensivequery/memory_usage_alarm.go
+++ b/util/expensivequery/memory_usage_alarm.go
@@ -174,8 +174,8 @@ func getCurrentMemoryUsage(refCount *stmtctx.ReferenceCount, stmtCtx *stmtctx.St
 			refCount.Decrease()
 		}()
 		if tracker := stmtCtx.MemTracker; tracker != nil {
-			failpoint.Inject("panicWhenGetCurrentMemoryUsage", func() { panic("panic when get current memory usage") })
 			ret = tracker.MaxConsumed()
+			failpoint.Inject("panicWhenGetCurrentMemoryUsage", func() { panic("panic when get current memory usage") })
 		}
 	}
 	return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58942

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix tidb panic in (*memoryUsageAlarm).recordSQL
```
