### PR TITLE
planner: report error when subquery doesn't has an alias | tidb-test=pr/2499

### DIFF
--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -769,6 +769,6 @@ func TestIssue55881(t *testing.T) {
 	// this is a random issue, so run it 100 times to increase the probability of the issue.
 	for i := 0; i < 100; i++ {
 		tk.MustQuery("with cte as (select * from aaa) select id, (select id from (select * from aaa where aaa.id != bbb.id union all select * from cte union all select * from cte) d limit 1)," +
-			"(select max(value) from (select * from cte union all select * from cte union all select * from aaa where aaa.id > bbb.id)) from bbb;")
+			"(select max(value) from (select * from cte union all select * from cte union all select * from aaa where aaa.id > bbb.id) x) from bbb;")
 	}
 }

--- a/pkg/executor/test/tiflashtest/tiflash_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_test.go
@@ -797,7 +797,7 @@ func TestMppUnionAll(t *testing.T) {
 
 	tk.MustExec("insert into x3 values (2, 2), (2, 3), (2, 4)")
 	// test nested union all
-	tk.MustQuery("select count(*) from (select a, b from x1 union all select a, b from x3 union all (select x1.a, x3.b from (select * from x3 union all select * from x2) x3 left join x1 on x3.a = x1.b))").Check(testkit.Rows("14"))
+	tk.MustQuery("select count(*) from (select a, b from x1 union all select a, b from x3 union all (select x1.a, x3.b from (select * from x3 union all select * from x2) x3 left join x1 on x3.a = x1.b)) x").Check(testkit.Rows("14"))
 	// test union all join union all
 	tk.MustQuery("select count(*) from (select * from x1 union all select * from x2 union all select * from x3) x join (select * from x1 union all select * from x2 union all select * from x3) y on x.a = y.b").Check(testkit.Rows("29"))
 	tk.MustExec("set @@session.tidb_broadcast_join_threshold_count=100000")

--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -592,7 +592,7 @@ func TestAvoidColumnEvaluatorForProjBelowUnion(t *testing.T) {
 	tk.MustExec(`set tidb_window_concurrency = 100;`)
 
 	testCases := []string{
-		`select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) order by a, b, c;`,
+		`select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) x order by a, b, c;`,
 		`select a+1, b+1 from (select cc1 as a, cc2 as b from t1 union select cc2, cc1 from t1) tmp`,
 	}
 

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -391,7 +391,9 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		}
 	case *ast.TableSource:
 		isModeOracle := p.sctx.GetSessionVars().SQLMode&mysql.ModeOracle != 0
-		if _, ok := node.Source.(*ast.SelectStmt); ok && !isModeOracle && len(node.AsName.L) == 0 {
+		_, isSelectStmt := node.Source.(*ast.SelectStmt)
+		_, isSetOprStmt := node.Source.(*ast.SetOprStmt)
+		if (isSelectStmt || isSetOprStmt) && !isModeOracle && len(node.AsName.L) == 0 {
 			p.err = dbterror.ErrDerivedMustHaveAlias.GenWithStackByArgs()
 		}
 		if v, ok := node.Source.(*ast.TableName); ok && v.TableSample != nil {

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -2476,11 +2476,11 @@ select x.a from (select 1 a) `x`, (select 2 a) `x`;
 Error 1052 (23000): Column 'a' in field list is ambiguous
 select a from (select 1 a), (select 2 a);
 Error 1052 (23000): Column 'a' in field list is ambiguous
-select * from (select 1 union select 2);
+select * from (select 1 union select 1);
 1
-2
 1
-select * from (select 1 INTERSECT select 2);
+select * from (select 1 INTERSECT select 1);
+1
 1
 set sql_mode = default;
 drop table if exists th;

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -2454,9 +2454,9 @@ select x.a from (select 1 a) `x`, (select 2 a) `x`;
 Error 1066 (42000): Not unique table/alias: 'x'
 select a from (select 1 a), (select 2 a);
 Error 1248 (42000): Every derived table must have its own alias
-select * from (select 1 union select 2);
+select * from (select 1 union select 1);
 Error 1248 (42000): Every derived table must have its own alias
-select * from (select 1 INTERSECT select 2);
+select * from (select 1 INTERSECT select 1);
 Error 1248 (42000): Every derived table must have its own alias
 set sql_mode = 'oracle';
 select a, b from (select 1 a) ``, (select 2 b) ``;

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -2454,6 +2454,10 @@ select x.a from (select 1 a) `x`, (select 2 a) `x`;
 Error 1066 (42000): Not unique table/alias: 'x'
 select a from (select 1 a), (select 2 a);
 Error 1248 (42000): Every derived table must have its own alias
+select * from (select 1 union select 2);
+Error 1248 (42000): Every derived table must have its own alias
+select * from (select 1 INTERSECT select 2);
+Error 1248 (42000): Every derived table must have its own alias
 set sql_mode = 'oracle';
 select a, b from (select 1 a) ``, (select 2 b) ``;
 a	b
@@ -2472,6 +2476,12 @@ select x.a from (select 1 a) `x`, (select 2 a) `x`;
 Error 1052 (23000): Column 'a' in field list is ambiguous
 select a from (select 1 a), (select 2 a);
 Error 1052 (23000): Column 'a' in field list is ambiguous
+select * from (select 1 union select 2);
+1
+2
+1
+select * from (select 1 INTERSECT select 2);
+1
 set sql_mode = default;
 drop table if exists th;
 create table th (a int, b int) partition by hash(a) partitions 3;

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -650,7 +650,7 @@ create table t2 (cc1 int,cc2 text,primary key(cc1));
 insert into t2 values (2, '2');
 set tidb_executor_concurrency = 1;
 set tidb_window_concurrency = 100;
-explain select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) order by a,b,c;
+explain select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) x order by a,b,c;
 id	estRows	task	access object	operator info
 Sort_15	20000.00	root		Column#8, Column#9, Column#10
 └─Union_18	20000.00	root		
@@ -664,7 +664,7 @@ Sort_15	20000.00	root		Column#8, Column#9, Column#10
           └─ShuffleReceiver_30	10000.00	root		
             └─TableReader_26	10000.00	root		data:TableFullScan_25
               └─TableFullScan_25	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) order by a,b,c;
