### PR TITLE
table: Revert "table: fix the issue that the default value for `BIT` column is wrong (#57303)"

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -961,20 +961,6 @@ func checkColumnDefaultValue(ctx sessionctx.Context, col *table.Column, value in
 			}
 		}
 	}
-	if value != nil && col.GetType() == mysql.TypeBit {
-		v, ok := value.(string)
-		if !ok {
-			return hasDefaultValue, value, types.ErrInvalidDefault.GenWithStackByArgs(col.Name.O)
-		}
-
-		uintVal, err := types.BinaryLiteral(v).ToInt(ctx.GetSessionVars().StmtCtx)
-		if err != nil {
-			return hasDefaultValue, value, types.ErrInvalidDefault.GenWithStackByArgs(col.Name.O)
-		}
-		if col.GetFlen() < 64 && uintVal >= 1<<(uint64(col.GetFlen())) {
-			return hasDefaultValue, value, types.ErrInvalidDefault.GenWithStackByArgs(col.Name.O)
-		}
-	}
 	return hasDefaultValue, value, nil
 }
 
@@ -4506,14 +4492,13 @@ func SetDefaultValue(ctx sessionctx.Context, col *table.Column, option *ast.Colu
 		}
 		col.DefaultIsExpr = isSeqExpr
 	}
