### PR TITLE
util: split the tests of workloadrepo into multiple shard

### DIFF
--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -41,10 +41,11 @@ go_library(
 
 go_test(
     name = "workloadrepo_test",
-    timeout = "long",
+    timeout = "short",
     srcs = ["worker_test.go"],
     embed = [":workloadrepo"],
     flaky = True,
+    shard_count = 13,
     deps = [
         "//pkg/domain",
         "//pkg/infoschema",

--- a/tools/tazel/util.go
+++ b/tools/tazel/util.go
@@ -46,5 +46,6 @@ func skipShardCount(path string) bool {
 			!strings.HasPrefix(path, "pkg/util/admin") &&
 			!strings.HasPrefix(path, "pkg/util/chunk") &&
 			!strings.HasPrefix(path, "pkg/util/topsql") &&
-			!strings.HasPrefix(path, "pkg/util/stmtsummary"))
+			!strings.HasPrefix(path, "pkg/util/stmtsummary") &&
+			!strings.HasPrefix(path, "pkg/util/workloadrepo"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58247 

Problem Summary:

### What changed and how does it work?

In https://github.com/pingcap/tidb/pull/58266, the timeout was set to long. From https://bazel.build/reference/test-encyclopedia, we can see that the `long` is 900s, which is too long for a whole dir. 
If it really has some tests exceeding the default short threshold, please verify the test first, then consider putting slow ones into a separate dir.

And enable the sharding

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
