### PR TITLE
planner: fix the possible panic when fixcontrol#44855 enabled

### DIFF
--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -189,6 +189,8 @@ func fillIndexPath(ds *logicalop.DataSource, path *util.AccessPath, conds []expr
 			}
 			// Don't add one column twice to the index. May cause unexpected errors.
 			if !alreadyHandle {
+				path.FullIdxCols = append(path.FullIdxCols, handleCol)
+				path.FullIdxColLens = append(path.FullIdxColLens, types.UnspecifiedLength)
 				path.IdxCols = append(path.IdxCols, handleCol)
 				path.IdxColLens = append(path.IdxColLens, types.UnspecifiedLength)
 				// Also updates the map that maps the index id to its prefix column ids.

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -773,3 +773,21 @@ _tidb_rowid
 1
 2
 3
+drop table if exists t, t1;
+create table t(a int);
+create table t1(a int primary key, b int, index idx(b));
+insert into t values(1), (2), (123);
+insert into t1 values(2, 123), (123, 2);
+set tidb_opt_fix_control='44855:on';
+explain select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
+id	estRows	task	access object	operator info
+Projection_9	12.50	root		test.t.a, test.t1.a, test.t1.b
+└─IndexJoin_12	12.50	root		inner join, inner:IndexReader_11, outer key:test.t.a, inner key:test.t1.a, equal cond:eq(test.t.a, test.t1.a)
+  ├─TableReader_20(Build)	9990.00	root		data:Selection_19
+  │ └─Selection_19	9990.00	cop[tikv]		not(isnull(test.t.a))
+  │   └─TableFullScan_18	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─IndexReader_11(Probe)	12.50	root		index:IndexRangeScan_10
+    └─IndexRangeScan_10	12.50	cop[tikv]	table:t1, index:idx(b)	range: decided by [eq(test.t1.a, test.t.a) eq(test.t1.b, 123)], keep order:false, stats:pseudo
+select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
+a	a	b
+2	2	123

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -542,3 +542,13 @@ insert into t values (1, 10);
 insert into t values (2, 20);
 insert into t values (3, 30);
 select _tidb_rowid from t where id in (1, 2, 3);
+
+# TestIssue59762
+drop table if exists t, t1;
+create table t(a int);
+create table t1(a int primary key, b int, index idx(b));
+insert into t values(1), (2), (123);
+insert into t1 values(2, 123), (123, 2);
+set tidb_opt_fix_control='44855:on';
+explain select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;
+select /*+ inl_join(t1), use_index(t1, idx) */ * from t join t1 on t.a = t1.a and t1.b = 123;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59762 

Problem Summary:

### What changed and how does it work?

when we fixed the `IdxCols` for the path, we didn't update the full one for it.
So the full one may be smaller than the prefix one.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix the issue that the TiDB may panic when fixcontrol#44855 is enabled
修复当 fixcontrol#44855 开启时，TiDB 的会话可能执行崩溃的问题
```
