### PR TITLE
statistics: release session met error to avoid possible leak

### DIFF
--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -1339,6 +1339,19 @@ func DeleteInternalSession(se any) {
 	sm.DeleteInternalSession(se)
 }
 
+// HasInternalSessionForTest is the entry function for check whether an internal session is stored in SessionManager.
+func HasInternalSessionForTest(se any) bool {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return false
+	}
+	sm := is.GetSessionManager()
+	if sm == nil {
+		return false
+	}
+	return sm.HasInternalSessionForTest(se)
+}
+
 // SetEtcdClient is only used for test.
 func SetEtcdClient(etcdCli *clientv3.Client) {
 	is, err := getGlobalInfoSyncer()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1064,6 +1064,14 @@ func (s *Server) StoreInternalSession(se any) {
 	s.sessionMapMutex.Unlock()
 }
 
+// HasInternalSessionForTest implements SessionManager interface.
+func (s *Server) HasInternalSessionForTest(se any) bool {
+	s.sessionMapMutex.Lock()
+	_, ok := s.internalSessions[se]
+	s.sessionMapMutex.Unlock()
+	return ok
+}
+
 // DeleteInternalSession implements SessionManager interface.
 // @param addr	The address of a session.session struct variable
 func (s *Server) DeleteInternalSession(se any) {

--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/statistics/handle/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/domain/infosync",
         "//pkg/infoschema",
         "//pkg/kv",
         "//pkg/meta/model",
@@ -45,7 +46,10 @@ go_test(
     flaky = True,
     deps = [
         ":util",
+        "//pkg/domain/infosync",
+        "//pkg/sessionctx",
         "//pkg/testkit",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
@@ -85,6 +86,8 @@ func CallWithSCtx(pool util.SessionPool, f func(sctx sessionctx.Context) error, 
 	defer func() {
 		if err == nil { // only recycle when no error
 			pool.Put(se)
+		} else {
+			infosync.DeleteInternalSession(se)
 		}
 	}()
 	sctx := se.(sessionctx.Context)

--- a/pkg/statistics/handle/util/util_test.go
+++ b/pkg/statistics/handle/util/util_test.go
@@ -17,6 +17,9 @@ package util_test
 import (
 	"testing"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/domain/infosync"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
@@ -54,4 +57,18 @@ func TestIsSpecialGlobalIndex(t *testing.T) {
 		}
 	}
 	require.Equal(t, cnt, len(tblInfo.Indices))
+}
+
+func TestCallSCtxFailed(t *testing.T) {
+	_, dom := testkit.CreateMockStoreAndDomain(t)
+
+	var sctxWithFailure sessionctx.Context
+	err := util.CallWithSCtx(dom.StatsHandle().SPool(), func(sctx sessionctx.Context) error {
+		sctxWithFailure = sctx
+		return errors.New("simulated error")
+	})
+	notReleased := infosync.HasInternalSessionForTest(sctxWithFailure)
+	require.Error(t, err)
+	require.Equal(t, "simulated error", err.Error())
+	require.False(t, notReleased)
 }

--- a/pkg/testkit/mocksessionmanager.go
+++ b/pkg/testkit/mocksessionmanager.go
@@ -137,6 +137,17 @@ func (msm *MockSessionManager) StoreInternalSession(s any) {
 	msm.mu.Unlock()
 }
 
+// HasInternalSessionForTest is to check whether the internal session is stored in the SessionManager
+func (msm *MockSessionManager) HasInternalSessionForTest(se any) bool {
+	msm.mu.Lock()
+	defer msm.mu.Unlock()
+	if msm.internalSessions == nil {
+		return false
+	}
+	_, ok := msm.internalSessions[se]
+	return ok
+}
+
 // DeleteInternalSession is to delete the internal session pointer from the map in the SessionManager
 func (msm *MockSessionManager) DeleteInternalSession(s any) {
 	msm.mu.Lock()

--- a/pkg/util/processinfo.go
+++ b/pkg/util/processinfo.go
@@ -218,6 +218,8 @@ type SessionManager interface {
 	ServerID() uint64
 	// StoreInternalSession puts the internal session pointer to the map in the SessionManager.
 	StoreInternalSession(se any)
+	// HasInternalSessionForTest checks whether the internal session is stored in the SessionManager.
+	HasInternalSessionForTest(se any) bool
 	// DeleteInternalSession deletes the internal session pointer from the map in the SessionManager.
 	DeleteInternalSession(se any)
 	// GetInternalSessionStartTSList gets all startTS of every transactions running in the current internal sessions.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #54022 

Problem Summary:

that pull request doesn't solve the root problem

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the internal session used by statistics may not be released and cause possible memory leak.
修复统计信息是使用的内部会话在遇到错误时可能没有被释放的问题，该问题可能导致内存溢出。
```
