### PR TITLE
executor: make retriever memory tracker fine grained

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -101,7 +101,10 @@ type memtableRetriever struct {
 	initialized bool
 	extractor   base.MemTablePredicateExtractor
 	is          infoschema.InfoSchema
-	memTracker  *memory.Tracker
+
+	memTracker      *memory.Tracker
+	accMemPerBatch  int64
+	accMemRecordCnt int
 }
 
 // retrieve implements the infoschemaRetriever interface
@@ -238,8 +241,10 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			return nil, err
 		}
 		e.initialized = true
-		if e.memTracker != nil {
-			e.memTracker.Consume(calculateDatumsSize(e.rows))
+		if e.memTracker != nil && e.accMemRecordCnt > 0 {
+			e.memTracker.Consume(e.accMemPerBatch)
+			e.accMemRecordCnt = 0
+			e.accMemPerBatch = 0
 		}
 	}
 
@@ -256,6 +261,20 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 	}
 	e.rowIdx += retCount
 	return adjustColumns(ret, e.columns, e.table), nil
+}
+
+func (e *memtableRetriever) recordMemoryConsume(data []types.Datum) {
+	if e.memTracker == nil {
+		return
+	}
+	size := types.EstimatedMemUsage(data, 1)
+	e.accMemPerBatch += size
+	e.accMemRecordCnt++
+	if e.accMemRecordCnt >= 1024 {
+		e.memTracker.Consume(int64(e.accMemPerBatch))
+		e.accMemPerBatch = 0
+		e.accMemRecordCnt = 0
+	}
 }
 
 func getAutoIncrementID(
@@ -342,6 +361,7 @@ func (e *memtableRetriever) setDataForVariablesInfo(ctx sessionctx.Context) erro
 			row[6].SetString(possibleValues, mysql.DefaultCollationName)
 		}
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -371,6 +391,7 @@ func (e *memtableRetriever) setDataForUserAttributes(ctx context.Context, sctx s
 		}
 		row := types.MakeDatums(user, host, attribute)
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 
 	e.rows = rows
@@ -418,6 +439,7 @@ func (e *memtableRetriever) setDataFromSchemata(ctx sessionctx.Context) error {
 			policyName,            // TIDB_PLACEMENT_POLICY_NAME
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 	return nil
@@ -476,6 +498,7 @@ func (e *memtableRetriever) setDataForStatisticsInTable(
 					nil,                   // Expression
 				)
 				rows = append(rows, record)
+				e.recordMemoryConsume(record)
 			}
 		}
 	}
@@ -538,6 +561,7 @@ func (e *memtableRetriever) setDataForStatisticsInTable(
 				expression,            // Expression
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	e.rows = append(e.rows, rows...)
@@ -590,6 +614,7 @@ func (e *memtableRetriever) setDataFromReferConst(ctx context.Context, sctx sess
 				fk.RefTable.O,         // REFERENCED_TABLE_NAME
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	e.rows = rows
@@ -701,6 +726,7 @@ func (e *memtableRetriever) setDataFromOneTable(
 			policyName,            // TIDB_PLACEMENT_POLICY_NAME
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	} else {
 		record := types.MakeDatums(
 			infoschema.CatalogVal, // TABLE_CATALOG
@@ -730,6 +756,7 @@ func (e *memtableRetriever) setDataFromOneTable(
 			nil,                   // TIDB_PLACEMENT_POLICY_NAME
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	return rows, nil
 }
@@ -833,6 +860,7 @@ func (e *memtableRetriever) setDataFromTables(ctx context.Context, sctx sessionc
 					nil,                   // TIDB_PLACEMENT_POLICY_NAME
 				)
 				rows = append(rows, record)
+				e.recordMemoryConsume(record)
 				return true
 			})
 			e.rows = rows
@@ -899,6 +927,7 @@ func (e *memtableRetriever) setDataFromCheckConstraints(ctx context.Context, sct
 						fmt.Sprintf("(%s)", constraint.ExprString), // CHECK_CLAUSE
 					)
 					rows = append(rows, record)
+					e.recordMemoryConsume(record)
 				}
 			}
 		}
