### PR TITLE
json, expr: `json_search` should return `NULL` when the search path is `NULL` | tidb-test=pr/2486

### DIFF
--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -565,11 +565,14 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 				return errIncorrectArgs.GenWithStackByArgs("ESCAPE")
 			}
 		}
+
+		var isNull bool
 		var pathExprs []types.JSONPathExpression
 		if pathBufs != nil {
 			pathExprs = make([]types.JSONPathExpression, 0, len(b.args)-4)
 			for j := 0; j < len(b.args)-4; j++ {
 				if pathBufs[j].IsNull(i) {
+					isNull = true
 					break
 				}
 				pathExpr, err := types.ParseJSONPathExpr(pathBufs[j].GetString(i))
@@ -579,6 +582,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 				pathExprs = append(pathExprs, pathExpr)
 			}
 		}
+		if isNull {
+			result.AppendNull()
+			continue
+		}
+
 		bj, isNull, err := jsonBuf.GetJSON(i).Search(containType, searchBuf.GetString(i), escape, pathExprs)
 		if err != nil {
 			return err

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -864,3 +864,12 @@ json_set('{"a":"b"}', '$[last]', 1)
 SELECT JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3));
 JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3))
 [1, [2, 3]]
+set tidb_enable_vectorized_expression = 'ON';
+select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
+json_search('{"h": "i"}', 'all', 'i', '\\', NULL)
+NULL
+set tidb_enable_vectorized_expression = 'OFF';
+select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
+json_search('{"h": "i"}', 'all', 'i', '\\', NULL)
+NULL
+set tidb_enable_vectorized_expression = default;

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -568,3 +568,11 @@ select json_set('{"a":"b"}', '$[last]', 1);
 
 # TestIssue59465
 SELECT JSON_ARRAY_APPEND('[1]', '$', JSON_ARRAY(2, 3));
+
+# TestIssue59463
+# should return NULL because the path is NULL
+set tidb_enable_vectorized_expression = 'ON';
+select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
+set tidb_enable_vectorized_expression = 'OFF';
+select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
+set tidb_enable_vectorized_expression = default;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59463

Problem Summary:

The `json_search` should return `NULL` when the search path is `NULL`. It's not the same with the situation when the search path is omitted.

This issue only affects the vectorized execution. The non-vectorized logic is correct.

### What changed and how does it work?

Return `NULL` when it found the search path is `NULL`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
