### PR TITLE
import: adjust data mem buf block size based on max_entry_size_limit | tidb-test=release-8.1.2

### DIFF
--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -90,7 +90,7 @@ go_test(
     embed = [":importinto"],
     flaky = True,
     race = "on",
-    shard_count = 18,
+    shard_count = 17,
     deps = [
         "//br/pkg/storage",
         "//pkg/ddl",

--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
     shard_count = 17,
     deps = [
         "//br/pkg/storage",
+        "//pkg/config",
         "//pkg/ddl",
         "//pkg/disttask/framework/planner",
         "//pkg/disttask/framework/proto",

--- a/pkg/disttask/importinto/encode_and_sort_operator.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator.go
@@ -92,7 +92,7 @@ func newEncodeAndSortOperator(
 		concurrency,
 		func() workerpool.Worker[*importStepMinimalTask, workerpool.None] {
 			return newChunkWorker(ctx, op, executor.dataKVMemSizePerCon,
-				executor.perIndexKVMemSizePerCon, executor.indexBlockSize)
+				executor.perIndexKVMemSizePerCon, executor.dataBlockSize, executor.indexBlockSize)
 		},
 	)
 	op.AsyncOperator = operator.NewAsyncOperator(subCtx, pool)
@@ -151,7 +151,7 @@ type chunkWorker struct {
 }
 
 func newChunkWorker(ctx context.Context, op *encodeAndSortOperator, dataKVMemSizePerCon,
-	perIndexKVMemSizePerCon uint64, indexBlockSize int) *chunkWorker {
+	perIndexKVMemSizePerCon uint64, dataBlockSize, indexBlockSize int) *chunkWorker {
 	w := &chunkWorker{
 		ctx: ctx,
 		op:  op,
@@ -178,7 +178,7 @@ func newChunkWorker(ctx context.Context, op *encodeAndSortOperator, dataKVMemSiz
 		builder := external.NewWriterBuilder().
 			SetOnCloseFunc(op.sharedVars.mergeDataSummary).
 			SetMemorySizeLimit(dataKVMemSizePerCon).
-			SetBlockSize(getKVGroupBlockSize(dataKVGroup))
+			SetBlockSize(dataBlockSize)
 		prefix := subtaskPrefix(op.taskID, op.subtaskID)
 		// writer id for data: data/{workerID}
 		writerID := path.Join("data", workerUUID)
@@ -276,18 +276,18 @@ func getKVGroupBlockSize(group string) int {
 	return external.DefaultBlockSize
 }
 
-func getAdjustedIndexBlockSize(perIndexKVMemSizePerCon uint64) int {
+func getAdjustedBlockSize(totalBufSize uint64, defBlockSize int) int {
 	// the buf size is aligned to block size, and the target table might have many
 	// indexes, one index KV writer might take much more memory when the buf size
 	// is slightly larger than the N*block-size.
 	// such as when dataKVMemSizePerCon = 2M, block-size = 16M, the aligned size
 	// is 16M, it's 8 times larger.
 	// so we adjust the block size when the aligned size is larger than 1.1 times
-	// of perIndexKVMemSizePerCon, to avoid OOM
-	indexBlockSize := getKVGroupBlockSize("")
-	alignedSize := membuf.GetAlignedSize(perIndexKVMemSizePerCon, uint64(indexBlockSize))
-	if float64(alignedSize)/float64(perIndexKVMemSizePerCon) > 1.1 {
-		return int(perIndexKVMemSizePerCon)
+	// of totalBufSize, to avoid OOM
+	// we also use this formula to calculate the block size for data KV writer.
+	alignedSize := membuf.GetAlignedSize(totalBufSize, uint64(defBlockSize))
+	if float64(alignedSize)/float64(totalBufSize) > 1.1 {
+		return int(totalBufSize)
 	}
-	return indexBlockSize
+	return defBlockSize
 }

--- a/pkg/disttask/importinto/encode_and_sort_operator_test.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/operator"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/lightning/backend"
+	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
@@ -225,16 +226,10 @@ func TestGetWriterMemorySizeLimit(t *testing.T) {
 	}
 }
 
-func TestGetKVGroupBlockSize(t *testing.T) {
-	require.Equal(t, 32*units.MiB, getKVGroupBlockSize(dataKVGroup))
-	require.Equal(t, 16*units.MiB, getKVGroupBlockSize(""))
-	require.Equal(t, 16*units.MiB, getKVGroupBlockSize("1"))
-}
-
 func TestGetAdjustedIndexBlockSize(t *testing.T) {
-	require.EqualValues(t, 1*units.MiB, getAdjustedIndexBlockSize(1*units.MiB))
-	require.EqualValues(t, 16*units.MiB, getAdjustedIndexBlockSize(15*units.MiB))
-	require.EqualValues(t, 16*units.MiB, getAdjustedIndexBlockSize(16*units.MiB))
-	require.EqualValues(t, 17*units.MiB, getAdjustedIndexBlockSize(17*units.MiB))
-	require.EqualValues(t, 16*units.MiB, getAdjustedIndexBlockSize(166*units.MiB))
+	require.EqualValues(t, 1*units.MiB, getAdjustedBlockSize(1*units.MiB, external.DefaultBlockSize))
+	require.EqualValues(t, 16*units.MiB, getAdjustedBlockSize(15*units.MiB, external.DefaultBlockSize))
+	require.EqualValues(t, 16*units.MiB, getAdjustedBlockSize(16*units.MiB, external.DefaultBlockSize))
+	require.EqualValues(t, 17*units.MiB, getAdjustedBlockSize(17*units.MiB, external.DefaultBlockSize))
+	require.EqualValues(t, 16*units.MiB, getAdjustedBlockSize(166*units.MiB, external.DefaultBlockSize))
 }

--- a/pkg/disttask/importinto/encode_and_sort_operator_test.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
+	tidbconfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/importinto/mock"
@@ -227,6 +228,10 @@ func TestGetWriterMemorySizeLimit(t *testing.T) {
 }
 
 func TestGetAdjustedIndexBlockSize(t *testing.T) {
+	// our block size is calculated based on MaxTxnEntrySizeLimit, if you want to
+	// change it, contact with us please.
+	require.EqualValues(t, 120*units.MiB, tidbconfig.MaxTxnEntrySizeLimit)
+
 	require.EqualValues(t, 1*units.MiB, getAdjustedBlockSize(1*units.MiB, external.DefaultBlockSize))
 	require.EqualValues(t, 16*units.MiB, getAdjustedBlockSize(15*units.MiB, external.DefaultBlockSize))
 	require.EqualValues(t, 16*units.MiB, getAdjustedBlockSize(16*units.MiB, external.DefaultBlockSize))

--- a/pkg/lightning/backend/external/onefile_writer.go
+++ b/pkg/lightning/backend/external/onefile_writer.go
@@ -29,10 +29,17 @@ import (
 	"go.uber.org/zap"
 )
 
-// defaultOneWriterMemSizeLimit is the memory size limit for one writer. OneWriter can write
-// data in stream, this memory limit is only used to avoid allocating too many times
-// for each KV pair.
-var defaultOneWriterMemSizeLimit uint64 = 128 * units.MiB
+var (
+	// defaultOneWriterMemSizeLimit is the memory size limit for one writer. OneWriter can write
+	// data in stream, this memory limit is only used to avoid allocating too many times
+	// for each KV pair.
+	defaultOneWriterMemSizeLimit uint64 = 128 * units.MiB
+	// DefaultOneWriterBlockSize is the default block size for one writer.
+	// TODO currently we don't have per-writer mem size limit, we always use the
+	// default, so we always use the default mem size limit as the block size too.
+	// it's ok for now, we can make it configurable in the future.
+	DefaultOneWriterBlockSize = int(defaultOneWriterMemSizeLimit)
+)
 
 // OneFileWriter is used to write data into external storage
 // with only one file for data and stat.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?
- previously, our data mem buf block size is aligned to 32MiB, so each row cannot exceed this size, this is the designed behavior. But we meet a case that will have 40MiB+ per row, so we align with current max_entry_size_limit, i.e. 120MiB.
- also set the block size of membuf of writers of merge-sort step to 128MiB which is also the mem limit size

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
