### PR TITLE
stmtctx: re-use the `usedStatsInfo` for different statements in a single session

### DIFF
--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -469,6 +469,11 @@ func NewStmtCtxWithTimeZone(tz *time.Location) *StatementContext {
 
 // Reset resets a statement context
 func (sc *StatementContext) Reset() {
+	usedStats := sc.usedStatsInfo.Load()
+	if usedStats != nil {
+		usedStats.store.Clear()
+	}
+
 	*sc = StatementContext{
 		ctxID:               contextutil.GenContextID(),
 		CTEStorageMap:       sc.CTEStorageMap,
@@ -493,6 +498,10 @@ func (sc *StatementContext) Reset() {
 		h.Reset()
 	} else {
 		sc.ExtraWarnHandler = contextutil.NewStaticWarnHandler(0)
+	}
+
+	if usedStats != nil {
+		sc.usedStatsInfo.Store(usedStats)
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59019

Problem Summary:

Previously, the data in `usedStatsInfo` is allocated for each statements. If we can re-use it across different statements in a session, it'll benefit the performance.

### What changed and how does it work?

Use `(*sync.Map).Clear()` to reset the map, and assign the existing map to the new stmtctx.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
