### PR TITLE
s3: fix compatibility issue when using AssumeWebIdentity with custom S3 endpoint

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -347,9 +347,10 @@ func NewS3Storage(ctx context.Context, backend *backuppb.S3, opts *ExternalStora
 		request.WithRetryer(awsConfig, defaultS3Retryer())
 	}
 
-	// for aws provider we cannot set global endpoint
-	// if set, it will make AssumeRoleWithWebIdentity failed.
-	// see https://github.com/aws/aws-sdk-go/issues/3972
+	// ⚠️ Do NOT set a global endpoint in the AWS config.
+	// Setting a global endpoint will break AssumeRoleWithWebIdentity,
+	// as it overrides the STS endpoint and causes authentication to fail.
+	// See: https://github.com/aws/aws-sdk-go/issues/3972
 	if len(qs.Endpoint) != 0 && qs.Provider != "aws" {
 		awsConfig.WithEndpoint(qs.Endpoint)
 	}


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/61547

Problem Summary:
We’re encountering the same issue when using a regular S3 endpoint together with assumeWebIdentity for authorization.
As mentioned in [aws/aws-sdk-go#3972](https://github.com/aws/aws-sdk-go/issues/3972), if the endpoint is not explicitly set when calling s3.New(...), it can unintentionally override the endpoint globally — including for STS — which breaks the WebIdentity auth flow.

### What changed and how does it work?
A workaround is to explicitly set the S3 endpoint only within the s3.New() call, rather than modifying the shared config.
Alternatively, migrating to AWS SDK for Go v2 would avoid this issue entirely, as endpoint resolution is better isolated in v2.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
prepare a eks environment and use eks pod identity to grant s3 permission (a sort of webIdentity).

without this fix
backup will report auth error.

```
[WARN] [s3.go:1293] ["failed to request s3, retrying"] [error="RequestError: send request failed\ncaused by: dial tcp: lookup s3-fips.us-east-1.amazonaws.com on 172.20.0.10:53: no such host"] [backoff=1.529244054s]
```

with this fix and set force-path-style to false.

```
sh-5.2# ./br-endpoint backup full -s "s3://xxx/with_endpoint?**force-path-style=false**" --s3.endpoint="https://s3-fips.us-east-1.amazonaws.com" --s3.provider="aws"

["Full Backup success summary"] [total-ranges=13] [ranges-succeed=13] [ranges-failed=0] [backup-checksum=27.171194ms] [default-CF-files=1] [backup-total-ranges=131] [backup-total-regions=131] [write-CF-files=12] [total-take=4.245545839s] [BackupTS=458540547164078081] [total-kv=1433] [total-kv-size=438.4kB] [average-speed=103.3kB/s] [backup-data-size(after-compressed)=97.96kB] [Size=97960]
sh-5.2#
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue where S3 operations would fail when using a Web Identity (IRSA) role in combination with a custom S3 endpoint (e.g., FIPS or private S3-compatible storage).  
```
