### PR TITLE
statistics: do not ignore DDL event handing errors

### DIFF
--- a/pkg/ddl/notifier/subscribe.go
+++ b/pkg/ddl/notifier/subscribe.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	goerr "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -161,7 +162,7 @@ func (n *DDLNotifier) start() {
 		case <-ticker.C:
 			if err := n.processEvents(ctx); err != nil {
 				intest.Assert(
-					errors.ErrorEqual(err, context.Canceled),
+					errors.ErrorEqual(err, context.Canceled) || strings.Contains(err.Error(), "mock handleTaskOnce error"),
 					fmt.Sprintf("error processing events: %v", err),
 				)
 				logutil.Logger(ctx).Error("Error processing events", zap.Error(err))

--- a/pkg/ddl/notifier/subscribe.go
+++ b/pkg/ddl/notifier/subscribe.go
@@ -160,7 +160,10 @@ func (n *DDLNotifier) start() {
 			return
 		case <-ticker.C:
 			if err := n.processEvents(ctx); err != nil {
-				intest.Assert(false, fmt.Sprintf("Error processing events: %v", err))
+				intest.Assert(
+					errors.ErrorEqual(err, context.Canceled) || errors.ErrorEqual(err, context.DeadlineExceeded),
+					fmt.Sprintf("error processing events: %v", err),
+				)
 				logutil.Logger(ctx).Error("Error processing events", zap.Error(err))
 			}
 		}

--- a/pkg/ddl/notifier/subscribe.go
+++ b/pkg/ddl/notifier/subscribe.go
@@ -160,6 +160,7 @@ func (n *DDLNotifier) start() {
 			return
 		case <-ticker.C:
 			if err := n.processEvents(ctx); err != nil {
+				intest.Assert(false, fmt.Sprintf("Error processing events: %v", err))
 				logutil.Logger(ctx).Error("Error processing events", zap.Error(err))
 			}
 		}

--- a/pkg/ddl/notifier/subscribe.go
+++ b/pkg/ddl/notifier/subscribe.go
@@ -161,7 +161,7 @@ func (n *DDLNotifier) start() {
 		case <-ticker.C:
 			if err := n.processEvents(ctx); err != nil {
 				intest.Assert(
-					errors.ErrorEqual(err, context.Canceled) || errors.ErrorEqual(err, context.DeadlineExceeded),
+					errors.ErrorEqual(err, context.Canceled),
 					fmt.Sprintf("error processing events: %v", err),
 				)
 				logutil.Logger(ctx).Error("Error processing events", zap.Error(err))

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -32,7 +32,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         ":ddl",
         "//pkg/ddl/notifier",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -16,6 +16,7 @@ package ddl
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
@@ -24,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 type ddlHandlerImpl struct {
@@ -48,7 +50,9 @@ func NewDDLHandler(
 
 // HandleDDLEvent begins to process a ddl task.
 func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Context, s *notifier.SchemaChangeEvent) error {
-	return h.sub.handle(ctx, sctx, s)
+	err := h.sub.handle(ctx, sctx, s)
+	intest.Assert(err == nil, fmt.Sprintf("handle ddl event failed, err: %v", err))
+	return err
 }
 
 // DDLEventCh returns ddl events channel in handle.

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
@@ -53,7 +54,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Con
 	err := h.sub.handle(ctx, sctx, s)
 	if err != nil {
 		intest.Assert(
-			errors.ErrorEqual(err, context.Canceled),
+			errors.ErrorEqual(err, context.Canceled) || strings.Contains(err.Error(), "mock handleTaskOnce error"),
 			fmt.Sprintf("handle ddl event failed, err: %v", err),
 		)
 	}

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -21,11 +21,9 @@ import (
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics/handle/lockstats"
-	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/storage"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
-	"go.uber.org/zap"
 )
 
 type ddlHandlerImpl struct {
@@ -50,16 +48,7 @@ func NewDDLHandler(
 
 // HandleDDLEvent begins to process a ddl task.
 func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Context, s *notifier.SchemaChangeEvent) error {
-	// Ideally, we shouldn't allow any errors to be ignored, but for now, some queries can fail.
-	// Temporarily ignore the error and we need to check all queries to ensure they are correct.
-	if err := h.sub.handle(ctx, sctx, s); err != nil {
-		statslogutil.StatsLogger().Warn(
-			"failed to handle DDL event",
-			zap.String("event", s.String()),
-			zap.Error(err),
-		)
-	}
-	return nil
+	return h.sub.handle(ctx, sctx, s)
 }
 
 // DDLEventCh returns ddl events channel in handle.

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -51,7 +51,13 @@ func NewDDLHandler(
 // HandleDDLEvent begins to process a ddl task.
 func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Context, s *notifier.SchemaChangeEvent) error {
 	err := h.sub.handle(ctx, sctx, s)
-	intest.Assert(err == nil, fmt.Sprintf("handle ddl event failed, err: %v", err))
+	if err != nil {
+		intest.Assert(
+			errors.ErrorEqual(err, context.Canceled) || errors.ErrorEqual(err, context.DeadlineExceeded),
+			fmt.Sprintf("handle ddl event failed, err: %v", err),
+		)
+	}
+
 	return err
 }
 

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -53,7 +53,7 @@ func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Con
 	err := h.sub.handle(ctx, sctx, s)
 	if err != nil {
 		intest.Assert(
-			errors.ErrorEqual(err, context.Canceled) || errors.ErrorEqual(err, context.DeadlineExceeded),
+			errors.ErrorEqual(err, context.Canceled),
 			fmt.Sprintf("handle ddl event failed, err: %v", err),
 		)
 	}

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -1390,8 +1390,34 @@ func TestDumpStatsDeltaBeforeHandleDDLEvent(t *testing.T) {
 	tk.MustExec("insert into t values (1), (2), (3)")
 	h := dom.StatsHandle()
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
+	// Also manually insert a histogram record.
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	_, err = tk.Exec("insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, version) values (?, 0, ?, 0, ?)", tbl.Meta().ID, 1, 1)
+	require.NoError(t, err)
 	// Find the DDL event.
 	event := findEvent(h.DDLEventCh(), model.ActionCreateTable)
-	err := statstestutil.HandleDDLEventWithTxn(h, event)
+	err = statstestutil.HandleDDLEventWithTxn(h, event)
+	require.NoError(t, err)
+}
+
+func TestDumpStatsDeltaBeforeHandleAddColumnEvent(t *testing.T) {
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t (c1 int, c2 int, index idx(c1, c2))")
+	// Insert some data.
+	testKit.MustExec("insert into t values (1, 2), (2, 3), (3, 4)")
+	testKit.MustExec("analyze table t")
+	// Add column.
+	testKit.MustExec("alter table t add column c10 int")
+	// Insert some data.
+	testKit.MustExec("insert into t values (4, 5, 6)")
+	// Analyze table to force create the histogram meta record.
+	testKit.MustExec("analyze table t")
+	// Find the add column event.
+	event := findEvent(do.StatsHandle().DDLEventCh(), model.ActionAddColumn)
+	err := statstestutil.HandleDDLEventWithTxn(do.StatsHandle(), event)
 	require.NoError(t, err)
 }

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -458,7 +458,7 @@ func InsertColStats2KV(
 			continue
 		}
 
-		// If this stats exists, we insert histogram meta first, the distinct_count will always be one.
+		// If this stats doest not exist, we insert histogram meta first, the distinct_count will always be one.
 		if _, err = util.ExecWithCtx(
 			ctx, sctx,
 			`insert into mysql.stats_histograms
@@ -501,7 +501,7 @@ func InsertTableStats2KV(
 	}
 	if _, err = util.ExecWithCtx(
 		ctx, sctx,
-		"insert into mysql.stats_meta (version, table_id) values(%?, %?)",
+		"insert ignore into mysql.stats_meta (version, table_id) values(%?, %?)",
 		startTS, physicalID,
 	); err != nil {
 		return 0, errors.Trace(err)
@@ -509,7 +509,7 @@ func InsertTableStats2KV(
 	for _, col := range info.Columns {
 		if _, err = util.ExecWithCtx(
 			ctx, sctx,
-			`insert into mysql.stats_histograms
+			`insert ignore into mysql.stats_histograms
 				(table_id, is_index, hist_id, distinct_count, version)
 			values (%?, 0, %?, 0, %?)`,
 			physicalID, col.ID, startTS,
@@ -520,7 +520,7 @@ func InsertTableStats2KV(
 	for _, idx := range info.Indices {
 		if _, err = util.ExecWithCtx(
 			ctx, sctx,
-			`insert into mysql.stats_histograms
+			`insert ignore into mysql.stats_histograms
 				(table_id, is_index, hist_id, distinct_count, version)
 			values(%?, 1, %?, 0, %?)`,
 			physicalID, idx.ID, startTS,


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/58545

Problem Summary:

### What changed and how does it work?

I checked all the ddl event handlers, the only one that can meet duplicate key error is insert the stats meta. So in this PR I used `insert ignore into` to avoid the error.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
