### PR TITLE
planner: stats async load only load real predicate columns

### DIFF
--- a/pkg/planner/core/casetest/planstats/testdata/plan_stats_suite_out.json
+++ b/pkg/planner/core/casetest/planstats/testdata/plan_stats_suite_out.json
@@ -128,7 +128,7 @@
           "└─IndexJoin 1.00 root  inner join, inner:IndexLookUp, outer key:test.tp.c, inner key:test.t.b, equal cond:eq(test.tp.c, test.t.b)",
           "  ├─TableReader(Build) 1.00 root partition:p1 data:Selection",
           "  │ └─Selection 1.00 cop[tikv]  eq(test.tp.a, 10), not(isnull(test.tp.c))",
-          "  │   └─TableFullScan 6.00 cop[tikv] table:tp keep order:false, stats:partial[c:allEvicted]",
+          "  │   └─TableFullScan 6.00 cop[tikv] table:tp keep order:false, stats:partial[c:unInitialized]",
           "  └─IndexLookUp(Probe) 1.00 root  ",
           "    ├─Selection(Build) 1.00 cop[tikv]  not(isnull(test.t.b))",
           "    │ └─IndexRangeScan 1.00 cop[tikv] table:t, index:idx(b) range: decided by [eq(test.t.b, test.tp.c)], keep order:false, stats:partial[idx:allEvicted, a:allEvicted, b:allEvicted]",
@@ -142,7 +142,7 @@
           "└─HashJoin 1.00 root  inner join, equal:[eq(test.tp.c, test.t.b)]",
           "  ├─TableReader(Build) 1.00 root partition:p1 data:Selection",
           "  │ └─Selection 1.00 cop[tikv]  eq(test.tp.a, 10), not(isnull(test.tp.c))",
-          "  │   └─TableFullScan 6.00 cop[tikv] table:tp keep order:false, stats:partial[c:allEvicted]",
+          "  │   └─TableFullScan 6.00 cop[tikv] table:tp keep order:false",
           "  └─TableReader(Probe) 3.00 root  data:Selection",
           "    └─Selection 3.00 cop[tikv]  not(isnull(test.t.b))",
           "      └─TableFullScan 3.00 cop[tikv] table:t keep order:false"
@@ -160,7 +160,7 @@
           "  │   └─TableRangeScan 3.00 cop[tikv] table:t range:[-inf,10), keep order:false",
           "  └─TableReader(Probe) 4.00 root partition:p0 data:Selection",
           "    └─Selection 4.00 cop[tikv]  gt(test.tp.c, 10), not(isnull(test.tp.c))",
-          "      └─TableFullScan 6.00 cop[tikv] table:tp keep order:false, stats:partial[c:allEvicted]"
+          "      └─TableFullScan 6.00 cop[tikv] table:tp keep order:false"
         ]
       }
     ]

