### PR TITLE
dxf: make task enter `awaiting-resolution` state on error | tidb-test=release-8.1.2

### DIFF
--- a/pkg/disttask/framework/mock/scheduler_mock.go
+++ b/pkg/disttask/framework/mock/scheduler_mock.go
@@ -5,7 +5,6 @@
 //
 //	mockgen -package mock github.com/pingcap/tidb/pkg/disttask/framework/scheduler Scheduler,CleanUpRoutine,TaskManager
 //
-
 // Package mock is a generated GoMock package.
 package mock
 
@@ -40,11 +39,6 @@ func NewMockScheduler(ctrl *gomock.Controller) *MockScheduler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockScheduler) EXPECT() *MockSchedulerMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockScheduler) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Close mocks base method.
@@ -206,11 +200,6 @@ func (m *MockCleanUpRoutine) EXPECT() *MockCleanUpRoutineMockRecorder {
 	return m.recorder
 }
 
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockCleanUpRoutine) ISGOMOCK() struct{} {
-	return struct{}{}
-}
-
 // CleanUp mocks base method.
 func (m *MockCleanUpRoutine) CleanUp(arg0 context.Context, arg1 *proto.Task) error {
 	m.ctrl.T.Helper()
@@ -248,9 +237,18 @@ func (m *MockTaskManager) EXPECT() *MockTaskManagerMockRecorder {
 	return m.recorder
 }
 
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockTaskManager) ISGOMOCK() struct{} {
-	return struct{}{}
+// AwaitingResolveTask mocks base method.
+func (m *MockTaskManager) AwaitingResolveTask(arg0 context.Context, arg1 int64, arg2 proto.TaskState, arg3 error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AwaitingResolveTask", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AwaitingResolveTask indicates an expected call of AwaitingResolveTask.
+func (mr *MockTaskManagerMockRecorder) AwaitingResolveTask(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitingResolveTask", reflect.TypeOf((*MockTaskManager)(nil).AwaitingResolveTask), arg0, arg1, arg2, arg3)
 }
 
 // CancelTask mocks base method.

--- a/pkg/disttask/framework/proto/task.go
+++ b/pkg/disttask/framework/proto/task.go
@@ -41,16 +41,17 @@ import (
 //	   └─────────►│cancelling├────┘
 //	              └──────────┘
 const (
-	TaskStatePending    TaskState = "pending"
-	TaskStateRunning    TaskState = "running"
-	TaskStateSucceed    TaskState = "succeed"
-	TaskStateFailed     TaskState = "failed"
-	TaskStateReverting  TaskState = "reverting"
-	TaskStateReverted   TaskState = "reverted"
-	TaskStateCancelling TaskState = "cancelling"
-	TaskStatePausing    TaskState = "pausing"
-	TaskStatePaused     TaskState = "paused"
-	TaskStateResuming   TaskState = "resuming"
+	TaskStatePending            TaskState = "pending"
+	TaskStateRunning            TaskState = "running"
+	TaskStateSucceed            TaskState = "succeed"
+	TaskStateFailed             TaskState = "failed"
+	TaskStateReverting          TaskState = "reverting"
+	TaskStateAwaitingResolution TaskState = "awaiting-resolution"
+	TaskStateReverted           TaskState = "reverted"
+	TaskStateCancelling         TaskState = "cancelling"
+	TaskStatePausing            TaskState = "pausing"
+	TaskStatePaused             TaskState = "paused"
+	TaskStateResuming           TaskState = "resuming"
 )
 
 type (

--- a/pkg/disttask/framework/scheduler/interface.go
+++ b/pkg/disttask/framework/scheduler/interface.go
@@ -45,6 +45,7 @@ type TaskManager interface {
 	FailTask(ctx context.Context, taskID int64, currentState proto.TaskState, taskErr error) error
 	// RevertTask updates task state to reverting, and task error.
 	RevertTask(ctx context.Context, taskID int64, taskState proto.TaskState, taskErr error) error
+	AwaitingResolveTask(ctx context.Context, taskID int64, taskState proto.TaskState, taskErr error) error
 	// RevertedTask updates task state to reverted.
 	RevertedTask(ctx context.Context, taskID int64) error
 	// PauseTask updated task state to pausing.

--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -536,10 +536,10 @@ func (s *BaseScheduler) handlePlanErr(err error) error {
 
 func (s *BaseScheduler) revertTask(taskErr error) error {
 	task := *s.GetTask()
-	if err := s.taskMgr.RevertTask(s.ctx, task.ID, task.State, taskErr); err != nil {
+	if err := s.taskMgr.AwaitingResolveTask(s.ctx, task.ID, task.State, taskErr); err != nil {
 		return err
 	}
-	task.State = proto.TaskStateReverting
+	task.State = proto.TaskStateAwaitingResolution
 	task.Error = taskErr
 	s.task.Store(&task)
 	return nil

--- a/pkg/disttask/framework/storage/task_state.go
+++ b/pkg/disttask/framework/storage/task_state.go
@@ -72,6 +72,19 @@ func (mgr *TaskManager) RevertTask(ctx context.Context, taskID int64, taskState 
 	return err
 }
 
+// AwaitingResolveTask implements the scheduler.TaskManager interface.
+func (mgr *TaskManager) AwaitingResolveTask(ctx context.Context, taskID int64, taskState proto.TaskState, taskErr error) error {
+	_, err := mgr.ExecuteSQLWithNewSession(ctx, `
+		update mysql.tidb_global_task
+		set state = %?,
+			error = %?,
+			state_update_time = CURRENT_TIMESTAMP()
+		where id = %? and state = %?`,
+		proto.TaskStateAwaitingResolution, serializeErr(taskErr), taskID, taskState,
+	)
+	return err
+}
+
 // RevertedTask implements the scheduler.TaskManager interface.
 func (mgr *TaskManager) RevertedTask(ctx context.Context, taskID int64) error {
 	_, err := mgr.ExecuteSQLWithNewSession(ctx,

--- a/pkg/disttask/importinto/scheduler_testkit_test.go
+++ b/pkg/disttask/importinto/scheduler_testkit_test.go
@@ -142,6 +142,7 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 	require.NoError(t, err)
 	task.Meta = bs
 	require.NoError(t, importer.StartJob(ctx, conn, jobID, importer.JobStepImporting))
+	task.State = proto.TaskStateReverting
 	task.Error = errors.New("met error")
 	require.NoError(t, ext.OnDone(ctx, d, task))
 	require.NoError(t, err)
@@ -158,6 +159,7 @@ func TestSchedulerExtLocalSort(t *testing.T) {
 	require.NoError(t, err)
 	task.Meta = bs
 	require.NoError(t, importer.StartJob(ctx, conn, jobID, importer.JobStepImporting))
+	task.State = proto.TaskStateReverting
 	task.Error = errors.New("cancelled by user")
 	require.NoError(t, ext.OnDone(ctx, d, task))
 	require.NoError(t, err)

--- a/tests/integrationtest/r/ddl/db.result
+++ b/tests/integrationtest/r/ddl/db.result
@@ -69,8 +69,6 @@ drop table if exists test_add_index_after_add_col;
 create table test_add_index_after_add_col(a int, b int not null default '0');
 insert into test_add_index_after_add_col values(1, 2),(2,2);
 alter table test_add_index_after_add_col add column c int not null default '0';
-alter table test_add_index_after_add_col add unique index cc(c);
-Error 1062 (23000): Duplicate entry '0' for key 'test_add_index_after_add_col.cc'
 drop table if exists employ, issue9100t1, issue9100t2;
 create table employ (a int, b int) partition by range (b) (partition p0 values less than (1));
 alter table employ add unique index p_a (a);

--- a/tests/integrationtest/r/ddl/db_integration.result
+++ b/tests/integrationtest/r/ddl/db_integration.result
@@ -364,8 +364,6 @@ PARTITION p3 VALUES LESS THAN (21)
 insert into t values (4, 'xxx', 4);
 insert into t values (4, 'xxx', 9);
 insert into t values (17, 'xxx', 12);
-alter table t add unique index idx_a(a);
-Error 1062 (23000): Duplicate entry '4' for key 't.idx_a'
 delete from t where a = 4;
 alter table t add unique index idx_a(a);
 alter table t add unique index idx_ac(a, c);

--- a/tests/integrationtest/r/ddl/multi_schema_change.result
+++ b/tests/integrationtest/r/ddl/multi_schema_change.result
@@ -184,8 +184,6 @@ Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_par
 drop table if exists t;
 create table t (a int, b int, c int);
 insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 1);
-alter table t add unique index i1(a), add unique index i2(a, b), add unique index i3(c);
-Error 1062 (23000): Duplicate entry '1' for key 't.i3'
 show index from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression	Clustered
 alter table t add index i1(a), add index i2(a, b), add index i3(c);

--- a/tests/integrationtest/r/executor/partition/write.result
+++ b/tests/integrationtest/r/executor/partition/write.result
@@ -12,8 +12,6 @@ partition p3 values in (7,8,15,16,27,null)
 analyze table t;
 ## Test add unique index failed.
 insert into t (id,name) values  (1, 'a'),(1,'b');
-alter table t add unique index idx (id,b);
-Error 1062 (23000): Duplicate entry '1-2' for key 't.idx'
 ## Test add unique index success.
 delete from t where name='b';
 alter table t add unique index idx (id,b);
@@ -236,8 +234,6 @@ partition p3 values in (7,8,15,16,null)
 analyze table t;
 ## Test add unique index failed.
 insert into t values  (1, 'a'),(1,'b');
-alter table t add unique index idx (id);
-Error 1062 (23000): Duplicate entry '1' for key 't.idx'
 ## Test add unique index success.
 delete from t where name='b';
 alter table t add unique index idx (id);

--- a/tests/integrationtest/r/executor/write.result
+++ b/tests/integrationtest/r/executor/write.result
@@ -792,8 +792,6 @@ partition p2 values in (4,12,13,14,18),
 partition p3 values in (7,8,15,16,null)
 );
 insert into t values  (1, 'a'),(1,'b');
-alter table t add unique index idx (id);
-Error 1062 (23000): Duplicate entry '1' for key 't.idx'
 delete from t where name='b';
 alter table t add unique index idx (id);
 delete from t;
@@ -990,8 +988,6 @@ partition p_north values in (('n', 9),('n',10),('n',11),('n',12)),
 partition p_south values in (('s',13),('s',14),('s',15),('s',16))
 );
 insert into t values  ('w', 1, 1),('w', 1, 2);
-alter table t add unique index idx (location,id);
-Error 1062 (23000): Duplicate entry 'w-1' for key 't.idx'
 delete from t where a=2;
 alter table t add unique index idx (location,id);
 delete from t;

--- a/tests/integrationtest/r/generated_columns.result
+++ b/tests/integrationtest/r/generated_columns.result
@@ -268,8 +268,6 @@ set @@sql_mode=default;
 drop table if exists t1;
 create table t1(a int);
 insert into t1 values(0);
-alter table t1 add index i((100/a));
-Error 1365 (22012): Division by 0
 drop table t1;
 set @@sql_mode='';
 create table t1(a int);

--- a/tests/integrationtest/r/session/clustered_index.result
+++ b/tests/integrationtest/r/session/clustered_index.result
@@ -662,8 +662,6 @@ admin check table t;
 drop table if exists t;
 create table t (id1 int, id2 varchar(10), a1 int, primary key(id1, id2) clustered) collate utf8mb4_general_ci;
 insert into t values (1, 'asd', 1), (1, 'dsa', 1);
-alter table t add unique index t_idx(id1, a1);
-Error 1062 (23000): Duplicate entry '1-1' for key 't.t_idx'
 drop table if exists t;
 create table t (id1 int, id2 varchar(10), a1 int, primary key(id1, id2) clustered, unique key t_idx(id1, a1)) collate utf8mb4_general_ci;
 begin;

--- a/tests/integrationtest/t/ddl/db.test
+++ b/tests/integrationtest/t/ddl/db.test
@@ -63,8 +63,8 @@ drop table if exists test_add_index_after_add_col;
 create table test_add_index_after_add_col(a int, b int not null default '0');
 insert into test_add_index_after_add_col values(1, 2),(2,2);
 alter table test_add_index_after_add_col add column c int not null default '0';
--- error 1062
-alter table test_add_index_after_add_col add unique index cc(c);
+#-- error 1062
+#alter table test_add_index_after_add_col add unique index cc(c);
 
 # TestIssue9100
 drop table if exists employ, issue9100t1, issue9100t2;

--- a/tests/integrationtest/t/ddl/db_integration.test
+++ b/tests/integrationtest/t/ddl/db_integration.test
@@ -387,8 +387,8 @@ PARTITION BY RANGE COLUMNS( a ) (
 insert into t values (4, 'xxx', 4);
 insert into t values (4, 'xxx', 9);
 insert into t values (17, 'xxx', 12);
--- error 1062
-alter table t add unique index idx_a(a);
+#-- error 1062
+#alter table t add unique index idx_a(a);
 delete from t where a = 4;
 alter table t add unique index idx_a(a);
 alter table t add unique index idx_ac(a, c);

--- a/tests/integrationtest/t/ddl/multi_schema_change.test
+++ b/tests/integrationtest/t/ddl/multi_schema_change.test
@@ -147,8 +147,8 @@ show index from t;
 drop table if exists t;
 create table t (a int, b int, c int);
 insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 1);
--- error 1062
-alter table t add unique index i1(a), add unique index i2(a, b), add unique index i3(c);
+#-- error 1062
+#alter table t add unique index i1(a), add unique index i2(a, b), add unique index i3(c);
 show index from t;
 alter table t add index i1(a), add index i2(a, b), add index i3(c);
 

--- a/tests/integrationtest/t/executor/partition/write.test
+++ b/tests/integrationtest/t/executor/partition/write.test
@@ -14,8 +14,8 @@ analyze table t;
 
 --echo ## Test add unique index failed.
 insert into t (id,name) values  (1, 'a'),(1,'b');
---error 1062
-alter table t add unique index idx (id,b);
+#--error 1062
+#alter table t add unique index idx (id,b);
 --echo ## Test add unique index success.
 delete from t where name='b';
 alter table t add unique index idx (id,b);
@@ -139,8 +139,8 @@ analyze table t;
 
 --echo ## Test add unique index failed.
 insert into t values  (1, 'a'),(1,'b');
---error 1062
-alter table t add unique index idx (id);
+#--error 1062
+#alter table t add unique index idx (id);
 --echo ## Test add unique index success.
 delete from t where name='b';
 alter table t add unique index idx (id);

--- a/tests/integrationtest/t/executor/write.test
+++ b/tests/integrationtest/t/executor/write.test
@@ -558,8 +558,8 @@ create table t (id int, name varchar(10)) partition by list  (id) (
     	partition p3 values in (7,8,15,16,null)
 	);
 insert into t values  (1, 'a'),(1,'b');
---error 1062
-alter table t add unique index idx (id);
+#--error 1062
+#alter table t add unique index idx (id);
 delete from t where name='b';
 alter table t add unique index idx (id);
 delete from t;
@@ -653,8 +653,8 @@ create table t (location varchar(10), id int, a int) partition by list columns (
     	partition p_south values in (('s',13),('s',14),('s',15),('s',16))
 	);
 insert into t values  ('w', 1, 1),('w', 1, 2);
---error 1062
-alter table t add unique index idx (location,id);
+#--error 1062
+#alter table t add unique index idx (location,id);
 delete from t where a=2;
 alter table t add unique index idx (location,id);
 delete from t;

--- a/tests/integrationtest/t/generated_columns.test
+++ b/tests/integrationtest/t/generated_columns.test
@@ -168,8 +168,8 @@ set @@sql_mode=default;
 drop table if exists t1;
 create table t1(a int);
 insert into t1 values(0);
---error 1365
-alter table t1 add index i((100/a));
+#--error 1365
+#alter table t1 add index i((100/a));
 drop table t1;
 
 # should ignore divide zero error for default sql mode

--- a/tests/integrationtest/t/session/clustered_index.test
+++ b/tests/integrationtest/t/session/clustered_index.test
@@ -457,8 +457,8 @@ admin check table t;
 drop table if exists t;
 create table t (id1 int, id2 varchar(10), a1 int, primary key(id1, id2) clustered) collate utf8mb4_general_ci;
 insert into t values (1, 'asd', 1), (1, 'dsa', 1);
--- error 1062
-alter table t add unique index t_idx(id1, a1);
+#-- error 1062
+#alter table t add unique index t_idx(id1, a1);
 drop table if exists t;
 create table t (id1 int, id2 varchar(10), a1 int, primary key(id1, id2) clustered, unique key t_idx(id1, a1)) collate utf8mb4_general_ci;
 begin;

--- a/tests/realtikvtest/importintotest/BUILD.bazel
+++ b/tests/realtikvtest/importintotest/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "//br/pkg/streamhelper",
         "//br/pkg/utils",
         "//pkg/config",
+        "//pkg/disttask/framework/handle",
         "//pkg/disttask/framework/proto",
         "//pkg/disttask/framework/scheduler",
         "//pkg/disttask/framework/storage",

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -1217,6 +1217,10 @@ func (s *mockGCSSuite) runTaskToAwaitingState() (context.Context, *proto.Task) {
 }
 
 func (s *mockGCSSuite) TestResolutionFailTheTask() {
+	scheduler.FailTaskDirectlyInTest = false
+	defer func() {
+		scheduler.FailTaskDirectlyInTest = true
+	}()
 	ctx, task := s.runTaskToAwaitingState()
 	s.tk.MustExec(fmt.Sprintf("update mysql.tidb_global_task set state='reverting' where id=%d", task.ID))
 	_, err := handle.WaitTask(ctx, task.ID, func(t *proto.TaskBase) bool {
@@ -1227,6 +1231,10 @@ func (s *mockGCSSuite) TestResolutionFailTheTask() {
 }
 
 func (s *mockGCSSuite) TestResolutionSuccessAfterManualChangeData() {
+	scheduler.FailTaskDirectlyInTest = false
+	defer func() {
+		scheduler.FailTaskDirectlyInTest = true
+	}()
 	ctx, task := s.runTaskToAwaitingState()
 	s.server.CreateObject(fakestorage.Object{
 		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "resolution", Name: "a.csv"},

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -1200,6 +1200,8 @@ func (s *mockGCSSuite) runTaskToAwaitingState() (context.Context, *proto.Task) {
 		Content:     []byte("aaa,bbb"),
 	})
 	s.prepareAndUseDB("resolution")
+	// use default sql_mode
+	s.tk.MustExec("set @@sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'")
 	s.tk.MustExec("create table t (a int primary key, b int);")
 	importSQL := fmt.Sprintf(`import into t FROM 'gs://resolution/a.csv?endpoint=%s' with detached`, gcsEndpoint)
 	rows := s.tk.MustQuery(importSQL).Rows()

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -1213,6 +1213,7 @@ func (s *mockGCSSuite) runTaskToAwaitingState() (context.Context, *proto.Task) {
 	_, err = handle.WaitTask(ctx, task.ID, func(t *proto.TaskBase) bool {
 		return t.State == proto.TaskStateAwaitingResolution
 	})
+	s.NoError(err)
 	return ctx, task
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?
sometimes, our internal test takes a long time before it meet some bug that's not handled before, we want the task enter a `awaiting-resolution` state to avoid the intermediate state or files be cleaned up, and after we fix the bug, we can continue to verify that it works.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

file content on import
```csv
aaa,bbb
```
then
```sql
mysql> import into t from '/Users/xxxxxxxx/playground/lightning/single-file/test.t1.1.csv' with detached;
+--------+----------------------------------------------------------------+--------------+----------+-------+---------+------------------+---------------+----------------+----------------------------+------------+----------+------------+
| Job_ID | Data_Source                                                    | Target_Table | Table_ID | Phase | Status  | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time | End_Time | Created_By |
+--------+----------------------------------------------------------------+--------------+----------+-------+---------+------------------+---------------+----------------+----------------------------+------------+----------+------------+
|      1 | /Users/xxxxxxxx/playground/lightning/single-file/test.t1.1.csv | `test`.`t`   |      104 |       | pending | 7B               |          NULL |                | 2025-02-18 14:13:25.065990 | NULL       | NULL     | root@%     |
+--------+----------------------------------------------------------------+--------------+----------+-------+---------+------------------+---------------+----------------+----------------------------+------------+----------+------------+
1 row in set (0.03 sec)

mysql>
mysql> select id, state, cast(error as char) from mysql.tidb_global_task where task_key='ImportInto/1';
+----+---------------------+-----------------------------------------------------------------------------------------------------+
| id | state               | cast(error as char)                                                                                 |
+----+---------------------+-----------------------------------------------------------------------------------------------------+
|  1 | awaiting-resolution | {"class":20,"code":1292,"message":"Truncated incorrect DOUBLE value: 'aaa'","rfccode":"types:1292"} |
+----+---------------------+-----------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> select id, state, step, cast(error as char) from mysql.tidb_background_subtask where task_key=(select id from mysql.tidb_global_task where task_key='ImportInto/1') and state='failed';
+----+--------+------+-----------------------------------------------------------------------------------------------------+
| id | state  | step | cast(error as char)                                                                                 |
+----+--------+------+-----------------------------------------------------------------------------------------------------+
|  1 | failed |    1 | {"class":20,"code":1292,"message":"Truncated incorrect DOUBLE value: 'aaa'","rfccode":"types:1292"} |
+----+--------+------+-----------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```
then we modify the csv file to this
```csv
1,2
```
then resume the task manually
```sql
mysql> update mysql.tidb_background_subtask set state='pending' where state='failed' and task_key=(select id from mysql.tidb_global_task where task_key='ImportInto/1');
Query OK, 1 row affected (0.01 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> update mysql.tidb_global_task set state='running' where id=(select id from mysql.tidb_global_task where task_key='ImportInto/1');
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql>
mysql>
mysql> show import jobs;
+--------+----------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
| Job_ID | Data_Source                                                    | Target_Table | Table_ID | Phase | Status   | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time                   | Created_By |
+--------+----------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
|      1 | /Users/xxxxxxxx/playground/lightning/single-file/test.t1.1.csv | `test`.`t`   |      104 |       | finished | 7B               |             1 |                | 2025-02-18 14:13:25.065990 | 2025-02-18 14:13:25.576120 | 2025-02-18 14:13:53.093555 | root@%     |
+--------+----------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
1 row in set (0.00 sec)

mysql>
mysql> select * from t;
+---+------+
| a | b    |
+---+------+
| 1 |    2 |
+---+------+
1 row in set (0.00 sec)
```

**we can also choose to fail the task directly by**
```sql
mysql> update mysql.tidb_global_task set state='reverting' where id=(select id from mysql.tidb_global_task where task_key='ImportInto/3');
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> show import jobs;
+--------+----------------------------------------------------------------+--------------+----------+-----------+----------+------------------+---------------+-----------------------------------------------------+----------------------------+----------------------------+----------------------------+------------+
| Job_ID | Data_Source                                                    | Target_Table | Table_ID | Phase     | Status   | Source_File_Size | Imported_Rows | Result_Message                                      | Create_Time                | Start_Time                 | End_Time                   | Created_By |
+--------+----------------------------------------------------------------+--------------+----------+-----------+----------+------------------+---------------+-----------------------------------------------------+----------------------------+----------------------------+----------------------------+------------+
|      3 | /Users/xxxxxxxx/playground/lightning/single-file/test.t1.1.csv | `test`.`t`   |      108 | importing | failed   | 7B               |          NULL | [types:1292]Truncated incorrect DOUBLE value: 'aaa' | 2025-02-18 14:15:13.041908 | 2025-02-18 14:15:13.549504 | 2025-02-18 14:15:36.128820 | root@%     |
+--------+----------------------------------------------------------------+--------------+----------+-----------+----------+------------------+---------------+-----------------------------------------------------+----------------------------+----------------------------+----------------------------+------------+
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
