### PR TITLE
ast: Allow SELECT statements to set user-defined variables in read-only mode.

### DIFF
--- a/pkg/parser/ast/util.go
+++ b/pkg/parser/ast/util.go
@@ -32,12 +32,7 @@ func IsReadOnly(node Node) bool {
 			}
 		}
 
-		checker := readOnlyChecker{
-			readOnly: true,
-		}
-
-		node.Accept(&checker)
-		return checker.readOnly
+		return true
 	case *ExplainStmt:
 		return !st.Analyze || IsReadOnly(st.Stmt)
 	case *DoStmt, *ShowStmt:
@@ -68,29 +63,4 @@ func IsReadOnly(node Node) bool {
 	default:
 		return false
 	}
-}
-
-// readOnlyChecker checks whether a query's ast is readonly, if it satisfied
-// 1. selectstmt;
-// 2. need not to set var;
-// it is readonly statement.
-type readOnlyChecker struct {
-	readOnly bool
-}
-
-// Enter implements Visitor interface.
-func (checker *readOnlyChecker) Enter(in Node) (out Node, skipChildren bool) {
-	if node, ok := in.(*VariableExpr); ok {
-		// like func rewriteVariable(), this stands for SetVar.
-		if !node.IsSystem && node.Value != nil {
-			checker.readOnly = false
-			return in, true
-		}
-	}
-	return in, false
-}
-
-// Leave implements Visitor interface.
-func (checker *readOnlyChecker) Leave(in Node) (out Node, ok bool) {
-	return in, checker.readOnly
 }

--- a/pkg/parser/ast/util_test.go
+++ b/pkg/parser/ast/util_test.go
@@ -29,50 +29,50 @@ import (
 func TestCacheable(t *testing.T) {
 	// test non-SelectStmt
 	var stmt Node = &DeleteStmt{}
-	require.False(t, IsReadOnly(stmt))
+	require.False(t, IsReadOnly(stmt, true))
 
 	stmt = &InsertStmt{}
-	require.False(t, IsReadOnly(stmt))
+	require.False(t, IsReadOnly(stmt, true))
 
 	stmt = &UpdateStmt{}
-	require.False(t, IsReadOnly(stmt))
+	require.False(t, IsReadOnly(stmt, true))
 
 	stmt = &ExplainStmt{}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &ExplainStmt{}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &DoStmt{}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &ExplainStmt{
 		Stmt: &InsertStmt{},
 	}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &ExplainStmt{
 		Analyze: true,
 		Stmt:    &InsertStmt{},
 	}
-	require.False(t, IsReadOnly(stmt))
+	require.False(t, IsReadOnly(stmt, true))
 
 	stmt = &ExplainStmt{
 		Stmt: &SelectStmt{},
 	}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &ExplainStmt{
 		Analyze: true,
 		Stmt:    &SelectStmt{},
 	}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &ShowStmt{}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 
 	stmt = &ShowStmt{}
-	require.True(t, IsReadOnly(stmt))
+	require.True(t, IsReadOnly(stmt, true))
 }
 
 func TestUnionReadOnly(t *testing.T) {
@@ -89,22 +89,22 @@ func TestUnionReadOnly(t *testing.T) {
 			Selects: []Node{selectReadOnly, selectReadOnly},
 		},
 	}
-	require.True(t, IsReadOnly(setOprStmt))
+	require.True(t, IsReadOnly(setOprStmt, true))
 
 	setOprStmt.SelectList.Selects = []Node{selectReadOnly, selectReadOnly, selectReadOnly}
-	require.True(t, IsReadOnly(setOprStmt))
+	require.True(t, IsReadOnly(setOprStmt, true))
 
 	setOprStmt.SelectList.Selects = []Node{selectReadOnly, selectForUpdate}
-	require.False(t, IsReadOnly(setOprStmt))
+	require.False(t, IsReadOnly(setOprStmt, true))
 
 	setOprStmt.SelectList.Selects = []Node{selectReadOnly, selectForUpdateNoWait}
-	require.False(t, IsReadOnly(setOprStmt))
+	require.False(t, IsReadOnly(setOprStmt, true))
 
 	setOprStmt.SelectList.Selects = []Node{selectForUpdate, selectForUpdateNoWait}
-	require.False(t, IsReadOnly(setOprStmt))
+	require.False(t, IsReadOnly(setOprStmt, true))
 
 	setOprStmt.SelectList.Selects = []Node{selectReadOnly, selectForUpdate, selectForUpdateNoWait}
-	require.False(t, IsReadOnly(setOprStmt))
+	require.False(t, IsReadOnly(setOprStmt, true))
 }
 
 // CleanNodeText set the text of node and all child node empty.

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -55,17 +55,17 @@ func IsReadOnly(node ast.Node, vars *variable.SessionVars) bool {
 	return isReadOnlyInternal(node, vars, true)
 }
 