@@ -945,6 +974,7 @@ func (e *memtableRetriever) setDataFromTiDBCheckConstraints(ctx context.Context,
 					table.ID,     // TABLE_ID
 				)
 				rows = append(rows, record)
+				e.recordMemoryConsume(record)
 			}
 		}
 	}
@@ -1287,6 +1317,7 @@ func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sess
 				nil,                   // TIDB_PLACEMENT_POLICY_NAME
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		} else {
 			for i, pi := range table.GetPartitionInfo().Definitions {
 				if !ex.HasPartition(pi.Name.L) {
@@ -1380,6 +1411,7 @@ func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sess
 					policyName,            // TIDB_PLACEMENT_POLICY_NAME
 				)
 				rows = append(rows, record)
+				e.recordMemoryConsume(record)
 			}
 		}
 	}
@@ -1412,7 +1444,7 @@ func (e *memtableRetriever) setDataFromIndexes(ctx context.Context, sctx session
 	return nil
 }
 
-func (*memtableRetriever) setDataFromIndex(
+func (e *memtableRetriever) setDataFromIndex(
 	sctx sessionctx.Context,
 	schema ast.CIStr,
 	tb *model.TableInfo,
@@ -1446,6 +1478,7 @@ func (*memtableRetriever) setDataFromIndex(
 			0,            // IS_GLOBAL
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	for _, idxInfo := range tb.Indices {
 		if idxInfo.State != model.StatePublic {
@@ -1492,6 +1525,7 @@ func (*memtableRetriever) setDataFromIndex(
 				idxInfo.Global,  // IS_GLOBAL
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	return rows, nil
@@ -1540,6 +1574,7 @@ func (e *memtableRetriever) setDataFromViews(ctx context.Context, sctx sessionct
 			collation,                       // COLLATION_CONNECTION
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 	return nil
@@ -1606,6 +1641,7 @@ func (e *memtableRetriever) dataForTiKVStoreStatus(ctx context.Context, sctx ses
 			}
 		}
 		e.rows = append(e.rows, row)
+		e.recordMemoryConsume(row)
 	}
 	return nil
 }
@@ -1687,16 +1723,16 @@ func (e *DDLJobsReaderExec) Close() error {
 
 func (e *memtableRetriever) setDataFromEngines() {
 	var rows [][]types.Datum
-	rows = append(rows,
-		types.MakeDatums(
-			"InnoDB",  // Engine
-			"DEFAULT", // Support
-			"Supports transactions, row-level locking, and foreign keys", // Comment
-			"YES", // Transactions
-			"YES", // XA
-			"YES", // Savepoints
-		),
+	record := types.MakeDatums(
+		"InnoDB",  // Engine
+		"DEFAULT", // Support
+		"Supports transactions, row-level locking, and foreign keys", // Comment
+		"YES", // Transactions
+		"YES", // XA
+		"YES", // Savepoints
 	)
+	rows = append(rows, record)
+	e.recordMemoryConsume(record)
 	e.rows = rows
 }
 
@@ -1704,9 +1740,9 @@ func (e *memtableRetriever) setDataFromCharacterSets() {
 	charsets := charset.GetSupportedCharsets()
 	var rows = make([][]types.Datum, 0, len(charsets))
 	for _, charset := range charsets {
-		rows = append(rows,
-			types.MakeDatums(charset.Name, charset.DefaultCollation, charset.Desc, charset.Maxlen),
-		)
+		record := types.MakeDatums(charset.Name, charset.DefaultCollation, charset.Desc, charset.Maxlen)
+		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 }
@@ -1719,10 +1755,10 @@ func (e *memtableRetriever) setDataFromCollations() {
 		if collation.IsDefault {
 			isDefault = "Yes"
 		}
-		rows = append(rows,
-			types.MakeDatums(collation.Name, collation.CharsetName, collation.ID,
-				isDefault, "Yes", collation.Sortlen, collation.PadAttribute),
-		)
+		record := types.MakeDatums(collation.Name, collation.CharsetName, collation.ID,
+			isDefault, "Yes", collation.Sortlen, collation.PadAttribute)
+		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 }
@@ -1731,9 +1767,9 @@ func (e *memtableRetriever) dataForCollationCharacterSetApplicability() {
 	collations := collate.GetSupportedCollations()
 	var rows = make([][]types.Datum, 0, len(collations))
 	for _, collation := range collations {
-		rows = append(rows,
-			types.MakeDatums(collation.Name, collation.CharsetName),
-		)
+		record := types.MakeDatums(collation.Name, collation.CharsetName)
+		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 }
@@ -1777,6 +1813,7 @@ func (e *memtableRetriever) dataForTiDBClusterInfo(ctx sessionctx.Context) error
 			}
 		}
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -1804,7 +1841,7 @@ func (e *memtableRetriever) setDataFromKeyColumnUsage(ctx context.Context, sctx 
 		if !ex.HasConstraintSchema(schema.L) {
 			continue
 		}
-		rs := keyColumnUsageInTable(schema, table, ex)
+		rs := e.keyColumnUsageInTable(schema, table, ex)
 		rows = append(rows, rs...)
 	}
 	e.rows = rows
@@ -1842,6 +1879,7 @@ func (e *memtableRetriever) setDataForProcessList(ctx sessionctx.Context) {
 		rows := pi.ToRow(ctx.GetSessionVars().StmtCtx.TimeZone())
 		record := types.MakeDatums(rows...)
 		records = append(records, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = records
 }
@@ -1869,11 +1907,12 @@ func (e *memtableRetriever) setDataForMetricTables() {
 			schema.Comment,                   // COMMENT
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 }
 
-func keyColumnUsageInTable(schema ast.CIStr, table *model.TableInfo, ex *plannercore.InfoSchemaKeyColumnUsageExtractor) [][]types.Datum {
+func (e *memtableRetriever) keyColumnUsageInTable(schema ast.CIStr, table *model.TableInfo, ex *plannercore.InfoSchemaKeyColumnUsageExtractor) [][]types.Datum {
 	var rows [][]types.Datum
 	if table.PKIsHandle && ex.HasPrimaryKey() {
 		for _, col := range table.Columns {
@@ -1893,6 +1932,7 @@ func keyColumnUsageInTable(schema ast.CIStr, table *model.TableInfo, ex *planner
 					nil,                          // REFERENCED_COLUMN_NAME
 				)
 				rows = append(rows, record)
+				e.recordMemoryConsume(record)
 				break
 			}
 		}
@@ -1939,6 +1979,7 @@ func keyColumnUsageInTable(schema ast.CIStr, table *model.TableInfo, ex *planner
 				nil,                   // REFERENCED_COLUMN_NAME
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	for _, fk := range table.ForeignKeys {
@@ -1967,6 +2008,7 @@ func keyColumnUsageInTable(schema ast.CIStr, table *model.TableInfo, ex *planner
 				fkRefCol,              // REFERENCED_COLUMN_NAME
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	return rows
@@ -2127,6 +2169,7 @@ func (e *memtableRetriever) setNewTiKVRegionStatusCol(region *pd.RegionInfo, tab
 		row[19].SetInt64(region.ReplicationStatus.StateID)
 	}
 	e.rows = append(e.rows, row)
+	e.recordMemoryConsume(row)
 }
 
 const (
@@ -2183,6 +2226,7 @@ func (e *memtableRetriever) setDataForHotRegionByMetrics(metrics []helper.HotTab
 		}
 		row[9].SetUint64(tblIndex.RegionMetric.FlowBytes)
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = append(e.rows, rows...)
 }
@@ -2222,6 +2266,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 					infoschema.PrimaryKeyType, // CONSTRAINT_TYPE
 				)
 				rows = append(rows, record)
+				e.recordMemoryConsume(record)
 			}
 		}
 
@@ -2252,6 +2297,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 				ctype,                 // CONSTRAINT_TYPE
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 		//  TiDB includes foreign key information for compatibility but foreign keys are not yet enforced.
 		for _, fk := range tbl.ForeignKeys {
@@ -2267,6 +2313,7 @@ func (e *memtableRetriever) setDataFromTableConstraints(ctx context.Context, sct
 				infoschema.ForeignKeyType, // CONSTRAINT_TYPE
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	e.rows = rows
@@ -2435,7 +2482,7 @@ func (e *tableStorageStatsRetriever) setDataForTableStorageStats(ctx context.Con
 }
 
 // dataForAnalyzeStatusHelper is a helper function which can be used in show_stats.go
-func dataForAnalyzeStatusHelper(ctx context.Context, sctx sessionctx.Context) (rows [][]types.Datum, err error) {
+func dataForAnalyzeStatusHelper(ctx context.Context, e *memtableRetriever, sctx sessionctx.Context) (rows [][]types.Datum, err error) {
 	const maxAnalyzeJobs = 30
 	const sql = "SELECT table_schema, table_name, partition_name, job_info, processed_rows, CONVERT_TZ(start_time, @@TIME_ZONE, '+00:00'), CONVERT_TZ(end_time, @@TIME_ZONE, '+00:00'), state, fail_reason, instance, process_id FROM mysql.analyze_jobs ORDER BY update_time DESC LIMIT %?"
 	exec := sctx.GetRestrictedSQLExecutor()
@@ -2517,6 +2564,9 @@ func dataForAnalyzeStatusHelper(ctx context.Context, sctx sessionctx.Context) (r
 			estimatedRowCntStr, // ESTIMATED_TOTAL_ROWS
 		)
 		rows = append(rows, row)
+		if e != nil {
+			e.recordMemoryConsume(row)
+		}
 	}
 	return
 }
@@ -2595,7 +2645,7 @@ func calRemainInfoForAnalyzeStatus(ctx context.Context, totalCnt int64, processe
 
 // setDataForAnalyzeStatus gets all the analyze jobs.
 func (e *memtableRetriever) setDataForAnalyzeStatus(ctx context.Context, sctx sessionctx.Context) (err error) {
-	e.rows, err = dataForAnalyzeStatusHelper(ctx, sctx)
+	e.rows, err = dataForAnalyzeStatusHelper(ctx, e, sctx)
 	return
 }
 
@@ -2623,6 +2673,7 @@ func (e *memtableRetriever) setDataForPseudoProfiling(sctx sessionctx.Context) {
 			0,                      // SOURCE_LINE
 		)
 		e.rows = append(e.rows, row)
+		e.recordMemoryConsume(row)
 	}
 }
 
@@ -2650,6 +2701,7 @@ func (e *memtableRetriever) setDataForServersInfo(ctx sessionctx.Context) error 
 			}
 		}
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -2691,6 +2743,7 @@ func (e *memtableRetriever) setDataFromSequences(ctx context.Context, sctx sessi
 			table.Sequence.Comment,    // COMMENT
 		)
 		rows = append(rows, record)
+		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 	return nil
@@ -2738,6 +2791,7 @@ func (e *memtableRetriever) dataForTableTiFlashReplica(_ context.Context, sctx s
 				progress,                                             // PROGRESS
 			)
 			rows = append(rows, record)
+			e.recordMemoryConsume(record)
 		}
 	}
 	e.rows = rows
@@ -2768,6 +2822,7 @@ func (e *memtableRetriever) setDataForClientErrorsSummary(ctx sessionctx.Context
 				lastSeen,                     // LAST_SEEN
 			)
 			rows = append(rows, row)
+			e.recordMemoryConsume(row)
 		}
 	case infoschema.TableClientErrorsSummaryByUser:
 		for user, agg := range errno.UserStats() {
@@ -2788,6 +2843,7 @@ func (e *memtableRetriever) setDataForClientErrorsSummary(ctx sessionctx.Context
 					lastSeen,                     // LAST_SEEN
 				)
 				rows = append(rows, row)
+				e.recordMemoryConsume(row)
 			}
 		}
 	case infoschema.TableClientErrorsSummaryByHost:
@@ -2808,6 +2864,7 @@ func (e *memtableRetriever) setDataForClientErrorsSummary(ctx sessionctx.Context
 					lastSeen,                     // LAST_SEEN
 				)
 				rows = append(rows, row)
+				e.recordMemoryConsume(row)
 			}
 		}
 	}
