### PR TITLE
json: fix the issue that two arrays are merged but not append in `JSON_ARRAY_APPEND`.

### DIFF
--- a/pkg/expression/builtin_json.go
+++ b/pkg/expression/builtin_json.go
@@ -1208,6 +1208,10 @@ func (b *builtinJSONArrayAppendSig) appendJSONArray(res types.BinaryJSON, p stri
 		}
 	}
 
+	// wrap the new value `v` into an array explicitly, in case that the `v` is an array itself.
+	// For example, `JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3))` should return `[1, [2, 3]]`
+	v = types.CreateBinaryJSON([]any{v})
+
 	obj = types.MergeBinaryJSON([]types.BinaryJSON{obj, v})
 	res, err = res.Modify([]types.JSONPathExpression{pathExpr}, []types.BinaryJSON{obj}, types.JSONModifySet)
 	return res, false, err

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -861,3 +861,6 @@ json_extract('{"a":"b"}', '$[last]')
 select json_set('{"a":"b"}', '$[last]', 1);
 json_set('{"a":"b"}', '$[last]', 1)
 1
+SELECT JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3));
+JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3))
+[1, [2, 3]]

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -565,3 +565,6 @@ select json_extract("{\"\\f\":\"\"}", "$");
 select json_extract('{"a":"b"}', '$[0]');
 select json_extract('{"a":"b"}', '$[last]');
 select json_set('{"a":"b"}', '$[last]', 1);
+
+# TestIssue59465
+SELECT JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59465

Problem Summary:

Previously, `JSON_ARRAY_APPEND('[1]', '$', '[2,3]')` will give `[1,2,3]`, which is not expected. It's because in TiDB the `JSON_ARRAY_APPEND` shared the same implementation with `JSON_MERGE`. To fix this issue, we should wrap the new item with an array when passing it to the merge logic.

### What changed and how does it work?

Wrap the new item with array before re-using the merge logic.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
