### PR TITLE
statistics: fix Clone method to include checked field in ColAndIdxExistenceMap

### DIFF
--- a/pkg/statistics/BUILD.bazel
+++ b/pkg/statistics/BUILD.bazel
@@ -79,11 +79,12 @@ go_test(
         "sample_test.go",
         "scalar_test.go",
         "statistics_test.go",
+        "table_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":statistics"],
     flaky = True,
-    shard_count = 37,
+    shard_count = 38,
     deps = [
         "//pkg/config",
         "//pkg/meta/model",

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -163,6 +163,7 @@ func (m *ColAndIdxExistenceMap) ColNum() int {
 // Clone deeply copies the map.
 func (m *ColAndIdxExistenceMap) Clone() *ColAndIdxExistenceMap {
 	mm := NewColAndIndexExistenceMap(len(m.colAnalyzed), len(m.idxAnalyzed))
+	mm.checked = m.checked
 	mm.colAnalyzed = maps.Clone(m.colAnalyzed)
 	mm.idxAnalyzed = maps.Clone(m.idxAnalyzed)
 	return mm

--- a/pkg/statistics/table_test.go
+++ b/pkg/statistics/table_test.go
@@ -1,0 +1,30 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package statistics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneColAndIdxExistenceMap(t *testing.T) {
+	m := NewColAndIndexExistenceMapWithoutSize()
+	m.InsertCol(1, true)
+	m.InsertIndex(1, true)
+	m.SetChecked()
+
+	m2 := m.Clone()
+	require.Equal(t, m, m2)
+}

--- a/pkg/statistics/table_test.go
+++ b/pkg/statistics/table_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package statistics
 
 import (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60104

Problem Summary:

### What changed and how does it work?

We should also clone the checked field. Otherwise, the sync load will mistakenly attempt to load the stats of a non-existent index.

Note: This bug only occurs when there are no further writes to the table. Otherwise, the stats item is correctly updated as checked, preventing this issue from happening.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
