### PR TITLE
compacted log restore: solve the race of rule.

### DIFF
--- a/br/pkg/restore/snap_client/import.go
+++ b/br/pkg/restore/snap_client/import.go
@@ -585,10 +585,6 @@ func (importer *SnapFileImporter) buildDownloadRequest(
 	regionInfo *split.RegionInfo,
 	cipher *backuppb.CipherInfo,
 ) (*import_sstpb.DownloadRequest, import_sstpb.SSTMeta, error) {
-	err := rewriteRules.SetTimeRangeFilter(file.Cf)
-	if err != nil {
-		return nil, import_sstpb.SSTMeta{}, err
-	}
 	// Get the rewrite rule for the file.
 	fileRule := restoreutils.FindMatchedRewriteRule(file, rewriteRules)
 	if fileRule == nil {
@@ -614,6 +610,11 @@ func (importer *SnapFileImporter) buildDownloadRequest(
 
 	// for the keyspace rewrite mode
 	rule := *fileRule
+
+	err := restoreutils.SetTimeRangeFilter(rewriteRules, &rule, file.Cf)
+	if err != nil {
+		return nil, import_sstpb.SSTMeta{}, err
+	}
 	// for the legacy rewrite mode
 	if importer.rewriteMode == RewriteModeLegacy {
 		rule.OldKeyPrefix = restoreutils.EncodeKeyPrefix(fileRule.GetOldKeyPrefix())

--- a/br/pkg/restore/utils/BUILD.bazel
+++ b/br/pkg/restore/utils/BUILD.bazel
@@ -35,7 +35,7 @@ go_test(
         "rewrite_rule_test.go",
     ],
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         ":utils",
         "//br/pkg/conn",

--- a/br/pkg/restore/utils/rewrite_rule.go
+++ b/br/pkg/restore/utils/rewrite_rule.go
@@ -107,32 +107,32 @@ func (r *RewriteRules) Append(other RewriteRules) {
 	r.Data = append(r.Data, other.Data...)
 }
 
-func (r *RewriteRules) SetTimeRangeFilter(cfName string) error {
+func SetTimeRangeFilter(tableRules *RewriteRules,
+	fileRule *import_sstpb.RewriteRule, cfName string) error {
 	// for some sst files like db restore copy ssts, we don't need to set the time range filter
-	if !r.HasSetTs() {
+	if !tableRules.HasSetTs() {
 		return nil
 	}
 
 	var ignoreBeforeTs uint64
 	switch {
 	case strings.Contains(cfName, DefaultCFName):
-		ignoreBeforeTs = r.ShiftStartTs
-		if ignoreBeforeTs > r.StartTs {
+		ignoreBeforeTs = tableRules.ShiftStartTs
+		if ignoreBeforeTs > tableRules.StartTs {
 			// for default cf, shift start ts could less than start ts
 			// this could happen when large kv txn happen after small kv txn.
 			// use the start ts to filter out irrelevant data for default cf is more safe
-			ignoreBeforeTs = r.StartTs
+			ignoreBeforeTs = tableRules.StartTs
 		}
 	case strings.Contains(cfName, WriteCFName):
-		ignoreBeforeTs = r.StartTs
+		ignoreBeforeTs = tableRules.StartTs
 	default:
 		return errors.Errorf("unsupported column family type: %s", cfName)
 	}
 
-	for _, rule := range r.Data {
-		rule.IgnoreBeforeTimestamp = ignoreBeforeTs
-		rule.IgnoreAfterTimestamp = r.RestoredTs
-	}
+	// Set both timestamps since file's range needs filtering
+	fileRule.IgnoreBeforeTimestamp = ignoreBeforeTs
+	fileRule.IgnoreAfterTimestamp = tableRules.RestoredTs
 	return nil
 }
 

--- a/br/pkg/restore/utils/rewrite_rule_test.go
+++ b/br/pkg/restore/utils/rewrite_rule_test.go
@@ -609,7 +609,8 @@ func TestSetTimeRangeFilter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.rules.SetTimeRangeFilter(tc.cfName)
+			rule := &import_sstpb.RewriteRule{}
+			err := utils.SetTimeRangeFilter(tc.rules, rule, tc.cfName)
 			if tc.expectError {
 				require.Error(t, err)
 				return
@@ -626,19 +627,62 @@ func TestSetTimeRangeFilter(t *testing.T) {
 			}
 
 			// Verify timestamps are set correctly
-			for _, rule := range tc.rules.Data {
-				require.Equal(t, tc.rules.RestoredTs, rule.IgnoreAfterTimestamp)
+			require.Equal(t, tc.rules.RestoredTs, rule.IgnoreAfterTimestamp)
 
-				if strings.Contains(tc.cfName, "default") {
-					if tc.rules.ShiftStartTs < tc.rules.StartTs {
-						require.Equal(t, tc.rules.ShiftStartTs, rule.IgnoreBeforeTimestamp)
-					} else {
-						require.Equal(t, tc.rules.StartTs, rule.IgnoreBeforeTimestamp)
-					}
-				} else if strings.Contains(tc.cfName, "write") {
+			if strings.Contains(tc.cfName, "default") {
+				if tc.rules.ShiftStartTs < tc.rules.StartTs {
+					require.Equal(t, tc.rules.ShiftStartTs, rule.IgnoreBeforeTimestamp)
+				} else {
 					require.Equal(t, tc.rules.StartTs, rule.IgnoreBeforeTimestamp)
 				}
+			} else if strings.Contains(tc.cfName, "write") {
+				require.Equal(t, tc.rules.StartTs, rule.IgnoreBeforeTimestamp)
 			}
 		})
 	}
+}
+
+func TestSetTimeRangeFilterRace(t *testing.T) {
+	// Create a shared rules object that will be read by multiple goroutines
+	rules := &utils.RewriteRules{
+		Data: []*import_sstpb.RewriteRule{
+			{OldKeyPrefix: []byte("old"), NewKeyPrefix: []byte("new")},
+		},
+		ShiftStartTs: 50,
+		StartTs:      100,
+		RestoredTs:   200,
+	}
+
+	// Number of concurrent goroutines
+	numGoroutines := 100
+	// Channel to collect results
+	resultChan := make(chan *import_sstpb.RewriteRule, numGoroutines)
+
+	// Launch multiple goroutines to concurrently call SetTimeRangeFilter
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			// Each goroutine creates its own rule
+			rule := &import_sstpb.RewriteRule{}
+			err := utils.SetTimeRangeFilter(rules, rule, "default")
+			if err != nil {
+				resultChan <- nil
+				return
+			}
+			resultChan <- rule
+		}()
+	}
+
+	// Wait for all goroutines to complete and check results
+	for i := 0; i < numGoroutines; i++ {
+		rule := <-resultChan
+		require.NotNil(t, rule)
+		// Verify the rule was correctly modified
+		require.Equal(t, uint64(50), rule.IgnoreBeforeTimestamp) // Should be ShiftStartTs for default cf
+		require.Equal(t, uint64(200), rule.IgnoreAfterTimestamp) // Should be RestoredTs
+	}
+
+	// Verify the rules were not modified
+	require.Equal(t, uint64(50), rules.ShiftStartTs)
+	require.Equal(t, uint64(100), rules.StartTs)
+	require.Equal(t, uint64(200), rules.RestoredTs)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60577

Problem Summary:

- As issue described.

### What changed and how does it work?
	1. The RewriteRules (specifically tableRules) are now handled after the data copy process.
	2. This ensures that different goroutines apply the correct start_ts when restoring entries, avoiding inconsistencies caused by early binding of rewrite rules.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
