### PR TITLE
grafana: fix the connection count panel in "tidb" page

### DIFF
--- a/pkg/metrics/grafana/overview.json
+++ b/pkg/metrics/grafana/overview.json
@@ -2308,7 +2308,7 @@
               "expr": "tidb_server_connections{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{instance}} {{resource_group}}",
               "refId": "A",
               "step": 10
             },

--- a/pkg/metrics/grafana/performance_overview.json
+++ b/pkg/metrics/grafana/performance_overview.json
@@ -2211,7 +2211,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{instance}} {{resource_group}}",
               "refId": "A",
               "step": 30
             },

--- a/pkg/metrics/grafana/tidb.json
+++ b/pkg/metrics/grafana/tidb.json
@@ -2919,7 +2919,7 @@
               "expr": "tidb_server_connections{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
+              "legendFormat": "{{instance}} {{resource_group}}",
               "refId": "A",
               "step": 40
             },


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #60535

Problem Summary:

Previously, the connection count panel doesn't have resource group name:
![image](https://github.com/user-attachments/assets/2fb3c0f1-6b6f-4aa4-bc85-4f9a8c1edbb0)

After this PR, it should have a resource group name:
![image](https://github.com/user-attachments/assets/4a656db3-197c-4497-b8a8-abf01765bbd7)

### What changed and how does it work?

Apply a similar change to https://github.com/pingcap/tidb/pull/51996. In https://github.com/pingcap/tidb/pull/51996 I forgot to modify the "tidb" page :facepalm: .

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Modify the grafana configuration, and you'll see the result.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
