### PR TITLE
infoschema: avoid strings.toUpper in the IsClusterTableByName

### DIFF
--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -118,10 +118,10 @@ func init() {
 // IsClusterTableByName used to check whether the table is a cluster memory table.
 // Export for PhysicalTableScan.ExplainID
 func IsClusterTableByName(dbName, tableName string) bool {
-	intest.Assert(dbName == strings.ToUpper(dbName))
+	dbName = strings.ToLower(dbName)
 	switch dbName {
 	case util.InformationSchemaName.O, util.PerformanceSchemaName.O:
-		intest.Assert(tableName == strings.ToUpper(tableName))
+		tableName = strings.ToUpper(tableName)
 		for _, name := range memTableToAllTiDBClusterTables {
 			intest.Assert(name == strings.ToUpper(name))
 			if name == tableName {

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -126,18 +126,26 @@ func init() {
 // IsClusterTableByName used to check whether the table is a cluster memory table.
 // Export for PhysicalTableScan.ExplainID
 func IsClusterTableByName(dbName, tableName string) bool {
-	intest.Assert(dbName == strings.ToLower(dbName))
+	intest.AssertFunc(func() bool {
+		return dbName == strings.ToLower(dbName)
+	})
 	switch dbName {
 	case util.InformationSchemaName.L, util.PerformanceSchemaName.L:
-		intest.Assert(tableName == strings.ToLower(tableName))
+		intest.AssertFunc(func() bool {
+			return tableName == strings.ToLower(tableName)
+		})
 		for _, name := range memTableToAllTiDBClusterTablesWithLowerCase {
-			intest.Assert(name == strings.ToLower(name))
+			intest.AssertFunc(func() bool {
+				return name == strings.ToLower(name)
+			})
 			if name == tableName {
 				return true
 			}
 		}
 		for _, name := range memTableToDDLOwnerClusterTablesWithLowerCase {
-			intest.Assert(name == strings.ToLower(name))
+			intest.AssertFunc(func() bool {
+				return name == strings.ToLower(name)
+			})
 			if name == tableName {
 				return true
 			}

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/sem"
 )
 
@@ -117,18 +118,18 @@ func init() {
 // IsClusterTableByName used to check whether the table is a cluster memory table.
 // Export for PhysicalTableScan.ExplainID
 func IsClusterTableByName(dbName, tableName string) bool {
-	dbName = strings.ToUpper(dbName)
+	intest.Assert(dbName == strings.ToUpper(dbName))
 	switch dbName {
 	case util.InformationSchemaName.O, util.PerformanceSchemaName.O:
-		tableName = strings.ToUpper(tableName)
+		intest.Assert(tableName == strings.ToUpper(tableName))
 		for _, name := range memTableToAllTiDBClusterTables {
-			name = strings.ToUpper(name)
+			intest.Assert(name == strings.ToUpper(name))
 			if name == tableName {
 				return true
 			}
 		}
 		for _, name := range memTableToDDLOwnerClusterTables {
-			name = strings.ToUpper(name)
+			intest.Assert(name == strings.ToUpper(name))
 			if name == tableName {
 				return true
 			}

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -128,7 +128,7 @@ func init() {
 func IsClusterTableByName(dbName, tableName string) bool {
 	intest.Assert(dbName == strings.ToLower(dbName))
 	switch dbName {
-	case util.InformationSchemaName.O, util.PerformanceSchemaName.O:
+	case util.InformationSchemaName.L, util.PerformanceSchemaName.L:
 		intest.Assert(tableName == strings.ToLower(tableName))
 		for _, name := range memTableToAllTiDBClusterTablesWithLowerCase {
 			intest.Assert(name == strings.ToLower(name))

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -78,14 +78,14 @@ var memTableToAllTiDBClusterTables = map[string]string{
 	TableTiDBPlanCache:            ClusterTableTiDBPlanCache,
 }
 
-var memTableToAllTiDBClusterTablesWithLowerCase map[string]string
+var memTableToAllTiDBClusterTablesWithLowerCase = make(map[string]string)
 
 // memTableToDDLOwnerClusterTables means add memory table to cluster table that will send cop request to DDL owner node.
 var memTableToDDLOwnerClusterTables = map[string]string{
 	TableTiFlashReplica: TableTiFlashReplica,
 }
 
-var memTableToDDLOwnerClusterTablesWithLowerCase map[string]string
+var memTableToDDLOwnerClusterTablesWithLowerCase = make(map[string]string)
 
 // ClusterTableCopDestination means the destination that cluster tables will send cop requests to.
 type ClusterTableCopDestination int

--- a/pkg/infoschema/cluster.go
+++ b/pkg/infoschema/cluster.go
@@ -130,7 +130,7 @@ func IsClusterTableByName(dbName, tableName string) bool {
 	switch dbName {
 	case util.InformationSchemaName.O, util.PerformanceSchemaName.O:
 		intest.Assert(tableName == strings.ToLower(tableName))
-		for _, name := range memTableToDDLOwnerClusterTablesWithLowerCase {
+		for _, name := range memTableToAllTiDBClusterTablesWithLowerCase {
 			intest.Assert(name == strings.ToLower(name))
 			if name == tableName {
 				return true

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -2493,7 +2493,7 @@ func createInfoSchemaTable(_ autoid.Allocators, _ func() (pools.Resource, error)
 		columns[i] = table.ToColumn(col)
 	}
 	tp := table.VirtualTable
-	if IsClusterTableByName(util.InformationSchemaName.O, meta.Name.O) {
+	if IsClusterTableByName(util.InformationSchemaName.L, meta.Name.L) {
 		tp = table.ClusterTable
 	}
 	return &infoschemaTable{meta: meta, cols: columns, tp: tp}, nil

--- a/pkg/planner/core/explain.go
+++ b/pkg/planner/core/explain.go
@@ -168,7 +168,7 @@ func (p *PhysicalTableScan) ExplainID() fmt.Stringer {
 
 // TP overrides the TP in order to match different range.
 func (p *PhysicalTableScan) TP() string {
-	if infoschema.IsClusterTableByName(p.DBName.O, p.Table.Name.O) {
+	if infoschema.IsClusterTableByName(p.DBName.L, p.Table.Name.L) {
 		return plancodec.TypeMemTableScan
 	} else if p.isChildOfIndexLookUp {
 		return plancodec.TypeTableRowIDScan
@@ -190,7 +190,7 @@ func (p *PhysicalTableScan) ExplainNormalizedInfo() string {
 
 // OperatorInfo implements dataAccesser interface.
 func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
-	if infoschema.IsClusterTableByName(p.DBName.O, p.Table.Name.O) {
+	if infoschema.IsClusterTableByName(p.DBName.L, p.Table.Name.L) {
 		return ""
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59606 

Problem Summary:

### What changed and how does it work?

<img width="794" alt="Image" src="https://github.com/user-attachments/assets/d1dbc50f-2aaa-43a5-b128-db159dec9d70" />

in fact, They have been upper.

```memTableToAllTiDBClusterTables``` and ```memTableToDDLOwnerClusterTables``` have been upper. the parameters of IsClusterTableByName have been upper, too.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
func BenchmarkIsClusterTableByName(b *testing.B) {
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		infoschema.IsClusterTableByName("test", "t1")
	}
}

```

before

```
BenchmarkIsClusterTableByName
BenchmarkIsClusterTableByName-8   	55993436	        20.92 ns/op
```

after

```
BenchmarkIsClusterTableByName
BenchmarkIsClusterTableByName-8   	895389862	         1.412 ns/op
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
