### PR TITLE
planner: add iter for HandleCols

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -3066,8 +3066,8 @@ func (b *executorBuilder) buildAnalyzeColumnsPushdown(
 		cols = append([]*model.ColumnInfo{colInfo}, cols...)
 	} else if task.HandleCols != nil && !task.HandleCols.IsInt() {
 		cols = make([]*model.ColumnInfo, 0, len(task.ColsInfo)+task.HandleCols.NumCols())
-		for i := 0; i < task.HandleCols.NumCols(); i++ {
-			cols = append(cols, task.TblInfo.Columns[task.HandleCols.GetCol(i).Index])
+		for col := range task.HandleCols.IterColumns() {
+			cols = append(cols, task.TblInfo.Columns[col.Index])
 		}
 		cols = append(cols, task.ColsInfo...)
 		task.ColsInfo = cols

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5391,8 +5391,7 @@ func pruneAndBuildSingleTableColPosInfoForDelete(
 
 	// Mark the columns in handle.
 	fixedPos := make(map[int]int, len(deletableCols))
-	for i := 0; i < colPosInfo.HandleCols.NumCols(); i++ {
-		col := colPosInfo.HandleCols.GetCol(i)
+	for col := range colPosInfo.HandleCols.IterColumns() {
 		fixedPos[col.Index-originalStart] = 0
 	}
 
@@ -5430,8 +5429,7 @@ func pruneAndBuildSingleTableColPosInfoForDelete(
 
 	// Fix the column offset of handle columns.
 	newStart := originalStart - prePrunedCount
-	for i := 0; i < colPosInfo.HandleCols.NumCols(); i++ {
-		col := colPosInfo.HandleCols.GetCol(i)
+	for col := range colPosInfo.HandleCols.IterColumns() {
 		// If the row id the hidden extra row id, it can not be in deletableCols.
 		// It will be appended to the end of the row.
 		// So we use newStart + tblLen to get the tail, then minus the pruned to the its new offset of the whole mixed row.
@@ -6108,8 +6106,8 @@ func (p *Delete) cleanTblID2HandleMap(
 		for i := len(cols) - 1; i >= 0; i-- {
 			hCols := cols[i]
 			var hasMatch bool
-			for j := 0; j < hCols.NumCols(); j++ {
-				if p.matchingDeletingTable(names, outputNames[hCols.GetCol(j).Index]) {
+			for col := range hCols.IterColumns() {
+				if p.matchingDeletingTable(names, outputNames[col.Index]) {
 					hasMatch = true
 					break
 				}

--- a/pkg/planner/core/operator/logicalop/logical_lock.go
+++ b/pkg/planner/core/operator/logicalop/logical_lock.go
@@ -67,8 +67,8 @@ func (p *LogicalLock) PruneColumns(parentUsedCols []*expression.Column, opt *opt
 
 	for tblID, cols := range p.TblID2Handle {
 		for _, col := range cols {
-			for i := 0; i < col.NumCols(); i++ {
-				parentUsedCols = append(parentUsedCols, col.GetCol(i))
+			for c := range col.IterColumns() {
+				parentUsedCols = append(parentUsedCols, c)
 			}
 		}
 		if physTblIDCol, ok := p.TblID2PhysTblIDCol[tblID]; ok {

--- a/pkg/planner/core/operator/logicalop/logical_table_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_table_scan.go
@@ -97,8 +97,8 @@ func (ts *LogicalTableScan) DeriveStats(_ []*property.StatsInfo, _ *expression.S
 func (ts *LogicalTableScan) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
 	if ts.HandleCols != nil {
 		cols := make([]*expression.Column, ts.HandleCols.NumCols())
-		for i := 0; i < ts.HandleCols.NumCols(); i++ {
-			cols[i] = ts.HandleCols.GetCol(i)
+		for i, c := range ts.HandleCols.IterColumns2() {
+			cols[i] = c
 		}
 		return [][]*expression.Column{cols}
 	}

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"iter"
+	"slices"
 	"strings"
 	"unsafe"
 
@@ -64,6 +66,10 @@ type HandleCols interface {
 	MemoryUsage() int64
 	// Clone clones the HandleCols.
 	Clone(newCtx *stmtctx.StatementContext) HandleCols
+	// IterColumns iterates the columns.
+	IterColumns() iter.Seq[*expression.Column]
+	// IterColumns2 iterates the columns.
+	IterColumns2() iter.Seq2[int, *expression.Column]
 }
 
 // CommonHandleCols implements the kv.HandleCols interface.
@@ -144,6 +150,16 @@ func (cb *CommonHandleCols) Equals(other any) bool {
 // GetColumns returns all the internal columns out.
 func (cb *CommonHandleCols) GetColumns() []*expression.Column {
 	return cb.columns
+}
+
+// IterColumns implements the kv.HandleCols interface. it implements the Seq2 interface.
+func (cb *CommonHandleCols) IterColumns() iter.Seq[*expression.Column] {
+	return slices.Values(cb.columns)
+}
+
+// IterColumns implements the kv.HandleCols interface. it implements the Seq2 interface.
+func (cb *CommonHandleCols) IterColumns2() iter.Seq2[int, *expression.Column] {
+	return slices.All(cb.columns)
 }
 
 func (cb *CommonHandleCols) buildHandleByDatumsBuffer(datumBuf []types.Datum) (kv.Handle, error) {
@@ -345,6 +361,14 @@ func (ib *IntHandleCols) Equals(other any) bool {
 // Clone implements the kv.HandleCols interface.
 func (ib *IntHandleCols) Clone(*stmtctx.StatementContext) HandleCols {
 	return &IntHandleCols{col: ib.col.Clone().(*expression.Column)}
+}
+
+func (cb *IntHandleCols) IterColumns() iter.Seq[*expression.Column] {
+	return slices.Values([]*expression.Column{cb.col})
+}
+
+func (cb *IntHandleCols) IterColumns2() iter.Seq2[int, *expression.Column] {
+	return slices.All([]*expression.Column{cb.col})
 }
 
 // BuildHandle implements the kv.HandleCols interface.

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -152,12 +152,12 @@ func (cb *CommonHandleCols) GetColumns() []*expression.Column {
 	return cb.columns
 }
 
-// IterColumns implements the kv.HandleCols interface. it implements the Seq2 interface.
+// IterColumns implements the kv.HandleCols interface.
 func (cb *CommonHandleCols) IterColumns() iter.Seq[*expression.Column] {
 	return slices.Values(cb.columns)
 }
 
-// IterColumns implements the kv.HandleCols interface. it implements the Seq2 interface.
+// IterColumns implements the kv.HandleCols interface.
 func (cb *CommonHandleCols) IterColumns2() iter.Seq2[int, *expression.Column] {
 	return slices.All(cb.columns)
 }

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -157,7 +157,7 @@ func (cb *CommonHandleCols) IterColumns() iter.Seq[*expression.Column] {
 	return slices.Values(cb.columns)
 }
 
-// IterColumns implements the kv.HandleCols interface.
+// IterColumns2 implements the kv.HandleCols interface.
 func (cb *CommonHandleCols) IterColumns2() iter.Seq2[int, *expression.Column] {
 	return slices.All(cb.columns)
 }
@@ -363,12 +363,14 @@ func (ib *IntHandleCols) Clone(*stmtctx.StatementContext) HandleCols {
 	return &IntHandleCols{col: ib.col.Clone().(*expression.Column)}
 }
 
-func (cb *IntHandleCols) IterColumns() iter.Seq[*expression.Column] {
-	return slices.Values([]*expression.Column{cb.col})
+// IterColumns implements the kv.HandleCols interface.
+func (ib *IntHandleCols) IterColumns() iter.Seq[*expression.Column] {
+	return slices.Values([]*expression.Column{ib.col})
 }
 
-func (cb *IntHandleCols) IterColumns2() iter.Seq2[int, *expression.Column] {
-	return slices.All([]*expression.Column{cb.col})
+// IterColumns2 implements the kv.HandleCols interface.
+func (ib *IntHandleCols) IterColumns2() iter.Seq2[int, *expression.Column] {
+	return slices.All([]*expression.Column{ib.col})
 }
 
 // BuildHandle implements the kv.HandleCols interface.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

1、 The more important is to write the less code
2、```GetCol ``` has bound check. now we use iter and avoid to use this ```GetCol```

```
pkg/planner/util/handle_cols.go:227:19: Found IsInBounds
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
