### PR TITLE
br: error out if pitr with table filter has exchange partition in/out filter range

### DIFF
--- a/br/pkg/restore/log_client/batch_meta_processor.go
+++ b/br/pkg/restore/log_client/batch_meta_processor.go
@@ -206,6 +206,13 @@ func (mp *MetaKVInfoProcessor) ProcessBatch(
 
 				// add to table rename history
 				mp.tableHistoryManager.AddTableHistory(tableInfo.ID, tableInfo.Name.String(), dbID)
+
+				// track partitions if this is a partitioned table
+				if tableInfo.Partition != nil {
+					for _, def := range tableInfo.Partition.Definitions {
+						mp.tableHistoryManager.AddPartitionHistory(def.ID, tableInfo.Name.String(), dbID, tableInfo.ID)
+					}
+				}
 			}
 		}
 	}

--- a/br/pkg/stream/table_history.go
+++ b/br/pkg/stream/table_history.go
@@ -16,8 +16,10 @@ package stream
 
 // TableLocationInfo stores the table name, db id, and parent table id if is a partition
 type TableLocationInfo struct {
-	DbID      int64
-	TableName string
+	DbID          int64
+	TableName     string
+	IsPartition   bool
+	ParentTableID int64 // only meaningful when IsPartition is true
 }
 
 type LogBackupTableHistoryManager struct {
@@ -36,10 +38,24 @@ func NewTableHistoryManager() *LogBackupTableHistoryManager {
 // AddTableHistory adds or updates history for a regular table
 func (info *LogBackupTableHistoryManager) AddTableHistory(tableId int64, tableName string, dbID int64) {
 	locationInfo := TableLocationInfo{
-		DbID:      dbID,
-		TableName: tableName,
+		DbID:          dbID,
+		TableName:     tableName,
+		IsPartition:   false,
+		ParentTableID: 0,
 	}
 	info.addHistory(tableId, locationInfo)
+}
+
+// AddPartitionHistory adds or updates history for a partition
+func (info *LogBackupTableHistoryManager) AddPartitionHistory(partitionID int64, tableName string,
+	dbID int64, parentTableID int64) {
+	locationInfo := TableLocationInfo{
+		DbID:          dbID,
+		TableName:     tableName,
+		IsPartition:   true,
+		ParentTableID: parentTableID,
+	}
+	info.addHistory(partitionID, locationInfo)
 }
 
 // addHistory is a helper method to maintain the history

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1981,7 +1981,10 @@ func buildPauseSafePointName(taskName string) string {
 	return fmt.Sprintf("%s_pause_safepoint", taskName)
 }
 
-func checkPiTRRequirements(mgr *conn.Mgr) error {
+func checkPiTRRequirements(mgr *conn.Mgr, hasExplicitFilter bool) error {
+	if hasExplicitFilter {
+		return nil
+	}
 	return restore.AssertUserDBsEmpty(mgr.GetDomain())
 }
 
@@ -2055,7 +2058,7 @@ func generatePiTRTaskInfo(
 			// Only when use checkpoint and not the first execution,
 			// skip checking requirements.
 			log.Info("check pitr requirements for the first execution")
-			if err := checkPiTRRequirements(mgr); err != nil {
+			if err := checkPiTRRequirements(mgr, cfg.ExplicitFilter); err != nil {
 				// delay cluster checks after we get the backupmeta.
 				// for the case that the restore inc + log backup,
 				// we can still restore them.

--- a/br/tests/br_pitr_table_filter/run.sh
+++ b/br/tests/br_pitr_table_filter/run.sh
@@ -947,6 +947,250 @@ test_partition_exchange() {
     echo "partition exchange test passed"
 }
 
+test_table_truncation() {
+    restart_services || { echo "Failed to restart services"; exit 1; }
+
+    echo "start testing table truncation with filter"
+    run_br --pd $PD_ADDR log start --task-name $TASK_NAME -s "local://$TEST_DIR/$TASK_NAME/log"
+
+    run_sql "create schema $DB;"
+
+    # Create tables for snapshot backup
+    echo "creating tables for snapshot backup..."
+    run_sql "CREATE TABLE $DB.snapshot_truncate (
+        id INT PRIMARY KEY,
+        value VARCHAR(50)
+    );"
+    
+    # Insert initial data
+    run_sql "INSERT INTO $DB.snapshot_truncate VALUES (1, 'initial data 1'), (2, 'initial data 2');"
+    
+    # Take full backup
+    run_br backup full -s "local://$TEST_DIR/$TASK_NAME/full" --pd $PD_ADDR
+
+    # Create tables during log backup phase
+    echo "creating tables during log backup phase..."
+    run_sql "CREATE TABLE $DB.log_truncate (
+        id INT PRIMARY KEY,
+        value VARCHAR(50)
+    );"
+    
+    # Insert data into log-created table
+    run_sql "INSERT INTO $DB.log_truncate VALUES (1, 'log data 1'), (2, 'log data 2');"
+    
+    # Add more data to snapshot table before truncation
+    run_sql "INSERT INTO $DB.snapshot_truncate VALUES (3, 'pre-truncate data');"
+    
+    # Truncate both tables
+    echo "truncating tables..."
+    run_sql "TRUNCATE TABLE $DB.snapshot_truncate;"
+    run_sql "TRUNCATE TABLE $DB.log_truncate;"
+    
+    # Insert new data after truncation
+    run_sql "INSERT INTO $DB.snapshot_truncate VALUES (10, 'post-truncate data 1'), (20, 'post-truncate data 2');"
+    run_sql "INSERT INTO $DB.log_truncate VALUES (10, 'post-truncate data 1'), (20, 'post-truncate data 2');"
+    
+    . "$CUR/../br_test_utils.sh" && wait_log_checkpoint_advance "$TASK_NAME"
+    
+    # Stop log backup before starting restore operations
+    run_br log stop --task-name $TASK_NAME --pd $PD_ADDR
+    
+    run_sql "drop schema if exists $DB;"
+
+    echo "Test 1: Restore both truncated tables"
+    run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" \
+        --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" \
+        -f "$DB.*"
+    
+    # Verify data after restore - should only have post-truncate data
+    run_sql "SELECT COUNT(*) = 2 FROM $DB.snapshot_truncate" || {
+        echo "snapshot_truncate doesn't have expected row count after restore"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 2 FROM $DB.log_truncate" || {
+        echo "log_truncate doesn't have expected row count after restore"
+        exit 1
+    }
+    
+    # Verify specific values to ensure we have post-truncate data
+    run_sql "SELECT COUNT(*) = 1 FROM $DB.snapshot_truncate WHERE id = 10" || {
+        echo "snapshot_truncate doesn't have expected post-truncate data"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 1 FROM $DB.log_truncate WHERE id = 10" || {
+        echo "log_truncate doesn't have expected post-truncate data"
+        exit 1
+    }
+    
+    # Verify pre-truncate data is gone
+    run_sql "SELECT COUNT(*) = 0 FROM $DB.snapshot_truncate WHERE id IN (1, 2, 3)" || {
+        echo "snapshot_truncate still has pre-truncate data which should be gone"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 0 FROM $DB.log_truncate WHERE id IN (1, 2)" || {
+        echo "log_truncate still has pre-truncate data which should be gone"
+        exit 1
+    }
+    
+    # Test 2: Restore only snapshot table
+    run_sql "drop schema if exists $DB;"
+    run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" \
+        --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" \
+        -f "$DB.snapshot_truncate"
+    
+    # Verify only snapshot table exists
+    verify_no_unexpected_tables 1 "$DB" || {
+        echo "Wrong number of tables restored with snapshot_truncate filter"
+        exit 1
+    }
+    
+    # Verify data is correct
+    run_sql "SELECT COUNT(*) = 2 FROM $DB.snapshot_truncate" || {
+        echo "snapshot_truncate doesn't have expected row count after filtered restore"
+        exit 1
+    }
+    
+    # Test 3: Restore only log table
+    run_sql "drop schema if exists $DB;"
+    run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" \
+        --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" \
+        -f "$DB.log_truncate"
+    
+    # Verify only log table exists
+    verify_no_unexpected_tables 1 "$DB" || {
+        echo "Wrong number of tables restored with log_truncate filter"
+        exit 1
+    }
+    
+    # Verify data is correct
+    run_sql "SELECT COUNT(*) = 2 FROM $DB.log_truncate" || {
+        echo "log_truncate doesn't have expected row count after filtered restore"
+        exit 1
+    }
+    
+    # cleanup
+    rm -rf "$TEST_DIR/$TASK_NAME"
+    
+    echo "table truncation test passed"
+}
+
+test_sequential_restore() {
+    restart_services || { echo "Failed to restart services"; exit 1; }
+
+    echo "start testing sequential table restore with filter"
+    run_br --pd $PD_ADDR log start --task-name $TASK_NAME -s "local://$TEST_DIR/$TASK_NAME/log"
+
+    run_sql "create schema $DB;"
+
+    # Create multiple tables with different data
+    echo "creating tables for testing sequential restore..."
+    run_sql "CREATE TABLE $DB.table1 (
+        id INT PRIMARY KEY,
+        value VARCHAR(50)
+    );"
+    run_sql "CREATE TABLE $DB.table2 (
+        id INT PRIMARY KEY,
+        value VARCHAR(50)
+    );"
+    run_sql "CREATE TABLE $DB.table3 (
+        id INT PRIMARY KEY,
+        value VARCHAR(50)
+    );"
+    
+    # Insert initial data
+    run_sql "INSERT INTO $DB.table1 VALUES (1, 'table1 data 1'), (2, 'table1 data 2');"
+    run_sql "INSERT INTO $DB.table2 VALUES (1, 'table2 data 1'), (2, 'table2 data 2');"
+    run_sql "INSERT INTO $DB.table3 VALUES (1, 'table3 data 1'), (2, 'table3 data 2');"
+    
+    # Take full backup
+    run_br backup full -s "local://$TEST_DIR/$TASK_NAME/full" --pd $PD_ADDR
+
+    # Add more data after backup
+    run_sql "INSERT INTO $DB.table1 VALUES (3, 'table1 data 3'), (4, 'table1 data 4');"
+    run_sql "INSERT INTO $DB.table2 VALUES (3, 'table2 data 3'), (4, 'table2 data 4');"
+    run_sql "INSERT INTO $DB.table3 VALUES (3, 'table3 data 3'), (4, 'table3 data 4');"
+    
+    # Wait for log backup to catch up with all operations
+    . "$CUR/../br_test_utils.sh" && wait_log_checkpoint_advance "$TASK_NAME"
+    
+    # Stop log backup before starting restore operations
+    run_br log stop --task-name $TASK_NAME --pd $PD_ADDR
+    
+    # Clean up the database before starting the sequential restore tests
+    run_sql "drop schema if exists $DB;"
+    
+    echo "Test 1: Restore first table"
+    run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" \
+        --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" \
+        -f "$DB.table1"
+    
+    # Verify only table1 exists with correct data
+    verify_no_unexpected_tables 1 "$DB" || {
+        echo "Wrong number of tables after restoring table1"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 4 FROM $DB.table1" || {
+        echo "table1 doesn't have expected row count after restore"
+        exit 1
+    }
+    
+    echo "Test 2: Restore second table without cleaning up"
+    run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" \
+        --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" \
+        -f "$DB.table2"
+    
+    # Verify both table1 and table2 exist with correct data
+    verify_no_unexpected_tables 2 "$DB" || {
+        echo "Wrong number of tables after restoring table2"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 4 FROM $DB.table1" || {
+        echo "table1 doesn't have expected row count after second restore"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 4 FROM $DB.table2" || {
+        echo "table2 doesn't have expected row count after restore"
+        exit 1
+    }
+    
+    echo "Test 3: Restore third table without cleaning up"
+    run_br --pd "$PD_ADDR" restore point -s "local://$TEST_DIR/$TASK_NAME/log" \
+        --full-backup-storage "local://$TEST_DIR/$TASK_NAME/full" \
+        -f "$DB.table3"
+    
+    # Verify all three tables exist with correct data
+    verify_no_unexpected_tables 3 "$DB" || {
+        echo "Wrong number of tables after restoring table3"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 4 FROM $DB.table1" || {
+        echo "table1 doesn't have expected row count after third restore"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 4 FROM $DB.table2" || {
+        echo "table2 doesn't have expected row count after third restore"
+        exit 1
+    }
+    
+    run_sql "SELECT COUNT(*) = 4 FROM $DB.table3" || {
+        echo "table3 doesn't have expected row count after restore"
+        exit 1
+    }
+    
+    # cleanup
+    rm -rf "$TEST_DIR/$TASK_NAME"
+    
+    echo "sequential restore test passed"
+}
+
 echo "run all test cases"
 test_basic_filter
 test_with_full_backup_filter
@@ -956,5 +1200,7 @@ test_system_tables
 test_foreign_keys
 test_index_filter
 test_partition_exchange
+test_table_truncation
+test_sequential_restore
 
 echo "br pitr table filter all tests passed"

--- a/br/tests/br_pitr_table_filter/run.sh
+++ b/br/tests/br_pitr_table_filter/run.sh
@@ -1244,7 +1244,7 @@ test_log_compaction() {
     echo "Verified no SST files exist before compaction"
     
     # Step 1: Get the Base64 encoded storage URL
-    echo "Step 1: Encoding storage URL to Base64..."
+    echo "Encoding storage URL to Base64"
 
     # Run the base64ify command and capture its output, redirecting stderr to stdout
     base64_output=$(run_br operator base64ify --storage "local://$TEST_DIR/$TASK_NAME/log" 2>&1)
@@ -1261,20 +1261,16 @@ test_log_compaction() {
 
     echo "Extracted Base64 encoded storage URL: $storage_base64"
     
-    # Get current timestamp and a timestamp from 1 hour ago for compaction range using Python
-    # This is more consistent across different operating systems
-    echo "Step 2: Generating timestamps using Python..."
+    # Get current timestamp and a timestamp from 1 hour ago for compaction range
     one_hour_ago_ts=$(python3 -c "import time; print(int((time.time() - 3600) * 1000) << 18)")
     
     echo "Current timestamp: $current_ts"
     echo "One hour ago timestamp: $one_hour_ago_ts"
     
-    # Step 3: Perform actual log compaction using tikv-ctl
-    echo "Step 3: Performing log compaction using tikv-ctl..."
     echo "Compacting logs from $one_hour_ago_ts to $current_ts"
     
     # Run tikv-ctl to perform compaction
-    tikv-ctl --log-level=info compact-log-backup --from "$one_hour_ago_ts" --until "$current_ts" -s "$storage_base64" -N 4
+    tikv-ctl --log-level=info compact-log-backup --from "$one_hour_ago_ts" --until "$current_ts" -s "$storage_base64" -N 4 --min-compaction-size 0
 
     # Verify SST files exist after compaction
     post_compaction_files=$(find "$TEST_DIR/$TASK_NAME/log" -name "*.sst" | wc -l)

--- a/br/tests/br_pitr_table_filter/run.sh
+++ b/br/tests/br_pitr_table_filter/run.sh
@@ -948,13 +948,13 @@ test_partition_exchange() {
 }
 
 echo "run all test cases"
-# test_basic_filter
-# test_with_full_backup_filter
-# test_table_rename
-# test_with_checkpoint
-# test_system_tables
-# test_foreign_keys
-# test_index_filter
+test_basic_filter
+test_with_full_backup_filter
+test_table_rename
+test_with_checkpoint
+test_system_tables
+test_foreign_keys
+test_index_filter
 test_partition_exchange
 
 echo "br pitr table filter all tests passed"

--- a/br/tests/br_pitr_table_filter/run.sh
+++ b/br/tests/br_pitr_table_filter/run.sh
@@ -1270,7 +1270,7 @@ test_log_compaction() {
     echo "Compacting logs from $one_hour_ago_ts to $current_ts"
     
     # Run tikv-ctl to perform compaction
-    tikv-ctl --log-level=info compact-log-backup --from "$one_hour_ago_ts" --until "$current_ts" -s "$storage_base64" -N 4 --min-compaction-size 0
+    tikv-ctl --log-level=info compact-log-backup --from "$one_hour_ago_ts" --until "$current_ts" -s "$storage_base64" -N 4 --minimal-compaction-size 0
 
     # Verify SST files exist after compaction
     post_compaction_files=$(find "$TEST_DIR/$TASK_NAME/log" -name "*.sst" | wc -l)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59723

Problem Summary:

### What changed and how does it work?

we detect partition changes during log restore, if we found a partition is moved in/out of the filter range during log restore, we throw an error since we cannot support on partition level right now. If the partition exchange happens totally in or out of the filter range without moving across the filter boundary, we can support that and no error will be thrown. 

also added a few more tests to piggyback on this PR
1. filter restore one table at a time and don't clean up cluster
2. filter restore with log compaction
3. filter restore with truncation 
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
