### PR TITLE
workloadrepo: Add permission checks to workload repo's ADMIN command.

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1596,7 +1596,7 @@ func (b *PlanBuilder) buildAdmin(ctx context.Context, as *ast.AdminStmt) (base.P
 			return nil, err
 		}
 	case ast.AdminWorkloadRepoCreate:
-		return &WorkloadRepoCreate{}, nil
+		ret = &WorkloadRepoCreate{}
 	default:
 		return nil, plannererrors.ErrUnsupportedType.GenWithStack("Unsupported ast.AdminStmt(%T) for buildAdmin", as)
 	}

--- a/pkg/util/workloadrepo/BUILD.bazel
+++ b/pkg/util/workloadrepo/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/kv",
         "//pkg/owner",
         "//pkg/parser/ast",
+        "//pkg/parser/auth",
         "//pkg/parser/mysql",
         "//pkg/sessionctx",
         "//pkg/sessionctx/variable",

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/owner"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
@@ -312,9 +313,20 @@ func TestAdminWorkloadRepo(t *testing.T) {
 		return len(res) >= 1
 	}, time.Minute, time.Second)
 
+	// Validate that user will out Super can not execute admin command.
+	tk.MustExec(`CREATE USER 'testcheck'@'localhost';`)
+	checkTk := testkit.NewTestKit(t, store)
+	require.NoError(t, checkTk.Session().Auth(&auth.UserIdentity{Username: "testcheck", Hostname: "localhost"}, nil, nil, nil))
+	checkTk.MustExecToErr("admin create workload snapshot")
+
+	// Add super to testcheck you and retry command.
+	tk.MustExec("grant super on *.* to 'testcheck'@'localhost'")
+	checkTk.MustExec("admin create workload snapshot")
+
 	// disable the worker and it will fail
 	tk.MustExec("set @@global.tidb_workload_repository_dest=''")
 	tk.MustExecToErr("admin create workload snapshot")
+	checkTk.MustExecToErr("admin create workload snapshot")
 }
 
 func getRows(t *testing.T, tk *testkit.TestKit, cnt int, maxSecs int, query string) [][]any {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58247

Problem Summary:
The "ADMIN CREATE WORKLOAD SNAPSHOT" command does not currently require that the user have any privileges.

### What changed and how does it work?
This patch will make "SUPER" required for users to initiate a manual workload repository snapshots.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
