### PR TITLE
br/restore: Add conc control to upload for PiTR

### DIFF
--- a/br/pkg/restore/snap_client/client.go
+++ b/br/pkg/restore/snap_client/client.go
@@ -434,6 +434,10 @@ func makeDBPool(size uint, dbFactory func() (*tidallocdb.DB, error)) ([]*tidallo
 }
 
 func (rc *SnapClient) InstallPiTRSupport(ctx context.Context, deps PiTRCollDep) error {
+	if err := deps.LoadMaxCopyConcurrency(ctx, rc.concurrencyPerStore); err != nil {
+		return errors.Trace(err)
+	}
+
 	collector, err := newPiTRColl(ctx, deps)
 	if err != nil {
 		return errors.Trace(err)

--- a/br/pkg/restore/snap_client/pitr_collector.go
+++ b/br/pkg/restore/snap_client/pitr_collector.go
@@ -250,7 +250,7 @@ func (c *pitrCollector) onBatch(ctx context.Context, fileSets restore.BatchBacku
 
 		for _, file := range fileSet.SSTFiles {
 			fileCount += 1
-			eg.Go(func() error {
+			c.concControl.ApplyOnErrorGroup(eg, func() error {
 				if err := c.putSST(ectx, file); err != nil {
 					return errors.Annotatef(err, "failed to put sst %s", file.GetName())
 				}

--- a/br/pkg/restore/snap_client/pitr_collector_test.go
+++ b/br/pkg/restore/snap_client/pitr_collector_test.go
@@ -299,11 +299,14 @@ func TestConcurrency(t *testing.T) {
 		}()
 	}
 
-	time.Sleep(time.Second)
-	require.Equal(t, atomic.LoadInt64(&cnt), 2)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&cnt) == 2
+	}, time.Second, 10*time.Millisecond)
 	close(fence)
 
 	for _, cb := range cbs {
 		require.NoError(t, cb())
 	}
+
+	coll.Done()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #(WIP)

Problem Summary:

When too many concurrent copy requests issued and throttled, we may OOM.

### What changed and how does it work?
added concurrency control

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
