### PR TITLE
stats, infoschema: avoid some network cost of reading table meta kv

### DIFF
--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -434,6 +434,15 @@ func (is *infoSchema) SchemaNameAndTableNameByPartitionID(partitionID int64) (sc
 	return db.Name, tbl.Meta().Name, true
 }
 
+// TableIDByPartitionID implements InfoSchema.TableIDByPartitionID.
+func (is *infoSchema) TableIDByPartitionID(partitionID int64) (tableID int64, ok bool) {
+	tbl, _, _ := is.FindTableByPartitionID(partitionID)
+	if tbl == nil {
+		return
+	}
+	return tbl.Meta().ID, true
+}
+
 // FindTableByPartitionID finds the partition-table info by the partitionID.
 // FindTableByPartitionID will traverse all the tables to find the partitionID partition in which partition-table.
 func (is *infoSchema) FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition) {

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -315,6 +315,19 @@ func (is *infoSchema) TableByID(_ stdctx.Context, id int64) (val table.Table, ok
 	return slice[idx], true
 }
 
+// SchemaNameAndTableNameByID implements InfoSchema.SchemaNameAndTableNameByID.
+func (is *infoSchema) SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool) {
+	tbl, ok := is.TableByID(stdctx.Background(), tableID)
+	if !ok {
+		return
+	}
+	db, ok := is.SchemaByID(tbl.Meta().DBID)
+	if !ok {
+		return
+	}
+	return db.Name, tbl.Meta().Name, true
+}
+
 func (is *infoSchema) SchemaNameByTableID(tableID int64) (schemaName ast.CIStr, ok bool) {
 	tbl, ok := is.TableByID(stdctx.Background(), tableID)
 	if !ok {
@@ -410,6 +423,15 @@ func (is *infoSchema) AllSchemaNames() (schemas []ast.CIStr) {
 		rs = append(rs, v.dbInfo.Name)
 	}
 	return rs
+}
+
+// SchemaNameAndTableNameByPartitionID implements InfoSchema.SchemaNameAndTableNameByPartitionID.
+func (is *infoSchema) SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool) {
+	tbl, db, _ := is.FindTableByPartitionID(partitionID)
+	if tbl == nil {
+		return
+	}
+	return db.Name, tbl.Meta().Name, true
 }
 
 // FindTableByPartitionID finds the partition-table info by the partitionID.

--- a/pkg/infoschema/infoschema.go
+++ b/pkg/infoschema/infoschema.go
@@ -315,30 +315,17 @@ func (is *infoSchema) TableByID(_ stdctx.Context, id int64) (val table.Table, ok
 	return slice[idx], true
 }
 
-// SchemaNameAndTableNameByID implements InfoSchema.SchemaNameAndTableNameByID.
-func (is *infoSchema) SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool) {
-	tbl, ok := is.TableByID(stdctx.Background(), tableID)
+// TableItemByID implements InfoSchema.TableItemByID.
+func (is *infoSchema) TableItemByID(id int64) (TableItem, bool) {
+	tbl, ok := is.TableByID(stdctx.Background(), id)
 	if !ok {
-		return
+		return TableItem{}, false
 	}
 	db, ok := is.SchemaByID(tbl.Meta().DBID)
 	if !ok {
-		return
+		return TableItem{}, false
 	}
-	return db.Name, tbl.Meta().Name, true
-}
-
-func (is *infoSchema) SchemaNameByTableID(tableID int64) (schemaName ast.CIStr, ok bool) {
-	tbl, ok := is.TableByID(stdctx.Background(), tableID)
-	if !ok {
-		return
-	}
-	db, ok := is.SchemaByID(tbl.Meta().DBID)
-	if !ok {
-		return
-	}
-
-	return db.Name, true
+	return TableItem{DBName: db.Name, TableName: tbl.Meta().Name}, true
 }
 
 // TableInfoByID implements InfoSchema.TableInfoByID
@@ -425,13 +412,12 @@ func (is *infoSchema) AllSchemaNames() (schemas []ast.CIStr) {
 	return rs
 }
 
-// SchemaNameAndTableNameByPartitionID implements InfoSchema.SchemaNameAndTableNameByPartitionID.
-func (is *infoSchema) SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool) {
+func (is *infoSchema) TableItemByPartitionID(partitionID int64) (TableItem, bool) {
 	tbl, db, _ := is.FindTableByPartitionID(partitionID)
 	if tbl == nil {
-		return
+		return TableItem{}, false
 	}
-	return db.Name, tbl.Meta().Name, true
+	return TableItem{DBName: db.Name, TableName: tbl.Meta().Name}, true
 }
 
 // TableIDByPartitionID implements InfoSchema.TableIDByPartitionID.

--- a/pkg/infoschema/infoschema_test.go
+++ b/pkg/infoschema/infoschema_test.go
@@ -283,9 +283,9 @@ func TestBasic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSchema, gotOK := is.SchemaNameByTableID(tt.tableID)
+			gotItem, gotOK := is.TableItemByID(tt.tableID)
 			require.Equal(t, tt.wantOK, gotOK)
-			require.Equal(t, tt.wantSchema, gotSchema)
+			require.Equal(t, tt.wantSchema, gotItem.DBName)
 		})
 	}
 }

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -734,6 +734,15 @@ func (is *infoschemaV2) TableByID(ctx context.Context, id int64) (val table.Tabl
 	return ret, true
 }
 
