### PR TITLE
statistics: enhance concurrency handling in stats initialization to reduce duplication

### DIFF
--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -600,12 +600,12 @@ func (h *Handle) initStatsBuckets(cache statstypes.StatsCache, totalMemory uint6
 		return nil
 	}
 	if config.GetGlobalConfig().Performance.ConcurrentlyInitStats {
-		err := h.initStatsBucketsConcurrenctly(cache, totalMemory, initstats.GetConcurrency())
+		err := h.initStatsBucketsConcurrently(cache, totalMemory, initstats.GetConcurrency())
 		if err != nil {
 			return errors.Trace(err)
 		}
 	} else {
-		err := h.initStatsBucketsConcurrenctly(cache, totalMemory, 1)
+		err := h.initStatsBucketsConcurrently(cache, totalMemory, 1)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -654,7 +654,7 @@ func (h *Handle) initStatsBucketsByPaging(cache statstypes.StatsCache, task init
 	return nil
 }
 
-func (h *Handle) initStatsBucketsConcurrenctly(cache statstypes.StatsCache, totalMemory uint64, concurrency int) error {
+func (h *Handle) initStatsBucketsConcurrently(cache statstypes.StatsCache, totalMemory uint64, concurrency int) error {
 	if IsFullCacheFunc(cache, totalMemory) {
 		return nil
 	}

--- a/pkg/statistics/handle/initstats/load_stats.go
+++ b/pkg/statistics/handle/initstats/load_stats.go
@@ -20,13 +20,13 @@ import (
 	"github.com/pingcap/tidb/pkg/config"
 )
 
-// getConcurrency gets the concurrency of loading stats.
+// GetConcurrency gets the concurrency of loading stats.
 // the concurrency is from 2 to 16.
 // when Performance.ForceInitStats is true, the concurrency is from 2 to GOMAXPROCS(0)-2.
 // -2 is to ensure that the system has enough resources to handle other tasks. such as GC and stats cache internal.
 // when Performance.ForceInitStats is false, the concurrency is from 2 to GOMAXPROCS(0)/2.
 // it is to ensure that concurrency doesn't affect the performance of customer's business.
-func getConcurrency() int {
+func GetConcurrency() int {
 	var concurrency int
 	if config.GetGlobalConfig().Performance.ForceInitStats {
 		concurrency = runtime.GOMAXPROCS(0) - 2

--- a/pkg/statistics/handle/initstats/load_stats_page.go
+++ b/pkg/statistics/handle/initstats/load_stats_page.go
@@ -90,7 +90,6 @@ func NewRangeWorker(
 
 // LoadStats loads stats concurrently when to init stats
 func (ls *RangeWorker) LoadStats() {
-	GetConcurrency()
 	for n := 0; n < ls.concurrency; n++ {
 		ls.wg.Run(func() {
 			ls.loadStats()

--- a/pkg/statistics/handle/initstats/load_stats_page.go
+++ b/pkg/statistics/handle/initstats/load_stats_page.go
@@ -46,6 +46,8 @@ type Task struct {
 }
 
 // RangeWorker is used to load stats concurrently by the range of table id.
+//
+//nolint:fieldalignment
 type RangeWorker struct {
 	logger *zap.Logger
 

--- a/pkg/statistics/handle/initstats/load_stats_page.go
+++ b/pkg/statistics/handle/initstats/load_stats_page.go
@@ -49,7 +49,7 @@ type Task struct {
 //
 //nolint:fieldalignment
 type RangeWorker struct {
-	logger *zap.Logger
+	progressLogger *zap.Logger
 
 	taskName        string
 	taskChan        chan Task
@@ -86,7 +86,7 @@ func NewRangeWorker(
 		totalPercentage:     InitStatsPercentage.Load(),
 		totalPercentageStep: totalPercentageStep,
 	}
-	worker.logger = singletonStatsSamplerLogger()
+	worker.progressLogger = singletonStatsSamplerLogger()
 	return worker
 }
 
@@ -104,11 +104,11 @@ func (ls *RangeWorker) loadStats() {
 		if err := ls.processTask(task); err != nil {
 			logutil.BgLogger().Error("load stats failed", zap.Error(err))
 		}
-		if ls.logger != nil {
+		if ls.progressLogger != nil {
 			completeTaskCnt := ls.completeTaskCnt.Add(1)
 			taskPercentage := float64(completeTaskCnt)/float64(ls.taskCnt)*ls.totalPercentageStep + ls.totalPercentage
 			InitStatsPercentage.Store(taskPercentage)
-			ls.logger.Info(fmt.Sprintf("load %s [%d/%d]", ls.taskName, completeTaskCnt, ls.taskCnt))
+			ls.progressLogger.Info(fmt.Sprintf("load %s [%d/%d]", ls.taskName, completeTaskCnt, ls.taskCnt))
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/55043

Problem Summary:

### What changed and how does it work?

We shouldn’t simply duplicate the same code for both concurrent and non-concurrent init stats.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/60090#issuecomment-2731649241)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
