### PR TITLE
globalsort: replace key and value slice with kvPair 

### DIFF
--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -86,9 +86,8 @@ const writeStepMemShareCount = 6.5
 const maxCloudStorageConnections = 1000
 
 type memKVsAndBuffers struct {
-	mu     sync.Mutex
-	keys   [][]byte
-	values [][]byte
+	mu  sync.Mutex
+	kvs []kvPair
 	// memKVBuffers contains two types of buffer, first half are used for small block
 	// buffer, second half are used for large one.
 	memKVBuffers []*membuf.Buffer
@@ -96,14 +95,13 @@ type memKVsAndBuffers struct {
 	droppedSize  int
 
 	// temporary fields to store KVs to reduce slice allocations.
-	keysPerFile        [][][]byte
-	valuesPerFile      [][][]byte
+	kvsPerFile         [][]kvPair
 	droppedSizePerFile []int
 }
 
 func (b *memKVsAndBuffers) build(ctx context.Context) {
 	sumKVCnt := 0
-	for _, keys := range b.keysPerFile {
+	for _, keys := range b.kvsPerFile {
 		sumKVCnt += len(keys)
 	}
 	b.droppedSize = 0
@@ -116,16 +114,12 @@ func (b *memKVsAndBuffers) build(ctx context.Context) {
 		zap.Int("sumKVCnt", sumKVCnt),
 		zap.Int("droppedSize", b.droppedSize))
 
-	b.keys = make([][]byte, 0, sumKVCnt)
-	b.values = make([][]byte, 0, sumKVCnt)
-	for i := range b.keysPerFile {
-		b.keys = append(b.keys, b.keysPerFile[i]...)
-		b.keysPerFile[i] = nil
-		b.values = append(b.values, b.valuesPerFile[i]...)
-		b.valuesPerFile[i] = nil
+	b.kvs = make([]kvPair, 0, sumKVCnt)
+	for i := range b.kvsPerFile {
+		b.kvs = append(b.kvs, b.kvsPerFile[i]...)
+		b.kvsPerFile[i] = nil
 	}
-	b.keysPerFile = nil
-	b.valuesPerFile = nil
+	b.kvsPerFile = nil
 }
 
 // Engine stored sorted key/value pairs in an external storage.
@@ -345,17 +339,16 @@ func (e *Engine) loadBatchRegionData(ctx context.Context, jobKeys [][]byte, outC
 	oldSortyGor := sorty.MaxGor
 	sorty.MaxGor = uint64(e.workerConcurrency * 2)
 	var dupKey atomic.Pointer[[]byte]
-	sorty.Sort(len(e.memKVsAndBuffers.keys), func(i, k, r, s int) bool {
-		cmp := bytes.Compare(e.memKVsAndBuffers.keys[i], e.memKVsAndBuffers.keys[k])
+	sorty.Sort(len(e.memKVsAndBuffers.kvs), func(i, k, r, s int) bool {
+		cmp := bytes.Compare(e.memKVsAndBuffers.kvs[i].key, e.memKVsAndBuffers.kvs[k].key)
 		if cmp < 0 { // strict comparator like < or >
 			if r != s {
-				e.memKVsAndBuffers.keys[r], e.memKVsAndBuffers.keys[s] = e.memKVsAndBuffers.keys[s], e.memKVsAndBuffers.keys[r]
-				e.memKVsAndBuffers.values[r], e.memKVsAndBuffers.values[s] = e.memKVsAndBuffers.values[s], e.memKVsAndBuffers.values[r]
+				e.memKVsAndBuffers.kvs[r], e.memKVsAndBuffers.kvs[s] = e.memKVsAndBuffers.kvs[s], e.memKVsAndBuffers.kvs[r]
 			}
 			return true
 		}
 		if cmp == 0 && i != k {
-			cloned := append([]byte(nil), e.memKVsAndBuffers.keys[i]...)
+			cloned := append([]byte(nil), e.memKVsAndBuffers.kvs[i].key...)
 			dupKey.Store(&cloned)
 		}
 		return false
@@ -378,14 +371,12 @@ func (e *Engine) loadBatchRegionData(ctx context.Context, jobKeys [][]byte, outC
 	sortRateHist.Observe(float64(size) / 1024.0 / 1024.0 / sortSecond)
 
 	data := e.buildIngestData(
-		e.memKVsAndBuffers.keys,
-		e.memKVsAndBuffers.values,
+		e.memKVsAndBuffers.kvs,
 		e.memKVsAndBuffers.memKVBuffers,
 	)
 
 	// release the reference of e.memKVsAndBuffers
-	e.memKVsAndBuffers.keys = nil
-	e.memKVsAndBuffers.values = nil
+	e.memKVsAndBuffers.kvs = nil
 	e.memKVsAndBuffers.memKVBuffers = nil
 	e.memKVsAndBuffers.size = 0
 
@@ -452,14 +443,13 @@ func (e *Engine) LoadIngestData(
 	return nil
 }
 
-func (e *Engine) buildIngestData(keys, values [][]byte, buf []*membuf.Buffer) *MemoryIngestData {
+func (e *Engine) buildIngestData(kvs []kvPair, buf []*membuf.Buffer) *MemoryIngestData {
 	return &MemoryIngestData{
 		keyAdapter:         e.keyAdapter,
 		duplicateDetection: e.duplicateDetection,
 		duplicateDB:        e.duplicateDB,
 		dupDetectOpt:       e.dupDetectOpt,
-		keys:               keys,
-		values:             values,
+		kvs:                kvs,
 		ts:                 e.ts,
 		memBuf:             buf,
 		refCnt:             atomic.NewInt64(0),
@@ -590,9 +580,8 @@ type MemoryIngestData struct {
 	duplicateDB        *pebble.DB
 	dupDetectOpt       common.DupDetectOpt
 
-	keys   [][]byte
-	values [][]byte
-	ts     uint64
+	kvs []kvPair
+	ts  uint64
 
 	memBuf          []*membuf.Buffer
 	refCnt          *atomic.Int64
@@ -606,26 +595,26 @@ func (m *MemoryIngestData) firstAndLastKeyIndex(lowerBound, upperBound []byte) (
 	firstKeyIdx := 0
 	if len(lowerBound) > 0 {
 		lowerBound = m.keyAdapter.Encode(nil, lowerBound, common.MinRowID)
-		firstKeyIdx = sort.Search(len(m.keys), func(i int) bool {
-			return bytes.Compare(lowerBound, m.keys[i]) <= 0
+		firstKeyIdx = sort.Search(len(m.kvs), func(i int) bool {
+			return bytes.Compare(lowerBound, m.kvs[i].key) <= 0
 		})
-		if firstKeyIdx == len(m.keys) {
+		if firstKeyIdx == len(m.kvs) {
 			return -1, -1
 		}
 	}
 
-	lastKeyIdx := len(m.keys) - 1
+	lastKeyIdx := len(m.kvs) - 1
 	if len(upperBound) > 0 {
 		upperBound = m.keyAdapter.Encode(nil, upperBound, common.MinRowID)
-		i := sort.Search(len(m.keys), func(i int) bool {
-			reverseIdx := len(m.keys) - 1 - i
-			return bytes.Compare(upperBound, m.keys[reverseIdx]) > 0
+		i := sort.Search(len(m.kvs), func(i int) bool {
+			reverseIdx := len(m.kvs) - 1 - i
+			return bytes.Compare(upperBound, m.kvs[reverseIdx].key) > 0
 		})
-		if i == len(m.keys) {
+		if i == len(m.kvs) {
 			// should not happen
 			return -1, -1
 		}
-		lastKeyIdx = len(m.keys) - 1 - i
+		lastKeyIdx = len(m.kvs) - 1 - i
 	}
 	return firstKeyIdx, lastKeyIdx
 }
@@ -636,11 +625,11 @@ func (m *MemoryIngestData) GetFirstAndLastKey(lowerBound, upperBound []byte) ([]
 	if firstKeyIdx < 0 || firstKeyIdx > lastKeyIdx {
 		return nil, nil, nil
 	}
-	firstKey, err := m.keyAdapter.Decode(nil, m.keys[firstKeyIdx])
+	firstKey, err := m.keyAdapter.Decode(nil, m.kvs[firstKeyIdx].key)
 	if err != nil {
 		return nil, nil, err
 	}
-	lastKey, err := m.keyAdapter.Decode(nil, m.keys[lastKeyIdx])
+	lastKey, err := m.keyAdapter.Decode(nil, m.kvs[lastKeyIdx].key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -648,8 +637,7 @@ func (m *MemoryIngestData) GetFirstAndLastKey(lowerBound, upperBound []byte) ([]
 }
 
 type memoryDataIter struct {
-	keys   [][]byte
-	values [][]byte
+	kvs []kvPair
 
 	firstKeyIdx int
 	lastKeyIdx  int
@@ -678,12 +666,12 @@ func (m *memoryDataIter) Next() bool {
 
 // Key implements ForwardIter.
 func (m *memoryDataIter) Key() []byte {
-	return m.keys[m.curIdx]
+	return m.kvs[m.curIdx].key
 }
 
 // Value implements ForwardIter.
 func (m *memoryDataIter) Value() []byte {
-	return m.values[m.curIdx]
+	return m.kvs[m.curIdx].value
 }
 
 // Close implements ForwardIter.
@@ -772,8 +760,7 @@ func (m *MemoryIngestData) NewIter(
 ) common.ForwardIter {
 	firstKeyIdx, lastKeyIdx := m.firstAndLastKeyIndex(lowerBound, upperBound)
 	iter := &memoryDataIter{
-		keys:        m.keys,
-		values:      m.values,
+		kvs:         m.kvs,
 		firstKeyIdx: firstKeyIdx,
 		lastKeyIdx:  lastKeyIdx,
 	}
@@ -802,8 +789,7 @@ func (m *MemoryIngestData) IncRef() {
 // DecRef implements IngestData.DecRef.
 func (m *MemoryIngestData) DecRef() {
 	if m.refCnt.Dec() == 0 {
-		m.keys = nil
-		m.values = nil
+		m.kvs = nil
 		for _, b := range m.memBuf {
 			b.Destroy()
 		}
@@ -814,5 +800,4 @@ func (m *MemoryIngestData) DecRef() {
 func (m *MemoryIngestData) Finish(totalBytes, totalCount int64) {
 	m.importedKVSize.Add(totalBytes)
 	m.importedKVCount.Add(totalCount)
-
 }

--- a/pkg/lightning/backend/external/engine_test.go
+++ b/pkg/lightning/backend/external/engine_test.go
@@ -44,64 +44,48 @@ func testNewIter(
 	t *testing.T,
 	data common.IngestData,
 	lowerBound, upperBound []byte,
-	expectedKeys, expectedValues [][]byte,
+	expectedKVs []kvPair,
 	bufPool *membuf.Pool,
 ) {
 	ctx := context.Background()
 	iter := data.NewIter(ctx, lowerBound, upperBound, bufPool)
-	var (
-		keys, values [][]byte
-	)
+	var kvs []kvPair
 	for iter.First(); iter.Valid(); iter.Next() {
 		require.NoError(t, iter.Error())
-		keys = append(keys, iter.Key())
-		values = append(values, iter.Value())
+		kvs = append(kvs, kvPair{key: iter.Key(), value: iter.Value()})
 	}
 	require.NoError(t, iter.Error())
 	require.NoError(t, iter.Close())
-	require.Equal(t, expectedKeys, keys)
-	require.Equal(t, expectedValues, values)
+	require.Equal(t, expectedKVs, kvs)
 }
 
-func checkDupDB(t *testing.T, db *pebble.DB, expectedKeys, expectedValues [][]byte) {
+func checkDupDB(t *testing.T, db *pebble.DB, expectedKVs []kvPair) {
 	iter, _ := db.NewIter(nil)
-	var (
-		gotKeys, gotValues [][]byte
-	)
+	var gotKVs []kvPair
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := make([]byte, len(iter.Key()))
 		copy(key, iter.Key())
-		gotKeys = append(gotKeys, key)
 		value := make([]byte, len(iter.Value()))
 		copy(value, iter.Value())
-		gotValues = append(gotValues, value)
+		gotKVs = append(gotKVs, kvPair{key: key, value: value})
 	}
 	require.NoError(t, iter.Close())
-	require.Equal(t, expectedKeys, gotKeys)
-	require.Equal(t, expectedValues, gotValues)
+	require.Equal(t, expectedKVs, gotKVs)
 	err := db.DeleteRange([]byte{0}, []byte{255}, nil)
 	require.NoError(t, err)
 }
 
 func TestMemoryIngestData(t *testing.T) {
-	keys := [][]byte{
-		[]byte("key1"),
-		[]byte("key2"),
-		[]byte("key3"),
-		[]byte("key4"),
-		[]byte("key5"),
-	}
-	values := [][]byte{
-		[]byte("value1"),
-		[]byte("value2"),
-		[]byte("value3"),
-		[]byte("value4"),
-		[]byte("value5"),
+	kvs := []kvPair{
+		{key: []byte("key1"), value: []byte("value1")},
+		{key: []byte("key2"), value: []byte("value2")},
+		{key: []byte("key3"), value: []byte("value3")},
+		{key: []byte("key4"), value: []byte("value4")},
+		{key: []byte("key5"), value: []byte("value5")},
 	}
 	data := &MemoryIngestData{
 		keyAdapter: common.NoopKeyAdapter{},
-		keys:       keys,
-		values:     values,
+		kvs:        kvs,
 		ts:         123,
 	}
 
@@ -115,13 +99,13 @@ func TestMemoryIngestData(t *testing.T) {
 	testGetFirstAndLastKey(t, data, []byte("key6"), []byte("key9"), nil, nil)
 
 	// MemoryIngestData without duplicate detection feature does not need pool
-	testNewIter(t, data, nil, nil, keys, values, nil)
-	testNewIter(t, data, []byte("key1"), []byte("key6"), keys, values, nil)
-	testNewIter(t, data, []byte("key2"), []byte("key5"), keys[1:4], values[1:4], nil)
-	testNewIter(t, data, []byte("key25"), []byte("key35"), keys[2:3], values[2:3], nil)
-	testNewIter(t, data, []byte("key25"), []byte("key26"), nil, nil, nil)
-	testNewIter(t, data, []byte("key0"), []byte("key1"), nil, nil, nil)
-	testNewIter(t, data, []byte("key6"), []byte("key9"), nil, nil, nil)
+	testNewIter(t, data, nil, nil, kvs, nil)
+	testNewIter(t, data, []byte("key1"), []byte("key6"), kvs, nil)
+	testNewIter(t, data, []byte("key2"), []byte("key5"), kvs[1:4], nil)
+	testNewIter(t, data, []byte("key25"), []byte("key35"), kvs[2:3], nil)
+	testNewIter(t, data, []byte("key25"), []byte("key26"), nil, nil)
+	testNewIter(t, data, []byte("key0"), []byte("key1"), nil, nil)
+	testNewIter(t, data, []byte("key6"), []byte("key9"), nil, nil)
 
 	dir := t.TempDir()
 	db, err := pebble.Open(path.Join(dir, "duplicate"), nil)
@@ -133,36 +117,29 @@ func TestMemoryIngestData(t *testing.T) {
 		duplicateDB:        db,
 		ts:                 234,
 	}
-	encodedKeys := make([][]byte, 0, len(keys)*2)
-	encodedValues := make([][]byte, 0, len(values)*2)
+	encodedKVs := make([]kvPair, 0, len(kvs)*2)
 	encodedZero := codec.EncodeInt(nil, 0)
 	encodedOne := codec.EncodeInt(nil, 1)
-	duplicatedKeys := make([][]byte, 0, len(keys)*2)
-	duplicatedValues := make([][]byte, 0, len(values)*2)
+	duplicatedKVs := make([]kvPair, 0, len(kvs)*2)
 
-	for i := range keys {
-		encodedKey := keyAdapter.Encode(nil, keys[i], encodedZero)
-		encodedKeys = append(encodedKeys, encodedKey)
-		encodedValues = append(encodedValues, values[i])
+	for i := range kvs {
+		encodedKey := keyAdapter.Encode(nil, kvs[i].key, encodedZero)
+		encodedKVs = append(encodedKVs, kvPair{key: encodedKey, value: kvs[i].value})
 		if i%2 == 0 {
 			continue
 		}
 
 		// duplicatedKeys will be like key2_0, key2_1, key4_0, key4_1
-		duplicatedKeys = append(duplicatedKeys, encodedKey)
-		duplicatedValues = append(duplicatedValues, values[i])
+		duplicatedKVs = append(duplicatedKVs, kvPair{key: encodedKey, value: kvs[i].value})
 
-		encodedKey = keyAdapter.Encode(nil, keys[i], encodedOne)
-		encodedKeys = append(encodedKeys, encodedKey)
-		newValues := make([]byte, len(values[i])+1)
-		copy(newValues, values[i])
-		newValues[len(values[i])] = 1
-		encodedValues = append(encodedValues, newValues)
-		duplicatedKeys = append(duplicatedKeys, encodedKey)
-		duplicatedValues = append(duplicatedValues, newValues)
+		encodedKey = keyAdapter.Encode(nil, kvs[i].key, encodedOne)
+		newValues := make([]byte, len(kvs[i].value)+1)
+		copy(newValues, kvs[i].value)
+		newValues[len(kvs[i].value)] = 1
+		encodedKVs = append(encodedKVs, kvPair{key: encodedKey, value: newValues})
+		duplicatedKVs = append(duplicatedKVs, kvPair{key: encodedKey, value: newValues})
 	}
-	data.keys = encodedKeys
-	data.values = encodedValues
+	data.kvs = encodedKVs
 
 	require.EqualValues(t, 234, data.GetTS())
 	testGetFirstAndLastKey(t, data, nil, nil, []byte("key1"), []byte("key5"))
@@ -175,22 +152,22 @@ func TestMemoryIngestData(t *testing.T) {
 
 	pool := membuf.NewPool()
 	defer pool.Destroy()
-	testNewIter(t, data, nil, nil, keys, values, pool)
-	checkDupDB(t, db, duplicatedKeys, duplicatedValues)
-	testNewIter(t, data, []byte("key1"), []byte("key6"), keys, values, pool)
-	checkDupDB(t, db, duplicatedKeys, duplicatedValues)
-	testNewIter(t, data, []byte("key1"), []byte("key3"), keys[:2], values[:2], pool)
-	checkDupDB(t, db, duplicatedKeys[:2], duplicatedValues[:2])
-	testNewIter(t, data, []byte("key2"), []byte("key5"), keys[1:4], values[1:4], pool)
-	checkDupDB(t, db, duplicatedKeys, duplicatedValues)
-	testNewIter(t, data, []byte("key25"), []byte("key35"), keys[2:3], values[2:3], pool)
-	checkDupDB(t, db, nil, nil)
-	testNewIter(t, data, []byte("key25"), []byte("key26"), nil, nil, pool)
-	checkDupDB(t, db, nil, nil)
-	testNewIter(t, data, []byte("key0"), []byte("key1"), nil, nil, pool)
-	checkDupDB(t, db, nil, nil)
-	testNewIter(t, data, []byte("key6"), []byte("key9"), nil, nil, pool)
-	checkDupDB(t, db, nil, nil)
+	testNewIter(t, data, nil, nil, kvs, pool)
+	checkDupDB(t, db, duplicatedKVs)
+	testNewIter(t, data, []byte("key1"), []byte("key6"), kvs, pool)
+	checkDupDB(t, db, duplicatedKVs)
+	testNewIter(t, data, []byte("key1"), []byte("key3"), kvs[:2], pool)
+	checkDupDB(t, db, duplicatedKVs[:2])
+	testNewIter(t, data, []byte("key2"), []byte("key5"), kvs[1:4], pool)
+	checkDupDB(t, db, duplicatedKVs)
+	testNewIter(t, data, []byte("key25"), []byte("key35"), kvs[2:3], pool)
+	checkDupDB(t, db, nil)
+	testNewIter(t, data, []byte("key25"), []byte("key26"), nil, pool)
+	checkDupDB(t, db, nil)
+	testNewIter(t, data, []byte("key0"), []byte("key1"), nil, pool)
+	checkDupDB(t, db, nil)
+	testNewIter(t, data, []byte("key6"), []byte("key9"), nil, pool)
+	checkDupDB(t, db, nil)
 }
 
 func TestSplit(t *testing.T) {

--- a/pkg/lightning/backend/external/file.go
+++ b/pkg/lightning/backend/external/file.go
@@ -40,13 +40,13 @@ func NewKeyValueStore(
 	ctx context.Context,
 	dataWriter storage.ExternalFileWriter,
 	rangePropertiesCollector *rangePropertiesCollector,
-) (*KeyValueStore, error) {
+) *KeyValueStore {
 	kvStore := &KeyValueStore{
 		dataWriter: dataWriter,
 		ctx:        ctx,
 		rc:         rangePropertiesCollector,
 	}
-	return kvStore, nil
+	return kvStore
 }
 
 // addEncodedData saves encoded key-value pairs to the KeyValueStore.

--- a/pkg/lightning/backend/external/file_test.go
+++ b/pkg/lightning/backend/external/file_test.go
@@ -46,8 +46,7 @@ func TestAddKeyValueMaintainRangeProperty(t *testing.T) {
 	}
 	rc.reset()
 	initRC := *rc
-	kvStore, err := NewKeyValueStore(ctx, writer, rc)
-	require.NoError(t, err)
+	kvStore := NewKeyValueStore(ctx, writer, rc)
 
 	require.Equal(t, &initRC, rc)
 	encoded := rc.encode()
@@ -101,8 +100,7 @@ func TestAddKeyValueMaintainRangeProperty(t *testing.T) {
 		propKeysDist: 100,
 	}
 	rc.reset()
-	kvStore, err = NewKeyValueStore(ctx, writer, rc)
-	require.NoError(t, err)
+	kvStore = NewKeyValueStore(ctx, writer, rc)
 	err = kvStore.addEncodedData(getEncodedData(k1, v1))
 	require.NoError(t, err)
 	require.Len(t, rc.props, 1)
@@ -146,8 +144,7 @@ func TestKVReadWrite(t *testing.T) {
 		propKeysDist: 2,
 	}
 	rc.reset()
-	kvStore, err := NewKeyValueStore(ctx, writer, rc)
-	require.NoError(t, err)
+	kvStore := NewKeyValueStore(ctx, writer, rc)
 
 	kvCnt := rand.Intn(10) + 10
 	keys := make([][]byte, kvCnt)

--- a/pkg/lightning/backend/external/iter_test.go
+++ b/pkg/lightning/backend/external/iter_test.go
@@ -77,8 +77,7 @@ func TestMergeKVIter(t *testing.T) {
 			propKeysDist: 2,
 		}
 		rc.reset()
-		kvStore, err := NewKeyValueStore(ctx, writer, rc)
-		require.NoError(t, err)
+		kvStore := NewKeyValueStore(ctx, writer, rc)
 		for _, kv := range data[i] {
 			err = kvStore.addEncodedData(getEncodedData([]byte(kv[0]), []byte(kv[1])))
 			require.NoError(t, err)
@@ -130,8 +129,7 @@ func TestOneUpstream(t *testing.T) {
 			propKeysDist: 2,
 		}
 		rc.reset()
-		kvStore, err := NewKeyValueStore(ctx, writer, rc)
-		require.NoError(t, err)
+		kvStore := NewKeyValueStore(ctx, writer, rc)
 		for _, kv := range data[i] {
 			err = kvStore.addEncodedData(getEncodedData([]byte(kv[0]), []byte(kv[1])))
 			require.NoError(t, err)
@@ -209,8 +207,7 @@ func TestCorruptContent(t *testing.T) {
 			propKeysDist: 2,
 		}
 		rc.reset()
-		kvStore, err := NewKeyValueStore(ctx, writer, rc)
-		require.NoError(t, err)
+		kvStore := NewKeyValueStore(ctx, writer, rc)
 		for _, kv := range data[i] {
 			err = kvStore.addEncodedData(getEncodedData([]byte(kv[0]), []byte(kv[1])))
 			require.NoError(t, err)
@@ -378,8 +375,7 @@ func TestHotspot(t *testing.T) {
 			propKeysDist: 2,
 		}
 		rc.reset()
-		kvStore, err := NewKeyValueStore(ctx, writer, rc)
-		require.NoError(t, err)
+		kvStore := NewKeyValueStore(ctx, writer, rc)
 		for _, k := range keys[i] {
 			err = kvStore.addEncodedData(getEncodedData([]byte(k), value))
 			require.NoError(t, err)
@@ -474,8 +470,7 @@ func TestMemoryUsageWhenHotspotChange(t *testing.T) {
 			propKeysDist: 2,
 		}
 		rc.reset()
-		kvStore, err := NewKeyValueStore(ctx, writer, rc)
-		require.NoError(t, err)
+		kvStore := NewKeyValueStore(ctx, writer, rc)
 		for j := 0; j < 1000; j++ {
 			key := fmt.Sprintf("key%06d", cur)
 			val := fmt.Sprintf("value%06d", cur)

--- a/pkg/lightning/backend/external/merge_v2.go
+++ b/pkg/lightning/backend/external/merge_v2.go
@@ -145,11 +145,10 @@ func MergeOverlappingFilesV2(
 		readTime := time.Since(now)
 		now = time.Now()
 		sorty.MaxGor = uint64(concurrency)
-		sorty.Sort(len(loaded.keys), func(i, k, r, s int) bool {
-			if bytes.Compare(loaded.keys[i], loaded.keys[k]) < 0 { // strict comparator like < or >
+		sorty.Sort(len(loaded.kvs), func(i, k, r, s int) bool {
+			if bytes.Compare(loaded.kvs[i].key, loaded.kvs[k].key) < 0 { // strict comparator like < or >
 				if r != s {
-					loaded.keys[r], loaded.keys[s] = loaded.keys[s], loaded.keys[r]
-					loaded.values[r], loaded.values[s] = loaded.values[s], loaded.values[r]
+					loaded.kvs[r], loaded.kvs[s] = loaded.kvs[s], loaded.kvs[r]
 				}
 				return true
 			}
@@ -157,8 +156,8 @@ func MergeOverlappingFilesV2(
 		})
 		sortTime := time.Since(now)
 		now = time.Now()
-		for i, key := range loaded.keys {
-			err1 = writer.WriteRow(ctx, key, loaded.values[i])
+		for _, kv := range loaded.kvs {
+			err1 = writer.WriteRow(ctx, kv.key, kv.value)
 			if err1 != nil {
 				logutil.Logger(ctx).Warn("write one row to writer failed", zap.Error(err1))
 				return
@@ -169,11 +168,10 @@ func MergeOverlappingFilesV2(
 			zap.Duration("read time", readTime),
 			zap.Duration("sort time", sortTime),
 			zap.Duration("write time", writeTime),
-			zap.Int("key len", len(loaded.keys)))
+			zap.Int("key len", len(loaded.kvs)))
 
 		curStart = curEnd.Clone()
-		loaded.keys = nil
-		loaded.values = nil
+		loaded.kvs = nil
 		loaded.memKVBuffers = nil
 		loaded.size = 0
 

--- a/pkg/lightning/backend/external/onefile_writer.go
+++ b/pkg/lightning/backend/external/onefile_writer.go
@@ -95,8 +95,8 @@ func (w *OneFileWriter) Init(ctx context.Context, partSize int64) (err error) {
 	if err != nil {
 		return err
 	}
-	w.kvStore, err = NewKeyValueStore(ctx, w.dataWriter, w.rc)
-	return err
+	w.kvStore = NewKeyValueStore(ctx, w.dataWriter, w.rc)
+	return nil
 }
 
 // WriteRow implements ingest.Writer.

--- a/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/pkg/lightning/backend/external/onefile_writer_test.go
@@ -215,8 +215,7 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 		true,
 	))
 
-	keys := make([][]byte, 0, kvCount)
-	values := make([][]byte, 0, kvCount)
+	kvs := make([]kvPair, 0, kvCount)
 
 	kvReader, err := newKVReader(ctx, "/test2/mergeID/one-file", memStore, 0, 100)
 	require.NoError(t, err)
@@ -227,8 +226,7 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 		copy(clonedKey, key)
 		clonedVal := make([]byte, len(value))
 		copy(clonedVal, value)
-		keys = append(keys, clonedKey)
-		values = append(values, clonedVal)
+		kvs = append(kvs, kvPair{key: clonedKey, value: clonedVal})
 	}
 	_, _, err = kvReader.nextKV()
 	require.ErrorIs(t, err, io.EOF)
@@ -243,8 +241,7 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 		duplicateDetection: true,
 		duplicateDB:        db,
 		dupDetectOpt:       common.DupDetectOpt{ReportErrOnDup: true},
-		keys:               keys,
-		values:             values,
+		kvs:                kvs,
 		ts:                 123,
 	}
 	pool := membuf.NewPool()

--- a/pkg/lightning/backend/external/reader.go
+++ b/pkg/lightning/backend/external/reader.go
@@ -50,8 +50,7 @@ func readAllData(
 	)
 	defer func() {
 		if err != nil {
-			output.keysPerFile = nil
-			output.valuesPerFile = nil
+			output.kvsPerFile = nil
 			for _, b := range output.memKVBuffers {
 				b.Destroy()
 			}
@@ -161,8 +160,7 @@ func readOneFile(
 		}
 	}
 
-	keys := make([][]byte, 0, 1024)
-	values := make([][]byte, 0, 1024)
+	kvs := make([]kvPair, 0, 1024)
 	size := 0
 	droppedSize := 0
 
@@ -183,14 +181,12 @@ func readOneFile(
 		}
 		// TODO(lance6716): we are copying every KV from rd's buffer to memBuf, can we
 		// directly read into memBuf?
-		keys = append(keys, smallBlockBuf.AddBytes(k))
-		values = append(values, smallBlockBuf.AddBytes(v))
+		kvs = append(kvs, kvPair{key: smallBlockBuf.AddBytes(k), value: smallBlockBuf.AddBytes(v)})
 		size += len(k) + len(v)
 	}
 	readAndSortDurHist.Observe(time.Since(ts).Seconds())
 	output.mu.Lock()
-	output.keysPerFile = append(output.keysPerFile, keys)
-	output.valuesPerFile = append(output.valuesPerFile, values)
+	output.kvsPerFile = append(output.kvsPerFile, kvs)
 	output.size += size
 	output.droppedSizePerFile = append(output.droppedSizePerFile, droppedSize)
 	output.mu.Unlock()

--- a/pkg/lightning/backend/external/reader_test.go
+++ b/pkg/lightning/backend/external/reader_test.go
@@ -154,6 +154,6 @@ func TestReadLargeFile(t *testing.T) {
 	err = readAllData(ctx, memStore, datas, stats, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
 	require.NoError(t, err)
 	output.build(ctx)
-	require.Equal(t, startKey, output.keys[0])
-	require.Equal(t, maxKey, output.keys[len(output.keys)-1])
+	require.Equal(t, startKey, output.kvs[0].key)
+	require.Equal(t, maxKey, output.kvs[len(output.kvs)-1].key)
 }

--- a/pkg/lightning/backend/external/testutil.go
+++ b/pkg/lightning/backend/external/testutil.go
@@ -88,26 +88,24 @@ func testReadAndCompare(
 
 		// check kvs sorted
 		sorty.MaxGor = uint64(8)
-		sorty.Sort(len(loaded.keys), func(i, k, r, s int) bool {
-			if bytes.Compare(loaded.keys[i], loaded.keys[k]) < 0 { // strict comparator like < or >
+		sorty.Sort(len(loaded.kvs), func(i, k, r, s int) bool {
+			if bytes.Compare(loaded.kvs[i].key, loaded.kvs[k].key) < 0 { // strict comparator like < or >
 				if r != s {
-					loaded.keys[r], loaded.keys[s] = loaded.keys[s], loaded.keys[r]
-					loaded.values[r], loaded.values[s] = loaded.values[s], loaded.values[r]
+					loaded.kvs[r], loaded.kvs[s] = loaded.kvs[s], loaded.kvs[r]
 				}
 				return true
 			}
 			return false
 		})
-		for i, key := range loaded.keys {
-			require.EqualValues(t, kvs[kvIdx].Key, key)
-			require.EqualValues(t, kvs[kvIdx].Val, loaded.values[i])
+		for _, kv := range loaded.kvs {
+			require.EqualValues(t, kvs[kvIdx].Key, kv.key)
+			require.EqualValues(t, kvs[kvIdx].Val, kv.value)
 			kvIdx++
 		}
 		curStart = curEnd.Clone()
 
 		// release
-		loaded.keys = nil
-		loaded.values = nil
+		loaded.kvs = nil
 		loaded.memKVBuffers = nil
 
 		if len(endKeyOfGroup) == 0 {

--- a/pkg/lightning/backend/external/writer.go
+++ b/pkg/lightning/backend/external/writer.go
@@ -536,10 +536,7 @@ func (w *Writer) flushSortedKVs(ctx context.Context) (string, string, error) {
 		}
 	}()
 	w.rc.reset()
-	kvStore, err := NewKeyValueStore(ctx, dataWriter, w.rc)
-	if err != nil {
-		return "", "", err
-	}
+	kvStore := NewKeyValueStore(ctx, dataWriter, w.rc)
 
 	for _, pair := range w.kvLocations {
 		err = kvStore.addEncodedData(w.kvBuffer.GetSlice(pair))

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -254,8 +254,7 @@ func TestWriterDuplicateDetect(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	keys := make([][]byte, 0, kvCount)
-	values := make([][]byte, 0, kvCount)
+	kvs := make([]kvPair, 0, kvCount)
 
 	kvReader, err := newKVReader(ctx, "/test2/mergeID/0", memStore, 0, 100)
 	require.NoError(t, err)
@@ -266,8 +265,7 @@ func TestWriterDuplicateDetect(t *testing.T) {
 		copy(clonedKey, key)
 		clonedVal := make([]byte, len(value))
 		copy(clonedVal, value)
-		keys = append(keys, clonedKey)
-		values = append(values, clonedVal)
+		kvs = append(kvs, kvPair{key: clonedKey, value: clonedVal})
 	}
 	_, _, err = kvReader.nextKV()
 	require.ErrorIs(t, err, io.EOF)
@@ -282,8 +280,7 @@ func TestWriterDuplicateDetect(t *testing.T) {
 		duplicateDetection: true,
 		duplicateDB:        db,
 		dupDetectOpt:       common.DupDetectOpt{ReportErrOnDup: true},
-		keys:               keys,
-		values:             values,
+		kvs:                kvs,
 		ts:                 123,
 	}
 	pool := membuf.NewPool()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #48779

Problem Summary:

### What changed and how does it work?
replace key and value slice with kvPair, refactor KV store

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