+// SchemaNameAndTableNameByID implements the InfoSchema interface.
+func (is *infoschemaV2) SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool) {
+	itm, ok := is.searchTableItemByID(tableID)
+	if !ok {
+		return
+	}
+	return itm.dbName, itm.tableName, true
+}
+
 func (is *infoschemaV2) SchemaNameByTableID(tableID int64) (schemaName ast.CIStr, ok bool) {
 	if !tableIDIsValid(tableID) {
 		return
@@ -1104,6 +1113,31 @@ func (is *infoschemaV2) AllSchemaNames() []ast.CIStr {
 func (is *infoschemaV2) SchemaExists(schema ast.CIStr) bool {
 	_, ok := is.SchemaByName(schema)
 	return ok
+}
+
+// SchemaNameAndTableNameByPartitionID implements InfoSchema.SchemaNameAndTableNameByPartitionID.
+func (is *infoschemaV2) SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool) {
+	var pi partitionItem
+	is.pid2tid.Load().DescendLessOrEqual(partitionItem{partitionID: partitionID, schemaVersion: math.MaxInt64},
+		func(item partitionItem) bool {
+			if item.partitionID != partitionID {
+				return false
+			}
+			if item.schemaVersion > is.infoSchema.schemaMetaVersion {
+				// Skip the record.
+				return true
+			}
+			if item.schemaVersion <= is.infoSchema.schemaMetaVersion {
+				ok = !item.tomb
+				pi = item
+				return false
+			}
+			return true
+		})
+	if !ok {
+		return
+	}
+	return is.SchemaNameAndTableNameByID(pi.tableID)
 }
 
 func (is *infoschemaV2) FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition) {

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -734,26 +734,14 @@ func (is *infoschemaV2) TableByID(ctx context.Context, id int64) (val table.Tabl
 	return ret, true
 }
 
-// SchemaNameAndTableNameByID implements the InfoSchema interface.
-func (is *infoschemaV2) SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool) {
+// TableItemByID implements the InfoSchema interface.
+// It only contains memory operations, no worries about accessing the storage.
+func (is *infoschemaV2) TableItemByID(tableID int64) (TableItem, bool) {
 	itm, ok := is.searchTableItemByID(tableID)
 	if !ok {
-		return
+		return TableItem{}, false
 	}
-	return itm.dbName, itm.tableName, true
-}
-
-func (is *infoschemaV2) SchemaNameByTableID(tableID int64) (schemaName ast.CIStr, ok bool) {
-	if !tableIDIsValid(tableID) {
-		return
-	}
-
-	itm, ok := is.searchTableItemByID(tableID)
-	if !ok {
-		return
-	}
-
-	return itm.dbName, true
+	return TableItem{DBName: itm.dbName, TableName: itm.tableName}, true
 }
 
 // TableItem is exported from tableItem.
@@ -1136,13 +1124,14 @@ func (is *infoschemaV2) searchPartitionItemByPartitionID(partitionID int64) (pi 
 	return pi, ok
 }
 
-// SchemaNameAndTableNameByPartitionID implements InfoSchema.SchemaNameAndTableNameByPartitionID.
-func (is *infoschemaV2) SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool) {
+// TableItemByPartitionID implements InfoSchema.TableItemByPartitionID.
+// It returns the lightweight meta info, no worries about access the storage.
+func (is *infoschemaV2) TableItemByPartitionID(partitionID int64) (TableItem, bool) {
 	pi, ok := is.searchPartitionItemByPartitionID(partitionID)
 	if !ok {
-		return
+		return TableItem{}, false
 	}
-	return is.SchemaNameAndTableNameByID(pi.tableID)
+	return is.TableItemByID(pi.tableID)
 }
 
 // TableIDByPartitionID implements InfoSchema.TableIDByPartitionID.

--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -152,10 +152,10 @@ func TestV2Basic(t *testing.T) {
 
 	for _, tt := range schemaNameByTableIDTests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSchema, gotOK := is.SchemaNameByTableID(tt.tableID)
+			gotItem, gotOK := is.TableItemByID(tt.tableID)
 
 			require.Equal(t, tt.wantOK, gotOK)
-			require.Equal(t, tt.wantSchema, gotSchema)
+			require.Equal(t, tt.wantSchema, gotItem.DBName)
 		})
 	}
 

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -30,10 +30,14 @@ type InfoSchema interface {
 	context.MetaOnlyInfoSchema
 	TableByName(ctx stdctx.Context, schema, table ast.CIStr) (table.Table, error)
 	TableByID(ctx stdctx.Context, id int64) (table.Table, bool)
+	// SchemaNameAndTableNameByID is a pure memory operation.
 	SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool)
