### PR TITLE
datum: remove wrong usage of pool and prealloc the buffer

### DIFF
--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2434,7 +2434,7 @@ func (ds *datumsSorter) Swap(i, j int) {
 func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 	n := len(datums)
 	builder := &strings.Builder{}
- builder.Grow(8 * n)
+	builder.Grow(8 * n)
 	if n > 1 {
 		builder.WriteString("(")
 	}

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unicode/utf8"
 	"unsafe"
@@ -2431,16 +2430,10 @@ func (ds *datumsSorter) Swap(i, j int) {
 	ds.datums[i], ds.datums[j] = ds.datums[j], ds.datums[i]
 }
 
-var strBuilderPool = sync.Pool{New: func() any { return &strings.Builder{} }}
-
 // DatumsToString converts several datums to formatted string.
 func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 	n := len(datums)
-	builder := strBuilderPool.Get().(*strings.Builder)
-	defer func() {
-		builder.Reset()
-		strBuilderPool.Put(builder)
-	}()
+	builder := &strings.Builder{}
 	if n > 1 {
 		builder.WriteString("(")
 	}

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2437,6 +2437,7 @@ func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 	if n > 1 {
 		builder.WriteString("(")
 	}
+	builder.Grow(8 * len(datums))
 	for i, datum := range datums {
 		if i > 0 {
 			builder.WriteString(", ")

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2434,10 +2434,10 @@ func (ds *datumsSorter) Swap(i, j int) {
 func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 	n := len(datums)
 	builder := &strings.Builder{}
+ builder.Grow(8 * n)
 	if n > 1 {
 		builder.WriteString("(")
 	}
-	builder.Grow(8 * len(datums))
 	for i, datum := range datums {
 		if i > 0 {
 			builder.WriteString(", ")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/59332

Problem Summary:

### What changed and how does it work?

1、reuse strings.Builder, but it cannot reuse buffer in the builder. so it is unnecessary to reuse builder
2、prealloc the buffer in the builder.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
