### PR TITLE
ddl: modify param at runtime for add-index on DXF local sort

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -877,7 +877,7 @@ func executeAndClosePipeline(ctx *OperatorCtx, pipe *operator.AsyncPipeline, job
 	}
 
 	err = pipe.Close()
-	failpoint.InjectCall("afterPipeLineClose")
+	failpoint.InjectCall("afterPipeLineClose", pipe)
 	cancel()
 	wg.Wait() // wait for adjustWorkerCntAndMaxWriteSpeed to exit
 	if opErr := ctx.OperatorErr(); opErr != nil {

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -850,8 +850,8 @@ func adjustWorkerCntAndMaxWriteSpeed(ctx context.Context, pipe *operator.AsyncPi
 			targetReaderCnt, targetWriterCnt := expectedIngestWorkerCnt(concurrency, avgRowSize)
 			currentReaderCnt, currentWriterCnt := reader.GetWorkerPoolSize(), writer.GetWorkerPoolSize()
 			if int32(targetReaderCnt) != currentReaderCnt || int32(targetWriterCnt) != currentWriterCnt {
-				reader.TuneWorkerPoolSize(int32(targetReaderCnt))
-				writer.TuneWorkerPoolSize(int32(targetWriterCnt))
+				reader.TuneWorkerPoolSize(int32(targetReaderCnt), false)
+				writer.TuneWorkerPoolSize(int32(targetWriterCnt), false)
 				logutil.DDLIngestLogger().Info("adjust ddl job config success",
 					zap.Int64("jobID", job.ID),
 					zap.Int32("table scan operator count", reader.GetWorkerPoolSize()),

--- a/pkg/ddl/backfilling_dist_executor.go
+++ b/pkg/ddl/backfilling_dist_executor.go
@@ -90,7 +90,7 @@ func decodeBackfillSubTaskMeta(raw []byte) (*BackfillSubTaskMeta, error) {
 	return &subtask, nil
 }
 
-func (s *backfillDistExecutor) newBackfillSubtaskExecutor(
+func (s *backfillDistExecutor) newBackfillStepExecutor(
 	stage proto.Step,
 ) (execute.StepExecutor, error) {
 	jobMeta := &s.taskMeta.Job
@@ -174,7 +174,7 @@ func (s *backfillDistExecutor) Init(ctx context.Context) error {
 func (s *backfillDistExecutor) GetStepExecutor(task *proto.Task) (execute.StepExecutor, error) {
 	switch task.Step {
 	case proto.BackfillStepReadIndex, proto.BackfillStepMergeSort, proto.BackfillStepWriteAndIngest:
-		return s.newBackfillSubtaskExecutor(task.Step)
+		return s.newBackfillStepExecutor(task.Step)
 	default:
 		return nil, errors.Errorf("unknown backfill step %d for task %d", task.Step, task.ID)
 	}

--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -195,8 +195,23 @@ func (*LitBackfillScheduler) IsRetryableErr(error) bool {
 }
 
 // ModifyMeta implements scheduler.Extension interface.
-func (*LitBackfillScheduler) ModifyMeta(oldMeta []byte, _ []proto.Modification) ([]byte, error) {
-	return oldMeta, nil
+func (sch *LitBackfillScheduler) ModifyMeta(oldMeta []byte, modifies []proto.Modification) ([]byte, error) {
+	taskMeta := &BackfillTaskMeta{}
+	if err := json.Unmarshal(oldMeta, taskMeta); err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, m := range modifies {
+		switch m.Type {
+		case proto.ModifyBatchSize:
+			taskMeta.Job.ReorgMeta.SetBatchSize(int(m.To))
+		case proto.ModifyMaxWriteSpeed:
+			taskMeta.Job.ReorgMeta.SetMaxWriteSpeed(int(m.To))
+		default:
+			logutil.DDLLogger().Warn("invalid modify type",
+				zap.Int64("taskId", sch.GetTask().ID), zap.Stringer("modify", m))
+		}
+	}
+	return json.Marshal(taskMeta)
 }
 
 func getTblInfo(ctx context.Context, d *ddl, job *model.Job) (tblInfo *model.TableInfo, err error) {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -173,8 +173,8 @@ func NewAddIndexIngestPipeline(
 	srcChkPool := createChunkPool(copCtx, reorgMeta)
 	readerCnt, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize)
 	rm := reorgMeta
-	if rm.IsDistReorg {
-		// Currently, only the batch size of local ingest mode can be adjusted
+	if rm.UseCloudStorage {
+		// param cannot be modified at runtime for global sort right now.
 		rm = nil
 	}
 

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -566,7 +566,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		failpoint.Inject("mockScanRecordError", func() {
 			failpoint.Return(errors.New("mock scan record error"))
 		})
-		failpoint.InjectCall("scanRecordExec")
+		failpoint.InjectCall("scanRecordExec", w.reorgMeta)
 		rs, err := buildTableScan(w.ctx, w.copCtx.GetBase(), startTS, task.Start, task.End)
 		if err != nil {
 			return err

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -218,12 +218,10 @@ func (r *readIndexExecutor) ResourceModified(ctx context.Context, newResource *p
 	targetReaderCnt, targetWriterCnt := expectedIngestWorkerCnt(int(newResource.CPU.Capacity()), avgRowSizeForDistTask)
 	currentReaderCnt, currentWriterCnt := reader.GetWorkerPoolSize(), writer.GetWorkerPoolSize()
 	if int32(targetReaderCnt) != currentReaderCnt {
-		reader.TuneWorkerPoolSize(int32(targetReaderCnt))
-		// wait
+		reader.TuneWorkerPoolSize(int32(targetReaderCnt), true)
 	}
 	if int32(targetWriterCnt) != currentWriterCnt {
-		writer.TuneWorkerPoolSize(int32(targetWriterCnt))
-		// wait
+		writer.TuneWorkerPoolSize(int32(targetWriterCnt), true)
 	}
 	return nil
 }

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -181,7 +181,7 @@ func (r *readIndexExecutor) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (r *readIndexExecutor) TaskMetaModified(ctx context.Context, newMeta []byte) error {
+func (r *readIndexExecutor) TaskMetaModified(_ context.Context, newMeta []byte) error {
 	if r.isGlobalSort() {
 		return goerrors.New("not support modify task meta for global sort")
 	}
@@ -203,7 +203,7 @@ func (r *readIndexExecutor) TaskMetaModified(ctx context.Context, newMeta []byte
 	return nil
 }
 
-func (r *readIndexExecutor) ResourceModified(ctx context.Context, newResource *proto.StepResource) error {
+func (r *readIndexExecutor) ResourceModified(_ context.Context, newResource *proto.StepResource) error {
 	if r.isGlobalSort() {
 		return goerrors.New("not support modify resource for global sort")
 	}

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -208,7 +208,8 @@ func (r *readIndexExecutor) ResourceModified(ctx context.Context, newResource *p
 		return goerrors.New("not support modify resource for global sort")
 	}
 	pipe := r.currPipe.Load()
-	if pipe == nil {
+	// Tune of work pool can only be called after start.
+	if pipe == nil || !pipe.IsStarted() {
 		// let framework retry
 		return goerrors.New("no subtask running")
 	}
@@ -227,7 +228,7 @@ func (r *readIndexExecutor) ResourceModified(ctx context.Context, newResource *p
 }
 
 func (r *readIndexExecutor) onFinished(ctx context.Context, subtask *proto.Subtask) error {
-	failpoint.InjectCall("mockDMLExecutionAddIndexSubTaskFinish")
+	failpoint.InjectCall("mockDMLExecutionAddIndexSubTaskFinish", r.backend)
 	if !r.isGlobalSort() {
 		return nil
 	}

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1232,20 +1232,21 @@ func TestAdminAlterDDLJobUnsupportedCases(t *testing.T) {
 	insertMockJob2Table(tk, &job)
 	// unsupported job type
 	tk.MustGetErrMsg(fmt.Sprintf("admin alter ddl jobs %d thread = 8;", job.ID),
-		"unsupported DDL operation: add column. Supported DDL operations are: ADD INDEX (with tidb_enable_dist_task=OFF), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION")
+		"unsupported DDL operation: add column. Supported DDL operations are: ADD INDEX (without global sort), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION")
 	deleteJobMetaByID(tk, 1)
 
 	job = model.Job{
 		ID:   1,
 		Type: model.ActionAddIndex,
 		ReorgMeta: &model.DDLReorgMeta{
-			IsDistReorg: true,
+			IsDistReorg:     true,
+			UseCloudStorage: true,
 		},
 	}
 	insertMockJob2Table(tk, &job)
 	// unsupported job type
 	tk.MustGetErrMsg(fmt.Sprintf("admin alter ddl jobs %d thread = 8;", job.ID),
-		"unsupported DDL operation: add index. Supported DDL operations are: ADD INDEX (with tidb_enable_dist_task=OFF), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION")
+		"unsupported DDL operation: add index. Supported DDL operations are: ADD INDEX (without global sort), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION")
 	deleteJobMetaByID(tk, 1)
 }
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2672,7 +2672,7 @@ func modifyTaskParamLoop(
 	jobID, taskID int64,
 	lastConcurrency, lastBatchSize, lastMaxWriteSpeed int,
 ) {
-	logger := logutil.DDLLogger().With(zap.Int64("jobId", jobID), zap.Int64("taskId", taskID))
+	logger := logutil.DDLLogger().With(zap.Int64("jobID", jobID), zap.Int64("taskID", taskID))
 	ticker := time.NewTicker(UpdateDDLJobReorgCfgInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -129,7 +129,7 @@ func TestAddIndexIngestPanic(t *testing.T) {
 	tk.MustExec("set global tidb_enable_dist_task = 0")
 
 	t.Run("Mock panic on scan record operator", func(t *testing.T) {
-		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/scanRecordExec", func() {
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/scanRecordExec", func(*model.DDLReorgMeta) {
 			panic("mock panic")
 		})
 		tk.MustExec("drop table if exists t;")
@@ -162,7 +162,7 @@ func TestAddIndexSetInternalSessions(t *testing.T) {
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/wrapInBeginRollbackStartTS", func(startTS uint64) {
 		expectInternalTS = append(expectInternalTS, startTS)
 	})
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/scanRecordExec", func() {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/scanRecordExec", func(*model.DDLReorgMeta) {
 		mgr := tk.Session().GetSessionManager()
 		actualInternalTS = mgr.GetInternalSessionStartTSList()
 	})

--- a/pkg/disttask/framework/taskexecutor/execute/interface.go
+++ b/pkg/disttask/framework/taskexecutor/execute/interface.go
@@ -54,7 +54,9 @@ type StepExecutor interface {
 	// happen, framework might recreate the step executor, so don't put code
 	// that's prone to error in it.
 	TaskMetaModified(ctx context.Context, newMeta []byte) error
-	// ResourceModified is called when the resource allowed to be used is modified,
+	// ResourceModified is called when the resource allowed to be used is modified
+	// and there is a subtask running. Note: if no subtask running, framework will
+	// call SetResource directly.
 	// application must make sure the resource in use conforms to the new resource
 	// before returning. When reducing resources, the framework depends on this
 	// to make sure current instance won't OOM.

--- a/pkg/disttask/framework/taskexecutor/interface.go
+++ b/pkg/disttask/framework/taskexecutor/interface.go
@@ -16,6 +16,7 @@ package taskexecutor
 
 import (
 	"context"
+	goerrors "errors"
 
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
@@ -144,10 +145,10 @@ func (*BaseStepExecutor) Cleanup(context.Context) error {
 
 // TaskMetaModified implements the StepExecutor interface.
 func (*BaseStepExecutor) TaskMetaModified(context.Context, []byte) error {
-	panic("not implemented")
+	return goerrors.New("not implemented")
 }
 
 // ResourceModified implements the StepExecutor interface.
 func (*BaseStepExecutor) ResourceModified(context.Context, *proto.StepResource) error {
-	panic("not implemented")
+	return goerrors.New("not implemented")
 }

--- a/pkg/disttask/framework/taskexecutor/task_executor.go
+++ b/pkg/disttask/framework/taskexecutor/task_executor.go
@@ -539,6 +539,7 @@ func (e *BaseTaskExecutor) detectAndHandleParamModify(ctx context.Context) error
 		}
 		e.metaModifyApplied(latestTask.Meta)
 	}
+	failpoint.InjectCall("afterDetectAndHandleParamModify")
 	return nil
 }
 

--- a/pkg/disttask/framework/testutil/context.go
+++ b/pkg/disttask/framework/testutil/context.go
@@ -424,14 +424,17 @@ func ReduceCheckInterval(t testing.TB) {
 	taskCheckIntervalBak := taskexecutor.TaskCheckInterval
 	checkIntervalBak := taskexecutor.SubtaskCheckInterval
 	maxIntervalBak := taskexecutor.MaxSubtaskCheckInterval
+	detectModifyIntBak := taskexecutor.DetectParamModifyInterval
 	t.Cleanup(func() {
 		scheduler.CheckTaskRunningInterval = schedulerMgrCheckIntervalBak
 		scheduler.CheckTaskFinishedInterval = schedulerCheckIntervalBak
 		taskexecutor.TaskCheckInterval = taskCheckIntervalBak
 		taskexecutor.SubtaskCheckInterval = checkIntervalBak
 		taskexecutor.MaxSubtaskCheckInterval = maxIntervalBak
+		taskexecutor.DetectParamModifyInterval = detectModifyIntBak
 	})
 	scheduler.CheckTaskRunningInterval, scheduler.CheckTaskFinishedInterval = 100*time.Millisecond, 100*time.Millisecond
 	taskexecutor.TaskCheckInterval, taskexecutor.MaxSubtaskCheckInterval, taskexecutor.SubtaskCheckInterval =
 		10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond
+	taskexecutor.DetectParamModifyInterval = 10 * time.Millisecond
 }

--- a/pkg/disttask/operator/operator.go
+++ b/pkg/disttask/operator/operator.go
@@ -94,8 +94,8 @@ func (c *AsyncOperator[T, R]) SetSink(ch DataChannel[R]) {
 }
 
 // TuneWorkerPoolSize tunes the worker pool size.
-func (c *AsyncOperator[T, R]) TuneWorkerPoolSize(workerNum int32) {
-	c.pool.Tune(workerNum)
+func (c *AsyncOperator[T, R]) TuneWorkerPoolSize(workerNum int32, wait bool) {
+	c.pool.Tune(workerNum, wait)
 }
 
 // GetWorkerPoolSize returns the worker pool size.

--- a/pkg/disttask/operator/pipeline.go
+++ b/pkg/disttask/operator/pipeline.go
@@ -14,12 +14,16 @@
 
 package operator
 
-import "strings"
+import (
+	"strings"
+	"sync/atomic"
+)
 
 // AsyncPipeline wraps a list of Operators.
 // The dataflow is from the first operator to the last operator.
 type AsyncPipeline struct {
-	ops []Operator
+	ops     []Operator
+	started atomic.Bool
 }
 
 // Execute opens all operators, it's run asynchronously.
@@ -35,7 +39,13 @@ func (p *AsyncPipeline) Execute() error {
 			return err
 		}
 	}
+	p.started.Store(true)
 	return nil
+}
+
+// IsStarted returns whether the pipeline is started.
+func (p *AsyncPipeline) IsStarted() bool {
+	return p.started.Load()
 }
 
 // Close waits all tasks done.
@@ -47,6 +57,7 @@ func (p *AsyncPipeline) Close() error {
 			firstErr = err
 		}
 	}
+	p.started.Store(false)
 	return firstErr
 }
 

--- a/pkg/executor/operate_ddl_jobs.go
+++ b/pkg/executor/operate_ddl_jobs.go
@@ -170,7 +170,7 @@ func (e *AlterDDLJobExec) processAlterDDLJobConfig(
 		}
 		if !job.IsAlterable() {
 			return fmt.Errorf("unsupported DDL operation: %s. "+
-				"Supported DDL operations are: ADD INDEX (with tidb_enable_dist_task=OFF), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION", job.Type.String())
+				"Supported DDL operations are: ADD INDEX (without global sort), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION", job.Type.String())
 		}
 		if err = e.updateReorgMeta(job, model.AdminCommandByEndUser); err != nil {
 			continue

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -644,7 +644,7 @@ func (job *Job) IsPausable() bool {
 // IsAlterable checks whether the job type can be altered.
 func (job *Job) IsAlterable() bool {
 	// Currently, only non-distributed add index reorg task can be altered
-	return job.Type == ActionAddIndex && !job.ReorgMeta.IsDistReorg ||
+	return job.Type == ActionAddIndex && !job.ReorgMeta.UseCloudStorage ||
 		job.Type == ActionModifyColumn ||
 		job.Type == ActionReorganizePartition
 }

--- a/pkg/resourcemanager/pool/workerpool/BUILD.bazel
+++ b/pkg/resourcemanager/pool/workerpool/BUILD.bazel
@@ -25,7 +25,7 @@ go_test(
     embed = [":workerpool"],
     flaky = True,
     race = "on",
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/resourcemanager/util",
         "//pkg/testkit/testsetup",

--- a/pkg/resourcemanager/pool/workerpool/workerpool.go
+++ b/pkg/resourcemanager/pool/workerpool/workerpool.go
@@ -16,6 +16,7 @@ package workerpool
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/resourcemanager/util"
@@ -41,6 +42,10 @@ type Worker[T TaskMayPanic, R any] interface {
 	Close()
 }
 
+type tuneConfig struct {
+	wg *sync.WaitGroup
+}
+
 // WorkerPool is a pool of workers.
 type WorkerPool[T TaskMayPanic, R any] struct {
 	ctx           context.Context
@@ -51,7 +56,7 @@ type WorkerPool[T TaskMayPanic, R any] struct {
 	runningTask   atomicutil.Int32
 	taskChan      chan T
 	resChan       chan R
-	quitChan      chan struct{}
+	quitChan      chan tuneConfig
 	wg            tidbutil.WaitGroupWrapper
 	createWorker  func() Worker[T, R]
 	lastTuneTs    atomicutil.Time
@@ -82,7 +87,7 @@ func NewWorkerPool[T TaskMayPanic, R any](
 		name:          name,
 		numWorkers:    int32(numWorkers),
 		originWorkers: int32(numWorkers),
-		quitChan:      make(chan struct{}),
+		quitChan:      make(chan tuneConfig),
 	}
 
 	for _, opt := range opts {
@@ -158,8 +163,9 @@ func (p *WorkerPool[T, R]) runAWorker() {
 					return
 				}
 				p.handleTaskWithRecover(w, task)
-			case <-p.quitChan:
+			case cfg := <-p.quitChan:
 				w.Close()
+				cfg.wg.Done()
 				return
 			case <-p.ctx.Done():
 				w.Close()
@@ -183,7 +189,8 @@ func (p *WorkerPool[T, R]) GetResultChan() <-chan R {
 }
 
 // Tune tunes the pool to the specified number of workers.
-func (p *WorkerPool[T, R]) Tune(numWorkers int32) {
+// wait: whether to wait for all workers to close when reducing workers count.
+func (p *WorkerPool[T, R]) Tune(numWorkers int32, wait bool) {
 	if numWorkers <= 0 {
 		numWorkers = 1
 	}
@@ -198,15 +205,21 @@ func (p *WorkerPool[T, R]) Tune(numWorkers int32) {
 		}
 	} else if diff < 0 {
 		// Remove workers
+		var wg sync.WaitGroup
 	outer:
 		for i := 0; i < int(-diff); i++ {
+			wg.Add(1)
 			select {
-			case p.quitChan <- struct{}{}:
+			case p.quitChan <- tuneConfig{wg: &wg}:
 			case <-p.ctx.Done():
 				logutil.BgLogger().Info("context done when tuning worker pool",
 					zap.Int32("from", p.numWorkers), zap.Int32("to", numWorkers))
+				wg.Done()
 				break outer
 			}
+		}
+		if wait {
+			wg.Wait()
 		}
 	}
 	p.numWorkers = numWorkers

--- a/pkg/resourcemanager/pool/workerpool/workerpool.go
+++ b/pkg/resourcemanager/pool/workerpool/workerpool.go
@@ -163,9 +163,11 @@ func (p *WorkerPool[T, R]) runAWorker() {
 					return
 				}
 				p.handleTaskWithRecover(w, task)
-			case cfg := <-p.quitChan:
+			case cfg, ok := <-p.quitChan:
 				w.Close()
-				cfg.wg.Done()
+				if ok {
+					cfg.wg.Done()
+				}
 				return
 			case <-p.ctx.Done():
 				w.Close()
@@ -190,6 +192,7 @@ func (p *WorkerPool[T, R]) GetResultChan() <-chan R {
 
 // Tune tunes the pool to the specified number of workers.
 // wait: whether to wait for all workers to close when reducing workers count.
+// this method can only be called after Start.
 func (p *WorkerPool[T, R]) Tune(numWorkers int32, wait bool) {
 	if numWorkers <= 0 {
 		numWorkers = 1

--- a/pkg/resourcemanager/pool/workerpool/workpool_test.go
+++ b/pkg/resourcemanager/pool/workerpool/workpool_test.go
@@ -16,9 +16,11 @@ package workerpool
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tidb/pkg/resourcemanager/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -82,7 +84,7 @@ func TestWorkerPool(t *testing.T) {
 	require.Equal(t, int64(45), globalCnt.Load())
 
 	// Enlarge the pool to 5 workers.
-	pool.Tune(5)
+	pool.Tune(5, false)
 
 	// Add some more tasks to the pool.
 	cntWg.Add(10)
@@ -95,7 +97,7 @@ func TestWorkerPool(t *testing.T) {
 	require.Equal(t, int64(90), globalCnt.Load())
 
 	// Decrease the pool to 2 workers.
-	pool.Tune(2)
+	pool.Tune(2, false)
 
 	// Add some more tasks to the pool.
 	cntWg.Add(10)
@@ -109,6 +111,35 @@ func TestWorkerPool(t *testing.T) {
 
 	// Wait for the tasks to be completed.
 	pool.ReleaseAndWait()
+}
+
+func TestTunePoolSize(t *testing.T) {
+	t.Run("random tune pool size", func(t *testing.T) {
+		pool := NewWorkerPool[int64Task]("test", util.UNKNOWN, 3, createMyWorker)
+		pool.Start(context.Background())
+		seed := time.Now().UnixNano()
+		rnd := rand.New(rand.NewSource(seed))
+		t.Logf("seed: %d", seed)
+		for i := 0; i < 100; i++ {
+			wait := rnd.Intn(2) == 0
+			larger := pool.Cap() + rnd.Int31n(10) + 2
+			pool.Tune(larger, wait)
+			require.Equal(t, larger, pool.Cap())
+			smaller := pool.Cap() / 2
+			pool.Tune(smaller, wait)
+			require.Equal(t, smaller, pool.Cap())
+		}
+		pool.Release()
+		pool.Wait()
+	})
+
+	t.Run("context done when reduce pool size and wait", func(t *testing.T) {
+		pool := NewWorkerPool[int64Task]("test", util.UNKNOWN, 10, createMyWorker)
+		pool.Start(context.Background())
+		pool.Release()
+		pool.Tune(5, true)
+		pool.Wait()
+	})
 }
 
 type dummyWorker[T, R any] struct {

--- a/tests/realtikvtest/addindextest1/BUILD.bazel
+++ b/tests/realtikvtest/addindextest1/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//pkg/disttask/framework/storage",
         "//pkg/disttask/framework/taskexecutor",
         "//pkg/errno",
+        "//pkg/lightning/backend/local",
         "//pkg/meta/model",
         "//pkg/sessionctx/vardef",
         "//pkg/testkit",

--- a/tests/realtikvtest/addindextest2/BUILD.bazel
+++ b/tests/realtikvtest/addindextest2/BUILD.bazel
@@ -12,8 +12,12 @@ go_test(
     deps = [
         "//br/pkg/storage",
         "//pkg/config",
+        "//pkg/ddl",
+        "//pkg/disttask/framework/testutil",
+        "//pkg/disttask/operator",
         "//pkg/kv",
         "//pkg/lightning/backend/external",
+        "//pkg/lightning/backend/local",
         "//pkg/meta/model",
         "//pkg/sessionctx/vardef",
         "//pkg/store/helper",

--- a/tests/realtikvtest/addindextest2/alter_job_test.go
+++ b/tests/realtikvtest/addindextest2/alter_job_test.go
@@ -116,7 +116,7 @@ func TestAlterJobOnDXF(t *testing.T) {
 			tk1.MustExec(fmt.Sprintf("admin alter ddl jobs %s thread = 8, batch_size = 256, max_write_speed=1024", rows[0][0]))
 			require.Eventually(t, func() bool {
 				return modified.Load()
-			}, 10*time.Second, 100*time.Millisecond)
+			}, 20*time.Second, 100*time.Millisecond)
 			require.Equal(t, 256, reorgMeta.GetBatchSize())
 		})
 	})

--- a/tests/realtikvtest/addindextest2/alter_job_test.go
+++ b/tests/realtikvtest/addindextest2/alter_job_test.go
@@ -16,14 +16,21 @@ package addindextest
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/disttask/framework/testutil"
+	"github.com/pingcap/tidb/pkg/disttask/operator"
+	"github.com/pingcap/tidb/pkg/lightning/backend/local"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAlterThreadRightAfterJobFinish(t *testing.T) {
@@ -31,23 +38,24 @@ func TestAlterThreadRightAfterJobFinish(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("set global tidb_enable_dist_task=0;")
+	t.Cleanup(func() {
+		tk.MustExec("set global tidb_enable_dist_task=1;")
+	})
+	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t (c1 int primary key, c2 int)")
 	tk.MustExec("insert t values (1, 1), (2, 2), (3, 3);")
 	var updated bool
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkJobCancelled", func(job *model.Job) {
 		if !updated && job.Type == model.ActionAddIndex && job.SchemaState == model.StateWriteReorganization {
 			updated = true
-			fmt.Println("TEST-LOG: set thread=1")
 			tk2 := testkit.NewTestKit(t, store)
 			tk2.MustExec(fmt.Sprintf("admin alter ddl jobs %d thread = 1", job.ID))
 		}
 	})
 	var pipeClosed atomic.Bool
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterPipeLineClose", func() {
-		fmt.Println("TEST-LOG: start sleep")
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterPipeLineClose", func(*operator.AsyncPipeline) {
 		pipeClosed.Store(true)
 		time.Sleep(5 * time.Second)
-		fmt.Println("TEST-LOG: end sleep")
 	})
 	var onUpdateJobParam bool
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onUpdateJobParam", func() {
@@ -56,8 +64,65 @@ func TestAlterThreadRightAfterJobFinish(t *testing.T) {
 			for !pipeClosed.Load() {
 				time.Sleep(100 * time.Millisecond)
 			}
-			fmt.Println("TEST-LOG: proceed update param")
 		}
 	})
 	tk.MustExec("alter table t add index idx(c2)")
+	require.True(t, updated)
+	require.True(t, pipeClosed.Load())
+}
+
+func TestAlterJobOnDXF(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", `return(16)`))
+	testutil.ReduceCheckInterval(t)
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists test;")
+	tk.MustExec("create database test;")
+	tk.MustExec("use test;")
+	tk.MustExec(`set global tidb_enable_dist_task=1;`)
+	tk.MustExec("create table t1(a bigint auto_random primary key);")
+	for i := 0; i < 16; i++ {
+		tk.MustExec("insert into t1 values (), (), (), ()")
+	}
+	tk.MustExec("split table t1 between (3) and (8646911284551352360) regions 50;")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1")
+	tk.MustExec("set @@tidb_ddl_reorg_batch_size = 32")
+	tk.MustExec("set global tidb_ddl_reorg_max_write_speed = 16")
+	t.Cleanup(func() {
+		tk.MustExec("set global tidb_ddl_reorg_max_write_speed = 0")
+	})
+	var pipeClosed bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterPipeLineClose", func(pipe *operator.AsyncPipeline) {
+		pipeClosed = true
+		reader, writer := pipe.GetLocalIngestModeReaderAndWriter()
+		require.EqualValues(t, 4, reader.(*ddl.TableScanOperator).GetWorkerPoolSize())
+		require.EqualValues(t, 6, writer.(*ddl.IndexIngestOperator).GetWorkerPoolSize())
+	})
+	var finishedSubtasks int
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/mockDMLExecutionAddIndexSubTaskFinish", func(be *local.Backend) {
+		finishedSubtasks++
+		require.EqualValues(t, 1024, be.GetWriteSpeedLimit())
+	})
+	var modified atomic.Bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterDetectAndHandleParamModify", func() {
+		modified.Store(true)
+	})
+	var once sync.Once
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/scanRecordExec", func(reorgMeta *model.DDLReorgMeta) {
+		once.Do(func() {
+			tk1 := testkit.NewTestKit(t, store)
+			rows := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
+			require.Len(t, rows, 1)
+			tk1.MustExec(fmt.Sprintf("admin alter ddl jobs %s thread = 8, batch_size = 256, max_write_speed=1024", rows[0][0]))
+			require.Eventually(t, func() bool {
+				return modified.Load()
+			}, 10*time.Second, 100*time.Millisecond)
+			require.Equal(t, 256, reorgMeta.GetBatchSize())
+		})
+	})
+	tk.MustExec("alter table t1 add index idx(a);")
+	require.True(t, pipeClosed)
+	require.EqualValues(t, 1, finishedSubtasks)
+	require.True(t, modified.Load())
+	tk.MustExec("admin check index t1 idx;")
 }

--- a/tests/realtikvtest/addindextest3/operator_test.go
+++ b/tests/realtikvtest/addindextest3/operator_test.go
@@ -312,7 +312,7 @@ func TestBackfillOperatorPipelineException(t *testing.T) {
 					}
 				}))
 			} else if strings.Contains(tc.failPointPath, "scanRecordExec") {
-				require.NoError(t, failpoint.EnableCall(tc.failPointPath, func() { cancel() }))
+				require.NoError(t, failpoint.EnableCall(tc.failPointPath, func(*model.DDLReorgMeta) { cancel() }))
 			} else {
 				require.NoError(t, failpoint.Enable(tc.failPointPath, `return`))
 			}

--- a/tests/realtikvtest/addindextest3/operator_test.go
+++ b/tests/realtikvtest/addindextest3/operator_test.go
@@ -421,9 +421,9 @@ func TestTuneWorkerPoolSize(t *testing.T) {
 
 		scanOp.Open()
 		require.Equal(t, scanOp.GetWorkerPoolSize(), int32(2))
-		scanOp.TuneWorkerPoolSize(8)
+		scanOp.TuneWorkerPoolSize(8, false)
 		require.Equal(t, scanOp.GetWorkerPoolSize(), int32(8))
-		scanOp.TuneWorkerPoolSize(1)
+		scanOp.TuneWorkerPoolSize(1, false)
 		require.Equal(t, scanOp.GetWorkerPoolSize(), int32(1))
 
 		cancel()
@@ -449,9 +449,9 @@ func TestTuneWorkerPoolSize(t *testing.T) {
 
 		ingestOp.Open()
 		require.Equal(t, ingestOp.GetWorkerPoolSize(), int32(2))
-		ingestOp.TuneWorkerPoolSize(8)
+		ingestOp.TuneWorkerPoolSize(8, false)
 		require.Equal(t, ingestOp.GetWorkerPoolSize(), int32(8))
-		ingestOp.TuneWorkerPoolSize(1)
+		ingestOp.TuneWorkerPoolSize(1, false)
 		require.Equal(t, ingestOp.GetWorkerPoolSize(), int32(1))
 
 		cancel()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #57497, ref #57229

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
    - ENV: 1pd/1tidb/1tikv
    - `create table t(id bigint primary key auto_increment, b varchar(1024), c varchar(1024));` and insert 16M rows
    - run `alter table t add index(b(128));`, the total index KV is about 5G

    - case 1: with initial thread=2/batch_size=32, after `admin alter ddl jobs 131 thread = 8, batch_size = 256;`, time of encoding part changes from `34s` -> `18s`
    - case 2: with initial thread=4/batch_size=256, after `admin alter ddl jobs 133 thread = 1, batch_size = 32;`, time of encoding part changes from `16s` -> `28s`
![wwg8I3shXS](https://github.com/user-attachments/assets/5e1d441b-1c86-4f5e-87a3-89cfe902f10c)
    - case 3: with initial thread=4/batch_size=256/max_write_speed=100M, after `admin alter ddl jobs 135 max_write_speed = 0;`, time of importing part changes from `53s` -> `23s`
    - case 4: with initial thread=4/batch_size=256/max_write_speed=200M, after `admin alter ddl jobs 137 max_write_speed = '100M';`, time of importing part changes from `26s` -> `49s`
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