--- a/pkg/planner/core/collect_column_stats_usage_test.go
+++ b/pkg/planner/core/collect_column_stats_usage_test.go
@@ -80,7 +80,7 @@ func getStatsLoadItem(t *testing.T, is infoschema.InfoSchema, item model.StatsLo
 }
 
 func checkColumnStatsUsageForPredicates(t *testing.T, is infoschema.InfoSchema, lp base.LogicalPlan, expected []string, comment string) {
-	tblColIDs, _, _, _ := CollectColumnStatsUsage(lp, false)
+	tblColIDs, _, _, _ := CollectColumnStatsUsage(lp)
 	cols := make([]string, 0, len(tblColIDs))
 	for tblColID := range tblColIDs {
 		col := getColumnName(t, is, tblColID, comment)
@@ -91,7 +91,7 @@ func checkColumnStatsUsageForPredicates(t *testing.T, is infoschema.InfoSchema, 
 }
 
 func checkColumnStatsUsageForStatsLoad(t *testing.T, is infoschema.InfoSchema, lp base.LogicalPlan, expectedCols []string, expectedParts map[string][]string, comment string) {
-	predicateCols, _, expandedPartitions, _ := CollectColumnStatsUsage(lp, true)
+	predicateCols, _, expandedPartitions, _ := CollectColumnStatsUsage(lp)
 	loadItems := make([]model.StatsLoadItem, 0, len(predicateCols))
 	for tblColID, fullLoad := range predicateCols {
 		loadItems = append(loadItems, model.StatsLoadItem{TableItemID: tblColID, FullLoad: fullLoad})

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -44,8 +44,8 @@ func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.Log
 		return plan, planChanged, nil
 	}
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait.Load()
-	histNeeded := syncWait > 0
-	predicateColumns, visitedPhysTblIDs, tid2pids, opNum := CollectColumnStatsUsage(plan, histNeeded)
+	syncLoadEnabled := syncWait > 0
+	predicateColumns, visitedPhysTblIDs, tid2pids, opNum := CollectColumnStatsUsage(plan)
 	// opNum is collected via the common stats load rule, some operators may be cleaned like proj for later rule.
 	// so opNum is not that accurate, but it's enough for the memo hashmap's init capacity.
 	plan.SCtx().GetSessionVars().StmtCtx.OperatorNum = opNum
@@ -65,10 +65,7 @@ func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.Log
 		tblID2TblInfo[int64(physicalTblID)] = tblInfo
 	})
 
-	c.markAtLeastOneFullStatsLoadForEachTable(plan.SCtx(), visitedPhysTblIDs, tblID2TblInfo, predicateColumns, histNeeded)
-	if !histNeeded {
-		return plan, planChanged, nil
-	}
+	c.markAtLeastOneFullStatsLoadForEachTable(plan.SCtx(), visitedPhysTblIDs, tblID2TblInfo, predicateColumns, syncLoadEnabled)
 	histNeededColumns := make([]model.StatsLoadItem, 0, len(predicateColumns))
 	for item, fullLoad := range predicateColumns {
 		histNeededColumns = append(histNeededColumns, model.StatsLoadItem{TableItemID: item, FullLoad: fullLoad})
@@ -82,10 +79,19 @@ func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.Log
 
 	histNeededIndices := collectSyncIndices(plan.SCtx(), append(histNeededColumns, dependingVirtualCols...), tblID2TblInfo)
 	histNeededItems := collectHistNeededItems(histNeededColumns, histNeededIndices)
+	// TODO: this part should be removed once we don't support the static pruning mode.
 	histNeededItems = c.expandStatsNeededColumnsForStaticPruning(histNeededItems, tid2pids)
-	if len(histNeededItems) > 0 {
+	if len(histNeededItems) == 0 {
+		return plan, planChanged, nil
+	}
+	if syncLoadEnabled {
 		err := RequestLoadStats(plan.SCtx(), histNeededItems, syncWait)
 		return plan, planChanged, err
+	}
+	// We are loading some unnecessary items here since the static pruning hasn't happened yet.
+	// It's not easy to solve the problem and the static pruning is being deprecated, so we just leave it here.
+	for _, item := range histNeededItems {
+		asyncload.AsyncLoadHistogramNeededItems.Insert(item.TableItemID, item.FullLoad)
 	}
 	return plan, planChanged, nil
 }

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/statistics"
-	"github.com/pingcap/tidb/pkg/statistics/asyncload"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	h "github.com/pingcap/tidb/pkg/util/hint"
@@ -531,16 +530,6 @@ func initStats(ds *logicalop.DataSource) {
 	for _, col := range ds.TableInfo.Columns {
 		if col.State != model.StatePublic {
 			continue
-		}
-		// If we enable lite stats init or we just found out the meta info of the column is missed, we need to register columns for async load.
-		_, isLoadNeeded, _ := ds.StatisticTable.ColumnIsLoadNeeded(col.ID, false)
-		if isLoadNeeded {
-			asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
-				TableID:          ds.TableInfo.ID,
-				ID:               col.ID,
-				IsIndex:          false,
-				IsSyncLoadFailed: ds.SCtx().GetSessionVars().StmtCtx.StatsLoad.Timeout > 0,
-			}, false)
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/59107

Problem Summary:

### What changed and how does it work?

As the issue said, the async load is loading more item than we expected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
