### PR TITLE
test: fix concurrency issue in pitr_collector_test

### DIFF
--- a/br/pkg/restore/snap_client/pitr_collector_test.go
+++ b/br/pkg/restore/snap_client/pitr_collector_test.go
@@ -302,9 +302,11 @@ func TestConcurrency(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 	close(fence)
 
+	l.Lock()
 	for _, cb := range cbs {
 		require.NoError(t, cb())
 	}
+	l.Unlock()
 
 	coll.Done()
 }

--- a/br/pkg/restore/snap_client/pitr_collector_test.go
+++ b/br/pkg/restore/snap_client/pitr_collector_test.go
@@ -302,11 +302,14 @@ func TestConcurrency(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 	close(fence)
 
-	l.Lock()
-	for _, cb := range cbs {
-		require.NoError(t, cb())
-	}
-	l.Unlock()
+	func() {
+		l.Lock()
+		defer l.Unlock()
+
+		for _, cb := range cbs {
+			require.NoError(t, cb())
+		}
+	}()
 
 	coll.Done()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60051

Problem Summary:

It is possible to trigger race after closing the fence. 

### What changed and how does it work?

Added lock to the callbacks. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > It is a test.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
