### PR TITLE
globalsort: encode keyspace when writing to external storage

### DIFF
--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -395,6 +395,7 @@ func (r *readIndexStepExecutor) buildExternalStorePipeline(
 		concurrency,
 		r.GetResource(),
 		rowCntListener,
+		r.backend.GetTiKVCodec(),
 	)
 }
 

--- a/pkg/disttask/importinto/encode_and_sort_operator.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator.go
@@ -166,7 +166,8 @@ func newChunkWorker(ctx context.Context, op *encodeAndSortOperator, dataKVMemSiz
 					op.sharedVars.mergeIndexSummary(indexID, summary)
 				}).
 				SetMemorySizeLimit(perIndexKVMemSizePerCon).
-				SetBlockSize(indexBlockSize)
+				SetBlockSize(indexBlockSize).
+				SetTiKVCodec(op.tableImporter.Backend().GetTiKVCodec())
 			prefix := subtaskPrefix(op.taskID, op.subtaskID)
 			// writer id for index: index/{indexID}/{workerID}
 			writerID := path.Join("index", strconv.Itoa(int(indexID)), workerUUID)
@@ -178,7 +179,8 @@ func newChunkWorker(ctx context.Context, op *encodeAndSortOperator, dataKVMemSiz
 		builder := external.NewWriterBuilder().
 			SetOnCloseFunc(op.sharedVars.mergeDataSummary).
 			SetMemorySizeLimit(dataKVMemSizePerCon).
-			SetBlockSize(getKVGroupBlockSize(dataKVGroup))
+			SetBlockSize(getKVGroupBlockSize(dataKVGroup)).
+			SetTiKVCodec(op.tableImporter.Backend().GetTiKVCodec())
 		prefix := subtaskPrefix(op.taskID, op.subtaskID)
 		// writer id for data: data/{workerID}
 		writerID := path.Join("data", workerUUID)

--- a/pkg/lightning/backend/external/BUILD.bazel
+++ b/pkg/lightning/backend/external/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
+        "@com_github_tikv_client_go_v2//tikv",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",

--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -525,7 +525,7 @@ func (e *Engine) GetRegionSplitKeys() ([][]byte, error) {
 // When duplicate detection feature is enabled, the **end key** comes from
 // DupDetectKeyAdapter.Encode or Key.Next(). We try to decode it and check the
 // error.
-func (e Engine) tryDecodeEndKey(key []byte) (decoded []byte, err error) {
+func (e *Engine) tryDecodeEndKey(key []byte) (decoded []byte, err error) {
 	decoded, err = e.keyAdapter.Decode(nil, key)
 	if err == nil {
 		return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/60418
Problem Summary:

### What changed and how does it work?
encode keyspace when writing to external storage
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tiup playground:nightly nightly --mode=tidb-cse \
  --db.binpath /DATA/disk1/gmhdbjd/code/tidb/bin/tidb-server --db.config /DATA/disk1/gmhdbjd/environment/cse/tidb.toml \
  --kv.binpath /DATA/disk1/gmhdbjd/code/cloud-storage-engine/target/debug/tikv-server \
  --tiflash 0
mysql> use test;
Database changed
mysql> create table t(id int);
Query OK, 0 rows affected (0.07 sec)

mysql> SET GLOBAL tidb_cloud_storage_uri = 's3://sort?access-key=minioadmin&secret-access-ke
y=minioadmin&endpoint=http://10.2.4.3:9000';
Query OK, 0 rows affected (0.02 sec)

mysql> IMPORT INTO t FROM 's3://data/test.csv?access-key=minioadmin&secret-access-key=minioa
dmin&endpoint=http://10.2.4.3:9000';
+--------+-----------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
| Job_ID | Data_Source                                                                                         | Target_Table | Table_ID | Phase | Status   | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time                   | Created_By |
+--------+-----------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
|      1 | s3://data/test.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F10.2.4.3%3A9000&secret-access-key=xxxxxx | `test`.`t`   |      112 |       | finished | 2B               |             1 |                | 2025-04-11 15:50:45.215654 | 2025-04-11 15:50:45.739379 | 2025-04-11 15:50:48.243171 | root@%     |
+--------+-----------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
1 row in set (3.35 sec)

mysql> alter table t add index idx1(id);
Query OK, 0 rows affected (2.34 sec)

mysql> admin check table t;
Query OK, 0 rows affected (0.00 sec)
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
