### PR TITLE
workloadrepo: Simplify the snapshot code.

### DIFF
--- a/pkg/executor/workloadrepo.go
+++ b/pkg/executor/workloadrepo.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TakeSnapshot is a hook from workload repo that may trigger manual snapshot.
-var TakeSnapshot func() error
+var TakeSnapshot func(context.Context) error
 
 // WorkloadRepoCreateExec indicates WorkloadRepoCreate executor.
 type WorkloadRepoCreateExec struct {
@@ -30,9 +30,9 @@ type WorkloadRepoCreateExec struct {
 }
 
 // Next implements the Executor Next interface.
-func (*WorkloadRepoCreateExec) Next(context.Context, *chunk.Chunk) error {
+func (*WorkloadRepoCreateExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	if TakeSnapshot != nil {
-		return TakeSnapshot()
+		return TakeSnapshot(ctx)
 	}
 	return nil
 }

--- a/pkg/util/workloadrepo/const.go
+++ b/pkg/util/workloadrepo/const.go
@@ -24,12 +24,9 @@ import (
 )
 
 const (
-	ownerKey       = "/tidb/workloadrepo/owner"
-	promptKey      = "workloadrepo"
-	snapIDKey      = "/tidb/workloadrepo/snap_id"
-	snapCommandKey = "/tidb/workloadrepo/snap_command"
-
-	snapCommandTake = "take_snapshot"
+	ownerKey  = "/tidb/workloadrepo/owner"
+	promptKey = "workloadrepo"
+	snapIDKey = "/tidb/workloadrepo/snap_id"
 
 	etcdOpTimeout   = 5 * time.Second
 	snapshotRetries = 5
@@ -49,4 +46,6 @@ var (
 
 	errWrongValueForVar        = dbterror.ClassUtil.NewStd(errno.ErrWrongValueForVar)
 	errUnsupportedEtcdRequired = dbterror.ClassUtil.NewStdErr(errno.ErrNotSupportedYet, mysql.Message("etcd client required for workload repository", nil))
+	errWorkloadNotStarted      = dbterror.ClassUtil.NewStdErr(errno.ErrNotSupportedYet, mysql.Message("Workload repository is not enabled", nil))
+	errCouldNotStartSnapshot   = dbterror.ClassUtil.NewStdErr(errno.ErrUnknown, mysql.Message("Snapshot initiation failed", nil))
 )

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -130,6 +130,8 @@ func (w *worker) snapshotTable(ctx context.Context, snapID uint64, rt *repositor
 	return nil
 }
 
+// takeSnapshot increments the value of snapIDKey, which triggers the tidb
+// nodes to run the snapshot process.  See the code in startSnapshot().
 func (w *worker) takeSnapshot(ctx context.Context) (uint64, error) {
 	_sessctx := w.getSessionWithRetry()
 	defer w.sesspool.Put(_sessctx)
@@ -189,6 +191,7 @@ func (w *worker) startSnapshot(_ctx context.Context) func() {
 			case <-ctx.Done():
 				return
 			case resp := <-snapIDCh:
+				// This case is triggered by both by w.snapshotInterval and the SQL command, which calls w.takeSnapshot() directly.
 				if len(resp.Events) < 1 {
 					// since there is no event, we don't know the latest snapid either
 					// really should not happen except creation

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -89,16 +89,6 @@ func (w *worker) getSnapID(ctx context.Context) (uint64, error) {
 	return strconv.ParseUint(snapIDStr, 10, 64)
 }
 
-func (w *worker) updateSnapID(ctx context.Context, oid, nid uint64) error {
-	return w.etcdCAS(ctx, snapIDKey,
-		strconv.FormatUint(oid, 10),
-		strconv.FormatUint(nid, 10))
-}
-
-func (w *worker) createSnapID(ctx context.Context, nid uint64) error {
-	return w.etcdCreate(ctx, snapIDKey, strconv.FormatUint(nid, 10))
-}
-
 func upsertHistSnapshot(ctx context.Context, sctx sessionctx.Context, snapID uint64) error {
 	// TODO: fill DB_VER, WR_VER
 	snapshotsInsert := sqlescape.MustEscapeSQL("INSERT INTO %n.%n (`BEGIN_TIME`, `SNAP_ID`) VALUES (now(), %%?) ON DUPLICATE KEY UPDATE `BEGIN_TIME` = now()",
@@ -107,7 +97,11 @@ func upsertHistSnapshot(ctx context.Context, sctx sessionctx.Context, snapID uin
 	return err
 }
 
-func updateHistSnapshot(ctx context.Context, sctx sessionctx.Context, snapID uint64, errs []error) error {
+func (w *worker) updateHistSnapshot(ctx context.Context, snapID uint64, errs []error) error {
+	_sessctx := w.getSessionWithRetry()
+	defer w.sesspool.Put(_sessctx)
+	sctx := _sessctx.(sessionctx.Context)
+
 	var nerr any
 	if err := stderrors.Join(errs...); err != nil {
 		nerr = err.Error()
@@ -136,34 +130,17 @@ func (w *worker) snapshotTable(ctx context.Context, snapID uint64, rt *repositor
 	return nil
 }
 
-func (w *worker) takeSnapshot(ctx context.Context, sess sessionctx.Context, sendCommand bool) {
-	// coordination logic
-	if !w.owner.IsOwner() {
-		if sendCommand {
-			command, err := w.etcdGet(ctx, snapCommandKey)
-			if err != nil {
-				logutil.BgLogger().Info("workload repository cannot get current snap command value", zap.NamedError("err", err))
-				return
-			}
+func (w *worker) takeSnapshot(ctx context.Context) (uint64, error) {
+	_sessctx := w.getSessionWithRetry()
+	defer w.sesspool.Put(_sessctx)
+	sess := _sessctx.(sessionctx.Context)
 
-			if command == "" {
-				err = w.etcdCreate(ctx, snapCommandKey, snapCommandTake)
-			} else {
-				err = w.etcdCAS(ctx, snapCommandKey, command, snapCommandTake)
-			}
-
-			if err != nil {
-				logutil.BgLogger().Info("workload repository cannot send snapshot command", zap.NamedError("err", err))
-				return
-			}
-		}
-		return
-	}
-
+	var snapID uint64
+	var err error = nil
 	for range snapshotRetries {
-		snapID, err := w.getSnapID(ctx)
+		snapID, err = w.getSnapID(ctx)
 		if err != nil {
-			logutil.BgLogger().Info("workload repository cannot get current snapid", zap.NamedError("err", err))
+			err = fmt.Errorf("cannot get current snapid: %w", err)
 			continue
 		}
 
@@ -174,57 +151,43 @@ func (w *worker) takeSnapshot(ctx context.Context, sess sessionctx.Context, send
 		// due to another owner winning the etcd CAS loop.
 		// While undesirable, this scenario is acceptable since both owners would
 		// likely share similar datetime values and same cluster version.
-		if err := upsertHistSnapshot(ctx, sess, snapID+1); err != nil {
-			logutil.BgLogger().Info("workload repository could not insert into hist_snapshots", zap.NamedError("err", err))
+		if err = upsertHistSnapshot(ctx, sess, snapID+1); err != nil {
+			err = fmt.Errorf("could not insert into hist_snapshots: %w", err)
 			continue
 		}
 
 		if snapID == 0 {
-			err = w.createSnapID(ctx, snapID+1)
+			err = w.etcdCreate(ctx, snapIDKey, strconv.FormatUint(snapID+1, 10))
 		} else {
-			err = w.updateSnapID(ctx, snapID, snapID+1)
+			err = w.etcdCAS(ctx, snapIDKey, strconv.FormatUint(snapID, 10), strconv.FormatUint(snapID+1, 10))
 		}
 
 		if err != nil {
-			logutil.BgLogger().Info("workload repository cannot update current snapid", zap.Uint64("new_id", snapID), zap.NamedError("err", err))
+			err = fmt.Errorf("cannot update current snapid to %d: %w", snapID, err)
 			continue
 		}
 
-		logutil.BgLogger().Info("workload repository fired snapshot", zap.String("owner", w.instanceID), zap.Uint64("snapID", snapID+1))
 		break
 	}
+
+	// return the last error seen, if it ended on an error
+	return snapID, err
 }
 
 func (w *worker) startSnapshot(_ctx context.Context) func() {
 	return func() {
 		w.resetSnapshotInterval(w.snapshotInterval)
 
-		_sessctx := w.getSessionWithRetry()
-		defer w.sesspool.Put(_sessctx)
-		sess := _sessctx.(sessionctx.Context)
-
 		// this is for etcd watch
 		// other wise wch won't be collected after the exit of this function
 		ctx, cancel := context.WithCancel(_ctx)
 		defer cancel()
 		snapIDCh := w.etcdClient.Watch(ctx, snapIDKey)
-		snapCmdCh := w.etcdClient.Watch(ctx, snapCommandKey)
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case resp := <-snapCmdCh:
-				if len(resp.Events) < 1 {
-					continue
-				}
-
-				// same as snapID events
-				// we only catch the last event if possible
-				snapCommandStr := string(resp.Events[len(resp.Events)-1].Kv.Value)
-				if snapCommandStr == snapCommandTake {
-					w.takeSnapshot(ctx, sess, false)
-				}
 			case resp := <-snapIDCh:
 				if len(resp.Events) < 1 {
 					// since there is no event, we don't know the latest snapid either
@@ -261,13 +224,17 @@ func (w *worker) startSnapshot(_ctx context.Context) func() {
 				}
 				wg.Wait()
 
-				if err := updateHistSnapshot(ctx, sess, snapID, errs); err != nil {
+				if err := w.updateHistSnapshot(ctx, snapID, errs); err != nil {
 					logutil.BgLogger().Info("workload repository snapshot failed: could not update hist_snapshots", zap.NamedError("err", err))
 				}
-			case <-w.snapshotChan:
-				w.takeSnapshot(ctx, sess, true)
 			case <-w.snapshotTicker.C:
-				w.takeSnapshot(ctx, sess, false)
+				if w.owner.IsOwner() {
+					if snapID, err := w.takeSnapshot(ctx); err != nil {
+						logutil.BgLogger().Info("workload repository snapshot failed", zap.NamedError("err", err))
+					} else {
+						logutil.BgLogger().Info("workload repository ran snapshot", zap.String("owner", w.instanceID), zap.Uint64("snapID", snapID))
+					}
+				}
 			}
 		}
 	}

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -136,7 +136,7 @@ func (w *worker) takeSnapshot(ctx context.Context) (uint64, error) {
 	sess := _sessctx.(sessionctx.Context)
 
 	var snapID uint64
-	var err error = nil
+	var err error
 	for range snapshotRetries {
 		snapID, err = w.getSnapID(ctx)
 		if err != nil {

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -139,9 +139,8 @@ func takeSnapshot(ctx context.Context) error {
 		return errCouldNotStartSnapshot.GenWithStackByArgs()
 	} else {
 		logutil.BgLogger().Info("workload repository ran manual snapshot", zap.String("owner", workerCtx.instanceID), zap.Uint64("snapID", snapID))
+		return nil
 	}
-
-	return nil
 }
 
 func init() {

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -134,13 +134,14 @@ func takeSnapshot(ctx context.Context) error {
 		return errWorkloadNotStarted.GenWithStackByArgs()
 	}
 
-	if snapID, err := workerCtx.takeSnapshot(ctx); err != nil {
+	snapID, err := workerCtx.takeSnapshot(ctx)
+	if err != nil {
 		logutil.BgLogger().Info("workload repository manual snapshot failed", zap.String("owner", workerCtx.instanceID), zap.NamedError("err", err))
 		return errCouldNotStartSnapshot.GenWithStackByArgs()
-	} else {
-		logutil.BgLogger().Info("workload repository ran manual snapshot", zap.String("owner", workerCtx.instanceID), zap.Uint64("snapID", snapID))
-		return nil
 	}
+
+	logutil.BgLogger().Info("workload repository ran manual snapshot", zap.String("owner", workerCtx.instanceID), zap.Uint64("snapID", snapID))
+	return nil
 }
 
 func init() {

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -169,13 +169,13 @@ func TestRaceToCreateTablesWorker(t *testing.T) {
 	require.Len(t, res, 0)
 
 	// manually trigger snapshot by sending a tick to all workers
-	wrk1.snapshotChan <- struct{}{}
+	wrk1.takeSnapshot(ctx)
 	require.Eventually(t, func() bool {
 		res := tk.MustQuery("select snap_id, count(*) from workload_schema.hist_snapshots group by snap_id").Rows()
 		return len(res) == 1
 	}, time.Minute, time.Second)
 
-	wrk2.snapshotChan <- struct{}{}
+	wrk2.takeSnapshot(ctx)
 	require.Eventually(t, func() bool {
 		res := tk.MustQuery("select snap_id, count(*) from workload_schema.hist_snapshots group by snap_id").Rows()
 		return len(res) == 2


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58247

Problem Summary:

This pull request simplifies the workload repository code.

### What changed and how does it work?

This pull request removes the snapshot command key (/tidb/workloadrepo/snap_command) and changes the snapshot command (admin create workload snapshot) to update the snapshot id key directly.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
