### PR TITLE
import: add a hidden option to enable manual recover for debug purpose

### DIFF
--- a/pkg/disttask/framework/mock/plan_mock.go
+++ b/pkg/disttask/framework/mock/plan_mock.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	planner "github.com/pingcap/tidb/pkg/disttask/framework/planner"
+	proto "github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -56,6 +57,20 @@ func (m *MockLogicalPlan) FromTaskMeta(arg0 []byte) error {
 func (mr *MockLogicalPlanMockRecorder) FromTaskMeta(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromTaskMeta", reflect.TypeOf((*MockLogicalPlan)(nil).FromTaskMeta), arg0)
+}
+
+// GetTaskExtraParams mocks base method.
+func (m *MockLogicalPlan) GetTaskExtraParams() proto.ExtraParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTaskExtraParams")
+	ret0, _ := ret[0].(proto.ExtraParams)
+	return ret0
+}
+
+// GetTaskExtraParams indicates an expected call of GetTaskExtraParams.
+func (mr *MockLogicalPlanMockRecorder) GetTaskExtraParams() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskExtraParams", reflect.TypeOf((*MockLogicalPlan)(nil).GetTaskExtraParams))
 }
 
 // ToPhysicalPlan mocks base method.

--- a/pkg/disttask/framework/planner/BUILD.bazel
+++ b/pkg/disttask/framework/planner/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         ":planner",
         "//pkg/disttask/framework/mock",
+        "//pkg/disttask/framework/proto",
         "//pkg/disttask/framework/storage",
         "//pkg/kv",
         "//pkg/testkit",

--- a/pkg/disttask/framework/planner/plan.go
+++ b/pkg/disttask/framework/planner/plan.go
@@ -49,6 +49,7 @@ type PlanCtx struct {
 // To integrate with current distribute framework, the flow becomes:
 // logical plan -> task meta -> physical plan -> subtaskmetas -> pipelines.
 type LogicalPlan interface {
+	GetTaskExtraParams() proto.ExtraParams
 	ToTaskMeta() ([]byte, error)
 	FromTaskMeta([]byte) error
 	ToPhysicalPlan(PlanCtx) (*PhysicalPlan, error)

--- a/pkg/disttask/framework/planner/planner.go
+++ b/pkg/disttask/framework/planner/planner.go
@@ -16,7 +16,6 @@ package planner
 
 import (
 	"github.com/pingcap/tidb/pkg/config"
-	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
 )
 
@@ -48,7 +47,7 @@ func (*Planner) Run(planCtx PlanCtx, plan LogicalPlan) (int64, error) {
 		planCtx.ThreadCnt,
 		config.GetGlobalConfig().Instance.TiDBServiceScope,
 		planCtx.MaxNodeCnt,
-		proto.ExtraParams{},
+		plan.GetTaskExtraParams(),
 		taskMeta,
 	)
 }

--- a/pkg/disttask/framework/planner/planner_test.go
+++ b/pkg/disttask/framework/planner/planner_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ngaut/pools"
 	"github.com/pingcap/tidb/pkg/disttask/framework/mock"
 	"github.com/pingcap/tidb/pkg/disttask/framework/planner"
+	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -55,7 +56,12 @@ func TestPlanner(t *testing.T) {
 	}
 	mockLogicalPlan := mock.NewMockLogicalPlan(ctrl)
 	mockLogicalPlan.EXPECT().ToTaskMeta().Return([]byte("mock"), nil)
+	mockLogicalPlan.EXPECT().GetTaskExtraParams().Return(proto.ExtraParams{ManualRecovery: true})
 	taskID, err := p.Run(pCtx, mockLogicalPlan)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), taskID)
+	task, err := mgr.GetTaskByID(ctx, taskID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, task.Concurrency)
+	require.EqualValues(t, "example", task.Type)
+	require.True(t, task.ManualRecovery)
 }

--- a/pkg/disttask/importinto/job_testkit_test.go
+++ b/pkg/disttask/importinto/job_testkit_test.go
@@ -73,9 +73,9 @@ func TestGetTaskImportedRows(t *testing.T) {
 		testutil.CreateSubTask(t, manager, taskID, proto.ImportStepImport,
 			"", bytes, proto.ImportInto, 11)
 	}
-	rows, err := importinto.GetTaskImportedRows(ctx, 111)
+	runInfo, err := importinto.GetRuntimeInfoForJob(ctx, 111)
 	require.NoError(t, err)
-	require.Equal(t, uint64(3), rows)
+	require.Equal(t, uint64(3), runInfo.ImportRows)
 
 	// global sort
 	taskMeta = importinto.TaskMeta{
@@ -105,7 +105,7 @@ func TestGetTaskImportedRows(t *testing.T) {
 		testutil.CreateSubTask(t, manager, taskID, proto.ImportStepWriteAndIngest,
 			"", bytes, proto.ImportInto, 11)
 	}
-	rows, err = importinto.GetTaskImportedRows(ctx, 222)
+	runInfo, err = importinto.GetRuntimeInfoForJob(ctx, 222)
 	require.NoError(t, err)
-	require.Equal(t, uint64(33), rows)
+	require.Equal(t, uint64(33), runInfo.ImportRows)
 }

