### PR TITLE
information_schema: add `CLUSTER_ID` column to the `information_schema.cluster_info`

### DIFF
--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -247,6 +247,8 @@ func TestTiDBClusterInfo(t *testing.T) {
 	tk.MustQuery("select type, instance from information_schema.cluster_info where type = 'tikv'").Check(testkit.Rows(
 		row("tikv", "store1"),
 	))
+	// The cluster_id of TiDB, TiKV and PD are all 1. 1 is the cluster_id of the mock pd.
+	tk.MustQuery("select cluster_id from information_schema.cluster_info").Check(testkit.Rows("1", "1", "1"))
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/infoschema/mockStoreTombstone", `return(true)`))
 	tk.MustQuery("select type, instance, start_time from information_schema.cluster_info where type = 'tikv'").Check(testkit.Rows())

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -1191,6 +1191,7 @@ var tableClusterInfoCols = []columnInfo{
 	{name: "START_TIME", tp: mysql.TypeDatetime, size: 19},
 	{name: "UPTIME", tp: mysql.TypeVarchar, size: 32},
 	{name: "SERVER_ID", tp: mysql.TypeLonglong, size: 21, comment: "invalid if the configuration item `enable-global-kill` is set to FALSE"},
+	{name: "CLUSTER_ID", tp: mysql.TypeLonglong, size: 21},
 }
 
 var tableTableTiFlashReplicaCols = []columnInfo{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59476

Problem Summary:

### What changed and how does it work?

Add the `CLUSTER_ID` column to the `information_schema.cluster_info` table to expose the `CLUSTER_ID` from PD.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Run `tiup playground --db.binpath=xxx` and execute `SELECT * FROM information_schema.cluster_info`:

```
mysql> select * from information_schema.cluster_info;
+---------+-----------------+-----------------+-----------------------------------+------------------------------------------+---------------------+--------------+-----------+---------------------+
| TYPE    | INSTANCE        | STATUS_ADDRESS  | VERSION                           | GIT_HASH                                 | START_TIME          | UPTIME       | SERVER_ID | CLUSTER_ID          |
+---------+-----------------+-----------------+-----------------------------------+------------------------------------------+---------------------+--------------+-----------+---------------------+
| tidb    | 127.0.0.1:4000  | 127.0.0.1:10080 | 9.0.0-alpha-244-g397b0f228a-dirty | 397b0f228a93d4b7323baa6f02a4c895449017f4 | 2025-02-12 16:40:11 | 1m41.821887s |      1142 | 7470449662449437074 |
| pd      | 127.0.0.1:2379  | 127.0.0.1:2379  | 8.5.0                             | d190c0e9082de46128b756f93b1291768dda645a | 2025-02-12 16:40:01 | 1m51.821896s |         0 | 7470449662449437074 |
| tikv    | 127.0.0.1:20160 | 127.0.0.1:20180 | 8.5.0                             | a2c58c94f89cbb410e66d8f85c236308d6fc64f0 | 2025-02-12 16:40:04 | 1m48.821898s |         0 | 7470449662449437074 |
| tiflash | 127.0.0.1:3930  | 127.0.0.1:20292 | 8.5.0                             | 6e12ba23c70f358f2ffbee837feac24118a3e988 | 2025-02-12 16:40:23 | 1m29.821908s |         0 | 7470449662449437074 |
+---------+-----------------+-----------------+-----------------------------------+------------------------------------------+---------------------+--------------+-----------+---------------------+
4 rows in set (0.02 sec)
```

Close and restart the `tiup playground --db.binpath=xxxxx`, execute the same SQL:

```
mysql> select * from information_schema.cluster_info;
+---------+-----------------+-----------------+-----------------------------------+------------------------------------------+---------------------+------------+-----------+---------------------+
| TYPE    | INSTANCE        | STATUS_ADDRESS  | VERSION                           | GIT_HASH                                 | START_TIME          | UPTIME     | SERVER_ID | CLUSTER_ID          |
+---------+-----------------+-----------------+-----------------------------------+------------------------------------------+---------------------+------------+-----------+---------------------+
| tidb    | 127.0.0.1:4000  | 127.0.0.1:10080 | 9.0.0-alpha-244-g397b0f228a-dirty | 397b0f228a93d4b7323baa6f02a4c895449017f4 | 2025-02-12 16:46:24 | 27.346209s |      1468 | 7470451251628040863 |
| pd      | 127.0.0.1:2379  | 127.0.0.1:2379  | 8.5.0                             | d190c0e9082de46128b756f93b1291768dda645a | 2025-02-12 16:46:11 | 40.346216s |         0 | 7470451251628040863 |
| tikv    | 127.0.0.1:20160 | 127.0.0.1:20180 | 8.5.0                             | a2c58c94f89cbb410e66d8f85c236308d6fc64f0 | 2025-02-12 16:46:13 | 38.346219s |         0 | 7470451251628040863 |
| tiflash | 127.0.0.1:3930  | 127.0.0.1:20292 | 8.5.0                             | 6e12ba23c70f358f2ffbee837feac24118a3e988 | 2025-02-12 16:46:40 | 11.346219s |         0 | 7470451251628040863 |
+---------+-----------------+-----------------+-----------------------------------+------------------------------------------+---------------------+------------+-----------+---------------------+
4 rows in set (0.01 sec)
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note


```release-note
Add the `CLUSTER_ID` column to the `INFORMATION_SCHEMA.CLUSTER_INFO` table.
```
