### PR TITLE
planner: add tableScan and indexScan build portal by feeling indexJoinProp.

### DIFF
--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -861,7 +861,7 @@ childLoop:
 	return wrapper
 }
 
-// buildDataSource2TableScanByIndexJoinProp builds an IndexScan as the inner child for an
+// buildDataSource2IndexScanByIndexJoinProp builds an IndexScan as the inner child for an
 // IndexJoin based on IndexJoinProp included in prop if possible.
 //
 // buildDataSource2TableScanByIndexJoinProp differs with buildIndexJoinInner2TableScan in that

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -864,7 +864,7 @@ childLoop:
 // buildDataSource2IndexScanByIndexJoinProp builds an IndexScan as the inner child for an
 // IndexJoin based on IndexJoinProp included in prop if possible.
 //
-// buildDataSource2TableScanByIndexJoinProp differs with buildIndexJoinInner2TableScan in that
+buildDataSource2IndexScanByIndexJoinProp
 // the first one is try to build a single table scan as the inner child of an index join then return
 // this inner task(raw table scan) bottom-up, which will be attached with other inner parents of an
 // index join in attach2Task when bottom-up of enumerating the physical plans;

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -864,14 +864,14 @@ childLoop:
 // buildDataSource2IndexScanByIndexJoinProp builds an IndexScan as the inner child for an
 // IndexJoin based on IndexJoinProp included in prop if possible.
 //
-buildDataSource2IndexScanByIndexJoinProp
+// buildDataSource2IndexScanByIndexJoinProp differs with buildIndexJoinInner2IndexScan in that
 // the first one is try to build a single table scan as the inner child of an index join then return
 // this inner task(raw table scan) bottom-up, which will be attached with other inner parents of an
 // index join in attach2Task when bottom-up of enumerating the physical plans;
 //
 // while the second is try to build a table scan as the inner child of an index join, then build
 // entire inner subtree of a index join out as innerTask instantly according those validated and
