### PR TITLE
metrics: update distsql_copr_resp_size unit

### DIFF
--- a/pkg/metrics/distsql.go
+++ b/pkg/metrics/distsql.go
@@ -89,6 +89,6 @@ func InitDistSQLMetrics() {
 			Subsystem: "distsql",
 			Name:      "copr_resp_size",
 			Help:      "copr task response data size in bytes.",
-			Buckets:   prometheus.ExponentialBuckets(1024, 2, 20),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 10),
 		}, []string{LblStore})
 }

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -23787,7 +23787,7 @@
           "yaxes": [
             {
               "$$hashKey": "object:394",
-              "format": "binBps",
+              "format": "KiBs",
               "label": "",
               "logBase": 1,
               "max": null,
@@ -23914,7 +23914,7 @@
           "yaxes": [
             {
               "$$hashKey": "object:394",
-              "format": "bytes",
+              "format": "kbytes",
               "label": "",
               "logBase": 1,
               "max": null,

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -23717,7 +23717,9 @@
           "datasource": "${DS_TEST-CLUSTER}",
           "description": "The total coprocessor response size between each tidb and tikv",
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "unit": "KiBs"
+            },
             "overrides": []
           },
           "fill": 0,
@@ -23817,7 +23819,9 @@
           "datasource": "${DS_TEST-CLUSTER}",
           "description": "Histogram of coprocessor response size in bytes between tidb and tikv",
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "unit": "kbytes"
+            },
             "overrides": []
           },
           "fill": 0,

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1453,7 +1453,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 	}
 	metrics.TiKVCoprocessorHistogram.WithLabelValues(storeID, strconv.FormatBool(staleRead), scope).Observe(costTime.Seconds())
 	if copResp != nil {
-		tidbmetrics.DistSQLCoprRespBodySize.WithLabelValues(storeAddr).Observe(float64(len(copResp.Data)))
+		tidbmetrics.DistSQLCoprRespBodySize.WithLabelValues(storeAddr).Observe(float64(len(copResp.Data) / 1024))
 	}
 
 	var result *copTaskResult


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #59990

Problem Summary:
In TiDB clusters with numerous nodes and high request loads, tidb_distsql_copr_resp_size is monitoring a large amount of data, consider reducing the number of buckets to reduce its data size.

### What changed and how does it work?
Change the minimum unit from B to KiB

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Before this PR:
<img width="862" alt="1" src="https://github.com/user-attachments/assets/76db4f24-14bb-41ba-9806-25200fd44ac6" />
<img width="702" alt="2" src="https://github.com/user-attachments/assets/1251913c-6e3d-4b18-999e-c1235929b7ab" />


After this PR:
<img width="862" alt="1-1" src="https://github.com/user-attachments/assets/2bb43dd3-a8dc-410f-8407-d4ce5caab00e" />
<img width="846" alt="2-1" src="https://github.com/user-attachments/assets/ed8bac3d-af34-40ad-9c63-359cbd60aacb" />

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
