### PR TITLE
ddl: DROP PARTITION sees a row from a dropped partition in StateDeleteOnly with Global Index

### DIFF
--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2205,21 +2205,20 @@ func (w *worker) rollbackLikeDropPartition(jobCtx *jobContext, job *model.Job) (
 //
 // StateDeleteReorganization
 //
-//		Old partitions are not accessible/used by any sessions.
-//	 Inserts/updates of global index which still have entries pointing to old partitions
-//	 will overwrite those entries
-//	 In the background we are reading all old partitions and deleting their entries from
-//	 the global indexes.
+//	Old partitions are not accessible/used by any sessions.
+//	Inserts/updates of global index which still have entries pointing to old partitions
+//	will overwrite those entries.
+//	In the background we are reading all old partitions and deleting their entries from
+//	the global indexes.
 //
 // StateDeleteOnly
 //
-//	 old partitions are no longer visible, but if there is inserts/updates to the global indexes,
-//	 duplicate key errors will be given, even if the entries are from dropped partitions
-//		Note that overlapping ranges (i.e. a dropped partitions with 'less than (N)' will now .. ?!?
+//	Old partitions are no longer visible, but if there is inserts/updates to the global indexes,
+//	duplicate key errors will be given, even if the entries are from dropped partitions.
 //
 // StateWriteOnly
 //
-//	old partitions are blocked for read and write. But for read we are allowing
+//	Old partitions are blocked for read and write. But for read we are allowing
 //	"overlapping" partition to be read instead. Which means that write can only
 //	happen in the 'overlapping' partitions original range, not into the extended
 //	range open by the dropped partitions.

--- a/pkg/ddl/tests/partition/multi_domain_test.go
+++ b/pkg/ddl/tests/partition/multi_domain_test.go
@@ -234,6 +234,8 @@ func TestMultiSchemaDropListColumnsDefaultPartition(t *testing.T) {
 			tkNO.MustContainErrMsg(`insert into t values (101,101,101)`, "[kv:1062]Duplicate entry '101' for key 't.a_2'")
 			tkNO.MustQuery(`select * from t`).Sort().Check(testkit.Rows("1 1 1", "101 101 101", "102 102 102", "2 2 2"))
 			tkO.MustQuery(`select * from t`).Sort().Check(testkit.Rows("101 101 101", "102 102 102"))
+			tkO.MustQuery(`select a from t where c = "2"`).Sort().Check(testkit.Rows())
+			tkNO.MustQuery(`select a from t where c = "2"`).Sort().Check(testkit.Rows("2"))
 		case "delete only":
 			// tkNO see non-readable/non-writable p0 partition, and should try to read from p1
 			// in case there is something written to overlapping p1
@@ -257,8 +259,10 @@ func TestMultiSchemaDropListColumnsDefaultPartition(t *testing.T) {
 			tkNO.MustQuery(`select * from t where a in (1,2,3)`).Sort().Check(testkit.Rows("3 3 3"))
 			tkNO.MustQuery(`select * from t where a < 100`).Sort().Check(testkit.Rows("3 3 3"))
 
-			tkNO.MustQuery(`select * from t where c = "2"`).Sort().Check(testkit.Rows("2 2 2"))
+			tkNO.MustQuery(`select * from t where c = "2"`).Sort().Check(testkit.Rows())
+			tkNO.MustQuery(`select a from t where c = "2"`).Sort().Check(testkit.Rows())
 			tkNO.MustQuery(`select * from t where b = "3"`).Sort().Check(testkit.Rows("3 3 3"))
+			tkO.MustQuery(`select * from t where c = "2"`).Sort().Check(testkit.Rows())
 			// TODO: Test update and delete!
 			// TODO: test key, hash and list partition without default partition :)
 			// Should we see the partition or not?!?

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -1065,7 +1065,7 @@ func (pi *PartitionInfo) IDsInDDLToIgnore() []int64 {
 			return ids
 		}
 	case ActionDropTablePartition:
-		if len(pi.DroppingDefinitions) > 0 && (pi.DDLState == StateDeleteOnly || pi.DDLState == StateWriteOnly) {
+		if len(pi.DroppingDefinitions) > 0 {
 			ids := make([]int64, 0, len(pi.DroppingDefinitions))
 			for _, def := range pi.DroppingDefinitions {
 				ids = append(ids, def.ID)

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -1065,7 +1065,7 @@ func (pi *PartitionInfo) IDsInDDLToIgnore() []int64 {
 			return ids
 		}
 	case ActionDropTablePartition:
-		if len(pi.DroppingDefinitions) > 0 && pi.DDLState == StateDeleteOnly {
+		if len(pi.DroppingDefinitions) > 0 && (pi.DDLState == StateDeleteOnly || pi.DDLState == StateWriteOnly) {
 			ids := make([]int64, 0, len(pi.DroppingDefinitions))
 			for _, def := range pi.DroppingDefinitions {
 				ids = append(ids, def.ID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60021 

Problem Summary:
The dropped partition was not filtered out when reading from the global index during StateWriteOnly, resulting in a rows from the dropped partition could be seen if the Global Index was used, but not if other access paths was used during that DDL State.

### What changed and how does it work?
Filtering out the dropped partition also for StateWriteOnly

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
During DROP PARTITION StateWriteOnly one could still access rows from the dropped partition through the Global Index.
```
