### PR TITLE
add retry for h2 disconnection errors

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -591,8 +591,35 @@ func (rs *S3Storage) WriteFile(ctx context.Context, file string, data []byte) er
 	return errors.Trace(err)
 }
 
-// ReadFile reads the file from the storage and returns the contents.
 func (rs *S3Storage) ReadFile(ctx context.Context, file string) ([]byte, error) {
+	backoff := 10 * time.Millisecond
+	remainRetry := 5
+	contRetry := func() bool {
+		if remainRetry <= 0 {
+			return false
+		}
+		time.Sleep(backoff)
+		remainRetry -= 1
+		return true
+	}
+	for {
+		data, err := rs.doReadFile(ctx, file)
+		if err != nil {
+			log.Warn("ReadFile: failed to read file.",
+				zap.String("file", file), logutil.ShortError(err), zap.Int("remained", remainRetry))
+			if !isHTTP2ConnAborted(err) {
+				return nil, err
+			}
+			if !contRetry() {
+				return nil, err
+			}
+			continue
+		}
+		return data, nil
+	}
+}
+
+func (rs *S3Storage) doReadFile(ctx context.Context, file string) ([]byte, error) {
 	var (
 		data    []byte
 		readErr error
@@ -1194,7 +1221,27 @@ func isConnectionRefusedError(err error) bool {
 	return strings.Contains(err.Error(), "connection refused")
 }
 
-func (rl retryerWithLog) ShouldRetry(r *request.Request) bool {
+func isHTTP2ConnAborted(err error) bool {
+	patterns := []string{
+		"http2: client connection force closed via ClientConn.Close",
+		"http2: server sent GOAWAY and closed the connection",
+		"unexpected EOF",
+	}
+	errMsg := err.Error()
+
+	for _, p := range patterns {
+		if strings.Contains(errMsg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rl retryerWithLog) ShouldRetry(r *request.Request) (retry bool) {
+	defer func() {
+		log.Warn("failed to request s3, checking whether we can retry", zap.Error(r.Error), zap.Bool("retry", retry))
+	}()
+
 	// for unit test
 	failpoint.Inject("replace-error-to-connection-reset-by-peer", func(_ failpoint.Value) {
 		log.Info("original error", zap.Error(r.Error))
@@ -1213,14 +1260,15 @@ func (rl retryerWithLog) ShouldRetry(r *request.Request) bool {
 	if isConnectionRefusedError(r.Error) {
 		return false
 	}
+	if isHTTP2ConnAborted(r.Error) {
+		return true
+	}
 	return rl.DefaultRetryer.ShouldRetry(r)
 }
 
 func (rl retryerWithLog) RetryRules(r *request.Request) time.Duration {
 	backoffTime := rl.DefaultRetryer.RetryRules(r)
-	if backoffTime > 0 {
-		log.Warn("failed to request s3, retrying", zap.Error(r.Error), zap.Duration("backoff", backoffTime))
-	}
+	log.Warn("failed to request s3, retrying", zap.Error(r.Error), zap.Duration("backoff", backoffTime))
 	return backoffTime
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59557

Problem Summary:
See the issue.

### What changed and how does it work?
This PR retry when encountered possible H2 disconnection messages. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
We verified this internally in a Tencent Cloud COS storage.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Now, br tolerances HTTP/2 GOAWAY messages / server cutting down connection.
```
