### PR TITLE
util: fix typo in `DestroyParser` function name

### DIFF
--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -211,7 +211,7 @@ func getBindingPlanDigest(sctx sessionctx.Context, schema, bindingSQL string) (p
 	vars.CurrentDB = schema
 
 	p := utilparser.GetParser()
-	defer utilparser.DestoryParser(p)
+	defer utilparser.DestroyParser(p)
 	p.SetSQLMode(vars.SQLMode)
 	p.SetParserConfig(vars.BuildParserConfig())
 

--- a/pkg/planner/core/plan_cache_param.go
+++ b/pkg/planner/core/plan_cache_param.go
@@ -190,7 +190,7 @@ func Params2Expressions(params []types.Datum) []expression.Expression {
 func ParseParameterizedSQL(sctx sessionctx.Context, paramSQL string) (ast.StmtNode, error) {
 	p := parserutil.GetParser()
 	defer func() {
-		parserutil.DestoryParser(p)
+		parserutil.DestroyParser(p)
 	}()
 	p.SetSQLMode(sctx.GetSessionVars().SQLMode)
 	p.SetParserConfig(sctx.GetSessionVars().BuildParserConfig())

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1391,7 +1391,7 @@ func (s *session) ParseSQL(ctx context.Context, sql string, params ...parser.Par
 	defer tracing.StartRegion(ctx, "ParseSQL").End()
 	p := parserutil.GetParser()
 	defer func() {
-		parserutil.DestoryParser(p)
+		parserutil.DestroyParser(p)
 	}()
 
 	sqlMode := s.sessionVars.SQLMode

--- a/pkg/util/generatedexpr/generated_expr.go
+++ b/pkg/util/generatedexpr/generated_expr.go
@@ -63,7 +63,7 @@ func ParseExpression(expr string) (node ast.ExprNode, err error) {
 	charset, collation := charset.GetDefaultCharsetAndCollate()
 	parse := parserutil.GetParser()
 	defer func() {
-		parserutil.DestoryParser(parse)
+		parserutil.DestroyParser(parse)
 	}()
 	stmts, _, err := parse.ParseSQL(expr,
 		parser.CharsetConnection(charset),

--- a/pkg/util/parser/parser.go
+++ b/pkg/util/parser/parser.go
@@ -36,8 +36,8 @@ func GetParser() *parser.Parser {
 	return pool.Get().(*parser.Parser)
 }
 
-// DestoryParser resets the parser and puts it back to the pool
-func DestoryParser(p *parser.Parser) {
+// DestroyParser resets the parser and puts it back to the pool
+func DestroyParser(p *parser.Parser) {
 	p.Reset()
 	pool.Put(p)
 }


### PR DESCRIPTION
### What problem does this PR solve?
Simple fix to rename `DestoryParser` to `DestroyParser` in the util package.

Issue Number: close #60493

Problem Summary: fix typo

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
