### PR TITLE
planner, executor: add privilege check for traffic replay

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5837,7 +5837,7 @@ func findStmtAsViewSchema(stmt ast.Node) *ast.SelectStmt {
 	return nil
 }
 
-func (p *PlanBuilder) buildTraffic(pc *ast.TrafficStmt) base.Plan {
+func (b *PlanBuilder) buildTraffic(pc *ast.TrafficStmt) base.Plan {
 	tf := &Traffic{
 		OpType:  pc.OpType,
 		Options: pc.Options,
@@ -5860,7 +5860,7 @@ func (p *PlanBuilder) buildTraffic(pc *ast.TrafficStmt) base.Plan {
 		privs = []string{"TRAFFIC_CAPTURE_ADMIN", "TRAFFIC_REPLAY_ADMIN"}
 	}
 	err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs(errMsg)
-	p.visitInfo = appendDynamicVisitInfo(p.visitInfo, privs, false, err)
+	b.visitInfo = appendDynamicVisitInfo(b.visitInfo, privs, false, err)
 	return tf
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5837,16 +5837,31 @@ func findStmtAsViewSchema(stmt ast.Node) *ast.SelectStmt {
 	return nil
 }
 
-func (*PlanBuilder) buildTraffic(pc *ast.TrafficStmt) base.Plan {
-	p := &Traffic{
+func (p *PlanBuilder) buildTraffic(pc *ast.TrafficStmt) base.Plan {
+	tf := &Traffic{
 		OpType:  pc.OpType,
 		Options: pc.Options,
 		Dir:     pc.Dir,
 	}
-	if pc.OpType == ast.TrafficOpShow {
-		p.setSchemaAndNames(buildShowTrafficJobsSchema())
+	var errMsg string
+	var privs []string
+	switch pc.OpType {
+	case ast.TrafficOpCapture:
+		errMsg = "SUPER or TRAFFIC_CAPTURE_ADMIN"
+		privs = []string{"TRAFFIC_CAPTURE_ADMIN"}
+	case ast.TrafficOpReplay:
+		errMsg = "SUPER or TRAFFIC_REPLAY_ADMIN"
+		privs = []string{"TRAFFIC_REPLAY_ADMIN"}
+	case ast.TrafficOpShow:
+		tf.setSchemaAndNames(buildShowTrafficJobsSchema())
+		fallthrough
+	case ast.TrafficOpCancel:
+		errMsg = "SUPER, TRAFFIC_CAPTURE_ADMIN or TRAFFIC_REPLAY_ADMIN"
+		privs = []string{"TRAFFIC_CAPTURE_ADMIN", "TRAFFIC_REPLAY_ADMIN"}
 	}
-	return p
+	err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs(errMsg)
+	p.visitInfo = appendDynamicVisitInfo(p.visitInfo, privs, false, err)
+	return tf
 }
 
 // buildCompactTable builds a plan for the "ALTER TABLE [NAME] COMPACT ..." statement.

--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -70,6 +70,8 @@ var dynamicPrivs = []string{
 	"RESTRICTED_REPLICA_WRITER_ADMIN", // Can write to the sever even when tidb_restriced_read_only is turned on.
 	"RESOURCE_GROUP_ADMIN",            // Create/Drop/Alter RESOURCE GROUP
 	"RESOURCE_GROUP_USER",             // Can change the resource group of current session.
+	"TRAFFIC_CAPTURE_ADMIN",           // Can capture traffic
+	"TRAFFIC_REPLAY_ADMIN",            // Can replay traffic
 }
 var dynamicPrivLock sync.Mutex
 var defaultTokenLife = 15 * time.Minute

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3217,8 +3217,8 @@ RESTRICTED_CONNECTION_ADMIN	Server Admin
 RESTRICTED_REPLICA_WRITER_ADMIN	Server Admin	
 RESOURCE_GROUP_ADMIN	Server Admin	
 RESOURCE_GROUP_USER	Server Admin	
-TRAFFIC_CAPTURE_ADMIN	Server Admin
-TRAFFIC_REPLAY_ADMIN	Server Admin
+TRAFFIC_CAPTURE_ADMIN	Server Admin	
+TRAFFIC_REPLAY_ADMIN	Server Admin	
 show table status;
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
 t	InnoDB	10	Compact	0	0	0	0	0	0	NULL	0	NULL	NULL	utf8mb4_bin			

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -3217,6 +3217,8 @@ RESTRICTED_CONNECTION_ADMIN	Server Admin
 RESTRICTED_REPLICA_WRITER_ADMIN	Server Admin	
 RESOURCE_GROUP_ADMIN	Server Admin	
 RESOURCE_GROUP_USER	Server Admin	
+TRAFFIC_CAPTURE_ADMIN	Server Admin
+TRAFFIC_REPLAY_ADMIN	Server Admin
 show table status;
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
 t	InnoDB	10	Compact	0	0	0	0	0	0	NULL	0	NULL	NULL	utf8mb4_bin			

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -615,6 +615,15 @@ GRANT UPDATE ON `role`.* TO 'joe'@'%'
 GRANT SELECT,DELETE ON `mysql`.`user` TO 'joe'@'%'
 GRANT 'admins'@'%', 'engineering'@'%', 'otherrole'@'%' TO 'joe'@'%'
 set global tidb_enable_resource_control = default;
+CREATE USER traffic_test;
+traffic capture to '/tmp' duration='1s';
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER or TRAFFIC_CAPTURE_ADMIN privilege(s) for this operation
+traffic replay from '/tmp' user='traffic_test';
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER or TRAFFIC_REPLAY_ADMIN privilege(s) for this operation
+cancel traffic jobs;
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER, TRAFFIC_CAPTURE_ADMIN or TRAFFIC_REPLAY_ADMIN privilege(s) for this operation
+show traffic jobs;
+Error 1227 (42000): Access denied; you need (at least one of) the SUPER, TRAFFIC_CAPTURE_ADMIN or TRAFFIC_REPLAY_ADMIN privilege(s) for this operation
 create table privilege__privileges.admin(a int, KEY idx_a (`a`));
 create user without_super;
 admin set bdr role primary;

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -833,6 +833,21 @@ connection default;
 
 set global tidb_enable_resource_control = default;
 
+# TestTraffic
+CREATE USER traffic_test;
+connect (traffic_test,localhost,traffic_test,,);
+connection traffic_test;
+--error 1227
+traffic capture to '/tmp' duration='1s';
+--error 1227
+traffic replay from '/tmp' user='traffic_test';
+--error 1227
+cancel traffic jobs;
+--error 1227
+show traffic jobs;
+disconnect traffic_test;
+connection default;
+
 # TestAdmin
 create table privilege__privileges.admin(a int, KEY idx_a (`a`));
 create user without_super;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59053 

Problem Summary:
- traffic capture: need `TRAFFIC_CAPTURE_ADMIN`
- traffic replay: need `TRAFFIC_REPLAY_ADMIN`
- show traffic: `TRAFFIC_CAPTURE_ADMIN` shows capture jobs, `TRAFFIC_REPLAY_ADMIN` shows replay jobs
- cancel traffic: `TRAFFIC_CAPTURE_ADMIN` cancels capture jobs, `TRAFFIC_REPLAY_ADMIN` cancels replay jobs

### What changed and how does it work?
- Add privilege check in the planner
- Filter the results for show traffic jobs
- Add HTTP parameters for cancel traffic

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
