### PR TITLE
objstore: fix read position on retry when reading a file range using s3

### DIFF
--- a/br/pkg/storage/ks3.go
+++ b/br/pkg/storage/ks3.go
@@ -450,6 +450,7 @@ func (rs *KS3Storage) Open(ctx context.Context, path string, o *ReaderOption) (E
 		storage:      rs,
 		name:         path,
 		reader:       reader,
+		pos:          r.Start,
 		rangeInfo:    r,
 		prefetchSize: prefetchSize,
 	}, nil

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -828,6 +828,7 @@ func (rs *S3Storage) Open(ctx context.Context, path string, o *ReaderOption) (Ex
 		storage:      rs,
 		name:         path,
 		reader:       reader,
+		pos:          r.Start,
 		ctx:          ctx,
 		rangeInfo:    r,
 		prefetchSize: prefetchSize,

--- a/br/pkg/storage/s3_test.go
+++ b/br/pkg/storage/s3_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -854,6 +855,52 @@ func (s *s3Suite) expectedCalls(ctx context.Context, t *testing.T, data []byte, 
 		}
 		lastCall = thisCall
 	}
+}
+
+type mockFailReader struct {
+	r         io.Reader
+	failCount *atomic.Int32
+}
+
+func (f *mockFailReader) Read(p []byte) (n int, err error) {
+	if f.failCount.Load() > 0 {
+		f.failCount.Add(-1)
+		return 0, errors.New("mock read error")
+	}
+	return f.r.Read(p)
+}
+
+func TestS3RangeReaderRetryRead(t *testing.T) {
+	s := createS3Suite(t)
+	ctx := aws.BackgroundContext()
+	content := []byte("0123456789")
+	var failCount atomic.Int32
+	s.s3.EXPECT().GetObjectWithContext(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *s3.GetObjectInput, opt ...request.Option) (*s3.GetObjectOutput, error) {
+			var start int
+			_, err := fmt.Sscanf(*input.Range, "bytes=%d-", &start)
+			require.NoError(t, err)
+			requestedBytes := content[start:]
+			return &s3.GetObjectOutput{
+				Body:         io.NopCloser(&mockFailReader{r: bytes.NewReader(requestedBytes), failCount: &failCount}),
+				ContentRange: aws.String(fmt.Sprintf("bytes %d-%d/%d", start, len(content)-1, len(content))),
+			}, nil
+		}).Times(2)
+	reader, err := s.storage.Open(ctx, "random", &ReaderOption{StartOffset: aws.Int64(3)})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+	slice := make([]byte, 2)
+	n, err := reader.Read(slice)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, []byte("34"), slice)
+	failCount.Store(1)
+	n, err = reader.Read(slice)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, []byte("56"), slice)
 }
 
 // TestS3ReaderWithRetryEOF check the Read with retry and end with io.EOF.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #50451

Problem Summary:

### What changed and how does it work?
when reading a file range using s3, the `pos` must be set, as we will use it as the start position when retry
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
