### PR TITLE
executor: fix schema-table inconsistent issue in `IS.tables`

### DIFF
--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -674,7 +674,7 @@ func findTableAndSchemaByName(
 		schema ast.CIStr
 		table  *model.TableInfo
 	}
-	tableMap := make(map[int64]schemaAndTable, len(tableNames))
+	schemaAndTbls := make([]schemaAndTable, 0, len(tableNames))
 	ctx = infoschema.WithRefillOption(ctx, false)
 	for _, n := range tableNames {
 		for _, s := range schemas {
@@ -689,24 +689,21 @@ func findTableAndSchemaByName(
 			if tblInfo.TempTableType == model.TempTableLocal {
 				continue
 			}
-			tableMap[tblInfo.ID] = schemaAndTable{s, tblInfo}
+			schemaAndTbls = append(schemaAndTbls, schemaAndTable{s, tblInfo})
 		}
 	}
-	schemaSlice := make([]ast.CIStr, 0, len(tableMap))
-	tableSlice := make([]*model.TableInfo, 0, len(tableMap))
-	for _, st := range tableMap {
+
+	sort.Slice(schemaAndTbls, func(i, j int) bool {
+		vi, vj := schemaAndTbls[i], schemaAndTbls[j]
+		return vi.schema.L < vj.schema.L ||
+			(vi.schema.L == vj.schema.L && vi.table.Name.L < vj.table.Name.L)
+	})
+	schemaSlice := make([]ast.CIStr, 0, len(schemaAndTbls))
+	tableSlice := make([]*model.TableInfo, 0, len(schemaAndTbls))
+	for _, st := range schemaAndTbls {
 		schemaSlice = append(schemaSlice, st.schema)
 		tableSlice = append(tableSlice, st.table)
 	}
-	sort.Slice(schemaSlice, func(i, j int) bool {
-		iSchema, jSchema := schemaSlice[i].L, schemaSlice[j].L
-		less := iSchema < jSchema ||
-			(iSchema == jSchema && tableSlice[i].Name.L < tableSlice[j].Name.L)
-		if less {
-			tableSlice[i], tableSlice[j] = tableSlice[j], tableSlice[i]
-		}
-		return less
-	})
 	return schemaSlice, tableSlice, nil
 }
 

--- a/pkg/planner/core/memtable_infoschema_extractor.go
+++ b/pkg/planner/core/memtable_infoschema_extractor.go
@@ -693,10 +693,11 @@ func findTableAndSchemaByName(
 		}
 	}
 
