### PR TITLE
types: avoid slicegrow in the FieldName.String()

### DIFF
--- a/pkg/types/field_name.go
+++ b/pkg/types/field_name.go
@@ -15,7 +15,7 @@
 package types
 
 import (
-	"strings"
+	"bytes"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/util/size"
@@ -43,10 +43,11 @@ const emptyName = "EMPTY_NAME"
 
 // String implements Stringer interface.
 func (name *FieldName) String() string {
-	builder := strings.Builder{}
 	if name.Hidden {
 		return emptyName
 	}
+	bs := make([]byte, 0, len(name.DBName.L)+1+len(name.TblName.L)+1+len(name.ColName.L))
+	builder := bytes.NewBuffer(bs)
 	if name.DBName.L != "" {
 		builder.WriteString(name.DBName.L + ".")
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59135

Problem Summary:

we observe the slicegrow in the FieldName.String()

![image](https://github.com/user-attachments/assets/90b562e7-2f1a-482e-af75-3b40b26cbfeb)

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
