### PR TITLE
ddl/ingest: add test for ADD INDEX with global sort recovery from retryable error

### DIFF
--- a/br/pkg/mock/backend.go
+++ b/br/pkg/mock/backend.go
@@ -154,20 +154,6 @@ func (mr *MockBackendMockRecorder) OpenEngine(arg0, arg1, arg2 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenEngine", reflect.TypeOf((*MockBackend)(nil).OpenEngine), arg0, arg1, arg2)
 }
 
-// ResetEngine mocks base method.
-func (m *MockBackend) ResetEngine(arg0 context.Context, arg1 uuid.UUID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResetEngine", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ResetEngine indicates an expected call of ResetEngine.
-func (mr *MockBackendMockRecorder) ResetEngine(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetEngine", reflect.TypeOf((*MockBackend)(nil).ResetEngine), arg0, arg1)
-}
-
 // RetryImportDelay mocks base method.
 func (m *MockBackend) RetryImportDelay() time.Duration {
 	m.ctrl.T.Helper()

--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -110,7 +110,6 @@ go_library(
         "//pkg/lightning/backend/local",
         "//pkg/lightning/common",
         "//pkg/lightning/config",
-        "//pkg/lightning/log",
         "//pkg/meta",
         "//pkg/meta/autoid",
         "//pkg/meta/metabuild",

--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -110,6 +110,7 @@ go_library(
         "//pkg/lightning/backend/local",
         "//pkg/lightning/common",
         "//pkg/lightning/config",
+        "//pkg/lightning/log",
         "//pkg/meta",
         "//pkg/meta/autoid",
         "//pkg/meta/metabuild",

--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -145,7 +145,6 @@ func (m *cloudImportExecutor) RunSubtask(ctx context.Context, subtask *proto.Sub
 	local.WorkerConcurrency = int(m.GetResource().CPU.Capacity()) * 2
 	err = local.ImportEngine(ctx, engineUUID, int64(config.SplitRegionSize), int64(config.SplitRegionKeys))
 	failpoint.Inject("mockCloudImportRunSubtaskError", func(_ failpoint.Value) {
-		logutil.Logger(ctx).Info("mockCloudImportRunSubtaskError")
 		err = context.DeadlineExceeded
 	})
 	if err == nil {

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -102,7 +102,6 @@ func (m *mergeSortExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 		true,
 	)
 	failpoint.Inject("mockMergeSortRunSubtaskError", func(_ failpoint.Value) {
-		logutil.Logger(ctx).Info("mockMergeSortRunSubtaskError")
 		err = context.DeadlineExceeded
 	})
 	if err != nil {

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor"
@@ -100,6 +101,10 @@ func (m *mergeSortExecutor) RunSubtask(ctx context.Context, subtask *proto.Subta
 		int(res.CPU.Capacity()),
 		true,
 	)
+	failpoint.Inject("mockMergeSortRunSubtaskError", func(_ failpoint.Value) {
+		logutil.Logger(ctx).Info("mockMergeSortRunSubtaskError")
+		err = context.DeadlineExceeded
+	})
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -51,7 +51,6 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/backend"
 	"github.com/pingcap/tidb/pkg/lightning/backend/local"
 	litconfig "github.com/pingcap/tidb/pkg/lightning/config"
-	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -2493,7 +2492,6 @@ func checkDuplicateForUniqueIndex(ctx context.Context, t table.Table, reorgInfo 
 			}
 			err = backendCtx.CollectRemoteDuplicateRows(indexInfo.ID, t)
 			failpoint.Inject("mockCheckDuplicateForUniqueIndexError", func(_ failpoint.Value) {
-				log.FromContext(ctx).Info("mockCheckDuplicateForUniqueIndexError")
 				err = context.DeadlineExceeded
 			})
 			if err != nil {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/backend"
 	"github.com/pingcap/tidb/pkg/lightning/backend/local"
 	litconfig "github.com/pingcap/tidb/pkg/lightning/config"
+	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -2492,6 +2493,7 @@ func checkDuplicateForUniqueIndex(ctx context.Context, t table.Table, reorgInfo 
 			}
 			err = backendCtx.CollectRemoteDuplicateRows(indexInfo.ID, t)
 			failpoint.Inject("mockCheckDuplicateForUniqueIndexError", func(_ failpoint.Value) {
+				log.FromContext(ctx).Info("mockCheckDuplicateForUniqueIndexError")
 				err = context.DeadlineExceeded
 			})
 			if err != nil {

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -2491,6 +2491,9 @@ func checkDuplicateForUniqueIndex(ctx context.Context, t table.Table, reorgInfo 
 				}
 			}
 			err = backendCtx.CollectRemoteDuplicateRows(indexInfo.ID, t)
+			failpoint.Inject("mockCheckDuplicateForUniqueIndexError", func(_ failpoint.Value) {
+				err = context.DeadlineExceeded
+			})
 			if err != nil {
 				return err
 			}

--- a/pkg/ddl/ingest/engine.go
+++ b/pkg/ddl/ingest/engine.go
@@ -53,7 +53,6 @@ type engineInfo struct {
 	openedEngine *backend.OpenedEngine
 
 	uuid        uuid.UUID
-	cfg         *backend.EngineConfig
 	writerCache generic.SyncMap[int, backend.EngineWriter]
 	memRoot     MemRoot
 	flushLock   *sync.RWMutex
@@ -64,7 +63,6 @@ func newEngineInfo(
 	ctx context.Context,
 	jobID, indexID int64,
 	unique bool,
-	cfg *backend.EngineConfig,
 	en *backend.OpenedEngine,
 	uuid uuid.UUID,
 	memRoot MemRoot,
@@ -74,7 +72,6 @@ func newEngineInfo(
 		jobID:        jobID,
 		indexID:      indexID,
 		unique:       unique,
-		cfg:          cfg,
 		openedEngine: en,
 		uuid:         uuid,
 		writerCache:  generic.NewSyncMap[int, backend.EngineWriter](4),

--- a/pkg/ddl/ingest/engine_mgr.go
+++ b/pkg/ddl/ingest/engine_mgr.go
@@ -77,7 +77,6 @@ func (bc *litBackendCtx) Register(indexIDs []int64, uniques []bool, tbl table.Ta
 			bc.jobID,
 			indexID,
 			uniques[i],
-			cfg,
 			openedEngine,
 			openedEngine.GetEngineUUID(),
 			bc.memRoot,

--- a/pkg/lightning/backend/backend.go
+++ b/pkg/lightning/backend/backend.go
@@ -216,9 +216,6 @@ type Backend interface {
 	// (e.g. preparing to resolve a disk quota violation).
 	FlushAllEngines(ctx context.Context) error
 
-	// ResetEngine clears all written KV pairs in this opened engine.
-	ResetEngine(ctx context.Context, engineUUID uuid.UUID) error
-
 	// LocalWriter obtains a thread-local EngineWriter for writing rows into the given engine.
 	LocalWriter(ctx context.Context, cfg *LocalWriterConfig, engineUUID uuid.UUID) (EngineWriter, error)
 }

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1600,11 +1600,6 @@ func (local *Backend) GetExternalEngineKVStatistics(engineUUID uuid.UUID) (
 	return local.engineMgr.getExternalEngineKVStatistics(engineUUID)
 }
 
-// ResetEngine reset the engine and reclaim the space.
-func (local *Backend) ResetEngine(ctx context.Context, engineUUID uuid.UUID) error {
-	return local.engineMgr.resetEngine(ctx, engineUUID, false)
-}
-
 // ResetEngineSkipAllocTS is like ResetEngine but the inner TS of the engine is
 // invalid. Caller must use SetTSBeforeImportEngine to set a valid TS before import
 // the engine.

--- a/pkg/lightning/backend/tidb/tidb.go
+++ b/pkg/lightning/backend/tidb/tidb.go
@@ -976,11 +976,6 @@ func (*tidbBackend) FlushAllEngines(context.Context) error {
 	return nil
 }
 
-// ResetEngine resets the engine.
-func (*tidbBackend) ResetEngine(context.Context, uuid.UUID) error {
-	return errors.New("cannot reset an engine in TiDB backend")
-}
-
 // LocalWriter returns a writer that writes data to local storage.
 func (be *tidbBackend) LocalWriter(
 	_ context.Context,

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -291,6 +291,44 @@ func TestGlobalSortDuplicateErrMsg(t *testing.T) {
 	tk.MustGetErrMsg("alter table t add unique index idx(b);", "[kv:1062]Duplicate entry '1' for key 't.idx'")
 }
 
+func TestGlobalSortAddIndexRecoverOnDuplicateCheck(t *testing.T) {
+	gcsHost, gcsPort, cloudStorageURI := genStorageURI(t)
+	opt := fakestorage.Options{
+		Scheme:     "http",
+		Host:       gcsHost,
+		Port:       gcsPort,
+		PublicHost: gcsHost,
+	}
+	server, err := fakestorage.NewServerWithOptions(opt)
+	require.NoError(t, err)
+	server.CreateBucketWithOpts(fakestorage.CreateBucketOpts{Name: "sorted"})
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists addindexlit;")
+	tk.MustExec("create database addindexlit;")
+	tk.MustExec("use addindexlit;")
+	tk.MustExec(`set @@global.tidb_ddl_enable_fast_reorg = 1;`)
+	tk.MustExec("set @@global.tidb_enable_dist_task = 1;")
+	tk.MustExec(fmt.Sprintf(`set @@global.tidb_cloud_storage_uri = "%s"`, cloudStorageURI))
+	defer func() {
+		tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
+		vardef.CloudStorageURI.Store("")
+	}()
+	failpoints := []string{
+		"github.com/pingcap/tidb/pkg/ddl/mockCheckDuplicateForUniqueIndexError",
+	}
+
+	for _, fp := range failpoints {
+		tk.MustExec("drop table if exists t;")
+		tk.MustExec("create table t (a int);")
+		tk.MustExec("insert into t values (1), (2), (3);")
+		failpoint.Enable(fp, "1*return")
+		tk.MustExec("alter table t add unique index idx(a);")
+		failpoint.Disable(fp)
+	}
+}
+
 func TestIngestUseGivenTS(t *testing.T) {
 	gcsHost, gcsPort, cloudStorageURI := genStorageURI(t)
 	opt := fakestorage.Options{

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -315,7 +315,7 @@ func TestGlobalSortAddIndexRecoverFromRetryableError(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/forceMergeSort", "return()")
 	defer func() {
 		tk.MustExec("set @@global.tidb_enable_dist_task = 0;")
-		vardef.CloudStorageURI.Store("")
+		tk.MustExec("set @@global.tidb_cloud_storage_uri = '';")
 	}()
 	failpoints := []string{
 		"github.com/pingcap/tidb/pkg/ddl/mockCheckDuplicateForUniqueIndexError",
@@ -327,9 +327,9 @@ func TestGlobalSortAddIndexRecoverFromRetryableError(t *testing.T) {
 		tk.MustExec("drop table if exists t;")
 		tk.MustExec("create table t (a int);")
 		tk.MustExec("insert into t values (1), (2), (3);")
-		failpoint.Enable(fp, "1*return")
+		require.NoError(t, failpoint.Enable(fp, "1*return"))
 		tk.MustExec("alter table t add unique index idx(a);")
-		failpoint.Disable(fp)
+		require.NoError(t, failpoint.Disable(fp))
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #57670

Problem Summary:

See the description of https://github.com/pingcap/tidb/pull/57770

### What changed and how does it work?

* remove some useless code (`ResetEngine`)
* add a test case to cover the global sort scenario that it can recover from retryable error

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
