### PR TITLE
executor: don't scanRowTable if build stage meet error

### DIFF
--- a/pkg/executor/join/hash_join_base.go
+++ b/pkg/executor/join/hash_join_base.go
@@ -64,6 +64,7 @@ type probeSideTupleFetcherBase struct {
 	probeResultChs     []chan *chunk.Chunk
 	requiredRows       int64
 	joinResultChannel  chan *hashjoinWorkerResult
+	probeFetchSkipped  bool
 }
 
 func (fetcher *probeSideTupleFetcherBase) initializeForProbeBase(concurrency uint, joinResultChannel chan *hashjoinWorkerResult) {
@@ -191,6 +192,7 @@ func (fetcher *probeSideTupleFetcherBase) fetchProbeSideChunks(ctx context.Conte
 			skipProbe := wait4BuildSide(isBuildEmpty, checkSpill, canSkipIfBuildEmpty, needScanAfterProbeDone, hashJoinCtx)
 			if skipProbe {
 				// there is no need to probe, so just return
+				fetcher.probeFetchSkipped = true
 				return
 			}
 			hasWaitedForBuild = true

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -878,7 +878,7 @@ func (e *HashJoinV2Exec) waitJoinWorkers(start time.Time) {
 	if !e.ProbeSideTupleFetcher.probeFetchSkipped {
 		// only scan the row table if probe fetch is not skipped
 		// probe fetch is skipped if
-		// 1. there is some error during build/probe stage
+		// 1. there is some error during build stage
 		// 2. the hash table is empty
 		// in both cases, there is no need to scan the row table again
 		if e.ProbeWorkers[0] != nil && e.ProbeWorkers[0].JoinProbe.NeedScanRowTable() {

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -787,6 +787,7 @@ func (e *HashJoinV2Exec) initializeForProbe() {
 	e.joinResultCh = make(chan *hashjoinWorkerResult, e.Concurrency+1)
 	e.ProbeSideTupleFetcher.initializeForProbeBase(e.Concurrency, e.joinResultCh)
 	e.ProbeSideTupleFetcher.canSkipProbeIfHashTableIsEmpty = e.canSkipProbeIfHashTableIsEmpty()
+	e.ProbeSideTupleFetcher.probeFetchSkipped = false
 
 	for i := uint(0); i < e.Concurrency; i++ {
 		e.ProbeWorkers[i].initializeForProbe(e.ProbeSideTupleFetcher.probeChkResourceCh, e.ProbeSideTupleFetcher.probeResultChs[i], e)
@@ -874,14 +875,21 @@ func (e *HashJoinV2Exec) waitJoinWorkers(start time.Time) {
 		}
 	}
 
-	if e.ProbeWorkers[0] != nil && e.ProbeWorkers[0].JoinProbe.NeedScanRowTable() {
-		for i := uint(0); i < e.Concurrency; i++ {
-			var workerID = i
-			e.workerWg.RunWithRecover(func() {
-				e.ProbeWorkers[workerID].scanRowTableAfterProbeDone()
-			}, e.handleJoinWorkerPanic)
+	if !e.ProbeSideTupleFetcher.probeFetchSkipped {
+		// only scan the row table if probe fetch is not skipped
+		// probe fetch is skipped if
+		// 1. there is some error during build/probe stage
+		// 2. the hash table is empty
+		// in both cases, there is no need to scan the row table again
+		if e.ProbeWorkers[0] != nil && e.ProbeWorkers[0].JoinProbe.NeedScanRowTable() {
+			for i := uint(0); i < e.Concurrency; i++ {
+				var workerID = i
+				e.workerWg.RunWithRecover(func() {
+					e.ProbeWorkers[workerID].scanRowTableAfterProbeDone()
+				}, e.handleJoinWorkerPanic)
+			}
+			e.workerWg.Wait()
 		}
-		e.workerWg.Wait()
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60466

Problem Summary:
Described in #60466
### What changed and how does it work?
The root cause is when build meet error, the hash table is not build, and in `scanRowTableAfterProbeDone` it will try to access hash table, which will cause the panic
This fix avoid scanRowTable if build meet error
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
   after this pr, there is no panic log in tidb.log
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