+select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) x order by a,b,c;
 a	b	c
 1	aaaa	1
 1	bbbb	2

--- a/tests/integrationtest/t/executor/executor.test
+++ b/tests/integrationtest/t/executor/executor.test
@@ -1409,9 +1409,9 @@ select x.a from (select 1 a) `x`, (select 2 a) `x`;
 -- error 1248
 select a from (select 1 a), (select 2 a);
 -- error 1248
-select * from (select 1 union select 2);
+select * from (select 1 union select 1);
 -- error 1248
-select * from (select 1 INTERSECT select 2);
+select * from (select 1 INTERSECT select 1);
 set sql_mode = 'oracle';
 select a, b from (select 1 a) ``, (select 2 b) ``;
 select a, b from (select 1 a) `x`, (select 2 b) `x`;
@@ -1424,8 +1424,8 @@ select a from (select 1 a) `x`, (select 2 a) `x`;
 select x.a from (select 1 a) `x`, (select 2 a) `x`;
 -- error 1052
 select a from (select 1 a), (select 2 a);
-select * from (select 1 union select 2);
-select * from (select 1 INTERSECT select 2);
+select * from (select 1 union select 1);
+select * from (select 1 INTERSECT select 1);
 set sql_mode = default;
 
 # TestSelectHashPartitionTable

--- a/tests/integrationtest/t/executor/executor.test
+++ b/tests/integrationtest/t/executor/executor.test
@@ -1408,6 +1408,10 @@ select a from (select 1 a) `x`, (select 2 a) `x`;
 select x.a from (select 1 a) `x`, (select 2 a) `x`;
 -- error 1248
 select a from (select 1 a), (select 2 a);
+-- error 1248
+select * from (select 1 union select 2);
+-- error 1248
+select * from (select 1 INTERSECT select 2);
 set sql_mode = 'oracle';
 select a, b from (select 1 a) ``, (select 2 b) ``;
 select a, b from (select 1 a) `x`, (select 2 b) `x`;
@@ -1420,6 +1424,8 @@ select a from (select 1 a) `x`, (select 2 a) `x`;
 select x.a from (select 1 a) `x`, (select 2 a) `x`;
 -- error 1052
 select a from (select 1 a), (select 2 a);
+select * from (select 1 union select 2);
+select * from (select 1 INTERSECT select 2);
 set sql_mode = default;
 
 # TestSelectHashPartitionTable

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -449,8 +449,8 @@ insert into t2 values (2, '2');
 
 set tidb_executor_concurrency = 1;
 set tidb_window_concurrency = 100;
-explain select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) order by a,b,c;
-select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) order by a,b,c;
+explain select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) x order by a,b,c;
+select * from (SELECT DISTINCT cc2 as a, cc2 as b, cc1 as c FROM t2 UNION ALL SELECT count(1) over (partition by cc1), cc2, cc1 FROM t1) x order by a,b,c;
 
 # TestIssue55818
 CREATE TABLE `t61a85298` (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60112

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Report error when subquery with union/expect/intersect doesn't has an alias, it's compatible with MySQL.
```
