### PR TITLE
executor: make TestWorkerPool stable

### DIFF
--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -15,9 +15,9 @@
 package executor
 
 import (
-	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -196,6 +196,9 @@ func TestWorkerPool(t *testing.T) {
 		list = list[:0]
 		lock.Unlock()
 	}
+	sleep := func(ms int) {
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+	}
 
 	t.Run("SingleWorker", func(t *testing.T) {
 		clean()
@@ -211,11 +214,11 @@ func TestWorkerPool(t *testing.T) {
 			wg.Add(1)
 			pool.submit(func() {
 				push(3)
-				runtime.Gosched()
+				sleep(10)
 				push(4)
 				wg.Done()
 			})
-			runtime.Gosched()
+			sleep(1)
 			push(2)
 			wg.Done()
 		})
@@ -237,11 +240,11 @@ func TestWorkerPool(t *testing.T) {
 			wg.Add(1)
 			pool.submit(func() {
 				push(3)
-				runtime.Gosched()
+				sleep(10)
 				push(4)
 				wg.Done()
 			})
-			runtime.Gosched()
+			sleep(1)
 			push(2)
 			wg.Done()
 		})
@@ -263,11 +266,11 @@ func TestWorkerPool(t *testing.T) {
 			wg.Add(1)
 			pool.submit(func() {
 				push(3)
-				runtime.Gosched()
+				sleep(10)
 				push(4)
 				wg.Done()
 			})
-			runtime.Gosched()
+			sleep(1)
 			push(2)
 			wg.Done()
 		})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59097

Problem Summary: `TestWorkerPool/TwoWorkers` is unstable because both workers are runnable after yield (`runtime.Gosched`), the execution order is not guaranteed by runtime scheduler.

### What changed and how does it work?

Use sleep instead of yield.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
