### PR TITLE
session: A safer way to close session from the pool

### DIFF
--- a/pkg/session/syssession/BUILD.bazel
+++ b/pkg/session/syssession/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     ],
     embed = [":syssession"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/kv",
         "//pkg/parser/ast",

--- a/pkg/session/syssession/pool_test.go
+++ b/pkg/session/syssession/pool_test.go
@@ -189,9 +189,8 @@ func TestSessionPoolPut(t *testing.T) {
 	// Put a Session that is inUse
 	se = getCachedSessionFromPool(sctx)
 	require.Equal(t, 0, len(p.pool))
-	_, _, err := se.internal.EnterOperation(se)
+	_, exit, err := se.internal.EnterOperation(se)
 	require.NoError(t, err)
-	sctx.On("Close").Once()
 	WithSuppressAssert(func() {
 		p.Put(se)
 	})
@@ -199,6 +198,8 @@ func TestSessionPoolPut(t *testing.T) {
 	require.False(t, se.IsOwner())
 	require.True(t, se.IsInternalClosed())
 	require.Equal(t, 0, len(p.pool))
+	sctx.On("Close").Once()
+	WithSuppressAssert(exit)
 	sctx.AssertExpectations(t)
 
 	// Put a Session that avoids reusing


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60115

Problem Summary:

Consider the below case:

```go 
var pool *AdvancedSessionPool
se, err := pool.Get()
go func() {
  se.ExecuteInternal(...)
}()

go func() {
  se.Close()
}()
```

If the above two operations are executed in parallel, a data race may occur in the current implementation.

Though it is unexpected, we still want to reduce unnecessary data race here.

### What changed and how does it work?

Postphone the close of the session when `inUse` decreased to `0` if `se.Close()` is called but found it is still in use.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
