### PR TITLE
planner: fix doesn't push down hash join to tiflash

### DIFF
--- a/pkg/planner/core/casetest/tpch/BUILD.bazel
+++ b/pkg/planner/core/casetest/tpch/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 3,
+    shard_count = 4,
     deps = [
         "//pkg/config",
         "//pkg/testkit",

--- a/pkg/planner/core/casetest/tpch/testdata/tpch_suite_in.json
+++ b/pkg/planner/core/casetest/tpch/testdata/tpch_suite_in.json
@@ -8,6 +8,12 @@
     ]
   },
   {
+    "name": "TestQ9",
+    "cases": [
+      "explain format='brief' SELECT nation, o_year, SUM(amount) AS sum_profit FROM (SELECT n_name AS nation, EXTRACT(YEAR FROM o_orderdate) AS o_year, l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount FROM part, supplier, lineitem, partsupp, orders, nation WHERE s_suppkey = l_suppkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND p_partkey = l_partkey AND o_orderkey = l_orderkey AND s_nationkey = n_nationkey AND p_name LIKE '%dim%') AS profit GROUP BY nation, o_year ORDER BY nation, o_year DESC;"
+    ]
+  },
+  {
     "name": "TestQ13",
     "cases": [
       "explain format='brief' select c_count, count(*) as custdist from ( select c_custkey, count(o_orderkey) as c_count from customer left outer join orders on c_custkey = o_custkey and o_comment not like '%pending%deposits%' group by c_custkey ) c_orders group by c_count order by custdist desc, c_count desc;"

--- a/pkg/planner/core/casetest/tpch/testdata/tpch_suite_out.json
+++ b/pkg/planner/core/casetest/tpch/testdata/tpch_suite_out.json
@@ -74,6 +74,64 @@
     ]
   },
   {
+    "Name": "TestQ9",
+    "Cases": [
+      {
+        "SQL": "explain format='brief' SELECT nation, o_year, SUM(amount) AS sum_profit FROM (SELECT n_name AS nation, EXTRACT(YEAR FROM o_orderdate) AS o_year, l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount FROM part, supplier, lineitem, partsupp, orders, nation WHERE s_suppkey = l_suppkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND p_partkey = l_partkey AND o_orderkey = l_orderkey AND s_nationkey = n_nationkey AND p_name LIKE '%dim%') AS profit GROUP BY nation, o_year ORDER BY nation, o_year DESC;",
+        "Result": [
+          "Sort 8000.00 root  test.nation.n_name, Column#52:desc",
+          "└─TableReader 8000.00 root  MppVersion: 3, data:ExchangeSender",
+          "  └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─Projection 8000.00 mpp[tiflash]  test.nation.n_name, Column#52, Column#54",
+          "      └─Projection 8000.00 mpp[tiflash]  Column#54, test.nation.n_name, Column#52",
+          "        └─HashAgg 8000.00 mpp[tiflash]  group by:Column#72, test.nation.n_name, funcs:sum(Column#73)->Column#54, funcs:firstrow(test.nation.n_name)->test.nation.n_name, funcs:firstrow(Column#72)->Column#52",
+          "          └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
+          "            └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.nation.n_name, collate: utf8mb4_bin]",
+          "              └─HashAgg 8000.00 mpp[tiflash]  group by:Column#77, Column#78, funcs:sum(Column#76)->Column#73",
+          "                └─Projection 24414.06 mpp[tiflash]  minus(mul(test.lineitem.l_extendedprice, minus(1, test.lineitem.l_discount)), mul(test.partsupp.ps_supplycost, test.lineitem.l_quantity))->Column#76, test.nation.n_name->Column#77, extract(YEAR, test.orders.o_orderdate)->Column#78",
+          "                  └─Projection 24414.06 mpp[tiflash]  test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.partsupp.ps_supplycost, test.orders.o_orderdate, test.nation.n_name",
+          "                    └─Projection 24414.06 mpp[tiflash]  test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.partsupp.ps_supplycost, test.orders.o_orderdate, test.nation.n_name, test.supplier.s_nationkey",
+          "                      └─HashJoin 24414.06 mpp[tiflash]  inner join, equal:[eq(test.supplier.s_nationkey, test.nation.n_nationkey)]",
+          "                        ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
+          "                        │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.nation.n_nationkey, collate: binary]",
+          "                        │   └─TableFullScan 10000.00 mpp[tiflash] table:nation keep order:false, stats:pseudo",
+          "                        └─ExchangeReceiver(Probe) 19531.25 mpp[tiflash]  ",
+          "                          └─ExchangeSender 19531.25 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.supplier.s_nationkey, collate: binary]",
+          "                            └─Projection 19531.25 mpp[tiflash]  test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.supplier.s_nationkey, test.partsupp.ps_supplycost, test.orders.o_orderdate, test.lineitem.l_orderkey",
+          "                              └─HashJoin 19531.25 mpp[tiflash]  inner join, equal:[eq(test.lineitem.l_orderkey, test.orders.o_orderkey)]",
+          "                                ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
+          "                                │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.orders.o_orderkey, collate: binary]",
+          "                                │   └─TableFullScan 10000.00 mpp[tiflash] table:orders keep order:false, stats:pseudo",
+          "                                └─ExchangeReceiver(Probe) 15625.00 mpp[tiflash]  ",
+          "                                  └─ExchangeSender 15625.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary]",
+          "                                    └─Projection 15625.00 mpp[tiflash]  test.lineitem.l_orderkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.supplier.s_nationkey, test.partsupp.ps_supplycost, test.lineitem.l_suppkey, test.lineitem.l_partkey",
+          "                                      └─HashJoin 15625.00 mpp[tiflash]  inner join, equal:[eq(test.lineitem.l_suppkey, test.partsupp.ps_suppkey) eq(test.lineitem.l_partkey, test.partsupp.ps_partkey)]",
+          "                                        ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
+          "                                        │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.partsupp.ps_suppkey, collate: binary], [name: test.partsupp.ps_partkey, collate: binary]",
+          "                                        │   └─TableFullScan 10000.00 mpp[tiflash] table:partsupp keep order:false, stats:pseudo",
+          "                                        └─ExchangeReceiver(Probe) 12500.00 mpp[tiflash]  ",
+          "                                          └─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_suppkey, collate: binary], [name: test.lineitem.l_partkey, collate: binary]",
+          "                                            └─Projection 12500.00 mpp[tiflash]  test.lineitem.l_orderkey, test.lineitem.l_partkey, test.lineitem.l_suppkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount, test.supplier.s_nationkey, test.supplier.s_suppkey",
+          "                                              └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(test.lineitem.l_suppkey, test.supplier.s_suppkey)]",
+          "                                                ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
+          "                                                │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_suppkey, collate: binary]",
+          "                                                │   └─Projection 10000.00 mpp[tiflash]  test.lineitem.l_orderkey, test.lineitem.l_partkey, test.lineitem.l_suppkey, test.lineitem.l_quantity, test.lineitem.l_extendedprice, test.lineitem.l_discount",
+          "                                                │     └─HashJoin 10000.00 mpp[tiflash]  inner join, equal:[eq(test.part.p_partkey, test.lineitem.l_partkey)]",
+          "                                                │       ├─ExchangeReceiver(Build) 8000.00 mpp[tiflash]  ",
+          "                                                │       │ └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.part.p_partkey, collate: binary]",
+          "                                                │       │   └─Selection 8000.00 mpp[tiflash]  like(test.part.p_name, \"%dim%\", 92)",
+          "                                                │       │     └─TableFullScan 10000.00 mpp[tiflash] table:part pushed down filter:empty, keep order:false, stats:pseudo",
+          "                                                │       └─ExchangeReceiver(Probe) 10000.00 mpp[tiflash]  ",
+          "                                                │         └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_partkey, collate: binary]",
+          "                                                │           └─TableFullScan 10000.00 mpp[tiflash] table:lineitem keep order:false, stats:pseudo",
+          "                                                └─ExchangeReceiver(Probe) 10000.00 mpp[tiflash]  ",
+          "                                                  └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.supplier.s_suppkey, collate: binary]",
+          "                                                    └─TableFullScan 10000.00 mpp[tiflash] table:supplier keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestQ13",
     "Cases": [
       {

--- a/pkg/planner/core/casetest/tpch/tpch_test.go
+++ b/pkg/planner/core/casetest/tpch/tpch_test.go
@@ -95,6 +95,122 @@ CREATE TABLE lineitem (
 	}
 }
 
+func TestQ9(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`
+CREATE TABLE lineitem (
+    L_ORDERKEY bigint NOT NULL,
+    L_PARTKEY bigint NOT NULL,
+    L_SUPPKEY bigint NOT NULL,
+    L_LINENUMBER bigint NOT NULL,
+    L_QUANTITY decimal(15,2) NOT NULL,
+    L_EXTENDEDPRICE decimal(15,2) NOT NULL,
+    L_DISCOUNT decimal(15,2) NOT NULL,
+    L_TAX decimal(15,2) NOT NULL,
+    L_RETURNFLAG char(1) NOT NULL,
+    L_LINESTATUS char(1) NOT NULL,
+    L_SHIPDATE date NOT NULL,
+    L_COMMITDATE date NOT NULL,
+    L_RECEIPTDATE date NOT NULL,
+    L_SHIPINSTRUCT char(25) NOT NULL,
+    L_SHIPMODE char(10) NOT NULL,
+    L_COMMENT varchar(44) NOT NULL,
+    PRIMARY KEY (L_ORDERKEY, L_LINENUMBER) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+`)
+	tk.MustExec(`CREATE TABLE nation (
+  N_NATIONKEY bigint NOT NULL,
+  N_NAME char(25) NOT NULL,
+  N_REGIONKEY bigint NOT NULL,
+  N_COMMENT varchar(152) DEFAULT NULL,
+  PRIMARY KEY (N_NATIONKEY) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+	tk.MustExec(`
+CREATE TABLE orders (
+    O_ORDERKEY bigint NOT NULL,
+    O_CUSTKEY bigint NOT NULL,
+    O_ORDERSTATUS char(1) NOT NULL,
+    O_TOTALPRICE decimal(15,2) NOT NULL,
+    O_ORDERDATE date NOT NULL,
+    O_ORDERPRIORITY char(15) NOT NULL,
+    O_CLERK char(15) NOT NULL,
+    O_SHIPPRIORITY bigint NOT NULL,
+    O_COMMENT varchar(79) NOT NULL,
+    PRIMARY KEY (O_ORDERKEY) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;`)
+	tk.MustExec(`CREATE TABLE part (
+  P_PARTKEY bigint NOT NULL,
+  P_NAME varchar(55) NOT NULL,
+  P_MFGR char(25) NOT NULL,
+  P_BRAND char(10) NOT NULL,
+  P_TYPE varchar(25) NOT NULL,
+  P_SIZE bigint NOT NULL,
+  P_CONTAINER char(10) NOT NULL,
+  P_RETAILPRICE decimal(15,2) NOT NULL,
+  P_COMMENT varchar(23) NOT NULL,
+  PRIMARY KEY (P_PARTKEY) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+	tk.MustExec(`CREATE TABLE partsupp (
+  PS_PARTKEY bigint NOT NULL,
+  PS_SUPPKEY bigint NOT NULL,
+  PS_AVAILQTY bigint NOT NULL,
+  PS_SUPPLYCOST decimal(15,2) NOT NULL,
+  PS_COMMENT varchar(199) NOT NULL,
+  PRIMARY KEY (PS_PARTKEY,PS_SUPPKEY) /*T![clustered_index] NONCLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+	tk.MustExec(`CREATE TABLE supplier (
+  S_SUPPKEY bigint NOT NULL,
+  S_NAME char(25) NOT NULL,
+  S_ADDRESS varchar(40) NOT NULL,
+  S_NATIONKEY bigint NOT NULL,
+  S_PHONE char(15) NOT NULL,
+  S_ACCTBAL decimal(15,2) NOT NULL,
+  S_COMMENT varchar(101) NOT NULL,
+  PRIMARY KEY (S_SUPPKEY) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin`)
+	tk.MustExec("set @@session.tidb_broadcast_join_threshold_size = 0")
+	tk.MustExec("set @@session.tidb_broadcast_join_threshold_count = 0")
+	testkit.SetTiFlashReplica(t, dom, "test", "orders")
+	testkit.SetTiFlashReplica(t, dom, "test", "lineitem")
+	testkit.SetTiFlashReplica(t, dom, "test", "nation")
+	testkit.SetTiFlashReplica(t, dom, "test", "part")
+	testkit.SetTiFlashReplica(t, dom, "test", "partsupp")
+	testkit.SetTiFlashReplica(t, dom, "test", "supplier")
+	tk.MustQuery(`explain select
+	nation,
+	o_year,
+	sum(amount) as sum_profit
+from
+	(
+		select
+			n_name as nation,
+			extract(year from o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+		from
+			part,
+			supplier,
+			lineitem,
+			partsupp,
+			orders,
+			nation
+		where
+			s_suppkey = l_suppkey
+			and ps_suppkey = l_suppkey
+			and ps_partkey = l_partkey
+			and p_partkey = l_partkey
+			and o_orderkey = l_orderkey
+			and s_nationkey = n_nationkey
+			and p_name like '%dim%'
+	) as profit
+group by
+	nation,
+	o_year
+order by
+	nation,
+	o_year desc;`).Check(testkit.Rows())
+}
 func TestQ13(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -964,20 +964,19 @@ type PhysicalTableScan struct {
 	runtimeFilterList []*RuntimeFilter `plan-cache-clone:"must-nil"` // plan with runtime filter is not cached
 	maxWaitTimeMs     int
 
-	AnnIndexExtra *VectorIndexExtra `plan-cache-clone:"must-nil"` // MPP plan should not be cached.
 	// UsedColumnarIndexes is used to store the used columnar index for the table scan.
-	UsedColumnarIndexes []*tipb.ColumnarIndexInfo `plan-cache-clone:"must-nil"`
+	UsedColumnarIndexes []*ColumnarIndexExtra `plan-cache-clone:"must-nil"` // MPP plan should not be cached.
 }
 
-// VectorIndexExtra is the extra information for vector index.
-type VectorIndexExtra struct {
-	// Note: Even if IndexInfo is not nil, it doesn't mean the VectorSearch push down
-	// will happen because optimizer will explore all available vector indexes and fill them
+// ColumnarIndexExtra is the extra information for columnar index.
+type ColumnarIndexExtra struct {
+	// Note: Even if IndexInfo is not nil, it doesn't mean the index will be used
+	// because optimizer will explore all available vector indexes and fill them
 	// in IndexInfo, and later invalid plans are filtered out according to a topper executor.
 	IndexInfo *model.IndexInfo
 
-	// Not nil if there is an VectorSearch push down.
-	PushDownQueryInfo *tipb.ANNQueryInfo
+	// Not nil if there is an ColumnarIndex used.
+	QueryInfo *tipb.ColumnarIndexInfo
 }
 
 // Clone implements op.PhysicalPlan interface.
@@ -1005,7 +1004,7 @@ func (ts *PhysicalTableScan) Clone(newCtx base.PlanContext) (base.PhysicalPlan, 
 		clonedRF := rf.Clone()
 		clonedScan.runtimeFilterList = append(clonedScan.runtimeFilterList, clonedRF)
 	}
-	clonedScan.UsedColumnarIndexes = make([]*tipb.ColumnarIndexInfo, 0, len(ts.UsedColumnarIndexes))
+	clonedScan.UsedColumnarIndexes = make([]*ColumnarIndexExtra, 0, len(ts.UsedColumnarIndexes))
 	for _, colIdx := range ts.UsedColumnarIndexes {
 		colIdxClone := *colIdx
 		clonedScan.UsedColumnarIndexes = append(clonedScan.UsedColumnarIndexes, &colIdxClone)

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -964,19 +964,20 @@ type PhysicalTableScan struct {
 	runtimeFilterList []*RuntimeFilter `plan-cache-clone:"must-nil"` // plan with runtime filter is not cached
 	maxWaitTimeMs     int
 
+	AnnIndexExtra *VectorIndexExtra `plan-cache-clone:"must-nil"` // MPP plan should not be cached.
 	// UsedColumnarIndexes is used to store the used columnar index for the table scan.
-	UsedColumnarIndexes []*ColumnarIndexExtra `plan-cache-clone:"must-nil"` // MPP plan should not be cached.
+	UsedColumnarIndexes []*tipb.ColumnarIndexInfo `plan-cache-clone:"must-nil"`
 }
 
-// ColumnarIndexExtra is the extra information for columnar index.
-type ColumnarIndexExtra struct {
-	// Note: Even if IndexInfo is not nil, it doesn't mean the index will be used
-	// because optimizer will explore all available vector indexes and fill them
+// VectorIndexExtra is the extra information for vector index.
+type VectorIndexExtra struct {
+	// Note: Even if IndexInfo is not nil, it doesn't mean the VectorSearch push down
+	// will happen because optimizer will explore all available vector indexes and fill them
 	// in IndexInfo, and later invalid plans are filtered out according to a topper executor.
 	IndexInfo *model.IndexInfo
 
-	// Not nil if there is an ColumnarIndex used.
-	QueryInfo *tipb.ColumnarIndexInfo
+	// Not nil if there is an VectorSearch push down.
+	PushDownQueryInfo *tipb.ANNQueryInfo
 }
 
 // Clone implements op.PhysicalPlan interface.
@@ -1004,7 +1005,7 @@ func (ts *PhysicalTableScan) Clone(newCtx base.PlanContext) (base.PhysicalPlan, 
 		clonedRF := rf.Clone()
 		clonedScan.runtimeFilterList = append(clonedScan.runtimeFilterList, clonedRF)
 	}
-	clonedScan.UsedColumnarIndexes = make([]*ColumnarIndexExtra, 0, len(ts.UsedColumnarIndexes))
+	clonedScan.UsedColumnarIndexes = make([]*tipb.ColumnarIndexInfo, 0, len(ts.UsedColumnarIndexes))
 	for _, colIdx := range ts.UsedColumnarIndexes {
 		colIdxClone := *colIdx
 		clonedScan.UsedColumnarIndexes = append(clonedScan.UsedColumnarIndexes, &colIdxClone)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60407

Problem Summary:

### What changed and how does it work?

caused by https://github.com/pingcap/tidb/pull/57417

because `NeedMPPExchangeByEquivalence` will change the hash partitioning information. Having different numbers of MPP partitions in the child nodes of a join can lead to invalid tasks, which ultimately result in incorrect plan.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
