### PR TITLE
importinto: check retryable schedule error

### DIFF
--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -116,6 +116,7 @@ go_test(
         "//pkg/parser/ast",
         "//pkg/planner/core",
         "//pkg/session",
+        "//pkg/store/driver/error",
         "//pkg/testkit",
         "//pkg/testkit/testfailpoint",
         "//pkg/util/mock",

--- a/pkg/disttask/importinto/scheduler.go
+++ b/pkg/disttask/importinto/scheduler.go
@@ -402,9 +402,8 @@ func (*importScheduler) GetEligibleInstances(_ context.Context, task *proto.Task
 }
 
 // IsRetryableErr implements scheduler.Extension interface.
-func (*importScheduler) IsRetryableErr(error) bool {
-	// TODO: check whether the error is retryable.
-	return false
+func (*importScheduler) IsRetryableErr(err error) bool {
+	return common.IsRetryableError(err)
 }
 
 // GetNextStep implements scheduler.Extension interface.

--- a/pkg/disttask/importinto/scheduler_test.go
+++ b/pkg/disttask/importinto/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/scheduler"
 	"github.com/pingcap/tidb/pkg/executor/importer"
+	drivererr "github.com/pingcap/tidb/pkg/store/driver/error"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -133,6 +134,11 @@ func (s *importIntoSuite) TestGetNextStep() {
 func (s *importIntoSuite) TestGetStepOfEncode() {
 	s.Equal(proto.ImportStepImport, getStepOfEncode(false))
 	s.Equal(proto.ImportStepEncodeAndSort, getStepOfEncode(true))
+}
+
+func (s *importIntoSuite) TestIsRetryable() {
+	ext := &importScheduler{}
+	require.True(s.T(), ext.IsRetryableErr(drivererr.ErrRegionUnavailable))
 }
 
 func TestIsImporting2TiKV(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #59754

Problem Summary:

### What changed and how does it work?
previously, we don't retry for scheduler error, but we might meet them,  like the one in the issue

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
