### PR TITLE
objstore: retry on "server sent GOAWAY" http2 error

### DIFF
--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -519,6 +519,7 @@ func shouldRetry(err error) bool {
 		"http2: client connection force closed via ClientConn.Close",
 		"broken pipe",
 		"http2: client connection lost",
+		"http2: server sent GOAWAY",
 	}
 
 	for _, msg := range retryableErrMsg {

--- a/br/pkg/storage/gcs.go
+++ b/br/pkg/storage/gcs.go
@@ -519,6 +519,7 @@ func shouldRetry(err error) bool {
 		"http2: client connection force closed via ClientConn.Close",
 		"broken pipe",
 		"http2: client connection lost",
+		// See https://stackoverflow.com/questions/45209168/http2-server-sent-goaway-and-closed-the-connection-laststreamid-1999 for details.
 		"http2: server sent GOAWAY",
 	}
 

--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -574,6 +574,7 @@ func TestSpeedReadManyFiles(t *testing.T) {
 }
 
 func TestGCSShouldRetry(t *testing.T) {
+	require.True(t, shouldRetry(&url.Error{Err: goerrors.New("http2: server sent GOAWAY and closed the connectiont"), Op: "Get", URL: "https://storage.googleapis.com/storage/v1/"}))
 	require.True(t, shouldRetry(&url.Error{Err: goerrors.New("http2: client connection lost"), Op: "Get", URL: "https://storage.googleapis.com/storage/v1/"}))
 	require.True(t, shouldRetry(&url.Error{Err: io.EOF, Op: "Get", URL: "https://storage.googleapis.com/storage/v1/"}))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60143

Problem Summary:

### What changed and how does it work?

Add "server sent GOAWAY" to retry error list, since gcp support recommends to retry on this error.

And see https://stackoverflow.com/questions/45209168/http2-server-sent-goaway-and-closed-the-connection-laststreamid-1999 for details.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
