### PR TITLE
planner: fix wrong HashAgg estrows for inner operator of index join

### DIFF
--- a/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
@@ -1711,9 +1711,9 @@
           "IndexJoin 9990.00 root  inner join, inner:HashAgg, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
           "├─TableReader(Build) 10000.00 root  data:TableFullScan",
           "│ └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─HashAgg(Probe) 79920000.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
-          "  └─IndexReader 79920000.00 root  index:HashAgg",
-          "    └─HashAgg 79920000.00 cop[tikv]  group by:test.t2.a, ",
+          "└─HashAgg(Probe) 9990.00 root  group by:test.t2.a, funcs:firstrow(test.t2.a)->test.t2.a",
+          "  └─IndexReader 9990.00 root  index:HashAgg",
+          "    └─HashAgg 9990.00 cop[tikv]  group by:test.t2.a, ",
           "      └─Selection 9990.00 cop[tikv]  not(isnull(test.t2.a))",
           "        └─IndexRangeScan 10000.00 cop[tikv] table:t2, index:ia(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"
         ],

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1486,6 +1486,12 @@ func constructIndexJoinInnerSideTaskWithAggCheck(p *logicalop.LogicalJoin, prop 
 	// build physical agg and attach to task
 	var aggTask base.Task
 	// build stream agg and change ds keep order to true
+	stats := la.StatsInfo()
+	if dsCopTask.indexPlan != nil {
+		stats = stats.ScaleByExpectCnt(dsCopTask.indexPlan.StatsInfo().RowCount)
+	} else if dsCopTask.tablePlan != nil {
+		stats = stats.ScaleByExpectCnt(dsCopTask.tablePlan.StatsInfo().RowCount)
+	}
 	if preferStream {
 		newGbyItems := make([]expression.Expression, len(la.GroupByItems))
 		copy(newGbyItems, la.GroupByItems)
@@ -1506,6 +1512,7 @@ func constructIndexJoinInnerSideTaskWithAggCheck(p *logicalop.LogicalJoin, prop 
 			if physicalIndexScan != nil {
 				physicalIndexScan.KeepOrder = true
 				dsCopTask.keepOrder = true
+				streamAgg.SetStats(stats)
 				aggTask = streamAgg.Attach2Task(dsCopTask)
 			}
 		}
@@ -1513,7 +1520,7 @@ func constructIndexJoinInnerSideTaskWithAggCheck(p *logicalop.LogicalJoin, prop 
 
 	// build hash agg, when the stream agg is illegal such as the order by prop is not matched
 	if aggTask == nil {
-		physicalHashAgg := NewPhysicalHashAgg(la, la.StatsInfo(), prop)
+		physicalHashAgg := NewPhysicalHashAgg(la, stats, prop)
 		physicalHashAgg.SetSchema(la.Schema().Clone())
 		aggTask = physicalHashAgg.Attach2Task(dsCopTask)
 	}

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 8,
+    shard_count = 9,
     deps = [
         "//pkg/parser",
         "//pkg/planner",

--- a/pkg/planner/core/issuetest/planner_issue_test.go
+++ b/pkg/planner/core/issuetest/planner_issue_test.go
@@ -107,11 +107,11 @@ func TestIssue54535(t *testing.T) {
 			"  ├─TableReader_43(Build) 9990.00 root  data:Selection_42",
 			"  │ └─Selection_42 9990.00 cop[tikv]  not(isnull(test.ta.a1))",
 			"  │   └─TableFullScan_41 10000.00 cop[tikv] table:ta keep order:false, stats:pseudo",
-			"  └─HashAgg_14(Probe) 79840080.00 root  group by:test.tb.b1, test.tb.b2, funcs:count(Column#11)->Column#9, funcs:firstrow(test.tb.b1)->test.tb.b1",
-			"    └─IndexLookUp_15 79840080.00 root  ",
+			"  └─HashAgg_14(Probe) 9990.00 root  group by:test.tb.b1, test.tb.b2, funcs:count(Column#11)->Column#9, funcs:firstrow(test.tb.b1)->test.tb.b1",
+			"    └─IndexLookUp_15 9990.00 root  ",
 			"      ├─Selection_12(Build) 9990.00 cop[tikv]  not(isnull(test.tb.b1))",
 			"      │ └─IndexRangeScan_10 10000.00 cop[tikv] table:tb, index:idx_b(b1) range: decided by [eq(test.tb.b1, test.ta.a1)], keep order:false, stats:pseudo",
-			"      └─HashAgg_13(Probe) 79840080.00 cop[tikv]  group by:test.tb.b1, test.tb.b2, funcs:count(test.tb.b3)->Column#11",
+			"      └─HashAgg_13(Probe) 9990.00 cop[tikv]  group by:test.tb.b1, test.tb.b2, funcs:count(test.tb.b3)->Column#11",
 			"        └─TableRowIDScan_11 9990.00 cop[tikv] table:tb keep order:false, stats:pseudo"))
 	// test for issues/55169
 	tk.MustExec("create table t1(col_1 int, index idx_1(col_1));")
@@ -264,4 +264,23 @@ GROUP BY field1;`).Check(testkit.Rows("HashJoin 2.00 root  CARTESIAN left outer 
 FROM t1 AS table1
 WHERE (EXISTS (SELECT SUBQUERY2_t1.a1 AS SUBQUERY2_field1 FROM t1 AS SUBQUERY2_t1)) OR table1.b1 >= 55
 GROUP BY field1;`).Check(testkit.Rows("0"))
+}
+
+func TestIssue59902(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t1(a int primary key, b int);")
+	tk.MustExec("create table t2(a int, b int, key idx(a));")
+	tk.MustExec("set tidb_enable_inl_join_inner_multi_pattern=on;")
+	tk.MustQuery("explain format='brief' select t1.b,(select count(*) from t2 where t2.a=t1.a) as a from t1 where t1.a=1;").
+		Check(testkit.Rows(
+			"Projection 1.00 root  test.t1.b, ifnull(Column#9, 0)->Column#9",
+			"└─IndexJoin 1.00 root  left outer join, inner:HashAgg, left side:Point_Get, outer key:test.t1.a, inner key:test.t2.a, equal cond:eq(test.t1.a, test.t2.a)",
+			"  ├─Point_Get(Build) 1.00 root table:t1 handle:1",
+			"  └─HashAgg(Probe) 1.00 root  group by:test.t2.a, funcs:count(Column#10)->Column#9, funcs:firstrow(test.t2.a)->test.t2.a",
+			"    └─IndexReader 1.00 root  index:HashAgg",
+			"      └─HashAgg 1.00 cop[tikv]  group by:test.t2.a, funcs:count(1)->Column#10",
+			"        └─Selection 1.00 cop[tikv]  not(isnull(test.t2.a))",
+			"          └─IndexRangeScan 1.00 cop[tikv] table:t2, index:idx(a) range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo"))
 }

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -3376,16 +3376,17 @@ show warnings;
 Level	Code	Message
 explain format = 'brief' SELECT ta.NAME,(SELECT sum(tb.CODE) FROM tb WHERE ta.id = tb.id) tb_sum_code FROM ta WHERE ta.NAME LIKE 'chad999%';
 id	estRows	task	access object	operator info
-HashJoin	250.00	root		left outer join, left side:IndexLookUp, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.ta.id, planner__core__casetest__physicalplantest__physical_plan.tb.id)]
+IndexHashJoin	250.00	root		left outer join, inner:HashAgg, left side:IndexLookUp, outer key:planner__core__casetest__physicalplantest__physical_plan.ta.id, inner key:planner__core__casetest__physicalplantest__physical_plan.tb.id, equal cond:eq(planner__core__casetest__physicalplantest__physical_plan.ta.id, planner__core__casetest__physicalplantest__physical_plan.tb.id)
 ├─IndexLookUp(Build)	250.00	root		
 │ ├─Selection(Build)	250.00	cop[tikv]		like(planner__core__casetest__physicalplantest__physical_plan.ta.name, "chad999%", 92)
 │ │ └─IndexRangeScan	250.00	cop[tikv]	table:ta, index:idx_ta_name(name)	range:["chad999","chad99:"), keep order:false, stats:pseudo
 │ └─TableRowIDScan(Probe)	250.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
