### PR TITLE
unistore: Added error if row is too long to be locked

### DIFF
--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -703,3 +703,14 @@ func TestInsertNullInNonStrictMode(t *testing.T) {
 	tk.MustExec("insert ignore t1 VALUES (4, 4) ON DUPLICATE KEY UPDATE col1 = null")
 	tk.MustQuery("select * from t1").Check(testkit.RowsWithSep("|", "1|", "2|", "3|", "4|", "5|"))
 }
+
+func TestInsertLargeRow(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key, b longtext)")
+	tk.MustExec("set tidb_txn_entry_size_limit = 1<<23")
+	// the unistore arena blocksize is 8MB (8388608 bytes), so Unistore cannot handle larger rows than that!
+	// since a row cannot span multiple arena blocks.
+	tk.MustExec("insert into t values (1, REPEAT('t',8388493))")
+}

--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -712,5 +712,5 @@ func TestInsertLargeRow(t *testing.T) {
 	tk.MustExec("set tidb_txn_entry_size_limit = 1<<23")
 	// the unistore arena blocksize is 8MB (8388608 bytes), so Unistore cannot handle larger rows than that!
 	// since a row cannot span multiple arena blocks.
-	tk.MustExec("insert into t values (1, REPEAT('t',8388493))")
+	tk.MustContainErrMsg("insert into t values (1, REPEAT('t',8388493))", "Lock entry too big")
 }

--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -17,6 +17,7 @@ package executor_test
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -707,10 +708,14 @@ func TestInsertNullInNonStrictMode(t *testing.T) {
 func TestInsertLargeRow(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+	ver := tk.MustQuery("select tidb_version()").Rows()[0][0].(string)
+	if !strings.Contains(ver, "Store: unistore") {
+		t.Skipf("Only support 'Store: unistore'\n%s", ver)
+	}
 	tk.MustExec("use test")
 	tk.MustExec("create table t (id int primary key, b longtext)")
 	tk.MustExec("set tidb_txn_entry_size_limit = 1<<23")
 	// the unistore arena blocksize is 8MB (8388608 bytes), so Unistore cannot handle larger rows than that!
 	// since a row cannot span multiple arena blocks.
-	tk.MustContainErrMsg("insert into t values (1, REPEAT('t',8388493))", "Lock entry too big")
+	tk.MustContainErrMsg("insert into t values (1, REPEAT('t',8388493))", "unistore lock entry too big")
 }

--- a/pkg/store/mockstore/unistore/lockstore/lockstore.go
+++ b/pkg/store/mockstore/unistore/lockstore/lockstore.go
@@ -353,6 +353,10 @@ func (ls *MemStore) replace(key, v []byte, hint *Hint, old *node) {
 	ls.getArena().free(old.addr)
 }
 
+func (ls *MemStore) MaxEntrySize() int {
+	return ls.getArena().blockSize - nodeHeaderSize - ls.getHeight()*8
+}
+
 func (ls *MemStore) newNode(arena *arena, key []byte, v []byte, height int) *node {
 	// The base level is already allocated in the node struct.
 	nodeSize := nodeHeaderSize + height*8 + len(key) + len(v)

--- a/pkg/store/mockstore/unistore/lockstore/lockstore.go
+++ b/pkg/store/mockstore/unistore/lockstore/lockstore.go
@@ -353,6 +353,8 @@ func (ls *MemStore) replace(key, v []byte, hint *Hint, old *node) {
 	ls.getArena().free(old.addr)
 }
 
+// MaxEntrySize will return the maximum entry size for the MemStore
+// Any entry larger than this will likely result in failure.
 func (ls *MemStore) MaxEntrySize() int {
 	return ls.getArena().blockSize - nodeHeaderSize - ls.getHeight()*8
 }

--- a/pkg/store/mockstore/unistore/tikv/write.go
+++ b/pkg/store/mockstore/unistore/tikv/write.go
@@ -16,7 +16,6 @@ package tikv
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -170,7 +169,7 @@ func (w writeLockWorker) run() {
 				default:
 					// Make sure it fits into an arena block.
 					if len(entry.Key.UserKey)+len(entry.Value) > ls.MaxEntrySize() {
-						batch.err = errors.New(fmt.Sprintf("Lock entry too big %d > %d", len(entry.Key.UserKey)+len(entry.Value), ls.MaxEntrySize()))
+						batch.err = fmt.Errorf("Lock entry too big %d > %d", len(entry.Key.UserKey)+len(entry.Value), ls.MaxEntrySize())
 						break
 					}
 					insertCnt++

--- a/pkg/store/mockstore/unistore/tikv/write.go
+++ b/pkg/store/mockstore/unistore/tikv/write.go
@@ -169,7 +169,7 @@ func (w writeLockWorker) run() {
 				default:
 					// Make sure it fits into an arena block.
 					if len(entry.Key.UserKey)+len(entry.Value) > ls.MaxEntrySize() {
-						batch.err = fmt.Errorf("Unistore lock entry too big %d > %d", len(entry.Key.UserKey)+len(entry.Value), ls.MaxEntrySize())
+						batch.err = fmt.Errorf("unistore lock entry too big %d > %d", len(entry.Key.UserKey)+len(entry.Value), ls.MaxEntrySize())
 						break
 					}
 					insertCnt++

--- a/pkg/store/mockstore/unistore/tikv/write.go
+++ b/pkg/store/mockstore/unistore/tikv/write.go
@@ -169,7 +169,7 @@ func (w writeLockWorker) run() {
 				default:
 					// Make sure it fits into an arena block.
 					if len(entry.Key.UserKey)+len(entry.Value) > ls.MaxEntrySize() {
-						batch.err = fmt.Errorf("Lock entry too big %d > %d", len(entry.Key.UserKey)+len(entry.Value), ls.MaxEntrySize())
+						batch.err = fmt.Errorf("Unistore lock entry too big %d > %d", len(entry.Key.UserKey)+len(entry.Value), ls.MaxEntrySize())
 						break
 					}
 					insertCnt++


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59651

Problem Summary:
The Unistore cannot handle a row is larger than the lockstore arena blocksize.

### What changed and how does it work?
Added an error when trying to lock a row that is too big.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Return error if a row is larger than the unistore lock blocksize instead of panic: runtime error: index out of range [-1]
```
