### PR TITLE
domain: cleanup topo keys properly

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1247,10 +1247,6 @@ func (do *Domain) Close() {
 	if do.ddl != nil {
 		terror.Log(do.ddl.Stop())
 	}
-	if do.info != nil {
-		do.info.RemoveServerInfo()
-		do.info.RemoveMinStartTS()
-	}
 	ttlJobManager := do.ttlJobManager.Load()
 	if ttlJobManager != nil {
 		logutil.BgLogger().Info("stopping ttlJobManager")
@@ -1275,20 +1271,30 @@ func (do *Domain) Close() {
 
 	do.runawayManager.Stop()
 
-	if do.unprefixedEtcdCli != nil {
-		terror.Log(errors.Trace(do.unprefixedEtcdCli.Close()))
-	}
-
 	do.slowQuery.Close()
+
 	do.cancelFns.mu.Lock()
 	for _, f := range do.cancelFns.fns {
 		f()
 	}
 	do.cancelFns.mu.Unlock()
+
+	// Clean etcd session and close the clients.
+	// We should wait all the etcd keys keeper to exit
+	// in case the keeper rewrite the key after the cleaning.
 	do.wg.Wait()
+	if do.info != nil {
+		do.info.RemoveServerInfo()
+		do.info.RemoveMinStartTS()
+		do.info.RemoveTopologyInfo()
+	}
+	if do.unprefixedEtcdCli != nil {
+		terror.Log(errors.Trace(do.unprefixedEtcdCli.Close()))
+	}
 	if do.etcdClient != nil {
 		terror.Log(errors.Trace(do.etcdClient.Close()))
 	}
+
 	do.sysSessionPool.Close()
 	variable.UnregisterStatistics(do.BindHandle())
 	if do.onClose != nil {

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -912,6 +912,21 @@ func (is *InfoSyncer) updateTopologyAliveness(ctx context.Context) error {
 		clientv3.WithLease(is.topologySession.Lease()))
 }
 
+func (is *InfoSyncer) RemoveTopologyInfo() {
+	if is.etcdCli == nil {
+		return
+	}
+	prefix := fmt.Sprintf(
+		"%s/%s",
+		TopologyInformationPath,
+		net.JoinHostPort(is.info.IP, strconv.Itoa(int(is.info.Port))),
+	)
+	err := util.DeleteKeysWithPrefixFromEtcd(prefix, is.etcdCli, keyOpDefaultRetryCnt, keyOpDefaultTimeout)
+	if err != nil {
+		logutil.BgLogger().Error("remove topology info failed", zap.Error(err))
+	}
+}
+
 // GetPrometheusAddr gets prometheus Address
 func GetPrometheusAddr() (string, error) {
 	is, err := getGlobalInfoSyncer()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58983 58983

Problem Summary:

TiDB should remove the topology keys while closing the domain.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviours
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
