### PR TITLE
expression: make `LPAD`/`RPAD` return an empty string for an empty padstr | tidb-test=pr/2488

### DIFF
--- a/pkg/expression/builtin_string.go
+++ b/pkg/expression/builtin_string.go
@@ -2205,8 +2205,11 @@ func (b *builtinLpadSig) evalString(ctx EvalContext, row chunk.Row) (string, boo
 	}
 	padLength := len(padStr)
 
-	if targetLength < 0 || targetLength > b.tp.GetFlen() || (byteLength < targetLength && padLength == 0) {
+	if targetLength < 0 || targetLength > b.tp.GetFlen() {
 		return "", true, nil
+	}
+	if byteLength < targetLength && padLength == 0 {
+		return "", false, nil
 	}
 
 	if tailLen := targetLength - byteLength; tailLen > 0 {
@@ -2253,8 +2256,11 @@ func (b *builtinLpadUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (string,
 	}
 	padLength := len([]rune(padStr))
 
-	if targetLength < 0 || targetLength*4 > b.tp.GetFlen() || (runeLength < targetLength && padLength == 0) {
+	if targetLength < 0 || targetLength*4 > b.tp.GetFlen() {
 		return "", true, nil
+	}
+	if runeLength < targetLength && padLength == 0 {
+		return "", false, nil
 	}
 
 	if tailLen := targetLength - runeLength; tailLen > 0 {
@@ -2329,8 +2335,11 @@ func (b *builtinRpadSig) evalString(ctx EvalContext, row chunk.Row) (string, boo
 	}
 	padLength := len(padStr)
 
-	if targetLength < 0 || targetLength > b.tp.GetFlen() || (byteLength < targetLength && padLength == 0) {
+	if targetLength < 0 || targetLength > b.tp.GetFlen() {
 		return "", true, nil
+	}
+	if byteLength < targetLength && padLength == 0 {
+		return "", false, nil
 	}
 
 	if tailLen := targetLength - byteLength; tailLen > 0 {
@@ -2377,8 +2386,11 @@ func (b *builtinRpadUTF8Sig) evalString(ctx EvalContext, row chunk.Row) (string,
 	}
 	padLength := len([]rune(padStr))
 
-	if targetLength < 0 || targetLength*4 > b.tp.GetFlen() || (runeLength < targetLength && padLength == 0) {
+	if targetLength < 0 || targetLength*4 > b.tp.GetFlen() {
 		return "", true, nil
+	}
+	if runeLength < targetLength && padLength == 0 {
+		return "", false, nil
 	}
 
 	if tailLen := targetLength - runeLength; tailLen > 0 {

--- a/pkg/expression/builtin_string_test.go
+++ b/pkg/expression/builtin_string_test.go
@@ -1557,13 +1557,13 @@ func TestLpad(t *testing.T) {
 		{"hi", 0, "?", ""},
 		{"hi", -1, "?", nil},
 		{"hi", 1, "", "h"},
-		{"hi", 5, "", nil},
+		{"hi", 5, "", ""},
 		{"hi", 5, "ab", "abahi"},
 		{"hi", 6, "ab", "ababhi"},
 		{"中文", 5, "字符", "字符字中文"},
 		{"中文", 1, "a", "中"},
 		{"中文", -5, "字符", nil},
-		{"中文", 10, "", nil},
+		{"中文", 10, "", ""},
 	}
 	fc := funcs[ast.Lpad]
 	for _, test := range tests {
@@ -1597,13 +1597,13 @@ func TestRpad(t *testing.T) {
 		{"hi", 0, "?", ""},
 		{"hi", -1, "?", nil},
 		{"hi", 1, "", "h"},
-		{"hi", 5, "", nil},
+		{"hi", 5, "", ""},
 		{"hi", 5, "ab", "hiaba"},
 		{"hi", 6, "ab", "hiabab"},
 		{"中文", 5, "字符", "中文字符字"},
 		{"中文", 1, "a", "中"},
 		{"中文", -5, "字符", nil},
-		{"中文", 10, "", nil},
+		{"中文", 10, "", ""},
 	}
 	fc := funcs[ast.Rpad]
 	for _, test := range tests {

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -1024,8 +1024,12 @@ func (b *builtinLpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 		strLength := len(str)
 		padStr := padBuf.GetString(i)
 		padLength := len(padStr)
-		if targetLength < 0 || targetLength > b.tp.GetFlen() || (strLength < targetLength && padLength == 0) {
+		if targetLength < 0 || targetLength > b.tp.GetFlen() {
 			result.AppendNull()
+			continue
+		}
+		if strLength < targetLength && padLength == 0 {
+			result.AppendString("")
 			continue
 		}
 		if tailLen := targetLength - strLength; tailLen > 0 {
@@ -1095,8 +1099,12 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 		runeLength := len([]rune(str))
 		padLength := len([]rune(padStr))
 
-		if targetLength < 0 || targetLength*4 > b.tp.GetFlen() || (runeLength < targetLength && padLength == 0) {
+		if targetLength < 0 || targetLength*4 > b.tp.GetFlen() {
 			result.AppendNull()
+			continue
+		}
+		if runeLength < targetLength && padLength == 0 {
+			result.AppendString("")
 			continue
 		}
 		if tailLen := targetLength - runeLength; tailLen > 0 {
@@ -1485,8 +1493,12 @@ func (b *builtinRpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 		strLength := len(str)
 		padStr := padBuf.GetString(i)
 		padLength := len(padStr)
-		if targetLength < 0 || targetLength > b.tp.GetFlen() || (strLength < targetLength && padLength == 0) {
+		if targetLength < 0 || targetLength > b.tp.GetFlen() {
 			result.AppendNull()
+			continue
+		}
+		if strLength < targetLength && padLength == 0 {
+			result.AppendString("")
 			continue
 		}
 		if tailLen := targetLength - strLength; tailLen > 0 {
@@ -2619,8 +2631,12 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 		runeLength := len([]rune(str))
 		padLength := len([]rune(padStr))
 
-		if targetLength < 0 || targetLength*4 > b.tp.GetFlen() || (runeLength < targetLength && padLength == 0) {
+		if targetLength < 0 || targetLength*4 > b.tp.GetFlen() {
 			result.AppendNull()
+			continue
+		}
+		if runeLength < targetLength && padLength == 0 {
+			result.AppendString("")
 			continue
 		}
 		if tailLen := targetLength - runeLength; tailLen > 0 {

--- a/tests/integrationtest/r/expression/builtin.result
+++ b/tests/integrationtest/r/expression/builtin.result
@@ -1616,9 +1616,15 @@ INSERT INTO t SELECT "中文", "abc";
 SELECT LPAD(a, 11, "a"), LPAD(b, 2, "xx") FROM t;
 LPAD(a, 11, "a")	LPAD(b, 2, "xx")
 a中文    	ab
+SELECT LPAD("abc", 5, "");
+LPAD("abc", 5, "")
+
 SELECT RPAD(a, 11, "a"), RPAD(b, 2, "xx") FROM t;
 RPAD(a, 11, "a")	RPAD(b, 2, "xx")
 中文    a	ab
+SELECT RPAD("abc", 5, "");
+RPAD("abc", 5, "")
+
 drop table if exists t;
 create table t(a int, b double, c datetime, d time, e char(20), f bit(10));
 insert into t values(1, 1.1, "2017-01-01 12:01:01", "12:01:01", "abcdef", 0b10101);

--- a/tests/integrationtest/r/expression/builtin.result
+++ b/tests/integrationtest/r/expression/builtin.result
@@ -1619,12 +1619,18 @@ a中文    	ab
 SELECT LPAD("abc", 5, "");
 LPAD("abc", 5, "")
 
+SELECT LPAD(a, 11, ""), LPAD(b, 5, "") FROM t;
+LPAD(a, 11, "")	LPAD(b, 5, "")
+	
 SELECT RPAD(a, 11, "a"), RPAD(b, 2, "xx") FROM t;
 RPAD(a, 11, "a")	RPAD(b, 2, "xx")
 中文    a	ab
 SELECT RPAD("abc", 5, "");
 RPAD("abc", 5, "")
 
+SELECT RPAD(a, 11, ""), RPAD(b, 5, "") FROM t;
+RPAD(a, 11, "")	RPAD(b, 5, "")
+	
 drop table if exists t;
 create table t(a int, b double, c datetime, d time, e char(20), f bit(10));
 insert into t values(1, 1.1, "2017-01-01 12:01:01", "12:01:01", "abcdef", 0b10101);

--- a/tests/integrationtest/t/expression/builtin.test
+++ b/tests/integrationtest/t/expression/builtin.test
@@ -719,7 +719,9 @@ DROP TABLE IF EXISTS t;
 CREATE TABLE t(a BINARY(10), b CHAR(10));
 INSERT INTO t SELECT "中文", "abc";
 SELECT LPAD(a, 11, "a"), LPAD(b, 2, "xx") FROM t;
+SELECT LPAD("abc", 5, "");
 SELECT RPAD(a, 11, "a"), RPAD(b, 2, "xx") FROM t;
+SELECT RPAD("abc", 5, "");
 
 # TestStringBuiltin
 drop table if exists t;

--- a/tests/integrationtest/t/expression/builtin.test
+++ b/tests/integrationtest/t/expression/builtin.test
@@ -720,8 +720,10 @@ CREATE TABLE t(a BINARY(10), b CHAR(10));
 INSERT INTO t SELECT "中文", "abc";
 SELECT LPAD(a, 11, "a"), LPAD(b, 2, "xx") FROM t;
 SELECT LPAD("abc", 5, "");
+SELECT LPAD(a, 11, ""), LPAD(b, 5, "") FROM t;
 SELECT RPAD(a, 11, "a"), RPAD(b, 2, "xx") FROM t;
 SELECT RPAD("abc", 5, "");
+SELECT RPAD(a, 11, ""), RPAD(b, 5, "") FROM t;
 
 # TestStringBuiltin
 drop table if exists t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59447

Problem Summary: In MySQL 8, [as of 8.0.13](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html#mysqld-8-0-13-bug), the `LPAD` and `RPAD` functions now return an empty string if the specified padding string is empty, and the given length is greater than the length of the string to pad. However, TiDB currently returns NULL instead.

### What changed and how does it work?

* Modify the implementations of `LPAD` and `RPAD` to return an empty string if the specified padding string is empty, and the given length is greater than the length of the string to pad.
* Update the `TestLpad` and `TestRpad` unit tests accordingly.
* Update the `expression/builtin` integration test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The `LPAD(str, len, padstr)` and `RPAD(str, len, padstr)` functions now return an
empty string if the specified string `padstr` is empty and `len` is greater than the
length of the string `str`, to aid MySQL 8.0 compatibility.
```