### PR TITLE
backup/pitr_coll: use target client of S3 (#59044)

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -106,9 +106,8 @@ func (rs *S3Storage) CopyFrom(ctx context.Context, e ExternalStorage, spec CopyS
 		Key:        aws.String(rs.options.Prefix + spec.To),
 	}
 
-	// NOTE: Maybe check whether the Go SDK will handle 200 OK errors.
-	// https://repost.aws/knowledge-center/s3-resolve-200-internalerror
-	_, err := s.svc.CopyObjectWithContext(ctx, copyInput)
+	// We must use the client of the target region.
+	_, err := rs.svc.CopyObjectWithContext(ctx, copyInput)
 	return err
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59043

Problem Summary:

We used the wrong client to copy object.

### What changed and how does it work?

Used the rightly configured client to copy object.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
With the new client, now it returns no more `BucketRegionError`.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
