### PR TITLE
br: fix intergration test check unapplied error type

### DIFF
--- a/br/tests/br_check_dup_table/run.sh
+++ b/br/tests/br_check_dup_table/run.sh
@@ -56,8 +56,8 @@ echo "restore start..."
 LOG_OUTPUT=$(run_br restore db --db "$DB" -s "local://$TEST_DIR/$DB" --pd "$PD_ADDR" 2>&1 || true)
 
 # Check if the log contains 'ErrTableAlreadyExisted'
-if ! echo "$LOG_OUTPUT" | grep -q "BR:Restore:ErrTablesAlreadyExisted"; then
-    echo "Error: 'ErrTableAlreadyExisted' not found in logs."
+if ! echo "$LOG_OUTPUT" | grep -q "table already exists:"; then
+    echo "table already exists:' not found in logs."
     echo "Log output:"
     echo "$LOG_OUTPUT"
     exit 1

--- a/br/tests/br_check_dup_table/run.sh
+++ b/br/tests/br_check_dup_table/run.sh
@@ -55,7 +55,7 @@ fi
 echo "restore start..."
 LOG_OUTPUT=$(run_br restore db --db "$DB" -s "local://$TEST_DIR/$DB" --pd "$PD_ADDR" 2>&1 || true)
 
-# Check if the log contains 'ErrTableAlreadyExisted'
+# Check if the log contains 'table already exists:'
 if ! echo "$LOG_OUTPUT" | grep -q "table already exists:"; then
     echo "table already exists:' not found in logs."
     echo "Log output:"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59269 59269

Problem Summary:

### What changed and how does it work?

The error `ErrTableAlreadyExisted` has not been applied on 8.1, we choose to check the log instead.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
