### PR TITLE
statistics: Simplify histogram async load with defer cleanup

### DIFF
--- a/pkg/statistics/asyncload/BUILD.bazel
+++ b/pkg/statistics/asyncload/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
     timeout = "short",
     srcs = ["async_load_test.go"],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         ":asyncload",
         "//pkg/parser/ast",

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -239,7 +239,7 @@ func TestLoadCorruptedStatistics(t *testing.T) {
 	tableInfo := tbl.Meta()
 	tableID := tableInfo.ID
 	// Corrupt the statistics.
-	testKit.MustExec("update mysql.stats_buckets set upper_bound = 'who knows what it is' where table_id = ?;", tableID)
+	testKit.MustExec("UPDATE mysql.stats_buckets SET upper_bound = 'who knows what it is' WHERE table_id = ?;", tableID)
 	// This will add the table to the AsyncLoadHistogramNeededItems.
 	testKit.MustExec("SELECT * FROM t1 WHERE b = 2;")
 

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -231,6 +231,7 @@ func TestLoadCorruptedStatistics(t *testing.T) {
 	handle := dom.StatsHandle()
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	// Only collect the histogram buckets.
 	testKit.MustExec("ANALYZE TABLE t1 ALL COLUMNS WITH 0 TOPN;")
 	is := dom.InfoSchema()
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t1"))

--- a/pkg/statistics/asyncload/async_load_test.go
+++ b/pkg/statistics/asyncload/async_load_test.go
@@ -258,11 +258,8 @@ func TestLoadCorruptedStatistics(t *testing.T) {
 		"table %d should be in the items", tableID,
 	)
 
-	// Drop the index.
-	testKit.MustExec("ALTER TABLE t1 DROP INDEX idx_b;")
 	err = handle.LoadNeededHistograms(dom.InfoSchema())
 	require.NoError(t, err)
-
 	// Check the table is removed from the items.
 	items := asyncload.AsyncLoadHistogramNeededItems.AllItems()
 	for _, item := range items {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60598

Problem Summary:

### What changed and how does it work?

1. Use defer statement to remove the redundant calls to AsyncLoadHistogramNeededItems.Delete(col)
throughout the loadNeededColumnHistograms function. 
2. Use defer statement to remove the redundant calls to AsyncLoadHistogramNeededItems.Delete(idx)
throughout the loadNeededIndexHistograms function. 

This change ensures cleanup happens
exactly once regardless of which path the function takes, making the code more maintainable
and less error-prone when adding new exit paths in the future.

I discussed this behavior with @terry1purcell and @time-and-fate. We all agreed that we should stop retrying to load the statistics after a failure, because the sync load process already has a retry mechanism. There’s no need to retry again here, and this change would also reduce the risk of entering an infinite loop.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
减少统计信息异步加载可能导致的死循环重试问题
Reduce the risk of infinite retry loops caused by asynchronous loading of statistics
```
