### PR TITLE
executor: fix traffic replay jobs are shown when the user doesn't have the TRAFFIC_REPLAY_ADMIN privilege

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -428,6 +428,7 @@ go_test(
         "//pkg/planner/core/resolve",
         "//pkg/planner/property",
         "//pkg/planner/util",
+        "//pkg/privilege",
         "//pkg/server",
         "//pkg/session",
         "//pkg/session/types",

--- a/pkg/executor/traffic.go
+++ b/pkg/executor/traffic.go
@@ -244,7 +244,7 @@ func request(ctx context.Context, addrs []string, readers []io.Reader, method, p
 		if err != nil {
 			logutil.Logger(ctx).Error("traffic request to tiproxy failed", zap.String("path", path), zap.String("addr", addr),
 				zap.String("resp", resp), zap.Error(err))
-			return resps, errors.Wrapf(err, "request to tiproxy '%s' failed", addr)
+			return resps, errors.Wrapf(err, "request to tiproxy '%s' failed: %s", addr, resp)
 		}
 		resps[addr] = resp
 	}
@@ -398,15 +398,10 @@ func formReader4Replay(ctx context.Context, args map[string]string, tiproxyNum i
 func hasTrafficPriv(ctx context.Context, sctx sessionctx.Context) (capturePriv, replayPriv bool) {
 	pm := privilege.GetPrivilegeManager(sctx)
 	if pm == nil {
-		// in test
-		if privs := ctx.Value(trafficPrivKey); privs != nil {
-			array := privs.([]bool)
-			return array[0], array[1]
-		}
 		return true, true
 	}
 	roles := sctx.GetSessionVars().ActiveRoles
 	capturePriv = pm.RequestDynamicVerification(roles, "TRAFFIC_CAPTURE_ADMIN", false)
-	replayPriv = pm.RequestDynamicVerification(roles, "TRAFFIC_CAPTURE_ADMIN", false)
+	replayPriv = pm.RequestDynamicVerification(roles, "TRAFFIC_REPLAY_ADMIN", false)
 	return
 }

--- a/pkg/executor/traffic.go
+++ b/pkg/executor/traffic.go
@@ -145,7 +145,7 @@ func (e *TrafficCancelExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 		return errors.Wrapf(err, "get tiproxy addresses failed")
 	}
 	// Cancel all traffic jobs by default.
-	hasCapturePriv, hasReplayPriv := hasTrafficPriv(ctx, e.Ctx())
+	hasCapturePriv, hasReplayPriv := hasTrafficPriv(e.Ctx())
 	args := make(map[string]string, 2)
 	if hasCapturePriv && !hasReplayPriv {
 		args["type"] = "capture"
@@ -182,7 +182,7 @@ func (e *TrafficShowExec) Open(ctx context.Context) error {
 		return err
 	}
 	// Filter the jobs by privilege.
-	hasCapturePriv, hasReplayPriv := hasTrafficPriv(ctx, e.Ctx())
+	hasCapturePriv, hasReplayPriv := hasTrafficPriv(e.Ctx())
 	allJobs := make([]trafficJob, 0, len(resps))
 	for addr, resp := range resps {
 		var jobs []trafficJob
@@ -395,7 +395,7 @@ func formReader4Replay(ctx context.Context, args map[string]string, tiproxyNum i
 	return readers, nil
 }
 
-func hasTrafficPriv(ctx context.Context, sctx sessionctx.Context) (capturePriv, replayPriv bool) {
+func hasTrafficPriv(sctx sessionctx.Context) (capturePriv, replayPriv bool) {
 	pm := privilege.GetPrivilegeManager(sctx)
 	if pm == nil {
 		return true, true

--- a/pkg/executor/traffic.go
+++ b/pkg/executor/traffic.go
@@ -45,11 +45,9 @@ import (
 // The keys for the mocked data that stored in context. They are only used for test.
 type tiproxyAddrKeyType struct{}
 type trafficPathKeyType struct{}
-type trafficPrivKeyType struct{}
 
 var tiproxyAddrKey tiproxyAddrKeyType
 var trafficPathKey trafficPathKeyType
-var trafficPrivKey trafficPrivKeyType
 
 type trafficJob struct {
 	Instance  string `json:"-"` // not passed from TiProxy


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59712

Problem Summary:
`Show traffic jobs` and `cancel traffic jobs` show or cancel replay jobs when the user has `TRAFFIC_CAPTURE_ADMIN` privilege but not the `TRAFFIC_REPLAY_ADMIN` privilege.

### What changed and how does it work?
- Fix the typo on privilege
- Add more info to the error message

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
