### PR TITLE
statistics: unexport the important fields of Column

### DIFF
--- a/cmd/importer/main.go
+++ b/cmd/importer/main.go
@@ -69,7 +69,7 @@ func main() {
 		for i, colInfo := range table.tblInfo.Columns {
 			if hist := statsInfo.GetCol(colInfo.ID); hist != nil && table.columns[i].hist == nil && len(hist.Buckets) > 0 {
 				table.columns[i].hist = &histogram{
-					Histogram: hist.Histogram,
+					Histogram: *hist.GetHistogramImmutable(),
 				}
 			}
 		}

--- a/pkg/planner/cardinality/ndv.go
+++ b/pkg/planner/cardinality/ndv.go
@@ -31,7 +31,7 @@ const distinctFactor = 0.8
 func EstimateColumnNDV(tbl *statistics.Table, colID int64) (ndv float64) {
 	hist := tbl.GetCol(colID)
 	if hist != nil && hist.IsStatsInitialized() {
-		ndv = float64(hist.Histogram.NDV)
+		ndv = float64(hist.SelfNDV())
 		// TODO: a better way to get the total row count derived from the last analyze.
 		analyzeCount := getTotalRowCount(tbl, hist)
 		if analyzeCount > 0 {

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -344,8 +344,8 @@ func getIndexRowCountForStatsV2(sctx planctx.PlanContext, idx *statistics.Index,
 				c := coll.GetCol(idx.Histogram.ID)
 				// If this is single column of a multi-column index - use the column's NDV rather than index NDV
 				isSingleColRange := len(indexRange.LowVal) == len(indexRange.HighVal) && len(indexRange.LowVal) == 1
-				if isSingleColRange && !isSingleColIdx && c != nil && c.Histogram.NDV > 0 {
-					histNDV = c.Histogram.NDV - int64(c.TopN.Num())
+				if isSingleColRange && !isSingleColIdx && c != nil && c.SelfNDV() > 0 {
+					histNDV = c.SelfNDV() - int64(c.TopNNum())
 				} else {
 					histNDV -= int64(idx.TopN.Num())
 				}

--- a/pkg/planner/cardinality/row_size.go
+++ b/pkg/planner/cardinality/row_size.go
@@ -132,7 +132,7 @@ func AvgColSize(c *statistics.Column, count int64, isKey bool) float64 {
 	if histCount > 0 {
 		notNullRatio = max(0, 1.0-float64(c.NullCount)/histCount)
 	}
-	switch c.Histogram.Tp.GetType() {
+	switch c.Info.GetType() {
 	case mysql.TypeFloat, mysql.TypeDouble, mysql.TypeDuration, mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
 		return 8 * notNullRatio
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear, mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet:
@@ -150,7 +150,7 @@ func AvgColSizeChunkFormat(c *statistics.Column, count int64) float64 {
 	if count == 0 {
 		return 0
 	}
-	fixedLen := chunk.GetFixedLen(c.Histogram.Tp)
+	fixedLen := chunk.GetFixedLen(&c.Info.FieldType)
 	if fixedLen >= 0 {
 		return float64(fixedLen)
 	}
@@ -175,7 +175,7 @@ func AvgColSizeDataInDiskByRows(c *statistics.Column, count int64) float64 {
 	if histCount > 0 {
 		notNullRatio = 1.0 - float64(c.NullCount)/histCount
 	}
-	size := chunk.GetFixedLen(c.Histogram.Tp)
+	size := chunk.GetFixedLen(&c.Info.FieldType)
 	if size >= 0 {
 		return float64(size) * notNullRatio
 	}

--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -322,12 +322,12 @@ func TestAnalyzeVectorIndex(t *testing.T) {
 	col := statsTbl.GetCol(1)
 	require.NotNil(t, col)
 	// It has stats.
-	require.True(t, (col.Histogram.Len()+col.TopN.Num()) > 0)
+	require.True(t, (col.HistBucketNum()+col.TopNNum()) > 0)
 	// vec col
 	col = statsTbl.GetCol(2)
 	require.NotNil(t, col)
 	// It doesn't have stats.
-	require.False(t, (col.Histogram.Len()+col.TopN.Num()) > 0)
+	require.False(t, (col.HistBucketNum()+col.TopNNum()) > 0)
 
 	tk.MustExec("set tidb_analyze_version=1")
 	tk.MustExec("analyze table t")

--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -255,7 +255,7 @@ func countFullStats(stats *statistics.HistColl, colID int64) int {
 	cnt := -1
 	stats.ForEachColumnImmutable(func(_ int64, col *statistics.Column) bool {
 		if col.Info.ID == colID {
-			cnt = col.Histogram.Len() + col.TopN.Num()
+			cnt = col.HistBucketNum() + col.TopNNum()
 			return true
 		}
 		return false

--- a/pkg/statistics/cmsketch.go
+++ b/pkg/statistics/cmsketch.go
@@ -622,6 +622,16 @@ func (c *TopN) MinCount() uint64 {
 	return minCount
 }
 
+// ForEachImmutable iterates the TopN and calls the given function without any modification.
+// The bool return value of f is used to control the iteration. If f returns true, the iteration will be stopped.
+func (c *TopN) ForEachImmutable(f func([]byte, uint64) bool) {
+	for _, t := range c.TopN {
+		if f(t.Encoded, t.Count) {
+			break
+		}
+	}
+}
+
 // TopNMeta stores the unit of the TopN.
 type TopNMeta struct {
 	Encoded []byte

--- a/pkg/statistics/debugtrace.go
+++ b/pkg/statistics/debugtrace.go
@@ -87,17 +87,16 @@ func traceColStats(colStats *Column, id int64, out *statsTblColOrIdxInfo) {
 	out.Correlation = colStats.Correlation
 	out.StatsVer = colStats.StatsVer
 	out.LoadingStatus = colStats.StatsLoadedStatus.StatusToString()
-	if colStats.Histogram.Buckets == nil {
+	out.HistogramSize = colStats.HistBucketNum()
+	if out.HistogramSize == 0 {
 		out.HistogramSize = -1
-	} else {
-		out.HistogramSize = len(colStats.Histogram.Buckets)
 	}
-	if colStats.TopN == nil {
+	if !colStats.HasTopN() {
 		out.TopNSize = -1
 	} else {
-		out.TopNSize = len(colStats.TopN.TopN)
+		out.TopNSize = colStats.TopNNum()
 	}
-	out.CMSketchInfo = traceCMSketchInfo(colStats.CMSketch)
+	out.CMSketchInfo = traceCMSketchInfo(colStats.GetCMSketchImmutable())
 }
 
 func traceIdxStats(idxStats *Index, id int64, out *statsTblColOrIdxInfo) {

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory_test.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory_test.go
@@ -251,18 +251,12 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 			partitionStats: map[priorityqueue.PartitionIDAndName]*statistics.Table{
 				priorityqueue.NewPartitionIDAndName("p0", 1): {
 					HistColl: *statistics.NewHistCollWithColsAndIdxs(0, statistics.AutoAnalyzeMinCnt+1, (statistics.AutoAnalyzeMinCnt+1)*2, map[int64]*statistics.Column{
-						1: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
-						2: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
+						1: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
+						2: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
 					}, nil),
 					Version:               currentTs,
 					ColAndIdxExistenceMap: analyzedMap,
@@ -270,18 +264,12 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 				},
 				priorityqueue.NewPartitionIDAndName("p1", 2): {
 					HistColl: *statistics.NewHistCollWithColsAndIdxs(0, statistics.AutoAnalyzeMinCnt+1, 0, map[int64]*statistics.Column{
-						1: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
-						2: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
+						1: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
+						2: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
 					}, nil),
 					Version:               currentTs,
 					ColAndIdxExistenceMap: analyzedMap,
@@ -313,18 +301,12 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 			partitionStats: map[priorityqueue.PartitionIDAndName]*statistics.Table{
 				priorityqueue.NewPartitionIDAndName("p0", 1): {
 					HistColl: *statistics.NewHistCollWithColsAndIdxs(0, statistics.AutoAnalyzeMinCnt+1, 0, map[int64]*statistics.Column{
-						1: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
-						2: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
+						1: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
+						2: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
 					}, nil),
 					Version:               currentTs,
 					ColAndIdxExistenceMap: analyzedMap,
@@ -332,18 +314,12 @@ func TestCalculateIndicatorsForPartitions(t *testing.T) {
 				},
 				priorityqueue.NewPartitionIDAndName("p1", 2): {
 					HistColl: *statistics.NewHistCollWithColsAndIdxs(0, statistics.AutoAnalyzeMinCnt+1, 0, map[int64]*statistics.Column{
-						1: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
-						2: {
-							StatsVer: 2,
-							Histogram: statistics.Histogram{
-								LastUpdateVersion: lastUpdateTs,
-							},
-						},
+						1: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
+						2: statistics.NewColumn(nil, 0, false, nil, nil, nil, statistics.Histogram{
+							LastUpdateVersion: lastUpdateTs,
+						}, 2),
 					}, nil),
 					Version:               currentTs,
 					ColAndIdxExistenceMap: analyzedMap,

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache_test.go
@@ -218,11 +218,11 @@ func TestLFUCachePutGetWithManyConcurrencyAndSmallConcurrency(t *testing.T) {
 func checkTable(t *testing.T, tbl *statistics.Table) {
 	tbl.ForEachColumnImmutable(func(_ int64, column *statistics.Column) bool {
 		if column.GetEvictedStatus() == statistics.AllEvicted {
-			require.Nil(t, column.TopN)
-			require.Equal(t, 0, cap(column.Histogram.Buckets))
+			require.False(t, column.HasTopN())
+			require.Equal(t, 0, cap(column.GetHistogramImmutable().Buckets))
 		} else {
-			require.NotNil(t, column.TopN)
-			require.Greater(t, cap(column.Histogram.Buckets), 0)
+			require.True(t, column.HasTopN())
+			require.Greater(t, cap(column.GetHistogramImmutable().Buckets), 0)
 		}
 		return false
 	})

--- a/pkg/statistics/handle/cache/internal/testutil/testutil.go
+++ b/pkg/statistics/handle/cache/internal/testutil/testutil.go
@@ -41,13 +41,16 @@ func NewMockStatisticsTable(columns int, indices int, withCMS, withTopN, withHis
 		if withHist {
 			hist = *statistics.NewHistogram(0, 10, 0, 0, types.NewFieldType(mysql.TypeBlob), 1, 0)
 		}
-		t.SetCol(int64(i), &statistics.Column{
-			Info:              &model.ColumnInfo{ID: int64(i)},
-			StatsLoadedStatus: statistics.NewStatsFullLoadStatus(),
-			CMSketch:          cms,
-			TopN:              topn,
-			Histogram:         hist,
-		})
+		t.SetCol(int64(i), statistics.NewColumn(
+			&model.ColumnInfo{ID: int64(i)},
+			0,
+			false,
+			cms,
+			topn,
+			nil,
+			hist,
+			0,
+		))
 	}
 	for i := 1; i <= indices; i++ {
 		var (
@@ -79,10 +82,16 @@ func NewMockStatisticsTable(columns int, indices int, withCMS, withTopN, withHis
 // MockTableAppendColumn appends a column to the table.
 func MockTableAppendColumn(t *statistics.Table) {
 	index := int64(t.ColNum() + 1)
-	t.SetCol(index, &statistics.Column{
-		Info:     &model.ColumnInfo{ID: index},
-		CMSketch: statistics.NewCMSketch(1, 1),
-	})
+	t.SetCol(index, statistics.NewColumn(
+		&model.ColumnInfo{ID: index},
+		0,
+		false,
+		statistics.NewCMSketch(1, 1),
+		nil,
+		nil,
+		statistics.Histogram{},
+		0,
+	))
 }
 
 // MockTableAppendIndex appends an index to the table.

--- a/pkg/statistics/handle/ddl/ddl_test.go
+++ b/pkg/statistics/handle/ddl/ddl_test.go
@@ -313,7 +313,7 @@ func TestDDLHistogram(t *testing.T) {
 	require.False(t, statsTbl.Pseudo)
 	require.True(t, statsTbl.GetCol(tableInfo.Columns[2].ID).IsStatsInitialized())
 	require.Equal(t, int64(2), statsTbl.GetCol(tableInfo.Columns[2].ID).NullCount)
-	require.Equal(t, int64(0), statsTbl.GetCol(tableInfo.Columns[2].ID).Histogram.NDV)
+	require.Equal(t, int64(0), statsTbl.GetCol(tableInfo.Columns[2].ID).SelfNDV())
 
 	testKit.MustExec("alter table t add column c3 int NOT NULL")
 	err = statstestutil.HandleNextDDLEventWithTxn(h)

--- a/pkg/statistics/handle/handletest/analyze/analyze_test.go
+++ b/pkg/statistics/handle/handletest/analyze/analyze_test.go
@@ -64,7 +64,7 @@ func checkForGlobalStatsWithOpts(t *testing.T, dom *domain.Domain, db, tt, pp st
 		if len(colStats.Buckets) == 0 {
 			return false // it's not loaded
 		}
-		numTopN := colStats.TopN.Num()
+		numTopN := colStats.TopNNum()
 		numBuckets := len(colStats.Buckets)
 		require.Equal(t, topn, numTopN)
 		require.GreaterOrEqual(t, numBuckets, buckets-delta)

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -350,7 +350,7 @@ func TestInitStats51358(t *testing.T) {
 	stats.ForEachColumnImmutable(func(_ int64, column *statistics.Column) bool {
 		if mysql.HasPriKeyFlag(column.Info.GetFlag()) {
 			// primary key column has no stats info, because primary key's is_index is false. so it cannot load the topn
-			require.Nil(t, column.TopN)
+			require.False(t, column.HasTopN())
 		}
 		require.False(t, column.IsFullLoad())
 		return false

--- a/pkg/statistics/handle/internal/testutil.go
+++ b/pkg/statistics/handle/internal/testutil.go
@@ -29,14 +29,15 @@ func AssertTableEqual(t *testing.T, a *statistics.Table, b *statistics.Table) {
 	a.ForEachColumnImmutable(func(id int64, col *statistics.Column) bool {
 		bCol := b.GetCol(id)
 		require.NotNil(t, bCol)
-		require.True(t, statistics.HistogramEqual(&col.Histogram, &bCol.Histogram, false))
-		if col.CMSketch == nil {
-			require.Nil(t, bCol.CMSketch)
+		require.True(t, statistics.HistogramEqual(col.GetHistogramImmutable(), bCol.GetHistogramImmutable(), false))
+		cms := col.GetCMSketchImmutable()
+		if cms == nil {
+			require.Nil(t, bCol.GetCMSketchImmutable())
 		} else {
-			require.True(t, col.CMSketch.Equal(bCol.CMSketch))
+			require.True(t, cms.Equal(bCol.GetCMSketchImmutable()))
 		}
 		// The nil case has been considered in (*TopN).Equal() so we don't need to consider it here.
-		require.Truef(t, col.TopN.Equal(bCol.TopN), "%v, %v", col.TopN, bCol.TopN)
+		require.Truef(t, col.GetTopNImmutable().Equal(bCol.GetTopNImmutable()), "%v, %v", col.GetTopNImmutable(), bCol.GetTopNImmutable())
 		return false
 	})
 	require.Equal(t, a.IdxNum(), b.IdxNum())

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -587,7 +587,7 @@ func (s *statsReadWriter) loadStatsFromJSON(tableInfo *model.TableInfo, physical
 		// loadStatsFromJSON doesn't support partition table now.
 		// The table level count and modify_count would be overridden by the SaveMetaToStorage below, so we don't need
 		// to care about them here.
-		if err := s.SaveStatsToStorage(tbl.PhysicalID, tbl.RealtimeCount, 0, 0, &col.Histogram, col.CMSketch, col.TopN, int(col.GetStatsVer()), false, util.StatsMetaHistorySourceLoadStats); err != nil {
+		if err := s.SaveStatsToStorage(tbl.PhysicalID, tbl.RealtimeCount, 0, 0, col.GetHistogramImmutable(), col.GetCMSketchImmutable(), col.GetTopNImmutable(), int(col.GetStatsVer()), false, util.StatsMetaHistorySourceLoadStats); err != nil {
 			outerErr = err
 			return true
 		}

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -466,16 +466,7 @@ func (*statsSyncLoad) readStatsForOneItem(sctx sessionctx.Context, item model.Ta
 		}
 		w.idx = idxHist
 	} else {
-		colHist := &statistics.Column{
-			PhysicalID: item.TableID,
-			Histogram:  *hg,
-			Info:       w.colInfo,
-			CMSketch:   cms,
-			TopN:       topN,
-			FMSketch:   fms,
-			IsHandle:   isPkIsHandle && mysql.HasPriKeyFlag(w.colInfo.GetFlag()),
-			StatsVer:   statsVer,
-		}
+		colHist := statistics.NewColumn(w.colInfo, item.TableID, isPkIsHandle && mysql.HasPriKeyFlag(w.colInfo.GetFlag()), cms, topN, fms, *hg, statsVer)
 		if colHist.StatsAvailable() {
 			if fullLoad {
 				colHist.StatsLoadedStatus = statistics.NewStatsFullLoadStatus()

--- a/pkg/statistics/statistics_test.go
+++ b/pkg/statistics/statistics_test.go
@@ -221,7 +221,7 @@ func SubTestColumnRange() func(*testing.T) {
 		require.NoError(t, err)
 		col := &Column{
 			Histogram:         *hg,
-			CMSketch:          buildCMSketch(s.rc.(*recordSet).data),
+			cmSketch:          buildCMSketch(s.rc.(*recordSet).data),
 			Info:              &model.ColumnInfo{},
 			StatsLoadedStatus: NewStatsFullLoadStatus(),
 		}

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -712,11 +712,11 @@ func (t *Table) GetStatsInfo(id int64, isIndex bool, needCopy bool) (*Histogram,
 	}
 	if colStatsInfo, ok := t.columns[id]; ok {
 		if needCopy {
-			return colStatsInfo.Histogram.Copy(), colStatsInfo.CMSketch.Copy(),
-				colStatsInfo.TopN.Copy(), colStatsInfo.FMSketch.Copy(), true
+			return colStatsInfo.Histogram.Copy(), colStatsInfo.cmSketch.Copy(),
+				colStatsInfo.topN.Copy(), colStatsInfo.FMSketch.Copy(), true
 		}
-		return &colStatsInfo.Histogram, colStatsInfo.CMSketch,
-			colStatsInfo.TopN, colStatsInfo.FMSketch, true
+		return &colStatsInfo.Histogram, colStatsInfo.cmSketch,
+			colStatsInfo.topN, colStatsInfo.FMSketch, true
 	}
 	// newly added column which is not analyzed yet
 	return nil, nil, nil, nil, false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/57949, ref https://github.com/pingcap/tidb/issues/52486, ref https://github.com/pingcap/tidb/issues/53666

Problem Summary:

### What changed and how does it work?

this pull unexports the memory awarded part of the column object.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
