### PR TITLE
executor: tiny cleanup for `WithRecovery`

### DIFF
--- a/pkg/util/wait_group_wrapper.go
+++ b/pkg/util/wait_group_wrapper.go
@@ -175,7 +175,7 @@ func (w *WaitGroupWrapper) RunWithLog(exec func()) {
 		defer w.Done()
 		defer func() {
 			if r := recover(); r != nil {
-				logutil.BgLogger().Error("panic in wait group", zap.Any("recover", r), zap.Stack("stack"))
+				logutil.BgLogger().Error("panic in the wait group", zap.Any("recover", r), zap.Stack("stack"))
 			}
 		}()
 		exec()
@@ -193,6 +193,9 @@ func (w *WaitGroupWrapper) RunWithRecover(exec func(), recoverFn func(r any)) {
 			r := recover()
 			if recoverFn != nil {
 				recoverFn(r)
+			}
+			if r != nil {
+				logutil.BgLogger().Error("panic in the wait group", zap.Any("recover", r), zap.Stack("stack"))
 			}
 			w.Done()
 		}()
@@ -253,7 +256,7 @@ func (g *ErrorGroupWithRecover) Go(fn func() error) {
 	g.Group.Go(func() (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				logutil.BgLogger().Error("panic in error group", zap.Any("recover", r), zap.Stack("stack"))
+				logutil.BgLogger().Error("panic in the error group", zap.Any("recover", r), zap.Stack("stack"))
 				err = GetRecoverError(r)
 			}
 		}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?
Using `wg.RunWithRecover` instead of `wg.Run` and `util.WithRecovery`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
