### PR TITLE
br: set default restore checksum to false

### DIFF
--- a/br/cmd/br/backup.go
+++ b/br/cmd/br/backup.go
@@ -26,7 +26,6 @@ func runBackupCommand(command *cobra.Command, cmdName string) error {
 		command.SilenceUsage = false
 		return errors.Trace(err)
 	}
-	overrideDefaultBackupConfigIfNeeded(&cfg, command)
 
 	if err := metricsutil.RegisterMetricsForBR(cfg.PD, cfg.KeyspaceName); err != nil {
 		return errors.Trace(err)
@@ -216,11 +215,4 @@ func newTxnBackupCommand() *cobra.Command {
 
 	task.DefineTxnBackupFlags(command)
 	return command
-}
-
-func overrideDefaultBackupConfigIfNeeded(config *task.BackupConfig, cmd *cobra.Command) {
-	// override only if flag not set by user
-	if !cmd.Flags().Changed(task.FlagChecksum) {
-		config.Checksum = false
-	}
 }

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -64,7 +64,7 @@ const (
 	flagRateLimit           = "ratelimit"
 	flagRateLimitUnit       = "ratelimit-unit"
 	flagConcurrency         = "concurrency"
-	FlagChecksum            = "checksum"
+	flagChecksum            = "checksum"
 	flagFilter              = "filter"
 	flagCaseSensitive       = "case-sensitive"
 	flagRemoveTiFlash       = "remove-tiflash"
@@ -300,7 +300,8 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 	flags.Uint(flagChecksumConcurrency, vardef.DefChecksumTableConcurrency, "The concurrency of checksumming in one table")
 
 	flags.Uint64(flagRateLimit, unlimited, "The rate limit of the task, MB/s per node")
-	flags.Bool(FlagChecksum, true, "Run checksum at end of task")
+	// default to false as we think it's unnecessary to run in production as it's resource intensive
+	flags.Bool(flagChecksum, false, "Run checksum at end of task")
 	flags.Bool(flagRemoveTiFlash, true,
 		"Remove TiFlash replicas before backup or restore, for unsupported versions of TiFlash")
 
@@ -362,7 +363,7 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 // HiddenFlagsForStream temporary hidden flags that stream cmd not support.
 func HiddenFlagsForStream(flags *pflag.FlagSet) {
-	_ = flags.MarkHidden(FlagChecksum)
+	_ = flags.MarkHidden(flagChecksum)
 	_ = flags.MarkHidden(flagLoadStats)
 	_ = flags.MarkHidden(flagChecksumConcurrency)
 	_ = flags.MarkHidden(flagRateLimit)
@@ -616,7 +617,7 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 		return errors.Trace(err)
 	}
 
-	if cfg.Checksum, err = flags.GetBool(FlagChecksum); err != nil {
+	if cfg.Checksum, err = flags.GetBool(flagChecksum); err != nil {
 		return errors.Trace(err)
 	}
 	if cfg.ChecksumConcurrency, err = flags.GetUint(flagChecksumConcurrency); err != nil {

--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -269,7 +269,7 @@ func expectedDefaultConfig() Config {
 		BackendOptions:            storage.BackendOptions{S3: storage.S3BackendOptions{ForcePathStyle: true}},
 		PD:                        []string{"127.0.0.1:2379"},
 		ChecksumConcurrency:       4,
-		Checksum:                  true,
+		Checksum:                  false,
 		SendCreds:                 true,
 		CheckRequirements:         true,
 		FilterStr:                 []string(nil),
@@ -287,7 +287,6 @@ func expectedDefaultConfig() Config {
 
 func expectedDefaultBackupConfig() BackupConfig {
 	defaultConfig := expectedDefaultConfig()
-	defaultConfig.Checksum = false
 	return BackupConfig{
 		Config: defaultConfig,
 		GCTTL:  utils.DefaultBRGCSafePointTTL,

--- a/pkg/executor/brie.go
+++ b/pkg/executor/brie.go
@@ -283,14 +283,8 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 	}
 	pds := strings.Split(tidbCfg.Path, ",")
 
-	// build common config and override for specific task if needed
+	// build common config
 	cfg := task.DefaultConfig()
-	switch s.Kind {
-	case ast.BRIEKindBackup:
-		cfg.OverrideDefaultForBackup()
-	default:
-	}
-
 	cfg.PD = pds
 	cfg.TLS = tlsCfg
 

--- a/pkg/executor/brie_test.go
+++ b/pkg/executor/brie_test.go
@@ -225,7 +225,7 @@ func TestBRIEBuilderOptions(t *testing.T) {
 	e, ok = exec.(*BRIEExec)
 	require.True(t, ok)
 	require.Equal(t, uint(4), e.restoreCfg.ChecksumConcurrency)
-	require.True(t, e.restoreCfg.Checksum)
+	require.False(t, e.restoreCfg.Checksum)
 	require.True(t, e.restoreCfg.WaitTiflashReady)
 	require.True(t, e.restoreCfg.WithSysTable)
 	require.True(t, e.restoreCfg.LoadStats)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60329

Problem Summary:

### What changed and how does it work?
Turn off both backup and restore checksum by default 
Default turned on by int test
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
We previously turned off backup checksum by default and this PR turns off restore checksum by default as well as we think it's resource intensive in production. User can still turn it on by enabling the flag explicitly. 
```
