### PR TITLE
ddl: set operation deadline for ModifyResourceGroup and DeleteResourceGroup

### DIFF
--- a/pkg/ddl/resource_group.go
+++ b/pkg/ddl/resource_group.go
@@ -123,7 +123,9 @@ func onAlterResourceGroup(jobCtx *jobContext, job *model.Job) (ver int64, _ erro
 		return ver, errors.Trace(err)
 	}
 
-	err = infosync.ModifyResourceGroup(context.TODO(), protoGroup)
+	ctx, cancel := context.WithTimeout(jobCtx.stepCtx, defaultInfosyncTimeout)
+	defer cancel()
+	err = infosync.ModifyResourceGroup(ctx, protoGroup)
 	if err != nil {
 		logutil.DDLLogger().Warn("update resource group failed", zap.Error(err))
 		job.State = model.JobStateCancelled
@@ -166,7 +168,9 @@ func onDropResourceGroup(jobCtx *jobContext, job *model.Job) (ver int64, _ error
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		err = infosync.DeleteResourceGroup(context.TODO(), groupInfo.Name.L)
+		ctx, cancel := context.WithTimeout(jobCtx.stepCtx, defaultInfosyncTimeout)
+		defer cancel()
+		err = infosync.DeleteResourceGroup(ctx, groupInfo.Name.L)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60639 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue of ModifyResourceGroup and DeleteResourceGroup getting stuck due to gprc communication timeout.
```
