### PR TITLE
statistics: refactor locking mechanism and enable prepared statement caching

### DIFF
--- a/pkg/statistics/handle/storage/update.go
+++ b/pkg/statistics/handle/storage/update.go
@@ -27,9 +27,9 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/statistics"
 	"github.com/pingcap/tidb/pkg/statistics/handle/cache"
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/types"
 	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
-	"github.com/pingcap/tidb/pkg/util/logutil"
 	"go.uber.org/zap"
 )
 
@@ -122,7 +122,7 @@ func UpdateStatsMeta(
 	defer func() {
 		_, err := statsutil.ExecWithCtx(ctx, sctx, "SET tidb_enable_prepared_plan_cache = OFF")
 		if err != nil {
-			logutil.BgLogger().Error("failed to reset prepared statement cache", zap.Error(errors.Trace(err)))
+			statslogutil.StatsLogger().Error("failed to reset prepared statement cache", zap.Error(errors.Trace(err)))
 		}
 	}()
 
@@ -136,7 +136,7 @@ func UpdateStatsMeta(
 	defer func() {
 		_, err := statsutil.ExecWithCtx(ctx, sctx, "DEALLOCATE PREPARE select_stmt_unlocked")
 		if err != nil {
-			logutil.BgLogger().Error("failed to deallocate prepared statement",
+			statslogutil.StatsLogger().Error("failed to deallocate prepared statement",
 				zap.String("statementName", "select_stmt_unlocked"),
 				zap.Error(errors.Trace(err)),
 			)
@@ -162,7 +162,7 @@ func UpdateStatsMeta(
 	defer func() {
 		_, err := statsutil.ExecWithCtx(ctx, sctx, "DEALLOCATE PREPARE select_stmt_locked")
 		if err != nil {
-			logutil.BgLogger().Error("failed to deallocate prepared statement",
+			statslogutil.StatsLogger().Error("failed to deallocate prepared statement",
 				zap.String("statementName", "select_stmt_locked"),
 				zap.Error(errors.Trace(err)),
 			)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/57869

Problem Summary:

### What changed and how does it work?

Get the lock one by one to avoid deadlock.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