--- a/pkg/disttask/importinto/planner.go
+++ b/pkg/disttask/importinto/planner.go
@@ -57,6 +57,13 @@ type LogicalPlan struct {
 	ChunkMap          map[int32][]importer.Chunk
 }
 
+// GetTaskExtraParams implements the planner.LogicalPlan interface.
+func (p *LogicalPlan) GetTaskExtraParams() proto.ExtraParams {
+	return proto.ExtraParams{
+		ManualRecovery: p.Plan.ManualRecovery,
+	}
+}
+
 // ToTaskMeta converts the logical plan to task meta.
 func (p *LogicalPlan) ToTaskMeta() ([]byte, error) {
 	taskMeta := TaskMeta{

--- a/pkg/disttask/importinto/scheduler.go
+++ b/pkg/disttask/importinto/scheduler.go
@@ -378,13 +378,17 @@ func (sch *importScheduler) OnDone(ctx context.Context, handle storage.TaskHandl
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if task.Error == nil {
-		return sch.finishJob(ctx, logger, handle, task, taskMeta)
+	if task.State == proto.TaskStateReverting {
+		errMsg := ""
+		if task.Error != nil {
+			if scheduler.IsCancelledErr(task.Error) {
+				return sch.cancelJob(ctx, handle, task, taskMeta, logger)
+			}
+			errMsg = task.Error.Error()
+		}
+		return sch.failJob(ctx, handle, task, taskMeta, logger, errMsg)
 	}
-	if scheduler.IsCancelledErr(task.Error) {
-		return sch.cancelJob(ctx, handle, task, taskMeta, logger)
-	}
-	return sch.failJob(ctx, handle, task, taskMeta, logger, task.Error.Error())
+	return sch.finishJob(ctx, logger, handle, task, taskMeta)
 }
 
 // GetEligibleInstances implements scheduler.Extension interface.

--- a/pkg/executor/import_into.go
+++ b/pkg/executor/import_into.go
@@ -201,7 +201,7 @@ func (e *ImportIntoExec) fillJobInfo(ctx context.Context, jobID int64, req *chun
 	}); err != nil {
 		return err
 	}
-	FillOneImportJobInfo(info, req, unknownImportedRowCount)
+	FillOneImportJobInfo(req, info, unknownImportedRowCount)
 	return nil
 }
 

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -101,8 +101,9 @@ const (
 	cloudStorageURIOption       = "cloud_storage_uri"
 	disablePrecheckOption       = "disable_precheck"
 	// used for test
-	maxEngineSizeOption = "__max_engine_size"
-	forceMergeStep      = "__force_merge_step"
+	maxEngineSizeOption  = "__max_engine_size"
+	forceMergeStep       = "__force_merge_step"
+	manualRecoveryOption = "__manual_recovery"
 )
 
 var (
@@ -126,6 +127,7 @@ var (
 		disableTiKVImportModeOption: false,
 		maxEngineSizeOption:         true,
 		forceMergeStep:              false,
+		manualRecoveryOption:        false,
 		cloudStorageURIOption:       true,
 		disablePrecheckOption:       false,
 	}
@@ -258,6 +260,8 @@ type Plan struct {
 	TotalFileSize int64
 	// used in tests to force enable merge-step when using global sort.
 	ForceMergeStep bool
+	// see ManualRecovery in proto.ExtraParams
+	ManualRecovery bool
 }
 
 // ASTArgs is the arguments for ast.LoadDataStmt.
@@ -752,6 +756,9 @@ func (p *Plan) initOptions(ctx context.Context, seCtx sessionctx.Context, option
 	}
 	if _, ok := specifiedOptions[forceMergeStep]; ok {
 		p.ForceMergeStep = true
+	}
+	if _, ok := specifiedOptions[manualRecoveryOption]; ok {
+		p.ManualRecovery = true
 	}
 
 	if sv, ok := seCtx.GetSessionVars().GetSystemVar(vardef.TiDBMaxDistTaskNodes); ok {

--- a/pkg/executor/show_test.go
+++ b/pkg/executor/show_test.go
@@ -48,12 +48,12 @@ func Test_fillOneImportJobInfo(t *testing.T) {
 	jobInfo := &importer.JobInfo{
 		Parameters: importer.ImportParameters{},
 	}
-	executor.FillOneImportJobInfo(jobInfo, c, -1)
+	executor.FillOneImportJobInfo(c, jobInfo, -1)
 	require.True(t, c.GetRow(0).IsNull(7))
 	require.True(t, c.GetRow(0).IsNull(10))
 	require.True(t, c.GetRow(0).IsNull(11))
 
-	executor.FillOneImportJobInfo(jobInfo, c, 0)
+	executor.FillOneImportJobInfo(c, jobInfo, 0)
 	require.False(t, c.GetRow(1).IsNull(7))
 	require.Equal(t, uint64(0), c.GetRow(1).GetUint64(7))
 	require.True(t, c.GetRow(1).IsNull(10))
@@ -62,7 +62,7 @@ func Test_fillOneImportJobInfo(t *testing.T) {
 	jobInfo.Summary = &importer.JobSummary{ImportedRows: 123}
 	jobInfo.StartTime = types.NewTime(types.FromGoTime(time.Now()), mysql.TypeTimestamp, 0)
 	jobInfo.EndTime = types.NewTime(types.FromGoTime(time.Now()), mysql.TypeTimestamp, 0)
-	executor.FillOneImportJobInfo(jobInfo, c, 0)
+	executor.FillOneImportJobInfo(c, jobInfo, 0)
 	require.False(t, c.GetRow(2).IsNull(7))
 	require.Equal(t, uint64(123), c.GetRow(2).GetUint64(7))
 	require.False(t, c.GetRow(2).IsNull(10))

--- a/tests/realtikvtest/importintotest4/BUILD.bazel
+++ b/tests/realtikvtest/importintotest4/BUILD.bazel
@@ -6,12 +6,14 @@ go_test(
     srcs = [
         "global_sort_test.go",
         "main_test.go",
+        "manual_recovery_test.go",
         "split_file_test.go",
     ],
     flaky = True,
     race = "on",
     deps = [
         "//pkg/config",
+        "//pkg/disttask/framework/handle",
         "//pkg/disttask/framework/proto",
         "//pkg/disttask/framework/storage",
         "//pkg/disttask/framework/testutil",

--- a/tests/realtikvtest/importintotest4/manual_recovery_test.go
+++ b/tests/realtikvtest/importintotest4/manual_recovery_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importintotest
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/pingcap/tidb/pkg/disttask/framework/handle"
+	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
+	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
+	"github.com/pingcap/tidb/pkg/disttask/importinto"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/tikv/client-go/v2/util"
+)
+
+func (s *mockGCSSuite) runTaskToAwaitingState() (context.Context, *proto.Task) {
+	ctx := context.Background()
+	ctx = util.WithInternalSourceType(ctx, "table_test")
+	s.server.CreateObject(fakestorage.Object{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "resolution", Name: "a.csv"},
+		Content:     []byte("aaa,bbb"),
+	})
+	s.prepareAndUseDB("resolution")
+	// use default sql_mode
+	s.tk.MustExec("set @@sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'")
+	s.tk.MustExec("create table t (a int primary key, b int);")
+	importSQL := fmt.Sprintf(`import into t FROM 'gs://resolution/a.csv?endpoint=%s' with detached, __manual_recovery`, gcsEndpoint)
+	rows := s.tk.MustQuery(importSQL).Rows()
+	s.Len(rows, 1)
+	jobID, err := strconv.Atoi(rows[0][0].(string))
+	s.NoError(err)
+	taskManager, err := storage.GetTaskManager()
+	s.NoError(err)
+	task, err := taskManager.GetTaskByKeyWithHistory(ctx, importinto.TaskKey(int64(jobID)))
+	s.NoError(err)
+	_, err = handle.WaitTask(ctx, task.ID, func(t *proto.TaskBase) bool {
+		return t.State == proto.TaskStateAwaitingResolution
+	})
+	s.NoError(err)
+	rows = s.tk.MustQuery(fmt.Sprintf("show import job %d", jobID)).Rows()
+	s.Len(rows, 1)
+	s.EqualValues("awaiting-resolution", rows[0][5])
+	s.Contains(rows[0][8].(string), "incorrect DOUBLE value")
+	return ctx, task
+}
+
+func (s *mockGCSSuite) TestResolutionFailTheTask() {
+	ctx, task := s.runTaskToAwaitingState()
+	s.tk.MustExec(fmt.Sprintf("update mysql.tidb_global_task set state='reverting' where id=%d", task.ID))
+	_, err := handle.WaitTask(ctx, task.ID, func(t *proto.TaskBase) bool {
+		return t.State == proto.TaskStateReverted
+	})
+	s.NoError(err)
+	s.tk.MustQuery("select * from t").Check(testkit.Rows())
+}
+
+func (s *mockGCSSuite) TestResolutionSuccessAfterManualChangeData() {
+	ctx, task := s.runTaskToAwaitingState()
+	s.server.CreateObject(fakestorage.Object{
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "resolution", Name: "a.csv"},
+		Content:     []byte("1,2"),
+	})
+	s.tk.MustExec(fmt.Sprintf("update mysql.tidb_background_subtask set state='pending' where state='failed' and task_key='%d'", task.ID))
+	s.tk.MustExec(fmt.Sprintf("update mysql.tidb_global_task set state='running' where id=%d", task.ID))
+	s.NoError(handle.WaitTaskDoneOrPaused(ctx, task.ID))
+	s.tk.MustQuery("select * from t").Check(testkit.Rows("1 2"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #59640 

Problem Summary:

### What changed and how does it work?
after https://github.com/pingcap/tidb/pull/59641, import into can integrate it.

for the step to do `manual recovery`, see the example in https://github.com/pingcap/tidb/pull/59599
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
