### PR TITLE
ddl notifier: allow another error in CI assert

### DIFF
--- a/pkg/ddl/notifier/subscribe.go
+++ b/pkg/ddl/notifier/subscribe.go
@@ -162,7 +162,9 @@ func (n *DDLNotifier) start() {
 		case <-ticker.C:
 			if err := n.processEvents(ctx); err != nil {
 				intest.Assert(
-					errors.ErrorEqual(err, context.Canceled) || strings.Contains(err.Error(), "mock handleTaskOnce error"),
+					errors.ErrorEqual(err, context.Canceled) ||
+						strings.Contains(err.Error(), "mock handleTaskOnce error") ||
+						strings.Contains(err.Error(), "session pool closed"),
 					fmt.Sprintf("error processing events: %v", err),
 				)
 				logutil.Logger(ctx).Error("Error processing events", zap.Error(err))

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -54,7 +54,9 @@ func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Con
 	err := h.sub.handle(ctx, sctx, s)
 	if err != nil {
 		intest.Assert(
-			errors.ErrorEqual(err, context.Canceled) || strings.Contains(err.Error(), "mock handleTaskOnce error"),
+			errors.ErrorEqual(err, context.Canceled) ||
+				strings.Contains(err.Error(), "mock handleTaskOnce error") ||
+				strings.Contains(err.Error(), "session pool closed"),
 			fmt.Sprintf("handle ddl event failed, err: %v", err),
 		)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59501

Problem Summary:

### What changed and how does it work?

seems when domain is closing, DDL notifier may not exit in time. So we tolerate some error

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
