### PR TITLE
planner: revert support sub-merge needEnforceExchanger

### DIFF
--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -2646,8 +2646,17 @@ func (t *MppTask) needEnforceExchanger(prop *property.PhysicalProperty) bool {
 			return true
 		}
 		// TODO: consider equalivant class
+		// TODO: `prop.IsSubsetOf` is enough, instead of equal.
 		// for example, if already partitioned by hash(B,C), then same (A,B,C) must distribute on a same node.
-		return !prop.IsSubset(t.hashCols)
+		if len(prop.MPPPartitionCols) != len(t.hashCols) {
+			return true
+		}
+		for i, col := range prop.MPPPartitionCols {
+			if !col.Equal(t.hashCols[i]) {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -2646,7 +2646,6 @@ func (t *MppTask) needEnforceExchanger(prop *property.PhysicalProperty) bool {
 			return true
 		}
 		// TODO: consider equalivant class
-		// TODO: `prop.IsSubsetOf` is enough, instead of equal.
 		// for example, if already partitioned by hash(B,C), then same (A,B,C) must distribute on a same node.
 		if len(prop.MPPPartitionCols) != len(t.hashCols) {
 			return true

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -297,21 +297,6 @@ func (p *PhysicalProperty) IsSubsetOf(keys []*MPPPartitionColumn) []int {
 	return matches
 }
 
-// IsSubset check if the keys can match the needs of partition.
-func (p *PhysicalProperty) IsSubset(keys []*MPPPartitionColumn) bool {
-	if len(p.MPPPartitionCols) > len(keys) {
-		return false
-	}
-	for _, partCol := range p.MPPPartitionCols {
-		for _, key := range keys {
-			if !partCol.Equal(key) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 // AllColsFromSchema checks whether all the columns needed by this physical
 // property can be found in the given schema.
 func (p *PhysicalProperty) AllColsFromSchema(schema *expression.Schema) bool {


### PR DESCRIPTION
This reverts commit 41c60da715d96a3a708ad0824dd5b544e8c25d0b.
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #38610

Problem Summary:

### What changed and how does it work?

it is some problem in this PR

```
if len(p.MPPPartitionCols) > len(keys) {
```

it is wrong. we must add an exchanger here.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
