### PR TITLE
log restore: fix the bottleneck of btree map

### DIFF
--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -1553,9 +1553,7 @@ func TestLogSplitStrategy(t *testing.T) {
 	count := 0
 	for i := helper.TryNext(ctx); !i.Finished; i = helper.TryNext(ctx) {
 		require.NoError(t, i.Err)
-		if mockStrategy.AccumulateCount == expectSplitCount-1 {
-			// only split once
-			require.GreaterOrEqual(t, count, len(smallFiles))
+		if count == len(smallFiles)+expectSplitCount {
 			// Verify that no split occurs initially due to insufficient data.
 			regions, err := mockPDCli.ScanRegions(ctx, []byte{}, []byte{}, 0)
 			require.NoError(t, err)

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -1513,15 +1513,20 @@ func TestLogSplitStrategy(t *testing.T) {
 	// Create a split client with the mock PD client.
 	client := split.NewClient(mockPDCli, nil, nil, 100, 4)
 
+	// these files should skip accumulation
+	smallFiles := make([]*backuppb.DataFileInfo, 0, 10)
+	for j := 0; j < 20; j++ {
+		smallFiles = append(smallFiles, fakeFile(1, 100, 1024*1024, 100))
+	}
+
 	// Define a mock iterator with sample data files.
-	mockIter := iter.FromSlice([]*backuppb.DataFileInfo{
-		fakeFile(1, 100, 100, 100),
+	mockIter := iter.FromSlice(append(smallFiles, []*backuppb.DataFileInfo{
 		fakeFile(1, 200, 2*units.MiB, 200),
 		fakeFile(2, 100, 3*units.MiB, 300),
 		fakeFile(3, 100, 10*units.MiB, 100000),
 		fakeFile(1, 300, 3*units.MiB, 10),
 		fakeFile(1, 400, 4*units.MiB, 10),
-	})
+	}...))
 	logIter := toLogDataFileInfoIter(mockIter)
 
 	// Initialize a wrapper for the file restorer with a region splitter.
@@ -1548,7 +1553,7 @@ func TestLogSplitStrategy(t *testing.T) {
 	count := 0
 	for i := helper.TryNext(ctx); !i.Finished; i = helper.TryNext(ctx) {
 		require.NoError(t, i.Err)
-		if count == expectSplitCount {
+		if mockStrategy.AccumulateCount == expectSplitCount-1 {
 			// Verify that no split occurs initially due to insufficient data.
 			regions, err := mockPDCli.ScanRegions(ctx, []byte{}, []byte{}, 0)
 			require.NoError(t, err)
@@ -1561,6 +1566,9 @@ func TestLogSplitStrategy(t *testing.T) {
 		// iter.Filterout execute first
 		count += 1
 	}
+
+	// iterate 20 small files + 4 valid files
+	require.Equal(t, 24, count)
 
 	// Verify that a split occurs on the second region due to excess data.
 	regions, err := mockPDCli.ScanRegions(ctx, []byte{}, []byte{}, 0)

--- a/br/pkg/restore/log_client/client_test.go
+++ b/br/pkg/restore/log_client/client_test.go
@@ -1554,6 +1554,8 @@ func TestLogSplitStrategy(t *testing.T) {
 	for i := helper.TryNext(ctx); !i.Finished; i = helper.TryNext(ctx) {
 		require.NoError(t, i.Err)
 		if mockStrategy.AccumulateCount == expectSplitCount-1 {
+			// only split once
+			require.GreaterOrEqual(t, count, len(smallFiles))
 			// Verify that no split occurs initially due to insufficient data.
 			regions, err := mockPDCli.ScanRegions(ctx, []byte{}, []byte{}, 0)
 			require.NoError(t, err)
@@ -1568,7 +1570,7 @@ func TestLogSplitStrategy(t *testing.T) {
 	}
 
 	// iterate 20 small files + 4 valid files
-	require.Equal(t, 24, count)
+	require.Equal(t, len(smallFiles)+4, count)
 
 	// Verify that a split occurs on the second region due to excess data.
 	regions, err := mockPDCli.ScanRegions(ctx, []byte{}, []byte{}, 0)

--- a/br/pkg/restore/log_client/log_split_strategy.go
+++ b/br/pkg/restore/log_client/log_split_strategy.go
@@ -63,25 +63,27 @@ func NewLogSplitStrategy(
 const splitFileThreshold = 1024 * 1024 // 1 MB
 
 func (ls *LogSplitStrategy) Accumulate(file *LogDataFileInfo) {
+	// skip accumulate file less than 1MB. to prevent too much split & scatter occurs
+	// and protect the performance of BTreeMap
 	if file.Length > splitFileThreshold {
 		ls.AccumulateCount += 1
-	}
-	splitHelper, exist := ls.TableSplitter[file.TableId]
-	if !exist {
-		splitHelper = split.NewSplitHelper()
-		ls.TableSplitter[file.TableId] = splitHelper
-	}
+		splitHelper, exist := ls.TableSplitter[file.TableId]
+		if !exist {
+			splitHelper = split.NewSplitHelper()
+			ls.TableSplitter[file.TableId] = splitHelper
+		}
 
-	splitHelper.Merge(split.Valued{
-		Key: split.Span{
-			StartKey: file.StartKey,
-			EndKey:   file.EndKey,
-		},
-		Value: split.Value{
-			Size:   file.Length,
-			Number: file.NumberOfEntries,
-		},
-	})
+		splitHelper.Merge(split.Valued{
+			Key: split.Span{
+				StartKey: file.StartKey,
+				EndKey:   file.EndKey,
+			},
+			Value: split.Value{
+				Size:   file.Length,
+				Number: file.NumberOfEntries,
+			},
+		})
+	}
 }
 
 func (ls *LogSplitStrategy) ShouldSplit() bool {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/59900

Problem Summary:
The current log restore process accumulates small files, which can negatively impact performance. During performance testing, log restore took twice as long as before due to the excessive number of small files. To optimize performance, we should skip accumulating small files, as was done previously.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before this PR
<img width="1832" alt="image" src="https://github.com/user-attachments/assets/eb87af02-af4f-4765-90f1-c6c251e6c022" />


after this PR
<img width="1893" alt="image" src="https://github.com/user-attachments/assets/0de2a766-fa6d-4575-858c-b9913ed2910a" />


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
