### PR TITLE
generatedexpr: reuse parser to improve performance

### DIFF
--- a/pkg/util/generatedexpr/generated_expr.go
+++ b/pkg/util/generatedexpr/generated_expr.go
@@ -16,6 +16,7 @@ package generatedexpr
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -53,6 +54,8 @@ func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 	return inNode, true
 }
 
+var parserPool = &sync.Pool{New: func() any { return parser.New() }}
+
 // ParseExpression parses an ExprNode from a string.
 // When TiDB loads infoschema from TiKV, `GeneratedExprString`
 // of `ColumnInfo` is a string field, so we need to parse
@@ -60,7 +63,9 @@ func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 func ParseExpression(expr string) (node ast.ExprNode, err error) {
 	expr = fmt.Sprintf("select %s", expr)
 	charset, collation := charset.GetDefaultCharsetAndCollate()
-	stmts, _, err := parser.New().ParseSQL(expr,
+	parse := parserPool.Get().(*parser.Parser)
+	defer parserPool.Put(parse)
+	stmts, _, err := parse.ParseSQL(expr,
 		parser.CharsetConnection(charset),
 		parser.CollationConnection(collation))
 	if err == nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59303 

Problem Summary:

### What changed and how does it work?

as shown, creating parser spend too much time. so we need to reuse this parser.

<img width="1920" alt="Image" src="https://github.com/user-attachments/assets/bcc91273-7a9e-41ff-94b0-ac517cc32c45" />

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
