### PR TITLE
json: extract the `$[last]` entry from json object should also return itself

### DIFF
--- a/pkg/types/json_binary_functions.go
+++ b/pkg/types/json_binary_functions.go
@@ -277,13 +277,13 @@ func (bj BinaryJSON) extractTo(buf []BinaryJSON, pathExpr JSONPathExpression, du
 	if currentLeg.typ == jsonPathLegArraySelection {
 		if bj.TypeCode != JSONTypeCodeArray {
 			// If the current object is not an array, still append them if the selection includes
-			// 0. But for asterisk, it still returns NULL.
+			// 0 or last. But for asterisk, it still returns NULL.
 			//
 			// don't call `getIndexRange` or `getIndexFromStart`, they will panic if the argument
 			// is not array.
 			switch selection := currentLeg.arraySelection.(type) {
 			case jsonPathArraySelectionIndex:
-				if selection.index == 0 {
+				if selection.index == 0 || selection.index == -1 {
 					buf = bj.extractTo(buf, subPathExpr, dup, one)
 				}
 			case jsonPathArraySelectionRange:

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -852,3 +852,12 @@ json_extract("{\"\\b\":\"\"}", "$")
 select json_extract("{\"\\f\":\"\"}", "$");
 json_extract("{\"\\f\":\"\"}", "$")
 {"\f": ""}
+select json_extract('{"a":"b"}', '$[0]');
+json_extract('{"a":"b"}', '$[0]')
+{"a": "b"}
+select json_extract('{"a":"b"}', '$[last]');
+json_extract('{"a":"b"}', '$[last]')
+{"a": "b"}
+select json_set('{"a":"b"}', '$[last]', 1);
+json_set('{"a":"b"}', '$[last]', 1)
+1

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -560,3 +560,8 @@ select json_extract('[1E27]', '$');
 # TestIssue58897
 select json_extract("{\"\\b\":\"\"}", "$");
 select json_extract("{\"\\f\":\"\"}", "$");
+
+# TestJSONExtractObjectFromLast
+select json_extract('{"a":"b"}', '$[0]');
+select json_extract('{"a":"b"}', '$[last]');
+select json_set('{"a":"b"}', '$[last]', 1);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59619

Problem Summary:

`json_extract('{"a":"b"}', '$[last]')` should also return `{"a":"b"}`. It also affects the `json_set` and any other json functions using the path.

TiDB already handled the case for `$[0]`, but we didn't handle this case for `$[last]`.

### What changed and how does it work?

Also return the object itself when the path is `$[last]`, just like `$[0]`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
