### PR TITLE
config: deprecate ConcurrentlyInitStats and make it always enabled by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -739,7 +739,8 @@ type Performance struct {
 	// of init stats the optimizer may make bad decisions due to pseudo stats.
 	ForceInitStats bool `toml:"force-init-stats" json:"force-init-stats"`
 
-	// ConcurrentlyInitStats indicates whether to use concurrency to init stats.
+	// Deprecated: This setting has no effect, as stats are now always initialized concurrently.
+	// ConcurrentlyInitStats indicates whether to use concurrency for initializing stats.
 	ConcurrentlyInitStats bool `toml:"concurrently-init-stats" json:"concurrently-init-stats"`
 
 	// Deprecated: this config will not have any effect
@@ -999,7 +1000,8 @@ var defaultConf = Config{
 		EnableLoadFMSketch:                false,
 		LiteInitStats:                     true,
 		ForceInitStats:                    true,
-		ConcurrentlyInitStats:             true,
+		// Deprecated: Stats are always initialized concurrently.
+		ConcurrentlyInitStats: true,
 	},
 	ProxyProtocol: ProxyProtocol{
 		Networks:      "",

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -599,17 +599,11 @@ func (h *Handle) initStatsBuckets(cache statstypes.StatsCache, totalMemory uint6
 	if IsFullCacheFunc(cache, totalMemory) {
 		return nil
 	}
-	if config.GetGlobalConfig().Performance.ConcurrentlyInitStats {
-		err := h.initStatsBucketsConcurrently(cache, totalMemory, initstats.GetConcurrency())
-		if err != nil {
-			return errors.Trace(err)
-		}
-	} else {
-		err := h.initStatsBucketsConcurrently(cache, totalMemory, 1)
-		if err != nil {
-			return errors.Trace(err)
-		}
+	err := h.initStatsBucketsConcurrently(cache, totalMemory, initstats.GetConcurrency())
+	if err != nil {
+		return errors.Trace(err)
 	}
+
 	tables := cache.Values()
 	for _, table := range tables {
 		table.CalcPreScalar()
@@ -750,25 +744,17 @@ func (h *Handle) InitStats(ctx context.Context, is infoschema.InfoSchema) (err e
 	}
 	statslogutil.StatsLogger().Info("complete to load the meta")
 	initstats.InitStatsPercentage.Store(initStatsPercentageInterval)
-	if config.GetGlobalConfig().Performance.ConcurrentlyInitStats {
-		err = h.initStatsHistogramsConcurrently(is, cache, totalMemory, initstats.GetConcurrency())
-	} else {
-		err = h.initStatsHistogramsConcurrently(is, cache, totalMemory, 1)
-	}
-	statslogutil.StatsLogger().Info("complete to load the histogram")
+	err = h.initStatsHistogramsConcurrently(is, cache, totalMemory, initstats.GetConcurrency())
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if config.GetGlobalConfig().Performance.ConcurrentlyInitStats {
-		err = h.initStatsTopNConcurrently(cache, totalMemory, initstats.GetConcurrency())
-	} else {
-		err = h.initStatsTopNConcurrently(cache, totalMemory, 1)
-	}
-	initstats.InitStatsPercentage.Store(initStatsPercentageInterval * 2)
-	statslogutil.StatsLogger().Info("complete to load the topn")
+	statslogutil.StatsLogger().Info("complete to load the histogram")
+	err = h.initStatsTopNConcurrently(cache, totalMemory, initstats.GetConcurrency())
 	if err != nil {
 		return err
 	}
+	initstats.InitStatsPercentage.Store(initStatsPercentageInterval * 2)
+	statslogutil.StatsLogger().Info("complete to load the topn")
 	if loadFMSketch {
 		err = h.initStatsFMSketch(cache)
 		if err != nil {

--- a/pkg/statistics/handle/handletest/initstats/load_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/load_stats_test.go
@@ -32,7 +32,6 @@ func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-		conf.Performance.ConcurrentlyInitStats = true
 	})
 	handle.IsFullCacheFunc = func(cache types.StatsCache, total uint64) bool {
 		return true
@@ -45,7 +44,6 @@ func TestConcurrentlyInitStatsWithoutMemoryLimit(t *testing.T) {
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-		conf.Performance.ConcurrentlyInitStats = true
 	})
 	handle.IsFullCacheFunc = func(cache types.StatsCache, total uint64) bool {
 		return false
@@ -108,7 +106,6 @@ func TestDropTableBeforeConcurrentlyInitStats(t *testing.T) {
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-		conf.Performance.ConcurrentlyInitStats = true
 	})
 	testDropTableBeforeInitStats(t)
 }
@@ -118,7 +115,6 @@ func TestDropTableBeforeNonLiteInitStats(t *testing.T) {
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-		conf.Performance.ConcurrentlyInitStats = false
 	})
 	testDropTableBeforeInitStats(t)
 }

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -235,36 +235,24 @@ func testInitStatsMemTrace(t *testing.T) {
 func TestInitStatsMemTraceWithLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Performance.ConcurrentlyInitStats = false
-	})
 	testInitStatsMemTraceFunc(t, true)
 }
 
 func TestInitStatsMemTraceWithoutLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Performance.ConcurrentlyInitStats = false
