### PR TITLE
planner: return error if binding sql is too long

### DIFF
--- a/pkg/bindinfo/BUILD.bazel
+++ b/pkg/bindinfo/BUILD.bazel
@@ -54,7 +54,7 @@ go_test(
     embed = [":bindinfo"],
     flaky = True,
     race = "on",
-    shard_count = 32,
+    shard_count = 33,
     deps = [
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/bindinfo/binding_operator.go
+++ b/pkg/bindinfo/binding_operator.go
@@ -93,6 +93,9 @@ func (op *bindingOperator) CreateBinding(sctx sessionctx.Context, bindings []*Bi
 			binding.CreateTime = now
 			binding.UpdateTime = now
 
+			// TODO: update the sql_mode or sctx.types.Flag to let execution engine returns errors like dataTooLong,
+			// overflow directly.
+
 			// Insert the Bindings to the storage.
 			_, err = exec(
 				sctx,

--- a/pkg/bindinfo/binding_operator.go
+++ b/pkg/bindinfo/binding_operator.go
@@ -118,6 +118,14 @@ func (op *bindingOperator) CreateBinding(sctx sessionctx.Context, bindings []*Bi
 			if err != nil {
 				return err
 			}
+
+			warnings, _, err := execRows(sctx, "show warnings")
+			if err != nil {
+				return err
+			}
+			if len(warnings) != 0 {
+				return errors.New(warnings[0].GetString(2))
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #51347

[Problem Summary: planner: refactor some code related to binding
](planner: return error if binding sql is too long)
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
