### PR TITLE
statistics: remove invalid histogram items in loadNeededColumnHistograms and loadNeededIndexHistograms

### DIFF
--- a/pkg/statistics/asyncload/BUILD.bazel
+++ b/pkg/statistics/asyncload/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     timeout = "short",
     srcs = ["async_load_test.go"],
     flaky = True,
+    shard_count = 4,
     deps = [
         ":asyncload",
         "//pkg/parser/ast",

--- a/pkg/statistics/asyncload/BUILD.bazel
+++ b/pkg/statistics/asyncload/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "asyncload",
@@ -6,4 +6,18 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/statistics/asyncload",
     visibility = ["//visibility:public"],
     deps = ["//pkg/meta/model"],
+)
+
+go_test(
+    name = "asyncload_test",
+    timeout = "short",
+    srcs = ["async_load_test.go"],
+    flaky = True,
+    deps = [
+        ":asyncload",
+        "//pkg/parser/ast",
+        "//pkg/testkit",
+        "//tests/realtikvtest",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asyncload_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/statistics/asyncload"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadStatisticsAfterTableDrop(t *testing.T) {
+	// Use real tikv to enable the sync and async load.
+	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
+	testKit := testkit.NewTestKit(t, store)
+	// Turn off the sync load.
+	testKit.MustExec("SET @@tidb_stats_load_sync_wait = 0;")
+	testKit.MustExec("use test")
+	testKit.MustExec("DROP TABLE IF EXISTS t1")
+	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT, INDEX idx_b (b));")
+	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
+	handle := dom.StatsHandle()
+	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
+	// This will add the table to the AsyncLoadHistogramNeededItems.
+	testKit.MustExec("SELECT * FROM t1 WHERE b = 2;")
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t1"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	tableID := tableInfo.ID
+	require.Eventually(t, func() bool {
+		// Check the table is in the items.
+		items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+		found := false
+		for _, item := range items {
+			if item.TableItemID.TableID == tableID {
+				found = true
+				break
+			}
+		}
+		return found
+	}, 5*time.Second, 2*time.Second,
+		"table %d should be in the items", tableID,
+	)
+
+	// Drop the table.
+	testKit.MustExec("DROP TABLE t1;")
+	err = handle.LoadNeededHistograms(dom.InfoSchema())
+	require.NoError(t, err)
+
+	// Check the table is removed from the items.
+	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+	for _, item := range items {
+		require.NotEqual(t, tableID, item.TableItemID.TableID)
+	}
+}

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -37,7 +37,7 @@ func TestLoadColumnStatisticsAfterTableDrop(t *testing.T) {
 	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT);")
 	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
 	handle := dom.StatsHandle()
-	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
 	// This will add the table to the AsyncLoadHistogramNeededItems.
@@ -85,7 +85,7 @@ func TestLoadStatisticsAfterColumnDrop(t *testing.T) {
 	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT);")
 	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
 	handle := dom.StatsHandle()
-	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
 	// This will add the table to the AsyncLoadHistogramNeededItems.
@@ -133,7 +133,7 @@ func TestLoadIndexStatisticsAfterTableDrop(t *testing.T) {
 	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT, INDEX idx_b (b));")
 	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
 	handle := dom.StatsHandle()
-	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
 	// This will add the table to the AsyncLoadHistogramNeededItems.
@@ -181,7 +181,7 @@ func TestLoadStatisticsAfterIndexDrop(t *testing.T) {
 	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT, INDEX idx_b (b));")
 	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
 	handle := dom.StatsHandle()
-	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
 	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
 	// This will add the table to the AsyncLoadHistogramNeededItems.

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -73,3 +73,51 @@ func TestLoadStatisticsAfterTableDrop(t *testing.T) {
 		require.NotEqual(t, tableID, item.TableItemID.TableID)
 	}
 }
