### PR TITLE
br: skip update follower handle region if no need to scan regions

### DIFF
--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -410,7 +410,7 @@ func setPDConfigCommand() *cobra.Command {
 			}
 
 			mgr, err := task.NewMgr(ctx, tidbGlue, cfg.PD, cfg.TLS, task.GetKeepalive(&cfg),
-				cfg.CheckRequirements, false, conn.NormalVersionChecker)
+				cfg.CheckRequirements, false, false, conn.NormalVersionChecker)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -236,7 +236,8 @@ func NewMgr(
 		if err = g.UseOneShotSession(storage, !needDomain, func(se glue.Session) error {
 			enableFollowerHandleRegion, err := se.GetGlobalSysVar(vardef.PDEnableFollowerHandleRegion)
 			if err != nil {
-				return err
+				log.Warn("failed to get enable follower handle region, maybe the cluster version is old", zap.Error(err))
+				return nil
 			}
 			return controller.SetFollowerHandle(variable.TiDBOptOn(enableFollowerHandleRegion))
 		}); err != nil {

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -406,7 +406,7 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	// Domain loads all table info into memory. By skipping Domain, we save
 	// lots of memory (about 500MB for 40K 40 fields YCSB tables).
 	needDomain := !skipStats
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, needDomain, conn.NormalVersionChecker)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, needDomain, false, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/backup_ebs.go
+++ b/br/pkg/task/backup_ebs.go
@@ -114,7 +114,7 @@ func RunBackupEBS(c context.Context, g glue.Glue, cfg *BackupConfig) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, false, conn.NormalVersionChecker)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, false, true, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/backup_raw.go
+++ b/br/pkg/task/backup_raw.go
@@ -138,7 +138,7 @@ func RunBackupRaw(c context.Context, g glue.Glue, cmdName string, cfg *RawKvConf
 	}
 	// Backup raw does not need domain.
 	needDomain := false
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, needDomain, conn.NormalVersionChecker)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, needDomain, false, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/backup_txn.go
+++ b/br/pkg/task/backup_txn.go
@@ -117,7 +117,7 @@ func RunBackupTxn(c context.Context, g glue.Glue, cmdName string, cfg *TxnKvConf
 	}
 	// Backup txn does not need domain.
 	needDomain := false
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, needDomain, conn.NormalVersionChecker)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, needDomain, false, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -796,6 +796,7 @@ func NewMgr(ctx context.Context,
 	keepalive keepalive.ClientParameters,
 	checkRequirements bool,
 	needDomain bool,
+	needRegionScan bool,
 	versionCheckerType conn.VersionCheckerType,
 ) (*conn.Mgr, error) {
 	var (
@@ -820,7 +821,7 @@ func NewMgr(ctx context.Context,
 	// Is it necessary to remove `StoreBehavior`?
 	return conn.NewMgr(
 		ctx, g, pds, tlsConf, securityOption, keepalive, util.SkipTiFlash,
-		checkRequirements, needDomain, versionCheckerType,
+		checkRequirements, needDomain, needRegionScan, versionCheckerType,
 	)
 }
 

--- a/br/pkg/task/operator/checksum_table.go
+++ b/br/pkg/task/operator/checksum_table.go
@@ -74,7 +74,7 @@ func RunChecksumTable(ctx context.Context, g glue.Glue, cfg ChecksumWithRewriteR
 func (c *checksumTableCtx) init(ctx context.Context, g glue.Glue) error {
 	cfg := c.cfg
 	var err error
-	c.mgr, err = task.NewMgr(ctx, g, cfg.PD, cfg.TLS, task.GetKeepalive(&cfg.Config), cfg.CheckRequirements, true, conn.NormalVersionChecker)
+	c.mgr, err = task.NewMgr(ctx, g, cfg.PD, cfg.TLS, task.GetKeepalive(&cfg.Config), cfg.CheckRequirements, true, true, conn.NormalVersionChecker)
 	if err != nil {
 		return err
 	}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -797,7 +797,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	})
 
 	// TODO: remove version checker from `NewMgr`
-	mgr, err := NewMgr(c, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, true, conn.NormalVersionChecker)
+	mgr, err := NewMgr(c, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config), cfg.CheckRequirements, true, true, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore_data.go
+++ b/br/pkg/task/restore_data.go
@@ -70,7 +70,7 @@ func RunResolveKvData(c context.Context, g glue.Glue, cmdName string, cfg *Resto
 	summary.CollectUint("resolve-ts", resolveTS)
 
 	keepaliveCfg := GetKeepalive(&cfg.Config)
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, keepaliveCfg, cfg.CheckRequirements, false, conn.NormalVersionChecker)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, keepaliveCfg, cfg.CheckRequirements, true, true, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore_txn.go
+++ b/br/pkg/task/restore_txn.go
@@ -30,7 +30,7 @@ func RunRestoreTxn(c context.Context, g glue.Glue, cmdName string, cfg *Config) 
 	defer cancel()
 
 	// Restore raw does not need domain.
-	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(cfg), cfg.CheckRequirements, false, conn.NormalVersionChecker)
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(cfg), cfg.CheckRequirements, false, true, conn.NormalVersionChecker)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -333,7 +333,7 @@ type streamMgr struct {
 
 func NewStreamMgr(ctx context.Context, cfg *StreamConfig, g glue.Glue, isStreamStart bool) (*streamMgr, error) {
 	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config),
-		cfg.CheckRequirements, false, conn.StreamVersionChecker)
+		cfg.CheckRequirements, false, false, conn.StreamVersionChecker)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -957,7 +957,7 @@ func RunStreamAdvancer(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	log.Info("starting", zap.String("cmd", cmdName))
 
 	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config),
-		cfg.CheckRequirements, false, conn.StreamVersionChecker)
+		cfg.CheckRequirements, false, true, conn.StreamVersionChecker)
 	if err != nil {
 		return err
 	}
@@ -1044,7 +1044,7 @@ func makeStatusController(ctx context.Context, cfg *StreamConfig, g glue.Glue) (
 		printer = stream.PrintTaskWithJSON(console)
 	}
 	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config),
-		cfg.CheckRequirements, false, conn.StreamVersionChecker)
+		cfg.CheckRequirements, false, false, conn.StreamVersionChecker)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58651

Problem Summary:
Some scenarios do not require scanning regions and it is best not to open domain.
### What changed and how does it work?
skip opening domain and update `follower_handle_region` configuration.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
