### PR TITLE
statistics: improve handling for slow stats updates and logging

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -480,6 +480,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 		for workerError := range errCh {
 			errSet[workerError.Error()] = struct{}{}
 		}
+		intest.Assert(len(errSet) > 0, "errSet should at least contain one error")
 		errMsg := slices.Collect(maps.Keys(errSet))
 		err = errors.New(strings.Join(errMsg, ","))
 	}

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -474,7 +474,7 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	wg.Wait()
 	close(errCh)
 	if len(errCh) > 0 {
-		errSet := make(map[string]struct{})
+		errSet := make(map[string]struct{}, len(errCh))
 		for err1 := range errCh {
 			errSet[err1.Error()] = struct{}{}
 		}

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -474,11 +474,17 @@ func (e *AnalyzeExec) handleResultsErrorWithConcurrency(
 	wg.Wait()
 	close(errCh)
 	if len(errCh) > 0 {
-		errMsg := make([]string, 0)
+		errSet := make(map[string]struct{})
 		for err1 := range errCh {
-			errMsg = append(errMsg, err1.Error())
+			errSet[err1.Error()] = struct{}{}
 		}
-		err = errors.New(strings.Join(errMsg, ","))
+		if len(errSet) > 0 {
+			errMsg := make([]string, 0, len(errSet))
+			for msg := range errSet {
+				errMsg = append(errMsg, msg)
+			}
+			err = errors.New(strings.Join(errMsg, ","))
+		}
 	}
 	for tableID := range tableIDs {
 		// Dump stats to historical storage.

--- a/pkg/executor/analyze_worker.go
+++ b/pkg/executor/analyze_worker.go
@@ -57,7 +57,7 @@ func (worker *analyzeSaveStatsWorker) run(ctx context.Context, statsHandle *hand
 			worker.errCh <- err
 			return
 		}
-		err := statsHandle.SaveTableStatsToStorage(results, analyzeSnapshot, util.StatsMetaHistorySourceAnalyze)
+		err := statsHandle.SaveAnalyzeResultToStorage(results, analyzeSnapshot, util.StatsMetaHistorySourceAnalyze)
 		if err != nil {
 			logutil.Logger(ctx).Error("save table stats to storage failed", zap.Error(err))
 			finishJobWithLog(statsHandle, results.Job, err)

--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -1065,7 +1065,7 @@ func TestSavedAnalyzeColumnOptions(t *testing.T) {
 
 	h := dom.StatsHandle()
 	oriLease := h.Lease()
-	h.SetLease(1)
+	h.SetLease(3 * time.Second)
 	defer func() {
 		h.SetLease(oriLease)
 	}()

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -38,6 +38,11 @@ import (
 	"go.uber.org/zap"
 )
 
+// LeaseOffset represents the time offset for the stats cache to load statistics from the store.
+// This value is crucial to ensure that the stats are retrieved at the correct interval.
+// See more at where it is used.
+const LeaseOffset = 5
+
 // StatsCacheImpl implements util.StatsCache.
 type StatsCacheImpl struct {
 	atomic.Pointer[StatsCache]
@@ -115,6 +120,7 @@ func newCacheOfBatchUpdate(batchSize int, op func(toUpdate []*statistics.Table, 
 
 // Update reads stats meta from store and updates the stats map.
 func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema, tableAndPartitionIDs ...int64) error {
+	onlyForAnalyzedTables := len(tableAndPartitionIDs) > 0
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
@@ -130,7 +136,7 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema, t
 		query := "SELECT version, table_id, modify_count, count, snapshot from mysql.stats_meta where version > %? "
 		args := []any{lastVersion}
 
-		if len(tableAndPartitionIDs) > 0 {
+		if onlyForAnalyzedTables {
 			// When updating specific tables, we skip incrementing the max stats version to avoid missing
 			// delta updates for other tables. The max version only advances when doing a full update.
 			skipMoveForwardStatsCache = true
@@ -240,7 +246,7 @@ func (s *StatsCacheImpl) GetNextCheckVersionWithOffset() uint64 {
 	// the table stats of A0 if we read stats that greater than lastVersion which is B0.
 	// We can read the stats if the diff between commit time and version is less than five lease.
 	offset := util.DurationToTS(5 * s.statsHandle.Lease()) // 5 lease is 15s.
-	if s.MaxTableStatsVersion() >= offset {
+	if lastVersion >= offset {
 		lastVersion = lastVersion - offset
 	} else {
 		lastVersion = 0

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -245,7 +245,7 @@ func (s *StatsCacheImpl) GetNextCheckVersionWithOffset() uint64 {
 	// and A0 < B0 < B1 < A1. We will first read the stats of B, and update the lastVersion to B0, but we cannot read
 	// the table stats of A0 if we read stats that greater than lastVersion which is B0.
 	// We can read the stats if the diff between commit time and version is less than five lease.
-	offset := util.DurationToTS(5 * s.statsHandle.Lease()) // 5 lease is 15s.
+	offset := util.DurationToTS(LeaseOffset * s.statsHandle.Lease())
 	if lastVersion >= offset {
 		lastVersion = lastVersion - offset
 	} else {

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -316,7 +316,7 @@ func (h subscriber) delayedDeleteStats4PhysicalID(
 	sctx sessionctx.Context,
 	id int64,
 ) error {
-	startTS, err2 := storage.UpdateStatsMetaVersionForGC(ctx, sctx, id)
+	startTS, err2 := storage.UpdateStatsMetaVersion(ctx, sctx, id)
 	if err2 != nil {
 		return errors.Trace(err2)
 	}

--- a/pkg/statistics/handle/globalstats/global_stats.go
+++ b/pkg/statistics/handle/globalstats/global_stats.go
@@ -379,7 +379,7 @@ func WriteGlobalStatsToStorage(statsHandle statstypes.StatsHandle, globalStats *
 			continue
 		}
 		// fms for global stats doesn't need to dump to kv.
-		err = statsHandle.SaveStatsToStorage(gid,
+		err = statsHandle.SaveColOrIdxStatsToStorage(gid,
 			globalStats.Count,
 			globalStats.ModifyCount,
 			info.IsIndex,

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sessionctx/variable",
         "//pkg/statistics",
         "//pkg/statistics/asyncload",
+        "//pkg/statistics/handle/cache",
         "//pkg/statistics/handle/lockstats",
         "//pkg/statistics/handle/logutil",
         "//pkg/statistics/handle/metrics",
@@ -58,7 +59,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 24,
+    shard_count = 25,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 26,
+    shard_count = 27,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -59,7 +59,7 @@ go_test(
         "stats_read_writer_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         ":storage",
         "//pkg/domain",

--- a/pkg/statistics/handle/storage/dump_test.go
+++ b/pkg/statistics/handle/storage/dump_test.go
@@ -410,7 +410,7 @@ func TestDumpCMSketchWithTopN(t *testing.T) {
 	cms, _, _, _ := statistics.NewCMSketchAndTopN(5, 2048, fakeData, 20, 100)
 
 	stat := h.GetTableStats(tableInfo)
-	err = h.SaveStatsToStorage(tableInfo.ID, 1, 0, 0, &stat.GetCol(tableInfo.Columns[0].ID).Histogram, cms, nil, statistics.Version1, false, handleutil.StatsMetaHistorySourceLoadStats)
+	err = h.SaveColOrIdxStatsToStorage(tableInfo.ID, 1, 0, 0, &stat.GetCol(tableInfo.Columns[0].ID).Histogram, cms, nil, statistics.Version1, false, handleutil.StatsMetaHistorySourceLoadStats)
 	require.NoError(t, err)
 	require.Nil(t, h.Update(context.Background(), is))
 

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -119,8 +119,8 @@ func saveBucketsToStorage(sctx sessionctx.Context, tableID int64, isIndex int, h
 	return
 }
 
-// SaveTableStatsToStorage saves the stats of a table to storage.
-func SaveTableStatsToStorage(sctx sessionctx.Context,
+// SaveAnalyzeResultToStorage saves the analyze result to the storage.
+func SaveAnalyzeResultToStorage(sctx sessionctx.Context,
 	results *statistics.AnalyzeResults, analyzeSnapshot bool) (statsVer uint64, err error) {
 	needDumpFMS := results.TableID.IsPartitionTable()
 	tableID := results.TableID.GetStatisticsID()
@@ -313,11 +313,11 @@ func SaveTableStatsToStorage(sctx sessionctx.Context,
 	return
 }
 
-// SaveStatsToStorage saves the stats to storage.
+// SaveColOrIdxStatsToStorage saves the column or index statistics to the storage.
 // If count is negative, both count and modify count would not be used and not be written to the table. Unless, corresponding
 // fields in the stats_meta table will be updated.
 // TODO: refactor to reduce the number of parameters
-func SaveStatsToStorage(
+func SaveColOrIdxStatsToStorage(
 	sctx sessionctx.Context,
 	tableID int64,
 	count, modifyCount int64,

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -142,7 +142,7 @@ func (s *statsReadWriter) handleSlowStatsSaving(results *statistics.AnalyzeResul
 			zap.String("jobInfo", results.Job.JobInfo),
 			zap.Error(err),
 		)
-		return 0, errors.Errorf("failed to update stats meta version when saving analyze result, please retry the analyze operation")
+		return 0, errors.Errorf("failed to update stats meta version during analyze result save. The system may be too busy. Please retry the operation later")
 	}
 
 	statslogutil.StatsLogger().Info("Successfully updated stats meta version for slow saving",

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -145,7 +145,20 @@ func TestFailedToHandleSlowStatsSaving(t *testing.T) {
 	testKit := testkit.NewTestKit(t, store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
-	testKit.MustExec("create table t (a int, b int, index idx(a))")
+	testKit.MustExec(`
+		create table t (
+			a int,
+			b int,
+			primary key(a),
+			index idx(b)
+		)
+		partition by range (a) (
+			partition p0 values less than (6),
+			partition p1 values less than (11),
+			partition p2 values less than (16),
+			partition p3 values less than (21)
+		)
+	`)
 	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
 	testKit.MustGetErrMsg("analyze table t with 0 topn", "failed to update stats meta version during analyze result save. The system may be too busy. Please retry the operation later")
 }

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -126,7 +126,6 @@ func TestSlowStatsSaving(t *testing.T) {
 	histVersion := rows[0][0].(string)
 	histVersionUint64, err := strconv.ParseUint(histVersion, 10, 64)
 	require.NoError(t, err)
-	require.NotEqual(t, versionUint64, histVersionUint64, "The version in stats_meta and stats_histograms should be different.")
 	require.True(t, versionUint64 > histVersionUint64, "The version in stats_meta should be greater than stats_histograms.")
 }
 

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -147,5 +147,5 @@ func TestFailedToHandleSlowStatsSaving(t *testing.T) {
 	testKit.MustExec("drop table if exists t")
 	testKit.MustExec("create table t (a int, b int, index idx(a))")
 	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
-	testKit.MustGetErrMsg("analyze table t with 0 topn", "failed to update stats meta version when saving analyze result, please retry the analyze operation")
+	testKit.MustGetErrMsg("analyze table t with 0 topn", "failed to update stats meta version during analyze result save. The system may be too busy. Please retry the operation later")
 }

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -167,7 +167,7 @@ func TestSlowStatsSavingForPartitionedTable(t *testing.T) {
 	require.False(t, statsTbl.Pseudo)
 
 	// Note: We deliberately focus on checking the global stats version here.
-	// For global stats, `SaveStatsToStorage` is used to persist statistics to storage.
+	// For global stats, `SaveColOrIdxStatsToStorage` is used to persist statistics to storage.
 	// We primarily verify the global stats version to confirm successful saving after the slow stats saving process.
 	// Get stats version from mysql.stats_meta.
 	rows := testKit.MustQuery(

--- a/pkg/statistics/handle/storage/stats_read_writer_test.go
+++ b/pkg/statistics/handle/storage/stats_read_writer_test.go
@@ -129,6 +129,69 @@ func TestSlowStatsSaving(t *testing.T) {
 	require.True(t, versionUint64 > histVersionUint64, "The version in stats_meta should be greater than stats_histograms.")
 }
 
+func TestSlowStatsSavingForPartitionedTable(t *testing.T) {
+	err := failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/storage/slowStatsSaving", "return(true)")
+	require.NoError(t, err)
+	defer func() {
+		err = failpoint.Disable("github.com/pingcap/tidb/pkg/statistics/handle/storage/slowStatsSaving")
+		require.NoError(t, err)
+	}()
+	store, do := testkit.CreateMockStoreAndDomain(t)
+	testKit := testkit.NewTestKit(t, store)
+	h := do.StatsHandle()
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec(`
+		create table t (
+			a int,
+			b int,
+			primary key(a),
+			index idx(b)
+		)
+		partition by range (a) (
+			partition p0 values less than (6),
+			partition p1 values less than (11),
+			partition p2 values less than (16),
+			partition p3 values less than (21)
+		)
+	`)
+	testKit.MustExec("insert into t values (1,2),(2,2),(6,2),(11,2),(16,2)")
+	testKit.MustExec("analyze table t with 0 topn")
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(context.Background(),
+		ast.NewCIStr("test"), ast.NewCIStr("t"),
+	)
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	statsTbl := h.GetTableStats(tableInfo)
+	require.False(t, statsTbl.Pseudo)
+
+	// Note: We deliberately focus on checking the global stats version here.
+	// For global stats, `SaveStatsToStorage` is used to persist statistics to storage.
+	// We primarily verify the global stats version to confirm successful saving after the slow stats saving process.
+	// Get stats version from mysql.stats_meta.
+	rows := testKit.MustQuery(
+		"select version from mysql.stats_meta where table_id = ?",
+		tableInfo.ID,
+	).Rows()
+	require.Equal(t, 1, len(rows))
+	version := rows[0][0].(string)
+	versionUint64, err := strconv.ParseUint(version, 10, 64)
+	require.NoError(t, err)
+	// Get stats version from mysql.stats_histograms.
+	rows = testKit.MustQuery(
+		"select version from mysql.stats_histograms where table_id = ?",
+		tableInfo.ID,
+	).Rows()
+	require.Equal(t, 3, len(rows))
+	for _, row := range rows {
+		histVersion := row[0].(string)
+		histVersionUint64, err := strconv.ParseUint(histVersion, 10, 64)
+		require.NoError(t, err)
+		require.True(t, versionUint64 > histVersionUint64, "The version in stats_meta should be greater than stats_histograms.")
+	}
+}
+
 func TestFailedToHandleSlowStatsSaving(t *testing.T) {
 	err := failpoint.Enable("github.com/pingcap/tidb/pkg/statistics/handle/storage/slowStatsSaving", "return(true)")
 	require.NoError(t, err)

--- a/pkg/statistics/handle/storage/update.go
+++ b/pkg/statistics/handle/storage/update.go
@@ -292,9 +292,8 @@ func ChangeGlobalStatsID(
 	return nil
 }
 
-// UpdateStatsMetaVersionForGC updates the version of stats_meta to be deleted
-// soon.
-func UpdateStatsMetaVersionForGC(
+// UpdateStatsMetaVersion updates the version to the newest TS for a table.
+func UpdateStatsMetaVersion(
 	ctx context.Context,
 	sctx sessionctx.Context,
 	physicalID int64,

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -342,12 +342,12 @@ type StatsReadWriter interface {
 	// ReloadExtendedStatistics drops the cache for extended statistics and reload data from mysql.stats_extended.
 	ReloadExtendedStatistics() error
 
-	// SaveStatsToStorage save the stats data to the storage.
-	SaveStatsToStorage(tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
+	// SaveColOrIdxStatsToStorage save the column or index stats to storage.
+	SaveColOrIdxStatsToStorage(tableID int64, count, modifyCount int64, isIndex int, hg *statistics.Histogram,
 		cms *statistics.CMSketch, topN *statistics.TopN, statsVersion int, updateAnalyzeTime bool, source string) (err error)
 
-	// SaveTableStatsToStorage saves the stats of a table to storage.
-	SaveTableStatsToStorage(results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) (err error)
+	// SaveAnalyzeResultToStorage saves the analyze result to the storage.
+	SaveAnalyzeResultToStorage(results *statistics.AnalyzeResults, analyzeSnapshot bool, source string) (err error)
 
 	// SaveMetaToStorage saves the stats meta of a table to storage.
 	SaveMetaToStorage(tableID, count, modifyCount int64, source string) (err error)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/54552

Problem Summary:

### What changed and how does it work?

In most cases, this would prevent the stats from being lost on other nodes.

The reason this could happen is that the stats update might be too slow and blocked for more than 3 * lease duration. Once this happens, there is no way to load the stats correctly on other nodes, as we push forward the maximum version from the stats cache.

In this PR, we aim to minimize the chances of the table failing to load after ANALYZE. If such a situation occurs, we will attempt to update the stats version again to ensure that other nodes can read it. This will be done through a very small transaction to ensure the version refresh, which triggers the normal loading process.

If even this recovery mechanism fails, the ANALYZE command will fail, and an error message will be shown to the user: “Failed to update stats meta version when saving analyze result, please retry the analyze operation.”

This issue is expected to occur only in very extreme scenarios, such as when the entire cluster has high duration, the table being analyzed has a large amount of collected stats, and the transaction for storing stats becomes large and slow.

From a technical perspective, solving this issue completely at the SQL layer is extremely difficult. From a benefit standpoint, even if we were to fully resolve it, the impact would be minimal (especially since the oncall was further complicated by DDL operations). Therefore, I’ve proposed a solution that attempts recovery, and if recovery fails, prompts the user to retry.


A summary table for functions that update the stats meta in the stats writer:

| Function      | Requirement     |
| ------------- | ------------- |
| SaveStatsToStorage | It needs to be handled because the global stats merge uses this method. Although we use a separate transaction for each column/index, the aggregated statistics may still be quite large, so it still needs to be addressed. |
| SaveTableStatsToStorage | It needs to be handled because this method is called after the analyze process completes. All statistics for the entire table are processed within a single transaction, which can be quite large, so it must be addressed. |
| SaveMetaToStorage | Not necessary, because it only modifies a single row in the meta, making the transaction small enough. |
| InsertExtendedStats/MarkExtendedStatsDeleted/SaveExtendedStatsToStorage | Not necessary, as the transaction is relatively small, and the ExtendedStat feature is disabled by default. |


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复潜在的 stats 状态在不同节点上不一致的问题
Fix the potential issue of inconsistent stats cache across different nodes
```
