### PR TITLE
domain: change @@tidb_schema_cache_size to 0 should not set the capacity to 0

### DIFF
--- a/pkg/domain/domain_sysvars.go
+++ b/pkg/domain/domain_sysvars.go
@@ -152,7 +152,12 @@ func (do *Domain) changeSchemaCacheSize(ctx context.Context, size uint64) error 
 	if err != nil {
 		return err
 	}
-	do.infoCache.Data.SetCacheCapacity(size)
+	if size > 0 {
+		// Note: change the value to 0 is changing from infoschema v2 to v1.
+		// What we do is change the implementation rather than set the cache capacity.
+		// The change will not take effect until a schema reload happen.
+		do.infoCache.Data.SetCacheCapacity(size)
+	}
 	return nil
 }
 


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59949

Problem Summary:

Change schema cache size take effect immediately, but switch from v2 to v1 take effect after a schema reload.
This cause a bug that during the period when @@tidb_schema_cache_size is set to 0, but the implement have not change to v1, the schame cache hit rate become 0.

### What changed and how does it work?


When set @@tidb_schema_cache_size to 0, do not change the schema cache capacity.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Now the result is expected, there is no data after changing from v2 to v1:

<img width="945" alt="image" src="https://github.com/user-attachments/assets/da69aa43-1b8d-4356-8bbc-8dcabf527ff3" />


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