-└─HashAgg(Probe)	7992.00	root		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:sum(Column#26)->Column#13, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.tb.id)->planner__core__casetest__physicalplantest__physical_plan.tb.id
-  └─TableReader	7992.00	root		data:HashAgg
-    └─HashAgg	7992.00	cop[tikv]		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:sum(planner__core__casetest__physicalplantest__physical_plan.tb.code)->Column#26
-      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.tb.id))
-        └─TableFullScan	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
+└─HashAgg(Probe)	250.00	root		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:sum(Column#15)->Column#13, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.tb.id)->planner__core__casetest__physicalplantest__physical_plan.tb.id
+  └─IndexLookUp	250.00	root		
+    ├─Selection(Build)	250.00	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.tb.id))
+    │ └─IndexRangeScan	250.25	cop[tikv]	table:tb, index:idx_tb_id(id)	range: decided by [eq(planner__core__casetest__physicalplantest__physical_plan.tb.id, planner__core__casetest__physicalplantest__physical_plan.ta.id)], keep order:false, stats:pseudo
+    └─HashAgg(Probe)	250.00	cop[tikv]		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:sum(planner__core__casetest__physicalplantest__physical_plan.tb.code)->Column#15
+      └─TableRowIDScan	250.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 SELECT ta.NAME,(SELECT sum(tb.CODE) FROM tb WHERE ta.id = tb.id) tb_sum_code FROM ta WHERE ta.NAME LIKE 'chad999%';
 NAME	tb_sum_code
 show warnings;
