### PR TITLE
parser: support `default(x)` syntax to compatible with MySQL8

### DIFF
--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -947,6 +947,7 @@ import (
 	StringLiteral                   "text literal"
 	ExpressionOpt                   "Optional expression"
 	SignedLiteral                   "Literal or NumLiteral with sign"
+	SignedLiteralParentheses        "SignedLiteral or SignedLiteral with Parentheses"
 	DefaultValueExpr                "DefaultValueExpr(Now or Signed Literal)"
 	NowSymOptionFraction            "NowSym with optional fraction part"
 	NowSymOptionFractionParentheses "NowSym with optional fraction part within potential parentheses"
@@ -4037,9 +4038,16 @@ ReferOpt:
  */
 DefaultValueExpr:
 	NowSymOptionFractionParentheses
-|	SignedLiteral
+|	SignedLiteralParentheses
 |	NextValueForSequenceParentheses
 |	BuiltinFunction
+
+SignedLiteralParentheses:
+	'(' SignedLiteral ')'
+	{
+		$$ = $2
+	}
+|	SignedLiteral
 
 BuiltinFunction:
 	'(' BuiltinFunction ')'
@@ -13801,7 +13809,7 @@ ConnectionOptions:
 		for _, option := range $2.([]*ast.ResourceOption) {
 			switch option.Type {
 			case ast.MaxUserConnections:
-				// do nothing.
+			// do nothing.
 			default:
 				needWarning = true
 			}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2991,6 +2991,10 @@ func TestDDL(t *testing.T) {
 		{"create table t (j json default (json_array(1,2,3)))", true, "CREATE TABLE `t` (`j` JSON DEFAULT (JSON_ARRAY(1, 2, 3)))"},
 		{"create table t (j json default (json_quote('foobar')))", true, "CREATE TABLE `t` (`j` JSON DEFAULT (JSON_QUOTE(_UTF8MB4'foobar')))"},
 
+		{"create table t (a int default(1))", true, "CREATE TABLE `t` (`a` INT DEFAULT 1)"},
+		{"create table t (a int default(\"1\"))", true, "CREATE TABLE `t` (`a` INT DEFAULT _UTF8MB4'1')"},
+		{"create table t (a int default (_utf8mb4'1'))", true, "CREATE TABLE `t` (`a` INT DEFAULT _UTF8MB4'1')"},
+
 		// For table option `ENCRYPTION`
 		{"create table t (a int) encryption = 'n';", true, "CREATE TABLE `t` (`a` INT) ENCRYPTION = 'n'"},
 		{"create table t (a int) encryption 'n';", true, "CREATE TABLE `t` (`a` INT) ENCRYPTION = 'n'"},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59878

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
