### PR TITLE
planner: avoid skipping plan cache when extracting funcdep

### DIFF
--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -280,7 +280,7 @@ func (a *AggFuncDesc) GetAggFunc(ctx expression.AggFuncBuildContext) Aggregation
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
 	for _, arg := range a.Args {
-		result, err := expression.EvaluateExprWithNull(ctx, schema, arg)
+		result, err := expression.EvaluateExprWithNull(ctx, schema, arg, false)
 		if err != nil {
 			return types.Datum{}, false, err
 		}
@@ -293,7 +293,7 @@ func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx expression.BuildContext
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4Sum(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
-	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], false)
 	if err != nil {
 		return types.Datum{}, false, err
 	}
@@ -305,7 +305,7 @@ func (a *AggFuncDesc) evalNullValueInOuterJoin4Sum(ctx expression.BuildContext, 
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4BitAnd(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
-	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], false)
 	if err != nil {
 		return types.Datum{}, false, err
 	}
@@ -317,7 +317,7 @@ func (a *AggFuncDesc) evalNullValueInOuterJoin4BitAnd(ctx expression.BuildContex
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4BitOr(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
-	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0])
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], false)
 	if err != nil {
 		return types.Datum{}, false, err
 	}

--- a/pkg/expression/aggregation/descriptor.go
+++ b/pkg/expression/aggregation/descriptor.go
@@ -280,7 +280,7 @@ func (a *AggFuncDesc) GetAggFunc(ctx expression.AggFuncBuildContext) Aggregation
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
 	for _, arg := range a.Args {
-		result, err := expression.EvaluateExprWithNull(ctx, schema, arg, false)
+		result, err := expression.EvaluateExprWithNull(ctx, schema, arg, true)
 		if err != nil {
 			return types.Datum{}, false, err
 		}
@@ -293,7 +293,7 @@ func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx expression.BuildContext
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4Sum(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
-	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], false)
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], true)
 	if err != nil {
 		return types.Datum{}, false, err
 	}
@@ -305,7 +305,7 @@ func (a *AggFuncDesc) evalNullValueInOuterJoin4Sum(ctx expression.BuildContext, 
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4BitAnd(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
-	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], false)
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], true)
 	if err != nil {
 		return types.Datum{}, false, err
 	}
