### PR TITLE
Lightning: Make sure we are using default block size of 16KB if user does not specify one.

### DIFF
--- a/lightning/pkg/importer/table_import.go
+++ b/lightning/pkg/importer/table_import.go
@@ -664,12 +664,14 @@ func (tr *TableImporter) preprocessEngine(
 	logTask := tr.logger.With(zap.Int32("engineNumber", engineID)).Begin(zap.InfoLevel, "encode kv data and write")
 	dataEngineCfg := &backend.EngineConfig{
 		TableInfo: tr.tableInfo,
+		Local: backend.LocalEngineConfig{
+			BlockSize: int(rc.cfg.TikvImporter.BlockSize),
+		},
 	}
 	if !tr.tableMeta.IsRowOrdered {
 		dataEngineCfg.Local.Compact = true
 		dataEngineCfg.Local.CompactConcurrency = 4
 		dataEngineCfg.Local.CompactThreshold = local.CompactionUpperThreshold
-		dataEngineCfg.Local.BlockSize = int(rc.cfg.TikvImporter.BlockSize)
 	}
 	dataEngine, err := rc.engineMgr.OpenEngine(ctx, dataEngineCfg, tr.tableName, engineID)
 	if err != nil {

--- a/lightning/pkg/importer/table_import.go
+++ b/lightning/pkg/importer/table_import.go
@@ -669,6 +669,7 @@ func (tr *TableImporter) preprocessEngine(
 		dataEngineCfg.Local.Compact = true
 		dataEngineCfg.Local.CompactConcurrency = 4
 		dataEngineCfg.Local.CompactThreshold = local.CompactionUpperThreshold
+		dataEngineCfg.Local.BlockSize = int(rc.cfg.TikvImporter.BlockSize)
 	}
 	dataEngine, err := rc.engineMgr.OpenEngine(ctx, dataEngineCfg, tr.tableName, engineID)
 	if err != nil {

--- a/pkg/lightning/backend/local/engine.go
+++ b/pkg/lightning/backend/local/engine.go
@@ -59,6 +59,9 @@ var (
 	normalIterStartKey = []byte{1}
 )
 
+// Make sure we are using block size larger than 16KB, whereas 4KB is the default block size of Pebble.
+var DefaultBlockSize = 16 * 1024
+
 type importMutexState uint32
 
 const (
@@ -1397,7 +1400,14 @@ func (w *Writer) addSST(ctx context.Context, meta *sstMeta) error {
 
 func (w *Writer) createSSTWriter() (*sstWriter, error) {
 	path := filepath.Join(w.engine.sstDir, uuid.New().String()+".sst")
-	writer, err := newSSTWriter(path, w.engine.config.BlockSize)
+
+	blockSize := w.engine.config.BlockSize
+	// Logic to check the block size we are using is at least 16KB.
+	if blockSize <= 0 {
+		blockSize = DefaultBlockSize
+	}
+	writer, err := newSSTWriter(path, blockSize)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lightning/backend/local/engine.go
+++ b/pkg/lightning/backend/local/engine.go
@@ -1400,14 +1400,7 @@ func (w *Writer) addSST(ctx context.Context, meta *sstMeta) error {
 
 func (w *Writer) createSSTWriter() (*sstWriter, error) {
 	path := filepath.Join(w.engine.sstDir, uuid.New().String()+".sst")
-
-	blockSize := w.engine.config.BlockSize
-	// Logic to check the block size we are using is at least 16KB.
-	if blockSize <= 0 {
-		blockSize = DefaultBlockSize
-	}
-	writer, err := newSSTWriter(path, blockSize)
-
+	writer, err := newSSTWriter(path, w.engine.config.BlockSize)
 	if err != nil {
 		return nil, err
 	}
@@ -1433,6 +1426,12 @@ func newSSTWriter(path string, blockSize int) (*sstable.Writer, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// Logic to check the block size we are using is 16KB by default.
+	if blockSize <= 0 {
+		blockSize = DefaultBlockSize
+	}
+
 	writable := objstorageprovider.NewFileWritable(f)
 	writer := sstable.NewWriter(writable, sstable.WriterOptions{
 		TablePropertyCollectors: []func() pebble.TablePropertyCollector{

--- a/pkg/lightning/backend/local/engine.go
+++ b/pkg/lightning/backend/local/engine.go
@@ -59,7 +59,7 @@ var (
 	normalIterStartKey = []byte{1}
 )
 
-// Make sure we are using block size larger than 16KB, whereas 4KB is the default block size of Pebble.
+// DefaultBlockSize ensures we are using a block size larger than 16KB, whereas 4KB is the default block size of Pebble.
 var DefaultBlockSize = 16 * 1024
 
 type importMutexState uint32

--- a/pkg/lightning/backend/local/engine_test.go
+++ b/pkg/lightning/backend/local/engine_test.go
@@ -243,11 +243,15 @@ func TestIterOutputHasUniqueMemorySpace(t *testing.T) {
 }
 
 func TestCreateSSTWriterDefaultBlockSize(t *testing.T) {
+	db, tmpPath := makePebbleDB(t, nil)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 	engine := &Engine{
 		config: backend.LocalEngineConfig{
 			BlockSize: 0, // BlockSize is not set
 		},
-		sstDir: "test_sst_dir",
+		sstDir: tmpPath,
 		logger: log.Logger{},
 	}
 

--- a/pkg/lightning/backend/local/engine_test.go
+++ b/pkg/lightning/backend/local/engine_test.go
@@ -271,7 +271,7 @@ func TestCreateSSTWriterDefaultBlockSize(t *testing.T) {
 	require.True(t, blockSizeField.IsValid(), "blockSize field should be valid")
 	require.Equal(t, config.DefaultBlockSize, int(blockSizeField.Int()))
 
-	// Clean up
+	// clean up
 	err = sstWriter.writer.Close()
 	require.NoError(t, err)
 }

--- a/pkg/lightning/backend/local/engine_test.go
+++ b/pkg/lightning/backend/local/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -239,4 +240,32 @@ func TestIterOutputHasUniqueMemorySpace(t *testing.T) {
 	require.NoError(t, iter.Close())
 	// after iter closed, the memory buffer of iter goes to pool
 	require.Greater(t, pool.TotalSize(), int64(0))
+}
+
+func TestCreateSSTWriterDefaultBlockSize(t *testing.T) {
+	engine := &Engine{
+		config: backend.LocalEngineConfig{
+			BlockSize: 0, // BlockSize is not set
+		},
+		sstDir: "test_sst_dir",
+		logger: log.Logger{},
+	}
+
+	writer := &Writer{
+		engine: engine,
+	}
+
+	sstWriter, err := writer.createSSTWriter()
+	require.NoError(t, err)
+	require.NotNil(t, sstWriter)
+
+	// blockSize is a private field of sstWriter.writer, so we use reflection to access the private field blockSize
+	writerValue := reflect.ValueOf(sstWriter.writer).Elem()
+	blockSizeField := writerValue.FieldByName("blockSize")
+	require.True(t, blockSizeField.IsValid(), "blockSize field should be valid")
+	require.Equal(t, DefaultBlockSize, int(blockSizeField.Int()))
+
+	// Clean up
+	err = sstWriter.writer.Close()
+	require.NoError(t, err)
 }

--- a/pkg/lightning/backend/local/engine_test.go
+++ b/pkg/lightning/backend/local/engine_test.go
@@ -242,6 +242,7 @@ func TestIterOutputHasUniqueMemorySpace(t *testing.T) {
 	require.Greater(t, pool.TotalSize(), int64(0))
 }
 
+// TestCreateSSTWriterDefaultBlockSize tests that createSSTWriter will use the default block size of 16KB if the block size is not set.
 func TestCreateSSTWriterDefaultBlockSize(t *testing.T) {
 	db, tmpPath := makePebbleDB(t, nil)
 	t.Cleanup(func() {

--- a/pkg/lightning/backend/local/engine_test.go
+++ b/pkg/lightning/backend/local/engine_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pingcap/tidb/pkg/lightning/backend"
 	"github.com/pingcap/tidb/pkg/lightning/common"
+	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/lightning/membuf"
 	"github.com/stretchr/testify/require"
@@ -268,7 +269,7 @@ func TestCreateSSTWriterDefaultBlockSize(t *testing.T) {
 	writerValue := reflect.ValueOf(sstWriter.writer).Elem()
 	blockSizeField := writerValue.FieldByName("blockSize")
 	require.True(t, blockSizeField.IsValid(), "blockSize field should be valid")
-	require.Equal(t, DefaultBlockSize, int(blockSizeField.Int()))
+	require.Equal(t, config.DefaultBlockSize, int(blockSizeField.Int()))
 
 	// Clean up
 	err = sstWriter.writer.Close()

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/errors"
 	tidbcfg "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/lightning/common"
+	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -1510,7 +1511,7 @@ func NewConfig() *Config {
 			DiskQuota:               ByteSize(math.MaxInt64),
 			DuplicateResolution:     NoneOnDup,
 			PausePDSchedulerScope:   PausePDSchedulerScopeTable,
-			BlockSize:               16 * 1024,
+			BlockSize:               config.DefaultBlockSize,
 			LogicalImportBatchSize:  ByteSize(defaultLogicalImportBatchSize),
 			LogicalImportBatchRows:  defaultLogicalImportBatchRows,
 			LogicalImportPrepStmt:   defaultLogicalImportPrepStmt,

--- a/pkg/lightning/config/config.go
+++ b/pkg/lightning/config/config.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/errors"
 	tidbcfg "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/lightning/common"
-	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -1511,7 +1510,7 @@ func NewConfig() *Config {
 			DiskQuota:               ByteSize(math.MaxInt64),
 			DuplicateResolution:     NoneOnDup,
 			PausePDSchedulerScope:   PausePDSchedulerScopeTable,
-			BlockSize:               config.DefaultBlockSize,
+			BlockSize:               DefaultBlockSize,
 			LogicalImportBatchSize:  ByteSize(defaultLogicalImportBatchSize),
 			LogicalImportBatchRows:  defaultLogicalImportBatchRows,
 			LogicalImportPrepStmt:   defaultLogicalImportPrepStmt,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59947

Problem Summary:
Make we are using a sufficient default block size. Ref https://github.com/pingcap/tidb/pull/49514

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > To test the specific issue addressed in this PR, I used a ~1.4TB dataset consisting mostly of duplicate data. Before the fix, memory usage spiked during the ingest phase due to the large index metadata loaded by Pebble, causing OOM kills on a 16c64g VM. With the fix, memory consumption remained stable, staying below 17GB and leading to no disastrous memory spikes.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
