### PR TITLE
Fix 59047

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -4903,3 +4903,12 @@ func TestIssue54829(t *testing.T) {
 }
 
 // TODO: check EXCHANGE how it handles null (for all types of partitioning!!!)
+
+func TestIssue59047(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (id bigint primary key, name varchar(20))`)
+	tk.MustExec(`alter table t add column d date not null`)
+	tk.MustExec(`update t set name = 'x'`)
+}

--- a/table/column.go
+++ b/table/column.go
@@ -568,7 +568,9 @@ func getColDefaultValue(ctx sessionctx.Context, col *model.ColumnInfo, defaultVa
 		return getColDefaultValueFromNil(ctx, col, args)
 	}
 
-	if col.GetType() != mysql.TypeTimestamp && col.GetType() != mysql.TypeDatetime {
+	switch col.GetType() {
+	case mysql.TypeTimestamp, mysql.TypeDate, mysql.TypeDatetime:
+	default:
 		value, err := CastValue(ctx, types.NewDatum(defaultVal), col, false, false)
 		if err != nil {
 			return types.Datum{}, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59047

Problem Summary:
During the executor build phase getColDefaultValue is called for the date column and fails, due to trying to cast the default value '0000-00-00' which fails due to default sql_mode.

### What changed and how does it work?
Do as DATETIME and TIMESTAMP, skip cast.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix UPDATE after ALTER ADD date column giving error for incorrect value '0000-00-00'.
```