@@ -2822,6 +2879,9 @@ func (e *memtableRetriever) setDataForTrxSummary(ctx sessionctx.Context) error {
 	}
 	rows := txninfo.Recorder.DumpTrxSummary()
 	e.rows = rows
+	for _, row := range rows {
+		e.recordMemoryConsume(row)
+	}
 	return nil
 }
 
@@ -2864,6 +2924,7 @@ func (e *memtableRetriever) setDataForMemoryUsage() error {
 		types.NewDatum(memory.QueryForceDisk.Load()),                 // QUERY_FORCE_DISK
 	}
 	e.rows = append(e.rows, row)
+	e.recordMemoryConsume(row)
 	return nil
 }
 
@@ -2882,6 +2943,9 @@ func (e *memtableRetriever) setDataForClusterMemoryUsage(ctx sessionctx.Context)
 
 func (e *memtableRetriever) setDataForMemoryUsageOpsHistory() error {
 	e.rows = servermemorylimit.GlobalMemoryOpsHistoryManager.GetRows()
+	for _, row := range e.rows {
+		e.recordMemoryConsume(row)
+	}
 	return nil
 }
 
@@ -3676,6 +3740,7 @@ func (e *memtableRetriever) setDataForAttributes(ctx context.Context, sctx sessi
 			kr,
 		)
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -3714,6 +3779,7 @@ func (e *memtableRetriever) setDataFromPlacementPolicies(sctx sessionctx.Context
 			policy.PlacementSettings.Learners,
 		)
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -3743,6 +3809,7 @@ func (e *memtableRetriever) setDataFromRunawayWatches(sctx sessionctx.Context) e
 			row[3].SetString("UNLIMITED", mysql.DefaultCollationName)
 		}
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -3853,6 +3920,7 @@ func (e *memtableRetriever) setDataFromResourceGroups() error {
 				row[5].SetNull()
 			}
 			rows = append(rows, row)