+	// SchemaNameByTableID is a pure memory operation.
 	SchemaNameByTableID(tableID int64) (ast.CIStr, bool)
+	// TableIDByPartitionID is a pure memory operation.
 	TableIDByPartitionID(partitionID int64) (tableID int64, ok bool)
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
+	// SchemaNameAndTableNameByPartitionID is a pure memory operation.
 	SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool)
 	base() *infoSchema
 }

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -32,6 +32,7 @@ type InfoSchema interface {
 	TableByID(ctx stdctx.Context, id int64) (table.Table, bool)
 	SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool)
 	SchemaNameByTableID(tableID int64) (ast.CIStr, bool)
+	TableIDByPartitionID(partitionID int64) (tableID int64, ok bool)
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
 	SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool)
 	base() *infoSchema

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -30,7 +30,9 @@ type InfoSchema interface {
 	context.MetaOnlyInfoSchema
 	TableByName(ctx stdctx.Context, schema, table ast.CIStr) (table.Table, error)
 	TableByID(ctx stdctx.Context, id int64) (table.Table, bool)
+	SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool)
 	SchemaNameByTableID(tableID int64) (ast.CIStr, bool)
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
+	SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool)
 	base() *infoSchema
 }

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -30,14 +30,14 @@ type InfoSchema interface {
 	context.MetaOnlyInfoSchema
 	TableByName(ctx stdctx.Context, schema, table ast.CIStr) (table.Table, error)
 	TableByID(ctx stdctx.Context, id int64) (table.Table, bool)
-	// SchemaNameAndTableNameByID is a pure memory operation.
-	SchemaNameAndTableNameByID(tableID int64) (schemaName, tableName ast.CIStr, ok bool)
-	// SchemaNameByTableID is a pure memory operation.
-	SchemaNameByTableID(tableID int64) (ast.CIStr, bool)
-	// TableIDByPartitionID is a pure memory operation.
+	// TableItemByID returns a lightweight table meta specified by the given ID,
+	// without loading the whole info from storage.
+	TableItemByID(id int64) (TableItem, bool)
+	// TableIDByPartitionID is a pure memory operation, returns the table ID by the partition ID.
 	TableIDByPartitionID(partitionID int64) (tableID int64, ok bool)
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
-	// SchemaNameAndTableNameByPartitionID is a pure memory operation.
-	SchemaNameAndTableNameByPartitionID(partitionID int64) (schemaName, tableName ast.CIStr, ok bool)
+	// TableItemByPartitionID returns a lightweight table meta specified by the partition ID,
+	// without loading the whole info from storage.
+	TableItemByPartitionID(partitionID int64) (TableItem, bool)
 	base() *infoSchema
 }

