### PR TITLE
ddl/dxf: some rename and merge explicit impl of scheduler.Extension with scheduler

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
         "backfilling_merge_sort.go",
         "backfilling_operators.go",
         "backfilling_read_index.go",
-        "backfilling_scheduler.go",
+        "backfilling_txn_executor.go",
         "bdr.go",
         "cluster.go",
         "column.go",

--- a/pkg/disttask/importinto/scheduler_test.go
+++ b/pkg/disttask/importinto/scheduler_test.go
@@ -43,7 +43,7 @@ func (s *importIntoSuite) enableFailPoint(path, term string) {
 }
 
 func (s *importIntoSuite) TestSchedulerGetEligibleInstances() {
-	sch := ImportSchedulerExt{}
+	sch := importScheduler{}
 	task := &proto.Task{Meta: []byte("{}")}
 	ctx := context.WithValue(context.Background(), "etcd", true)
 	eligibleInstances, err := sch.GetEligibleInstances(ctx, task)
@@ -66,7 +66,7 @@ func (s *importIntoSuite) TestUpdateCurrentTask() {
 	bs, err := json.Marshal(taskMeta)
 	require.NoError(s.T(), err)
 
-	sch := ImportSchedulerExt{}
+	sch := importScheduler{}
 	require.Equal(s.T(), int64(0), sch.currTaskID.Load())
 	require.False(s.T(), sch.disableTiKVImportMode.Load())
 
@@ -99,7 +99,7 @@ func (s *importIntoSuite) TestSchedulerInit() {
 		}, scheduler.Param{}),
 	}
 	s.NoError(sch.Init())
-	s.False(sch.Extension.(*ImportSchedulerExt).GlobalSort)
+	s.False(sch.Extension.(*importScheduler).GlobalSort)
 
 	meta.Plan.CloudStorageURI = "s3://test"
 	bytes, err = json.Marshal(meta)
@@ -110,19 +110,19 @@ func (s *importIntoSuite) TestSchedulerInit() {
 		}, scheduler.Param{}),
 	}
 	s.NoError(sch.Init())
-	s.True(sch.Extension.(*ImportSchedulerExt).GlobalSort)
+	s.True(sch.Extension.(*importScheduler).GlobalSort)
 }
 
 func (s *importIntoSuite) TestGetNextStep() {
 	task := &proto.TaskBase{Step: proto.StepInit}
-	ext := &ImportSchedulerExt{}
+	ext := &importScheduler{}
 	for _, nextStep := range []proto.Step{proto.ImportStepImport, proto.ImportStepPostProcess, proto.StepDone} {
 		s.Equal(nextStep, ext.GetNextStep(task))
 		task.Step = nextStep
 	}
 
 	task.Step = proto.StepInit
-	ext = &ImportSchedulerExt{GlobalSort: true}
+	ext = &importScheduler{GlobalSort: true}
 	for _, nextStep := range []proto.Step{proto.ImportStepEncodeAndSort, proto.ImportStepMergeSort,
 		proto.ImportStepWriteAndIngest, proto.ImportStepPostProcess, proto.StepDone} {
 		s.Equal(nextStep, ext.GetNextStep(task))
@@ -136,7 +136,7 @@ func (s *importIntoSuite) TestGetStepOfEncode() {
 }
 
 func TestIsImporting2TiKV(t *testing.T) {
-	ext := &ImportSchedulerExt{}
+	ext := &importScheduler{}
 	require.False(t, ext.isImporting2TiKV(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepEncodeAndSort}}))
 	require.False(t, ext.isImporting2TiKV(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepMergeSort}}))
 	require.False(t, ext.isImporting2TiKV(&proto.Task{TaskBase: proto.TaskBase{Step: proto.ImportStepPostProcess}}))

--- a/pkg/disttask/importinto/scheduler_testkit_test.go
+++ b/pkg/disttask/importinto/scheduler_testkit_test.go
@@ -92,7 +92,7 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 
 	// to import stage, job should be running
 	d := sch.MockScheduler(task)
-	ext := importinto.ImportSchedulerExt{}
+	ext := importinto.NewImportSchedulerForTest(false)
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 1)
@@ -235,9 +235,7 @@ func TestSchedulerExtGlobalSort(t *testing.T) {
 
 	// to encode-sort stage, job should be running
 	d := sch.MockScheduler(task)
-	ext := importinto.ImportSchedulerExt{
-		GlobalSort: true,
-	}
+	ext := importinto.NewImportSchedulerForTest(true)
 	subtaskMetas, err := ext.OnNextSubtasksBatch(ctx, d, task, []string{":4000"}, ext.GetNextStep(&task.TaskBase))
 	require.NoError(t, err)
 	require.Len(t, subtaskMetas, 2)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #57497

Problem Summary:

### What changed and how does it work?
- previous `backfillScheduler` doesn't schedule anything, it only send tasks to its worker and run them, so rename it to `backfillExecutor` to avoid confusion with other schedulers like job scheduler, and dxf scheduler.
- merge explicit impl of `scheduler.Extension` into impl of `scheduler.Scheduler`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
