### PR TITLE
expression: Add failpoint to force pushdown expression to tikv for debug usage

### DIFF
--- a/pkg/expression/util.go
+++ b/pkg/expression/util.go
@@ -1510,6 +1510,10 @@ func jsonUnquoteFunctionBenefitsFromPushedDown(sf *ScalarFunction) bool {
 // Projections are not pushed down to tikv by default, thus we need to check strictly here to avoid potential performance degradation.
 // Note: virtual column is not considered here, since this function cares performance instead of functionality
 func ProjectionBenefitsFromPushedDown(exprs []Expression, inputSchemaLen int) bool {
+	// In debug usage, we need to force push down projections to tikv to check tikv expression behavior.
+	failpoint.Inject("forcePushDownTiKV", func() {
+		failpoint.Return(true)
+	})
 	allColRef := true
 	colRefCount := 0
 	for _, expr := range exprs {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51876

Problem Summary:
To debug expression behaviors not consistent between tidb and tikv, we need to force push down these projection expressions to tikv ignoring cost consideration. So we add a failpoint here to help debug tikv expression behavior.
### What changed and how does it work?

```
mysql> create table t0(a int, b int);
Query OK, 0 rows affected (0.02 sec)

mysql> insert into t0 values(3, 20);
Query OK, 1 row affected (0.01 sec)

mysql> insert into t0 values(29, 30);
Query OK, 1 row affected (0.01 sec)

mysql> explain select a-b, a+b from t0;
+-------------------------+----------+-----------+---------------+-----------------------------------------------------------------------------+
| id                      | estRows  | task      | access object | operator info                                                               |
+-------------------------+----------+-----------+---------------+-----------------------------------------------------------------------------+
| Projection_3            | 10000.00 | root      |               | minus(test.t0.a, test.t0.b)->Column#4, plus(test.t0.a, test.t0.b)->Column#5 |
| └─TableReader_5         | 10000.00 | root      |               | data:TableFullScan_4                                                        |
|   └─TableFullScan_4     | 10000.00 | cop[tikv] | table:t0      | keep order:false, stats:pseudo                                              |
+-------------------------+----------+-----------+---------------+-----------------------------------------------------------------------------+
3 rows in set (0.00 sec)
```

Now, after build tidb with failpoint enable: "make failpoint-enable"
export GO_FAILPOINTS="github.com/pingcap/tidb/pkg/expression/forcePushDownTiKV=return(true)"
start tidb server, then a+b and a-b will be pushed down to tikv side:
```
mysql> explain select a-b, a+b from t0;
+-------------------------+----------+-----------+---------------+-----------------------------------------------------------------------------+
| id                      | estRows  | task      | access object | operator info                                                               |
+-------------------------+----------+-----------+---------------+-----------------------------------------------------------------------------+
| TableReader_8           | 10000.00 | root      |               | data:Projection_4                                                           |
| └─Projection_4          | 10000.00 | cop[tikv] |               | minus(test.t0.a, test.t0.b)->Column#4, plus(test.t0.a, test.t0.b)->Column#5 |
|   └─TableFullScan_7     | 10000.00 | cop[tikv] | table:t0      | keep order:false, stats:pseudo                                              |
+-------------------------+----------+-----------+---------------+-----------------------------------------------------------------------------+
3 rows in set (0.00 sec)
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
