### PR TITLE
table: use writable columns to avoid columns not match when add column DDL exec parallel with update DML

### DIFF
--- a/pkg/table/tables/partition.go
+++ b/pkg/table/tables/partition.go
@@ -367,13 +367,13 @@ func (kp *ForKeyPruning) LocateKeyPartition(numParts uint64, r []types.Datum) (i
 
 func initEvalBufferType(t *partitionedTable) {
 	hasExtraHandle := false
-	numCols := len(t.Cols())
+	numCols := len(t.WritableCols())
 	if !t.Meta().PKIsHandle {
 		hasExtraHandle = true
 		numCols++
 	}
 	t.evalBufferTypes = make([]*types.FieldType, numCols)
-	for i, col := range t.Cols() {
+	for i, col := range t.WritableCols() {
 		t.evalBufferTypes[i] = &col.FieldType
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60047

Problem Summary:

### What changed and how does it work?
When execute `evalBuffer.SetDatums(r...) ` in `locateRangeColumnPartition`，a non-public column may overlap with handle column, which causes locating to a wrong partition.

* How to judge?
1）On the Update Path: partitionedTableUpdateRecord -> locatePartition -> locateRangeColumnPartition, currData and newData both contain writable Columns。
That is to say，if `add column` DDL reach StateWriteOnly phase, updated currData and newData both contain the new added column。
2）While in `locateRangeColumnPartition` method，we get MutRow from t.evalBufferPool, whose Columns are all public, and actually extraHandle column is added at the end(see `initEvalBufferType`)。

* Give an example?
A table like the following:
```
CREATE TABLE t (
		a INT, b INT, c VARCHAR(10),
		unique key idx(a, c)
) partition by range columns(c) (
	partition p0 values less than ('30'),
	partition p1 values less than ('60'),
	partition p2 values less than ('90'));
```
When DDL `add column d decimal(20,4) not null default '0'` reaches StateWriteOnly phase：
* DML `insert...on duplicate key update...` updates a row from (20, 20, '20') to (20, 15, '20'). Then we can get currData as (20, 20, '20', 0), and newData as (20, 15, '20', 0). Both of them contains the non-public column, at the same time columns in evalBuffer are still (a, b, c)。
`evalBuffer.SetDatum` in locateRangeColumnPartition method set columns (a, b, c, handle) as (20, 20, '20', 0)。
Notice, handle is int64 type，but the written column d is decimal type. So they have different types and SetDatum sets the wrong value:
```
func (mr MutRow) SetDatum(colIdx int, d types.Datum) {
	switch d.Kind() {
    case types.KindMysqlDecimal:
    	*(*types.MyDecimal)(unsafe.Pointer(&col.data[0])) = *d.GetMysqlDecimal()
  }
}
```
* When debugging，I found t.c column's value is overlapped by zero:
```
// before handle column is set
*{length: 1,
  nullBitmap: []uint8 len: 1, cap: 1, [1],
  offsets: []int64 len: 2, cap: 2, [0,2],
  data: []uint8 len: 2, cap: 3, [51,49],
  elemBuf: []uint8 len: 0, cap: 0, nil,},
// after handle column is set
*{length: 1,
  nullBitmap: []uint8 len: 1, cap: 1, [0],
  offsets: []int64 len: 2, cap: 2, [0,0],
  data: []uint8 len: 2, cap: 3, [0,0],
  elemBuf: []uint8 len: 0, cap: 0, nil,},
```
t.c column's nullBitmap becomes 0，so EvalString get isNull=true. So the first partition is visited.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
