### PR TITLE
*: fix incorrect handling IterAllTables

### DIFF
--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1276,8 +1276,6 @@ func TestGetAllTableInfos(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 
-	//tk.MustExec("create table test.t1 (a int)")
-
 	for i := 0; i < 213; i++ {
 		tk.MustExec(fmt.Sprintf("create database test%d", i))
 		tk.MustExec(fmt.Sprintf("use test%d", i))
@@ -1289,23 +1287,19 @@ func TestGetAllTableInfos(t *testing.T) {
 	tblInfos1 := make([]*model.TableInfo, 0)
 	tblInfos2 := make([]*model.TableInfo, 0)
 	dbs := dom.InfoSchema().AllSchemas()
-	maxDBID := int64(0)
 	for _, db := range dbs {
 		if infoschema.IsSpecialDB(db.Name.L) {
 			continue
-		}
-		if db.ID > maxDBID {
-			maxDBID = db.ID
 		}
 		info, err := dom.InfoSchema().SchemaTableInfos(context.Background(), db.Name)
 		require.NoError(t, err)
 		tblInfos1 = append(tblInfos1, info...)
 	}
 
-	err := meta.IterAllTables(context.Background(), store, oracle.GoTimeToTS(time.Now()), 10, func(tblInfo *model.TableInfo) error {
+	err := meta.IterAllTables(context.Background(), store, oracle.GoTimeToTS(time.Now()), 13, func(tblInfo *model.TableInfo) error {
 		tblInfos2 = append(tblInfos2, tblInfo)
 		return nil
-	}, maxDBID)
+	})
 	require.NoError(t, err)
 
 	slices.SortFunc(tblInfos1, func(i, j *model.TableInfo) int {

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1309,14 +1309,6 @@ func TestGetAllTableInfos(t *testing.T) {
 		return int(i.ID - j.ID)
 	})
 
-	for _, tbl := range tblInfos2 {
-		println(fmt.Sprintf("table id: %d, db id: %d", tbl.ID, tbl.DBID))
-	}
-
-	for _, tbl := range tblInfos1 {
-		println(fmt.Sprintf("table id: %d, db id: %d", tbl.ID, tbl.DBID))
-	}
-
 	require.Equal(t, len(tblInfos1), len(tblInfos2))
 	for i := range tblInfos1 {
 		require.Equal(t, tblInfos1[i].ID, tblInfos2[i].ID)

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1276,7 +1276,7 @@ func TestGetAllTableInfos(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 
-	for i := 0; i < 213; i++ {
+	for i := 0; i < 113; i++ {
 		tk.MustExec(fmt.Sprintf("create database test%d", i))
 		tk.MustExec(fmt.Sprintf("use test%d", i))
 		tk.MustExec("create table t1 (a int)")

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1318,6 +1318,11 @@ func TestGetAllTableInfos(t *testing.T) {
 	for _, tbl := range tblInfos2 {
 		println(fmt.Sprintf("table id: %d, db id: %d", tbl.ID, tbl.DBID))
 	}
+
+	for _, tbl := range tblInfos1 {
+		println(fmt.Sprintf("table id: %d, db id: %d", tbl.ID, tbl.DBID))
+	}
+
 	require.Equal(t, len(tblInfos1), len(tblInfos2))
 	for i := range tblInfos1 {
 		require.Equal(t, tblInfos1[i].ID, tblInfos2[i].ID)

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1276,7 +1276,15 @@ func TestGetAllTableInfos(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 
-	tk.MustExec("create table test.t1 (a int)")
+	//tk.MustExec("create table test.t1 (a int)")
+
+	for i := 0; i < 213; i++ {
+		tk.MustExec(fmt.Sprintf("create database test%d", i))
+		tk.MustExec(fmt.Sprintf("use test%d", i))
+		tk.MustExec("create table t1 (a int)")
+		tk.MustExec("create table t2 (a int)")
+		tk.MustExec("create table t3 (a int)")
+	}
 
 	tblInfos1 := make([]*model.TableInfo, 0)
 	tblInfos2 := make([]*model.TableInfo, 0)
@@ -1306,6 +1314,10 @@ func TestGetAllTableInfos(t *testing.T) {
 	slices.SortFunc(tblInfos2, func(i, j *model.TableInfo) int {
 		return int(i.ID - j.ID)
 	})
+
+	for _, tbl := range tblInfos2 {
+		println(fmt.Sprintf("table id: %d, db id: %d", tbl.ID, tbl.DBID))
+	}
 	require.Equal(t, len(tblInfos1), len(tblInfos2))
 	for i := range tblInfos1 {
 		require.Equal(t, tblInfos1[i].ID, tblInfos2[i].ID)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1020,7 +1020,7 @@ func splitRangeInt64Max(n int64) [][]string {
 	return ranges
 }
 
-// IterAllTables iterates all the table at once, in order to avoid oom. It can use at most 15 goroutines to iterate.
+// IterAllTables iterates all the table at once, in order to avoid oom. It can use at most 15 concurrency to iterate.
 func IterAllTables(ctx context.Context, store kv.Storage, startTs uint64, concurrency int, fn func(info *model.TableInfo) error) error {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1021,6 +1021,7 @@ func splitRangeInt64Max(n int64) [][]string {
 }
 
 // IterAllTables iterates all the table at once, in order to avoid oom. It can use at most 15 concurrency to iterate.
+// This function is optimized for 'many databases' scenario. Only 1 concurrency can work for 'many tables in one database' scenario.
 func IterAllTables(ctx context.Context, store kv.Storage, startTs uint64, concurrency int, fn func(info *model.TableInfo) error) error {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -999,11 +999,9 @@ func (m *Mutator) IterTables(dbID int64, fn func(info *model.TableInfo) error) e
 }
 
 func splitRangeInt64Max(n int64) [][]string {
-	const N uint64 = 9999999999999999999
-
 	ranges := make([][]string, n)
 
-	batch := N / uint64(n)
+	batch := 9999999999999999999 / uint64(n)
 
 	for k := int64(0); k < n; k++ {
 		start := batch * uint64(k)
@@ -1045,7 +1043,6 @@ func IterAllTables(ctx context.Context, store kv.Storage, startTs uint64, concur
 			startKey = codec.EncodeBytes(startKey, []byte(kvRanges[i][0]))
 			endKey := []byte(fmt.Sprintf("%s:", mDBPrefix))
 			endKey = codec.EncodeBytes(endKey, []byte(kvRanges[i][1]))
-			println("startKey", kvRanges[i][0], kvRanges[i][1])
 
 			return t.IterateHashWithBoundedKey(startKey, endKey, func(key []byte, field []byte, value []byte) error {
 				// only handle table meta


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59912

Problem Summary:
We used number order to split subtasks, which is wrong.

### What changed and how does it work?
Use string order to split subtasks.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
