### PR TITLE
planner:  gen shallow ref of logical aggregation and sort & move some func to util to avoid import cycle

### DIFF
--- a/pkg/planner/cascades/old/transformation_rules.go
+++ b/pkg/planner/cascades/old/transformation_rules.go
@@ -1183,7 +1183,7 @@ func (*MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*mem
 	for i, expr := range proj.Exprs {
 		newExpr := expr.Clone()
 		ruleutil.ResolveExprAndReplace(newExpr, replace)
-		newProj.Exprs[i] = plannercore.ReplaceColumnOfExpr(newExpr, child, childGroup.Prop.Schema)
+		newProj.Exprs[i] = ruleutil.ReplaceColumnOfExpr(newExpr, child.Exprs, childGroup.Prop.Schema)
 	}
 
 	newProjExpr := memo.NewGroupExpr(newProj)

--- a/pkg/planner/core/generator/shallow_ref/shallow_ref_generator.go
+++ b/pkg/planner/core/generator/shallow_ref/shallow_ref_generator.go
@@ -41,7 +41,8 @@ import (
 // clonedJoin._EqualConditionsShallowRef()
 // clonedJoin.EqualConditions[0] = newFunction(xx, clonedJoin.EqualConditions[0].FuncName, clodJoin.EqualConditions[0].tp|nullable)
 func GenShallowRef4LogicalOps() ([]byte, error) {
-	var structures = []any{logicalop.LogicalJoin{}, logicalop.LogicalProjection{}}
+	var structures = []any{logicalop.LogicalJoin{}, logicalop.LogicalProjection{}, logicalop.LogicalAggregation{},
+		logicalop.LogicalSort{}}
 	c := new(cc)
 	c.write(codeGenLogicalOpCowPrefix)
 	for _, s := range structures {
@@ -112,7 +113,10 @@ func (c *cc) shallowRefElement(fType reflect.Type, caller, fieldName string) str
 		}
 		c.write("%v = append(%v, %v)", tmpFieldName, tmpFieldName, res)
 		c.write("}")
-		c.write("%v = %v", caller+fieldName, tmpFieldName)
+		// only the outermost caller need to assign the new slice back to the original one.
+		if !strings.HasPrefix(fieldName, "one") {
+			c.write("%v = %v", caller+fieldName, tmpFieldName)
+		}
 	case reflect.Pointer: // just ref it.
 	case reflect.String:
 	case reflect.Interface:
@@ -163,6 +167,8 @@ package logicalop
 
 import (
 	"github.com/pingcap/tidb/pkg/expression"
+    "github.com/pingcap/tidb/pkg/expression/aggregation"
+    "github.com/pingcap/tidb/pkg/planner/util"
 )
 `
 

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -40,14 +40,14 @@ import (
 type LogicalAggregation struct {
 	LogicalSchemaProducer `hash64-equals:"true"`
 
-	AggFuncs     []*aggregation.AggFuncDesc `hash64-equals:"true"`
-	GroupByItems []expression.Expression    `hash64-equals:"true"`
+	AggFuncs     []*aggregation.AggFuncDesc `hash64-equals:"true" shallow-ref:"true"`
+	GroupByItems []expression.Expression    `hash64-equals:"true" shallow-ref:"true"`
 
 	// PreferAggType And PreferAggToCop stores aggregation hint information.
 	PreferAggType  uint
 	PreferAggToCop bool
 
-	PossibleProperties [][]*expression.Column `hash64-equals:"true"`
+	PossibleProperties [][]*expression.Column `hash64-equals:"true" shallow-ref:"true"`
 	InputCount         float64                // InputCount is the input count of this plan.
 
 	// NoCopPushDown indicates if planner must not push this agg down to coprocessor.

--- a/pkg/planner/core/operator/logicalop/logical_sort.go
+++ b/pkg/planner/core/operator/logicalop/logical_sort.go
@@ -33,7 +33,7 @@ import (
 type LogicalSort struct {
 	BaseLogicalPlan
 
-	ByItems []*util.ByItems `hash64-equals:"true"`
+	ByItems []*util.ByItems `hash64-equals:"true" shallow-ref:"true"`
 }
 
 // Init initializes LogicalSort.
@@ -158,6 +158,14 @@ func (ls *LogicalSort) ExtractCorrelatedCols() []*expression.CorrelatedColumn {
 // ConvertOuterToInnerJoin inherits BaseLogicalPlan.LogicalPlan.<24th> implementation.
 
 // *************************** end implementation of logicalPlan interface ***************************
+
+// GetUsedCols extracts all of the Columns used by agg including ByItems.
+func (ls *LogicalSort) GetUsedCols() (usedCols []*expression.Column) {
+	for _, byItem := range ls.ByItems {
+		usedCols = append(usedCols, expression.ExtractColumns(byItem.Expr)...)
+	}
+	return usedCols
+}
 
 func appendSortPassByItemsTraceStep(sort *LogicalSort, topN *LogicalTopN, opt *optimizetrace.LogicalOptimizeOp) {
 	ectx := sort.SCtx().GetExprCtx().GetEvalCtx()

--- a/pkg/planner/core/operator/logicalop/shallow_ref_generated.go
+++ b/pkg/planner/core/operator/logicalop/shallow_ref_generated.go
@@ -18,6 +18,8 @@ package logicalop
 
 import (
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/aggregation"
+	"github.com/pingcap/tidb/pkg/planner/util"
 )
 
 // LogicalJoinShallowRef implements the copy-on-write usage.
@@ -90,4 +92,60 @@ func (op *LogicalProjection) ExprsShallowRef() []expression.Expression {
 	}
 	op.Exprs = ExprsCP
 	return op.Exprs
+}
+
+// LogicalAggregationShallowRef implements the copy-on-write usage.
+func (op *LogicalAggregation) LogicalAggregationShallowRef() *LogicalAggregation {
+	shallow := *op
+	return &shallow
+}
+
+// AggFuncsShallowRef implements the copy-on-write usage.
+func (op *LogicalAggregation) AggFuncsShallowRef() []*aggregation.AggFuncDesc {
+	AggFuncsCP := make([]*aggregation.AggFuncDesc, 0, len(op.AggFuncs))
+	for _, one := range op.AggFuncs {
+		AggFuncsCP = append(AggFuncsCP, one)
+	}
+	op.AggFuncs = AggFuncsCP
+	return op.AggFuncs
+}
+
+// GroupByItemsShallowRef implements the copy-on-write usage.
+func (op *LogicalAggregation) GroupByItemsShallowRef() []expression.Expression {
+	GroupByItemsCP := make([]expression.Expression, 0, len(op.GroupByItems))
+	for _, one := range op.GroupByItems {
+		GroupByItemsCP = append(GroupByItemsCP, one)
+	}
+	op.GroupByItems = GroupByItemsCP
+	return op.GroupByItems
+}
+
+// PossiblePropertiesShallowRef implements the copy-on-write usage.
+func (op *LogicalAggregation) PossiblePropertiesShallowRef() [][]*expression.Column {
+	PossiblePropertiesCP := make([][]*expression.Column, 0, len(op.PossibleProperties))
+	for _, one := range op.PossibleProperties {
+		oneCP := make([]*expression.Column, 0, len(one))
+		for _, onee := range one {
+			oneCP = append(oneCP, onee)
+		}
+		PossiblePropertiesCP = append(PossiblePropertiesCP, one)
+	}
+	op.PossibleProperties = PossiblePropertiesCP
+	return op.PossibleProperties
+}
+
+// LogicalSortShallowRef implements the copy-on-write usage.
+func (op *LogicalSort) LogicalSortShallowRef() *LogicalSort {
+	shallow := *op
+	return &shallow
+}
+
+// ByItemsShallowRef implements the copy-on-write usage.
+func (op *LogicalSort) ByItemsShallowRef() []*util.ByItems {
+	ByItemsCP := make([]*util.ByItems, 0, len(op.ByItems))
+	for _, one := range op.ByItems {
+		ByItemsCP = append(ByItemsCP, one)
+	}
+	op.ByItems = ByItemsCP
+	return op.ByItems
 }

--- a/pkg/planner/core/rule/util/misc.go
+++ b/pkg/planner/core/rule/util/misc.go
@@ -43,6 +43,22 @@ func ResolveColumnAndReplace(origin *expression.Column, replace map[string]*expr
 	}
 }
 
+// ReplaceColumnOfExpr replaces column of expression by another LogicalProjection.
+func ReplaceColumnOfExpr(expr expression.Expression, exprs []expression.Expression, schema *expression.Schema) expression.Expression {
+	switch v := expr.(type) {
+	case *expression.Column:
+		idx := schema.ColumnIndex(v)
+		if idx != -1 && idx < len(exprs) {
+			return exprs[idx]
+		}
+	case *expression.ScalarFunction:
+		for i := range v.GetArgs() {
+			v.GetArgs()[i] = ReplaceColumnOfExpr(v.GetArgs()[i], exprs, schema)
+		}
+	}
+	return expr
+}
+
 // IsColsAllFromOuterTable check whether the cols all from outer plan
 func IsColsAllFromOuterTable(cols []*expression.Column, outerUniqueIDs *intset.FastIntSet) bool {
 	// There are two cases "return false" here:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/51664

Problem Summary:

### What changed and how does it work?
this is a split pr from 59743 which finished some util preparation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
