### PR TITLE
executor: fix wrong statistic from memory tracker in hash agg

### DIFF
--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -555,8 +555,6 @@ func (e *HashAggExec) spill() {
 func (e *HashAggExec) waitPartialWorkerAndCloseOutputChs(waitGroup *sync.WaitGroup) {
 	waitGroup.Wait()
 	close(e.inputCh)
-	for range e.inputCh {
-	}
 	for _, ch := range e.partialOutputChs {
 		close(ch)
 	}

--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -498,6 +498,7 @@ func (e *HashAggExec) fetchChildData(ctx context.Context, waitGroup *sync.WaitGr
 		err = exec.Next(ctx, e.Children(0), chk)
 		if err != nil {
 			e.finalOutputCh <- &AfFinalResult{err: err}
+			e.memTracker.Consume(-consumedMemory)
 			return
 		}
 

--- a/pkg/executor/aggregate/agg_hash_executor.go
+++ b/pkg/executor/aggregate/agg_hash_executor.go
@@ -555,6 +555,9 @@ func (e *HashAggExec) spill() {
 func (e *HashAggExec) waitPartialWorkerAndCloseOutputChs(waitGroup *sync.WaitGroup) {
 	waitGroup.Wait()
 	close(e.inputCh)
+	for input := range e.inputCh {
+		e.memTracker.Consume(-input.chk.MemoryUsage())
+	}
 	for _, ch := range e.partialOutputChs {
 		close(ch)
 	}

--- a/pkg/executor/aggregate/agg_hash_partial_worker.go
+++ b/pkg/executor/aggregate/agg_hash_partial_worker.go
@@ -198,6 +198,7 @@ func (w *HashAggPartialWorker) run(ctx sessionctx.Context, waitGroup *sync.WaitG
 
 		w.finalizeWorkerProcess(needShuffle, finalConcurrency, hasError)
 
+		w.memTracker.Consume(-w.chk.MemoryUsage())
 		updateWorkerTime(w.stats, start)
 
 		// We must ensure that there is no panic before `waitGroup.Done()` or there will be hang

--- a/pkg/executor/aggregate/agg_hash_partial_worker.go
+++ b/pkg/executor/aggregate/agg_hash_partial_worker.go
@@ -100,10 +100,7 @@ func (w *HashAggPartialWorker) fetchChunkAndProcess(ctx sessionctx.Context, hasE
 
 	w.intestDuringPartialWorkerRun()
 
-	sizeBefore := w.chk.MemoryUsage()
 	w.chk.SwapColumns(chk)
-	w.memTracker.Consume(w.chk.MemoryUsage() - sizeBefore)
-
 	w.giveBackCh <- &HashAggInput{
 		chk:        chk,
 		giveBackCh: w.inputCh,
@@ -201,7 +198,6 @@ func (w *HashAggPartialWorker) run(ctx sessionctx.Context, waitGroup *sync.WaitG
 
 		w.finalizeWorkerProcess(needShuffle, finalConcurrency, hasError)
 
-		w.memTracker.Consume(-w.chk.MemoryUsage())
 		updateWorkerTime(w.stats, start)
 
 		// We must ensure that there is no panic before `waitGroup.Done()` or there will be hang


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58822

Problem Summary:

### What changed and how does it work?

We delete the memory tracking for received chunk in partial worker. Received chunk in partial worker has been tracked in fetcher, if we receive a smaller chunk compared to the current chunk both held by fetcher and partial worker, memory tracker will double minus the memory usage it tracked. However, duplicate operation will decrease more memory usage and will lead to negative counter in the end.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that getting wrong statistic from memory tracker in hash agg
```
