### PR TITLE
statistics: add warnings for missing table, column, and histogram information during async loading

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2702,7 +2702,7 @@ func (do *Domain) asyncLoadHistogram() {
 		case <-cleanupTicker.C:
 			err = statsHandle.LoadNeededHistograms(do.InfoSchema())
 			if err != nil {
-				logutil.ErrVerboseLogger().Warn("load histograms failed", zap.Error(err))
+				statslogutil.StatsErrVerboseSampleLogger().Warn("load histograms failed", zap.Error(err))
 			}
 		case <-do.exit:
 			return

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2702,7 +2702,7 @@ func (do *Domain) asyncLoadHistogram() {
 		case <-cleanupTicker.C:
 			err = statsHandle.LoadNeededHistograms(do.InfoSchema())
 			if err != nil {
-				statslogutil.StatsErrVerboseSampleLogger().Warn("load histograms failed", zap.Error(err))
+				statslogutil.StatsErrVerboseSampleLogger().Warn("Load histograms failed", zap.Error(err))
 			}
 		case <-do.exit:
 			return

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -874,7 +874,6 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
 		)
-		intest.Assert(false, "Table statistics not found but async load was triggered")
 		return nil
 	}
 	tbl = tbl.Copy()

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -810,7 +810,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	hgMeta, statsVer, err := HistMetaFromStorageWithHighPriority(sctx, &idx, nil)
 	if hgMeta == nil || err != nil {
 		if hgMeta == nil {
-			statslogutil.StatsSampleLogger().Warn(
+			statslogutil.StatsLogger().Warn(
 				"Histogram not found, possibly due to DDL event is not handled, please consider analyze the table",
 				zap.Int64("tableID", idx.TableID),
 				zap.Int64("indexID", idx.ID),
@@ -822,7 +822,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	tblInfo, ok := statsHandle.TableInfoByID(is, idx.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Table information not found, possibly due to table being dropped",
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -810,7 +810,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	hgMeta, statsVer, err := HistMetaFromStorageWithHighPriority(sctx, &idx, nil)
 	if hgMeta == nil || err != nil {
 		if hgMeta == nil {
-			statslogutil.StatsSampleLogger().Info(
+			statslogutil.StatsSampleLogger().Warn(
 				"Histogram not found, possibly due to DDL event is not handled, please consider analyze the table",
 				zap.Int64("tableID", idx.TableID),
 				zap.Int64("indexID", idx.ID),

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -656,7 +656,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	statsTbl, ok := statsHandle.Get(col.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Table statistics item not found, possibly due to table being dropped",
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
@@ -670,7 +670,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	tbl, ok := statsHandle.TableInfoByID(is, col.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Table information not found, possibly due to table being dropped",
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
@@ -681,7 +681,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	colInfo := tblInfo.GetColumnByID(col.ID)
 	if colInfo == nil {
 		// This could happen when the column is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Column information not found, possibly due to column being dropped",
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
@@ -756,7 +756,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	statsTbl, ok = statsHandle.Get(col.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Table statistics item not found, possibly due to table being dropped",
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
@@ -781,7 +781,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	})
 	asyncload.AsyncLoadHistogramNeededItems.Delete(col)
 	if col.IsSyncLoadFailed {
-		logutil.BgLogger().Warn("Column histogram loaded asynchronously after sync load failure",
+		statslogutil.StatsLogger().Warn("Column histogram loaded asynchronously after sync load failure",
 			zap.Int64("tableID", colHist.PhysicalID),
 			zap.Int64("columnID", colHist.Info.ID),
 			zap.String("columnName", colHist.Info.Name.O))
@@ -795,7 +795,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	tbl, ok := statsHandle.Get(idx.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Table statistics item not found, possibly due to table being dropped",
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
@@ -832,7 +832,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	idxInfo := tblInfo.Meta().FindIndexByID(idx.ID)
 	if idxInfo == nil {
 		// This could happen when the index is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Index information not found, possibly due to index being dropped",
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
@@ -869,7 +869,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	tbl, ok = statsHandle.Get(idx.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.
-		statslogutil.StatsLogger().Info(
+		statslogutil.StatsSampleLogger().Info(
 			"Table statistics item not found, possibly due to table being dropped",
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
@@ -887,7 +887,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	})
 	asyncload.AsyncLoadHistogramNeededItems.Delete(idx)
 	if idx.IsSyncLoadFailed {
-		logutil.BgLogger().Warn("Index histogram loaded asynchronously after sync load failure",
+		statslogutil.StatsLogger().Warn("Index histogram loaded asynchronously after sync load failure",
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idxHist.Info.ID),
 			zap.String("indexName", idxHist.Info.Name.O))

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -610,7 +610,7 @@ func LoadNeededHistograms(sctx sessionctx.Context, is infoschema.InfoSchema, sta
 			err = loadNeededIndexHistograms(sctx, is, statsHandle, item.TableItemID, loadFMSketch)
 		}
 		if err != nil {
-			statslogutil.StatsLogger().Error("load needed histogram failed",
+			statslogutil.StatsSampleLogger().Error("load needed histogram failed",
 				zap.Error(err),
 				zap.Int64("tableID", item.TableID),
 				zap.Int64("histID", item.ID),

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -833,7 +833,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	if idxInfo == nil {
 		// This could happen when the index is dropped after the async load is triggered.
 		statslogutil.StatsLogger().Info(
-			"Index information not found, possibly due to column being dropped",
+			"Index information not found, possibly due to index being dropped",
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
 		)

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -710,8 +710,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	hg, statsVer, err := HistMetaFromStorageWithHighPriority(sctx, &col, colInfo)
 	if hg == nil || err != nil {
 		if hg == nil {
-			// TODO: Use sample later.
-			statslogutil.StatsLogger().Warn(
+			statslogutil.StatsSampleLogger().Warn(
 				"Histogram not found, possibly due to DDL event is not handled, please consider analyze the table",
 				zap.Int64("tableID", col.TableID),
 				zap.Int64("columnID", col.ID),
@@ -811,7 +810,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 	hgMeta, statsVer, err := HistMetaFromStorageWithHighPriority(sctx, &idx, nil)
 	if hgMeta == nil || err != nil {
 		if hgMeta == nil {
-			statslogutil.StatsLogger().Info(
+			statslogutil.StatsSampleLogger().Info(
 				"Histogram not found, possibly due to DDL event is not handled, please consider analyze the table",
 				zap.Int64("tableID", idx.TableID),
 				zap.Int64("indexID", idx.ID),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/59939

Problem Summary:

### What changed and how does it work?

- Updated logging calls (using StatsSampleLogger and StatsErrVerboseSampleLogger) across histogram loading functions to provide clearer diagnostic messages.
- Added and clarified inline comments to explain when items (table, column, index) are missing due to being dropped after async load is triggered.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/60213#issuecomment-2750403496)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