-// IsReadOnly check whether the ast.Node is a read only statement.
-func isReadOnlyInternal(node ast.Node, vars *variable.SessionVars, checkVariables bool) bool {
+// If checkGlobalVars is true, false will be returned when there are updates to global variables.
+func isReadOnlyInternal(node ast.Node, vars *variable.SessionVars, checkGlobalVars bool) bool {
 	if execStmt, isExecStmt := node.(*ast.ExecuteStmt); isExecStmt {
 		prepareStmt, err := core.GetPreparedStmt(execStmt, vars)
 		if err != nil {
 			logutil.BgLogger().Warn("GetPreparedStmt failed", zap.Error(err))
 			return false
 		}
-		return ast.IsReadOnly(prepareStmt.PreparedAst.Stmt, checkVariables)
+		return ast.IsReadOnly(prepareStmt.PreparedAst.Stmt, checkGlobalVars)
 	}
-	return ast.IsReadOnly(node, checkVariables)
+	return ast.IsReadOnly(node, checkGlobalVars)
 }
 
 // getPlanFromNonPreparedPlanCache tries to get an available cached plan from the NonPrepared Plan Cache for this stmt.
@@ -421,6 +421,7 @@ func allowInReadOnlyMode(sctx planctx.PlanContext, node ast.Node) (bool, error) 
 	}
 
 	vars := sctx.GetSessionVars()
+	// Passing false allows global variables updates in read-only mode.
 	return isReadOnlyInternal(node, vars, false), nil
 }
 

--- a/tests/integrationtest/r/session/user_variables.result
+++ b/tests/integrationtest/r/session/user_variables.result
@@ -1,0 +1,42 @@
+select @i := 1;
+@i := 1
+1
+select @i := @i + 1;
+@i := @i + 1
+2
+select @i;
+@i
+2
+set @k := 1;
+select @k := @i + 1;
+@k := @i + 1
+3
+select @k;
+@k
+3
+select @l := @l + 1;
+@l := @l + 1
+NULL
+select @l;
+@l
+NULL
+set global tidb_super_read_only=1;
+select @i := @i + 1;
+@i := @i + 1
+3
+select @i;
+@i
+3
+select @i := 2;
+@i := 2
+2
+select @i;
+@i
+2
+select @m := @m + 1;
+@m := @m + 1
+NULL
+select @m;
+@m
+NULL
+set global tidb_super_read_only=0;

--- a/tests/integrationtest/t/session/user_variables.test
+++ b/tests/integrationtest/t/session/user_variables.test
@@ -1,0 +1,23 @@
+# Test that a variable can be added to itself.
+select @i := 1;
+select @i := @i + 1;
+select @i;
+
+# Test that a variable can be added to another variable.
+set @k := 1;
+select @k := @i + 1;
+select @k;
+
+# Test that a variable can be added to itself when it is not defined, which results in null.
+select @l := @l + 1;
+select @l;
+
+# Test that variables can be set in readonly mode.
+set global tidb_super_read_only=1;
+select @i := @i + 1;
+select @i;
+select @i := 2;
+select @i;
+select @m := @m + 1;
+select @m;
+set global tidb_super_read_only=0;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55281

Problem Summary:
In read-only mode user-defined variables cannot be set with select statements.  You can reproduce this by running:

`set global tidb_super_read_only=1; select @i:=@i+1;`

This is allowed on MySQL.

### What changed and how does it work?
After reviewing the various code paths that can reach ast.IsReadOnly, I could find no reason this function would need to return false for read-only queries that set user-defined variables. This patch removes the part of ast.IsReadOnly that checks for writes to user-defined variables, which fixes the bug.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
