### PR TITLE
lightning: set block size for pebble SSTWriter

### DIFF
--- a/lightning/pkg/importer/table_import.go
+++ b/lightning/pkg/importer/table_import.go
@@ -664,6 +664,9 @@ func (tr *TableImporter) preprocessEngine(
 	logTask := tr.logger.With(zap.Int32("engineNumber", engineID)).Begin(zap.InfoLevel, "encode kv data and write")
 	dataEngineCfg := &backend.EngineConfig{
 		TableInfo: tr.tableInfo,
+		Local: backend.LocalEngineConfig{
+			BlockSize: int(rc.cfg.TikvImporter.BlockSize),
+		},
 	}
 	if !tr.tableMeta.IsRowOrdered {
 		dataEngineCfg.Local.Compact = true

--- a/pkg/util/extsort/disk_sorter.go
+++ b/pkg/util/extsort/disk_sorter.go
@@ -168,6 +168,7 @@ func newSSTWriter(
 	}
 	writable := objstorageprovider.NewFileWritable(f)
 	w := sstable.NewWriter(writable, sstable.WriterOptions{
+		BlockSize: 16 * 1024,
 		TablePropertyCollectors: []func() sstable.TablePropertyCollector{
 			func() sstable.TablePropertyCollector {
 				return newKVStatsCollector(kvStatsBucketSize)

--- a/pkg/util/extsort/disk_sorter.go
+++ b/pkg/util/extsort/disk_sorter.go
@@ -168,7 +168,6 @@ func newSSTWriter(
 	}
 	writable := objstorageprovider.NewFileWritable(f)
 	w := sstable.NewWriter(writable, sstable.WriterOptions{
-		BlockSize: 16 * 1024,
 		TablePropertyCollectors: []func() sstable.TablePropertyCollector{
 			func() sstable.TablePropertyCollector {
 				return newKVStatsCollector(kvStatsBucketSize)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59014

Problem Summary:

For local sort using pebbles, it seems like the default block size (16K) is only set in index engine.

https://github.com/pingcap/tidb/blob/543c3344b502ff27322b674e037d4444b841e16c/lightning/pkg/importer/table_import.go#L460-L465

### What changed and how does it work?

Set `BlockSize` to `rc.cfg.TikvImporter.BlockSize`. 

Test was done on my local machine, which using lightning to import a single csv with 2 million rows and 250 columns.

In order to make a relatively fair comparison, I cleared the data and restart the cluster using tiup before each test.

**Before:**

![image](https://github.com/user-attachments/assets/e0d04872-28e1-429f-8cc9-059be42fa41d)

**After:**

![image](https://github.com/user-attachments/assets/deb5f0b0-b190-4b12-9e9d-28a6ba48570f)


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
