### PR TITLE
statistics: fix async merge global stats use cmsketch twice

### DIFF
--- a/pkg/statistics/handle/globalstats/BUILD.bazel
+++ b/pkg/statistics/handle/globalstats/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     ],
     embed = [":globalstats"],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         "//pkg/domain",
         "//pkg/kv",

--- a/pkg/statistics/handle/globalstats/global_stats_async.go
+++ b/pkg/statistics/handle/globalstats/global_stats_async.go
@@ -388,9 +388,6 @@ func (a *AsyncMergePartitionStats2GlobalStats) loadCMsketch(sctx sessionctx.Cont
 			if err != nil {
 				return err
 			}
-			a.cmsketch <- mergeItem[*statistics.CMSketch]{
-				cmsketch, i,
-			}
 			select {
 			case a.cmsketch <- mergeItem[*statistics.CMSketch]{
 				cmsketch, i,

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -977,7 +977,7 @@ func TestGlobalStatsAndSQLBindingWithConcurrency(t *testing.T) {
 }
 
 func TestMergeGlobalStatsForCMSketch(t *testing.T) {
-	store, _ := testkit.CreateMockStoreAndDomain(t)
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/pkg/statistics/handle/globalstats/global_stats_test.go
+++ b/pkg/statistics/handle/globalstats/global_stats_test.go
@@ -975,3 +975,23 @@ func TestGlobalStatsAndSQLBindingWithConcurrency(t *testing.T) {
 	tk.MustExec("set global tidb_merge_partition_stats_concurrency=2")
 	testGlobalStatsAndSQLBinding(tk)
 }
+
+func TestMergeGlobalStatsForCMSketch(t *testing.T) {
+	store, _ := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(`
+		create table t (a int) partition by range (a) (
+			partition p0 values less than (10),
+			partition p1 values less than (20)
+		)`)
+	tk.MustExec("set @@tidb_analyze_version=1")
+	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("insert into t values (1), (2), (3), (4), (5), (6), (6), (null), (11), (12), (13), (14), (15), (16), (17), (18), (19), (19)")
+	tk.MustExec("analyze table t")
+	tk.MustQuery("explain select * from t where a = 1").Check(
+		testkit.Rows("TableReader_7 1.00 root partition:p0 data:Selection_6",
+			"└─Selection_6 1.00 cop[tikv]  eq(test.t.a, 1)",
+			"  └─TableFullScan_5 18.00 cop[tikv] table:t keep order:false"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59194 

Problem Summary:
the same cmsketch is merge twice, which affects row estimation.

### What changed and how does it work?
remove the unnecessary part.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
