### PR TITLE
statistics: add Destroy method and handle session recycling

### DIFF
--- a/pkg/bindinfo/global_handle.go
+++ b/pkg/bindinfo/global_handle.go
@@ -88,8 +88,7 @@ type GlobalBindingHandle interface {
 
 // globalBindingHandle is used to handle all global sql bind operations.
 type globalBindingHandle struct {
-	sPool util.SessionPool
-
+	sPool        util.DestroyableSessionPool
 	bindingCache BindingCache
 
 	// lastTaskTime records the last update time for the global sql bind cache.
@@ -121,7 +120,7 @@ const (
 )
 
 // NewGlobalBindingHandle creates a new GlobalBindingHandle.
-func NewGlobalBindingHandle(sPool util.SessionPool) GlobalBindingHandle {
+func NewGlobalBindingHandle(sPool util.DestroyableSessionPool) GlobalBindingHandle {
 	h := &globalBindingHandle{sPool: sPool}
 	h.lastUpdateTime.Store(types.ZeroTimestamp)
 	h.bindingCache = newBindCache()
@@ -484,6 +483,9 @@ func (h *globalBindingHandle) callWithSCtx(wrapTxn bool, f func(sctx sessionctx.
 	defer func() {
 		if err == nil { // only recycle when no error
 			h.sPool.Put(resource)
+		} else {
+			// Note: Otherwise, the session will be leaked.
+			h.sPool.Destroy(resource)
 		}
 	}()
 	sctx := resource.(sessionctx.Context)

--- a/pkg/bindinfo/global_handle_test.go
+++ b/pkg/bindinfo/global_handle_test.go
@@ -607,6 +607,8 @@ func (p *mockSessionPool) Get() (pools.Resource, error) {
 
 func (p *mockSessionPool) Put(pools.Resource) {}
 
+func (p *mockSessionPool) Destroy(pools.Resource) {}
+
 func (p *mockSessionPool) Close() {}
 
 func TestShowBindingDigestField(t *testing.T) {

--- a/pkg/bindinfo/tests/cross_db_binding_test.go
+++ b/pkg/bindinfo/tests/cross_db_binding_test.go
@@ -342,4 +342,6 @@ func (p *mockSessionPool) Get() (pools.Resource, error) {
 
 func (p *mockSessionPool) Put(pools.Resource) {}
 
+func (p *mockSessionPool) Destroy(pools.Resource) {}
+
 func (p *mockSessionPool) Close() {}

--- a/pkg/ddl/notifier/testkit_test.go
+++ b/pkg/ddl/notifier/testkit_test.go
@@ -79,6 +79,7 @@ func TestBasicPubSub(t *testing.T) {
 		},
 		nil,
 		nil,
+		nil,
 	)
 
 	n := notifier.NewDDLNotifier(sessionPool, s, 50*time.Millisecond)
@@ -148,6 +149,7 @@ func TestDeliverOrderAndCleanup(t *testing.T) {
 		func() (pools.Resource, error) {
 			return tk.Session(), nil
 		},
+		nil,
 		nil,
 		nil,
 	)
@@ -324,6 +326,7 @@ func Test2OwnerForAShortTime(t *testing.T) {
 		},
 		nil,
 		nil,
+		nil,
 	)
 
 	n := notifier.NewDDLNotifier(sessionPool, s, 50*time.Millisecond)
@@ -458,6 +461,7 @@ func TestBeginTwice(t *testing.T) {
 		},
 		nil,
 		nil,
+		nil,
 	)
 
 	n := notifier.NewDDLNotifier(sessionPool, s, 50*time.Millisecond)
@@ -506,6 +510,7 @@ func TestHandlersSeePessimisticTxnError(t *testing.T) {
 		func() (pools.Resource, error) {
 			return testkit.NewTestKit(t, store).Session(), nil
 		},
+		nil,
 		nil,
 		nil,
 	)
@@ -559,6 +564,7 @@ func TestCommitFailed(t *testing.T) {
 		func() (pools.Resource, error) {
 			return testkit.NewTestKit(t, store).Session(), nil
 		},
+		nil,
 		nil,
 		nil,
 	)

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2616,7 +2616,7 @@ func (do *Domain) asyncLoadHistogram() {
 		case <-cleanupTicker.C:
 			err = statsHandle.LoadNeededHistograms(do.InfoSchema())
 			if err != nil {
-				logutil.BgLogger().Warn("load histograms failed", zap.Error(err))
+				logutil.BgLogger().Warn("load histograms failed", zap.Error(err), zap.Stack("stack"))
 			}
 		case <-do.exit:
 			return

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -158,8 +158,10 @@ type Domain struct {
 	m               syncutil.Mutex
 	SchemaValidator SchemaValidator
 	schemaLease     time.Duration
-	sysSessionPool  util.DestroyableSessionPool
-	exit            chan struct{}
+	// Note: If you no longer need the session, you must call Destroy to release it.
+	// Otherwise, the session will be leaked. Because there is a strong reference from the session to the domain.
+	sysSessionPool util.DestroyableSessionPool
+	exit           chan struct{}
 	// `etcdClient` must be used when keyspace is not set, or when the logic to each etcd path needs to be separated by keyspace.
 	etcdClient *clientv3.Client
 	// autoidClient is used when there are tables with AUTO_ID_CACHE=1, it is the client to the autoid service.

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1818,7 +1818,7 @@ func (do *Domain) distTaskFrameworkLoop(ctx context.Context, taskManager *storag
 }
 
 // SysSessionPool returns the system session pool.
-func (do *Domain) SysSessionPool() util.SessionPool {
+func (do *Domain) SysSessionPool() util.DestroyableSessionPool {
 	return do.sysSessionPool
 }
 

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1345,6 +1345,10 @@ func NewDomainWithEtcdClient(store kv.Storage, schemaLease time.Duration, statsL
 				})
 				infosync.DeleteInternalSession(r)
 			},
+			func(r pools.Resource) {
+				intest.Assert(r != nil)
+				infosync.DeleteInternalSession(r)
+			},
 		),
 		statsLease:        statsLease,
 		schemaLease:       schemaLease,

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2616,7 +2616,7 @@ func (do *Domain) asyncLoadHistogram() {
 		case <-cleanupTicker.C:
 			err = statsHandle.LoadNeededHistograms(do.InfoSchema())
 			if err != nil {
-				logutil.BgLogger().Warn("load histograms failed", zap.Error(err), zap.Stack("stack"))
+				logutil.ErrVerboseLogger().Warn("load histograms failed", zap.Error(err))
 			}
 		case <-do.exit:
 			return

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -159,7 +159,7 @@ type Domain struct {
 	SchemaValidator SchemaValidator
 	schemaLease     time.Duration
 	// Note: If you no longer need the session, you must call Destroy to release it.
-	// Otherwise, the session will be leaked. Because there is a strong reference from the session to the domain.
+	// Otherwise, the session will be leaked. Because there is a strong reference from the domain to the session.
 	sysSessionPool util.DestroyableSessionPool
 	exit           chan struct{}
 	// `etcdClient` must be used when keyspace is not set, or when the logic to each etcd path needs to be separated by keyspace.

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -158,7 +158,7 @@ type Domain struct {
 	m               syncutil.Mutex
 	SchemaValidator SchemaValidator
 	schemaLease     time.Duration
-	sysSessionPool  util.SessionPool
+	sysSessionPool  util.DestroyableSessionPool
 	exit            chan struct{}
 	// `etcdClient` must be used when keyspace is not set, or when the logic to each etcd path needs to be separated by keyspace.
 	etcdClient *clientv3.Client

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2554,7 +2554,7 @@ func (do *Domain) initStats(ctx context.Context) {
 	}
 	initstats.InitStatsPercentage.Store(100)
 	if err != nil {
-		logutil.BgLogger().Error("init stats info failed", zap.Bool("lite", liteInitStats), zap.Duration("take time", time.Since(t)), zap.Error(err))
+		logutil.ErrVerboseLogger().Error("init stats info failed", zap.Bool("lite", liteInitStats), zap.Duration("take time", time.Since(t)), zap.Error(err))
 	} else {
 		logutil.BgLogger().Info("init stats info time", zap.Bool("lite", liteInitStats), zap.Duration("take time", time.Since(t)))
 	}

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -1339,6 +1339,21 @@ func DeleteInternalSession(se any) {
 	sm.DeleteInternalSession(se)
 }
 
+// ContainsInternalSessionForTest is the entry function for check whether an internal session is in SessionManager.
+// It is only used for test.
+func ContainsInternalSessionForTest(se any) bool {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return false
+	}
+	sm := is.GetSessionManager()
+	if sm == nil {
+		return false
+	}
+
+	return sm.ContainsInternalSession(se)
+}
+
 // SetEtcdClient is only used for test.
 func SetEtcdClient(etcdCli *clientv3.Client) {
 	is, err := getGlobalInfoSyncer()

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -259,11 +259,11 @@ func RequestLoadStats(ctx base.PlanContext, neededHistItems []model.StatsLoadIte
 	if err != nil {
 		stmtCtx.IsSyncStatsFailed = true
 		if vardef.StatsLoadPseudoTimeout.Load() {
-			logutil.BgLogger().Warn("RequestLoadStats failed", zap.Error(err))
+			logutil.ErrVerboseLogger().Warn("RequestLoadStats failed", zap.Error(err))
 			stmtCtx.AppendWarning(err)
 			return nil
 		}
-		logutil.BgLogger().Warn("RequestLoadStats failed", zap.Error(err))
+		logutil.ErrVerboseLogger().Warn("RequestLoadStats failed", zap.Error(err))
 		return err
 	}
 	return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1064,6 +1064,14 @@ func (s *Server) StoreInternalSession(se any) {
 	s.sessionMapMutex.Unlock()
 }
 
+// ContainsInternalSession implements SessionManager interface.
+func (s *Server) ContainsInternalSession(se any) bool {
+	s.sessionMapMutex.Lock()
+	defer s.sessionMapMutex.Unlock()
+	_, ok := s.internalSessions[se]
+	return ok
+}
+
 // DeleteInternalSession implements SessionManager interface.
 // @param addr	The address of a session.session struct variable
 func (s *Server) DeleteInternalSession(se any) {

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -342,6 +342,9 @@ func (h *Handle) initStatsHistogramsByPaging(is infoschema.InfoSchema, cache sta
 	defer func() {
 		if err == nil { // only recycle when no error
 			h.Pool.SPool().Put(se)
+		} else {
+			// Note: Otherwise, the session will be leaked.
+			h.Pool.SPool().Destroy(se)
 		}
 	}()
 
@@ -468,6 +471,9 @@ func (h *Handle) initStatsTopNByPaging(cache statstypes.StatsCache, task initsta
 	defer func() {
 		if err == nil { // only recycle when no error
 			h.Pool.SPool().Put(se)
+		} else {
+			// Note: Otherwise, the session will be leaked.
+			h.Pool.SPool().Destroy(se)
 		}
 	}()
 	sctx := se.(sessionctx.Context)
@@ -667,6 +673,9 @@ func (h *Handle) initStatsBucketsByPaging(cache statstypes.StatsCache, task init
 	defer func() {
 		if err == nil { // only recycle when no error
 			h.Pool.SPool().Put(se)
+		} else {
+			// Note: Otherwise, the session will be leaked.
+			h.Pool.SPool().Destroy(se)
 		}
 	}()
 	sctx := se.(sessionctx.Context)

--- a/pkg/statistics/handle/handle.go
+++ b/pkg/statistics/handle/handle.go
@@ -115,7 +115,7 @@ func NewHandle(
 	initStatsCtx sessionctx.Context,
 	lease time.Duration,
 	is infoschema.InfoSchema,
-	pool pkgutil.SessionPool,
+	pool pkgutil.DestroyableSessionPool,
 	tracker sysproctrack.Tracker,
 	ddlNotifier *notifier.DDLNotifier,
 	autoAnalyzeProcIDGetter func() uint64,

--- a/pkg/statistics/handle/lockstats/lock_stats.go
+++ b/pkg/statistics/handle/lockstats/lock_stats.go
@@ -41,11 +41,11 @@ const (
 
 // statsLockImpl implements the util.StatsLock interface.
 type statsLockImpl struct {
-	pool pkgutil.SessionPool
+	pool pkgutil.DestroyableSessionPool
 }
 
 // NewStatsLock creates a new StatsLock.
-func NewStatsLock(pool pkgutil.SessionPool) types.StatsLock {
+func NewStatsLock(pool pkgutil.DestroyableSessionPool) types.StatsLock {
 	return &statsLockImpl{pool: pool}
 }
 

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -609,9 +609,9 @@ func LoadNeededHistograms(sctx sessionctx.Context, is infoschema.InfoSchema, sta
 			err = loadNeededIndexHistograms(sctx, is, statsHandle, item.TableItemID, loadFMSketch)
 		}
 		if err != nil {
-			statslogutil.StatsLogger().Error("load needed histogram failed",
+			logutil.ErrVerboseLogger().Error("load needed histogram failed",
+				zap.String("category", "stats"),
 				zap.Error(err),
-				zap.Stack("stack"),
 				zap.Int64("tableID", item.TableID),
 				zap.Int64("histID", item.ID),
 				zap.Bool("isIndex", item.IsIndex),

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -610,8 +610,7 @@ func LoadNeededHistograms(sctx sessionctx.Context, is infoschema.InfoSchema, sta
 			err = loadNeededIndexHistograms(sctx, is, statsHandle, item.TableItemID, loadFMSketch)
 		}
 		if err != nil {
-			logutil.ErrVerboseLogger().Error("load needed histogram failed",
-				zap.String("category", "stats"),
+			statslogutil.StatsLogger().Error("load needed histogram failed",
 				zap.Error(err),
 				zap.Int64("tableID", item.TableID),
 				zap.Int64("histID", item.ID),

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -609,7 +609,16 @@ func LoadNeededHistograms(sctx sessionctx.Context, is infoschema.InfoSchema, sta
 			err = loadNeededIndexHistograms(sctx, is, statsHandle, item.TableItemID, loadFMSketch)
 		}
 		if err != nil {
-			return err
+			statslogutil.StatsLogger().Error("load needed histogram failed",
+				zap.Error(err),
+				zap.Stack("stack"),
+				zap.Int64("tableID", item.TableID),
+				zap.Int64("histID", item.ID),
+				zap.Bool("isIndex", item.IsIndex),
+				zap.Bool("IsSyncLoadFailed", item.IsSyncLoadFailed),
+				zap.Bool("fullLoad", item.FullLoad),
+			)
+			return errors.Trace(err)
 		}
 	}
 	return nil

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -618,6 +619,7 @@ func LoadNeededHistograms(sctx sessionctx.Context, is infoschema.InfoSchema, sta
 				zap.Bool("IsSyncLoadFailed", item.IsSyncLoadFailed),
 				zap.Bool("fullLoad", item.FullLoad),
 			)
+			intest.Assert(false, "load needed histogram failed")
 			return errors.Trace(err)
 		}
 	}

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -303,6 +303,9 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 		if err == nil { // only recycle when no error
 			sctx.GetSessionVars().StmtCtx.Priority = mysql.NoPriority
 			s.statsHandle.SPool().Put(se)
+		} else {
+			// Note: Otherwise, the session will be leaked.
+			s.statsHandle.SPool().Destroy(se)
 		}
 	}()
 	var skipTypes map[string]struct{}

--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -45,7 +45,10 @@ go_test(
     flaky = True,
     deps = [
         ":util",
+        "//pkg/domain/infosync",
+        "//pkg/sessionctx",
         "//pkg/testkit",
+        "@com_github_pingcap_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/statistics/handle/util/pool.go
+++ b/pkg/statistics/handle/util/pool.go
@@ -28,7 +28,7 @@ type Pool interface {
 	GPool() *gp.Pool
 
 	// SPool returns the session pool.
-	SPool() util.SessionPool
+	SPool() util.DestroyableSessionPool
 
 	// Close closes the goroutine pool.
 	Close()
@@ -39,11 +39,11 @@ var _ Pool = (*pool)(nil)
 type pool struct {
 	// This gpool is used to reuse goroutine in the mergeGlobalStatsTopN.
 	gpool *gp.Pool
-	pool  util.SessionPool
+	pool  util.DestroyableSessionPool
 }
 
 // NewPool creates a new Pool.
-func NewPool(p util.SessionPool) Pool {
+func NewPool(p util.DestroyableSessionPool) Pool {
 	return &pool{
 		gpool: gp.New(math.MaxInt16, time.Minute),
 		pool:  p,
@@ -56,7 +56,7 @@ func (p *pool) GPool() *gp.Pool {
 }
 
 // SPool returns the session pool.
-func (p *pool) SPool() util.SessionPool {
+func (p *pool) SPool() util.DestroyableSessionPool {
 	return p.pool
 }
 

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -85,6 +85,9 @@ func CallWithSCtx(pool util.SessionPool, f func(sctx sessionctx.Context) error, 
 	defer func() {
 		if err == nil { // only recycle when no error
 			pool.Put(se)
+		} else {
+			// Note: Otherwise, the session will be leaked.
+			pool.Destroy(se)
 		}
 	}()
 	sctx := se.(sessionctx.Context)

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -76,7 +76,7 @@ var (
 )
 
 // CallWithSCtx allocates a sctx from the pool and call the f().
-func CallWithSCtx(pool util.SessionPool, f func(sctx sessionctx.Context) error, flags ...int) (err error) {
+func CallWithSCtx(pool util.DestroyableSessionPool, f func(sctx sessionctx.Context) error, flags ...int) (err error) {
 	defer util.Recover(metrics.LabelStats, "CallWithSCtx", nil, false)
 	se, err := pool.Get()
 	if err != nil {
@@ -187,7 +187,7 @@ func UpdateSCtxVarsForStats(sctx sessionctx.Context) error {
 }
 
 // GetCurrentPruneMode returns the current latest partitioning table prune mode.
-func GetCurrentPruneMode(pool util.SessionPool) (mode string, err error) {
+func GetCurrentPruneMode(pool util.DestroyableSessionPool) (mode string, err error) {
 	err = CallWithSCtx(pool, func(sctx sessionctx.Context) error {
 		mode = sctx.GetSessionVars().PartitionPruneMode.Load()
 		return nil

--- a/pkg/statistics/handle/util/util.go
+++ b/pkg/statistics/handle/util/util.go
@@ -80,7 +80,7 @@ func CallWithSCtx(pool util.SessionPool, f func(sctx sessionctx.Context) error, 
 	defer util.Recover(metrics.LabelStats, "CallWithSCtx", nil, false)
 	se, err := pool.Get()
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	defer func() {
 		if err == nil { // only recycle when no error
@@ -92,7 +92,7 @@ func CallWithSCtx(pool util.SessionPool, f func(sctx sessionctx.Context) error, 
 	}()
 	sctx := se.(sessionctx.Context)
 	if err := UpdateSCtxVarsForStats(sctx); err != nil { // update stats variables automatically
-		return err
+		return errors.Trace(err)
 	}
 
 	wrapTxn := false
@@ -106,7 +106,7 @@ func CallWithSCtx(pool util.SessionPool, f func(sctx sessionctx.Context) error, 
 	} else {
 		err = f(sctx)
 	}
-	return err
+	return errors.Trace(err)
 }
 
 // UpdateSCtxVarsForStats updates all necessary variables that may affect the behavior of statistics.

--- a/pkg/testkit/mocksessionmanager.go
+++ b/pkg/testkit/mocksessionmanager.go
@@ -137,6 +137,18 @@ func (msm *MockSessionManager) StoreInternalSession(s any) {
 	msm.mu.Unlock()
 }
 
+// ContainsInternalSession checks if the internal session pointer is in the map in the SessionManager
+func (msm *MockSessionManager) ContainsInternalSession(se any) bool {
+	msm.mu.Lock()
+	defer msm.mu.Unlock()
+	if msm.internalSessions == nil {
+		return false
+	}
+	_, ok := msm.internalSessions[se]
+	return ok
+
+}
+
 // DeleteInternalSession is to delete the internal session pointer from the map in the SessionManager
 func (msm *MockSessionManager) DeleteInternalSession(s any) {
 	msm.mu.Lock()

--- a/pkg/testkit/mocksessionmanager.go
+++ b/pkg/testkit/mocksessionmanager.go
@@ -146,7 +146,6 @@ func (msm *MockSessionManager) ContainsInternalSession(se any) bool {
 	}
 	_, ok := msm.internalSessions[se]
 	return ok
-
 }
 
 // DeleteInternalSession is to delete the internal session pointer from the map in the SessionManager

--- a/pkg/timer/tablestore/sql_test.go
+++ b/pkg/timer/tablestore/sql_test.go
@@ -575,10 +575,6 @@ func (p *mockSessionPool) Put(r pools.Resource) {
 	p.Called(r)
 }
 
-func (p *mockSessionPool) Destroy(r pools.Resource) {
-	p.Called(r)
-}
-
 func (p *mockSessionPool) Close() {}
 
 type mockSession struct {

--- a/pkg/timer/tablestore/sql_test.go
+++ b/pkg/timer/tablestore/sql_test.go
@@ -575,6 +575,10 @@ func (p *mockSessionPool) Put(r pools.Resource) {
 	p.Called(r)
 }
 
+func (p *mockSessionPool) Destroy(r pools.Resource) {
+	p.Called(r)
+}
+
 func (p *mockSessionPool) Close() {}
 
 type mockSession struct {

--- a/pkg/util/processinfo.go
+++ b/pkg/util/processinfo.go
@@ -220,6 +220,8 @@ type SessionManager interface {
 	StoreInternalSession(se any)
 	// DeleteInternalSession deletes the internal session pointer from the map in the SessionManager.
 	DeleteInternalSession(se any)
+	// ContainsInternalSession checks if the internal session pointer is in the map in the SessionManager.
+	ContainsInternalSession(se any) bool
 	// GetInternalSessionStartTSList gets all startTS of every transactions running in the current internal sessions.
 	GetInternalSessionStartTSList() []uint64
 	// CheckOldRunningTxn checks if there is an old transaction running in the current sessions

--- a/pkg/util/session_pool.go
+++ b/pkg/util/session_pool.go
@@ -107,10 +107,10 @@ func (p *pool) Put(resource pools.Resource) {
 
 // Destroy destroys the session.
 func (p *pool) Destroy(resource pools.Resource) {
-	resource.Close()
 	if p.destroyCallback != nil {
 		p.destroyCallback(resource)
 	}
+	resource.Close()
 }
 
 // Close closes the pool to release all resources.

--- a/pkg/util/session_pool.go
+++ b/pkg/util/session_pool.go
@@ -31,6 +31,7 @@ type SessionPool interface {
 
 // DestroyableSessionPool is a session pool that can destroy the session resource.
 // If the caller meets an error when using the session, it can destroy the session.
+// See more by searching `StoreInternalSession`.
 type DestroyableSessionPool interface {
 	SessionPool
 	Destroy(pools.Resource)

--- a/pkg/util/session_pool.go
+++ b/pkg/util/session_pool.go
@@ -26,8 +26,14 @@ import (
 type SessionPool interface {
 	Get() (pools.Resource, error)
 	Put(pools.Resource)
-	Destroy(pools.Resource)
 	Close()
+}
+
+// DestroyableSessionPool is a session pool that can destroy the session resource.
+// If the caller meets an error when using the session, it can destroy the session.
+type DestroyableSessionPool interface {
+	SessionPool
+	Destroy(pools.Resource)
 }
 
 // resourceCallback is a helper function to be triggered after Get/Put call.
@@ -46,7 +52,7 @@ type pool struct {
 }
 
 // NewSessionPool creates a new session pool with the given capacity and factory function.
-func NewSessionPool(capacity int, factory pools.Factory, getCallback, putCallback, destroyCallback resourceCallback) SessionPool {
+func NewSessionPool(capacity int, factory pools.Factory, getCallback, putCallback, destroyCallback resourceCallback) DestroyableSessionPool {
 	return &pool{
 		resources:       make(chan pools.Resource, capacity),
 		factory:         factory,

--- a/pkg/util/session_pool_test.go
+++ b/pkg/util/session_pool_test.go
@@ -30,7 +30,11 @@ func TestSessionPool(t *testing.T) {
 		1, f,
 		func(r pools.Resource) {
 			r.(*testResource).refCount++
-		}, func(r pools.Resource) {
+		},
+		func(r pools.Resource) {
+			r.(*testResource).refCount--
+		},
+		func(r pools.Resource) {
 			r.(*testResource).refCount--
 		},
 	)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59524 close https://github.com/pingcap/tidb/issues/59560

Problem Summary:

### What changed and how does it work?

ref https://github.com/pingcap/tidb/pull/59522

This is an alternative API design to solve the problem. I believe explicitly using destroy instead of exposing implementation details is a better approach to fix it.

I also added more logs to help us inspect error cases.

Note: This PR doesn’t address the root cause of the issues; it only ensures that we don’t encounter OOM problems. We still need to figure out why we’re running into this kind of stats loading.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the internal session used by statistics may not be released and cause possible memory leak.
修复统计信息在使用的内部会话在遇到错误时可能没有被释放的问题，该问题可能导致内存泄漏。
```