@@ -3506,11 +3507,11 @@ Projection	9.99	root		planner__core__casetest__physicalplantest__physical_plan.t
   │ └─Selection(Probe)	9.99	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.ta.id))
   │   └─TableRowIDScan	10.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
   └─Selection(Probe)	63872.06	root		gt(Column#9, 900)
-    └─HashAgg	79840.08	root		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:max(Column#13)->Column#9, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.tb.id)->planner__core__casetest__physicalplantest__physical_plan.tb.id
-      └─IndexLookUp	79840.08	root		
+    └─HashAgg	9.99	root		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:max(Column#13)->Column#9, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.tb.id)->planner__core__casetest__physicalplantest__physical_plan.tb.id
+      └─IndexLookUp	9.99	root		
         ├─Selection(Build)	9.99	cop[tikv]		not(isnull(planner__core__casetest__physicalplantest__physical_plan.tb.id))
         │ └─IndexRangeScan	10.00	cop[tikv]	table:tb, index:idx_tb_id(id)	range: decided by [eq(planner__core__casetest__physicalplantest__physical_plan.tb.id, planner__core__casetest__physicalplantest__physical_plan.ta.id)], keep order:false, stats:pseudo
-        └─HashAgg(Probe)	79840.08	cop[tikv]		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:max(planner__core__casetest__physicalplantest__physical_plan.tb.code)->Column#13
+        └─HashAgg(Probe)	9.99	cop[tikv]		group by:planner__core__casetest__physicalplantest__physical_plan.tb.id, funcs:max(planner__core__casetest__physicalplantest__physical_plan.tb.code)->Column#13
           └─TableRowIDScan	9.99	cop[tikv]	table:tb	keep order:false, stats:pseudo
 SELECT ta.id, 'split' as flag FROM ta WHERE ta.NAME ='chad999' and (select max(tb.code) from tb where ta.id=tb.id ) > 900;
 id	flag

--- a/tests/integrationtest/r/planner/core/indexjoin.result
+++ b/tests/integrationtest/r/planner/core/indexjoin.result
@@ -52,9 +52,9 @@ Projection	9990.00	root		planner__core__indexjoin.t.a, Column#4, planner__core__
   └─IndexJoin	9990.00	root		inner join, inner:HashAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
     ├─IndexReader(Build)	9990.00	root		index:IndexFullScan
     │ └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
-    └─HashAgg(Probe)	79840080.00	root		group by:planner__core__indexjoin.t.a, funcs:count(Column#8)->Column#4, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a
-      └─IndexReader	79840080.00	root		index:HashAgg
-        └─HashAgg	79840080.00	cop[tikv]		group by:planner__core__indexjoin.t.a, funcs:count(planner__core__indexjoin.t.b)->Column#8
+    └─HashAgg(Probe)	9990.00	root		group by:planner__core__indexjoin.t.a, funcs:count(Column#8)->Column#4, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a
+      └─IndexReader	9990.00	root		index:HashAgg
+        └─HashAgg	9990.00	cop[tikv]		group by:planner__core__indexjoin.t.a, funcs:count(planner__core__indexjoin.t.b)->Column#8
           └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
             └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:false, stats:pseudo
 select /*+ INL_JOIN(tmp) */ t1.a, tmp.count_b from (select a, count(b) count_b from t group by a) tmp, t1 where tmp.a=t1.a order by t1.a, tmp.count_b;
@@ -73,9 +73,9 @@ Projection	9980.01	root		planner__core__indexjoin.t.a, Column#4, planner__core__
     ├─IndexReader(Build)	9980.01	root		index:Selection
     │ └─Selection	9980.01	cop[tikv]		not(isnull(planner__core__indexjoin.t1.b))
     │   └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
-    └─HashAgg(Probe)	79760239.92	root		group by:planner__core__indexjoin.t.a, funcs:count(Column#8)->Column#4, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a
-      └─IndexReader	79760239.92	root		index:HashAgg
-        └─HashAgg	79760239.92	cop[tikv]		group by:planner__core__indexjoin.t.a, funcs:count(planner__core__indexjoin.t.b)->Column#8
+    └─HashAgg(Probe)	9980.01	root		group by:planner__core__indexjoin.t.a, funcs:count(Column#8)->Column#4, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a
+      └─IndexReader	9980.01	root		index:HashAgg
+        └─HashAgg	9980.01	cop[tikv]		group by:planner__core__indexjoin.t.a, funcs:count(planner__core__indexjoin.t.b)->Column#8
           └─Selection	9980.01	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
             └─IndexRangeScan	9990.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:false, stats:pseudo
 select /*+ INL_JOIN(tmp) */  t1.a, tmp.count_b from (select a, count(b) count_b from t group by a) tmp, t1 where tmp.a=t1.a and tmp.count_b = t1.b order by  t1.a, tmp.count_b;
@@ -170,9 +170,9 @@ Projection	9990.00	root		planner__core__indexjoin.t3.b, planner__core__indexjoin
   ├─TableReader(Build)	9990.00	root		data:Selection
   │ └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t4.b))
   │   └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
-  └─HashAgg(Probe)	79840080.00	root		group by:planner__core__indexjoin.t3.b, funcs:firstrow(planner__core__indexjoin.t3.b)->planner__core__indexjoin.t3.b
-    └─IndexReader	79840080.00	root		index:HashAgg
-      └─HashAgg	79840080.00	cop[tikv]		group by:planner__core__indexjoin.t3.b, 
+  └─HashAgg(Probe)	9990.00	root		group by:planner__core__indexjoin.t3.b, funcs:firstrow(planner__core__indexjoin.t3.b)->planner__core__indexjoin.t3.b
+    └─IndexReader	9990.00	root		index:HashAgg
+      └─HashAgg	9990.00	cop[tikv]		group by:planner__core__indexjoin.t3.b, 
         └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t3.b))
           └─IndexRangeScan	10000.00	cop[tikv]	table:t3, index:idx(b)	range: decided by [eq(planner__core__indexjoin.t3.b, planner__core__indexjoin.t4.b)], keep order:false, stats:pseudo
 select /*+ INL_JOIN(tmp) */ tmp.b, t4.b from (select b from t3 group by b) tmp, t4 where tmp.b=t4.b order by tmp.b, t4.b;
@@ -205,9 +205,9 @@ Projection	9990.00	root		planner__core__indexjoin.t.a, Column#4, planner__core__
   └─IndexJoin	9990.00	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
     ├─IndexReader(Build)	9990.00	root		index:IndexFullScan
     │ └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
-    └─StreamAgg(Probe)	79840080.00	root		group by:planner__core__indexjoin.t.a, funcs:count(Column#8)->Column#4, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a
-      └─IndexReader	79840080.00	root		index:StreamAgg
-        └─StreamAgg	79840080.00	cop[tikv]		group by:planner__core__indexjoin.t.a, funcs:count(planner__core__indexjoin.t.b)->Column#8
+    └─StreamAgg(Probe)	9990.00	root		group by:planner__core__indexjoin.t.a, funcs:count(Column#8)->Column#4, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a
+      └─IndexReader	9990.00	root		index:StreamAgg
+        └─StreamAgg	9990.00	cop[tikv]		group by:planner__core__indexjoin.t.a, funcs:count(planner__core__indexjoin.t.b)->Column#8
           └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
             └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select /*+ stream_agg() */ b, a from t group by b, a) tmp, t1 where tmp.a=t1.a;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59902

Problem Summary:

### What changed and how does it work?

in the ```constructIndexJoinInnerSideTaskWithAggCheck```, we forget to transfer the parents stats by the child stats.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix wrong HashAgg estrows for inner operator of index join

修复 index join 的 inner operator 中 HashAgg 估算行数错误的问题
```
