### PR TITLE
br: concurrently repairing indexes (#59159)

### DIFF
--- a/br/pkg/checkpoint/log_restore.go
+++ b/br/pkg/checkpoint/log_restore.go
@@ -315,6 +315,9 @@ type CheckpointIngestIndexRepairSQL struct {
 	IndexName  string       `json:"index-name"`
 	AddSQL     string       `json:"add-sql"`
 	AddArgs    []any        `json:"add-args"`
+
+	OldIndexIDFound bool `json:"-"`
+	IndexRepaired   bool `json:"-"`
 }
 
 type CheckpointIngestIndexRepairSQLs struct {

--- a/br/pkg/glue/progressing.go
+++ b/br/pkg/glue/progressing.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/vbauerster/mpb/v7"
 	"github.com/vbauerster/mpb/v7/decor"
+	"go.uber.org/zap"
 	"golang.org/x/term"
 )
 
@@ -172,4 +175,81 @@ func buildOneTaskBar(pb *mpb.Progress, title string, total int) *mpb.Bar {
 		mpb.AppendDecorators(decor.OnAbort(decor.OnComplete(decor.Spinner(spinnerText), spinnerDoneText),
 			color.RedString("ABORTED"))),
 	)
+}
+
+type ProgressBar interface {
+	Increment()
+	Done()
+}
+
+type MultiProgress interface {
+	AddTextBar(string, int64) ProgressBar
+	Wait()
+}
+
+func (ops ConsoleOperations) StartMultiProgress() MultiProgress {
+	if !ops.OutputIsTTY() {
+		return &NopMultiProgress{}
+	}
+	pb := mpb.New(mpb.WithOutput(ops.Out()), mpb.WithRefreshRate(400*time.Millisecond))
+	return &TerminalMultiProgress{
+		progress: pb,
+	}
+}
+
+type NopMultiProgress struct{}
+
+type LogBar struct {
+	name  string
+	total int64
+}
+
+func (nmp *NopMultiProgress) AddTextBar(name string, total int64) ProgressBar {
+	log.Info("progress start", zap.String("name", name))
+	return &LogBar{
+		name:  name,
+		total: total,
+	}
+}
+
+func (nmp *NopMultiProgress) Wait() {}
+
+func (lb *LogBar) Increment() {
+	if atomic.AddInt64(&lb.total, -1) <= 0 {
+		log.Info("progress done", zap.String("name", lb.name))
+	}
+}
+
+func (lb *LogBar) Done() {}
+
+type TerminalBar struct {
+	bar *mpb.Bar
+}
+
+func (tb *TerminalBar) Increment() {
+	tb.bar.Increment()
+}
+
+func (tb *TerminalBar) Done() {
+	tb.bar.Abort(false)
+	tb.bar.Wait()
+}
+
+type TerminalMultiProgress struct {
+	progress *mpb.Progress
+}
+
+func (tmp *TerminalMultiProgress) AddTextBar(name string, total int64) ProgressBar {
+	bar := tmp.progress.New(total,
+		mpb.NopStyle(),
+		mpb.PrependDecorators(decor.Name(name)),
+		mpb.AppendDecorators(decor.OnAbort(decor.OnComplete(decor.Spinner(spinnerText), spinnerDoneText),
+			color.RedString("ABORTED"),
+		)),
+	)
+	return &TerminalBar{bar: bar}
+}
+
+func (tmp *TerminalMultiProgress) Wait() {
+	tmp.progress.Wait()
 }

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -80,6 +80,10 @@ const maxSplitKeysOnce = 10240
 // rawKVBatchCount specifies the count of entries that the rawkv client puts into TiKV.
 const rawKVBatchCount = 64
 
