### PR TITLE
*: add method to distinguish storage and build separate binary for NG tidb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,15 @@ else
 	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' ./cmd/tidb-server
 endif
 
+.PHONY: ng_server
+ng_server:
+ifeq ($(TARGET), "")
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' \
+	-ldflags '-X "github.com/pingcap/tidb/pkg/config.storeEngineGeneration=cloud"' -o bin/tidb-server ./cmd/tidb-server
+else
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' ./cmd/tidb-server
+endif
+
 .PHONY: server_debug
 server_debug:
 ifeq ($(TARGET), "")

--- a/pkg/config/store.go
+++ b/pkg/config/store.go
@@ -46,3 +46,23 @@ func (t StoreType) Valid() bool {
 func StoreTypeList() []StoreType {
 	return []StoreType{StoreTypeTiKV, StoreTypeUniStore, StoreTypeMockTiKV}
 }
+
+const (
+	// in this generation, TiKV store all data in its own disk, and each KV will
+	// have 3 replica normally.
+	storeEngineGenerationOP = "op"
+	// in this generation, TiKV store all data in cloud storage, such as S3, and
+	// use cloud infrastructure to make sure high availability. TiKV will load
+	// data from cloud storage when needed.
+	storeEngineGenerationCloud = "cloud"
+)
+
+// this var will be set at compile time.
+var storeEngineGeneration = storeEngineGenerationOP
+
+// IsCloudStore returns true if the store engine is based on cloud storage.
+// currently, we use same TiDB code base for both OP and cloud store, we will use
+// this method to distinguish them and run different code path.
+func IsCloudStore() bool {
+	return storeEngineGeneration == storeEngineGenerationCloud
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418

Problem Summary:

### What changed and how does it work?
- see the issue, and comment in the code, we use a compile variable to determine current binary type
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

change the code to print the value of `IsCloudStore`
use `make ng_server`, and run, check it's true
use `make sever`, run and check it's false

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
