### PR TITLE
util,executor: Fix incorrect execution info issue of pessimistic lock error

### DIFF
--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -1532,10 +1532,8 @@ func (e *InsertRuntimeStat) Clone() execdetails.RuntimeStats {
 		snapshotStats := e.SnapshotRuntimeStats.Clone()
 		newRs.SnapshotRuntimeStats = snapshotStats
 	}
-	if e.BasicRuntimeStats != nil {
-		basicStats := e.BasicRuntimeStats.Clone()
-		newRs.BasicRuntimeStats = basicStats.(*execdetails.BasicRuntimeStats)
-	}
+	// BasicRuntimeStats is unique for all executor instances mapping to the same plan id
+	newRs.BasicRuntimeStats = e.BasicRuntimeStats
 	if e.AllocatorRuntimeStats != nil {
 		newRs.AllocatorRuntimeStats = e.AllocatorRuntimeStats.Clone()
 	}
@@ -1556,13 +1554,8 @@ func (e *InsertRuntimeStat) Merge(other execdetails.RuntimeStats) {
 			e.SnapshotRuntimeStats.Merge(tmp.SnapshotRuntimeStats)
 		}
 	}
-	if tmp.BasicRuntimeStats != nil {
-		if e.BasicRuntimeStats == nil {
-			basicStats := tmp.BasicRuntimeStats.Clone()
-			e.BasicRuntimeStats = basicStats.(*execdetails.BasicRuntimeStats)
-		} else {
-			e.BasicRuntimeStats.Merge(tmp.BasicRuntimeStats)
-		}
+	if tmp.BasicRuntimeStats != nil && e.BasicRuntimeStats == nil {
+		e.BasicRuntimeStats = tmp.BasicRuntimeStats
 	}
 	if tmp.AllocatorRuntimeStats != nil {
 		if e.AllocatorRuntimeStats == nil {

--- a/pkg/executor/insert_test.go
+++ b/pkg/executor/insert_test.go
@@ -426,7 +426,9 @@ func TestInsertRuntimeStat(t *testing.T) {
 	stats.BasicRuntimeStats.Record(5*time.Second, 1)
 	require.Equal(t, "prepare: 3s, check_insert: {total_time: 2s, mem_insert_time: 1s, prefetch: 1s}", stats.String())
 	require.Equal(t, stats.Clone().String(), stats.String())
-	stats.Merge(stats.Clone())
+	newStats := stats.Clone()
+	newStats.(*executor.InsertRuntimeStat).BasicRuntimeStats.Record(5*time.Second, 1)
+	stats.Merge(newStats)
 	require.Equal(t, "prepare: 6s, check_insert: {total_time: 4s, mem_insert_time: 2s, prefetch: 2s}", stats.String())
 	stats.FKCheckTime = time.Second
 	require.Equal(t, "prepare: 6s, check_insert: {total_time: 4s, mem_insert_time: 2s, prefetch: 2s, fk_check: 1s}", stats.String())

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1087,7 +1087,6 @@ func (sc *StatementContext) ResetForRetry() {
 	sc.TableIDs = sc.TableIDs[:0]
 	sc.IndexNames = sc.IndexNames[:0]
 	sc.TaskID = AllocateTaskID()
-	sc.SyncExecDetails.Reset()
 	sc.WarnHandler.TruncateWarnings(0)
 	sc.ExtraWarnHandler.TruncateWarnings(0)
 

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1542,7 +1542,7 @@ func (e *BasicRuntimeStats) GetActRows() int64 {
 }
 
 // Clone implements the RuntimeStats interface.
-func (e *BasicRuntimeStats) Clone() RuntimeStats {
+func (_ *BasicRuntimeStats) Clone() RuntimeStats {
 	panic("BasicRuntimeStats should not implement Clone function")
 }
 

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1542,6 +1542,8 @@ func (e *BasicRuntimeStats) GetActRows() int64 {
 }
 
 // Clone implements the RuntimeStats interface.
+// BasicRuntimeStats shouldn't implement Clone interface because all executors with the same executor_id
+// should share with the same BasicRuntimeStats, duplicated BasicRuntimeStats are easy to cause mistakes.
 func (*BasicRuntimeStats) Clone() RuntimeStats {
 	panic("BasicRuntimeStats should not implement Clone function")
 }

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1711,7 +1711,7 @@ func (e *RuntimeStatsColl) RegisterStats(planID int, info RuntimeStats) {
 		}
 	}
 	if !found {
-		stats.groupRss = append(stats.groupRss, info.Clone())
+		stats.groupRss = append(stats.groupRss, info)
 	}
 }
 

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1542,7 +1542,7 @@ func (e *BasicRuntimeStats) GetActRows() int64 {
 }
 
 // Clone implements the RuntimeStats interface.
-func (_ *BasicRuntimeStats) Clone() RuntimeStats {
+func (*BasicRuntimeStats) Clone() RuntimeStats {
 	panic("BasicRuntimeStats should not implement Clone function")
 }
 

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1543,7 +1543,7 @@ func (e *BasicRuntimeStats) GetActRows() int64 {
 
 // Clone implements the RuntimeStats interface.
 // BasicRuntimeStats shouldn't implement Clone interface because all executors with the same executor_id
-// should share with the same BasicRuntimeStats, duplicated BasicRuntimeStats are easy to cause mistakes.
+// should share the same BasicRuntimeStats, duplicated BasicRuntimeStats are easy to cause mistakes.
 func (*BasicRuntimeStats) Clone() RuntimeStats {
 	panic("BasicRuntimeStats should not implement Clone function")
 }

--- a/pkg/util/execdetails/execdetails.go
+++ b/pkg/util/execdetails/execdetails.go
@@ -1543,14 +1543,7 @@ func (e *BasicRuntimeStats) GetActRows() int64 {
 
 // Clone implements the RuntimeStats interface.
 func (e *BasicRuntimeStats) Clone() RuntimeStats {
-	result := &BasicRuntimeStats{}
-	result.executorCount.Store(e.executorCount.Load())
-	result.loop.Store(e.loop.Load())
-	result.consume.Store(e.consume.Load())
-	result.open.Store(e.open.Load())
-	result.close.Store(e.close.Load())
-	result.rows.Store(e.rows.Load())
-	return result
+	panic("BasicRuntimeStats should not implement Clone function")
 }
 
 // Merge implements the RuntimeStats interface.
@@ -1718,7 +1711,7 @@ func (e *RuntimeStatsColl) RegisterStats(planID int, info RuntimeStats) {
 		}
 	}
 	if !found {
-		stats.groupRss = append(stats.groupRss, info)
+		stats.groupRss = append(stats.groupRss, info.Clone())
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59356 

Problem Summary:
In #54004, some stats' clone operations are removed. However, the removal of clone operation in RegisterStats function introduced new issue:
https://github.com/pingcap/tidb/blob/d13e52ed6e22cc5789bed7c64c861578cd2ed55b/pkg/util/execdetails/execdetails.go#L1462 
Because, for insert operator's stats, it keeps a pointer to the BasicRuntimeStats which is unique for all executors with the same executor_id. For issue 59356, tidb first tries the insert executor, but fails with write conflicts,registering the executor stats in close function. Then it retries, using a new insert executor, while still has a pointer to the registered BasicRuntimeStats. Finally, when the new insert executor closes, it register the stats also, triggering the BasicRuntimeStats' merge operation which now is actually a self-merge operation. It leads to the double-calculated execution time issue.
Besides, when retries happen, we reset the collected exec details in statement context, which will drop the execution details for failed tries. 

### What changed and how does it work?
1. Don't actually clone and merge BasicRuntimeStats inside InsertRuntimeStat
2. Don't reset exec details when reseting statement context for retrying.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Manually started two sessions and execute queries in #59356, confirmed the insert executor's execution time is correct and the lock_keys details are displayed:
```
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 	id      	task	estRows	operator info	actRows	execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             	memory   	disk
	Insert_1	root	0      	N/A          	0      	total_time:982ms, total_open:5.21µs, total_close:2.58µs, loops:4, prepare: 981.1ms, check_insert: {total_time: 903.2µs, mem_insert_time: 72.2µs, prefetch: 831µs, rpc:{BatchGet:{num_rpc:4, total_time:765.1µs}, time_detail: {total_kv_read_wall_time: 229.4µs, tikv_wall_time: 274.9µs}, scan_detail: {total_process_keys: 4, total_process_keys_size: 170, total_keys: 5, get_snapshot_time: 40.8µs, rocksdb: {key_skipped_count: 1, block: {}}}}}, lock_keys: {time:981ms, region:2, keys:4, slowest_rpc: {total: 0.000s, region_id: 16, store: 127.0.0.1:20160, time_detail: {tikv_wall_time: 52.2µs}, scan_detail: {get_snapshot_time: 8.33µs, rocksdb: {delete_skipped_count: 2, key_skipped_count: 5, block: {}}}, }, lock_rpc:980.877749ms, rpc_count:2, retry_count:1}	144 Bytes	N/A |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that insert operator's execution time may be incorrect when retrying pessimistic locks.
```
