### PR TITLE
br: clone backend options

### DIFF
--- a/br/pkg/storage/parse.go
+++ b/br/pkg/storage/parse.go
@@ -86,11 +86,12 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 		}
 		prefix := strings.Trim(u.Path, "/")
 		s3 := &backuppb.S3{Bucket: u.Host, Prefix: prefix}
-		if options == nil {
-			options = &BackendOptions{S3: S3BackendOptions{ForcePathStyle: true}}
+		var s3Options S3BackendOptions = S3BackendOptions{ForcePathStyle: true}
+		if options != nil {
+			s3Options = options.S3
 		}
-		ExtractQueryParameters(u, &options.S3)
-		if err := options.S3.Apply(s3); err != nil {
+		ExtractQueryParameters(u, &s3Options)
+		if err := s3Options.Apply(s3); err != nil {
 			return nil, errors.Trace(err)
 		}
 		if u.Scheme == "ks3" {
@@ -104,11 +105,12 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 		}
 		prefix := strings.Trim(u.Path, "/")
 		gcs := &backuppb.GCS{Bucket: u.Host, Prefix: prefix}
-		if options == nil {
-			options = &BackendOptions{}
+		var gcsOptions GCSBackendOptions
+		if options != nil {
+			gcsOptions = options.GCS
 		}
-		ExtractQueryParameters(u, &options.GCS)
-		if err := options.GCS.apply(gcs); err != nil {
+		ExtractQueryParameters(u, &gcsOptions)
+		if err := gcsOptions.apply(gcs); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &backuppb.StorageBackend{Backend: &backuppb.StorageBackend_Gcs{Gcs: gcs}}, nil
@@ -119,11 +121,12 @@ func parseBackend(u *url.URL, rawURL string, options *BackendOptions) (*backuppb
 		}
 		prefix := strings.Trim(u.Path, "/")
 		azblob := &backuppb.AzureBlobStorage{Bucket: u.Host, Prefix: prefix}
-		if options == nil {
-			options = &BackendOptions{}
+		var azblobOptions AzblobBackendOptions
+		if options != nil {
+			azblobOptions = options.Azblob
 		}
-		ExtractQueryParameters(u, &options.Azblob)
-		if err := options.Azblob.apply(azblob); err != nil {
+		ExtractQueryParameters(u, &azblobOptions)
+		if err := azblobOptions.apply(azblob); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &backuppb.StorageBackend{Backend: &backuppb.StorageBackend_AzureBlobStorage{AzureBlobStorage: azblob}}, nil

--- a/br/pkg/storage/parse_test.go
+++ b/br/pkg/storage/parse_test.go
@@ -311,18 +311,108 @@ func TestIsLocal(t *testing.T) {
 }
 
 func TestParseBackend(t *testing.T) {
-	backendOptions := &BackendOptions{
-		S3:     S3BackendOptions{},
-		GCS:    GCSBackendOptions{},
-		Azblob: AzblobBackendOptions{},
+	{
+		backendOptions := &BackendOptions{
+			S3:     S3BackendOptions{},
+			GCS:    GCSBackendOptions{},
+			Azblob: AzblobBackendOptions{},
+		}
+		_, err := ParseBackend("s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=0&sse-kms-key-id=TestKey&xyz=abc", backendOptions)
+		require.NoError(t, err)
+		require.Equal(t, "", backendOptions.S3.SseKmsKeyID)
+		_, err = ParseBackend("gcs://bucket?endpoint=http://127.0.0.1&predefined-acl=1234", backendOptions)
+		require.NoError(t, err)
+		require.Equal(t, "", backendOptions.GCS.PredefinedACL)
+		_, err = ParseBackend("azure://bucket1/prefix/path?account-name=user&account-key=cGFzc3dk&endpoint=http://127.0.0.1/user&encryption-scope=test", backendOptions)
+		require.NoError(t, err)
+		require.Equal(t, "", backendOptions.Azblob.EncryptionScope)
 	}
-	_, err := ParseBackend("s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=0&sse-kms-key-id=TestKey&xyz=abc", backendOptions)
-	require.NoError(t, err)
-	require.Equal(t, "", backendOptions.S3.SseKmsKeyID)
-	_, err = ParseBackend("gcs://bucket?endpoint=http://127.0.0.1&predefined-acl=1234", backendOptions)
-	require.NoError(t, err)
-	require.Equal(t, "", backendOptions.GCS.PredefinedACL)
-	_, err = ParseBackend("azure://bucket1/prefix/path?account-name=user&account-key=cGFzc3dk&endpoint=http://127.0.0.1/user&encryption-scope=test", backendOptions)
-	require.NoError(t, err)
-	require.Equal(t, "", backendOptions.Azblob.EncryptionScope)
+	{
+		backendOptions := &BackendOptions{
+			S3:     S3BackendOptions{StorageClass: "test"},
+			GCS:    GCSBackendOptions{StorageClass: "test"},
+			Azblob: AzblobBackendOptions{AccessTier: "test"},
+		}
+		u, err := ParseBackend("s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=0&sse-kms-key-id=TestKey&xyz=abc", backendOptions)
+		require.NoError(t, err)
+		require.Equal(t, S3BackendOptions{StorageClass: "test"}, backendOptions.S3)
+		retBackend1, ok := u.Backend.(*backuppb.StorageBackend_S3)
+		require.True(t, ok)
+		require.Equal(t, backuppb.S3{
+			Endpoint:     "https://127.0.0.1:9000",
+			Bucket:       "bucket3",
+			Prefix:       "prefix/path",
+			StorageClass: "test",
+			SseKmsKeyId:  "TestKey",
+		}, *retBackend1.S3)
+		u, err = ParseBackend("gcs://bucket?endpoint=http://127.0.0.1&predefined-acl=1234", backendOptions)
+		require.NoError(t, err)
+		require.Equal(t, GCSBackendOptions{StorageClass: "test"}, backendOptions.GCS)
+		retBackend2, ok := u.Backend.(*backuppb.StorageBackend_Gcs)
+		require.True(t, ok)
+		require.Equal(t, backuppb.GCS{
+			Endpoint:      "http://127.0.0.1",
+			Bucket:        "bucket",
+			StorageClass:  "test",
+			PredefinedAcl: "1234",
+		}, *retBackend2.Gcs)
+		u, err = ParseBackend("azure://bucket1/prefix/path?account-name=user&account-key=cGFzc3dk&endpoint=http://127.0.0.1/user&encryption-scope=test", backendOptions)
+		require.NoError(t, err)
+		require.Equal(t, AzblobBackendOptions{AccessTier: "test"}, backendOptions.Azblob)
+		retBackend3, ok := u.Backend.(*backuppb.StorageBackend_AzureBlobStorage)
+		require.True(t, ok)
+		require.Equal(t, backuppb.AzureBlobStorage{
+			Endpoint:        "http://127.0.0.1/user",
+			Bucket:          "bucket1",
+			Prefix:          "prefix/path",
+			StorageClass:    "test",
+			AccountName:     "user",
+			SharedKey:       "cGFzc3dk",
+			EncryptionScope: "test",
+		}, *retBackend3.AzureBlobStorage)
+	}
+	{
+		u, err := ParseBackend("s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=0&sse-kms-key-id=TestKey&xyz=abc", nil)
+		require.NoError(t, err)
+		retBackend1, ok := u.Backend.(*backuppb.StorageBackend_S3)
+		require.True(t, ok)
+		require.Equal(t, backuppb.S3{
+			Endpoint:    "https://127.0.0.1:9000",
+			Bucket:      "bucket3",
+			Prefix:      "prefix/path",
+			SseKmsKeyId: "TestKey",
+		}, *retBackend1.S3)
+		u, err = ParseBackend("s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&sse-kms-key-id=TestKey&xyz=abc", nil)
+		require.NoError(t, err)
+		retBackend1, ok = u.Backend.(*backuppb.StorageBackend_S3)
+		require.True(t, ok)
+		require.Equal(t, backuppb.S3{
+			Endpoint:       "https://127.0.0.1:9000",
+			Bucket:         "bucket3",
+			Prefix:         "prefix/path",
+			ForcePathStyle: true,
+			SseKmsKeyId:    "TestKey",
+		}, *retBackend1.S3)
+		u, err = ParseBackend("gcs://bucket?endpoint=http://127.0.0.1&predefined-acl=1234", nil)
+		require.NoError(t, err)
+		retBackend2, ok := u.Backend.(*backuppb.StorageBackend_Gcs)
+		require.True(t, ok)
+		require.Equal(t, backuppb.GCS{
+			Endpoint:      "http://127.0.0.1",
+			Bucket:        "bucket",
+			PredefinedAcl: "1234",
+		}, *retBackend2.Gcs)
+		u, err = ParseBackend("azure://bucket1/prefix/path?account-name=user&account-key=cGFzc3dk&endpoint=http://127.0.0.1/user&encryption-scope=test", nil)
+		require.NoError(t, err)
+		retBackend3, ok := u.Backend.(*backuppb.StorageBackend_AzureBlobStorage)
+		require.True(t, ok)
+		require.Equal(t, backuppb.AzureBlobStorage{
+			Endpoint:        "http://127.0.0.1/user",
+			Bucket:          "bucket1",
+			Prefix:          "prefix/path",
+			AccountName:     "user",
+			SharedKey:       "cGFzc3dk",
+			EncryptionScope: "test",
+		}, *retBackend3.AzureBlobStorage)
+	}
 }

--- a/br/pkg/storage/parse_test.go
+++ b/br/pkg/storage/parse_test.go
@@ -309,3 +309,20 @@ func TestIsLocal(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBackend(t *testing.T) {
+	backendOptions := &BackendOptions{
+		S3:     S3BackendOptions{},
+		GCS:    GCSBackendOptions{},
+		Azblob: AzblobBackendOptions{},
+	}
+	_, err := ParseBackend("s3://bucket3/prefix/path?endpoint=https://127.0.0.1:9000&force_path_style=0&sse-kms-key-id=TestKey&xyz=abc", backendOptions)
+	require.NoError(t, err)
+	require.Equal(t, "", backendOptions.S3.SseKmsKeyID)
+	_, err = ParseBackend("gcs://bucket?endpoint=http://127.0.0.1&predefined-acl=1234", backendOptions)
+	require.NoError(t, err)
+	require.Equal(t, "", backendOptions.GCS.PredefinedACL)
+	_, err = ParseBackend("azure://bucket1/prefix/path?account-name=user&account-key=cGFzc3dk&endpoint=http://127.0.0.1/user&encryption-scope=test", backendOptions)
+	require.NoError(t, err)
+	require.Equal(t, "", backendOptions.Azblob.EncryptionScope)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59548

Problem Summary:
The external storage backend becomes dirty after parse any external storage URL.
### What changed and how does it work?
Clone the backend options when parse it.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
