### PR TITLE
executor: adjust the SQL digest of stmtsummary to match that of bindings

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -232,6 +232,7 @@ go_library(
         "//pkg/util/logutil/consistency",
         "//pkg/util/mathutil",
         "//pkg/util/memory",
+        "//pkg/util/parser",
         "//pkg/util/password-validation",
         "//pkg/util/plancodec",
         "//pkg/util/printer",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #60148 

Problem Summary:

SPM will use the execution and runtime stats collected by the statement summary when automatically creating bindings, and thus needs to be able to identify a SQL query consistently across statements summary and bindings. However, currently the normalization used for generating SQL digests differs slightly between the two: for bindings, SQL queries are first normalized to always include a schema name.

For example, these queries will have the same SQL digest for bindings, but will have two different SQL digests in the statement summary:

```sql
SELECT * FROM test.t;
SELECT * FROM t;
```

### What changed and how does it work?

* Modify the statement summary's SQL digest logic to always include a schema name.
* Use `parser.NormalizeDigestForBinding()` rather than `parser.NormalizeDigest()` to ensure that the digests in the statement summary match those used for bindings.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
