### PR TITLE
util: unite the parser's Pool

### DIFF
--- a/pkg/planner/core/plan_cache_param.go
+++ b/pkg/planner/core/plan_cache_param.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
+	parserutil "github.com/pingcap/tidb/pkg/util/parser"
 )
 
 var (
@@ -186,12 +187,10 @@ func Params2Expressions(params []types.Datum) []expression.Expression {
 	return exprs
 }
 
-var parserPool = &sync.Pool{New: func() any { return parser.New() }}
-
 // ParseParameterizedSQL parse this parameterized SQL with the specified sctx.
 func ParseParameterizedSQL(sctx sessionctx.Context, paramSQL string) (ast.StmtNode, error) {
-	p := parserPool.Get().(*parser.Parser)
-	defer parserPool.Put(p)
+	p := parserutil.Pool.Get().(*parser.Parser)
+	defer parserutil.Pool.Put(p)
 	p.SetSQLMode(sctx.GetSessionVars().SQLMode)
 	p.SetParserConfig(sctx.GetSessionVars().BuildParserConfig())
 	tmp, _, err := p.ParseSQL(paramSQL, sctx.GetSessionVars().GetParseParams()...)

--- a/pkg/util/generatedexpr/BUILD.bazel
+++ b/pkg/util/generatedexpr/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/parser/ast",
         "//pkg/parser/charset",
         "//pkg/util",
+        "//pkg/util/parser",
         "@com_github_pingcap_errors//:errors",
     ],
 )

--- a/pkg/util/generatedexpr/generated_expr.go
+++ b/pkg/util/generatedexpr/generated_expr.go
@@ -16,7 +16,6 @@ package generatedexpr
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -24,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/util"
+	parserutil "github.com/pingcap/tidb/pkg/util/parser"
 )
 
 // nameResolver is the visitor to resolve table name and column name.
@@ -54,8 +54,6 @@ func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 	return inNode, true
 }
 
-var parserPool = &sync.Pool{New: func() any { return parser.New() }}
-
 // ParseExpression parses an ExprNode from a string.
 // When TiDB loads infoschema from TiKV, `GeneratedExprString`
 // of `ColumnInfo` is a string field, so we need to parse
@@ -63,8 +61,8 @@ var parserPool = &sync.Pool{New: func() any { return parser.New() }}
 func ParseExpression(expr string) (node ast.ExprNode, err error) {
 	expr = fmt.Sprintf("select %s", expr)
 	charset, collation := charset.GetDefaultCharsetAndCollate()
-	parse := parserPool.Get().(*parser.Parser)
-	defer parserPool.Put(parse)
+	parse := parserutil.Pool.Get().(*parser.Parser)
+	defer parserutil.Pool.Put(parse)
 	stmts, _, err := parse.ParseSQL(expr,
 		parser.CharsetConnection(charset),
 		parser.CollationConnection(collation))

--- a/pkg/util/parser/BUILD.bazel
+++ b/pkg/util/parser/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/util/parser",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/format",
         "//pkg/util/logutil",

--- a/pkg/util/parser/parser.go
+++ b/pkg/util/parser/parser.go
@@ -16,14 +16,19 @@ package parser
 
 import (
 	"strconv"
+	"sync"
 	"unicode"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/parser"
 )
 
 var (
 	// ErrPatternNotMatch represents an error that patterns doesn't match.
 	ErrPatternNotMatch = errors.New("Pattern not match")
+
+	// Pool is a pool of parser.Parser
+	Pool = &sync.Pool{New: func() any { return parser.New() }}
 )
 
 // Match matches the `pat` at least `times`, and returns the match, the rest and the error


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

merge parser's Pool into a global pool

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
