### PR TITLE
session, variable: add privilege check to `set session_states`

### DIFF
--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2826,7 +2826,6 @@ func (s *SessionVars) EncodeSessionStates(_ context.Context, sessionStates *sess
 	sessionStates.SequenceLatestValues = s.SequenceState.GetAllStates()
 	sessionStates.FoundInPlanCache = s.PrevFoundInPlanCache
 	sessionStates.FoundInBinding = s.PrevFoundInBinding
-	sessionStates.ResourceGroupName = s.ResourceGroupName
 	sessionStates.HypoIndexes = s.HypoIndexes
 	sessionStates.HypoTiFlashReplicas = s.HypoTiFlashReplicas
 
@@ -2862,7 +2861,6 @@ func (s *SessionVars) DecodeSessionStates(_ context.Context, sessionStates *sess
 	s.SequenceState.SetAllStates(sessionStates.SequenceLatestValues)
 	s.FoundInPlanCache = sessionStates.FoundInPlanCache
 	s.FoundInBinding = sessionStates.FoundInBinding
-	s.SetResourceGroupName(sessionStates.ResourceGroupName)
 	s.HypoIndexes = sessionStates.HypoIndexes
 	s.HypoTiFlashReplicas = sessionStates.HypoTiFlashReplicas
 

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -101,6 +101,30 @@ id
 REVOKE SELECT on test_rc.* FROM resource_group_admin;
 REVOKE SELECT on test_rc.* FROM resource_group_user;
 DROP DATABASE test_rc;
+DROP USER resource_group_admin;
+DROP USER resource_group_user;
+DROP RESOURCE GROUP test;
+CREATE USER resource_group_user;
+CREATE USER no_resource_group;
+CREATE RESOURCE GROUP test RU_PER_SEC = 666;
+GRANT RESOURCE_GROUP_USER ON *.* TO resource_group_user;
+SET SESSION_STATES '{"rs-group":"test"}';
+SELECT CURRENT_RESOURCE_GROUP();
+CURRENT_RESOURCE_GROUP()
+default
+SET SESSION_STATES '{"rs-group":"test"}';
+SELECT CURRENT_RESOURCE_GROUP();
+CURRENT_RESOURCE_GROUP()
+test
+set @@global.tidb_resource_control_strict_mode = 0;
+SET SESSION_STATES '{"rs-group":"test"}';
+SELECT CURRENT_RESOURCE_GROUP();
+CURRENT_RESOURCE_GROUP()
+test
+set @@global.tidb_resource_control_strict_mode = default;
+DROP RESOURCE GROUP test;
+DROP USER resource_group_user;
+DROP USER no_resource_group;
 CREATE SCHEMA IF NOT EXISTS privilege__privileges;
 USE privilege__privileges;
 CREATE TABLE reftest (a int);

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -139,6 +139,40 @@ connection default;
 REVOKE SELECT on test_rc.* FROM resource_group_admin;
 REVOKE SELECT on test_rc.* FROM resource_group_user;
 DROP DATABASE test_rc;
+DROP USER resource_group_admin;
+DROP USER resource_group_user;
+DROP RESOURCE GROUP test;
+
+# TestSetSessionStatesPriv
+CREATE USER resource_group_user;
+CREATE USER no_resource_group;
+
+connection default;
+CREATE RESOURCE GROUP test RU_PER_SEC = 666;
+GRANT RESOURCE_GROUP_USER ON *.* TO resource_group_user;
+
+connect (no_resource_group,localhost,no_resource_group,,);
+SET SESSION_STATES '{"rs-group":"test"}';
+SELECT CURRENT_RESOURCE_GROUP();
+
+connect (resource_group_user,localhost,resource_group_user,,);
+SET SESSION_STATES '{"rs-group":"test"}';
+SELECT CURRENT_RESOURCE_GROUP();
+
+connection default;
+set @@global.tidb_resource_control_strict_mode = 0;
+
+connection no_resource_group;
+SET SESSION_STATES '{"rs-group":"test"}';
+SELECT CURRENT_RESOURCE_GROUP();
+
+disconnect resource_group_user;
+disconnect no_resource_group;
+connection default;
+set @@global.tidb_resource_control_strict_mode = default;
+DROP RESOURCE GROUP test;
+DROP USER resource_group_user;
+DROP USER no_resource_group;
 
 # TestGrantReferences
 CREATE SCHEMA IF NOT EXISTS privilege__privileges;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59600

Problem Summary:
`set session_states` sets the current resource group but doesn't check the dynamic privilege.

### What changed and how does it work?
If the resource group changes and `tidb_resource_control_strict_mode` is ON, check the privilege.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix missing dynamic privilege check to `SET SESSION_STATES`.
```
