### PR TITLE
planner: add tolerance for row count floating point comparison

### DIFF
--- a/pkg/planner/core/casetest/index/testdata/index_range_out.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_out.json
@@ -391,8 +391,8 @@
         "SQL": "SELECT 1 FROM t_inlist_test FORCE INDEX (twoColIndex) WHERE a1 IN (44, 70, 76) AND (a1 > 70 OR (a1 = 70 AND b1 > 41));",
         "Plan": [
           "Projection 43.33 root  1->Column#5",
-          "└─IndexReader 54.17 root  index:IndexRangeScan",
-          "  └─IndexRangeScan 54.17 cop[tikv] table:t_inlist_test, index:twoColIndex(a1, b1) range:(70 41,70 +inf], [76,76], keep order:false, stats:pseudo"
+          "└─IndexReader 43.33 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 43.33 cop[tikv] table:t_inlist_test, index:twoColIndex(a1, b1) range:(70 41,70 +inf], [76,76], keep order:false, stats:pseudo"
         ],
         "Result": null
       },

--- a/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
+++ b/pkg/planner/core/casetest/testdata/plan_normalized_suite_out.json
@@ -428,8 +428,8 @@
         "Plan": [
           " TableReader         root         ",
           " └─ExchangeSender    cop[tiflash] ",
-          "   └─Selection       cop[tiflash] gt(test.t1.c, ?)",
-          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.a, ?), gt(test.t1.b, ?), keep order:false"
+          "   └─Selection       cop[tiflash] gt(test.t1.a, ?)",
+          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], pushed down filter:gt(test.t1.b, ?), gt(test.t1.c, ?), keep order:false"
         ]
       },
       {

--- a/pkg/planner/core/cost/factors_thresholds.go
+++ b/pkg/planner/core/cost/factors_thresholds.go
@@ -24,6 +24,10 @@ const (
 	SelectionFactor = 0.8
 
 	DistinctFactor = 0.8
+
+	// ToleranceFactor is an aribtrary value used in (some) floating point
+	// comparisons to account for precision errors
+	ToleranceFactor = 0.00001
 )
 
 // AggFuncFactor is the basic factor for aggregation.

--- a/pkg/planner/core/cost/factors_thresholds.go
+++ b/pkg/planner/core/cost/factors_thresholds.go
@@ -25,7 +25,7 @@ const (
 
 	DistinctFactor = 0.8
 
-	// ToleranceFactor is an aribtrary value used in (some) floating point
+	// ToleranceFactor is an arbitrary value used in (some) floating point
 	// comparisons to account for precision errors
 	ToleranceFactor = 0.00001
 )

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1704,9 +1704,8 @@ func convertToIndexMergeScan(ds *logicalop.DataSource, prop *property.PhysicalPr
 		scans = append(scans, scan)
 	}
 	totalRowCount := path.CountAfterAccess
-	tolerance := 0.00001
 	// Add an arbitrary tolerance factor to account for comparison with floating point
-	if (prop.ExpectedCnt + tolerance) < ds.StatsInfo().RowCount {
+	if (prop.ExpectedCnt + cost.ToleranceFactor) < ds.StatsInfo().RowCount {
 		totalRowCount *= prop.ExpectedCnt / ds.StatsInfo().RowCount
 	}
 	ts, remainingFilters2, moreColumn, err := buildIndexMergeTableScan(ds, path.TableFilters, totalRowCount, candidate.isMatchProp)
@@ -2950,9 +2949,8 @@ func getOriginalPhysicalTableScan(ds *logicalop.DataSource, prop *property.Physi
 	}.Init(ds.SCtx(), ds.QueryBlockOffset())
 	ts.SetSchema(ds.Schema().Clone())
 	rowCount := path.CountAfterAccess
-	tolerance := 0.00001
 	// Add an arbitrary tolerance factor to account for comparison with floating point
-	if (prop.ExpectedCnt + tolerance) < ds.StatsInfo().RowCount {
+	if (prop.ExpectedCnt + cost.ToleranceFactor) < ds.StatsInfo().RowCount {
 		rowCount = cardinality.AdjustRowCountForTableScanByLimit(ds.SCtx(),
 			ds.StatsInfo(), ds.TableStats, ds.StatisticTable,
 			path, prop.ExpectedCnt, isMatchProp && prop.SortItems[0].Desc)

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1704,7 +1704,9 @@ func convertToIndexMergeScan(ds *logicalop.DataSource, prop *property.PhysicalPr
 		scans = append(scans, scan)
 	}
 	totalRowCount := path.CountAfterAccess
-	if prop.ExpectedCnt < ds.StatsInfo().RowCount {
+	tolerance := 0.00001
+	// Add an arbitrary tolerance factor to account for comparison with floating point
+	if (prop.ExpectedCnt + tolerance) < ds.StatsInfo().RowCount {
 		totalRowCount *= prop.ExpectedCnt / ds.StatsInfo().RowCount
 	}
 	ts, remainingFilters2, moreColumn, err := buildIndexMergeTableScan(ds, path.TableFilters, totalRowCount, candidate.isMatchProp)
@@ -2948,7 +2950,9 @@ func getOriginalPhysicalTableScan(ds *logicalop.DataSource, prop *property.Physi
 	}.Init(ds.SCtx(), ds.QueryBlockOffset())
 	ts.SetSchema(ds.Schema().Clone())
 	rowCount := path.CountAfterAccess
-	if prop.ExpectedCnt < ds.StatsInfo().RowCount {
+	tolerance := 0.00001
+	// Add an arbitrary tolerance factor to account for comparison with floating point
+	if (prop.ExpectedCnt + tolerance) < ds.StatsInfo().RowCount {
 		rowCount = cardinality.AdjustRowCountForTableScanByLimit(ds.SCtx(),
 			ds.StatsInfo(), ds.TableStats, ds.StatisticTable,
 			path, prop.ExpectedCnt, isMatchProp && prop.SortItems[0].Desc)

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -234,8 +234,7 @@ func deriveIndexPathStats(ds *logicalop.DataSource, path *util.AccessPath, _ []e
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	// Add an arbitrary tolerance factor to account for comparison with floating point
-	tolerance := 0.00001
-	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
+	if (path.CountAfterAccess+cost.ToleranceFactor) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
 	if path.IndexFilters != nil {
@@ -335,8 +334,7 @@ func deriveTablePathStats(ds *logicalop.DataSource, path *util.AccessPath, conds
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	// Add an arbitrary tolerance factor to account for comparison with floating point
-	tolerance := 0.00001
-	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
+	if (path.CountAfterAccess+cost.ToleranceFactor) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
 	return err
@@ -375,8 +373,7 @@ func deriveCommonHandleTablePathStats(ds *logicalop.DataSource, path *util.Acces
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	// Add an arbitrary tolerance factor to account for comparison with floating point
-	tolerance := 0.00001
-	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
+	if (path.CountAfterAccess+cost.ToleranceFactor) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
 	return nil

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -234,7 +234,7 @@ func deriveIndexPathStats(ds *logicalop.DataSource, path *util.AccessPath, _ []e
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
 	// Add an arbitrary tolerance factor to account for comparison with floating point
-	tolerance := 0.0001
+	tolerance := 0.00001
 	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
@@ -334,7 +334,9 @@ func deriveTablePathStats(ds *logicalop.DataSource, path *util.AccessPath, conds
 	path.CountAfterAccess, err = cardinality.GetRowCountByIntColumnRanges(ds.SCtx(), &ds.StatisticTable.HistColl, pkCol.ID, path.Ranges)
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
-	if path.CountAfterAccess < ds.StatsInfo().RowCount && !isIm {
+	// Add an arbitrary tolerance factor to account for comparison with floating point
+	tolerance := 0.00001
+	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
 	return err
@@ -372,7 +374,9 @@ func deriveCommonHandleTablePathStats(ds *logicalop.DataSource, path *util.Acces
 	}
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
-	if path.CountAfterAccess < ds.StatsInfo().RowCount && !isIm {
+	// Add an arbitrary tolerance factor to account for comparison with floating point
+	tolerance := 0.00001
+	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
 	return nil

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -233,7 +233,9 @@ func deriveIndexPathStats(ds *logicalop.DataSource, path *util.AccessPath, _ []e
 	path.IndexFilters = append(path.IndexFilters, indexFilters...)
 	// If the `CountAfterAccess` is less than `stats.RowCount`, there must be some inconsistent stats info.
 	// We prefer the `stats.RowCount` because it could use more stats info to calculate the selectivity.
-	if path.CountAfterAccess < ds.StatsInfo().RowCount && !isIm {
+	// Add an arbitrary tolerance factor to account for comparison with floating point
+	tolerance := 0.0001
+	if (path.CountAfterAccess+tolerance) < ds.StatsInfo().RowCount && !isIm {
 		path.CountAfterAccess = math.Min(ds.StatsInfo().RowCount/cost.SelectionFactor, float64(ds.StatisticTable.RealtimeCount))
 	}
 	if path.IndexFilters != nil {

--- a/tests/integrationtest/r/clustered_index.result
+++ b/tests/integrationtest/r/clustered_index.result
@@ -109,11 +109,11 @@ id	estRows	task	access object	operator info
 StreamAgg_17	1.00	root		funcs:count(Column#8)->Column#6
 └─IndexReader_18	1.00	root		index:StreamAgg_9
   └─StreamAgg_9	1.00	cop[tikv]		funcs:count(1)->Column#8
-    └─IndexRangeScan_16	133.89	cop[tikv]	table:tbl_0, index:idx_3(col_0)	range:[803163,+inf], keep order:false
+    └─IndexRangeScan_16	107.12	cop[tikv]	table:tbl_0, index:idx_3(col_0)	range:[803163,+inf], keep order:false
 explain select count(*) from wout_cluster_index.tbl_0 where col_0 >= 803163  ;
 id	estRows	task	access object	operator info
 StreamAgg_17	1.00	root		funcs:count(Column#9)->Column#7
 └─IndexReader_18	1.00	root		index:StreamAgg_9
   └─StreamAgg_9	1.00	cop[tikv]		funcs:count(1)->Column#9
-    └─IndexRangeScan_16	133.89	cop[tikv]	table:tbl_0, index:idx_3(col_0)	range:[803163,+inf], keep order:false
+    └─IndexRangeScan_16	107.12	cop[tikv]	table:tbl_0, index:idx_3(col_0)	range:[803163,+inf], keep order:false
 set @@tidb_enable_outer_join_reorder=false;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59133

Problem Summary:

### What changed and how does it work?

Due to precision errors in floating point, a small tolerance is needed to ensure that an unnecessary adjustments are not made for cardinality estimation. An arbitrary value of 0.00001 is used as the tolerance.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