-// zipped inner patterns with calling constructInnerTableScanTask. That's not done yet, it also
+// zipped inner patterns with calling constructInnerIndexScanTask. That's not done yet, it also
 // tries to enumerate kinds of index join operators based on the finished innerTask and un-decided
 // outer child which will be physical-ed in the future.
 func buildDataSource2IndexScanByIndexJoinProp(

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -938,7 +938,7 @@ func buildDataSource2TableScanByIndexJoinProp(
 	if tblPath == nil {
 		return base.InvalidTask
 	}
-	keyOff2IdxOff := make([]int, len(prop.IndexJoinProp.InnerJoinKeys))
+	var keyOff2IdxOff []int
 	var ranges ranger.MutableRanges = ranger.Ranges{}
 	var innerTask base.Task
 	var indexJoinResult *indexJoinPathResult

--- a/pkg/planner/core/index_join_path.go
+++ b/pkg/planner/core/index_join_path.go
@@ -630,6 +630,53 @@ func getIndexJoinIntPKPathInfo(ds *logicalop.DataSource, innerJoinKeys, outerJoi
 	return keyOff2IdxOff, newOuterJoinKeys, ranges, chosenPath, true
 }
 
+// getBestIndexJoinPathResultByProp tries to iterate all possible access paths of the inner child and builds
+// index join path for each access path based on push-down indexIndexProp. It returns the best index join path result and the mapping.
+func getBestIndexJoinPathResultByProp(
+	innerDS *logicalop.DataSource,
+	indexJoinProp *property.IndexJoinRuntimeProp,
+	checkPathValid func(path *util.AccessPath) bool) (*indexJoinPathResult, []int) {
+	indexJoinInfo := &indexJoinPathInfo{
+		joinOtherConditions:   indexJoinProp.OtherConditions, // other conditions is for complete last col non-eq range
+		outerJoinKeys:         indexJoinProp.OuterJoinKeys,
+		innerJoinKeys:         indexJoinProp.InnerJoinKeys,
+		innerPushedConditions: innerDS.PushedDownConds,
+		innerSchema:           innerDS.Schema(),
+		innerStats:            innerDS.StatsInfo(),
+	}
+	var bestResult *indexJoinPathResult
+	for _, path := range innerDS.PossibleAccessPaths {
+		if checkPathValid(path) {
+			// here we still wrap indexJoinPathInfo to call index indexJoinPathBuild to get the chosen path result.
+			result, emptyRange, err := indexJoinPathBuild(innerDS.SCtx(), path, indexJoinInfo, false)
+			if emptyRange {
+				return nil, nil
+			}
+			if err != nil {
+				logutil.BgLogger().Warn("build index join failed", zap.Error(err))
+				continue
+			}
+			if indexJoinPathCompare(bestResult, result) {
+				bestResult = result
+			}
+		}
+	}
+	if bestResult == nil || bestResult.chosenPath == nil {
+		return nil, nil
+	}
+	keyOff2IdxOff := make([]int, len(indexJoinProp.InnerJoinKeys))
+	for i := range keyOff2IdxOff {
+		keyOff2IdxOff[i] = -1
+	}
+	// reverse idxOff2KeyOff as keyOff2IdxOff, from the perspective of inner join key, we could easily get the offset of index col.
+	for idxOff, keyOff := range bestResult.idxOff2KeyOff {
+		if keyOff != -1 {
+			keyOff2IdxOff[keyOff] = idxOff
+		}
+	}
+	return bestResult, keyOff2IdxOff
+}
+
 // getBestIndexJoinPathResult tries to iterate all possible access paths of the inner child and builds
 // index join path for each access path. It returns the best index join path result and the mapping.
 func getBestIndexJoinPathResult(
@@ -668,6 +715,7 @@ func getBestIndexJoinPathResult(
 	for i := range keyOff2IdxOff {
 		keyOff2IdxOff[i] = -1
 	}
+	// reverse idxOff2KeyOff as keyOff2IdxOff, from the perspective of inner join key, we could easily get the offset of index col.
 	for idxOff, keyOff := range bestResult.idxOff2KeyOff {
 		if keyOff != -1 {
 			keyOff2IdxOff[keyOff] = idxOff


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/60106

Problem Summary:

### What changed and how does it work?
this is a split pull request from the complete one: https://github.com/pingcap/tidb/pull/60204

in this pull request, we add 3 functions:
* `getBestIndexJoinPathResultByProp` which is changed from `getBestIndexJoinPathResult`, which we don't give them the operator join and related info, because all elements should be passed down with indexJoinProp in our refactor, so I change the parameter to receive indexJoinProp, besides that, the basic detect whether the index path can be valid by this kind of indexJoinProp is still the same by call indexJoinPathBuild with a wrapped structure as indexJoinPathInfo as before.
* `buildDataSource2TableScanByIndexJoinProp` which is changed from `buildIndexJoinInner2TableScan`, the main change between this two is as below:
```
// buildDataSource2TableScanByIndexJoinProp differs with buildIndexJoinInner2TableScan in that
// the first one is try to build a single table scan as the inner child of an index join then return
// this inner task(raw table scan) bottom-up, which will be attached with other inner parents of an
// index join in attach2Task when bottom-up of enumerating the physical plans;
//
// while the second is try to build a table scan as the inner child of an index join, then build
// entire inner subtree of a index join out as innerTask instantly according those validated and
// zipped inner patterns with calling constructInnerTableScanTask. That's not done yet, it also
// tries to enumerate kinds of index join operators based on the finished innerTask and un-decided
// outer child which will be physical-ed in the future.
```
* `buildDataSource2TableScanByIndexJoinProp` which is changed from `buildIndexJoinInner2IndexScan`, the main change is quite same as buildDataSource2TableScanByIndexJoinProp, we just call getBestIndexJoinPathResultByProp to get the index path or table path choosing information, and build raw table-scan or index-scan copTask, with indexJoinInfo wrapped inside, which will be passed upward and end usage in PhysicalIndexJoin.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
