### PR TITLE
workloadrepo: exclude tables that contact the PD server on read

### DIFF
--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -85,7 +85,6 @@ var workloadTables = []repositoryTable{
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_BY_HOST", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_BY_USER", snapshotTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "CLIENT_ERRORS_SUMMARY_GLOBAL", snapshotTable, "", "", "", ""},
-	{"INFORMATION_SCHEMA", "TIKV_REGION_STATUS", snapshotTable, "", "", "", ""},
 
 	{"INFORMATION_SCHEMA", "PROCESSLIST", samplingTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "DATA_LOCK_WAITS", samplingTable, "", "", "", ""},
@@ -93,10 +92,12 @@ var workloadTables = []repositoryTable{
 	{"INFORMATION_SCHEMA", "MEMORY_USAGE", samplingTable, "", "", "", ""},
 	{"INFORMATION_SCHEMA", "DEADLOCKS", samplingTable, "", "", "", ""},
 
-	{"INFORMATION_SCHEMA", "CLUSTER_LOAD", samplingTable, "", "", "", ""},
-	{"INFORMATION_SCHEMA", "TIDB_HOT_REGIONS", samplingTable, "", "", "", ""},
+	// TODO: These tables are excluded for now, because reading from them adds unnecessary load to the PD.
+	//{"INFORMATION_SCHEMA", "TIKV_REGION_STATUS", snapshotTable, "", "", "", ""},
+	//{"INFORMATION_SCHEMA", "CLUSTER_LOAD", samplingTable, "", "", "", ""},
+	//{"INFORMATION_SCHEMA", "TIDB_HOT_REGIONS", samplingTable, "", "", "", ""},
 	//{"INFORMATION_SCHEMA", "TIDB_HOT_REGIONS_HISTORY", samplingTable, "", "", "", ""},
-	{"INFORMATION_SCHEMA", "TIKV_STORE_STATUS", samplingTable, "", "", "", ""},
+	//{"INFORMATION_SCHEMA", "TIKV_STORE_STATUS", samplingTable, "", "", "", ""},
 }
 
 type sessionPool interface {

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -670,16 +670,16 @@ func TestCreatePartition(t *testing.T) {
 	// Should not create any partitions on a table with a partition for the day after tomorrow.
 	partitions = []time.Time{now.AddDate(0, 0, 2)}
 	expectedParts = []time.Time{now.AddDate(0, 0, 2)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "CLUSTER_LOAD", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "DEADLOCKS", partitions, expectedParts)
 
 	// Should not fill in missing partitions on a table with a partition for dates beyond tomorrow.
 	partitions = []time.Time{now, now.AddDate(0, 0, 3)}
 	expectedParts = []time.Time{now, now.AddDate(0, 0, 3)}
-	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "TIDB_HOT_REGIONS", partitions, expectedParts)
+	validatePartitionCreation(ctx, now, t, sess, tk, wrk, false, "TIDB_INDEX_USAGE", partitions, expectedParts)
 
 	// this table should be updated when the repository is enabled
 	partitions = []time.Time{now}
-	createTableWithParts(ctx, t, tk, getTable(t, "DEADLOCKS", wrk), sess, partitions)
+	createTableWithParts(ctx, t, tk, getTable(t, "TIDB_STATEMENTS_STATS", wrk), sess, partitions)
 
 	// turn on the repository and see if it creates the remaining tables
 	now = time.Now()
@@ -748,17 +748,17 @@ func TestDropOldPartitions(t *testing.T) {
 	// should trim one partition
 	partitions = []time.Time{now.AddDate(0, 0, -3), now.AddDate(0, 0, -2), now.AddDate(0, 0, 1)}
 	expectedParts = []time.Time{now.AddDate(0, 0, -2), now.AddDate(0, 0, 1)}
-	validatePartitionDrop(ctx, now, t, sess, tk, wrk, "CLUSTER_LOAD", partitions, 2, false, expectedParts)
+	validatePartitionDrop(ctx, now, t, sess, tk, wrk, "DEADLOCKS", partitions, 2, false, expectedParts)
 
 	// validate that it works when not dropping any partitions
 	partitions = []time.Time{now.AddDate(0, 0, -1)}
 	expectedParts = []time.Time{now.AddDate(0, 0, -1)}
-	validatePartitionDrop(ctx, now, t, sess, tk, wrk, "TIDB_HOT_REGIONS", partitions, 2, false, expectedParts)
+	validatePartitionDrop(ctx, now, t, sess, tk, wrk, "TIDB_INDEX_USAGE", partitions, 2, false, expectedParts)
 
 	// there must be partitions, so this should error
 	partitions = []time.Time{now.AddDate(0, 0, -2)}
 	expectedParts = []time.Time{now.AddDate(0, 0, -2)}
-	validatePartitionDrop(ctx, now, t, sess, tk, wrk, "TIKV_STORE_STATUS", partitions, 1, true, expectedParts)
+	validatePartitionDrop(ctx, now, t, sess, tk, wrk, "TIDB_STATEMENTS_STATS", partitions, 1, true, expectedParts)
 }
 
 func TestAddNewPartitionsOnStart(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #59243, ref #58247 

Problem Summary: Reading from these memory tables sends requests to the PD. For sampled tables especially, this adds unwanted load to the PD. Additionally, frequently sampling `INFORMATION_SCHEMA.TIDB_HOT_REGIONS` introduces a throughput regression (#59243).

### What changed and how does it work?

The following tables are no longer snapshotted by the workload repository:
* `INFORMATION_SCHEMA.TIKV_REGION_STATUS`

The following tables are no longer sampled by the workload repository:
* `INFORMATION_SCHEMA.CLUSTER_LOAD`
* `INFORMATION_SCHEMA.TIDB_HOT_REGIONS`
* `INFORMATION_SCHEMA.TIKV_STORE_STATUS`

The partition unit tests (`TestCreatePartition` and `TestDropOldPartitions`) have also been modified to remove the excluded tables. In a couple of cases, they have been replaced with snapshotted tables instead.

(Note: While this PR technically fixes the regression reported in issue #59243, it does not address the underlying root cause. Therefore, this PR only references the issue, rather than closing it.)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
mysql> set global tidb_workload_repository_dest = 'table';                                                                                                                                                      
Query OK, 0 rows affected (0.37 sec)

mysql> show tables in workload_schema;                                                                                                                                                                          
+------------------------------------+                                                                                                                                                                          
| Tables_in_workload_schema          |                                                                                                                                                                          
+------------------------------------+
| HIST_CLIENT_ERRORS_SUMMARY_BY_HOST |
| HIST_CLIENT_ERRORS_SUMMARY_BY_USER |
| HIST_CLIENT_ERRORS_SUMMARY_GLOBAL  |
| HIST_DATA_LOCK_WAITS               |
| HIST_DEADLOCKS                     |
| HIST_MEMORY_USAGE                  |
| HIST_PROCESSLIST                   |
| HIST_SNAPSHOTS                     |
| HIST_TIDB_INDEX_USAGE              |
| HIST_TIDB_STATEMENTS_STATS         |
| HIST_TIDB_TRX                      |
+------------------------------------+
11 rows in set (0.00 sec)
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```