-	})
 	testInitStatsMemTraceFunc(t, false)
 }
 
 func TestInitStatsMemTraceWithConcurrrencyLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Performance.ConcurrentlyInitStats = true
-	})
 	testInitStatsMemTraceFunc(t, true)
 }
 
 func TestInitStatsMemTraceWithoutConcurrrencyLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.Performance.ConcurrentlyInitStats = true
-	})
 	testInitStatsMemTraceFunc(t, false)
 }
 
@@ -359,25 +347,19 @@ func TestInitStats51358(t *testing.T) {
 
 func TestInitStatsVer2(t *testing.T) {
 	originValue := config.GetGlobalConfig().Performance.LiteInitStats
-	concurrentlyInitStatsValue := config.GetGlobalConfig().Performance.ConcurrentlyInitStats
 	defer func() {
 		config.GetGlobalConfig().Performance.LiteInitStats = originValue
-		config.GetGlobalConfig().Performance.ConcurrentlyInitStats = concurrentlyInitStatsValue
 	}()
 	config.GetGlobalConfig().Performance.LiteInitStats = false
-	config.GetGlobalConfig().Performance.ConcurrentlyInitStats = false
 	initStatsVer2(t)
 }
 
 func TestInitStatsVer2Concurrency(t *testing.T) {
 	originValue := config.GetGlobalConfig().Performance.LiteInitStats
-	concurrentlyInitStatsValue := config.GetGlobalConfig().Performance.ConcurrentlyInitStats
 	defer func() {
 		config.GetGlobalConfig().Performance.LiteInitStats = originValue
-		config.GetGlobalConfig().Performance.ConcurrentlyInitStats = concurrentlyInitStatsValue
 	}()
 	config.GetGlobalConfig().Performance.LiteInitStats = false
-	config.GetGlobalConfig().Performance.ConcurrentlyInitStats = true
 	initStatsVer2(t)
 }
 

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -244,13 +244,13 @@ func TestInitStatsMemTraceWithoutLite(t *testing.T) {
 	testInitStatsMemTraceFunc(t, false)
 }
 
-func TestInitStatsMemTraceWithConcurrencyLite(t *testing.T) {
+func TestInitStatsMemTraceWithConcurrentLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	testInitStatsMemTraceFunc(t, true)
 }
 
-func TestInitStatsMemTraceWithoutConcurrencyLite(t *testing.T) {
+func TestInitStatsMemTraceWithoutConcurrentLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	testInitStatsMemTraceFunc(t, false)

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -244,13 +244,13 @@ func TestInitStatsMemTraceWithoutLite(t *testing.T) {
 	testInitStatsMemTraceFunc(t, false)
 }
 
-func TestInitStatsMemTraceWithConcurrrencyLite(t *testing.T) {
+func TestInitStatsMemTraceWithConcurrencyLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	testInitStatsMemTraceFunc(t, true)
 }
 
-func TestInitStatsMemTraceWithoutConcurrrencyLite(t *testing.T) {
+func TestInitStatsMemTraceWithoutConcurrencyLite(t *testing.T) {
 	restore := config.RestoreFunc()
 	defer restore()
 	testInitStatsMemTraceFunc(t, false)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60206, close https://github.com/pingcap/tidb/issues/60138

Problem Summary:

### What changed and how does it work?

The current default value is true, as we believe it makes sense to initialize stats concurrently by default. The reasons are as follows:
1. It only runs once when the TiDB node starts.
2. For clusters with a large number of tables, single-threaded stats initialization is too slow. See https://github.com/pingcap/tidb/issues/60138
4. There is no need to expose this implementation detail to users anymore.

So this PR is to deprecate this configuration and initialize stats concurrently by default.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
弃用 concurrently-init-stats 配置参数，默认并发初始化统计信息
Deprecate the concurrently-init-stats configuration parameter and enable concurrent stats initialization by default
```
