### PR TITLE
ddl, meta: don't update `tblInfo.UpdateTS` for exchangePartition and truncatePartition

### DIFF
--- a/pkg/ddl/table_test.go
+++ b/pkg/ddl/table_test.go
@@ -827,12 +827,12 @@ func TestIssue59238(t *testing.T) {
 		" PARTITION p2 VALUES LESS THAN (20000)," +
 		" PARTITION p3 VALUES LESS THAN (MAXVALUE))")
 
-	rs := tk.MustQuery("select create_time from information_schema.partitions where table_name = 't' limit 1").String()
+	rs := tk.MustQuery("select distinct create_time from information_schema.partitions where table_name = 't'").String()
 
 	tk.MustExec("alter table t truncate partition p1")
-	require.True(t, tk.MustQuery("select create_time from information_schema.partitions where table_name = 't' limit 1").Equal(testkit.Rows(rs)))
+	require.True(t, tk.MustQuery("select distinct create_time from information_schema.partitions where table_name = 't'").Equal(testkit.Rows(rs)))
 
 	tk.MustExec("create table t1 (a int, b int, index idx(b))")
 	tk.MustExec("alter table t exchange partition p1 with table t1")
-	require.True(t, tk.MustQuery("select create_time from information_schema.partitions where table_name = 't' limit 1").Equal(testkit.Rows(rs)))
+	require.True(t, tk.MustQuery("select distinct create_time from information_schema.partitions where table_name = 't'").Equal(testkit.Rows(rs)))
 }

--- a/pkg/ddl/table_test.go
+++ b/pkg/ddl/table_test.go
@@ -815,3 +815,24 @@ func TestCreateViewTwice(t *testing.T) {
 	tk.MustExec("create view v as select * from t_raw")
 	wg.Wait()
 }
+
+func TestIssue59238(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE t ( a INT, b INT, INDEX idx(b))" +
+		" PARTITION BY RANGE(a) (" +
+		" PARTITION p1 VALUES LESS THAN (10000)," +
+		" PARTITION p2 VALUES LESS THAN (20000)," +
+		" PARTITION p3 VALUES LESS THAN (MAXVALUE))")
+
+	rs := tk.MustQuery("select create_time from information_schema.partitions where table_name = 't' limit 1").String()
+
+	tk.MustExec("alter table t truncate partition p1")
+	require.True(t, tk.MustQuery("select create_time from information_schema.partitions where table_name = 't' limit 1").Equal(testkit.Rows(rs)))
+
+	tk.MustExec("create table t1 (a int, b int, index idx(b))")
+	tk.MustExec("alter table t exchange partition p1 with table t1")
+	require.True(t, tk.MustQuery("select create_time from information_schema.partitions where table_name = 't' limit 1").Equal(testkit.Rows(rs)))
+}

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -136,7 +136,8 @@ type TableInfo struct {
 	MaxForeignKeyID int64 `json:"max_fk_id"`
 	MaxConstraintID int64 `json:"max_cst_id"`
 	// UpdateTS is used to record the timestamp of updating the table's schema information.
-	// These changing schema operations don't include 'truncate table' and 'rename table'.
+	// These changing schema operations don't include 'truncate table', 'rename table',
+	// 'rename tables', 'truncate partition' and 'exchange partition'.
 	UpdateTS uint64 `json:"update_timestamp"`
 	// OldSchemaID :
 	// Because auto increment ID has schemaID as prefix,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59238

Problem Summary: Follow MySQL, don't update UpdateTS for truncate partition and exchange partition.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
