### PR TITLE
dxf: optimize querying eligible tasks in task executor manager

### DIFF
--- a/pkg/disttask/framework/storage/table_test.go
+++ b/pkg/disttask/framework/storage/table_test.go
@@ -1180,4 +1180,8 @@ func TestGetActiveTaskExecInfo(t *testing.T) {
 	require.Equal(t, 6, taskExecInfos[1].SubtaskConcurrency)
 	checkBasicTaskEq(t, &tasks[3].TaskBase, taskExecInfos[2].TaskBase)
 	require.Equal(t, 8, taskExecInfos[2].SubtaskConcurrency)
+	// :4002, no such subtasks
+	taskExecInfos, err = tm.GetTaskExecInfoByExecID(ctx, ":4002")
+	require.NoError(t, err)
+	require.Empty(t, taskExecInfos)
 }

--- a/pkg/disttask/framework/storage/task_table.go
+++ b/pkg/disttask/framework/storage/task_table.go
@@ -271,7 +271,7 @@ func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID stri
 	var res []*TaskExecInfo
 	err := mgr.WithNewSession(func(se sessionctx.Context) error {
 		// as the task will not go into next step when there are subtasks in those
-		// states, so their steps will be their current step of corresponding task,
+		// states, so their steps will be current step of their corresponding task,
 		// so we don't need to query by step here.
 		rs, err := sqlexec.ExecSQL(ctx, se.GetSQLExecutor(),
 			`select st.task_key, max(st.concurrency) from mysql.tidb_background_subtask st
@@ -296,7 +296,7 @@ func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID stri
 			if i > 0 {
 				taskIDsBuf.WriteString(",")
 			}
-			taskIDsBuf.WriteString(strconv.FormatInt(taskID, 10))
+			taskIDsBuf.WriteString(taskIDStr)
 		}
 		rs, err = sqlexec.ExecSQL(ctx, se.GetSQLExecutor(),
 			`select `+basicTaskColumns+` from mysql.tidb_global_task t

--- a/pkg/disttask/framework/storage/task_table.go
+++ b/pkg/disttask/framework/storage/task_table.go
@@ -85,7 +85,7 @@ type TaskExecInfo struct {
 	// also update subtask concurrency.
 	// TODO: we might need create one task executor for each step in this case, to alloc
 	// TODO: minimal resource
-	SubtaskConcurrency int
+	subtaskConcurrency int
 }
 
 // SessionExecutor defines the interface for executing SQLs in a session.
@@ -274,9 +274,8 @@ func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID stri
 		// states, so their steps will be their current step of corresponding task,
 		// so we don't need to query by step here.
 		rs, err := sqlexec.ExecSQL(ctx, se.GetSQLExecutor(),
-			`select st.task_key, max(st.concurrency) from mysql.tidb_background_subtask st
-			where st.exec_id = %? and st.state in (%?, %?)
-			group by st.task_key`,
+			`select distinct st.task_key from mysql.tidb_background_subtask st
+			where st.exec_id = %? and st.state in (%?, %?)`,
 			execID, proto.SubtaskStatePending, proto.SubtaskStateRunning)
 		if err != nil {
 			return err
@@ -284,7 +283,6 @@ func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID stri
 		if len(rs) == 0 {
 			return nil
 		}
-		maxSubtaskCon := make(map[int64]int, len(rs))
 		var taskIDsBuf strings.Builder
 		for i, r := range rs {
 			taskIDStr := r.GetString(0)
@@ -292,7 +290,6 @@ func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID stri
 			if err2 != nil {
 				return errors.Trace(err2)
 			}
-			maxSubtaskCon[taskID] = int(r.GetInt64(1))
 			if i > 0 {
 				taskIDsBuf.WriteString(",")
 			}
@@ -310,8 +307,7 @@ func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID stri
 		for _, r := range rs {
 			taskBase := row2TaskBasic(r)
 			res = append(res, &TaskExecInfo{
-				TaskBase:           taskBase,
-				SubtaskConcurrency: maxSubtaskCon[taskBase.ID],
+				TaskBase: taskBase,
 			})
 		}
 		return nil

--- a/pkg/disttask/framework/storage/task_table.go
+++ b/pkg/disttask/framework/storage/task_table.go
@@ -268,27 +268,55 @@ func (mgr *TaskManager) GetTopUnfinishedTasks(ctx context.Context) ([]*proto.Tas
 
 // GetTaskExecInfoByExecID implements the scheduler.TaskManager interface.
 func (mgr *TaskManager) GetTaskExecInfoByExecID(ctx context.Context, execID string) ([]*TaskExecInfo, error) {
-	rs, err := mgr.ExecuteSQLWithNewSession(ctx,
-		`select `+basicTaskColumns+`, max(st.concurrency)
-			from mysql.tidb_global_task t join mysql.tidb_background_subtask st
-				on t.id = st.task_key and t.step = st.step
-			where t.state in (%?, %?, %?) and st.state in (%?, %?) and st.exec_id = %?
-			group by t.id
+	var res []*TaskExecInfo
+	err := mgr.WithNewSession(func(se sessionctx.Context) error {
+		// as the task will not go into next step when there are subtasks in those
+		// states, so their steps will be their current step of corresponding task,
+		// so we don't need to query by step here.
+		rs, err := sqlexec.ExecSQL(ctx, se.GetSQLExecutor(),
+			`select st.task_key, max(st.concurrency) from mysql.tidb_background_subtask st
+			where st.exec_id = %? and st.state in (%?, %?)
+			group by st.task_key`,
+			execID, proto.SubtaskStatePending, proto.SubtaskStateRunning)
+		if err != nil {
+			return err
+		}
+		if len(rs) == 0 {
+			return nil
+		}
+		maxSubtaskCon := make(map[int64]int, len(rs))
+		var taskIDsBuf strings.Builder
+		for i, r := range rs {
+			taskIDStr := r.GetString(0)
+			taskID, err2 := strconv.ParseInt(taskIDStr, 10, 0)
+			if err2 != nil {
+				return errors.Trace(err2)
+			}
+			maxSubtaskCon[taskID] = int(r.GetInt64(1))
+			if i > 0 {
+				taskIDsBuf.WriteString(",")
+			}
+			taskIDsBuf.WriteString(strconv.FormatInt(taskID, 10))
+		}
+		rs, err = sqlexec.ExecSQL(ctx, se.GetSQLExecutor(),
+			`select `+basicTaskColumns+` from mysql.tidb_global_task t
+			where t.id in (`+taskIDsBuf.String()+`) and t.state in (%?, %?, %?)
 			order by priority asc, create_time asc, id asc`,
-		proto.TaskStateRunning, proto.TaskStateReverting, proto.TaskStatePausing,
-		proto.SubtaskStatePending, proto.SubtaskStateRunning, execID)
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]*TaskExecInfo, 0, len(rs))
-	for _, r := range rs {
-		res = append(res, &TaskExecInfo{
-			TaskBase:           row2TaskBasic(r),
-			SubtaskConcurrency: int(r.GetInt64(9)),
-		})
-	}
-	return res, nil
+			proto.TaskStateRunning, proto.TaskStateReverting, proto.TaskStatePausing)
+		if err != nil {
+			return err
+		}
+		res = make([]*TaskExecInfo, 0, len(rs))
+		for _, r := range rs {
+			taskBase := row2TaskBasic(r)
+			res = append(res, &TaskExecInfo{
+				TaskBase:           taskBase,
+				SubtaskConcurrency: maxSubtaskCon[taskBase.ID],
+			})
+		}
+		return nil
+	})
+	return res, err
 }
 
 // GetTasksInStates gets the tasks in the states(order by priority asc, create_time acs, id asc).


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59344

Problem Summary:

### What changed and how does it work?
see issue

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before vs after
**Note:**: for the `after`, out of the remaining 1.9% CPU, only 0.5 is taken by DXF, others are taken by bindinfo/metric collect/cpu observer/runaway watcher, etc, see the third graph
![58e0283f-e78e-4e7e-95ec-d022a584495f](https://github.com/user-attachments/assets/850507b8-1d23-4eef-ac44-c854b42454f9)
![278256a7-aa34-4e74-b848-14c7d07d75c1](https://github.com/user-attachments/assets/700e3542-1f21-4a6a-803c-7702a371a4f1)
how DXF query frequency affects CPU usage
![image](https://github.com/user-attachments/assets/0759e563-2167-4903-9a63-10e61301966d)

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