@@ -317,7 +317,7 @@ func (a *AggFuncDesc) evalNullValueInOuterJoin4BitAnd(ctx expression.BuildContex
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4BitOr(ctx expression.BuildContext, schema *expression.Schema) (types.Datum, bool, error) {
-	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], false)
+	result, err := expression.EvaluateExprWithNull(ctx, schema, a.Args[0], true)
 	if err != nil {
 		return types.Datum{}, false, err
 	}

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -920,6 +920,7 @@ func SplitDNFItems(onExpr Expression) []Expression {
 // EvaluateExprWithNull sets columns in schema as null and calculate the final result of the scalar function.
 // If the Expression is a non-constant value, it means the result is unknown.
 // When to extract functional dependencies, we need to close thie skipPlanCache.
+// so it only is closed by pkg/planner/core.ExtractNotNullFromConds
 func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, skipPlanCache bool) (Expression, error) {
 	if skipPlanCache && MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
 		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -919,8 +919,8 @@ func SplitDNFItems(onExpr Expression) []Expression {
 
 // EvaluateExprWithNull sets columns in schema as null and calculate the final result of the scalar function.
 // If the Expression is a non-constant value, it means the result is unknown.
-// Set the skip cache to false when the caller will not change the logical plan tree
-// it is currently closed only by pkg/planner/core.ExtractNotNullFromConds
+// Set the skip cache to false when the caller will not change the logical plan tree.
+// it is currently closed only by pkg/planner/core.ExtractNotNullFromConds when to extractFD.
 func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, skipPlanCacheCheck bool) (Expression, error) {
 	if skipPlanCacheCheck && MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
 		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -919,23 +919,23 @@ func SplitDNFItems(onExpr Expression) []Expression {
 
 // EvaluateExprWithNull sets columns in schema as null and calculate the final result of the scalar function.
 // If the Expression is a non-constant value, it means the result is unknown.
-func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression) (Expression, error) {
-	if MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
+func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, notSkipPlanCache bool) (Expression, error) {
+	if !notSkipPlanCache && MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
 		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 	}
 	if ctx.IsInNullRejectCheck() {
 		res, _, err := evaluateExprWithNullInNullRejectCheck(ctx, schema, expr)
 		return res, err
 	}
-	return evaluateExprWithNull(ctx, schema, expr)
+	return evaluateExprWithNull(ctx, schema, expr, notSkipPlanCache)
 }
 
-func evaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression) (Expression, error) {
+func evaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, notSkipPlanCache bool) (Expression, error) {
 	switch x := expr.(type) {
 	case *ScalarFunction:
 		args := make([]Expression, len(x.GetArgs()))
 		for i, arg := range x.GetArgs() {
-			res, err := EvaluateExprWithNull(ctx, schema, arg)
+			res, err := EvaluateExprWithNull(ctx, schema, arg, notSkipPlanCache)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -921,15 +921,15 @@ func SplitDNFItems(onExpr Expression) []Expression {
 // If the Expression is a non-constant value, it means the result is unknown.
 // When to extract functional dependencies, we need to close thie skipPlanCache.
 // so it only is closed by pkg/planner/core.ExtractNotNullFromConds
-func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, skipPlanCache bool) (Expression, error) {
-	if skipPlanCache && MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
+func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, skipPlanCacheCheck bool) (Expression, error) {
+	if skipPlanCacheCheck && MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
 		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))
 	}
 	if ctx.IsInNullRejectCheck() {
 		res, _, err := evaluateExprWithNullInNullRejectCheck(ctx, schema, expr)
 		return res, err
 	}
-	return evaluateExprWithNull(ctx, schema, expr, skipPlanCache)
+	return evaluateExprWithNull(ctx, schema, expr, skipPlanCacheCheck)
 }
 
 func evaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, notSkipPlanCache bool) (Expression, error) {

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -919,8 +919,8 @@ func SplitDNFItems(onExpr Expression) []Expression {
 
 // EvaluateExprWithNull sets columns in schema as null and calculate the final result of the scalar function.
 // If the Expression is a non-constant value, it means the result is unknown.
-// When to extract functional dependencies, we need to close thie skipPlanCache.
-// so it only is closed by pkg/planner/core.ExtractNotNullFromConds
+// Set the skip cache to false when the caller will not change the logical plan tree
+// it is currently closed only by pkg/planner/core.ExtractNotNullFromConds
 func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, skipPlanCacheCheck bool) (Expression, error) {
 	if skipPlanCacheCheck && MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
 		ctx.SetSkipPlanCache(fmt.Sprintf("%v affects null check", expr.StringWithCtx(ctx.GetEvalCtx(), errors.RedactLogDisable)))

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -932,12 +932,12 @@ func EvaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, ski
 	return evaluateExprWithNull(ctx, schema, expr, skipPlanCacheCheck)
 }
 
-func evaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, notSkipPlanCache bool) (Expression, error) {
+func evaluateExprWithNull(ctx BuildContext, schema *Schema, expr Expression, skipPlanCache bool) (Expression, error) {
 	switch x := expr.(type) {
 	case *ScalarFunction:
 		args := make([]Expression, len(x.GetArgs()))
 		for i, arg := range x.GetArgs() {
-			res, err := EvaluateExprWithNull(ctx, schema, arg, notSkipPlanCache)
+			res, err := EvaluateExprWithNull(ctx, schema, arg, skipPlanCache)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -75,7 +75,7 @@ func TestEvaluateExprWithNullMeetError(t *testing.T) {
 	require.NoError(t, err)
 
 	// the inner function has an error
-	_, err = EvaluateExprWithNull(ctx, schema, outerIfNull, true)
+	_, err = EvaluateExprWithNull(ctx, schema, outerIfNull, false)
 	require.NotNil(t, err)
 	// check in NullRejectCheck ctx
 	_, err = EvaluateExprWithNull(ctx.GetNullRejectCheckExprCtx(), schema, outerIfNull, false)

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -48,14 +48,14 @@ func TestEvaluateExprWithNull(t *testing.T) {
 	outerIfNull, err := newFunctionForTest(ctx, ast.Ifnull, col0, innerIfNull)
 	require.NoError(t, err)
 
-	res, err := EvaluateExprWithNull(ctx, schema, outerIfNull)
+	res, err := EvaluateExprWithNull(ctx, schema, outerIfNull, false)
 	require.Nil(t, err)
 	require.Equal(t, "ifnull(Column#1, 1)", res.StringWithCtx(ctx, errors.RedactLogDisable))
 	require.Equal(t, "ifnull(Column#1, ?)", res.StringWithCtx(ctx, errors.RedactLogEnable))
 	require.Equal(t, "ifnull(Column#1, ‹1›)", res.StringWithCtx(ctx, errors.RedactLogMarker))
 	schema.Columns = append(schema.Columns, col1)
 	// ifnull(null, ifnull(null, 1))
-	res, err = EvaluateExprWithNull(ctx, schema, outerIfNull)
+	res, err = EvaluateExprWithNull(ctx, schema, outerIfNull, false)
 	require.Nil(t, err)
 	require.True(t, res.Equal(ctx, NewOne()))
 }
@@ -75,10 +75,10 @@ func TestEvaluateExprWithNullMeetError(t *testing.T) {
 	require.NoError(t, err)
 
 	// the inner function has an error
-	_, err = EvaluateExprWithNull(ctx, schema, outerIfNull)
+	_, err = EvaluateExprWithNull(ctx, schema, outerIfNull, false)
 	require.NotNil(t, err)
 	// check in NullRejectCheck ctx
-	_, err = EvaluateExprWithNull(ctx.GetNullRejectCheckExprCtx(), schema, outerIfNull)
+	_, err = EvaluateExprWithNull(ctx.GetNullRejectCheckExprCtx(), schema, outerIfNull, false)
 	require.NotNil(t, err)
 }
 
@@ -93,7 +93,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	// cases for parameters
 	ltWithoutParam, err := newFunctionForTest(ctx, ast.LT, col0, NewOne())
 	require.NoError(t, err)
-	res, err := EvaluateExprWithNull(ctx, schema, ltWithoutParam)
+	res, err := EvaluateExprWithNull(ctx, schema, ltWithoutParam, false)
 	require.Nil(t, err)
 	require.True(t, res.Equal(ctx, NewNull())) // the expression is evaluated to null
 	param := NewOne()
@@ -101,7 +101,7 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	ctx.GetSessionVars().PlanCacheParams.Append(types.NewIntDatum(10))
 	ltWithParam, err := newFunctionForTest(ctx, ast.LT, col0, param)
 	require.NoError(t, err)
-	res, err = EvaluateExprWithNull(ctx, schema, ltWithParam)
+	res, err = EvaluateExprWithNull(ctx, schema, ltWithParam, false)
 	require.Nil(t, err)
 	_, isConst := res.(*Constant)
 	require.True(t, isConst) // this expression is evaluated and skip-plan cache flag is set.
@@ -127,7 +127,7 @@ func TestEvaluateExprWithNullNoChangeRetType(t *testing.T) {
 	require.False(t, mysql.HasParseToJSONFlag(flagInCast))
 
 	// after EvaluateExprWithNull, this flag should be still false
-	EvaluateExprWithNull(ctx, schema, eq)
+	EvaluateExprWithNull(ctx, schema, eq, false)
 	flagInCast = eq.(*ScalarFunction).GetArgs()[1].(*ScalarFunction).RetType.GetFlag()
 	require.False(t, mysql.HasParseToJSONFlag(flagInCast))
 }

--- a/pkg/expression/expression_test.go
+++ b/pkg/expression/expression_test.go
@@ -75,10 +75,10 @@ func TestEvaluateExprWithNullMeetError(t *testing.T) {
 	require.NoError(t, err)
 
 	// the inner function has an error
-	_, err = EvaluateExprWithNull(ctx, schema, outerIfNull, false)
+	_, err = EvaluateExprWithNull(ctx, schema, outerIfNull, true)
 	require.NotNil(t, err)
 	// check in NullRejectCheck ctx
-	_, err = EvaluateExprWithNull(ctx.GetNullRejectCheckExprCtx(), schema, outerIfNull, false)
+	_, err = EvaluateExprWithNull(ctx.GetNullRejectCheckExprCtx(), schema, outerIfNull, true)
 	require.NotNil(t, err)
 }
 

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -393,7 +393,7 @@ func (la *LogicalAggregation) ExtractFD() *fd.FDSet {
 				determinants.Insert(int(one.UniqueID))
 				groupByColsOutputCols.Insert(int(one.UniqueID))
 			}
-			notnull := util.IsNullRejected(la.SCtx(), la.Schema(), x)
+			notnull := util.IsNullRejected(la.SCtx(), la.Schema(), x, false)
 			if notnull || determinants.SubsetOf(fds.NotNullCols) {
 				notnullColsUniqueIDs.Insert(scalarUniqueID)
 			}
@@ -705,7 +705,7 @@ func (la *LogicalAggregation) CanPullUp() bool {
 	}
 	for _, f := range la.AggFuncs {
 		for _, arg := range f.Args {
-			expr, err := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg)
+			expr, err := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg, false)
 			if err != nil {
 				return false
 			}

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -393,7 +393,7 @@ func (la *LogicalAggregation) ExtractFD() *fd.FDSet {
 				determinants.Insert(int(one.UniqueID))
 				groupByColsOutputCols.Insert(int(one.UniqueID))
 			}
-			notnull := util.IsNullRejected(la.SCtx(), la.Schema(), x, false)
+			notnull := util.IsNullRejected(la.SCtx(), la.Schema(), x, true)
 			if notnull || determinants.SubsetOf(fds.NotNullCols) {
 				notnullColsUniqueIDs.Insert(scalarUniqueID)
 			}
@@ -705,7 +705,7 @@ func (la *LogicalAggregation) CanPullUp() bool {
 	}
 	for _, f := range la.AggFuncs {
 		for _, arg := range f.Args {
-			expr, err := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg, false)
+			expr, err := expression.EvaluateExprWithNull(la.SCtx().GetExprCtx(), la.Children()[0].Schema(), arg, true)
 			if err != nil {
 				return false
 			}

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -678,7 +678,7 @@ func (p *LogicalJoin) ConvertOuterToInnerJoin(predicates []expression.Expression
 	if p.JoinType == LeftOuterJoin || p.JoinType == RightOuterJoin {
 		canBeSimplified := false
 		for _, expr := range predicates {
-			isOk := util.IsNullRejected(p.SCtx(), innerTable.Schema(), expr, false)
+			isOk := util.IsNullRejected(p.SCtx(), innerTable.Schema(), expr, true)
 			if isOk {
 				canBeSimplified = true
 				break
@@ -1253,13 +1253,13 @@ func (p *LogicalJoin) ExtractOnCondition(
 				}
 				if leftCol != nil && rightCol != nil {
 					if deriveLeft {
-						if util.IsNullRejected(ctx, leftSchema, expr, false) && !mysql.HasNotNullFlag(leftCol.RetType.GetFlag()) {
+						if util.IsNullRejected(ctx, leftSchema, expr, true) && !mysql.HasNotNullFlag(leftCol.RetType.GetFlag()) {
 							notNullExpr := expression.BuildNotNullExpr(ctx.GetExprCtx(), leftCol)
 							leftCond = append(leftCond, notNullExpr)
 						}
 					}
 					if deriveRight {
-						if util.IsNullRejected(ctx, rightSchema, expr, false) && !mysql.HasNotNullFlag(rightCol.RetType.GetFlag()) {
+						if util.IsNullRejected(ctx, rightSchema, expr, true) && !mysql.HasNotNullFlag(rightCol.RetType.GetFlag()) {
 							notNullExpr := expression.BuildNotNullExpr(ctx.GetExprCtx(), rightCol)
 							rightCond = append(rightCond, notNullExpr)
 						}
@@ -1865,7 +1865,7 @@ func deriveNotNullExpr(ctx base.PlanContext, expr expression.Expression, schema 
 	if childCol == nil {
 		childCol = schema.RetrieveColumn(arg1)
 	}
-	if util.IsNullRejected(ctx, schema, expr, false) && !mysql.HasNotNullFlag(childCol.RetType.GetFlag()) {
+	if util.IsNullRejected(ctx, schema, expr, true) && !mysql.HasNotNullFlag(childCol.RetType.GetFlag()) {
 		return expression.BuildNotNullExpr(ctx.GetExprCtx(), childCol)
 	}
 	return nil

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -678,7 +678,7 @@ func (p *LogicalJoin) ConvertOuterToInnerJoin(predicates []expression.Expression
 	if p.JoinType == LeftOuterJoin || p.JoinType == RightOuterJoin {
 		canBeSimplified := false
 		for _, expr := range predicates {
-			isOk := util.IsNullRejected(p.SCtx(), innerTable.Schema(), expr)
+			isOk := util.IsNullRejected(p.SCtx(), innerTable.Schema(), expr, false)
 			if isOk {
 				canBeSimplified = true
 				break
@@ -1253,13 +1253,13 @@ func (p *LogicalJoin) ExtractOnCondition(
 				}
 				if leftCol != nil && rightCol != nil {
 					if deriveLeft {
-						if util.IsNullRejected(ctx, leftSchema, expr) && !mysql.HasNotNullFlag(leftCol.RetType.GetFlag()) {
+						if util.IsNullRejected(ctx, leftSchema, expr, false) && !mysql.HasNotNullFlag(leftCol.RetType.GetFlag()) {
 							notNullExpr := expression.BuildNotNullExpr(ctx.GetExprCtx(), leftCol)
 							leftCond = append(leftCond, notNullExpr)
 						}
 					}
 					if deriveRight {
-						if util.IsNullRejected(ctx, rightSchema, expr) && !mysql.HasNotNullFlag(rightCol.RetType.GetFlag()) {
+						if util.IsNullRejected(ctx, rightSchema, expr, false) && !mysql.HasNotNullFlag(rightCol.RetType.GetFlag()) {
 							notNullExpr := expression.BuildNotNullExpr(ctx.GetExprCtx(), rightCol)
 							rightCond = append(rightCond, notNullExpr)
 						}
@@ -1865,7 +1865,7 @@ func deriveNotNullExpr(ctx base.PlanContext, expr expression.Expression, schema 
 	if childCol == nil {
 		childCol = schema.RetrieveColumn(arg1)
 	}
-	if util.IsNullRejected(ctx, schema, expr) && !mysql.HasNotNullFlag(childCol.RetType.GetFlag()) {
+	if util.IsNullRejected(ctx, schema, expr, false) && !mysql.HasNotNullFlag(childCol.RetType.GetFlag()) {
 		return expression.BuildNotNullExpr(ctx.GetExprCtx(), childCol)
 	}
 	return nil

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -461,7 +461,7 @@ func (p *LogicalProjection) ExtractFD() *fd.FDSet {
 				// the dependent columns in scalar function should be also considered as output columns as well.
 				outputColsUniqueIDs.Insert(int(one.UniqueID))
 			}
-			notnull := util.IsNullRejected(p.SCtx(), p.Schema(), x, false)
+			notnull := util.IsNullRejected(p.SCtx(), p.Schema(), x, true)
 			if notnull || determinants.SubsetOf(fds.NotNullCols) {
 				notnullColsUniqueIDs.Insert(scalarUniqueID)
 			}

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -461,7 +461,7 @@ func (p *LogicalProjection) ExtractFD() *fd.FDSet {
 				// the dependent columns in scalar function should be also considered as output columns as well.
 				outputColsUniqueIDs.Insert(int(one.UniqueID))
 			}
-			notnull := util.IsNullRejected(p.SCtx(), p.Schema(), x)
+			notnull := util.IsNullRejected(p.SCtx(), p.Schema(), x, false)
 			if notnull || determinants.SubsetOf(fds.NotNullCols) {
 				notnullColsUniqueIDs.Insert(scalarUniqueID)
 			}

--- a/pkg/planner/util/funcdep_misc.go
+++ b/pkg/planner/util/funcdep_misc.go
@@ -39,7 +39,7 @@ func ExtractNotNullFromConds(conditions []expression.Expression, p base.LogicalP
 	for _, condition := range conditions {
 		var cols []*expression.Column
 		cols = expression.ExtractColumnsFromExpressions(cols, []expression.Expression{condition}, nil)
-		if IsNullRejected(p.SCtx(), p.Schema(), condition) {
+		if IsNullRejected(p.SCtx(), p.Schema(), condition, true) {
 			for _, col := range cols {
 				notnullColsUniqueIDs.Insert(int(col.UniqueID))
 			}

--- a/pkg/planner/util/funcdep_misc.go
+++ b/pkg/planner/util/funcdep_misc.go
@@ -39,7 +39,7 @@ func ExtractNotNullFromConds(conditions []expression.Expression, p base.LogicalP
 	for _, condition := range conditions {
 		var cols []*expression.Column
 		cols = expression.ExtractColumnsFromExpressions(cols, []expression.Expression{condition}, nil)
-		if IsNullRejected(p.SCtx(), p.Schema(), condition, true) {
+		if IsNullRejected(p.SCtx(), p.Schema(), condition, false) {
 			for _, col := range cols {
 				notnullColsUniqueIDs.Insert(int(col.UniqueID))
 			}

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -46,7 +46,7 @@ func allConstants(ctx expression.BuildContext, expr expression.Expression) bool 
 // has problems with IN list. For example, constant in (outer-table.col1, inner-table.col2)
 // is not null rejecting since constant in (outer-table.col1, NULL) is not false/unknown.
 func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
-	innerSchema *expression.Schema, notSkipPlanCache bool) bool {
+	innerSchema *expression.Schema, skipPlanCache bool) bool {
 	for i, arg := range expr.GetArgs() {
 		if i > 0 {
 			newArgs := make([]expression.Expression, 0, 2)
@@ -57,7 +57,7 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 			if err != nil {
 				return false
 			}
-			if !(isNullRejectedSimpleExpr(ctx, innerSchema, eQCondition, notSkipPlanCache)) {
+			if !(isNullRejectedSimpleExpr(ctx, innerSchema, eQCondition, skipPlanCache)) {
 				return false
 			}
 		}
@@ -69,7 +69,7 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 // IsNullRejected(A OR B) = IsNullRejected(A) AND IsNullRejected(B)
 // IsNullRejected(A AND B) = IsNullRejected(A) OR IsNullRejected(B)
 func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predicate expression.Expression,
-	notSkipPlanCache bool) bool {
+	skipPlanCache bool) bool {
 	predicate = expression.PushDownNot(ctx.GetNullRejectCheckExprCtx(), predicate)
 	if expression.ContainOuterNot(predicate) {
 		return false
@@ -78,22 +78,22 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 	switch expr := predicate.(type) {
 	case *expression.ScalarFunction:
 		if expr.FuncName.L == ast.LogicAnd {
-			if IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], notSkipPlanCache) {
+			if IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], skipPlanCache) {
 				return true
 			}
-			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], notSkipPlanCache)
+			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], skipPlanCache)
 		} else if expr.FuncName.L == ast.LogicOr {
-			if !(IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], notSkipPlanCache)) {
+			if !(IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], skipPlanCache)) {
 				return false
 			}
-			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], notSkipPlanCache)
+			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], skipPlanCache)
 		} else if expr.FuncName.L == ast.In {
-			return isNullRejectedInList(ctx, expr, innerSchema, notSkipPlanCache)
+			return isNullRejectedInList(ctx, expr, innerSchema, skipPlanCache)
 		} else {
-			return isNullRejectedSimpleExpr(ctx, innerSchema, expr, notSkipPlanCache)
+			return isNullRejectedSimpleExpr(ctx, innerSchema, expr, skipPlanCache)
 		}
 	default:
-		return isNullRejectedSimpleExpr(ctx, innerSchema, predicate, notSkipPlanCache)
+		return isNullRejectedSimpleExpr(ctx, innerSchema, predicate, skipPlanCache)
 	}
 }
 
@@ -102,14 +102,14 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 // If it is a predicate containing a reference to an inner table (null producing side) that evaluates
 // to UNKNOWN or FALSE when one of its arguments is NULL.
 func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema, expr expression.Expression,
-	notSkipPlanCache bool) bool {
+	skipPlanCache bool) bool {
 	// The expression should reference at least one field in innerSchema or all constants.
 	if !expression.ExprReferenceSchema(expr, schema) && !allConstants(ctx.GetExprCtx(), expr) {
 		return false
 	}
 	exprCtx := ctx.GetNullRejectCheckExprCtx()
 	sc := ctx.GetSessionVars().StmtCtx
-	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr, notSkipPlanCache)
+	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr, skipPlanCache)
 	if err != nil {
 		return false
 	}

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -45,7 +45,8 @@ func allConstants(ctx expression.BuildContext, expr expression.Expression) bool 
 // Reason is that null filtering through evaluation by isNullRejectedSimpleExpr
 // has problems with IN list. For example, constant in (outer-table.col1, inner-table.col2)
 // is not null rejecting since constant in (outer-table.col1, NULL) is not false/unknown.
-func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction, innerSchema *expression.Schema) bool {
+func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
+	innerSchema *expression.Schema, notSkipPlanCache bool) bool {
 	for i, arg := range expr.GetArgs() {
 		if i > 0 {
 			newArgs := make([]expression.Expression, 0, 2)
@@ -56,7 +57,7 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 			if err != nil {
 				return false
 			}
-			if !(isNullRejectedSimpleExpr(ctx, innerSchema, eQCondition)) {
+			if !(isNullRejectedSimpleExpr(ctx, innerSchema, eQCondition, notSkipPlanCache)) {
 				return false
 			}
 		}
@@ -67,7 +68,8 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 // IsNullRejected takes care of complex predicates like this:
 // IsNullRejected(A OR B) = IsNullRejected(A) AND IsNullRejected(B)
 // IsNullRejected(A AND B) = IsNullRejected(A) OR IsNullRejected(B)
-func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predicate expression.Expression) bool {
+func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predicate expression.Expression,
+	notSkipPlanCache bool) bool {
 	predicate = expression.PushDownNot(ctx.GetNullRejectCheckExprCtx(), predicate)
 	if expression.ContainOuterNot(predicate) {
 		return false
@@ -76,22 +78,22 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 	switch expr := predicate.(type) {
 	case *expression.ScalarFunction:
 		if expr.FuncName.L == ast.LogicAnd {
-			if IsNullRejected(ctx, innerSchema, expr.GetArgs()[0]) {
+			if IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], notSkipPlanCache) {
 				return true
 			}
-			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1])
+			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], notSkipPlanCache)
 		} else if expr.FuncName.L == ast.LogicOr {
-			if !(IsNullRejected(ctx, innerSchema, expr.GetArgs()[0])) {
+			if !(IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], notSkipPlanCache)) {
 				return false
 			}
-			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1])
+			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], notSkipPlanCache)
 		} else if expr.FuncName.L == ast.In {
-			return isNullRejectedInList(ctx, expr, innerSchema)
+			return isNullRejectedInList(ctx, expr, innerSchema, notSkipPlanCache)
 		} else {
-			return isNullRejectedSimpleExpr(ctx, innerSchema, expr)
+			return isNullRejectedSimpleExpr(ctx, innerSchema, expr, notSkipPlanCache)
 		}
 	default:
-		return isNullRejectedSimpleExpr(ctx, innerSchema, predicate)
+		return isNullRejectedSimpleExpr(ctx, innerSchema, predicate, notSkipPlanCache)
 	}
 }
 
@@ -99,14 +101,15 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 // A condition would be null-rejected in one of following cases:
 // If it is a predicate containing a reference to an inner table (null producing side) that evaluates
 // to UNKNOWN or FALSE when one of its arguments is NULL.
-func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema, expr expression.Expression) bool {
+func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema, expr expression.Expression,
+	notSkipPlanCache bool) bool {
 	// The expression should reference at least one field in innerSchema or all constants.
 	if !expression.ExprReferenceSchema(expr, schema) && !allConstants(ctx.GetExprCtx(), expr) {
 		return false
 	}
 	exprCtx := ctx.GetNullRejectCheckExprCtx()
 	sc := ctx.GetSessionVars().StmtCtx
-	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr)
+	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr, notSkipPlanCache)
 	if err != nil {
 		return false
 	}

--- a/pkg/planner/util/null_misc.go
+++ b/pkg/planner/util/null_misc.go
@@ -46,7 +46,7 @@ func allConstants(ctx expression.BuildContext, expr expression.Expression) bool 
 // has problems with IN list. For example, constant in (outer-table.col1, inner-table.col2)
 // is not null rejecting since constant in (outer-table.col1, NULL) is not false/unknown.
 func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
-	innerSchema *expression.Schema, skipPlanCache bool) bool {
+	innerSchema *expression.Schema, skipPlanCacheCheck bool) bool {
 	for i, arg := range expr.GetArgs() {
 		if i > 0 {
 			newArgs := make([]expression.Expression, 0, 2)
@@ -57,7 +57,7 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 			if err != nil {
 				return false
 			}
-			if !(isNullRejectedSimpleExpr(ctx, innerSchema, eQCondition, skipPlanCache)) {
+			if !(isNullRejectedSimpleExpr(ctx, innerSchema, eQCondition, skipPlanCacheCheck)) {
 				return false
 			}
 		}
@@ -69,7 +69,7 @@ func isNullRejectedInList(ctx base.PlanContext, expr *expression.ScalarFunction,
 // IsNullRejected(A OR B) = IsNullRejected(A) AND IsNullRejected(B)
 // IsNullRejected(A AND B) = IsNullRejected(A) OR IsNullRejected(B)
 func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predicate expression.Expression,
-	skipPlanCache bool) bool {
+	skipPlanCacheCheck bool) bool {
 	predicate = expression.PushDownNot(ctx.GetNullRejectCheckExprCtx(), predicate)
 	if expression.ContainOuterNot(predicate) {
 		return false
@@ -78,22 +78,22 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 	switch expr := predicate.(type) {
 	case *expression.ScalarFunction:
 		if expr.FuncName.L == ast.LogicAnd {
-			if IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], skipPlanCache) {
+			if IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], skipPlanCacheCheck) {
 				return true
 			}
-			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], skipPlanCache)
+			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], skipPlanCacheCheck)
 		} else if expr.FuncName.L == ast.LogicOr {
-			if !(IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], skipPlanCache)) {
+			if !(IsNullRejected(ctx, innerSchema, expr.GetArgs()[0], skipPlanCacheCheck)) {
 				return false
 			}
-			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], skipPlanCache)
+			return IsNullRejected(ctx, innerSchema, expr.GetArgs()[1], skipPlanCacheCheck)
 		} else if expr.FuncName.L == ast.In {
-			return isNullRejectedInList(ctx, expr, innerSchema, skipPlanCache)
+			return isNullRejectedInList(ctx, expr, innerSchema, skipPlanCacheCheck)
 		} else {
-			return isNullRejectedSimpleExpr(ctx, innerSchema, expr, skipPlanCache)
+			return isNullRejectedSimpleExpr(ctx, innerSchema, expr, skipPlanCacheCheck)
 		}
 	default:
-		return isNullRejectedSimpleExpr(ctx, innerSchema, predicate, skipPlanCache)
+		return isNullRejectedSimpleExpr(ctx, innerSchema, predicate, skipPlanCacheCheck)
 	}
 }
 
@@ -102,14 +102,14 @@ func IsNullRejected(ctx base.PlanContext, innerSchema *expression.Schema, predic
 // If it is a predicate containing a reference to an inner table (null producing side) that evaluates
 // to UNKNOWN or FALSE when one of its arguments is NULL.
 func isNullRejectedSimpleExpr(ctx planctx.PlanContext, schema *expression.Schema, expr expression.Expression,
-	skipPlanCache bool) bool {
+	skipPlanCacheCheck bool) bool {
 	// The expression should reference at least one field in innerSchema or all constants.
 	if !expression.ExprReferenceSchema(expr, schema) && !allConstants(ctx.GetExprCtx(), expr) {
 		return false
 	}
 	exprCtx := ctx.GetNullRejectCheckExprCtx()
 	sc := ctx.GetSessionVars().StmtCtx
-	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr, skipPlanCache)
+	result, err := expression.EvaluateExprWithNull(exprCtx, schema, expr, skipPlanCacheCheck)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
…

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #38610

Problem Summary:

### What changed and how does it work?

when we need to extract the functional dependencies duration the physical optimization, it will skip the plan cache. but it is wrong. so we need to avoid skipPlanCache when to extract FD.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