+// session count for repairing ingest indexes. Currently only one TiDB node executes adding index jobs
+// at the same time and the add-index job concurrency is about min(10, `TiDB CPUs / 4`).
+const defaultRepairIndexSessionCount uint = 10
+
 type LogClient struct {
 	cipher        *backuppb.CipherInfo
 	pdClient      pd.Client
@@ -223,16 +227,48 @@ func (rc *LogClient) StartCheckpointRunnerForLogRestore(ctx context.Context, g g
 	return runner, errors.Trace(err)
 }
 
-// Init create db connection and domain for storage.
-func (rc *LogClient) Init(g glue.Glue, store kv.Storage) error {
-	var err error
-	rc.se, err = g.CreateSession(store)
+func createSession(ctx context.Context, g glue.Glue, store kv.Storage) (glue.Session, error) {
+	unsafeSession, err := g.CreateSession(store)
 	if err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-
 	// Set SQL mode to None for avoiding SQL compatibility problem
-	err = rc.se.Execute(context.Background(), "set @@sql_mode=''")
+	err = unsafeSession.Execute(ctx, "set @@sql_mode=''")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return unsafeSession, nil
+}
+
+func createSessions(ctx context.Context, g glue.Glue, store kv.Storage, count uint) (createdUnsafeSessions []glue.Session, createErr error) {
+	unsafeSessions := make([]glue.Session, 0, count)
+	defer func() {
+		if createErr != nil {
+			closeSessions(unsafeSessions)
+		}
+	}()
+	for range count {
+		unsafeSession, err := createSession(ctx, g, store)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		unsafeSessions = append(unsafeSessions, unsafeSession)
+	}
+	return unsafeSessions, nil
+}
+
+func closeSessions(sessions []glue.Session) {
+	for _, session := range sessions {
+		if session != nil {
+			session.Close()
+		}
+	}
+}
+
+// Init create db connection and domain for storage.
+func (rc *LogClient) Init(ctx context.Context, g glue.Glue, store kv.Storage) error {
+	var err error
+	rc.se, err = createSession(ctx, g, store)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1423,39 +1459,60 @@ func (rc *LogClient) RepairIngestIndex(ctx context.Context, ingestRecorder *inge
 
 	info := rc.dom.InfoSchema()
 	console := glue.GetConsole(g)
-NEXTSQL:
-	for _, sql := range sqls {
-		progressTitle := fmt.Sprintf("repair ingest index %s for table %s.%s", sql.IndexName, sql.SchemaName, sql.TableName)
-
+	for i, sql := range sqls {
 		tableInfo, err := info.TableByName(ctx, sql.SchemaName, sql.TableName)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		oldIndexIDFound := false
+		sqls[i].OldIndexIDFound = false
+		sqls[i].IndexRepaired = false
 		if fromCheckpoint {
 			for _, idx := range tableInfo.Indices() {
 				indexInfo := idx.Meta()
 				if indexInfo.ID == sql.IndexID {
 					// the original index id is not dropped
-					oldIndexIDFound = true
+					sqls[i].OldIndexIDFound = true
 					break
 				}
 				// what if index's state is not public?
 				if indexInfo.Name.O == sql.IndexName {
+					progressTitle := fmt.Sprintf("repair ingest index %s for table %s.%s", sql.IndexName, sql.SchemaName, sql.TableName)
 					// find the same name index, but not the same index id,
 					// which means the repaired index id is created
 					if _, err := fmt.Fprintf(console.Out(), "%s ... %s\n", progressTitle, color.HiGreenString("SKIPPED DUE TO CHECKPOINT MODE")); err != nil {
 						return errors.Trace(err)
 					}
-					continue NEXTSQL
+					sqls[i].IndexRepaired = true
+					break
 				}
 			}
 		}
+	}
 
-		if err := func(sql checkpoint.CheckpointIngestIndexRepairSQL) error {
-			w := console.StartProgressBar(progressTitle, glue.OnlyOneTask)
-			defer w.Close()
+	sessionCount := defaultRepairIndexSessionCount
+	indexSessions, err := createSessions(ctx, g, rc.dom.Store(), sessionCount)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer func() {
+		closeSessions(indexSessions)
+	}()
+	workerpool := tidbutil.NewWorkerPool(sessionCount, "repair ingest index")
+	eg, ectx := errgroup.WithContext(ctx)
+	mp := console.StartMultiProgress()
+	for _, sql := range sqls {
+		if sql.IndexRepaired {
+			continue
+		}
+		if ectx.Err() != nil {
+			break
+		}
+		progressTitle := fmt.Sprintf("repair ingest index %s for table %s.%s", sql.IndexName, sql.SchemaName, sql.TableName)
+		w := mp.AddTextBar(progressTitle, 1)
+		workerpool.ApplyWithIDInErrorGroup(eg, func(id uint64) error {
+			defer w.Done()
 
+			indexSession := indexSessions[id%uint64(len(indexSessions))]
 			// TODO: When the TiDB supports the DROP and CREATE the same name index in one SQL,
 			//   the checkpoint for ingest recorder can be removed and directly use the SQL:
 			//      ALTER TABLE db.tbl DROP INDEX `i_1`, ADD IDNEX `i_1` ...
@@ -1466,8 +1523,8 @@ NEXTSQL:
 			// restored metakv and then skips repairing it.
 
 			// only when first execution or old index id is not dropped
-			if !fromCheckpoint || oldIndexIDFound {
-				if err := rc.se.ExecuteInternal(ctx, alterTableDropIndexSQL, sql.SchemaName.O, sql.TableName.O, sql.IndexName); err != nil {
+			if !fromCheckpoint || sql.OldIndexIDFound {
+				if err := indexSession.ExecuteInternal(ectx, alterTableDropIndexSQL, sql.SchemaName.O, sql.TableName.O, sql.IndexName); err != nil {
 					return errors.Trace(err)
 				}
 			}
@@ -1477,17 +1534,15 @@ NEXTSQL:
 				}
 			})
 			// create the repaired index when first execution or not found it
-			if err := rc.se.ExecuteInternal(ctx, sql.AddSQL, sql.AddArgs...); err != nil {
+			if err := indexSession.ExecuteInternal(ectx, sql.AddSQL, sql.AddArgs...); err != nil {
 				return errors.Trace(err)
 			}
-			w.Inc()
-			if err := w.Wait(ctx); err != nil {
-				return errors.Trace(err)
-			}
+			w.Increment()
 			return nil
-		}(sql); err != nil {
-			return errors.Trace(err)
-		}
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return errors.Trace(err)
 	}
 
 	return nil

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -16,6 +16,7 @@ package logclient_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sync"
@@ -25,15 +26,20 @@ import (
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/tidb/br/pkg/checkpoint"
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/gluetidb"
 	"github.com/pingcap/tidb/br/pkg/mock"
+	"github.com/pingcap/tidb/br/pkg/restore/ingestrec"
 	logclient "github.com/pingcap/tidb/br/pkg/restore/log_client"
 	"github.com/pingcap/tidb/br/pkg/restore/utils"
 	"github.com/pingcap/tidb/br/pkg/stream"
 	"github.com/pingcap/tidb/br/pkg/utils/iter"
 	"github.com/pingcap/tidb/br/pkg/utiltest"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	parsermodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx"
@@ -91,7 +97,7 @@ func TestDeleteRangeQueryExec(t *testing.T) {
 	g := gluetidb.New()
 	client := logclient.NewRestoreClient(
 		utiltest.NewFakePDClient(nil, false, nil), nil, nil, keepalive.ClientParameters{})
-	err := client.Init(g, m.Storage)
+	err := client.Init(ctx, g, m.Storage)
 	require.NoError(t, err)
 
 	client.RunGCRowsLoader(ctx)
@@ -110,7 +116,7 @@ func TestDeleteRangeQuery(t *testing.T) {
 	g := gluetidb.New()
 	client := logclient.NewRestoreClient(
 		utiltest.NewFakePDClient(nil, false, nil), nil, nil, keepalive.ClientParameters{})
-	err := client.Init(g, m.Storage)
+	err := client.Init(ctx, g, m.Storage)
 	require.NoError(t, err)
 
 	client.RunGCRowsLoader(ctx)
@@ -1504,4 +1510,185 @@ func TestPITRIDMap(t *testing.T) {
 			}
 		}
 	}
+}
+
+
+func TestRepairIngestIndex(t *testing.T) {
+	s := utiltest.CreateRestoreSchemaSuite(t)
+	tk := testkit.NewTestKit(t, s.Mock.Storage)
+	tk.Exec("CREATE TABLE test.repair_index_t1(id int, a int, b int, key i1(id), key i2(a));")
+	g := gluetidb.New()
+	ctx := context.Background()
+	client := logclient.TEST_NewLogClient(123, 1, 2, 1, s.Mock.Domain, fakeSession{})
+
+	fakeJob := func(
+		schemaName string,
+		tableName string,
+		tableID int64,
+		indexID int64,
+		indexName string,
+		columnName string,
+		args json.RawMessage,
+	) *model.Job {
+		return &model.Job{
+			Version:    model.JobVersion1,
+			SchemaName: schemaName,
+			TableName:  tableName,
+			TableID:    tableID,
+			Type:       model.ActionAddIndex,
+			State:      model.JobStateSynced,
+			RowCount:   100,
+			RawArgs:    args,
+			ReorgMeta: &model.DDLReorgMeta{
+				ReorgTp: model.ReorgTypeLitMerge,
+			},
+			BinlogInfo: &model.HistoryInfo{
+				TableInfo: &model.TableInfo{
+					Indices: []*model.IndexInfo{
+						{
+							ID:   indexID,
+							Name: parsermodel.NewCIStr(indexName),
+							Columns: []*model.IndexColumn{{
+								Name: parsermodel.NewCIStr(columnName),
+							}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	{
+		infoschema := s.Mock.InfoSchema()
+		table, err := infoschema.TableByName(ctx, parsermodel.NewCIStr("test"), parsermodel.NewCIStr("repair_index_t1"))
+		require.NoError(t, err)
+		tableInfo := table.Meta()
+		indexIDi1 := int64(0)
+		indexIDi2 := int64(0)
+		for _, indexInfo := range tableInfo.Indices {
+			switch indexInfo.Name.L {
+			case "i1":
+				indexIDi1 = indexInfo.ID
+			case "i2":
+				indexIDi2 = indexInfo.ID
+			}
+		}
+		require.NotEqual(t, int64(0), indexIDi1)
+		require.NotEqual(t, int64(0), indexIDi2)
+		ingestRecorder := ingestrec.New()
+		require.NoError(t, ingestRecorder.TryAddJob(fakeJob(
+			"test", "repair_index_t1", tableInfo.ID, indexIDi1, "i1", "id",
+			json.RawMessage(fmt.Sprintf("[%d, false, [], false]", indexIDi1)),
+		), false))
+		require.NoError(t, ingestRecorder.TryAddJob(fakeJob(
+			"test", "repair_index_t1", tableInfo.ID, indexIDi2, "i2", "a",
+			json.RawMessage(fmt.Sprintf("[%d, false, [], false]", indexIDi2)),
+		), false))
+		require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, g))
+		infoschema = s.Mock.InfoSchema()
+		table2, err := infoschema.TableByName(ctx, parsermodel.NewCIStr("test"), parsermodel.NewCIStr("repair_index_t1"))
+		require.NoError(t, err)
+		tableInfo2 := table2.Meta()
+		existsCount := 0
+		for _, indexInfo2 := range tableInfo2.Indices {
+			switch indexInfo2.Name.L {
+			case "i1":
+				require.Less(t, indexIDi1, indexInfo2.ID)
+				existsCount++
+			case "i2":
+				require.Less(t, indexIDi2, indexInfo2.ID)
+				existsCount++
+			}
+		}
+		require.Equal(t, 2, existsCount)
+	}
+}
+
+func TestRepairIngestIndexFromCheckpoint(t *testing.T) {
+	s := utiltest.CreateRestoreSchemaSuite(t)
+	tk := testkit.NewTestKit(t, s.Mock.Storage)
+	tk.Exec("CREATE TABLE test.repair_index_t1(id int, a int, b int, key i1(id), key i2(a));")
+	g := gluetidb.New()
+	ctx := context.Background()
+	se, err := g.CreateSession(s.Mock.Storage)
+	require.NoError(t, err)
+	client := logclient.TEST_NewLogClient(123, 1, 2, 1, s.Mock.Domain, se)
+	client.SetUseCheckpoint()
+
+	infoschema := s.Mock.InfoSchema()
+	table, err := infoschema.TableByName(ctx, parsermodel.NewCIStr("test"), parsermodel.NewCIStr("repair_index_t1"))
+	require.NoError(t, err)
+	tableInfo := table.Meta()
+	indexIDi1 := int64(0)
+	indexIDi2 := int64(0)
+	for _, indexInfo := range tableInfo.Indices {
+		switch indexInfo.Name.L {
+		case "i1":
+			indexIDi1 = indexInfo.ID
+		case "i2":
+			indexIDi2 = indexInfo.ID
+		}
+	}
+	require.NotEqual(t, int64(0), indexIDi1)
+	require.NotEqual(t, int64(0), indexIDi2)
+
+	// add checkpoint
+	_, err = tk.Exec("CREATE DATABASE __TiDB_BR_Temporary_Log_Restore_Checkpoint")
+	require.NoError(t, err)
+	defer func() {
+		_, err = tk.Exec("DROP DATABASE __TiDB_BR_Temporary_Log_Restore_Checkpoint")
+		require.NoError(t, err)
+	}()
+	require.NoError(t, checkpoint.SaveCheckpointIngestIndexRepairSQLs(ctx, se, &checkpoint.CheckpointIngestIndexRepairSQLs{
+		SQLs: []checkpoint.CheckpointIngestIndexRepairSQL{
+			{
+				// from checkpoint and old index (i1) id is found
+				IndexID:    indexIDi1,
+				SchemaName: parsermodel.NewCIStr("test"),
+				TableName:  parsermodel.NewCIStr("repair_index_t1"),
+				IndexName:  "i1",
+				AddSQL:     "ALTER TABLE %n.%n ADD INDEX %n(%n) USING BTREE VISIBLE",
+				AddArgs:    []any{"test", "repair_index_t1", "i1", "id"},
+			},
+			{
+				// from checkpoint and the index (i2) is repaired
+				IndexID:    indexIDi2 + 99,
+				SchemaName: parsermodel.NewCIStr("test"),
+				TableName:  parsermodel.NewCIStr("repair_index_t1"),
+				IndexName:  "i2",
+				AddSQL:     "ALTER TABLE %n.%n ADD INDEX %n(%n) USING BTREE VISIBLE",
+				AddArgs:    []any{"test", "repair_index_t1", "i2", "a"},
+			},
+			{
+				// from checkpoint and old index (i3) id is not found
+				IndexID:    indexIDi2 + 100,
+				SchemaName: parsermodel.NewCIStr("test"),
+				TableName:  parsermodel.NewCIStr("repair_index_t1"),
+				IndexName:  "i3",
+				AddSQL:     "ALTER TABLE %n.%n ADD INDEX %n(%n) USING BTREE VISIBLE",
+				AddArgs:    []any{"test", "repair_index_t1", "i3", "b"},
+			},
+		},
+	}))
+	ingestRecorder := ingestrec.New()
+	require.NoError(t, client.RepairIngestIndex(ctx, ingestRecorder, g))
+	infoschema = s.Mock.InfoSchema()
+	table2, err := infoschema.TableByName(ctx, parsermodel.NewCIStr("test"), parsermodel.NewCIStr("repair_index_t1"))
+	require.NoError(t, err)
+	tableInfo2 := table2.Meta()
+	existsCount := 0
+	for _, indexInfo2 := range tableInfo2.Indices {
+		switch indexInfo2.Name.L {
+		case "i1":
+			require.Less(t, indexIDi2, indexInfo2.ID)
+			existsCount++
+		case "i2":
+			require.Equal(t, indexIDi2, indexInfo2.ID)
+			existsCount++
+		case "i3":
+			require.Less(t, indexIDi2, indexInfo2.ID)
+			existsCount++
+		}
+	}
+	require.Equal(t, 3, existsCount)
 }

--- a/br/pkg/restore/log_client/export_test.go
+++ b/br/pkg/restore/log_client/export_test.go
@@ -69,6 +69,10 @@ func TEST_NewLogClient(clusterID, startTS, restoreTS, upstreamClusterID uint64, 
 	}
 }
 
+func (rc *LogClient) SetUseCheckpoint() {
+	rc.useCheckpoint = true
+}
+
 func TEST_NewLogFileManager(startTS, restoreTS, shiftStartTS uint64, helper streamMetadataHelper) *LogFileManager {
 	return &LogFileManager{
 		startTS:      startTS,

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1551,7 +1551,7 @@ func createRestoreClient(ctx context.Context, g glue.Glue, cfg *RestoreConfig, m
 	keepaliveCfg := GetKeepalive(&cfg.Config)
 	keepaliveCfg.PermitWithoutStream = true
 	client := logclient.NewRestoreClient(mgr.GetPDClient(), mgr.GetPDHTTPClient(), mgr.GetTLSConfig(), keepaliveCfg)
-	err = client.Init(g, mgr.GetStorage())
+	err = client.Init(ctx, g, mgr.GetStorage())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Manual cherry-pick of #59159 to 8.5 release, obsoletes #59639.

Recent BR/restore refactorings make it so that it does not cherry-pick cleanly, so manually applied diffs.

---

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close pingcap/tidb#59158

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
