### PR TITLE
br: fix ci fail due to unexpected gc safepoint

### DIFF
--- a/br/pkg/task/operator/config.go
+++ b/br/pkg/task/operator/config.go
@@ -32,9 +32,9 @@ const (
 type PauseGcConfig struct {
 	task.Config
 
-	SafePoint uint64        `json:"safepoint" yaml:"safepoint"`
-	SafePointID string      `json:"safepoint-id" yaml:"safepoint-id"`
-	TTL       time.Duration `json:"ttl" yaml:"ttl"`
+	SafePoint   uint64        `json:"safepoint" yaml:"safepoint"`
+	SafePointID string        `json:"safepoint-id" yaml:"safepoint-id"`
+	TTL         time.Duration `json:"ttl" yaml:"ttl"`
 
 	OnAllReady func() `json:"-" yaml:"-"`
 	OnExit     func() `json:"-" yaml:"-"`

--- a/br/pkg/task/operator/config.go
+++ b/br/pkg/task/operator/config.go
@@ -33,6 +33,8 @@ type PauseGcConfig struct {
 	task.Config
 
 	SafePoint   uint64        `json:"safepoint" yaml:"safepoint"`
+	// SafePointID is used to identify a specific safepoint.
+	// This field is only used in ***TEST*** now, you shouldn't use it in the src codes.
 	SafePointID string        `json:"safepoint-id" yaml:"safepoint-id"`
 	TTL         time.Duration `json:"ttl" yaml:"ttl"`
 

--- a/br/pkg/task/operator/config.go
+++ b/br/pkg/task/operator/config.go
@@ -33,6 +33,7 @@ type PauseGcConfig struct {
 	task.Config
 
 	SafePoint uint64        `json:"safepoint" yaml:"safepoint"`
+	SafePointID string      `json:"safepoint-id" yaml:"safepoint-id"`
 	TTL       time.Duration `json:"ttl" yaml:"ttl"`
 
 	OnAllReady func() `json:"-" yaml:"-"`

--- a/br/pkg/task/operator/config.go
+++ b/br/pkg/task/operator/config.go
@@ -32,7 +32,7 @@ const (
 type PauseGcConfig struct {
 	task.Config
 
-	SafePoint   uint64        `json:"safepoint" yaml:"safepoint"`
+	SafePoint uint64 `json:"safepoint" yaml:"safepoint"`
 	// SafePointID is used to identify a specific safepoint.
 	// This field is only used in ***TEST*** now, you shouldn't use it in the src codes.
 	SafePointID string        `json:"safepoint-id" yaml:"safepoint-id"`

--- a/br/pkg/task/operator/prepare_snap.go
+++ b/br/pkg/task/operator/prepare_snap.go
@@ -123,7 +123,7 @@ func hintAllReady() {
 
 // AdaptEnvForSnapshotBackup blocks the current goroutine and pause the GC safepoint and remove the scheduler by the config.
 // This function will block until the context being canceled.
-func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig, spID string) error {
+func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig) error {
 	utils.DumpGoroutineWhenExit.Store(true)
 	mgr, err := dialPD(ctx, &cfg.Config)
 	if err != nil {
@@ -153,7 +153,7 @@ func AdaptEnvForSnapshotBackup(ctx context.Context, cfg *PauseGcConfig, spID str
 	defer cx.Close()
 
 	initChan := make(chan struct{})
-	cx.run(func() error { return pauseGCKeeper(cx, spID) })
+	cx.run(func() error { return pauseGCKeeper(cx, cfg.SafePointID) })
 	cx.run(func() error {
 		log.Info("Pause scheduler waiting all connections established.")
 		select {

--- a/tests/realtikvtest/brietest/BUILD.bazel
+++ b/tests/realtikvtest/brietest/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "//br/pkg/summary",
         "//br/pkg/task",
         "//br/pkg/task/operator",
+        "//br/pkg/utils",
         "//pkg/config",
         "//pkg/domain",
         "//pkg/executor",

--- a/tests/realtikvtest/brietest/operator_test.go
+++ b/tests/realtikvtest/brietest/operator_test.go
@@ -247,8 +247,8 @@ func TestOperator(t *testing.T) {
 		}
 	}, 10*time.Second, time.Second)
 
+	verifySchedulerNotStopped(req, cfg)
 	verifyTargetGCSafePointNotExist(req, cfg, spID)
-	verifyTargetGCSafePointExist(req, cfg, spID)
 }
 
 func TestFailure(t *testing.T) {
@@ -278,6 +278,6 @@ func TestFailure(t *testing.T) {
 	err := operator.AdaptEnvForSnapshotBackup(ctx, &cfg, spID)
 	require.Error(t, err)
 
-	verifyTargetGCSafePointNotExist(req, cfg, spID)
 	verifySchedulerNotStopped(req, cfg)
+	verifyTargetGCSafePointNotExist(req, cfg, spID)
 }

--- a/tests/realtikvtest/brietest/operator_test.go
+++ b/tests/realtikvtest/brietest/operator_test.go
@@ -204,8 +204,8 @@ func TestOperator(t *testing.T) {
 		Config: task.Config{
 			PD: []string{"127.0.0.1:2379"},
 		},
-		TTL:       5 * time.Minute,
-		SafePoint: oracle.GoTimeToTS(time.Now()),
+		TTL:         5 * time.Minute,
+		SafePoint:   oracle.GoTimeToTS(time.Now()),
 		SafePointID: utils.MakeSafePointID(),
 		OnAllReady: func() {
 			close(rd)
@@ -265,8 +265,8 @@ func TestFailure(t *testing.T) {
 		Config: task.Config{
 			PD: []string{"127.0.0.1:2379"},
 		},
-		TTL:       5 * time.Minute,
-		SafePoint: oracle.GoTimeToTS(time.Now()),
+		TTL:         5 * time.Minute,
+		SafePoint:   oracle.GoTimeToTS(time.Now()),
 		SafePointID: utils.MakeSafePointID(),
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59604 

Problem Summary:

The CI test idc-jenkins-ci-tidb/check_dev_2  may fail when checking safepoint.
This is because there is gc safepoint registered by other concurrent test.

### What changed and how does it work?

Only check the gc safepoint registered by current test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
