### PR TITLE
workloadrepo: Fix a data race in TestMultipleWorker test.

### DIFF
--- a/pkg/util/workloadrepo/worker.go
+++ b/pkg/util/workloadrepo/worker.go
@@ -308,7 +308,6 @@ func (w *worker) startRepository(ctx context.Context) func() {
 	// TODO: add another txn type
 	ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnOthers)
 	return func() {
-		w.owner = w.newOwner(ownerKey, promptKey)
 		if err := w.owner.CampaignOwner(); err != nil {
 			logutil.BgLogger().Error("repository could not campaign for owner", zap.NamedError("err", err))
 		}
@@ -370,6 +369,7 @@ func (w *worker) start() error {
 		return errUnsupportedEtcdRequired.GenWithStackByArgs()
 	}
 
+	w.owner = w.newOwner(ownerKey, promptKey)
 	_ = stmtsummary.StmtSummaryByDigestMap.SetHistoryEnabled(false)
 	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60200

Problem Summary:

The TestMultipleWorker test accessed the 'owner' member of 'workloadrepo.worker' without using any form of mutual exclusion control.

### What changed and how does it work?
This patch makes the following changes:
* The 'worker.owner' member will be created in 'workerloadrepo.start()' instead of in 'workloadrepo.startRepository().'   This change is solely to make testing easier.
* This patch removes the "worker.owner == nil" checks used to validate the owner object has been created.  The test will now validate workers have started by checking for inserted rows, and then check the status with the owner.IsOwner() function afterwards, which is thread safe.
 * It fixes bugs in the code using 'getMultipleWorkerCount().'

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
