### PR TITLE
*: revert to load full privilege data on v8.5

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1839,7 +1839,9 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 		return err
 	}
 	do.privHandle = privileges.NewHandle(sctx.GetRestrictedSQLExecutor())
-	do.privHandle.Update()
+	if err := do.privHandle.Update(); err != nil {
+		return errors.Trace(err)
+	}
 
 	var watchCh clientv3.WatchChan
 	duration := 5 * time.Minute

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1839,6 +1839,7 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 		return err
 	}
 	do.privHandle = privileges.NewHandle(sctx.GetRestrictedSQLExecutor())
+	do.privHandle.Update()
 
 	var watchCh clientv3.WatchChan
 	duration := 5 * time.Minute

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -1834,26 +1834,6 @@ func NewHandle(sctx sqlexec.RestrictedSQLExecutor) *Handle {
 
 // ensureActiveUser ensure that the specific user data is loaded in-memory.
 func (h *Handle) ensureActiveUser(user string) error {
-	_, exist := h.activeUsers.Load(user)
-	if exist {
-		return nil
-	}
-
-	var data immutable
-	err := data.loadSomeUsers(h.sctx, user)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	for {
-		old := h.Get()
-		swapped := h.priv.CompareAndSwap(old, old.merge(&data))
-		if swapped {
-			break
-		}
-	}
-	h.activeUsers.Store(user, struct{}{})
-
 	return nil
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3653,15 +3653,16 @@ func bootstrapSessionImpl(ctx context.Context, store kv.Storage, createSessionsI
 		}
 	}
 
+	err = dom.InitDistTaskLoop()
+	if err != nil {
+		return nil, err
+	}
+
 	// This only happens in testing, since the failure of loading or parsing sql file
 	// would panic the bootstrapping.
 	if intest.InTest && failToLoadOrParseSQLFile {
 		dom.Close()
 		return nil, errors.New("Fail to load or parse sql file")
-	}
-	err = dom.InitDistTaskLoop()
-	if err != nil {
-		return nil, err
 	}
 	return dom, err
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #55563

Problem Summary:

### What changed and how does it work?

On 8.5 branch, the feature to [support 2M users](https://github.com/pingcap/tidb/issues/55563) is not completed,  but some code sneak in.

That cause subtle bug,  the `loadSomeUser` function should load user and also the roles of the user,  on the bug-free version, it is:

```
	// Load the full role edge table first.
	p.roleGraph = make(map[string]roleGraphEdgesTable)
	err := p.loadTable(ctx, sqlLoadRoleGraph, p.decodeRoleEdgesTable)
	if err != nil {
		return nil, errors.Trace(err)
	}

	// Including the user list and also their roles
	extendedUserList := make(map[string]struct{}, len(userList))
	for _, user := range userList {
		extendedUserList[user] = struct{}{}
	}
	findUserAndAllRoles(extendedUserList, p.roleGraph)
	// Re-generate the user list.
	userList = userList[:0]
	for user := range extendedUserList {
		userList = append(userList, user)
	}
```

Revert some code and turn back to full reload is the best way to fix on v8.5, instead of cherry-pick too much code.

The change of this PR is:
1. load all privilege data when tidb startup.
2. make `ensureActiveUser` dummy operation because all users are in-memory already.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test

It should be covered by the integration test already, but the bug is subtle.
If the tidb start and the quey immediately run role related things, the privilege data is not loaded.
But if the query run 10min later after a privilege full reload, the privilege data is in-memory and nothing goes wrong.

- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->



Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