-	sort.Slice(schemaAndTbls, func(i, j int) bool {
-		vi, vj := schemaAndTbls[i], schemaAndTbls[j]
-		return vi.schema.L < vj.schema.L ||
-			(vi.schema.L == vj.schema.L && vi.table.Name.L < vj.table.Name.L)
+	slices.SortFunc(schemaAndTbls, func(a, b schemaAndTable) int {
+		if a.schema.L == b.schema.L {
+			return strings.Compare(a.table.Name.L, b.table.Name.L)
+		}
+		return strings.Compare(a.schema.L, b.schema.L)
 	})
 	schemaSlice := make([]ast.CIStr, 0, len(schemaAndTbls))
 	tableSlice := make([]*model.TableInfo, 0, len(schemaAndTbls))

--- a/tests/integrationtest/r/executor/infoschema_reader.result
+++ b/tests/integrationtest/r/executor/infoschema_reader.result
@@ -513,3 +513,5 @@ test2	t26	0
 test2	t27	0
 test2	t28	0
 test2	t29	0
+drop database test1;
+drop database test2;

--- a/tests/integrationtest/r/executor/infoschema_reader.result
+++ b/tests/integrationtest/r/executor/infoschema_reader.result
@@ -464,3 +464,52 @@ select table_name from information_schema.referential_constraints where table_na
 table_name
 select table_name from information_schema.referential_constraints where constraint_schema = 'a' and constraint_schema = 'b';
 table_name
+drop database if exists test1;
+create database test1;
+use test1;
+create table t10(id int);
+create table t11 like t10;
+create table t12 like t10;
+create table t13 like t10;
+create table t14 like t10;
+create table t15 like t10;
+create table t16 like t10;
+create table t17 like t10;
+create table t18 like t10;
+create table t19 like t10;
+drop database if exists test2;
+create database test2;
+use test2;
+create table t20(id int);
+create table t21 like t20;
+create table t22 like t20;
+create table t23 like t20;
+create table t24 like t20;
+create table t25 like t20;
+create table t26 like t20;
+create table t27 like t20;
+create table t28 like t20;
+create table t29 like t20;
+SELECT table_schema, table_name,data_length FROM information_schema.TABLES
+WHERE (TABLE_NAME IN ('t10','t11','t12','t13','t14','t15','t16','t17','t18','t19','t20','t21','t22','t23','t24','t25','t26','t27','t28','t29'));
+table_schema	table_name	data_length
+test1	t10	0
+test1	t11	0
+test1	t12	0
+test1	t13	0
+test1	t14	0
+test1	t15	0
+test1	t16	0
+test1	t17	0
+test1	t18	0
+test1	t19	0
+test2	t20	0
+test2	t21	0
+test2	t22	0
+test2	t23	0
+test2	t24	0
+test2	t25	0
+test2	t26	0
+test2	t27	0
+test2	t28	0
+test2	t29	0

--- a/tests/integrationtest/t/executor/infoschema_reader.test
+++ b/tests/integrationtest/t/executor/infoschema_reader.test
@@ -334,3 +334,34 @@ select table_name from information_schema.statistics where table_name = 'a' and 
 select table_name from information_schema.statistics where table_schema = 'a' and table_schema = 'b';
 select table_name from information_schema.referential_constraints where table_name = 'a' and table_name = 'b';
 select table_name from information_schema.referential_constraints where constraint_schema = 'a' and constraint_schema = 'b';
+
+drop database if exists test1;
+create database test1;
+use test1;
+create table t10(id int);
+create table t11 like t10;
+create table t12 like t10;
+create table t13 like t10;
+create table t14 like t10;
+create table t15 like t10;
+create table t16 like t10;
+create table t17 like t10;
+create table t18 like t10;
+create table t19 like t10;
+
+drop database if exists test2;
+create database test2;
+use test2;
+create table t20(id int);
+create table t21 like t20;
+create table t22 like t20;
+create table t23 like t20;
+create table t24 like t20;
+create table t25 like t20;
+create table t26 like t20;
+create table t27 like t20;
+create table t28 like t20;
+create table t29 like t20;
+
+SELECT table_schema, table_name,data_length FROM information_schema.TABLES
+WHERE (TABLE_NAME IN ('t10','t11','t12','t13','t14','t15','t16','t17','t18','t19','t20','t21','t22','t23','t24','t25','t26','t27','t28','t29'));

--- a/tests/integrationtest/t/executor/infoschema_reader.test
+++ b/tests/integrationtest/t/executor/infoschema_reader.test
@@ -365,3 +365,5 @@ create table t29 like t20;
 
 SELECT table_schema, table_name,data_length FROM information_schema.TABLES
 WHERE (TABLE_NAME IN ('t10','t11','t12','t13','t14','t15','t16','t17','t18','t19','t20','t21','t22','t23','t24','t25','t26','t27','t28','t29'));
+drop database test1;
+drop database test2;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60593

Problem Summary:

Previous sorting impl is problematic.

### What changed and how does it work?

The original code mistakenly swapped the elements of `tableSlice` manually during sorting, causing it to be out of sync with `schemaSlice`. By merging the data and sorting them uniformly, the order consistency of the two is ensured, eliminating the data misalignment problem caused by manual swapping.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
