### PR TITLE
ddl: filter zero job IDs when puting `DDLAllSchemaVersionsByJob` key

### DIFF
--- a/pkg/ddl/schemaver/syncer.go
+++ b/pkg/ddl/schemaver/syncer.go
@@ -280,6 +280,10 @@ func (s *etcdSyncer) UpdateSelfVersion(ctx context.Context, jobID int64, version
 	var err error
 	var path string
 	if variable.EnableMDL.Load() {
+		// If jobID is 0, it doesn't need to put into etcd `DDLAllSchemaVersionsByJob` key.
+		if jobID == 0 {
+			return nil
+		}
 		path = fmt.Sprintf("%s/%d/%s", util.DDLAllSchemaVersionsByJob, jobID, s.ddlID)
 		err = util.PutKVToEtcdMono(ctx, s.etcdCli, keyOpDefaultRetryCnt, path, ver)
 	} else {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/58992

Problem Summary:

### What changed and how does it work?
If enable MDL, doesn't put DDLAllSchemaVersionsByJob key when job id = 0.
The etcd key DDLAllSchemaVersionsByJob with job id = 0 not be used anywhere.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. start tidb
2. check there is no `/keyspaces/tidb/1/tidb/ddl/all_schema_by_job_versions/0/xxx` in etcd 
```
ETCDCTL_API=3 etcdctl --endpoints 127.0.0.1:2379 get / --prefix
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
If enable MDL, doesn't put DDLAllSchemaVersionsByJob key when job id = 0
```
