### PR TITLE
Revert "expr: support str_to_date pushdown to tikv #59362"

### DIFF
--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -1845,26 +1845,26 @@ func TestExprPushDownToTiKV(t *testing.T) {
 			retType:      types.NewFieldType(mysql.TypeString),
 			args:         []Expression{decimalColumn, stringColumn},
 		},
-		{
-			functionName: ast.StrToDate,
-			retType:      types.NewFieldType(mysql.TypeDatetime),
-			args:         []Expression{stringColumn, stringColumn},
-		},
-		{
-			functionName: ast.StrToDate,
-			retType:      types.NewFieldType(mysql.TypeDuration),
-			args:         []Expression{stringColumn, NewStrConst("%h")},
-		},
-		{
-			functionName: ast.StrToDate,
-			retType:      types.NewFieldType(mysql.TypeDate),
-			args:         []Expression{stringColumn, NewStrConst("%y")},
-		},
-		{
-			functionName: ast.StrToDate,
-			retType:      types.NewFieldType(mysql.TypeDatetime),
-			args:         []Expression{stringColumn, NewStrConst("%h%y")},
-		},
+		//{
+		//	functionName: ast.StrToDate,
+		//	retType:      types.NewFieldType(mysql.TypeDatetime),
+		//	args:         []Expression{stringColumn, stringColumn},
+		//},
+		//{
+		//	functionName: ast.StrToDate,
+		//	retType:      types.NewFieldType(mysql.TypeDuration),
+		//	args:         []Expression{stringColumn, NewStrConst("%h")},
+		//},
+		//{
+		//	functionName: ast.StrToDate,
+		//	retType:      types.NewFieldType(mysql.TypeDate),
+		//	args:         []Expression{stringColumn, NewStrConst("%y")},
+		//},
+		//{
+		//	functionName: ast.StrToDate,
+		//	retType:      types.NewFieldType(mysql.TypeDatetime),
+		//	args:         []Expression{stringColumn, NewStrConst("%h%y")},
+		//},
 		{
 			functionName: ast.TimestampDiff,
 			retType:      types.NewFieldType(mysql.TypeLong),

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -212,7 +212,7 @@ func scalarExprSupportedByTiKV(ctx EvalContext, sf *ScalarFunction) bool {
 		ast.FromDays, /* ast.ToDays */
 		ast.PeriodAdd, ast.PeriodDiff, ast.TimestampDiff, ast.FromUnixTime,
 		/* ast.LastDay */
-		ast.Sysdate, ast.StrToDate,
+		ast.Sysdate, /* ast.StrToDate, */
 
 		// encryption functions.
 		ast.MD5, ast.SHA1, ast.UncompressedLength,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref  https://github.com/pingcap/tidb/issues/59566

Problem Summary:
TiKV can't get the sql_mode and get wrong result.
So now we disable str_to_date pushdown to tikv.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
