### PR TITLE
br: fix pre allocate id exceeds bound

### DIFF
--- a/br/pkg/restore/internal/prealloc_table_id/BUILD.bazel
+++ b/br/pkg/restore/internal/prealloc_table_id/BUILD.bazel
@@ -19,7 +19,11 @@ go_test(
     deps = [
         ":prealloc_table_id",
         "//br/pkg/metautil",
+        "//br/pkg/utiltest",
+        "//pkg/kv",
+        "//pkg/meta",
         "//pkg/meta/model",
+        "//pkg/testkit",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/br/pkg/restore/internal/prealloc_table_id/alloc.go
+++ b/br/pkg/restore/internal/prealloc_table_id/alloc.go
@@ -87,7 +87,7 @@ func (p *PreallocIDs) Alloc(m Allocator) error {
 	if err != nil {
 		return err
 	}
-	p.allocedFrom = alloced
+	p.allocedFrom = alloced + 1
 	return nil
 }
 

--- a/br/pkg/restore/internal/prealloc_table_id/alloc_test.go
+++ b/br/pkg/restore/internal/prealloc_table_id/alloc_test.go
@@ -43,16 +43,16 @@ func TestAllocator(t *testing.T) {
 		{
 			tableIDs:              []int64{1, 2, 5, 6, 7},
 			hasAllocatedTo:        6,
-			successfullyAllocated: []int64{6, 7},
+			successfullyAllocated: []int64{7},
 			shouldAllocatedTo:     8,
-			msg:                   "ID:[6,8)",
+			msg:                   "ID:[7,8)",
 		},
 		{
 			tableIDs:              []int64{4, 6, 9, 2},
 			hasAllocatedTo:        1,
 			successfullyAllocated: []int64{2, 4, 6, 9},
 			shouldAllocatedTo:     10,
-			msg:                   "ID:[1,10)",
+			msg:                   "ID:[2,10)",
 		},
 		{
 			tableIDs:              []int64{1, 2, 3, 4},
@@ -66,17 +66,17 @@ func TestAllocator(t *testing.T) {
 			hasAllocatedTo:        3,
 			successfullyAllocated: []int64{5, 6},
 			shouldAllocatedTo:     7,
-			msg:                   "ID:[3,7)",
+			msg:                   "ID:[4,7)",
 		},
 		{
 			tableIDs:              []int64{1, 2, 5, 6, 7},
 			hasAllocatedTo:        6,
-			successfullyAllocated: []int64{6, 7},
+			successfullyAllocated: []int64{7},
 			shouldAllocatedTo:     13,
 			partitions: map[int64][]int64{
 				7: {8, 9, 10, 11, 12},
 			},
-			msg: "ID:[6,13)",
+			msg: "ID:[7,13)",
 		},
 		{
 			tableIDs:              []int64{1, 2, 5, 6, 7, 13},
@@ -86,7 +86,7 @@ func TestAllocator(t *testing.T) {
 			partitions: map[int64][]int64{
 				7: {8, 9, 10, 11, 12},
 			},
-			msg: "ID:[9,14)",
+			msg: "ID:[10,14)",
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59718

Problem Summary:
BR snapshot restore reuses the last global ID when pre-allocates table IDs
### What changed and how does it work?
pre-allocate from `last global ID + 1`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
