### PR TITLE
privilege: handle username with "@" correctly for role(RBAC) related code

### DIFF
--- a/pkg/privilege/privileges/cache_test.go
+++ b/pkg/privilege/privileges/cache_test.go
@@ -315,13 +315,13 @@ func TestLoadRoleGraph(t *testing.T) {
 	p = privileges.NewMySQLPrivilege()
 	require.NoError(t, p.LoadRoleGraph(se.GetRestrictedSQLExecutor()))
 	graph := p.RoleGraph()
-	require.True(t, graph[auth.RoleIdentity{"root", "%"}].Find("r_2", "%"))
-	require.True(t, graph[auth.RoleIdentity{"root", "%"}].Find("r_4", "%"))
-	require.True(t, graph[auth.RoleIdentity{"user2", "%"}].Find("r_1", "%"))
-	require.True(t, graph[auth.RoleIdentity{"user1", "%"}].Find("r_3", "%"))
+	require.True(t, graph[auth.RoleIdentity{Username: "root", Hostname: "%"}].Find("r_2", "%"))
+	require.True(t, graph[auth.RoleIdentity{Username: "root", Hostname: "%"}].Find("r_4", "%"))
+	require.True(t, graph[auth.RoleIdentity{Username: "user2", Hostname: "%"}].Find("r_1", "%"))
+	require.True(t, graph[auth.RoleIdentity{Username: "user1", Hostname: "%"}].Find("r_3", "%"))
 	_, ok := graph[auth.RoleIdentity{Username: "illedal"}]
 	require.False(t, ok)
-	require.False(t, graph[auth.RoleIdentity{"root", "%"}].Find("r_1", "%"))
+	require.False(t, graph[auth.RoleIdentity{Username: "root", Hostname: "%"}].Find("r_1", "%"))
 }
 
 func TestRoleGraphBFS(t *testing.T) {

--- a/pkg/privilege/privileges/cache_test.go
+++ b/pkg/privilege/privileges/cache_test.go
@@ -315,13 +315,13 @@ func TestLoadRoleGraph(t *testing.T) {
 	p = privileges.NewMySQLPrivilege()
 	require.NoError(t, p.LoadRoleGraph(se.GetRestrictedSQLExecutor()))
 	graph := p.RoleGraph()
-	require.True(t, graph["root@%"].Find("r_2", "%"))
-	require.True(t, graph["root@%"].Find("r_4", "%"))
-	require.True(t, graph["user2@%"].Find("r_1", "%"))
-	require.True(t, graph["user1@%"].Find("r_3", "%"))
-	_, ok := graph["illedal"]
+	require.True(t, graph[auth.RoleIdentity{"root", "%"}].Find("r_2", "%"))
+	require.True(t, graph[auth.RoleIdentity{"root", "%"}].Find("r_4", "%"))
+	require.True(t, graph[auth.RoleIdentity{"user2", "%"}].Find("r_1", "%"))
+	require.True(t, graph[auth.RoleIdentity{"user1", "%"}].Find("r_3", "%"))
+	_, ok := graph[auth.RoleIdentity{Username: "illedal"}]
 	require.False(t, ok)
-	require.False(t, graph["root@%"].Find("r_1", "%"))
+	require.False(t, graph[auth.RoleIdentity{"root", "%"}].Find("r_1", "%"))
 }
 
 func TestRoleGraphBFS(t *testing.T) {

--- a/pkg/privilege/privileges/tidb_auth_token_test.go
+++ b/pkg/privilege/privileges/tidb_auth_token_test.go
@@ -30,6 +30,7 @@ import (
 	jwsRepo "github.com/lestrrat-go/jwx/v2/jws"
 	jwtRepo "github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/lestrrat-go/jwx/v2/jwt/openid"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/stretchr/testify/require"
 )
@@ -482,7 +483,7 @@ func (p *MySQLPrivilege) GlobalPriv(user string) []globalPrivRecord {
 	return ret.data
 }
 
-func (p *MySQLPrivilege) RoleGraph() map[string]roleGraphEdgesTable {
+func (p *MySQLPrivilege) RoleGraph() map[auth.RoleIdentity]roleGraphEdgesTable {
 	return p.roleGraph
 }
 

--- a/tests/integrationtest/r/privilege/privileges.result
+++ b/tests/integrationtest/r/privilege/privileges.result
@@ -696,3 +696,13 @@ update privilege__privileges.tt1 inner join t_f
 set t_f.fullname=t_f.fullname
 where tt1.id=t_f.id;
 Error 1288 (HY000): The target table t_f of the UPDATE is not updatable
+drop user if exists u1;
+create user u1;
+create role 'aa@bb';
+grant 'aa@bb' to u1;
+show grants for u1;
+Grants for u1@%
+GRANT USAGE ON *.* TO 'u1'@'%'
+GRANT 'aa@bb'@'%' TO 'u1'@'%'
+drop user u1;
+drop role 'aa@bb';

--- a/tests/integrationtest/t/privilege/privileges.test
+++ b/tests/integrationtest/t/privilege/privileges.test
@@ -947,3 +947,12 @@ with t_f as (
 
 disconnect u53490;
 connection default;
+
+# TestIssue59552
+drop user if exists u1;
+create user u1;
+create role 'aa@bb';
+grant 'aa@bb' to u1;
+show grants for u1;
+drop user u1;
+drop role 'aa@bb';


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59552

Problem Summary:

### What changed and how does it work?

The old code use key = username + "@" + host, and also split by "@" to get back the username.
This is not stable enough when the username itself contains "@"

Change key from username + "@" + host to {username, host} struct makes the code more robust.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