--- a/pkg/infoschema/interface.go
+++ b/pkg/infoschema/interface.go
@@ -32,12 +32,15 @@ type InfoSchema interface {
 	TableByID(ctx stdctx.Context, id int64) (table.Table, bool)
 	// TableItemByID returns a lightweight table meta specified by the given ID,
 	// without loading the whole info from storage.
+	// So it's all in memory operation. No need to worry about network or disk cost.
 	TableItemByID(id int64) (TableItem, bool)
 	// TableIDByPartitionID is a pure memory operation, returns the table ID by the partition ID.
+	// It's all in memory operation. No need to worry about network or disk cost.
 	TableIDByPartitionID(partitionID int64) (tableID int64, ok bool)
 	FindTableByPartitionID(partitionID int64) (table.Table, *model.DBInfo, *model.PartitionDefinition)
 	// TableItemByPartitionID returns a lightweight table meta specified by the partition ID,
 	// without loading the whole info from storage.
+	// So it's all in memory operation. No need to worry about network or disk cost.
 	TableItemByPartitionID(partitionID int64) (TableItem, bool)
 	base() *infoSchema
 }

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -204,6 +204,33 @@ func (h *Handle) getPartitionStats(tblInfo *model.TableInfo, pid int64, returnPs
 	return tbl
 }
 
