### PR TITLE
optimizer: postpone AdviseWarmup after processing binding

### DIFF
--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -401,7 +401,7 @@ func allowInReadOnlyMode(sctx planctx.PlanContext, node ast.Node) (bool, error) 
 	switch node.(type) {
 	// allow change variables (otherwise can't unset read-only mode)
 	case *ast.SetStmt,
-	// allow analyze table
+		// allow analyze table
 		*ast.AnalyzeTableStmt,
 		*ast.UseStmt,
 		*ast.ShowStmt,

--- a/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
+++ b/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
@@ -218,15 +218,36 @@ func TestPipelinedDMLPositive(t *testing.T) {
 	// enable by hint
 	// Hint works for DELETE and UPDATE, but not for INSERT if the hint is in its select clause.
 	tk.MustExec("set @@tidb_dml_type = standard")
-	err = panicToErr(
-		func() error {
-			_, err := tk.Exec("delete /*+ SET_VAR(tidb_dml_type=bulk) */ from t")
-			// "insert into t select /*+ SET_VAR(tidb_dml_type=bulk) */ * from t" won't work
-			return err
-		},
-	)
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "pipelined memdb is enabled"), err.Error())
+	dmls := [][2]string{
+		{"update t set b = b + 1", "update /*+ SET_VAR(tidb_dml_type=bulk) */ t set b = b + 1"},
+		{"insert into t select * from t", "insert /*+ SET_VAR(tidb_dml_type=bulk) */ into t select * from t"},
+		{"delete from t", "delete /*+ SET_VAR(tidb_dml_type=bulk) */ from t"},
+	}
+	for _, dmlPair := range dmls {
+		err := panicToErr(
+			func() error {
+				_, err := tk.Exec(dmlPair[1])
+				return err
+			},
+		)
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "pipelined memdb is enabled"), err.Error())
+	}
+
+	// test global binding
+	for _, dmlPair := range dmls {
+		tk.MustExec("create global binding for " + dmlPair[0] + " using " + dmlPair[1])
+	}
+	for _, dmlPair := range dmls {
+		err := panicToErr(
+			func() error {
+				_, err := tk.Exec(dmlPair[0])
+				return err
+			},
+		)
+		require.Error(t, err, dmlPair[0])
+		require.True(t, strings.Contains(err.Error(), "pipelined memdb is enabled"), err.Error())
+	}
 }
 
 func TestPipelinedDMLNegative(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60231 close #60229

Problem Summary:

### What changed and how does it work?

https://github.com/pingcap/tidb/pull/34702 says AdviceWarmUp in only an optimization, won't affect the correctness. 

Because 

1. AdviceWarmUp will use pipeline DML flag when creating TS future
2. binding is processed after AdviceWarmUp
3. binding may change the pipeline DML flag

in order to let pipeline DML flag in binding really take effect, I postpone AdviceWarmUp.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
