### PR TITLE
runaway: fix the issue where COOLDOWN/SWITCH_GROUP can't be triggered

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -562,12 +562,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			return nil, err
 		}
 		if len(switchGroupName) > 0 {
-			group, err := rm.ResourceGroupCtl.GetResourceGroup(switchGroupName)
-			if err != nil || group == nil {
-				logutil.BgLogger().Debug("invalid switch resource group", zap.String("switch-group-name", switchGroupName), zap.Error(err))
-			} else {
-				stmtCtx.ResourceGroupName = switchGroupName
-			}
+			stmtCtx.ResourceGroupName = switchGroupName
 		}
 	}
 	ctx = a.observeStmtBeginForTopSQL(ctx)

--- a/pkg/resourcegroup/runaway/checker.go
+++ b/pkg/resourcegroup/runaway/checker.go
@@ -50,6 +50,9 @@ type Checker struct {
 	// watchAction is the specified watch action for the runaway query.
 	// If it's not given, the action defined in `settings` will be used.
 	watchAction rmpb.RunawayAction
+	// watchSwitchGroupName is the specified switch group name for its corresponding runaway action.
+	// If it's not given, the switch group name defined in `settings` will be used.
+	watchSwitchGroupName string
 
 	// mutable fields below
 	// using total processed_keys to accumulate all coprocessor tasks.
@@ -112,6 +115,13 @@ func (rm *Manager) DeriveChecker(resourceGroupName, originalSQL, sqlDigest, plan
 	return NewChecker(rm, resourceGroupName, group.RunawaySettings, originalSQL, sqlDigest, planDigest, startTime)
 }
 
+func (r *Checker) isMarkedByIdentifyInRunawaySettings() bool {
+	if r == nil {
+		return false
+	}
+	return r.markedByIdentifyInRunawaySettings.Load()
+}
+
 // BeforeExecutor checks whether query is in watch list before executing and after compiling.
 func (r *Checker) BeforeExecutor() (string, error) {
 	if r == nil {
@@ -149,7 +159,7 @@ func (r *Checker) BeforeExecutor() (string, error) {
 			return "", nil
 		case rmpb.RunawayAction_SwitchGroup:
 			// Return the switch group name to switch the resource group before executing.
-			return switchGroupName, nil
+			return r.checkSwitchGroupName(switchGroupName), nil
 		default:
 			// Continue to examine other convicts.
 		}
@@ -157,26 +167,35 @@ func (r *Checker) BeforeExecutor() (string, error) {
 	return "", nil
 }
 
+func (r *Checker) checkSwitchGroupName(groupName string) string {
+	if len(groupName) == 0 {
+		return ""
+	}
+	group, err := r.manager.ResourceGroupCtl.GetResourceGroup(groupName)
+	if err != nil || group == nil {
+		logutil.BgLogger().Debug("invalid switch resource group", zap.String("switch-group-name", groupName), zap.Error(err))
+		return ""
+	}
+	return groupName
+}
+
 // BeforeCopRequest checks runaway and modifies the request if necessary before sending coprocessor request.
 func (r *Checker) BeforeCopRequest(req *tikvrpc.Request) error {
 	if r == nil {
 		return nil
 	}
-	// If the group settings are not available, and it's not marked by watch, skip this part.
-	if r.settings == nil && !r.markedByQueryWatchRule {
-		return nil
-	}
-	// If it's marked by watch and the action is cooldown, override the priority,
+	// If it's marked by watch and the action is cooldown, override the priority.
+	// Other watch actions should already been handled in `BeforeExecutor` before.
 	if r.markedByQueryWatchRule && r.watchAction == rmpb.RunawayAction_CoolDown {
 		req.ResourceControlContext.OverridePriority = 1 // set priority to lowest
 	}
-	// If group settings are available and the query is not marked by a rule,
-	// verify if it matches any rules in the settings.
-	if r.settings != nil && !r.markedByIdentifyInRunawaySettings.Load() {
+	// If group settings are available, verify if it matches any rules in the settings.
+	if r.settings != nil {
 		now := time.Now()
-		// only check time and need to ensure deadline existed.
+		// Check and ensure the deadline exists.
 		exceedCause := r.exceedsThresholds(now, nil, 0)
-		if exceedCause == "" { // only set timeout when the query is not runaway.
+		// Only set timeout when the query has not been marked as runaway yet.
+		if !r.isMarkedByIdentifyInRunawaySettings() && len(exceedCause) == 0 {
 			if r.settings.Action == rmpb.RunawayAction_Kill {
 				until := r.deadline.Sub(now)
 				// if the execution time is close to the threshold, set a timeout
@@ -186,7 +205,8 @@ func (r *Checker) BeforeCopRequest(req *tikvrpc.Request) error {
 			}
 			return nil
 		}
-		// execution time exceeds the threshold, mark the query as runaway
+		// Try to mark the query as runaway, it's safe to call this method concurrently.
+		// So it's possible that the query has already been marked as runaway in `CheckThresholds`.
 		r.markRunawayByIdentifyInRunawaySettings(&now, exceedCause)
 		// Take action if needed.
 		switch r.settings.Action {
@@ -196,7 +216,9 @@ func (r *Checker) BeforeCopRequest(req *tikvrpc.Request) error {
 			req.ResourceControlContext.OverridePriority = 1 // set priority to lowest
 			return nil
 		case rmpb.RunawayAction_SwitchGroup:
-			req.ResourceControlContext.ResourceGroupName = r.settings.SwitchGroupName
+			if switchGroupName := r.checkSwitchGroupName(r.settings.SwitchGroupName); len(switchGroupName) != 0 {
+				req.ResourceControlContext.ResourceGroupName = switchGroupName
+			}
 			return nil
 		default:
 			return nil
@@ -214,7 +236,7 @@ func (r *Checker) CheckAction() rmpb.RunawayAction {
 	if r.markedByQueryWatchRule {
 		return r.watchAction
 	}
-	if r.markedByIdentifyInRunawaySettings.Load() {
+	if r.isMarkedByIdentifyInRunawaySettings() {
 		return r.settings.Action
 	}
 	return rmpb.RunawayAction_NoneAction
@@ -227,7 +249,7 @@ func (r *Checker) CheckRuleKillAction() (string, bool) {
 		return "", false
 	}
 	// If the group settings are available, and it's not marked by rule, check the execution time.
-	if r.settings != nil && !r.markedByIdentifyInRunawaySettings.Load() {
+	if r.settings != nil && !r.isMarkedByIdentifyInRunawaySettings() {
 		now := time.Now()
 		exceedCause := r.exceedsThresholds(now, nil, 0)
 		if exceedCause == "" {
@@ -249,7 +271,7 @@ func (r *Checker) markQuarantine(now *time.Time, exceedCause string) {
 		r.settings.Action, r.settings.SwitchGroupName, ttl, now, exceedCause)
 }
 
-func (r *Checker) markRunawayByIdentifyInRunawaySettings(now *time.Time, exceedCause string) bool {
+func (r *Checker) markRunawayByIdentifyInRunawaySettings(now *time.Time, exceedCause string) {
 	swapped := r.markedByIdentifyInRunawaySettings.CompareAndSwap(false, true)
 	if swapped {
 		r.markRunaway("identify", r.settings.Action, r.settings.SwitchGroupName, now, exceedCause)
@@ -257,12 +279,12 @@ func (r *Checker) markRunawayByIdentifyInRunawaySettings(now *time.Time, exceedC
 			r.markQuarantine(now, exceedCause)
 		}
 	}
-	return swapped
 }
 
 func (r *Checker) markRunawayByQueryWatchRule(action rmpb.RunawayAction, switchGroupName, exceedCause string) {
 	r.markedByQueryWatchRule = true
 	r.watchAction = action
+	r.watchSwitchGroupName = switchGroupName
 	now := time.Now()
 	r.markRunaway("watch", action, switchGroupName, &now, exceedCause)
 }
@@ -320,7 +342,7 @@ func (r *Checker) CheckThresholds(ruDetail *util.RUDetails, processKeys int64, e
 			processKeys = int64(100)
 		}
 	})
-	if r.settings == nil || r.settings.Action != rmpb.RunawayAction_Kill {
+	if r.settings == nil {
 		return err
 	}
 
@@ -333,18 +355,15 @@ func (r *Checker) CheckThresholds(ruDetail *util.RUDetails, processKeys int64, e
 	atomic.AddInt64(&r.totalProcessedKeys, processKeys)
 	totalProcessedKeys := atomic.LoadInt64(&r.totalProcessedKeys)
 	exceedCause := r.exceedsThresholds(checkTime, ruDetail, totalProcessedKeys)
-	if !r.markedByIdentifyInRunawaySettings.Load() {
-		if exceedCause != "" && r.markRunawayByIdentifyInRunawaySettings(&now, exceedCause) {
-			if r.markRunawayByIdentifyInRunawaySettings(&now, exceedCause) {
-				return exeerrors.ErrResourceGroupQueryRunawayInterrupted.FastGenByArgs(exceedCause)
-			}
-		}
+	// No need to mark as runaway if the query is not exceeded any threshold.
+	if len(exceedCause) == 0 {
+		return err
 	}
-	// Due to concurrency, check again.
-	if r.markedByIdentifyInRunawaySettings.Load() {
+	r.markRunawayByIdentifyInRunawaySettings(&now, exceedCause)
+	// Other actions will be handled in `BeforeCopRequest` since they need to modify the request.
+	if r.settings.Action == rmpb.RunawayAction_Kill {
 		return exeerrors.ErrResourceGroupQueryRunawayInterrupted.FastGenByArgs(exceedCause)
 	}
-
 	return err
 }
 

--- a/pkg/resourcegroup/runaway/checker.go
+++ b/pkg/resourcegroup/runaway/checker.go
@@ -50,9 +50,6 @@ type Checker struct {
 	// watchAction is the specified watch action for the runaway query.
 	// If it's not given, the action defined in `settings` will be used.
 	watchAction rmpb.RunawayAction
-	// watchSwitchGroupName is the specified switch group name for its corresponding runaway action.
-	// If it's not given, the switch group name defined in `settings` will be used.
-	watchSwitchGroupName string
 
 	// mutable fields below
 	// using total processed_keys to accumulate all coprocessor tasks.
@@ -284,7 +281,6 @@ func (r *Checker) markRunawayByIdentifyInRunawaySettings(now *time.Time, exceedC
 func (r *Checker) markRunawayByQueryWatchRule(action rmpb.RunawayAction, switchGroupName, exceedCause string) {
 	r.markedByQueryWatchRule = true
 	r.watchAction = action
-	r.watchSwitchGroupName = switchGroupName
 	now := time.Now()
 	r.markRunaway("watch", action, switchGroupName, &now, exceedCause)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60404

Problem Summary:

Run the corresponding actions in `BeforeCopRequest` once it's marked by `IdentifyInRunawaySettings`.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

<img width="885" alt="image" src="https://github.com/user-attachments/assets/8bb51bed-6367-4351-aa87-f38ae94e5faf" />

<img width="3007" alt="image" src="https://github.com/user-attachments/assets/594b80b4-1029-48fc-940c-cc54bf816a0f" />

<img width="832" alt="image" src="https://github.com/user-attachments/assets/d3d59dd7-a2f6-4cd2-9402-308b5134a7a0" />

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
