### PR TITLE
br: fix pitr meta kv fail to parse in during table filter code refactor 

### DIFF
--- a/br/pkg/stream/table_mapping.go
+++ b/br/pkg/stream/table_mapping.go
@@ -515,10 +515,12 @@ func ExtractValue(e *kv.Entry, cf string) ([]byte, error) {
 		if err := rawWriteCFValue.ParseFrom(e.Value); err != nil {
 			return nil, errors.Trace(err)
 		}
-		if rawWriteCFValue.HasShortValue() {
-			return rawWriteCFValue.shortValue, nil
+		// have to be consistent with rewrite_meta_rawkv.go otherwise value like p/xxx/xxx will fall through
+		// and fail to parse
+		if rawWriteCFValue.IsDelete() || rawWriteCFValue.IsRollback() || !rawWriteCFValue.HasShortValue() {
+			return nil, nil
 		}
-		return nil, nil
+		return rawWriteCFValue.GetShortValue(), nil
 	default:
 		return nil, errors.Errorf("unsupported column family: %s", cf)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60024, close #57613

Problem Summary:

The pitr restore meta kv parsing phase has some issue regarding to writeCF value, and the pitr restore could fail

### What changed and how does it work?

this PR made it exact same as the rewrite_meta_kv logic to avoid the parsing failure found in e2e test.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
