### PR TITLE
stats: use `GetColOriginDefaultValue` to get default value of a column

### DIFF
--- a/pkg/statistics/handle/storage/BUILD.bazel
+++ b/pkg/statistics/handle/storage/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/statistics/handle/usage/predicatecolumn",
         "//pkg/statistics/handle/util",
         "//pkg/statistics/util",
+        "//pkg/table",
         "//pkg/types",
         "//pkg/util/chunk",
         "//pkg/util/compress",

--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/statistics"
 	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/statistics/handle/util"
+	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/sqlescape"
@@ -444,8 +445,7 @@ func InsertColStats2KV(
 	}
 	count := req.GetRow(0).GetInt64(0)
 	for _, colInfo := range colInfos {
-		value := types.NewDatum(colInfo.GetOriginDefaultValue())
-		value, err = value.ConvertTo(sctx.GetSessionVars().StmtCtx.TypeCtx(), &colInfo.FieldType)
+		value, err := table.GetColOriginDefaultValue(sctx.GetExprCtx(), colInfo)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}

--- a/tests/integrationtest/r/statistics/handle.result
+++ b/tests/integrationtest/r/statistics/handle.result
@@ -79,3 +79,14 @@ insert into t values(1,1),(2,2),(3,3);
 alter table t add stats_extended s1 correlation(a,b);
 analyze table t;
 set session tidb_enable_extended_stats = default;
+drop table if exists t;
+set time_zone = '+08:00';
+create table t(a int);
+alter table t add column ts timestamp DEFAULT '1970-01-01 08:00:01';
+drop table if exists t;
+set time_zone = '+09:00';
+create table t(a int);
+alter table t add column ts timestamp DEFAULT '1970-01-01 08:00:01';
+Error 1067 (42000): Invalid default value for 'ts'
+drop table if exists t;
+set time_zone = default;

--- a/tests/integrationtest/t/statistics/handle.test
+++ b/tests/integrationtest/t/statistics/handle.test
@@ -82,3 +82,16 @@ alter table t add stats_extended s1 correlation(a,b);
 ## no error
 analyze table t;
 set session tidb_enable_extended_stats = default;
+
+# TestHandleDDLEventForTimestampDefaultValue
+drop table if exists t;
+set time_zone = '+08:00';
+create table t(a int);
+alter table t add column ts timestamp DEFAULT '1970-01-01 08:00:01';
+drop table if exists t;
+set time_zone = '+09:00';
+create table t(a int);
+-- error 1067
+alter table t add column ts timestamp DEFAULT '1970-01-01 08:00:01';
+drop table if exists t;
+set time_zone = default;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #60194

Problem Summary:

### What changed and how does it work?

Fix the issue that the `HandleDDLEvent` cannot handle timezone issues properly.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