-	if !col.DefaultIsExpr {
-		if hasDefaultValue, value, err = checkColumnDefaultValue(ctx, col, value); err != nil {
-			return hasDefaultValue, errors.Trace(err)
-		}
-		value, err = convertTimestampDefaultValToUTC(ctx, value, col)
-		if err != nil {
-			return hasDefaultValue, errors.Trace(err)
-		}
+
+	if hasDefaultValue, value, err = checkColumnDefaultValue(ctx, col, value); err != nil {
+		return hasDefaultValue, errors.Trace(err)
+	}
+	value, err = convertTimestampDefaultValToUTC(ctx, value, col)
+	if err != nil {
+		return hasDefaultValue, errors.Trace(err)
 	}
 	err = setDefaultValueWithBinaryPadding(col, value)
 	if err != nil {

--- a/ddl/integration_test.go
+++ b/ddl/integration_test.go
@@ -156,20 +156,3 @@ func TestExchangePartitionAfterDropForeignKey(t *testing.T) {
 	tk.MustExec("alter table child drop foreign key fk_1;")
 	tk.MustExec("alter table child_with_partition exchange partition p1 with table child;")
 }
-
-func TestTooLongDefaultValueForBit(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-
-	tk.MustExec("use test;")
-
-	tk.MustGetErrCode("create table t(a bit(2) default b'111');", 1067)
-	tk.MustGetErrCode("create table t(a bit(65) default b'111');", 1439)
-	tk.MustExec("create table t(a bit(64) default b'1111111111111111111111111111111111111111111111111111111111111111');")
-	tk.MustExec("drop table t")
-	tk.MustExec("create table t(a bit(3) default b'111');")
-	tk.MustExec("drop table t")
-	tk.MustExec("create table t(a bit(3) default b'000111');")
-	tk.MustExec("drop table t;")
-	tk.MustExec("create table t(a bit(32) default b'1111111111111111111111111111111');")
-}

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1930,7 +1930,7 @@ func TestIssue18681(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	createSQL := `drop table if exists load_data_test;
-		create table load_data_test (a bit(1),b bit(1),c bit(1),d bit(1),e bit(32),f bit(1));`
+		create table load_data_test (a bit(1),b bit(1),c bit(1),d bit(1));`
 	tk.MustExec(createSQL)
 	tk.MustExec("load data local infile '/tmp/nonexistence.csv' ignore into table load_data_test")
 	ctx := tk.Session().(sessionctx.Context)
@@ -1940,7 +1940,7 @@ func TestIssue18681(t *testing.T) {
 	require.NotNil(t, ld)
 
 	deleteSQL := "delete from load_data_test"
-	selectSQL := "select bin(a), bin(b), bin(c), bin(d), bin(e), bin(f) from load_data_test;"
+	selectSQL := "select bin(a), bin(b), bin(c), bin(d) from load_data_test;"
 	ctx.GetSessionVars().StmtCtx.DupKeyAsWarning = true
 	ctx.GetSessionVars().StmtCtx.BadNullAsWarning = true
 	ld.SetMaxRowsInBatch(20000)
@@ -1952,7 +1952,7 @@ func TestIssue18681(t *testing.T) {
 	}()
 	sc.IgnoreTruncate = false
 	tests := []testCase{
-		{nil, []byte("true\tfalse\t0\t1\tb'1'\tb'1'\n"), []string{"1|1|1|1|1100010001001110011000100100111|1"}, nil, "Records: 1  Deleted: 0  Skipped: 0  Warnings: 5"},
+		{nil, []byte("true\tfalse\t0\t1\n"), []string{"1|0|0|1"}, nil, "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"},
 	}
 	checkCases(tests, ld, t, tk, ctx, selectSQL, deleteSQL)
 	require.Equal(t, uint16(0), sc.WarningCount())

--- a/types/datum.go
+++ b/types/datum.go
@@ -1559,13 +1559,38 @@ func (d *Datum) ConvertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 	return ret, errors.Trace(err)
 }
 
+func (d *Datum) convertStringToMysqlBit(sc *stmtctx.StatementContext) (uint64, error) {
+	bitStr, err := ParseBitStr(BinaryLiteral(d.b).ToString())
+	if err != nil {
+		// It cannot be converted to bit type, so we need to convert it to int type.
+		return BinaryLiteral(d.b).ToInt(sc)
+	}
+	return bitStr.ToInt(sc)
+}
+
 func (d *Datum) convertToMysqlBit(sc *stmtctx.StatementContext, target *FieldType) (Datum, error) {
 	var ret Datum
 	var uintValue uint64
 	var err error
 	switch d.k {
-	case KindString, KindBytes:
+	case KindBytes:
 		uintValue, err = BinaryLiteral(d.b).ToInt(sc)
+	case KindString:
+		// For single bit value, we take string like "true", "1" as 1, and "false", "0" as 0,
+		// this behavior is not documented in MySQL, but it behaves so, for more information, see issue #18681
+		s := BinaryLiteral(d.b).ToString()
+		if target.GetFlen() == 1 {
+			switch strings.ToLower(s) {
+			case "true", "1":
+				uintValue = 1
+			case "false", "0":
+				uintValue = 0
+			default:
+				uintValue, err = d.convertStringToMysqlBit(sc)
+			}
+		} else {
+			uintValue, err = d.convertStringToMysqlBit(sc)
+		}
 	case KindInt64:
 		// if input kind is int64 (signed), when trans to bit, we need to treat it as unsigned
 		d.k = KindUint64

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -528,37 +528,24 @@ func prepareCompareDatums() ([]Datum, []Datum) {
 
 func TestStringToMysqlBit(t *testing.T) {
 	tests := []struct {
-		a         Datum
-		out       []byte
-		flen      int
-		truncated bool
+		a   Datum
+		out []byte
 	}{
-		{NewStringDatum("true"), []byte{1}, 1, true},
-		{NewStringDatum("true"), []byte{0x74, 0x72, 0x75, 0x65}, 32, false},
-		{NewStringDatum("false"), []byte{0x1}, 1, true},
-		{NewStringDatum("false"), []byte{0x66, 0x61, 0x6c, 0x73, 0x65}, 40, false},
-		{NewStringDatum("1"), []byte{1}, 1, true},
-		{NewStringDatum("1"), []byte{0x31}, 8, false},
-		{NewStringDatum("0"), []byte{1}, 1, true},
-		{NewStringDatum("0"), []byte{0x30}, 8, false},
-		{NewStringDatum("b'1'"), []byte{0x62, 0x27, 0x31, 0x27}, 32, false},
-		{NewStringDatum("b'0'"), []byte{0x62, 0x27, 0x30, 0x27}, 32, false},
+		{NewStringDatum("true"), []byte{1}},
+		{NewStringDatum("false"), []byte{0}},
+		{NewStringDatum("1"), []byte{1}},
+		{NewStringDatum("0"), []byte{0}},
+		{NewStringDatum("b'1'"), []byte{1}},
+		{NewStringDatum("b'0'"), []byte{0}},
 	}
 	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
+	tp := NewFieldType(mysql.TypeBit)
+	tp.SetFlen(1)
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s %d %t", tt.a.GetString(), tt.flen, tt.truncated), func(t *testing.T) {
-			tp := NewFieldType(mysql.TypeBit)
-			tp.SetFlen(tt.flen)
-
-			bin, err := tt.a.convertToMysqlBit(sc, tp)
-			if tt.truncated {
-				require.Contains(t, err.Error(), "Data Too Long")
-			} else {
-				require.NoError(t, err)
-			}
-			require.Equal(t, tt.out, bin.b)
-		})
+		bin, err := tt.a.convertToMysqlBit(nil, tp)
+		require.NoError(t, err)
+		require.Equal(t, tt.out, bin.b)
 	}
 }
 


### PR DESCRIPTION
Reverts pingcap/tidb#57354 because of https://github.com/pingcap/tidb/issues/59759

close #59769

We'll need to reconsider the solution / bugfix for both issues before the next release of 6.5.