### PR TITLE
session: syssession checks the concurrency of thread-unsafe calls

### DIFF
--- a/pkg/session/syssession/BUILD.bazel
+++ b/pkg/session/syssession/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
     ],
     embed = [":syssession"],
     flaky = True,
-    shard_count = 19,
+    shard_count = 21,
     deps = [
         "//pkg/kv",
         "//pkg/parser/ast",

--- a/pkg/session/syssession/pool_test.go
+++ b/pkg/session/syssession/pool_test.go
@@ -189,7 +189,7 @@ func TestSessionPoolPut(t *testing.T) {
 	// Put a Session that is inUse
 	se = getCachedSessionFromPool(sctx)
 	require.Equal(t, 0, len(p.pool))
-	_, exit, err := se.internal.EnterOperation(se)
+	_, exit, err := se.internal.EnterOperation(se, false)
 	require.NoError(t, err)
 	WithSuppressAssert(func() {
 		p.Put(se)

--- a/pkg/session/syssession/session.go
+++ b/pkg/session/syssession/session.go
@@ -312,8 +312,9 @@ func (s *session) EnterOperation(caller sessionOwner, threadSafe bool) (SessionC
 		if r := recover(); r != nil {
 			s.OwnerMarkAvoidReuse(caller)
 			defer func() {
-				// If the outside code panics, we should also panic in defer function.
-				// The panic from business has higher priority to throw than the one from the assertions.
+				// The panic is from the proxied internal operation.
+				// If it happens, the defer function should also panic here to keep the same behavior as directly called.
+				// The panic from internal operation has higher priority to throw than the one from the assertions.
 				logutil.BgLogger().Error(
 					"EnterOperation error: panic occurs, avoid to use session again",
 					zap.Any("panic", r),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60115

Problem Summary:

Consider below case:

```go
pool := NewAdvancedSessionPool(256, factory);
s, err := pool.Get()
// handle error ...
go func() {
    rs, err := s.ExecuteInternal(ctx, "select * from t");
    // handle result
}()

go func() {
    rs, err := s.ExecuteInternal(ctx, "select * from t");
    // handle result
}()
```

The above two statements are executed concurrently which is not expected and may cause data race. It's better to deny the second execution and return an error instead.

### What changed and how does it work?

This PR adds some checks of the concurrency of thread-unsafe calls. When one thread-unsafe operation is ongoing and another operation (also thread-unsafe) begins, the latter one will return an error.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
