### PR TITLE
workloadrepo: try to recover etcd snapID from table

### DIFF
--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -50,7 +50,7 @@ go_test(
     srcs = ["worker_test.go"],
     embed = [":workloadrepo"],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/domain",
         "//pkg/infoschema",

--- a/pkg/util/workloadrepo/const.go
+++ b/pkg/util/workloadrepo/const.go
@@ -15,6 +15,7 @@
 package workloadrepo
 
 import (
+	"errors"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/errno"
@@ -46,4 +47,6 @@ var (
 	errUnsupportedEtcdRequired = dbterror.ClassUtil.NewStdErr(errno.ErrNotSupportedYet, mysql.Message("etcd client required for workload repository", nil))
 	errWorkloadNotStarted      = dbterror.ClassUtil.NewStdErr(errno.ErrNotSupportedYet, mysql.Message("Workload repository is not enabled", nil))
 	errCouldNotStartSnapshot   = dbterror.ClassUtil.NewStdErr(errno.ErrUnknown, mysql.Message("Snapshot initiation failed", nil))
+
+	errKeyNotFound = errors.New("key not found")
 )

--- a/pkg/util/workloadrepo/snapshot.go
+++ b/pkg/util/workloadrepo/snapshot.go
@@ -79,7 +79,7 @@ func (w *worker) etcdCAS(ctx context.Context, key, oval, nval string) error {
 }
 
 func queryMaxSnapID(ctx context.Context, sctx sessionctx.Context) (uint64, error) {
-	query := sqlescape.MustEscapeSQL("SELECT MAX(`SNAP_ID`) FROM %n.%n", WorkloadSchema, histSnapshotsTable)
+	query := sqlescape.MustEscapeSQL("SELECT MAX(`SNAP_ID`) FROM %n.%n", mysql.WorkloadSchema, histSnapshotsTable)
 	rs, err := runQuery(ctx, sctx, query)
 	if err != nil {
 		return 0, err

--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -139,7 +139,7 @@ func takeSnapshot(ctx context.Context) error {
 	snapID, err := workerCtx.takeSnapshot(ctx)
 	if err != nil {
 		logutil.BgLogger().Info("workload repository manual snapshot failed", zap.String("owner", workerCtx.instanceID), zap.NamedError("err", err))
-		return errCouldNotStartSnapshot.GenWithStackByArgs(err)
+		return errCouldNotStartSnapshot.GenWithStackByArgs()
 	}
 
 	logutil.BgLogger().Info("workload repository ran manual snapshot", zap.String("owner", workerCtx.instanceID), zap.Uint64("snapID", snapID))

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -61,21 +61,7 @@ func setupWorkerForTest(ctx context.Context, etcdCli *clientv3.Client, dom *doma
 	return wrk
 }
 
-func setupDomainAndContext(t *testing.T) (context.Context, kv.Storage, *domain.Domain, string) {
-	ctx := context.Background()
-	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnOthers)
-	var cancel context.CancelFunc = nil
-	if ddl, ok := t.Deadline(); ok {
-		ctx, cancel = context.WithDeadline(ctx, ddl)
-	}
-	t.Cleanup(func() {
-		if cancel != nil {
-			cancel()
-		}
-	})
-
-	store, dom := testkit.CreateMockStoreAndDomain(t)
-
+func setupEtcd(t *testing.T) string {
 	cfg := embed.NewConfig()
 	cfg.Dir = t.TempDir()
 
@@ -99,7 +85,25 @@ func setupDomainAndContext(t *testing.T) (context.Context, kv.Storage, *domain.D
 		require.False(t, true, "server took too long to start")
 	}
 
-	return ctx, store, dom, embedEtcd.Clients[0].Addr().String()
+	return embedEtcd.Clients[0].Addr().String()
+}
+
+func setupDomainAndContext(t *testing.T) (context.Context, kv.Storage, *domain.Domain, string) {
+	ctx := context.Background()
+	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnOthers)
+	var cancel context.CancelFunc = nil
+	if ddl, ok := t.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(ctx, ddl)
+	}
+	t.Cleanup(func() {
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	etcdAddr := setupEtcd(t)
+	return ctx, store, dom, etcdAddr
 }
 
 func setupWorker(ctx context.Context, t *testing.T, addr string, dom *domain.Domain, id string, testWorker bool) *worker {
@@ -957,4 +961,64 @@ func TestOwnerRandomDown(t *testing.T) {
 			})
 		}, time.Minute, 100*time.Millisecond)
 	}
+}
+
+func TestRecoverSnapID(t *testing.T) {
+	ctx, store, dom, addr := setupDomainAndContext(t)
+	worker := setupWorker(ctx, t, addr, dom, "worker1", true)
+	worker.snapshotInterval = 600
+	worker.samplingInterval = 600
+
+	require.NoError(t, worker.setRepositoryDest(ctx, "table"))
+	now := time.Now()
+
+	require.Eventually(t, func() bool {
+		return worker.checkTablesExists(ctx, now)
+	}, time.Minute, 100*time.Millisecond)
+
+	// it is zero
+	newSnapID, err := queryMaxSnapID(ctx, worker.getSessionWithRetry().(sessionctx.Context))
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), newSnapID)
+
+	// start the worker
+	tk := testkit.NewTestKit(t, store)
+	worker.changeSnapshotInterval(context.TODO(), "1")
+	prevSnapID := uint64(0)
+	require.Eventually(t, func() bool {
+		res := tk.MustQuery("select max(snap_id) from workload_schema.hist_snapshots").Rows()
+		if len(res) == 0 || len(res[0]) == 0 {
+			return false
+		}
+		snapID, err := strconv.ParseUint(res[0][0].(string), 10, 64)
+		prevSnapID = snapID
+		return err == nil && snapID > 0
+	}, time.Minute, 100*time.Millisecond)
+
+	// wait for worker to stop
+	worker.stop()
+	require.Eventually(t, func() bool {
+		return worker.cancel == nil
+	}, time.Second*10, time.Millisecond*100)
+
+	// setup a new etcd cluster and a new worker
+	etcd2 := setupEtcd(t)
+	worker2 := setupWorker(ctx, t, etcd2, dom, "worker2", true)
+	// new cluster, so not found
+	snapIDStr, err := worker2.etcdGet(ctx, snapIDKey)
+	require.Nil(t, err)
+	require.Equal(t, "", snapIDStr)
+	_, err = worker2.getSnapID(ctx)
+	require.EqualError(t, errKeyNotFound, err.Error())
+	// it is equal to the previous maximum snap id
+	newSnapID, err = queryMaxSnapID(ctx, worker2.getSessionWithRetry().(sessionctx.Context))
+	require.Nil(t, err)
+	require.Equal(t, newSnapID, prevSnapID)
+
+	// start the new worker and snapID is recovered
+	require.NoError(t, worker2.setRepositoryDest(ctx, "table"))
+	require.Eventually(t, func() bool {
+		newSnapID, err = worker2.getSnapID(ctx)
+		return err == nil && newSnapID >= prevSnapID
+	}, time.Minute, 100*time.Millisecond)
 }

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -884,6 +884,17 @@ func TestOwnerRandomDown(t *testing.T) {
 		return workers[0].checkTablesExists(ctx, now)
 	}, time.Minute, 100*time.Millisecond)
 
+	require.Eventually(t, func() bool {
+		var err error
+		for _, wrk := range workers {
+			if wrk.owner.IsOwner() {
+				_, err = wrk.getSnapID(ctx)
+				break
+			}
+		}
+		return err == nil
+	}, time.Minute, 100*time.Millisecond)
+
 	// let us randomly stop the owner
 	for j := 0; j < testNum; j++ {
 		var err error


### PR DESCRIPTION

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:  ref #58247

Problem Summary: Serverless TiDB wants a specialized auto-scalable etcd cluster for etcd usages in TiDB, rather than relying on PD. However, moving from PD to the new etcd cluster will also remove all persistent data on PD. We can workaround this by recovering snapID from table.

Also check tidbcloud/tidb-cse#1522

### What changed and how does it work?

As title.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
