### PR TITLE
expression: fix incorrect results of `json_keys(json, path)` with JSONTypeCodeArray as the first argument | tidb-test=pr/2480

### DIFF
--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -1816,10 +1816,7 @@ func (b *builtinJSONKeys2ArgsSig) evalJSON(ctx EvalContext, row chunk.Row) (res 
 	}
 
 	res, exists := res.Extract([]types.JSONPathExpression{pathExpr})
-	if !exists {
-		return res, true, nil
-	}
-	if res.TypeCode != types.JSONTypeCodeObject {
+	if !exists || res.TypeCode != types.JSONTypeCodeObject {
 		return res, true, nil
 	}
 

--- a/pkg/expression/builtin_json_test.go
+++ b/pkg/expression/builtin_json_test.go
@@ -712,7 +712,6 @@ func TestJSONKeys(t *testing.T) {
 		expected any
 		success  bool
 	}{
-
 		// Tests nil arguments
 		{[]any{nil}, nil, true},
 		{[]any{nil, "$.c"}, nil, true},
@@ -749,6 +748,11 @@ func TestJSONKeys(t *testing.T) {
 		{[]any{`{"a": 1}`, "$.b"}, nil, true},
 		{[]any{`{"a": {"c": 3}, "b": 2}`, "$.c"}, nil, true},
 		{[]any{`{"a": {"c": 3}, "b": 2}`, "$.a.d"}, nil, true},
+
+		// Tests path expression contains any square bracket
+		{[]any{`[{"A1": 1, "B1": 2, "C1": 3}, {"A2": 10, "B2": 20, "C2": {"D": 4}}, {"A3": 1, "B3": 2, "C3": 6}]`, "$[1]"}, `["A2", "B2", "C2"]`, true},
+		{[]any{`[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]`, `$[last].C`}, nil, true},
+		{[]any{`[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]`, `$[last].C[1]`}, `["E"]`, true},
 	}
 	for _, tt := range tbl {
 		args := types.MakeDatums(tt.input...)

--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -796,11 +796,6 @@ func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 		}
 
 		jsonItem := jsonBuf.GetJSON(i)
-		if jsonItem.TypeCode != types.JSONTypeCodeObject {
-			result.AppendNull()
-			continue
-		}
-
 		res, exists := jsonItem.Extract([]types.JSONPathExpression{pathExpr})
 		if !exists || res.TypeCode != types.JSONTypeCodeObject {
 			result.AppendNull()

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -423,6 +423,26 @@ json_keys('{"a": {"c": 3}, "b": 2}'),
 json_keys('{"a": {"c": 3}, "b": 2}', "$.a");
 json_keys('[]')	json_keys('{}')	json_keys('{"a": 1, "b": 2}')	json_keys('{"a": {"c": 3}, "b": 2}')	json_keys('{"a": {"c": 3}, "b": 2}', "$.a")
 NULL	[]	["a", "b"]	["a", "b"]	["c"]
+SELECT JSON_KEYS('[{"X": 1}, {"Y": 2}]', '$[1]');
+JSON_KEYS('[{"X": 1}, {"Y": 2}]', '$[1]')
+["Y"]
+SELECT JSON_KEYS('[{"A1": 1, "B1": 2, "C1": 3}, {"A2": 10, "B2": 20, "C2": {"D": 4}}, {"A3": 1, "B3": 2, "C3": 6}]', '$[1]');
+JSON_KEYS('[{"A1": 1, "B1": 2, "C1": 3}, {"A2": 10, "B2": 20, "C2": {"D": 4}}, {"A3": 1, "B3": 2, "C3": 6}]', '$[1]')
+["A2", "B2", "C2"]
+SELECT JSON_KEYS('[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]', '$[last].C');
+JSON_KEYS('[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]', '$[last].C')
+NULL
+SELECT JSON_KEYS('[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]', '$[last].C[1]');
+JSON_KEYS('[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]', '$[last].C[1]')
+["E"]
+SELECT JSON_KEYS('[{"A": 1, "B": 2}, {"C": 3, "D": [{"F": 5}, {"E": 55}]}]', '$[1].D[1]');
+JSON_KEYS('[{"A": 1, "B": 2}, {"C": 3, "D": [{"F": 5}, {"E": 55}]}]', '$[1].D[1]')
+["E"]
+SELECT JSON_KEYS('[{"X": 1}, {"Y": {"a": 1, "b": 2, "c": 3}}]', '$[1].Y');
+JSON_KEYS('[{"X": 1}, {"Y": {"a": 1, "b": 2, "c": 3}}]', '$[1].Y')
+["a", "b", "c"]
+SELECT JSON_KEYS('[{"X": 1}, {"Y": [a,b,c]}]', '$.Y');
+Error 3140 (22032): Invalid JSON text: The document root must not be followed by other values.
 select
 json_length('1'),
 json_length('{}'),

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -242,6 +242,17 @@ select
 		json_keys('{"a": 1, "b": 2}'),
 		json_keys('{"a": {"c": 3}, "b": 2}'),
 		json_keys('{"a": {"c": 3}, "b": 2}', "$.a");
+
+# issue 56788
+SELECT JSON_KEYS('[{"X": 1}, {"Y": 2}]', '$[1]');
+SELECT JSON_KEYS('[{"A1": 1, "B1": 2, "C1": 3}, {"A2": 10, "B2": 20, "C2": {"D": 4}}, {"A3": 1, "B3": 2, "C3": 6}]', '$[1]');
+SELECT JSON_KEYS('[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]', '$[last].C');
+SELECT JSON_KEYS('[{"A": 1, "B": 2, "C": {"D": 3}}, {"A": 10, "B": 20, "C": {"D": 4}}, {"A": 1, "B": 2, "C": [{"D": 5}, {"E": 55}]}]', '$[last].C[1]');
+SELECT JSON_KEYS('[{"A": 1, "B": 2}, {"C": 3, "D": [{"F": 5}, {"E": 55}]}]', '$[1].D[1]');
+SELECT JSON_KEYS('[{"X": 1}, {"Y": {"a": 1, "b": 2, "c": 3}}]', '$[1].Y');
+-- error 3140
+SELECT JSON_KEYS('[{"X": 1}, {"Y": [a,b,c]}]', '$.Y');
+
 select
 		json_length('1'),
 		json_length('{}'),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/56788

Problem Summary:

Fix the issue where the json_keys function returns incorrect results when called with two arguments and the first argument is of type JSONTypeCodeArray.


### What changed and how does it work?
* Make `builtinJSONKeys2ArgsSig.vecEvalJSON` has the same behavior as `builtinJSONKeys2ArgsSig.evalJSON` and add tests.
* Add some tests for `evalJSON`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
