### PR TITLE
*: (release-6.5) Validate ts only for stale read

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3603,8 +3603,8 @@ def go_deps():
         name = "com_github_tikv_client_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/tikv/client-go/v2",
-        sum = "h1:YGhrcemIm3lAQ79g8Lb7aF/PhW6e7M5owperqKdLrb8=",
-        version = "v2.0.4-0.20250217042910-ad4338d3d0f9",
+        sum = "h1:TueUCiXuPnVK512DZoDfT/6cvpXBD1CMhg8fVu1nFDs=",
+        version = "v2.0.4-0.20250225113719-8f4f76934362",
     )
     go_repository(
         name = "com_github_tikv_pd_client",

--- a/executor/BUILD.bazel
+++ b/executor/BUILD.bazel
@@ -225,6 +225,7 @@ go_library(
         "@com_github_tikv_client_go_v2//error",
         "@com_github_tikv_client_go_v2//kv",
         "@com_github_tikv_client_go_v2//oracle",
+        "@com_github_tikv_client_go_v2//oracle/oracles",
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//tikvrpc",
         "@com_github_tikv_client_go_v2//txnkv",

--- a/executor/set.go
+++ b/executor/set.go
@@ -16,6 +16,7 @@ package executor
 
 import (
 	"context"
+	"github.com/tikv/client-go/v2/oracle/oracles"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -198,7 +199,13 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 	newSnapshotIsSet := newSnapshotTS > 0 && newSnapshotTS != oldSnapshotTS
 	if newSnapshotIsSet {
 		isStaleRead := name == variable.TiDBTxnReadTS
-		err = sessionctx.ValidateSnapshotReadTS(ctx, e.ctx.GetStore(), newSnapshotTS, isStaleRead)
+		var ctxForReadTsValidator context.Context
+		if name == variable.TiDBSnapshot {
+			ctxForReadTsValidator = context.WithValue(ctx, oracles.ValidateReadTSForTidbSnapshot{}, struct{}{})
+		} else {
+			ctxForReadTsValidator = ctx
+		}
+		err = sessionctx.ValidateSnapshotReadTS(ctxForReadTsValidator, e.ctx.GetStore(), newSnapshotTS, isStaleRead)
 		if name != variable.TiDBTxnReadTS {
 			// Also check gc safe point for snapshot read.
 			// We don't check snapshot with gc safe point for read_ts

--- a/executor/set.go
+++ b/executor/set.go
@@ -16,7 +16,6 @@ package executor
 
 import (
 	"context"
-	"github.com/tikv/client-go/v2/oracle/oracles"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -36,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/util/gcutil"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sem"
+	"github.com/tikv/client-go/v2/oracle/oracles"
 	"go.uber.org/zap"
 )
 

--- a/executor/set.go
+++ b/executor/set.go
@@ -200,7 +200,7 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 	if newSnapshotIsSet {
 		isStaleRead := name == variable.TiDBTxnReadTS
 		var ctxForReadTsValidator context.Context
-		if name == variable.TiDBSnapshot {
+		if !isStaleRead {
 			ctxForReadTsValidator = context.WithValue(ctx, oracles.ValidateReadTSForTidbSnapshot{}, struct{}{})
 		} else {
 			ctxForReadTsValidator = ctx

--- a/go.mod
+++ b/go.mod
@@ -270,7 +270,6 @@ replace (
 	// fix potential security issue(CVE-2020-26160) introduced by indirect dependency.
 	github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
 	github.com/pingcap/tidb/parser => ./parser
-
 	go.opencensus.io => go.opencensus.io v0.23.1-0.20220331163232-052120675fac
 
 	// TODO: `sourcegraph.com/sourcegraph/appdash` has been archived, and the original host has been removed.

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tdakkota/asciicheck v0.1.1
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.4-0.20250217042910-ad4338d3d0f9
+	github.com/tikv/client-go/v2 v2.0.4-0.20250225113719-8f4f76934362
 	github.com/tikv/pd/client v0.0.0-20230904040343-947701a32c05
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144
 	github.com/twmb/murmur3 v1.1.3
@@ -270,6 +270,7 @@ replace (
 	// fix potential security issue(CVE-2020-26160) introduced by indirect dependency.
 	github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
 	github.com/pingcap/tidb/parser => ./parser
+
 	go.opencensus.io => go.opencensus.io v0.23.1-0.20220331163232-052120675fac
 
 	// TODO: `sourcegraph.com/sourcegraph/appdash` has been archived, and the original host has been removed.

--- a/go.sum
+++ b/go.sum
@@ -948,8 +948,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tikv/client-go/v2 v2.0.4-0.20250217042910-ad4338d3d0f9 h1:YGhrcemIm3lAQ79g8Lb7aF/PhW6e7M5owperqKdLrb8=
-github.com/tikv/client-go/v2 v2.0.4-0.20250217042910-ad4338d3d0f9/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
+github.com/tikv/client-go/v2 v2.0.4-0.20250225113719-8f4f76934362 h1:TueUCiXuPnVK512DZoDfT/6cvpXBD1CMhg8fVu1nFDs=
+github.com/tikv/client-go/v2 v2.0.4-0.20250225113719-8f4f76934362/go.mod h1:mmVCLP2OqWvQJPOIevQPZvGphzh/oq9vv8J5LDfpadQ=
 github.com/tikv/pd/client v0.0.0-20230904040343-947701a32c05 h1:e4hLUKfgfPeJPZwOfU+/I/03G0sn6IZqVcbX/5o+hvM=
 github.com/tikv/pd/client v0.0.0-20230904040343-947701a32c05/go.mod h1:MLIl+d2WbOF4A3U88WKtyXrQQW417wZDDvBcq2IW9bQ=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDHS9/4U9yQo1UcPQM0kOMJHn29EoH/Ro=


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #59402

Problem Summary:

The TS validator has no switch to control. Enabling it by default in an old release version is risky.

### What changed and how does it work?

Do not return errors in the ts validator. Only logs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test in client-go
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
