### PR TITLE
types: allow '5e' as int value

### DIFF
--- a/pkg/types/convert.go
+++ b/pkg/types/convert.go
@@ -499,14 +499,20 @@ func floatStrToIntStr(validFloat string, oriStr string) (intStr string, _ error)
 		intCnt = len(digits)
 		digits = append(digits, validFloat[dotIdx+1:eIdx]...)
 	}
-	exp, err := strconv.Atoi(validFloat[eIdx+1:])
-	if err != nil {
-		if digits[0] == '-' {
-			intStr = minIntStr
-		} else {
-			intStr = maxUintStr
+	var exp int
+	var err error
+	if eIdx == len(validFloat)-1 { // '5e'
+		exp = 0
+	} else {
+		exp, err = strconv.Atoi(validFloat[eIdx+1:])
+		if err != nil {
+			if digits[0] == '-' {
+				intStr = minIntStr
+			} else {
+				intStr = maxUintStr
+			}
+			return intStr, ErrOverflow.GenWithStackByArgs("BIGINT", oriStr)
 		}
-		return intStr, ErrOverflow.GenWithStackByArgs("BIGINT", oriStr)
 	}
 	intCnt += exp
 	if exp >= 0 && (intCnt > 21 || intCnt < 0) {
@@ -733,6 +739,7 @@ func getValidFloatPrefix(ctx Context, s string, isFuncCast bool) (valid string, 
 				break
 			}
 			eIdx = i
+			validLen = i + 1
 		} else if c == '\u0000' {
 			s = s[:validLen]
 			break


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60671 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Handling of integers that ended in 'e' was improved
```