+			e.recordMemoryConsume(row)
 		default:
 			//mode = "UNKNOWN_MODE"
 			row := types.MakeDatums(
@@ -3864,6 +3932,7 @@ func (e *memtableRetriever) setDataFromResourceGroups() error {
 				nil,
 			)
 			rows = append(rows, row)
+			e.recordMemoryConsume(row)
 		}
 	}
 	e.rows = rows
@@ -3875,6 +3944,7 @@ func (e *memtableRetriever) setDataFromKeywords() error {
 	for _, kw := range parser.Keywords {
 		row := types.MakeDatums(kw.Word, kw.Reserved)
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 	e.rows = rows
 	return nil
@@ -3925,6 +3995,7 @@ func (e *memtableRetriever) setDataFromIndexUsage(ctx context.Context, sctx sess
 			}
 			row = append(row, lastUsedAt)
 			rows = append(rows, row)
+			e.recordMemoryConsume(row)
 		}
 	}
 
@@ -3973,6 +4044,7 @@ func (e *memtableRetriever) setDataFromPlanCache(_ context.Context, sctx session
 			types.NewTime(types.FromGoTime(lastTime), mysql.TypeTimestamp, types.DefaultFsp)))
 
 		rows = append(rows, row)
+		e.recordMemoryConsume(row)
 	}
 
 	if cluster {

--- a/pkg/executor/show_stats.go
+++ b/pkg/executor/show_stats.go
@@ -562,7 +562,7 @@ func (e *ShowExec) fetchShowHistogramsInFlight() {
 }
 
 func (e *ShowExec) fetchShowAnalyzeStatus(ctx context.Context) error {
-	rows, err := dataForAnalyzeStatusHelper(ctx, e.BaseExecutor.Ctx())
+	rows, err := dataForAnalyzeStatusHelper(ctx, nil, e.BaseExecutor.Ctx())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58985

Problem Summary: See https://github.com/pingcap/tidb/issues/58985#issuecomment-2594879519

### What changed and how does it work?

Move memory tracker consumption calling into each info schema table.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
