### PR TITLE
planner: optimize return type of partial sum for tiflash

### DIFF
--- a/pkg/expression/aggregation/BUILD.bazel
+++ b/pkg/expression/aggregation/BUILD.bazel
@@ -69,7 +69,7 @@ go_test(
     ],
     embed = [":aggregation"],
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/expression",
         "//pkg/kv",

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -262,6 +262,9 @@ func (a *baseFuncDesc) TypeInfer4AvgSum(isTiFlash bool, avgRetTp *types.FieldTyp
 			}
 			if avgArgRetTp.GetDecimal() > 0 {
 				a.RetTp.SetDecimal(avgArgRetTp.GetDecimal())
+			} else {
+				// Normally cannot reach here for decimal type.
+				a.RetTp.SetDecimal(avgRetTp.GetDecimal())
 			}
 		} else {
 			a.RetTp.SetFlen(min(mysql.MaxDecimalWidth, a.RetTp.GetFlen()+22))

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -246,7 +246,10 @@ func (a *baseFuncDesc) typeInfer4Sum(ctx expression.EvalContext) {
 
 // TypeInfer4AvgSum infers the type of sum from avg, which should extend the precision of decimal
 // compatible with mysql.
-func (a *baseFuncDesc) TypeInfer4AvgSum(ctx expression.EvalContext, avgRetType *types.FieldType) {
+func (a *baseFuncDesc) TypeInfer4AvgSum(ctx expression.EvalContext, avgRetType *types.FieldType) error {
+	if a.Name != ast.AggFuncSum {
+		return errors.Errorf("expect sum func, but got %s", a.Name)
+	}
 	if _, ok := a.Args[0].(*expression.Column); ok {
 		a.typeInfer4Sum(ctx)
 	} else {
@@ -254,6 +257,7 @@ func (a *baseFuncDesc) TypeInfer4AvgSum(ctx expression.EvalContext, avgRetType *
 			a.RetTp.SetFlen(min(mysql.MaxDecimalWidth, a.RetTp.GetFlen()+22))
 		}
 	}
+	return nil
 }
 
 // TypeInfer4FinalCount infers the type of sum agg which is rewritten from final count agg run on MPP mode.

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -244,6 +244,18 @@ func (a *baseFuncDesc) typeInfer4Sum(ctx expression.EvalContext) {
 	types.SetBinChsClnFlag(a.RetTp)
 }
 
+// TypeInfer4AvgSum infers the type of sum from avg, which should extend the precision of decimal
+// compatible with mysql.
+func (a *baseFuncDesc) TypeInfer4AvgSum(ctx expression.EvalContext, avgRetType *types.FieldType) {
+	if _, ok := a.Args[0].(*expression.Column); ok {
+		a.typeInfer4Sum(ctx)
+	} else {
+		if avgRetType.GetType() == mysql.TypeNewDecimal {
+			a.RetTp.SetFlen(min(mysql.MaxDecimalWidth, a.RetTp.GetFlen()+22))
+		}
+	}
+}
+
 // TypeInfer4FinalCount infers the type of sum agg which is rewritten from final count agg run on MPP mode.
 func (a *baseFuncDesc) TypeInfer4FinalCount(finalCountRetType *types.FieldType) {
 	a.RetTp = finalCountRetType.Clone()

--- a/pkg/expression/aggregation/base_func.go
+++ b/pkg/expression/aggregation/base_func.go
@@ -246,8 +246,8 @@ func (a *baseFuncDesc) typeInfer4Sum(ctx expression.EvalContext) {
 
 // TypeInfer4AvgSum infers the type of sum from avg, which should extend the precision of decimal
 // compatible with mysql.
-func (a *baseFuncDesc) TypeInfer4AvgSum(isTiFlash bool, avgArgRetTp *types.FieldType) {
-	if a.RetTp.GetType() == mysql.TypeNewDecimal {
+func (a *baseFuncDesc) TypeInfer4AvgSum(isTiFlash bool, avgRetTp *types.FieldType, avgArgRetTp *types.FieldType) {
+	if avgRetTp.GetType() == mysql.TypeNewDecimal {
 		if isTiFlash && avgArgRetTp.GetType() == mysql.TypeNewDecimal {
 			// For tiflash, different precision use different type to compute decimal.
 			// For precision in (18, 38], will use Int128.
@@ -258,7 +258,10 @@ func (a *baseFuncDesc) TypeInfer4AvgSum(isTiFlash bool, avgArgRetTp *types.Field
 			} else if avgArgRetTp.GetFlen() <= 18 {
 				a.RetTp.SetFlen(min(avgArgRetTp.GetFlen()+22, 38))
 			} else {
-				a.RetTp.SetFlen(min(mysql.MaxDecimalWidth, a.RetTp.GetFlen()+22))
+				a.RetTp.SetFlen(min(mysql.MaxDecimalWidth, avgArgRetTp.GetFlen()+22))
+			}
+			if avgArgRetTp.GetDecimal() > 0 {
+				a.RetTp.SetDecimal(avgArgRetTp.GetDecimal())
 			}
 		} else {
 			a.RetTp.SetFlen(min(mysql.MaxDecimalWidth, a.RetTp.GetFlen()+22))

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1611,7 +1611,9 @@ func BuildFinalModeAggregation(
 				// we must call deep clone in this case, to avoid sharing the arguments.
 				sumAgg := aggFunc.Clone()
 				sumAgg.Name = ast.AggFuncSum
-				sumAgg.TypeInfer4AvgSum(isMPPTask, aggFunc.RetTp, aggFunc.Args[0].GetType(ectx))
+				if err := sumAgg.TypeInfer(sctx.GetExprCtx()); err != nil {
+					// todo err
+				}
 				partial.Schema.Columns[partialCursor-1].RetType = sumAgg.RetTp
 				partial.AggFuncs = append(partial.AggFuncs, cntAgg, sumAgg)
 			} else if aggFunc.Name == ast.AggFuncApproxCountDistinct || aggFunc.Name == ast.AggFuncGroupConcat {
@@ -1686,7 +1688,9 @@ func (p *basePhysicalAgg) convertAvgForMPP() *PhysicalProjection {
 			// insert a sum(column)
 			avgSum := aggFunc.Clone()
 			avgSum.Name = ast.AggFuncSum
-			avgSum.TypeInfer4AvgSum(true, aggFunc.RetTp, aggFunc.Args[0].GetType(exprCtx.GetEvalCtx()))
+			if err := avgSum.TypeInfer(exprCtx); err != nil {
+				// todo err
+			}
 			newAggFuncs = append(newAggFuncs, avgSum)
 			avgSumCol := &expression.Column{
 				UniqueID: p.schema.Columns[i].UniqueID,

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1611,7 +1611,7 @@ func BuildFinalModeAggregation(
 				// we must call deep clone in this case, to avoid sharing the arguments.
 				sumAgg := aggFunc.Clone()
 				sumAgg.Name = ast.AggFuncSum
-				sumAgg.TypeInfer4AvgSum(isMPPTask, aggFunc.Args[0].GetType(ectx))
+				sumAgg.TypeInfer4AvgSum(isMPPTask, aggFunc.RetTp, aggFunc.Args[0].GetType(ectx))
 				partial.Schema.Columns[partialCursor-1].RetType = sumAgg.RetTp
 				partial.AggFuncs = append(partial.AggFuncs, cntAgg, sumAgg)
 			} else if aggFunc.Name == ast.AggFuncApproxCountDistinct || aggFunc.Name == ast.AggFuncGroupConcat {
@@ -1686,7 +1686,7 @@ func (p *basePhysicalAgg) convertAvgForMPP() *PhysicalProjection {
 			// insert a sum(column)
 			avgSum := aggFunc.Clone()
 			avgSum.Name = ast.AggFuncSum
-			avgSum.TypeInfer4AvgSum(true, aggFunc.Args[0].GetType(exprCtx.GetEvalCtx()))
+			avgSum.TypeInfer4AvgSum(true, aggFunc.RetTp, aggFunc.Args[0].GetType(exprCtx.GetEvalCtx()))
 			newAggFuncs = append(newAggFuncs, avgSum)
 			avgSumCol := &expression.Column{
 				UniqueID: p.schema.Columns[i].UniqueID,

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -1612,7 +1612,9 @@ func BuildFinalModeAggregation(
 				sumAgg := aggFunc.Clone()
 				sumAgg.Name = ast.AggFuncSum
 				if err := sumAgg.TypeInfer(sctx.GetExprCtx()); err != nil {
-					// todo err
+					partial = nil
+					final = original
+					return
 				}
 				partial.Schema.Columns[partialCursor-1].RetType = sumAgg.RetTp
 				partial.AggFuncs = append(partial.AggFuncs, cntAgg, sumAgg)
@@ -1689,7 +1691,7 @@ func (p *basePhysicalAgg) convertAvgForMPP() *PhysicalProjection {
 			avgSum := aggFunc.Clone()
 			avgSum.Name = ast.AggFuncSum
 			if err := avgSum.TypeInfer(exprCtx); err != nil {
-				// todo err
+				return nil
 			}
 			newAggFuncs = append(newAggFuncs, avgSum)
 			avgSumCol := &expression.Column{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59708

Problem Summary: 
the type infer of `avg(col_decimal_15_2)`:
  1. In `plan builder`, call [typeInfer4Avg](https://github.com/pingcap/tidb/blob/62165a41faa800def93a0582dad918ad669ca435/pkg/expression/aggregation/base_func.go#L138), the return type of avg becomes `decimal(19, 6)`
  2. In `task.go`, trying to convert normal `avg` to mpp `avg`, which will be spilit to `count() and sum(col_decimal_15_2)`(1 phase) and `sum/count`(2 phase). And the return type of 1 phase `sum(col_decimal_15_2)` is `decimal(41, 6)` because of calling [TypeInfer4AvgSum](https://github.com/pingcap/tidb/blob/62165a41faa800def93a0582dad918ad669ca435/pkg/expression/aggregation/base_func.go#L249)

`decimal(41, 6)` will use Int256 to compute, which is slow. So we need to optimize type infer.

### What changed and how does it work?

1. optimize the partial sum of avg for tiflash. So appropriate type will be used to compute sum.
2. the final avg ret type should not be changed.

Workload: tpch50G
Query: `explain analyze select avg(l_quantity) from lineitem group by l_orderkey;`
performance: 4-> 2.9 (**+26%**)
before:
```
mysql> mysql> explain analyze select avg(l_quantity) avgres from lineitem group by l_orderkey having avgres > 100000;
+--------------------------------------+--------------+-----------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| id                                   | estRows      | actRows   | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | operator info                                                                                                                       | memory  | disk |
+--------------------------------------+--------------+-----------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| TableReader_65                       | 59126579.20  | 0         | root         |                | time:3.98s, open:1.53ms, close:6.64µs, loops:1, RU:113028.94, cop_task: {num: 2, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | MppVersion: 3, data:ExchangeSender_64                                                                                               | 1.50 KB | N/A  |
| └─ExchangeSender_64                  | 59126579.20  | 0         | mpp[tiflash] |                | tiflash_task:{proc max:3.98s, min:3.92s, avg: 3.95s, p80:3.98s, p95:3.98s, iters:0, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | ExchangeType: PassThrough                                                                                                           | N/A     | N/A  |
|   └─Selection_63                     | 59126579.20  | 0         | mpp[tiflash] |                | tiflash_task:{proc max:3.98s, min:3.92s, avg: 3.95s, p80:3.98s, p95:3.98s, iters:0, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | gt(Column#17, 100000)                                                                                                               | N/A     | N/A  |
|     └─Projection_57                  | 73908224.00  | 75000000  | mpp[tiflash] |                | tiflash_task:{proc max:3.94s, min:3.88s, avg: 3.91s, p80:3.94s, p95:3.94s, iters:4096, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | div(Column#17, cast(case(eq(Column#31, 0), 1, Column#31), decimal(20,0) BINARY))->Column#17                                         | N/A     | N/A  |
|       └─HashAgg_58                   | 73908224.00  | 75000000  | mpp[tiflash] |                | tiflash_task:{proc max:2.82s, min:2.81s, avg: 2.82s, p80:2.82s, p95:2.82s, iters:4096, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | group by:test.lineitem.l_orderkey, funcs:sum(Column#32)->Column#31, funcs:sum(Column#33)->Column#17, stream_count: 16               | N/A     | N/A  |
|         └─ExchangeReceiver_60        | 73908224.00  | 75000093  | mpp[tiflash] |                | tiflash_task:{proc max:2.19s, min:2.15s, avg: 2.17s, p80:2.19s, p95:2.19s, iters:7226, tasks:2, threads:32}, tiflash_wait: {pipeline_queue_wait: 511ms}, tiflash_network: {inner_zone_receive_bytes: 561417293}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | stream_count: 16                                                                                                                    | N/A     | N/A  |
|           └─ExchangeSender_59        | 73908224.00  | 75000093  | mpp[tiflash] |                | tiflash_task:{proc max:2.61s, min:0s, avg: 1.3s, p80:2.61s, p95:2.61s, iters:1536, tasks:2, threads:144}, tiflash_network: {inner_zone_send_bytes: 561417293}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary], stream_count: 16      | N/A     | N/A  |
|             └─HashAgg_55             | 73908224.00  | 75000093  | mpp[tiflash] |                | tiflash_task:{proc max:1.9s, min:0s, avg: 951.2ms, p80:1.9s, p95:1.9s, iters:1536, tasks:2, threads:144}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | group by:test.lineitem.l_orderkey, funcs:count(test.lineitem.l_quantity)->Column#32, funcs:sum(test.lineitem.l_quantity)->Column#33 | N/A     | N/A  |
|               └─TableFullScan_35     | 300005811.00 | 300005811 | mpp[tiflash] | table:lineitem | tiflash_task:{proc max:786.5ms, min:0s, avg: 393.2ms, p80:786.5ms, p95:786.5ms, iters:4757, tasks:2, threads:144}, tiflash_wait: {pipeline_queue_wait: 772ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:217, remote_regions:0, tot_learner_read:6ms, region_balance:{instance_num: 2, max/min: 109/108=1.009259}, delta_rows:0, delta_bytes:0, segments:434, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:25ms, tot_build_inputstream:226ms, min_local_stream:323ms, max_local_stream:780ms, dtfile:{data_scanned_rows:300005811, data_skipped_rows:682517, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:27ms, tot_read:5806ms}} | keep order:false                                                                                                                    | N/A     | N/A  |
+--------------------------------------+--------------+-----------+--------------+----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------+------+
9 rows in set (4.00 sec)

```

after:
```
mysql> mysql> explain analyze select avg(l_quantity) avgres from lineitem group by l_orderkey having avgres > 100000;
+--------------------------------------+--------------+-----------+--------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| id                                   | estRows      | actRows   | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | operator info                                                                                                                       | memory  | disk |
+--------------------------------------+--------------+-----------+--------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| TableReader_65                       | 59126579.20  | 0         | root         |                | time:2.91s, open:1.53ms, close:5.11µs, loops:1, RU:102874.94, cop_task: {num: 2, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | MppVersion: 3, data:ExchangeSender_64                                                                                               | 1.50 KB | N/A  |
| └─ExchangeSender_64                  | 59126579.20  | 0         | mpp[tiflash] |                | tiflash_task:{proc max:2.91s, min:2.88s, avg: 2.89s, p80:2.91s, p95:2.91s, iters:0, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ExchangeType: PassThrough                                                                                                           | N/A     | N/A  |
|   └─Selection_63                     | 59126579.20  | 0         | mpp[tiflash] |                | tiflash_task:{proc max:2.91s, min:2.88s, avg: 2.89s, p80:2.91s, p95:2.91s, iters:0, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | gt(Column#17, 100000)                                                                                                               | N/A     | N/A  |
|     └─Projection_57                  | 73908224.00  | 75000000  | mpp[tiflash] |                | tiflash_task:{proc max:2.87s, min:2.85s, avg: 2.86s, p80:2.87s, p95:2.87s, iters:4096, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | div(Column#17, cast(case(eq(Column#31, 0), 1, Column#31), decimal(20,0) BINARY))->Column#17                                         | N/A     | N/A  |
|       └─HashAgg_58                   | 73908224.00  | 75000000  | mpp[tiflash] |                | tiflash_task:{proc max:2.42s, min:2.41s, avg: 2.42s, p80:2.42s, p95:2.42s, iters:4096, tasks:2, threads:32}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | group by:test.lineitem.l_orderkey, funcs:sum(Column#32)->Column#31, funcs:sum(Column#33)->Column#17, stream_count: 16               | N/A     | N/A  |
|         └─ExchangeReceiver_60        | 73908224.00  | 75000091  | mpp[tiflash] |                | tiflash_task:{proc max:1.87s, min:1.83s, avg: 1.85s, p80:1.87s, p95:1.87s, iters:7238, tasks:2, threads:32}, tiflash_wait: {pipeline_queue_wait: 356ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | stream_count: 16                                                                                                                    | N/A     | N/A  |
|           └─ExchangeSender_59        | 73908224.00  | 75000091  | mpp[tiflash] |                | tiflash_task:{proc max:2.21s, min:0s, avg: 1.11s, p80:2.21s, p95:2.21s, iters:1536, tasks:2, threads:144}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary], stream_count: 16      | N/A     | N/A  |
|             └─HashAgg_55             | 73908224.00  | 75000091  | mpp[tiflash] |                | tiflash_task:{proc max:2.04s, min:0s, avg: 1.02s, p80:2.04s, p95:2.04s, iters:1536, tasks:2, threads:144}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | group by:test.lineitem.l_orderkey, funcs:count(test.lineitem.l_quantity)->Column#32, funcs:sum(test.lineitem.l_quantity)->Column#33 | N/A     | N/A  |
|               └─TableFullScan_35     | 300005811.00 | 300005811 | mpp[tiflash] | table:lineitem | tiflash_task:{proc max:806ms, min:0s, avg: 403ms, p80:806ms, p95:806ms, iters:4757, tasks:2, threads:144}, tiflash_wait: {pipeline_queue_wait: 785ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:217, remote_regions:0, tot_learner_read:8ms, region_balance:{instance_num: 2, max/min: 109/108=1.009259}, delta_rows:0, delta_bytes:0, segments:434, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:13ms, tot_build_inputstream:233ms, min_local_stream:317ms, max_local_stream:799ms, dtfile:{data_scanned_rows:300005811, data_skipped_rows:682517, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:33ms, tot_read:6088ms}} | keep order:false                                                                                                                    | N/A     | N/A  |
+--------------------------------------+--------------+-----------+--------------+----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------+---------+------+
9 rows in set (2.93 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
create table tt1(c1 decimal(15, 2) not null, c2 int not null);
insert into tt1 values(1, 1), (2, 2);
alter table tt1 set tiflash replica 1;
explain analyze select /*+ mpp_2phase_agg() */ avg(c1) from tt1 group by c2;
```

before: need to cast sum(table_scan_0) (which is Decimal(37, 2)) to Decimal(41, 6) in task1.
```
task1
[2024/07/24 11:19:42.698 +08:00] [INFO] [executeQuery.cpp:424] ["Query pipeline:
ExchangeSender: <enable fine grained shuffle> header: ExchangeSender_27_CAST(count()_collator , Int64_String)_collator_0  0 Int64 Int64(size = 0), ExchangeSender_27_CAST(sum(table_scan_0)_collator_0 , Nullable(Decimal(41,6))_String)_collator_0  0 Nullable(Decimal(41,6)) Nullable(size = 0, Decimal256(size = 0), UInt8(size = 0)), ExchangeSender_27_table_scan_1 2 Int32 Int32(size = 0)
 Expression: <final projection> header: ExchangeSender_27_CAST(count()_collator , Int64_String)_collator_0  0 Int64 Int64(size = 0), ExchangeSender_27_CAST(sum(table_scan_0)_collator_0 , Nullable(Decimal(41,6))_String)_collator_0  0 Nullable(Decimal(41,6)) Nullable(size = 0, Decimal256(size = 0), UInt8(size = 0)), ExchangeSender_27_table_scan_1 2 Int32 Int32(size = 0)
  Expression: <expr after aggregation> header: CAST(count()_collator , Int64_String)_collator_0  0 Int64 Int64(size = 0), CAST(sum(table_scan_0)_collator_0 , Nullable(Decimal(41,6))_String)_collator_0  0 Nullable(Decimal(41,6)) Nullable(size = 0, Decimal256(size = 0), UInt8(size = 0)), table_scan_1 2 Int32 Int32(size = 0)
   Aggregating header: table_scan_1 2 Int32 Int32(size = 0), count()_collator  0 UInt64 UInt64(size = 0), sum(table_scan_0)_collator_0  0 Decimal(37,2) Decimal128(size = 0)
    Expression: <table scan schema projection> header: table_scan_0 1 Decimal(15,2) Decimal64(size = 0), table_scan_1 2 Int32 Int32(size = 0)
     UnorderedInputStream header: c1 1 Decimal(15,2) Decimal64(size = 0), c2 2 Int32 Int32(size = 0)
"] [source="MPP<gather_id:1, query_ts:1721791182686661720, local_query_id:5, server_id:578, start_ts:451357227788009473,task_id:1>"] [thread_id=157]

task2:
[2024/07/24 11:19:42.703 +08:00] [INFO] [executeQuery.cpp:424] ["Query pipeline:
Union: <for mpp> header: ExchangeSender_29_CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_String)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_String)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
 ExchangeSender x 10 header: ExchangeSender_29_CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_String)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_String)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
  Expression: <final projection> header: ExchangeSender_29_CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_String)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_String)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
   Expression: <projection> header: CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_String)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_String)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
    Expression: <expr after aggregation> header: sumWithOverflow(exchange_receiver_0)_collator_0  0 Int64 Int64(size = 0), sumWithOverflow(exchange_receiver_1)_collator_0  0 Nullable(Decimal(41,6)) Nullable(size = 0, Decimal256(size = 0), UInt8(size = 0)), exchange_receiver_2 0 Int32 Int32(size = 0)
     Aggregating: <enable fine grained shuffle> header: exchange_receiver_2 0 Int32 Int32(size = 0), sumWithOverflow(exchange_receiver_0)_collator_0  0 Int64 Int64(size = 0), sumWithOverflow(exchange_receiver_1)_collator_0  0 Nullable(Decimal(41,6)) Nullable(size = 0, Decimal256(size = 0), UInt8(size = 0))
      TiRemote(ExchangeReceiver): <squashing after exchange receiver, enable fine grained shuffle> header: exchange_receiver_0 0 Int64 Int64(size = 0), exchange_receiver_1 0 Nullable(Decimal(41,6)) Nullable(size = 0, Decimal256(size = 0), UInt8(size = 0)), exchange_receiver_2 0 Int32 Int32(size = 0): schema: {<exchange_receiver_0, Int64>, <exchange_receiver_1, Nullable(Decimal(41,6))>, <exchange_receiver_2, Int32>}
"] [source="MPP<gather_id:1, query_ts:1721791182686661720, local_query_id:5, server_id:578, start_ts:451357227788009473,task_id:2>"] [thread_id=158]

```


after: no cast is needed
```
task1:
[2025/02/24 16:50:08.250 +08:00] [DEBUG] [executeQuery.cpp:424] ["Query pipeline:
ExchangeSender: <enable fine grained shuffle>, header: ExchangeSender_27_CAST(count()_collator , Int64_StringV2)_collator_0  0 Int64 Int64(size = 0), ExchangeSender_27_CAST(sum(table_scan_0)_collator_0 , Nullable(Decimal(37,2))_StringV2)_collator_0  0 Nullable(Decimal(37,2)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0)), ExchangeSender_27_table_scan_1 2 Int32 Int32(size = 0)
 Expression: <final projection>, header: ExchangeSender_27_CAST(count()_collator , Int64_StringV2)_collator_0  0 Int64 Int64(size = 0), ExchangeSender_27_CAST(sum(table_scan_0)_collator_0 , Nullable(Decimal(37,2))_StringV2)_collator_0  0 Nullable(Decimal(37,2)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0)), ExchangeSender_27_table_scan_1 2 Int32 Int32(size = 0)
  Expression: <expr after aggregation>, header: CAST(count()_collator , Int64_StringV2)_collator_0  0 Int64 Int64(size = 0), sum(table_scan_0)_collator_0  0 Decimal(37,2) Decimal128(size = 0), table_scan_1 2 Int32 Int32(size = 0)
   Aggregating, header: table_scan_1 2 Int32 Int32(size = 0), count()_collator  0 UInt64 UInt64(size = 0), sum(table_scan_0)_collator_0  0 Decimal(37,2) Decimal128(size = 0)
    Expression: <table scan schema projection>, header: table_scan_0 1 Decimal(15,2) Decimal64(size = 0), table_scan_1 2 Int32 Int32(size = 0)
     UnorderedInputStream, header: c1 1 Decimal(15,2) Decimal64(size = 0), c2 2 Int32 Int32(size = 0)
"] [source="MPP<gather_id:1, query_ts:1740387008208933368, local_query_id:3, server_id:1492, start_ts:456232011865522178,task_id:1>"] [thread_id=388]

task2:
[2025/02/24 16:50:08.264 +08:00] [DEBUG] [executeQuery.cpp:424] ["Query pipeline:
Union: <for mpp>, header: ExchangeSender_29_CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_StringV2)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_StringV2)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
 ExchangeSender x 20, header: ExchangeSender_29_CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_StringV2)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_StringV2)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
  Expression: <final projection>, header: ExchangeSender_29_CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_StringV2)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_StringV2)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
   Expression: <projection>, header: CAST(tidbDivide(sumWithOverflow(exchange_receiver_1)_collator_0 , tidb_cast(multiIf(equals(sumWithOverflow(exchange_receiver_0)_collator_0 , 0_UInt8)_collator_63 , 1_UInt8, sumWithOverflow(exchange_receiver_0)_collator_0 )_collator_63 , Nullable(Decimal(20,0))_StringV2)_collator_0 128|20)_collator_63 , Nullable(Decimal(19,6))_StringV2)_collator_0  0 Nullable(Decimal(19,6)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
    Expression: <expr after aggregation>, header: sumWithOverflow(exchange_receiver_0)_collator_0  0 Int64 Int64(size = 0), sumWithOverflow(exchange_receiver_1)_collator_0  0 Nullable(Decimal(37,2)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0)), exchange_receiver_2 0 Int32 Int32(size = 0)
     Aggregating: <enable fine grained shuffle>, header: exchange_receiver_2 0 Int32 Int32(size = 0), sumWithOverflow(exchange_receiver_0)_collator_0  0 Int64 Int64(size = 0), sumWithOverflow(exchange_receiver_1)_collator_0  0 Nullable(Decimal(37,2)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0))
      TiRemote(ExchangeReceiver): <squashing after exchange receiver, enable fine grained shuffle>, header: exchange_receiver_0 0 Int64 Int64(size = 0), exchange_receiver_1 0 Nullable(Decimal(37,2)) Nullable(size = 0, Decimal128(size = 0), UInt8(size = 0)), exchange_receiver_2 0 Int32 Int32(size = 0): schema: {<exchange_receiver_0, Int64>, <exchange_receiver_1, Nullable(Decimal(37,2))>, <exchange_receiver_2, Int32>}
"] [source="MPP<gather_id:1, query_ts:1740387008208933368, local_query_id:3, server_id:1492, start_ts:456232011865522178,task_id:2>"] [thread_id=389]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
