### PR TITLE
planner: fix bug in `PhysicalExchangeSender::ResolveIndicesItself`

### DIFF
--- a/pkg/planner/core/physical_plan_test.go
+++ b/pkg/planner/core/physical_plan_test.go
@@ -600,3 +600,36 @@ func TestAvoidColumnEvaluatorForProjBelowUnion(t *testing.T) {
 		checkResult(sql)
 	}
 }
+
+func TestExchangeSenderResolveIndices(t *testing.T) {
+	schemaCols1 := make([]*expression.Column, 0, 4)
+	schemaCols1 = append(schemaCols1, &expression.Column{UniqueID: 1})
+	schemaCols1 = append(schemaCols1, &expression.Column{UniqueID: 2})
+	schemaCols1 = append(schemaCols1, &expression.Column{UniqueID: 3})
+	schemaCols1 = append(schemaCols1, &expression.Column{UniqueID: 4})
+	schema1 := expression.NewSchema(schemaCols1...)
+
+	schemaCols2 := make([]*expression.Column, 0, 2)
+	schemaCols2 = append(schemaCols2, &expression.Column{UniqueID: 3})
+	schemaCols2 = append(schemaCols2, &expression.Column{UniqueID: 4})
+	schema2 := expression.NewSchema(schemaCols2...)
+
+	partitionCol1 := &property.MPPPartitionColumn{Col: &expression.Column{UniqueID: 4}}
+
+	// two exchange sender share the same MPPPartitionColumn
+	exchangeSender1 := &core.PhysicalExchangeSender{
+		HashCols: []*property.MPPPartitionColumn{partitionCol1},
+	}
+	exchangeSender2 := &core.PhysicalExchangeSender{
+		HashCols: []*property.MPPPartitionColumn{partitionCol1},
+	}
+
+	err := exchangeSender1.ResolveIndicesItselfWithSchema(schema1)
+	require.NoError(t, err)
+
+	err = exchangeSender2.ResolveIndicesItselfWithSchema(schema2)
+	require.NoError(t, err)
+
+	// after resolving, the partition col in two different exchange sender should have different index
+	require.NotEqual(t, exchangeSender1.HashCols[0].Col.Index, exchangeSender2.HashCols[0].Col.Index)
+}

--- a/pkg/planner/core/resolve_indices.go
+++ b/pkg/planner/core/resolve_indices.go
@@ -507,12 +507,17 @@ func (p *PhysicalSelection) ResolveIndices() (err error) {
 
 // ResolveIndicesItself resolve indices for PhysicalPlan itself
 func (p *PhysicalExchangeSender) ResolveIndicesItself() (err error) {
-	for i, col := range p.HashCols {
-		colExpr, err1 := col.Col.ResolveIndices(p.Children()[0].Schema())
-		if err1 != nil {
-			return err1
+	return p.ResolveIndicesItselfWithSchema(p.Children()[0].Schema())
+}
+
+// ResolveIndicesItselfWithSchema is added for test usage
+func (p *PhysicalExchangeSender) ResolveIndicesItselfWithSchema(inputSchema *expression.Schema) (err error) {
+	for i, hashCol := range p.HashCols {
+		newHashCol, err := hashCol.ResolveIndices(inputSchema)
+		if err != nil {
+			return err
 		}
-		p.HashCols[i].Col, _ = colExpr.(*expression.Column)
+		p.HashCols[i] = newHashCol
 	}
 	return
 }

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -122,6 +122,18 @@ type MPPPartitionColumn struct {
 	CollateID int32
 }
 
+func (partitionCol *MPPPartitionColumn) ResolveIndices(schema *expression.Schema) (*MPPPartitionColumn, error) {
+	newColExpr, err := partitionCol.Col.ResolveIndices(schema)
+	if err != nil {
+		return nil, err
+	}
+	newCol, _ := newColExpr.(*expression.Column)
+	return &MPPPartitionColumn{
+		Col:       newCol,
+		CollateID: partitionCol.CollateID,
+	}, nil
+}
+
 // Clone makes a copy of MPPPartitionColumn.
 func (partitionCol *MPPPartitionColumn) Clone() *MPPPartitionColumn {
 	return &MPPPartitionColumn{

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -122,6 +122,7 @@ type MPPPartitionColumn struct {
 	CollateID int32
 }
 
+// ResolveIndices resolve index for MPPPartitionColumn
 func (partitionCol *MPPPartitionColumn) ResolveIndices(schema *expression.Schema) (*MPPPartitionColumn, error) {
 	newColExpr, err := partitionCol.Col.ResolveIndices(schema)
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60517

Problem Summary:
Described in #60517
### What changed and how does it work?
Use deep copy instead of shallow copy in `PhysicalExchangeSender::ResolveIndicesItself`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that will cause TiFlash crash or return wrong query result
```
