### PR TITLE
executor: skip execution when build query for VIEW in I_S (#58203)

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -842,7 +842,7 @@ func (e *hugeMemTableRetriever) dataForColumnsInTable(ctx context.Context, sctx 
 			// Build plan is not thread safe, there will be concurrency on sessionctx.
 			if err := runWithSystemSession(internalCtx, sctx, func(s sessionctx.Context) error {
 				is := sessiontxn.GetTxnManager(s).GetTxnInfoSchema()
-				planBuilder, _ := plannercore.NewPlanBuilder().Init(s, is, &hint.BlockHintProcessor{})
+				planBuilder, _ := plannercore.NewPlanBuilder(plannercore.PlanBuilderOptNoExecution{}).Init(s, is, &hint.BlockHintProcessor{})
 				var err error
 				viewLogicalPlan, err = planBuilder.BuildDataSourceFromView(ctx, schema.Name, tbl, nil, nil)
 				return errors.Trace(err)
@@ -1003,27 +1003,27 @@ ForColumnsTag:
 			}
 		}
 		record := types.MakeDatums(
-			infoschema.CatalogVal, // TABLE_CATALOG
-			schema.Name.O,         // TABLE_SCHEMA
-			tbl.Name.O,            // TABLE_NAME
-			col.Name.O,            // COLUMN_NAME
-			i,                     // ORDINAL_POSITION
-			columnDefault,         // COLUMN_DEFAULT
-			columnDesc.Null,       // IS_NULLABLE
-			types.TypeToStr(ft.GetType(), ft.GetCharset()), // DATA_TYPE
-			charMaxLen,           // CHARACTER_MAXIMUM_LENGTH
-			charOctLen,           // CHARACTER_OCTET_LENGTH
-			numericPrecision,     // NUMERIC_PRECISION
-			numericScale,         // NUMERIC_SCALE
-			datetimePrecision,    // DATETIME_PRECISION
-			columnDesc.Charset,   // CHARACTER_SET_NAME
-			columnDesc.Collation, // COLLATION_NAME
-			columnType,           // COLUMN_TYPE
-			columnDesc.Key,       // COLUMN_KEY
-			columnDesc.Extra,     // EXTRA
+			infoschema.CatalogVal,                                                                // TABLE_CATALOG
+			schema.Name.O,                                                                        // TABLE_SCHEMA
+			tbl.Name.O,                                                                           // TABLE_NAME
+			col.Name.O,                                                                           // COLUMN_NAME
+			i,                                                                                    // ORDINAL_POSITION
+			columnDefault,                                                                        // COLUMN_DEFAULT
+			columnDesc.Null,                                                                      // IS_NULLABLE
+			types.TypeToStr(ft.GetType(), ft.GetCharset()),                                       // DATA_TYPE
+			charMaxLen,                                                                           // CHARACTER_MAXIMUM_LENGTH
+			charOctLen,                                                                           // CHARACTER_OCTET_LENGTH
+			numericPrecision,                                                                     // NUMERIC_PRECISION
+			numericScale,                                                                         // NUMERIC_SCALE
+			datetimePrecision,                                                                    // DATETIME_PRECISION
+			columnDesc.Charset,                                                                   // CHARACTER_SET_NAME
+			columnDesc.Collation,                                                                 // COLLATION_NAME
+			columnType,                                                                           // COLUMN_TYPE
+			columnDesc.Key,                                                                       // COLUMN_KEY
+			columnDesc.Extra,                                                                     // EXTRA
 			strings.ToLower(privileges.PrivToString(priv, mysql.AllColumnPrivs, mysql.Priv2Str)), // PRIVILEGES
-			columnDesc.Comment,      // COLUMN_COMMENT
-			col.GeneratedExprString, // GENERATION_EXPRESSION
+			columnDesc.Comment,                                                                   // COLUMN_COMMENT
+			col.GeneratedExprString,                                                              // GENERATION_EXPRESSION
 		)
 		e.rows = append(e.rows, record)
 		i++
@@ -1460,12 +1460,12 @@ func (e *memtableRetriever) setDataFromEngines() {
 	var rows [][]types.Datum
 	rows = append(rows,
 		types.MakeDatums(
-			"InnoDB",  // Engine
-			"DEFAULT", // Support
+			"InnoDB",                                                     // Engine
+			"DEFAULT",                                                    // Support
 			"Supports transactions, row-level locking, and foreign keys", // Comment
-			"YES", // Transactions
-			"YES", // XA
-			"YES", // Savepoints
+			"YES",                                                        // Transactions
+			"YES",                                                        // XA
+			"YES",                                                        // Savepoints
 		),
 	)
 	e.rows = rows
@@ -2229,14 +2229,14 @@ func (e *memtableRetriever) setDataForServersInfo(ctx sessionctx.Context) error 
 	rows := make([][]types.Datum, 0, len(serversInfo))
 	for _, info := range serversInfo {
 		row := types.MakeDatums(
-			info.ID,              // DDL_ID
-			info.IP,              // IP
-			int(info.Port),       // PORT
-			int(info.StatusPort), // STATUS_PORT
-			info.Lease,           // LEASE
-			info.Version,         // VERSION
-			info.GitHash,         // GIT_HASH
-			info.BinlogStatus,    // BINLOG_STATUS
+			info.ID,                                       // DDL_ID
+			info.IP,                                       // IP
+			int(info.Port),                                // PORT
+			int(info.StatusPort),                          // STATUS_PORT
+			info.Lease,                                    // LEASE
+			info.Version,                                  // VERSION
+			info.GitHash,                                  // GIT_HASH
+			info.BinlogStatus,                             // BINLOG_STATUS
 			stringutil.BuildStringFromLabels(info.Labels), // LABELS
 		)
 		if sem.IsEnabled() {
@@ -2314,10 +2314,10 @@ func (e *memtableRetriever) dataForTableTiFlashReplica(ctx sessionctx.Context, s
 			progressString := types.TruncateFloatToString(progress, 2)
 			progress, _ = strconv.ParseFloat(progressString, 64)
 			record := types.MakeDatums(
-				schema.Name.O,                   // TABLE_SCHEMA
-				tbl.Name.O,                      // TABLE_NAME
-				tbl.ID,                          // TABLE_ID
-				int64(tbl.TiFlashReplica.Count), // REPLICA_COUNT
+				schema.Name.O,                                        // TABLE_SCHEMA
+				tbl.Name.O,                                           // TABLE_NAME
+				tbl.ID,                                               // TABLE_ID
+				int64(tbl.TiFlashReplica.Count),                      // REPLICA_COUNT
 				strings.Join(tbl.TiFlashReplica.LocationLabels, ","), // LOCATION_LABELS
 				tbl.TiFlashReplica.Available,                         // AVAILABLE
 				progress,                                             // PROGRESS

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1003,27 +1003,27 @@ ForColumnsTag:
 			}
 		}
 		record := types.MakeDatums(
-			infoschema.CatalogVal,                                                                // TABLE_CATALOG
-			schema.Name.O,                                                                        // TABLE_SCHEMA
-			tbl.Name.O,                                                                           // TABLE_NAME
-			col.Name.O,                                                                           // COLUMN_NAME
-			i,                                                                                    // ORDINAL_POSITION
-			columnDefault,                                                                        // COLUMN_DEFAULT
-			columnDesc.Null,                                                                      // IS_NULLABLE
-			types.TypeToStr(ft.GetType(), ft.GetCharset()),                                       // DATA_TYPE
-			charMaxLen,                                                                           // CHARACTER_MAXIMUM_LENGTH
-			charOctLen,                                                                           // CHARACTER_OCTET_LENGTH
-			numericPrecision,                                                                     // NUMERIC_PRECISION
-			numericScale,                                                                         // NUMERIC_SCALE
-			datetimePrecision,                                                                    // DATETIME_PRECISION
-			columnDesc.Charset,                                                                   // CHARACTER_SET_NAME
-			columnDesc.Collation,                                                                 // COLLATION_NAME
-			columnType,                                                                           // COLUMN_TYPE
-			columnDesc.Key,                                                                       // COLUMN_KEY
-			columnDesc.Extra,                                                                     // EXTRA
+			infoschema.CatalogVal, // TABLE_CATALOG
+			schema.Name.O,         // TABLE_SCHEMA
+			tbl.Name.O,            // TABLE_NAME
+			col.Name.O,            // COLUMN_NAME
+			i,                     // ORDINAL_POSITION
+			columnDefault,         // COLUMN_DEFAULT
+			columnDesc.Null,       // IS_NULLABLE
+			types.TypeToStr(ft.GetType(), ft.GetCharset()), // DATA_TYPE
+			charMaxLen,           // CHARACTER_MAXIMUM_LENGTH
+			charOctLen,           // CHARACTER_OCTET_LENGTH
+			numericPrecision,     // NUMERIC_PRECISION
+			numericScale,         // NUMERIC_SCALE
+			datetimePrecision,    // DATETIME_PRECISION
+			columnDesc.Charset,   // CHARACTER_SET_NAME
+			columnDesc.Collation, // COLLATION_NAME
+			columnType,           // COLUMN_TYPE
+			columnDesc.Key,       // COLUMN_KEY
+			columnDesc.Extra,     // EXTRA
 			strings.ToLower(privileges.PrivToString(priv, mysql.AllColumnPrivs, mysql.Priv2Str)), // PRIVILEGES
-			columnDesc.Comment,                                                                   // COLUMN_COMMENT
-			col.GeneratedExprString,                                                              // GENERATION_EXPRESSION
+			columnDesc.Comment,      // COLUMN_COMMENT
+			col.GeneratedExprString, // GENERATION_EXPRESSION
 		)
 		e.rows = append(e.rows, record)
 		i++
@@ -1460,12 +1460,12 @@ func (e *memtableRetriever) setDataFromEngines() {
 	var rows [][]types.Datum
 	rows = append(rows,
 		types.MakeDatums(
-			"InnoDB",                                                     // Engine
-			"DEFAULT",                                                    // Support
+			"InnoDB",  // Engine
+			"DEFAULT", // Support
 			"Supports transactions, row-level locking, and foreign keys", // Comment
-			"YES",                                                        // Transactions
-			"YES",                                                        // XA
-			"YES",                                                        // Savepoints
+			"YES", // Transactions
+			"YES", // XA
+			"YES", // Savepoints
 		),
 	)
 	e.rows = rows
@@ -2229,14 +2229,14 @@ func (e *memtableRetriever) setDataForServersInfo(ctx sessionctx.Context) error 
 	rows := make([][]types.Datum, 0, len(serversInfo))
 	for _, info := range serversInfo {
 		row := types.MakeDatums(
-			info.ID,                                       // DDL_ID
-			info.IP,                                       // IP
-			int(info.Port),                                // PORT
-			int(info.StatusPort),                          // STATUS_PORT
-			info.Lease,                                    // LEASE
-			info.Version,                                  // VERSION
-			info.GitHash,                                  // GIT_HASH
-			info.BinlogStatus,                             // BINLOG_STATUS
+			info.ID,              // DDL_ID
+			info.IP,              // IP
+			int(info.Port),       // PORT
+			int(info.StatusPort), // STATUS_PORT
+			info.Lease,           // LEASE
+			info.Version,         // VERSION
+			info.GitHash,         // GIT_HASH
+			info.BinlogStatus,    // BINLOG_STATUS
 			stringutil.BuildStringFromLabels(info.Labels), // LABELS
 		)
 		if sem.IsEnabled() {
@@ -2314,10 +2314,10 @@ func (e *memtableRetriever) dataForTableTiFlashReplica(ctx sessionctx.Context, s
 			progressString := types.TruncateFloatToString(progress, 2)
 			progress, _ = strconv.ParseFloat(progressString, 64)
 			record := types.MakeDatums(
-				schema.Name.O,                                        // TABLE_SCHEMA
-				tbl.Name.O,                                           // TABLE_NAME
-				tbl.ID,                                               // TABLE_ID
-				int64(tbl.TiFlashReplica.Count),                      // REPLICA_COUNT
+				schema.Name.O,                   // TABLE_SCHEMA
+				tbl.Name.O,                      // TABLE_NAME
+				tbl.ID,                          // TABLE_ID
+				int64(tbl.TiFlashReplica.Count), // REPLICA_COUNT
 				strings.Join(tbl.TiFlashReplica.LocationLabels, ","), // LOCATION_LABELS
 				tbl.TiFlashReplica.Available,                         // AVAILABLE
 				progress,                                             // PROGRESS

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -855,11 +855,14 @@ func TestShowColumnsWithSubQueryView(t *testing.T) {
 	tk.MustExec("create view temp_view as (select * from `added` where id > (select max(id) from `incremental`));")
 	// Show columns should not send coprocessor request to the storage.
 	require.NoError(t, failpoint.Enable("tikvclient/tikvStoreSendReqResult", `return("timeout")`))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/planner/core/BuildDataSourceFailed", "panic"))
 	tk.MustQuery("show columns from temp_view;").Check(testkit.Rows(
 		"id int(11) YES  <nil> ",
 		"name text YES  <nil> ",
 		"some_date timestamp YES  <nil> "))
+	tk.MustQuery("select COLUMN_NAME from information_schema.columns where table_name = 'temp_view';").Check(testkit.Rows("id", "name", "some_date"))
 	require.NoError(t, failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/planner/core/BuildDataSourceFailed"))
 }
 
 func TestNullColumns(t *testing.T) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -5345,6 +5345,7 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName model.
 			terror.ErrorNotEqual(err, ErrNotSupportedYet) {
 			err = ErrViewInvalid.GenWithStackByArgs(dbName.O, tableInfo.Name.O)
 		}
+		failpoint.Inject("BuildDataSourceFailed", func() {})
 		return nil, err
 	}
 	pm := privilege.GetPrivilegeManager(b.ctx)


### PR DESCRIPTION
This is an manual cherry-pick of #58203

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58184

Problem Summary:

### What changed and how does it work?

use `PlanBuilderOptNoExecution` to skip unnecessary execution. This should be the same behaviour with `SHOW COLUMNS`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

I tested the new `PlanBuilderOptNoExecution` based on release-6.5 with the reproduce steps in issue. Before this PR (which is v6.5.11)

```
mysql> select count(1) from INFORMATION_SCHEMA.columns;
+----------+
| count(1) |
+----------+
|     4635 |
+----------+
1 row in set (0.66 sec)

mysql> trace select count(1) from INFORMATION_SCHEMA.columns;
+-----------------------------------------------------------------------------+-----------------+-------------+
| operation                                                                   | startTS         | duration    |
+-----------------------------------------------------------------------------+-----------------+-------------+
| trace                                                                       | 15:19:40.955394 | 28.741875ms |
|   ├─session.ExecuteStmt                                                     | 15:19:40.955411 | 897.25µs    |
|   │ ├─executor.Compile                                                      | 15:19:40.955448 | 293.25µs    |
|   │ └─session.runStmt                                                       | 15:19:40.956066 | 196.333µs   |
|   ├─*executor.HashAggExec.Next                                              | 15:19:40.956323 | 27.783083ms |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.956367 | 5.175042ms  |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.961575 | 4.542083ms  |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.966134 | 4.1615ms    |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.970309 | 3.901959ms  |
|   │ ├─*executor.MemTableReaderExec.Next                                     | 15:19:40.974224 | 9.777625ms  |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.977166 | 832.333µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.977198 | 62.292µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.977220 | 26.75µs     |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.977293 | 594.75µs    |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.977314 | 558.375µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.977316 | 195.75µs    |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.977316 | 41.708µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.977316 | 41.708µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.977273 | 714.667µs   |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.977275 | 703.458µs   |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.977276 | 691.042µs   |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.977281 | 649.375µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.977943 | 16.5µs      |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.977973 | 542ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.977983 | 542ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.978578 | 494.875µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.978592 | 26.541µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.978601 | 10.916µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.978640 | 362.875µs   |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.978648 | 347.334µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.978648 | 103.959µs   |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.978648 | 20.291µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.978648 | 20.291µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.978625 | 442.625µs   |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.978626 | 431.334µs   |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.978627 | 421.458µs   |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.978629 | 394.625µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.979033 | 9.958µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.979053 | 417ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.979062 | 334ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.979615 | 519.291µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.979634 | 27.583µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.979645 | 11.459µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.979682 | 358.625µs   |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.979689 | 344.542µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.979690 | 108.958µs   |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.979690 | 19.458µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.979690 | 19.458µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.979669 | 460.375µs   |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.979670 | 451.083µs   |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.979670 | 441.5µs     |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.979673 | 389.833µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.980092 | 12.75µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.980117 | 417ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.980125 | 333ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.980505 | 1.343084ms  |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.980519 | 34.292µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.980531 | 12.958µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.980573 | 339.75µs    |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.980582 | 321.542µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.980582 | 88.792µs    |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.980582 | 18.458µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.980582 | 18.458µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.980560 | 1.281041ms  |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.980561 | 1.272291ms  |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.980562 | 1.259083ms  |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.980564 | 367.958µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.980940 | 8.542µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.981829 | 833ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.981838 | 333ns       |
|   │ │ ├─executor.EvalSubQuery                                               | 15:19:40.982310 | 398.042µs   |
|   │ │ │ ├─TableReaderExecutor.Open                                          | 15:19:40.982322 | 27.666µs    |
|   │ │ │ │ └─distsql.Select                                                  | 15:19:40.982331 | 13.875µs    |
|   │ │ │ │   └─regionRequest.SendReqCtx                                      | 15:19:40.982370 | 262.708µs   |
|   │ │ │ │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.982377 | 249.208µs   |
|   │ │ │ │       └─tikv.RPC                                                  | 15:19:40.982377 | 77.459µs    |
|   │ │ │ │         └─tikv.Wait                                               | 15:19:40.982377 | 17.458µs    |
|   │ │ │ │           └─tikv.GetSnapshot                                      | 15:19:40.982377 | 17.458µs    |
|   │ │ │ └─*executor.MaxOneRowExec.Next                                      | 15:19:40.982356 | 346µs       |
|   │ │ │   ├─*executor.StreamAggExec.Next                                    | 15:19:40.982357 | 325.5µs     |
|   │ │ │   │ ├─*executor.TopNExec.Next                                       | 15:19:40.982358 | 316.625µs   |
|   │ │ │   │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.982361 | 290.833µs   |
|   │ │ │   │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.982659 | 9.917µs     |
|   │ │ │   │ └─*executor.TopNExec.Next                                       | 15:19:40.982679 | 416ns       |
|   │ │ │   └─*executor.StreamAggExec.Next                                    | 15:19:40.982698 | 417ns       |
|   │ │ └─executor.EvalSubQuery                                               | 15:19:40.983042 | 401.166µs   |
|   │ │   ├─TableReaderExecutor.Open                                          | 15:19:40.983054 | 27.25µs     |
|   │ │   │ └─distsql.Select                                                  | 15:19:40.983062 | 13µs        |
|   │ │   │   └─regionRequest.SendReqCtx                                      | 15:19:40.983101 | 277.667µs   |
|   │ │   │     └─rpcClient.SendRequest, region ID: 90, type: Cop             | 15:19:40.983107 | 265.083µs   |
|   │ │   │       └─tikv.RPC                                                  | 15:19:40.983108 | 94.5µs      |
|   │ │   │         └─tikv.Wait                                               | 15:19:40.983108 | 22.083µs    |
|   │ │   │           └─tikv.GetSnapshot                                      | 15:19:40.983108 | 22.083µs    |
|   │ │   └─*executor.MaxOneRowExec.Next                                      | 15:19:40.983088 | 349.375µs   |
|   │ │     ├─*executor.StreamAggExec.Next                                    | 15:19:40.983089 | 340.459µs   |
|   │ │     │ ├─*executor.TopNExec.Next                                       | 15:19:40.983090 | 329.916µs   |
|   │ │     │ │ ├─*executor.TableReaderExecutor.Next                          | 15:19:40.983092 | 305.541µs   |
|   │ │     │ │ └─*executor.TableReaderExecutor.Next                          | 15:19:40.983406 | 8.208µs     |
|   │ │     │ └─*executor.TopNExec.Next                                       | 15:19:40.983424 | 375ns       |
|   │ │     └─*executor.StreamAggExec.Next                                    | 15:19:40.983434 | 375ns       |
|   │ └─*executor.MemTableReaderExec.Next                                     | 15:19:40.984015 | 1.75µs      |
|   └─*executor.HashAggExec.Next                                              | 15:19:40.984115 | 750ns       |
+-----------------------------------------------------------------------------+-----------------+-------------+
102 rows in set (0.03 sec)
```

with this PR

```
mysql> select count(1) from INFORMATION_SCHEMA.columns;
+----------+
| count(1) |
+----------+
|     4635 |
+----------+
1 row in set (0.03 sec)

mysql> trace SELECT COUNT(1) FROM INFORMATION_SCHEMA.COLUMNS;
+-----------------------------------------------+-----------------+-------------+
| operation                                     | startTS         | duration    |
+-----------------------------------------------+-----------------+-------------+
| trace                                         | 15:17:33.199398 | 28.597792ms |
|   ├─session.ExecuteStmt                       | 15:17:33.199704 | 1.093833ms  |
|   │ ├─executor.Compile                        | 15:17:33.199750 | 317.875µs   |
|   │ └─session.runStmt                         | 15:17:33.200340 | 181.5µs     |
|   ├─*executor.HashAggExec.Next                | 15:17:33.200809 | 27.12125ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.200850 | 5.302125ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.206185 | 4.823458ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.211029 | 4.406417ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.215453 | 7.002666ms  |
|   │ ├─*executor.MemTableReaderExec.Next       | 15:17:33.222477 | 5.324958ms  |
|   │ └─*executor.MemTableReaderExec.Next       | 15:17:33.227816 | 1.667µs     |
|   └─*executor.HashAggExec.Next                | 15:17:33.227942 | 17.833µs    |
+-----------------------------------------------+-----------------+-------------+
12 rows in set (0.03 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
