### PR TITLE
statistics: replace StatsLoad mutex with a dedicated mutex for statsCache protection

### DIFF
--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -64,9 +64,9 @@ type statsSyncLoad struct {
 	statsHandle statstypes.StatsHandle
 	is          infoschema.InfoSchema
 	StatsLoad   statstypes.StatsLoad
-	// This mutex is used to protect the statsCache when updating it.
-	// Because there are multiple workers updating the statsCache concurrently even for the same table.
-	// The lock is used to protect the statsCache when updating it.
+	// This mutex protects the statsCache from concurrent modifications by multiple workers.
+	// Since multiple workers may update the statsCache for the same table simultaneously,
+	// the mutex ensures thread-safety during these updates.
 	mu sync.Mutex
 }
 

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -67,7 +67,7 @@ type statsSyncLoad struct {
 	// This mutex protects the statsCache from concurrent modifications by multiple workers.
 	// Since multiple workers may update the statsCache for the same table simultaneously,
 	// the mutex ensures thread-safety during these updates.
-	mu sync.Mutex
+	mutexForStatsCache sync.Mutex
 }
 
 var globalStatsSyncLoadSingleFlight singleflight.Group
@@ -569,8 +569,8 @@ func (*statsSyncLoad) writeToResultChan(resultCh chan stmtctx.StatsLoadResult, r
 
 // updateCachedItem updates the column/index hist to global statsCache.
 func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.TableItemID, colHist *statistics.Column, idxHist *statistics.Index, fullLoaded bool) (updated bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mutexForStatsCache.Lock()
+	defer s.mutexForStatsCache.Unlock()
 	// Reload the latest stats cache, otherwise the `updateStatsCache` may fail with high probability, because functions
 	// like `GetPartitionStats` called in `fmSketchFromStorage` would have modified the stats cache already.
 	tbl, ok := s.statsHandle.Get(item.TableID)

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -63,11 +63,11 @@ func GetSyncLoadConcurrencyByCPU() int {
 type statsSyncLoad struct {
 	statsHandle statstypes.StatsHandle
 	is          infoschema.InfoSchema
+	StatsLoad   statstypes.StatsLoad
 	// This mutex is used to protect the statsCache when updating it.
 	// Because there are multiple workers updating the statsCache concurrently even for the same table.
 	// The lock is used to protect the statsCache when updating it.
-	mu        sync.Mutex
-	StatsLoad statstypes.StatsLoad
+	mu sync.Mutex
 }
 
 var globalStatsSyncLoadSingleFlight singleflight.Group

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -18,6 +18,7 @@ import (
 	stderrors "errors"
 	"math/rand"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -62,7 +63,11 @@ func GetSyncLoadConcurrencyByCPU() int {
 type statsSyncLoad struct {
 	statsHandle statstypes.StatsHandle
 	is          infoschema.InfoSchema
-	StatsLoad   statstypes.StatsLoad
+	// This mutex is used to protect the statsCache when updating it.
+	// Because there are multiple workers updating the statsCache concurrently even for the same table.
+	// The lock is used to protect the statsCache when updating it.
+	mu        sync.Mutex
+	StatsLoad statstypes.StatsLoad
 }
 
 var globalStatsSyncLoadSingleFlight singleflight.Group
@@ -564,8 +569,8 @@ func (*statsSyncLoad) writeToResultChan(resultCh chan stmtctx.StatsLoadResult, r
 
 // updateCachedItem updates the column/index hist to global statsCache.
 func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.TableItemID, colHist *statistics.Column, idxHist *statistics.Index, fullLoaded bool) (updated bool) {
-	s.StatsLoad.Lock()
-	defer s.StatsLoad.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	// Reload the latest stats cache, otherwise the `updateStatsCache` may fail with high probability, because functions
 	// like `GetPartitionStats` called in `fmSketchFromStorage` would have modified the stats cache already.
 	tbl, ok := s.statsHandle.Get(item.TableID)

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
@@ -469,7 +468,6 @@ type NeededItemTask struct {
 type StatsLoad struct {
 	NeededItemsCh  chan *NeededItemTask
 	TimeoutItemsCh chan *NeededItemTask
-	sync.Mutex
 }
 
 // StatsSyncLoad implement the sync-load feature.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55043

Problem Summary:

### What changed and how does it work?

I moved the lock to the correct position because placing it near the two channels was too confusing.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