+
+func TestLoadStatisticsAfterIndexDrop(t *testing.T) {
+	// Use real tikv to enable the sync and async load.
+	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
+	testKit := testkit.NewTestKit(t, store)
+	// Turn off the sync load.
+	testKit.MustExec("SET @@tidb_stats_load_sync_wait = 0;")
+	testKit.MustExec("use test")
+	testKit.MustExec("DROP TABLE IF EXISTS t1")
+	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT, INDEX idx_b (b));")
+	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
+	handle := dom.StatsHandle()
+	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
+	// This will add the table to the AsyncLoadHistogramNeededItems.
+	testKit.MustExec("SELECT * FROM t1 WHERE b = 2;")
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t1"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	tableID := tableInfo.ID
+	require.Eventually(t, func() bool {
+		// Check the table is in the items.
+		items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+		found := false
+		for _, item := range items {
+			if item.TableItemID.TableID == tableID {
+				found = true
+				break
+			}
+		}
+		return found
+	}, 5*time.Second, 2*time.Second,
+		"table %d should be in the items", tableID,
+	)
+
+	// Drop the index.
+	testKit.MustExec("ALTER TABLE t1 DROP INDEX idx_b;")
+	err = handle.LoadNeededHistograms(dom.InfoSchema())
+	require.NoError(t, err)
+
+	// Check the table is removed from the items.
+	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+	for _, item := range items {
+		require.NotEqual(t, tableID, item.TableItemID.TableID)
+	}
+}

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -26,7 +26,103 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadStatisticsAfterTableDrop(t *testing.T) {
+func TestLoadColumnStatisticsAfterTableDrop(t *testing.T) {
+	// Use real tikv to enable the sync and async load.
+	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
+	testKit := testkit.NewTestKit(t, store)
+	// Turn off the sync load.
+	testKit.MustExec("SET @@tidb_stats_load_sync_wait = 0;")
+	testKit.MustExec("use test")
+	testKit.MustExec("DROP TABLE IF EXISTS t1")
+	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT);")
+	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
+	handle := dom.StatsHandle()
+	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
+	// This will add the table to the AsyncLoadHistogramNeededItems.
+	testKit.MustExec("SELECT * FROM t1 WHERE b = 2;")
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t1"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	tableID := tableInfo.ID
+	require.Eventually(t, func() bool {
+		// Check the table is in the items.
+		items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+		found := false
+		for _, item := range items {
+			if item.TableItemID.TableID == tableID {
+				found = true
+				break
+			}
+		}
+		return found
+	}, 5*time.Second, 2*time.Second,
+		"table %d should be in the items", tableID,
+	)
+
+	// Drop the table.
+	testKit.MustExec("DROP TABLE t1;")
+	err = handle.LoadNeededHistograms(dom.InfoSchema())
+	require.NoError(t, err)
+
+	// Check the table is removed from the items.
+	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+	for _, item := range items {
+		require.NotEqual(t, tableID, item.TableItemID.TableID)
+	}
+}
+
+func TestLoadStatisticsAfterColumnDrop(t *testing.T) {
+	// Use real tikv to enable the sync and async load.
+	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
+	testKit := testkit.NewTestKit(t, store)
+	// Turn off the sync load.
+	testKit.MustExec("SET @@tidb_stats_load_sync_wait = 0;")
+	testKit.MustExec("use test")
+	testKit.MustExec("DROP TABLE IF EXISTS t1")
+	testKit.MustExec("CREATE TABLE t1 (a INT, b INT, c INT);")
+	testKit.MustExec("INSERT INTO t1 VALUES (1,3,0), (2,2,0), (3,2,0);")
+	handle := dom.StatsHandle()
+	require.NoError(t, handle.DumpColStatsUsageToKV())
+	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS;")
+	// This will add the table to the AsyncLoadHistogramNeededItems.
+	testKit.MustExec("SELECT * FROM t1 WHERE b = 2;")
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t1"))
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	tableID := tableInfo.ID
+	require.Eventually(t, func() bool {
+		// Check the table is in the items.
+		items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+		found := false
+		for _, item := range items {
+			if item.TableItemID.TableID == tableID {
+				found = true
+				break
+			}
+		}
+		return found
+	}, 5*time.Second, 2*time.Second,
+		"table %d should be in the items", tableID,
+	)
+
+	// Drop the column.
+	testKit.MustExec("ALTER TABLE t1 DROP COLUMN b;")
+	err = handle.LoadNeededHistograms(dom.InfoSchema())
+	require.NoError(t, err)
+
+	// Check the table is removed from the items.
+	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
+	for _, item := range items {
+		require.NotEqual(t, tableID, item.TableItemID.TableID)
+	}
+}
+
+func TestLoadIndexStatisticsAfterTableDrop(t *testing.T) {
 	// Use real tikv to enable the sync and async load.
 	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
 	testKit := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -661,6 +661,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
 		)
+		asyncload.AsyncLoadHistogramNeededItems.Delete(col)
 		return nil
 	}
 	// When lite-init-stats is disabled, we cannot store the column info in the ColAndIdxExistenceMap.
@@ -675,6 +676,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
 		)
+		asyncload.AsyncLoadHistogramNeededItems.Delete(col)
 		return nil
 	}
 	tblInfo := tbl.Meta()
@@ -800,6 +802,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
 		)
+		asyncload.AsyncLoadHistogramNeededItems.Delete(idx)
 		return nil
 	}
 	_, loadNeeded := tbl.IndexIsLoadNeeded(idx.ID)
@@ -827,6 +830,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
 		)
+		asyncload.AsyncLoadHistogramNeededItems.Delete(idx)
 		return nil
 	}
 	idxInfo := tblInfo.Meta().FindIndexByID(idx.ID)
@@ -838,7 +842,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 			zap.Int64("indexID", idx.ID),
 		)
 		asyncload.AsyncLoadHistogramNeededItems.Delete(idx)
-		return errors.NotFoundf("index %d in table %d", idx.ID, idx.TableID)
+		return nil
 	}
 	hg, err := HistogramFromStorageWithPriority(sctx, idx.TableID, idx.ID, types.NewFieldType(mysql.TypeBlob), hgMeta.NDV, 1, hgMeta.LastUpdateVersion, hgMeta.NullCount, hgMeta.TotColSize, hgMeta.Correlation, kv.PriorityHigh)
 	if err != nil {

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -763,6 +763,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 			zap.Int64("tableID", col.TableID),
 			zap.Int64("columnID", col.ID),
 		)
+		asyncload.AsyncLoadHistogramNeededItems.Delete(col)
 		return nil
 	}
 	statsTbl = statsTbl.Copy()
@@ -878,6 +879,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 			zap.Int64("tableID", idx.TableID),
 			zap.Int64("indexID", idx.ID),
 		)
+		asyncload.AsyncLoadHistogramNeededItems.Delete(idx)
 		return nil
 	}
 	tbl = tbl.Copy()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->


### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60247

Problem Summary:

### What changed and how does it work?

If the stats item or table information cannot be found, we should not attempt to load the statistics again, as this could lead to an infinite loop. Therefore, in this PR, I have removed the invalid items from loadNeededColumnHistograms and loadNeededIndexHistograms.

Additionally, if the index has been dropped, we shouldn't return an error; we can simply delete it from the load list.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
