### PR TITLE
prepare, stmtctx: fix the issue that errors/warnings in parse stage are not cleaned or reported

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3353,3 +3353,32 @@ func TestAuthSocket(t *testing.T) {
 		ts.CheckRows(t, rows, "u2@%")
 	})
 }
+
+func TestWarningForParseError(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		conn, err := dbt.GetDB().Conn(context.Background())
+		require.NoError(t, err)
+
+		assertWarningCount := func() {
+			rows, err := conn.QueryContext(context.Background(), "show warnings")
+			require.NoError(t, err)
+			defer rows.Close()
+
+			count := 0
+			for rows.Next() {
+				count++
+			}
+			require.Equal(t, 1, count)
+		}
+
+		for i := 0; i < 5; i++ {
+			stmt, err := conn.PrepareContext(context.Background(), "VALUES ( ('foo'), ROW('bar') )")
+			require.Error(t, err)
+			require.Nil(t, stmt)
+
+			assertWarningCount()
+		}
+	})
+}

--- a/tests/integrationtest/r/executor/prepared.result
+++ b/tests/integrationtest/r/executor/prepared.result
@@ -357,3 +357,21 @@ HashAgg_8	1.00	root		group by:executor__prepared.t.id, executor__prepared.t.k, f
 └─TableReader_15	0.01	root		data:Selection_14
   └─Selection_14	0.01	cop[tikv]		eq(1, executor__prepared.t.id), eq(1, executor__prepared.t.k)
     └─TableFullScan_13	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+PREPARE stmt FROM 'VALUES ( ("foo"), ROW("bar") )';
+Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ("foo"), ROW("bar") )" 
+SHOW ERRORS;
+Level	Code	Message
+Error	1105	line 1 column 8 near "( ("foo"), ROW("bar") )" 
+Error	1064	You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ("foo"), ROW("bar") )" 
+PREPARE stmt FROM 'VALUES ( ("foo"), ROW("bar") )';
+Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ("foo"), ROW("bar") )" 
+SHOW ERRORS;
+Level	Code	Message
+Error	1105	line 1 column 8 near "( ("foo"), ROW("bar") )" 
+Error	1064	You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ("foo"), ROW("bar") )" 
+PREPARE stmt FROM 'VALUES ( ("foo"), ROW("bar") )';
+Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ("foo"), ROW("bar") )" 
+SHOW ERRORS;
+Level	Code	Message
+Error	1105	line 1 column 8 near "( ("foo"), ROW("bar") )" 
+Error	1064	You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ("foo"), ROW("bar") )" 

--- a/tests/integrationtest/r/session/session.result
+++ b/tests/integrationtest/r/session/session.result
@@ -198,3 +198,18 @@ last_insert_id(0)
 select last_insert_id();
 last_insert_id()
 0
+VALUES ( ('foo'), ROW('bar') );
+Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ('foo'), ROW('bar') )" 
+show warnings;
+Level	Code	Message
+Error	1064	You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ('foo'), ROW('bar') )" 
+VALUES ( ('foo'), ROW('bar') );
+Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ('foo'), ROW('bar') )" 
+show warnings;
+Level	Code	Message
+Error	1064	You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ('foo'), ROW('bar') )" 
+VALUES ( ('foo'), ROW('bar') );
+Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ('foo'), ROW('bar') )" 
+show warnings;
+Level	Code	Message
+Error	1064	You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 8 near "( ('foo'), ROW('bar') )" 

--- a/tests/integrationtest/t/executor/prepared.test
+++ b/tests/integrationtest/t/executor/prepared.test
@@ -264,3 +264,13 @@ set @a = 1;
 execute stmt using @a, @a;
 explain select * from t where 1 = id and 1 = k group by id, k;
 
+# TestIssue59275
+-- error 1064
+PREPARE stmt FROM 'VALUES ( ("foo"), ROW("bar") )';
+SHOW ERRORS;
+-- error 1064
+PREPARE stmt FROM 'VALUES ( ("foo"), ROW("bar") )';
+SHOW ERRORS;
+-- error 1064
+PREPARE stmt FROM 'VALUES ( ("foo"), ROW("bar") )';
+SHOW ERRORS;

--- a/tests/integrationtest/t/session/session.test
+++ b/tests/integrationtest/t/session/session.test
@@ -131,3 +131,14 @@ select c1 from t where c2 = 20;
 select last_insert_id(1);
 select last_insert_id(0);
 select last_insert_id();
+
+# TestIssue59132
+-- error 1064
+VALUES ( ('foo'), ROW('bar') );
+show warnings;
+-- error 1064
+VALUES ( ('foo'), ROW('bar') );
+show warnings;
+-- error 1064
+VALUES ( ('foo'), ROW('bar') );
+show warnings;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59275, close #59132

Problem Summary:

1. The errors/warnings are not cleaned because the stmtctx is not reset when `Parse` returns error.
2. When `Parse` returns error, the error is not appended to the stmtctx for the `PREPARE` binary protocol.

### What changed and how does it work?

1. Reset the warnings in stmtctx if `Parse` returns error.
2. Append the error for the `PREPARE` binary protocol.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that errors/warnings in parse stage are not cleaned or reported
```
