### PR TITLE
dxf: increase memory quota for session of generating subtasks (part 2) | tidb-test=release-8.1.2

### DIFF
--- a/pkg/disttask/framework/storage/task_table.go
+++ b/pkg/disttask/framework/storage/task_table.go
@@ -609,8 +609,8 @@ func (mgr *TaskManager) SwitchTaskStep(
 		vars := se.GetSessionVars()
 		// in most cases the def memory quota is enough, but when importing 200TiB
 		// data using global sort, when transiting to write&ingest step, the txn
-		// might be cancelled, so we double it.
-		targetQuota := 2 * variable.DefTiDBMemQuotaQuery
+		// might be cancelled, so we quadruple it.
+		targetQuota := 4 * variable.DefTiDBMemQuotaQuery
 		if int(vars.MemQuotaQuery) < targetQuota {
 			bak := vars.MemQuotaQuery
 			if err := vars.SetSystemVar(variable.TiDBMemQuotaQuery,


### PR DESCRIPTION
### What problem does this PR solve?

[Double](https://github.com/pingcap/tidb/pull/59750) the memory quota is not enough, let's quadruple it

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
