### PR TITLE
br/storage: adapt copier for azure and gcs

### DIFF
--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//bloberror",
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//blockblob",
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//container",
+        "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//sas",
         "@com_github_go_resty_resty_v2//:resty",
         "@com_github_google_uuid//:uuid",
         "@com_github_klauspost_compress//gzip",

--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -56,7 +56,7 @@ go_library(
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//bloberror",
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//blockblob",
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//container",
-        "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//sas",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_go_resty_resty_v2//:resty",
         "@com_github_google_uuid//:uuid",
         "@com_github_klauspost_compress//gzip",
@@ -108,7 +108,6 @@ go_test(
     deps = [
         "//br/pkg/mock",
         "//pkg/util/intest",
-        "@com_github_apache_arrow_go_v12//arrow/endian",
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/request",

--- a/br/pkg/storage/BUILD.bazel
+++ b/br/pkg/storage/BUILD.bazel
@@ -107,6 +107,7 @@ go_test(
     deps = [
         "//br/pkg/mock",
         "//pkg/util/intest",
+        "@com_github_apache_arrow_go_v12//arrow/endian",
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/request",

--- a/br/pkg/storage/azblob.go
+++ b/br/pkg/storage/azblob.go
@@ -155,6 +155,7 @@ type ClientBuilder interface {
 	// Example of serviceURL: https://<your_storage_account>.blob.core.windows.net
 	GetServiceClient() (*azblob.Client, error)
 	GetAccountName() string
+	GetServiceURL() string
 }
 
 func urlOfObjectByEndpoint(endpoint, container, object string) (string, error) {
@@ -175,6 +176,11 @@ type sharedKeyClientBuilder struct {
 	clientOptions *azblob.ClientOptions
 }
 
+// GetServiceURL implements ClientBuilder.
+func (b *sharedKeyClientBuilder) GetServiceURL() string {
+	return b.serviceURL
+}
+
 func (b *sharedKeyClientBuilder) GetServiceClient() (*azblob.Client, error) {
 	return azblob.NewClientWithSharedKeyCredential(b.serviceURL, b.cred, b.clientOptions)
 }
@@ -192,6 +198,11 @@ type sasClientBuilder struct {
 	clientOptions *azblob.ClientOptions
 }
 
+// GetServiceURL implements ClientBuilder.
+func (b *sasClientBuilder) GetServiceURL() string {
+	return b.serviceURL
+}
+
 func (b *sasClientBuilder) GetServiceClient() (*azblob.Client, error) {
 	return azblob.NewClientWithNoCredential(b.serviceURL, b.clientOptions)
 }
@@ -207,6 +218,11 @@ type tokenClientBuilder struct {
 	serviceURL  string
 
 	clientOptions *azblob.ClientOptions
+}
+
+// GetServiceURL implements ClientBuilder.
+func (b *tokenClientBuilder) GetServiceURL() string {
+	return b.serviceURL
 }
 
 func (b *tokenClientBuilder) GetServiceClient() (*azblob.Client, error) {
@@ -340,7 +356,8 @@ type AzureBlobStorage struct {
 	cpkInfo  *blob.CPKInfo
 
 	// resolvedAccountName is the final account name we are going to use.
-	resolvedAccountName string
+	resolvedAccountName     string
+	resolvedServiceEndpoint string
 }
 
 // CopyFrom implements Copier.
@@ -440,6 +457,7 @@ func newAzureBlobStorageWithClientBuilder(ctx context.Context, options *backuppb
 		cpkScope,
 		cpkInfo,
 		clientBuilder.GetAccountName(),
+		clientBuilder.GetServiceURL(),
 	}, nil
 }
 

--- a/br/pkg/storage/azblob.go
+++ b/br/pkg/storage/azblob.go
@@ -155,7 +155,6 @@ type ClientBuilder interface {
 	// Example of serviceURL: https://<your_storage_account>.blob.core.windows.net
 	GetServiceClient() (*azblob.Client, error)
 	GetAccountName() string
-	GetServiceURL() string
 }
 
 func urlOfObjectByEndpoint(endpoint, container, object string) (string, error) {
@@ -176,11 +175,6 @@ type sharedKeyClientBuilder struct {
 	clientOptions *azblob.ClientOptions
 }
 
-// GetServiceURL implements ClientBuilder.
-func (b *sharedKeyClientBuilder) GetServiceURL() string {
-	return b.serviceURL
-}
-
 func (b *sharedKeyClientBuilder) GetServiceClient() (*azblob.Client, error) {
 	return azblob.NewClientWithSharedKeyCredential(b.serviceURL, b.cred, b.clientOptions)
 }
@@ -198,11 +192,6 @@ type sasClientBuilder struct {
 	clientOptions *azblob.ClientOptions
 }
 
-// GetServiceURL implements ClientBuilder.
-func (b *sasClientBuilder) GetServiceURL() string {
-	return b.serviceURL
-}
-
 func (b *sasClientBuilder) GetServiceClient() (*azblob.Client, error) {
 	return azblob.NewClientWithNoCredential(b.serviceURL, b.clientOptions)
 }
@@ -218,11 +207,6 @@ type tokenClientBuilder struct {
 	serviceURL  string
 
 	clientOptions *azblob.ClientOptions
-}
-
-// GetServiceURL implements ClientBuilder.
-func (b *tokenClientBuilder) GetServiceURL() string {
-	return b.serviceURL
 }
 
 func (b *tokenClientBuilder) GetServiceClient() (*azblob.Client, error) {
@@ -356,8 +340,7 @@ type AzureBlobStorage struct {
 	cpkInfo  *blob.CPKInfo
 
 	// resolvedAccountName is the final account name we are going to use.
-	resolvedAccountName     string
-	resolvedServiceEndpoint string
+	resolvedAccountName string
 }
 
 // CopyFrom implements Copier.
@@ -457,7 +440,6 @@ func newAzureBlobStorageWithClientBuilder(ctx context.Context, options *backuppb
 		cpkScope,
 		cpkInfo,
 		clientBuilder.GetAccountName(),
-		clientBuilder.GetServiceURL(),
 	}, nil
 }
 

--- a/br/pkg/storage/azblob_test.go
+++ b/br/pkg/storage/azblob_test.go
@@ -410,7 +410,7 @@ func TestCopyObject(t *testing.T) {
 		builder := &sharedKeyAzuriteClientBuilder{}
 		skip, err := createContainer(ctx, builder, options.Bucket)
 		if skip || err != nil {
-			t.Skip(fmt.Sprintf("azurite is not running, skip test (err = %s)", err))
+			t.Skipf("azurite is not running, skip test (err = %s)", err)
 			panic("just a note, should never reach here")
 		}
 		require.NoError(t, err)

--- a/br/pkg/storage/azblob_test.go
+++ b/br/pkg/storage/azblob_test.go
@@ -27,11 +27,6 @@ import (
 type sharedKeyAzuriteClientBuilder struct {
 }
 
-// GetServiceURL implements ClientBuilder.
-func (b *sharedKeyAzuriteClientBuilder) GetServiceURL() string {
-	return "http://127.0.0.1:10000/devstoreaccount1"
-}
-
 func (b *sharedKeyAzuriteClientBuilder) GetServiceClient() (*azblob.Client, error) {
 	connStr := "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
 	return azblob.NewClientFromConnectionString(connStr, nil)
@@ -347,11 +342,6 @@ func TestNewAzblobStorage(t *testing.T) {
 
 type fakeClientBuilder struct {
 	Endpoint string
-}
-
-// GetServiceURL implements ClientBuilder.
-func (b *fakeClientBuilder) GetServiceURL() string {
-	return b.Endpoint
 }
 
 func (b *fakeClientBuilder) GetServiceClient() (*azblob.Client, error) {

--- a/br/pkg/storage/azblob_test.go
+++ b/br/pkg/storage/azblob_test.go
@@ -27,6 +27,11 @@ import (
 type sharedKeyAzuriteClientBuilder struct {
 }
 
+// GetServiceURL implements ClientBuilder.
+func (b *sharedKeyAzuriteClientBuilder) GetServiceURL() string {
+	return "http://127.0.0.1:10000/devstoreaccount1"
+}
+
 func (b *sharedKeyAzuriteClientBuilder) GetServiceClient() (*azblob.Client, error) {
 	connStr := "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
 	return azblob.NewClientFromConnectionString(connStr, nil)
@@ -342,6 +347,11 @@ func TestNewAzblobStorage(t *testing.T) {
 
 type fakeClientBuilder struct {
 	Endpoint string
+}
+
+// GetServiceURL implements ClientBuilder.
+func (b *fakeClientBuilder) GetServiceURL() string {
+	return b.Endpoint
 }
 
 func (b *fakeClientBuilder) GetServiceClient() (*azblob.Client, error) {

--- a/br/pkg/storage/azblob_test.go
+++ b/br/pkg/storage/azblob_test.go
@@ -247,8 +247,10 @@ func TestNewAzblobStorage(t *testing.T) {
 			Prefix:    "a/b",
 			SharedKey: "cGFzc3dk",
 		}
-		_, err := getAzureServiceClientBuilder(options, nil)
-		require.Error(t, err)
+		builder, err := getAzureServiceClientBuilder(options, nil)
+		require.NoError(t, err)
+		_, ok := builder.(*defaultClientBuilder)
+		require.True(t, ok, "it is %T", builder)
 	}
 
 	err = os.Setenv("AZURE_STORAGE_KEY", "cGFzc3dk")

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -390,12 +390,12 @@ func NewGCSStorage(ctx context.Context, gcs *backuppb.GCS, opts *ExternalStorage
 					clientOps = append(clientOps, option.WithoutAuthentication())
 					goto skipHandleCred
 				}
-				return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "%v Or you should provide '--gcs.credentials_file'", err)
+				return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig, "%v Or you should provide '--%s'", gcsCredentialsFile, err)
 			}
 			if opts.SendCredentials {
 				if len(creds.JSON) <= 0 {
-					return nil, errors.Annotate(berrors.ErrStorageInvalidConfig,
-						"You should provide '--gcs.credentials_file' when '--send-credentials-to-tikv' is true")
+					return nil, errors.Annotatef(berrors.ErrStorageInvalidConfig,
+						"You should provide '--%s' when '--send-credentials-to-tikv' is true", gcsCredentialsFile)
 				}
 				gcs.CredentialsBlob = string(creds.JSON)
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59339

Problem Summary:

When log backup enabled, restoring from azure blob storage and GCS is still impossible because they didn't implement `Copier`.

### What changed and how does it work?

This Added support to `CopyFrom` for `AzureBlobStorage` and `GCSStorage`.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
Tested Azure by `azurite`. 
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Start PiTR by:
```fish
#! /usr/bin/env fish

set pfx $fish_pid
set -q container || set container "tc-tidb-0"
set -q strg_prefix || set strg_prefix "test"

function strg
	echo "gs://br-datasets/$argv[1]"
end


function br
	kubectl exec '-it' $container '--' /br-for-restore $argv
end

br backup full -s (strg "juncen/tpcc-test/$pfx/$strg_prefix-full") $argv
gcloud storage cp (strg "juncen/tpcc-test/$pfx/$strg_prefix-full/backupmeta") ./.backupmeta.tmp
set backupts (cat ./.backupmeta.tmp | _get_brpb BackupMeta | rg -r '$1' 'end_version: (\d+)$')
br log start -s (strg "juncen/tpcc-test/$pfx/$strg_prefix-incr") --task-name fiolvit $argv --start-ts "$backupts"
br log status $argv
```
Restore a backup by:
```fish
/br-for-restore restore full -s 'gcs://br-datasets/juncen/tpcc-40' --checksum=false -u tc-pd:2379 --gcs.credentials-file /gcloud-cred.json
```
Then restore with:
```fish
/br-for-restore restore point -s 'gs://br-datasets/juncen/tpcc-test/3078828/test-incr' --checksum=false -u tc-pd:2379 --gcs.credentials-file /gcloud-cred.json --full-backup-storage 'gs://br-datasets/juncen/tpcc-test/3078828/test-full' 
```
Check the restored data:
```console
TiDB root@tc-tidb:test> select count(*) from history;
+----------+
| count(*) |
+----------+
| 1200000  |
+----------+
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