+func (h *Handle) GetPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table {
+	return h.getPartitionStatsByID(is, pid, true)
+}
+
+func (h *Handle) getPartitionStatsByID(is infoschema.InfoSchema, pid int64, returnPseudo bool) *statistics.Table {
+	var statsTbl *statistics.Table
+	intest.Assert(h != nil, "stats handle is nil")
+	tbl, ok := h.Get(pid)
+	if !ok {
+		if returnPseudo {
+			tbl, ok := h.TableInfoByID(is, pid)
+			if !ok {
+				return nil
+			}
+			statsTbl = statistics.PseudoTable(tbl.Meta(), false, true)
+			statsTbl.PhysicalID = pid
+			if tbl.Meta().GetPartitionInfo() == nil || h.Len() < 64 {
+				h.UpdateStatsCache(types.CacheUpdate{
+					Updated: []*statistics.Table{statsTbl},
+				})
+			}
+		}
+		return nil
+	}
+	return tbl
+}
+
 // FlushStats flushes the cached stats update into store.
 func (h *Handle) FlushStats() {
 	if err := h.DumpStatsDeltaToKV(true); err != nil {

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -204,6 +204,7 @@ func (h *Handle) getPartitionStats(tblInfo *model.TableInfo, pid int64, returnPs
 	return tbl
 }
 
+// GetPartitionStatsByID retrieves the partition stats from cache by partition ID.
 func (h *Handle) GetPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table {
 	return h.getPartitionStatsByID(is, pid, true)
 }

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -547,6 +547,9 @@ type StatsHandle interface {
 	// GetPartitionStats retrieves the partition stats from cache.
 	GetPartitionStats(tblInfo *model.TableInfo, pid int64) *statistics.Table
 
+	// GetPartitionStatsByID retrieves the partition stats from cache by partition ID.
+	GetPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table
+
 	// GetPartitionStatsForAutoAnalyze retrieves the partition stats from cache, but it will not return pseudo.
 	GetPartitionStatsForAutoAnalyze(tblInfo *model.TableInfo, pid int64) *statistics.Table
 

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -253,8 +253,8 @@ func (s *statsUsageImpl) dumpStatsDeltaToKV(
 		// Add psychical table ID.
 		allTableIDs = append(allTableIDs, update.TableID)
 		// Add parent table ID if it's a partition table.
-		if tbl, _, _ := is.FindTableByPartitionID(update.TableID); tbl != nil {
-			allTableIDs = append(allTableIDs, tbl.Meta().ID)
+		if tblID, ok := is.TableIDByPartitionID(update.TableID); ok {
+			allTableIDs = append(allTableIDs, tblID)
 		}
 	}
 
@@ -271,9 +271,8 @@ func (s *statsUsageImpl) dumpStatsDeltaToKV(
 			continue
 		}
 
-		tbl, _, _ := is.FindTableByPartitionID(update.TableID)
-		if tbl != nil { // It's a partition table.
-			tableID := tbl.Meta().ID
+		tableID, ok := is.TableIDByPartitionID(update.TableID)
+		if ok { // It's a partition table.
 			isTableLocked := false
 			isPartitionLocked := false
 

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -73,7 +73,7 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 		return true
 	}
 	statsTbl := s.statsHandle.GetPartitionStatsByID(is, id)
-	if statsTbl.Pseudo || statsTbl.RealtimeCount == 0 || float64(item.Count)/float64(statsTbl.RealtimeCount) > DumpStatsDeltaRatio {
+	if statsTbl == nil || statsTbl.Pseudo || statsTbl.RealtimeCount == 0 || float64(item.Count)/float64(statsTbl.RealtimeCount) > DumpStatsDeltaRatio {
 		// Dump the stats when there are many modifications.
 		return true
 	}

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -55,11 +55,11 @@ var (
 // 3. If the stats delta haven't been dumped in the past hour, then return true.
 // 4. If the table stats is pseudo or empty or `Modify Count / Table Count` exceeds the threshold.
 func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bool, id int64, item variable.TableDelta, currentTime time.Time) bool {
-	dbName, _, ok := s.statsHandle.SchemaNameAndTableNameByID(is, id)
+	tableItem, ok := s.statsHandle.TableItemByID(is, id)
 	if !ok {
 		return false
 	}
-	if util.IsMemOrSysDB(dbName.L) {
+	if util.IsMemOrSysDB(tableItem.DBName.L) {
 		return false
 	}
 	if dumpAll {

--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/kv",
         "//pkg/meta/model",
         "//pkg/metrics",
-        "//pkg/parser/ast",
         "//pkg/parser/terror",
         "//pkg/planner/core/resolve",
         "//pkg/sessionctx",

--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/kv",
         "//pkg/meta/model",
         "//pkg/metrics",
+        "//pkg/parser/ast",
         "//pkg/parser/terror",
         "//pkg/planner/core/resolve",
         "//pkg/sessionctx",

--- a/pkg/statistics/handle/util/table_info.go
+++ b/pkg/statistics/handle/util/table_info.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pingcap/tidb/pkg/infoschema"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/table"
 )
 
@@ -27,9 +26,9 @@ type TableInfoGetter interface {
 	// TableInfoByID returns the table info specified by the physicalID.
 	// If the physicalID is corresponding to a partition, return its parent table.
 	TableInfoByID(is infoschema.InfoSchema, physicalID int64) (table.Table, bool)
-	// SchemaNameAndTableNameByID returns the schema name and table name specified by the physicalID.
+	// TableItemByID returns the schema name and table name specified by the physicalID.
 	// This is pure memory operation.
-	SchemaNameAndTableNameByID(is infoschema.InfoSchema, physicalID int64) (schemaName, tableName ast.CIStr, ok bool)
+	TableItemByID(is infoschema.InfoSchema, id int64) (infoschema.TableItem, bool)
 }
 
 // tableInfoGetterImpl is used to get table meta info.
@@ -52,11 +51,11 @@ func (*tableInfoGetterImpl) TableInfoByID(is infoschema.InfoSchema, physicalID i
 	return tbl, tbl != nil
 }
 
-// SchemaNameAndTableNameByID returns the schema name and table name specified by the physicalID.
-func (*tableInfoGetterImpl) SchemaNameAndTableNameByID(is infoschema.InfoSchema, physicalID int64) (schemaName, tableName ast.CIStr, ok bool) {
-	schemaName, tableName, ok = is.SchemaNameAndTableNameByID(physicalID)
+// TableItemByID returns the lightweight table meta specified by the physicalID.
+func (*tableInfoGetterImpl) TableItemByID(is infoschema.InfoSchema, id int64) (infoschema.TableItem, bool) {
+	tableItem, ok := is.TableItemByID(id)
 	if ok {
-		return
+		return tableItem, true
 	}
-	return is.SchemaNameAndTableNameByPartitionID(physicalID)
+	return is.TableItemByPartitionID(id)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/59104, ref #57869 

Problem Summary:

### What changed and how does it work?

Add some new APIs to `InfoSchema`. All of them only contain memory operations.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
