### PR TITLE
executor: show the error message from TiProxy when replay traffic fails

### DIFF
--- a/pkg/executor/traffic.go
+++ b/pkg/executor/traffic.go
@@ -92,7 +92,7 @@ func (e *TrafficCaptureExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	e.Args[startTimeKey] = time.Now().Format(time.RFC3339)
 	addrs, err := getTiProxyAddrs(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "get tiproxy addresses failed")
+		return err
 	}
 	// For shared storage, append a suffix to the output path for each TiProxy so that they won't write to the same path.
 	readers, err := formReader4Capture(e.Args, len(addrs))
@@ -114,7 +114,7 @@ func (e *TrafficReplayExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	e.Args[startTimeKey] = time.Now().Format(time.RFC3339)
 	addrs, err := getTiProxyAddrs(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "get tiproxy addresses failed")
+		return err
 	}
 	// For shared storage, read the sub-direcotires from the input path and assign each sub-directory to a TiProxy instance.
 	formCtx, cancel := context.WithTimeout(ctx, sharedStorageTimeout)
@@ -148,7 +148,7 @@ type TrafficCancelExec struct {
 func (e *TrafficCancelExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	addrs, err := getTiProxyAddrs(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "get tiproxy addresses failed")
+		return err
 	}
 	// Cancel all traffic jobs by default.
 	hasCapturePriv, hasReplayPriv := hasTrafficPriv(e.Ctx())
@@ -181,7 +181,7 @@ func (e *TrafficShowExec) Open(ctx context.Context) error {
 	}
 	addrs, err := getTiProxyAddrs(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "get tiproxy addresses failed")
+		return err
 	}
 	resps, err := request(ctx, addrs, nil, http.MethodGet, showPath)
 	if err != nil {
@@ -257,7 +257,7 @@ func request(ctx context.Context, addrs []string, readers []io.Reader, method, p
 		if err != nil {
 			logutil.Logger(ctx).Error("traffic request to tiproxy failed", zap.String("path", path), zap.String("addr", addr),
 				zap.String("resp", resp), zap.Error(err))
-			return resps, errors.Wrapf(err, "request to tiproxy '%s' failed: %s", addr, resp)
+			return resps, errors.Errorf("request to tiproxy '%s' failed: %s", addr, err.Error())
 		}
 		resps[addr] = resp
 	}
@@ -274,7 +274,7 @@ func getTiProxyAddrs(ctx context.Context) ([]string, error) {
 		tiproxyNodes, err = infosync.GetTiProxyServerInfo(ctx)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if len(tiproxyNodes) == 0 {
 		return nil, errors.Errorf("no tiproxy server found")
@@ -290,24 +290,27 @@ func requestOne(method, addr, path string, rd io.Reader) (string, error) {
 	url := fmt.Sprintf("%s://%s%s", util.InternalHTTPSchema(), addr, path)
 	req, err := http.NewRequest(method, url, rd)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	if method == http.MethodPost {
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
 	resp, err := util.InternalHTTPClient().Do(req)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	defer func() {
 		terror.Log(resp.Body.Close())
 	}()
 	resb, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return string(resb), err
+		return string(resb), nil
 	default:
-		return string(resb), errors.Errorf("request %s failed: %s", url, resp.Status)
+		return string(resb), errors.New(string(resb))
 	}
 }
 

--- a/pkg/executor/traffic_test.go
+++ b/pkg/executor/traffic_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -166,8 +167,7 @@ func TestTrafficError(t *testing.T) {
 	defer server.Close()
 	tempCtx = fillCtxWithTiProxyAddr(ctx, []int{port})
 	err := exec.Next(tempCtx, nil)
-	require.ErrorContains(t, err, "500 Internal Server Error")
-	require.ErrorContains(t, err, "mock error")
+	require.ErrorContains(t, errors.Cause(err), "mock error")
 }
 
 func TestCapturePath(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59906

Problem Summary:
Currently, when any error occurs on TiProxy, TiDB just shows `Internal Server Error` to the user because TiDB writes the unwrapped error to the client. This error message is useless and users need to check the logs.

### What changed and how does it work?
- Replace `errors.Wrapf` with `errors.Errorf` to create only one error
- Remove some `errors.Wrapf` and `errors.Trace`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```sql
mysql> traffic capture to '/tmp/traffic' duration="10s";
ERROR 1105 (HY000): request to tiproxy '127.0.0.1:3080' failed: start capture failed: file meta already exists, please remove it before capture
mysql> traffic capture to '/tmp/traffic' duration="10s";
ERROR 1105 (HY000): request to tiproxy '127.0.0.1:3080' failed: Post "http://127.0.0.1:3080/api/traffic/capture": EOF
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
