### PR TITLE
planner: Fix issue #60556: Simplify Range Intersection Logic

### DIFF
--- a/pkg/planner/core/casetest/index/index_test.go
+++ b/pkg/planner/core/casetest/index/index_test.go
@@ -198,6 +198,8 @@ func TestRangeIntersection(t *testing.T) {
 	tk.MustExec("INSERT INTO tkey_string VALUES('zhenjiang','zhenjiang','zhenjiang','zhenjiang','zhenjiang','zhenjiang','medium','c','linpin');")
 	tk.MustExec("INSERT INTO tkey_string VALUES('suzhou','suzhou','suzhou','suzhou','suzhou','suzhou','large','d','linpin');")
 	tk.MustExec("INSERT INTO tkey_string VALUES('wuxi','wuxi','wuxi','wuxi','wuxi','wuxi','x-large','a','linpin');")
+	tk.MustExec("create table t_issue_60556(a int, b int, ac char(3), bc char(3), key ab(a,b), key acbc(ac,bc));")
+	tk.MustExec("insert into t_issue_60556 values (100, 500, '100', '500');")
 
 	var input []string
 	var output []struct {

--- a/pkg/planner/core/casetest/index/testdata/index_range_in.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_in.json
@@ -51,7 +51,10 @@
 	// Empty intersections.
 	"select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (0, 20)", 
 	"select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (2, 20) and b1 <5",
-	"select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (4, 20) and a1 < 0"
+	"select count(*) from t1 where (a1, b1) > (1, 10) and (a1, b1) < (4, 20) and a1 < 0",
+	// Issue 60556
+        "SELECT 1 FROM t_issue_60556 FORCE INDEX (ab) where ((a>100) or (a=100 and b>0)) and ((a<100) or (a=100 and b<10))",
+        "SELECT 1 FROM t_issue_60556 FORCE INDEX (acbc) where ((ac>'100') or (ac='100' and bc>'0')) and ((ac<'100') or (ac='100' and bc<'10'))"
     ]
   }
 ]

--- a/pkg/planner/core/casetest/index/testdata/index_range_out.json
+++ b/pkg/planner/core/casetest/index/testdata/index_range_out.json
@@ -445,6 +445,24 @@
         "Result": [
           "0"
         ]
+      },
+      {
+        "SQL": "SELECT 1 FROM t_issue_60556 FORCE INDEX (ab) where ((a>100) or (a=100 and b>0)) and ((a<100) or (a=100 and b<10))",
+        "Plan": [
+          "Projection 2.50 root  1->Column#6",
+          "└─IndexReader 2.50 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 2.50 cop[tikv] table:t_issue_60556, index:ab(a, b) range:(100 0,100 10), keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "SELECT 1 FROM t_issue_60556 FORCE INDEX (acbc) where ((ac>'100') or (ac='100' and bc>'0')) and ((ac<'100') or (ac='100' and bc<'10'))",
+        "Plan": [
+          "Projection 2.50 root  1->Column#6",
+          "└─IndexReader 2.50 root  index:IndexRangeScan",
+          "  └─IndexRangeScan 2.50 cop[tikv] table:t_issue_60556, index:acbc(ac, bc) range:(\"100\" \"0\",\"100\" \"10\"), keep order:false, stats:pseudo"
+        ],
+        "Result": null
       }
     ]
   }

--- a/pkg/util/ranger/types_test.go
+++ b/pkg/util/ranger/types_test.go
@@ -16,6 +16,7 @@ package ranger_test
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/domain"
@@ -167,8 +168,8 @@ func TestIsFullRange(t *testing.T) {
 	}{
 		{
 			ran: ranger.Range{
-				LowVal:    []types.Datum{types.NewIntDatum(math.MinInt64)},
-				HighVal:   []types.Datum{types.NewIntDatum(math.MaxInt64)},
+				LowVal:    []types.Datum{types.MinNotNullDatum()},
+				HighVal:   []types.Datum{types.MaxValueDatum()},
 				Collators: collate.GetBinaryCollatorSlice(1),
 			},
 			unsignedIntHandle: false,
@@ -176,8 +177,8 @@ func TestIsFullRange(t *testing.T) {
 		},
 		{
 			ran: ranger.Range{
-				LowVal:    []types.Datum{types.NewIntDatum(math.MaxInt64)},
-				HighVal:   []types.Datum{types.NewIntDatum(math.MinInt64)},
+				LowVal:    []types.Datum{types.MaxValueDatum()},
+				HighVal:   []types.Datum{types.MinNotNullDatum()},
 				Collators: collate.GetBinaryCollatorSlice(1),
 			},
 			unsignedIntHandle: false,
@@ -253,365 +254,321 @@ func TestRangeMemUsage(t *testing.T) {
 	require.Equal(t, mem1+mem2, ranges.MemUsage())
 }
 
+// Build an integer range value with input: lowVal, highVal, open or closed for lower/upper limit.
+func buildRange(lowVals []int64, highVals []int64, lowExclude bool, highExclude bool) ranger.Range {
+	datums := func(ints []int64) []types.Datum {
+		ds := make([]types.Datum, len(ints))
+		for i, val := range ints {
+			if val == math.MinInt64 {
+				ds[i] = types.MinNotNullDatum()
+			} else if val == math.MaxInt64 {
+				ds[i] = types.MaxValueDatum()
+			} else {
+				ds[i] = types.NewIntDatum(val)
+			}
+		}
+		return ds
+	}
+
+	return ranger.Range{
+		LowVal:      datums(lowVals),
+		HighVal:     datums(highVals),
+		LowExclude:  lowExclude,
+		HighExclude: highExclude,
+		Collators:   collate.GetBinaryCollatorSlice(len(lowVals)),
+	}
+}
+
+func TestIntersectionList(t *testing.T) {
+	ctx := core.MockContext()
+	defer domain.GetDomain(ctx).StatsHandle().Close()
+
+	// First list of ranges representing: (a > 100) OR (a = 100 AND b > 0)
+	r1 := buildRange([]int64{100, 0}, []int64{100, math.MaxInt64}, true, false) // (100 0, 100 +inf]
+	r2 := buildRange([]int64{100}, []int64{math.MaxInt64}, true, false)         // (100, +inf]
+	rangeList1 := ranger.Ranges{&r1, &r2}
+
+	// Second list of ranges representing: (a < 101) OR (a = 101 AND b < 10)
+	r3 := buildRange([]int64{math.MinInt64}, []int64{101}, false, true)          // [-inf, 101)
+	r4 := buildRange([]int64{101, math.MinInt64}, []int64{101, 10}, false, true) // [101 -inf, 101 10)
+	rangeList2 := ranger.Ranges{&r3, &r4}
+
+	// Intersect the two range lists
+	intersected := rangeList1.IntersectRanges(ctx.GetRangerCtx().TypeCtx, rangeList2)
+
+	// Convert result to string representation
+	actual := joinRanges(intersected)
+	expected := "(100 0,100 +inf],(100,101),[101 -inf,101 10)"
+	require.Equal(t, expected, actual)
+}
+
+// Helper to join a list of ranges into a single string representation.
+func joinRanges(ranges []*ranger.Range) string {
+	var sb strings.Builder
+	for i, r := range ranges {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(rangeToString(r))
+	}
+	return sb.String()
+}
+
 // Test intersections that result in empty sets.
 func TestIntersectionEmpty(t *testing.T) {
-	expectedResult := make(map[string]string)
-	actualResult := make(map[string]string)
-	expectedResult["[1,2] [3,4]"] = "<nil>"
-	expectedResult["(1,2] (3,4]"] = "<nil>"
-	expectedResult["[1,2) [3,4)"] = "<nil>"
-	expectedResult["(1,2) (3,4)"] = "<nil>"
-	expectedResult["[1 2,1 3] (1 3,1 4]"] = "<nil>"
-	expectedResult["[-inf,1] [2,+inf]"] = "<nil>"
-	expectedResult["[1 2,1 3] [1 3,1 4]"] = "[1 3,1 3]"
-	expectedResult["[1 1 2,1 1 5] (1 2,1 3)"] = "<nil>"
+	type testCase struct {
+		start1, end1 []int64
+		exclLow1     bool
+		exclHigh1    bool
+		start2, end2 []int64
+		exclLow2     bool
+		exclHigh2    bool
+		expected     string
+	}
 
-	var range1, range2 ranger.Range
-	var intersection1, intersection2 *ranger.Range
+	cases := []testCase{
+		{[]int64{1}, []int64{2}, false, false, []int64{3}, []int64{4}, false, false, "<nil>"},
+		{[]int64{1}, []int64{2}, true, false, []int64{3}, []int64{4}, true, false, "<nil>"},
+		{[]int64{1}, []int64{2}, false, true, []int64{3}, []int64{4}, false, true, "<nil>"},
+		{[]int64{1}, []int64{2}, true, true, []int64{3}, []int64{4}, true, true, "<nil>"},
+		{[]int64{1, 2}, []int64{1, 3}, false, false, []int64{1, 3}, []int64{1, 4}, true, false, "<nil>"},
+		{[]int64{math.MinInt64}, []int64{1}, false, false, []int64{2}, []int64{math.MaxInt64}, false, false, "<nil>"},
+		{[]int64{1, 2}, []int64{1, 3}, false, false, []int64{1, 3}, []int64{1, 4}, false, false, "[1 3,1 3]"},
+		{[]int64{1, 1, 2}, []int64{1, 1, 5}, false, false, []int64{1, 2}, []int64{1, 3}, true, true, "<nil>"},
+		{[]int64{100, 0}, []int64{100, math.MaxInt64}, true, false, []int64{math.MinInt64, math.MinInt64}, []int64{100, math.MinInt64}, false, false, "<nil>"},
+		{[]int64{100, 0}, []int64{100, math.MaxInt64}, true, false, []int64{math.MinInt64}, []int64{100}, false, true, "<nil>"},
+		{[]int64{5}, []int64{5}, false, false, []int64{5}, []int64{math.MaxInt64}, true, false, "<nil>"},
+		{[]int64{1}, []int64{1}, false, false, []int64{5}, []int64{math.MaxInt64}, true, false, "<nil>"},
+		{[]int64{5}, []int64{5}, false, false, []int64{5, 1}, []int64{5, math.MaxInt64}, true, false, "<nil>"},
+		{[]int64{1}, []int64{1}, false, false, []int64{5, 1}, []int64{5, math.MaxInt64}, true, false, "<nil>"},
+	}
+
+	expectedResult := map[string]string{
+		"[1,2] [3,4]":                           "<nil>",
+		"(1,2] (3,4]":                           "<nil>",
+		"[1,2) [3,4)":                           "<nil>",
+		"(1,2) (3,4)":                           "<nil>",
+		"[1 2,1 3] (1 3,1 4]":                   "<nil>",
+		"[-inf,1] [2,+inf]":                     "<nil>",
+		"[1 2,1 3] [1 3,1 4]":                   "[1 3,1 3]",
+		"[1 1 2,1 1 5] (1 2,1 3)":               "<nil>",
+		"(100 0,100 +inf] [-inf -inf,100 -inf]": "<nil>",
+		"(100 0,100 +inf] [-inf,100)":           "<nil>",
+		"[5,5] (5,+inf]":                        "<nil>",
+		"[1,1] (5,+inf]":                        "<nil>",
+		"[5,5] (5 1,5 +inf]":                    "(5 1,5 +inf]",
+		"[1,1] (5 1,5 +inf]":                    "<nil>",
+	}
+
 	ctx := core.MockContext()
+	actualResult := make(map[string]string)
 
-	// All ranges closed. intersection of [1,2] [3,4] is empty
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1)},
-		HighVal:   []types.Datum{types.NewIntDatum(2)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(3)},
-		HighVal:   []types.Datum{types.NewIntDatum(4)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+	for _, c := range cases {
+		range1 := buildRange(c.start1, c.end1, c.exclLow1, c.exclHigh1)
+		range2 := buildRange(c.start2, c.end2, c.exclLow2, c.exclHigh2)
+		intersection1, _ := range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
+		intersection2, _ := range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
+		require.Equal(t, intersection1, intersection2)
 
-	// Low open.  intersection of (1,2] (3,4] is empty
-	range1.LowExclude = true
-	range1.HighExclude = false
-	range2.LowExclude = true
-	range2.HighExclude = false
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+		key := range1.String() + " " + range2.String()
+		value := rangeToString(intersection1)
 
-	// high bound open. intersection of [1,2) [3,4) is empty
-	range1.LowExclude = false
-	range1.HighExclude = true
-	range2.LowExclude = false
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+		actualResult[key] = value
+	}
 
-	// both open. intersection of (1,2) (3,4) is empty
-	range1.LowExclude = true
-	range1.HighExclude = true
-	range2.LowExclude = true
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-	// Use of inifinity in ragnes. Intersection of [-infinity, 1] and [2, +infinity]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(math.MinInt64)},
-		HighVal:   []types.Datum{types.NewIntDatum(1)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(math.MaxInt64)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	// Multi column range. Intersection of [1 2,1 3] (1 3,1 4] is empty
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(3)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(3)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(4)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	range2.LowExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	range2.LowExclude = false // negative test for disjoint ranges when high = low.
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	// Multi column range with different number of columns. Intersection of [1 1 2,1 1 5] (1 2,1 3) is empty
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(3),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(3)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	range2.LowExclude = true
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	// Compare actual vs expected
 	for k, v := range actualResult {
 		require.Equal(t, v, expectedResult[k])
 	}
-	// cleanup
+
 	domain.GetDomain(ctx).StatsHandle().Close()
 }
 
 // Test intersections where one input is a subset of the other.
 func TestIntersectionSubset(t *testing.T) {
-	expectedResult := make(map[string]string)
-	actualResult := make(map[string]string)
-	expectedResult["[1,5] [2,4]"] = "[2,4]"
-	expectedResult["(1,5] (2,4]"] = "(2,4]"
-	expectedResult["[1,5) [2,4)"] = "[2,4)"
-	expectedResult["(1,5) (2,4)"] = "(2,4)"
-	expectedResult["[-inf,5] [2,4]"] = "[2,4]"
-	expectedResult["[1 2,1 5] (1 3,1 4]"] = "(1 3,1 4]"
-	expectedResult["[1 1 -inf,1 1 15] [1 1,1 1]"] = "[1 1 -inf,1 1 15]"
+	expectedResult := map[string]string{
+		"[1,5] [2,4]":                 "[2,4]",
+		"(1,5] (2,4]":                 "(2,4]",
+		"[1,5) [2,4)":                 "[2,4)",
+		"(1,5) (2,4)":                 "(2,4)",
+		"[-inf,5] [2,4]":              "[2,4]",
+		"[1 2,1 5] (1 3,1 4]":         "(1 3,1 4]",
+		"[1 1 -inf,1 1 15] [1 1,1 1]": "[1 1 -inf,1 1 15]",
+	}
 
-	var range1, range2 ranger.Range
-	var intersection1, intersection2 *ranger.Range
+	type testCase struct {
+		low1, high1     []int64
+		lowEx1, highEx1 bool
+		coll1           int
+		low2, high2     []int64
+		lowEx2, highEx2 bool
+		coll2           int
+	}
+
+	cases := []testCase{
+		{[]int64{1}, []int64{5}, false, false, 1, []int64{2}, []int64{4}, false, false, 1},
+		{[]int64{1}, []int64{5}, true, false, 1, []int64{2}, []int64{4}, true, false, 1},
+		{[]int64{1}, []int64{5}, false, true, 1, []int64{2}, []int64{4}, false, true, 1},
+		{[]int64{1}, []int64{5}, true, true, 1, []int64{2}, []int64{4}, true, true, 1},
+		{[]int64{math.MinInt64}, []int64{5}, false, false, 1, []int64{2}, []int64{4}, false, false, 1},
+		{[]int64{1, 2}, []int64{1, 5}, false, false, 2, []int64{1, 3}, []int64{1, 4}, true, false, 2},
+		{[]int64{1, 1, math.MinInt64}, []int64{1, 1, 15}, false, false, 3, []int64{1, 1}, []int64{1, 1}, false, false, 2},
+	}
+
+	actualResult := make(map[string]string)
 	ctx := core.MockContext()
 
-	// All ranges closed. intersection of [1,5] [2,4] is [2,4]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1)},
-		HighVal:   []types.Datum{types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(4)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+	for _, c := range cases {
+		range1 := buildRange(c.low1, c.high1, c.lowEx1, c.highEx1)
+		range1.Collators = collate.GetBinaryCollatorSlice(c.coll1)
 
-	// Low open.  intersection of (1,5] (2,4] is (2,4]
-	range1.LowExclude = true
-	range1.HighExclude = false
-	range2.LowExclude = true
-	range2.HighExclude = false
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+		range2 := buildRange(c.low2, c.high2, c.lowEx2, c.highEx2)
+		range2.Collators = collate.GetBinaryCollatorSlice(c.coll2)
 
-	// high bound open. intersection of [1,5) [2,4) is [2,4)
-	range1.LowExclude = false
-	range1.HighExclude = true
-	range2.LowExclude = false
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+		intersection1, _ := range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
+		intersection2, _ := range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
 
-	// both open. intersection of (1,5) (2,4) is (2,4)
-	range1.LowExclude = true
-	range1.HighExclude = true
-	range2.LowExclude = true
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-	// Use of inifinity in ragnes. Intersection of [-infinity, 5] and [2, 4]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(math.MinInt64)},
-		HighVal:   []types.Datum{types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(4)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+		require.Equal(t, intersection1, intersection2)
 
-	// Multi column range. Intersection of [1 2,1 5] (1 3,1 4] = (1 3,1 4]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(2),
+		actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
 	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(3)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(4)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	range2.LowExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
 
-	// Multi column range with different number of columns. Intersection of [1 1 -inf,1 1 15] [1 1,1 1] is [1 1 -inf,1 1 15]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(math.MinInt64)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(15)},
-		Collators: collate.GetBinaryCollatorSlice(3),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	// Compare actual vs expected
 	for k, v := range actualResult {
 		require.Equal(t, v, expectedResult[k])
 	}
-	// cleanup
+
 	domain.GetDomain(ctx).StatsHandle().Close()
 }
 
 // Test intersections for overlapping ranges and not subset.
 func TestIntersectionOverlap(t *testing.T) {
-	expectedResult := make(map[string]string)
-	actualResult := make(map[string]string)
-	expectedResult["[1,5] [2,7]"] = "[2,5]"
-	expectedResult["(1,5] (2,7]"] = "(2,5]"
-	expectedResult["[1,5) [2,7)"] = "[2,5)"
-	expectedResult["(1,5) (2,7)"] = "(2,5)"
-	expectedResult["[-inf,5] [2,14]"] = "[2,5]"
-	expectedResult["[1 2,1 5] (1 3,1 4]"] = "(1 3,1 4]"
-	expectedResult["[1 1 -inf,1 1 15] [1 1 4,1 1 25]"] = "[1 1 4,1 1 15]"
-
-	var range1, range2 ranger.Range
-	var intersection1, intersection2 *ranger.Range
 	ctx := core.MockContext()
+	type testCase struct {
+		range1         ranger.Range
+		range2         ranger.Range
+		expectedString string
+	}
 
-	// All ranges closed. intersection of [1,5] [2,7] is [2,5]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1)},
-		HighVal:   []types.Datum{types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(7)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+	col := collate.GetBinaryCollatorSlice(1)
+	col2 := collate.GetBinaryCollatorSlice(2)
+	col3 := collate.GetBinaryCollatorSlice(3)
+	negInfinity := types.MinNotNullDatum()
 
-	// Low open.  intersection of (1,5] (2,7] is (2,5]
-	range1.LowExclude = true
-	range1.HighExclude = false
-	range2.LowExclude = true
-	range2.HighExclude = false
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+	tests := []testCase{
+		{
+			ranger.Range{
+				LowVal:    []types.Datum{types.NewIntDatum(1)},
+				HighVal:   []types.Datum{types.NewIntDatum(5)},
+				Collators: col,
+			},
+			ranger.Range{
+				LowVal:    []types.Datum{types.NewIntDatum(2)},
+				HighVal:   []types.Datum{types.NewIntDatum(7)},
+				Collators: col,
+			},
+			"[2,5]",
+		},
+		{
+			ranger.Range{
+				LowVal:      []types.Datum{types.NewIntDatum(1)},
+				HighVal:     []types.Datum{types.NewIntDatum(5)},
+				LowExclude:  true,
+				HighExclude: false,
+				Collators:   col,
+			},
+			ranger.Range{
+				LowVal:      []types.Datum{types.NewIntDatum(2)},
+				HighVal:     []types.Datum{types.NewIntDatum(7)},
+				LowExclude:  true,
+				HighExclude: false,
+				Collators:   col,
+			},
+			"(2,5]",
+		},
+		{
+			ranger.Range{
+				LowVal:      []types.Datum{types.NewIntDatum(1)},
+				HighVal:     []types.Datum{types.NewIntDatum(5)},
+				LowExclude:  false,
+				HighExclude: true,
+				Collators:   col,
+			},
+			ranger.Range{
+				LowVal:      []types.Datum{types.NewIntDatum(2)},
+				HighVal:     []types.Datum{types.NewIntDatum(7)},
+				LowExclude:  false,
+				HighExclude: true,
+				Collators:   col,
+			},
+			"[2,5)",
+		},
+		{
+			ranger.Range{
+				LowVal:      []types.Datum{types.NewIntDatum(1)},
+				HighVal:     []types.Datum{types.NewIntDatum(5)},
+				LowExclude:  true,
+				HighExclude: true,
+				Collators:   col,
+			},
+			ranger.Range{
+				LowVal:      []types.Datum{types.NewIntDatum(2)},
+				HighVal:     []types.Datum{types.NewIntDatum(7)},
+				LowExclude:  true,
+				HighExclude: true,
+				Collators:   col,
+			},
+			"(2,5)",
+		},
+		{
+			ranger.Range{
+				LowVal:    []types.Datum{negInfinity},
+				HighVal:   []types.Datum{types.NewIntDatum(5)},
+				Collators: col,
+			},
+			ranger.Range{
+				LowVal:    []types.Datum{types.NewIntDatum(2)},
+				HighVal:   []types.Datum{types.NewIntDatum(14)},
+				Collators: col,
+			},
+			"[2,5]",
+		},
+		{
+			ranger.Range{
+				LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)},
+				HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(5)},
+				Collators: col2,
+			},
+			ranger.Range{
+				LowVal:     []types.Datum{types.NewIntDatum(1), types.NewIntDatum(3)},
+				HighVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(4)},
+				LowExclude: true,
+				Collators:  col2,
+			},
+			"(1 3,1 4]",
+		},
+		{
+			ranger.Range{
+				LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), negInfinity},
+				HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(15)},
+				Collators: col3,
+			},
+			ranger.Range{
+				LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(4)},
+				HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(25)},
+				Collators: col3,
+			},
+			"[1 1 4,1 1 15]",
+		},
+	}
 
-	// high bound open. intersection of [1,5) [2,7) is [2,5)
-	range1.LowExclude = false
-	range1.HighExclude = true
-	range2.LowExclude = false
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
+	for _, tt := range tests {
+		intersection1, _ := tt.range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &tt.range2)
+		intersection2, _ := tt.range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &tt.range1)
 
-	// both open. intersection of (1,5) (2,7) is (2,5)
-	range1.LowExclude = true
-	range1.HighExclude = true
-	range2.LowExclude = true
-	range2.HighExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-	// Use of inifinity in ragnes. Intersection of [-infinity, 5] and [2, 14]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(math.MinInt64)},
-		HighVal:   []types.Datum{types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(1),
+		label := tt.range1.String() + " " + tt.range2.String()
+		actual := rangeToString(intersection1)
+		require.Equal(t, tt.expectedString, actual, "unexpected intersection for %s", label)
+		require.Equal(t, intersection1, intersection2, "intersection not symmetric for %s", label)
 	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(14)},
-		Collators: collate.GetBinaryCollatorSlice(1),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
 
-	// Multi column range. Intersection of [1 2,1 5] (1 3,1 4] = (1 3,1 4]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(2)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(5)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(3)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(4)},
-		Collators: collate.GetBinaryCollatorSlice(2),
-	}
-	range2.LowExclude = true
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	// Multi column range with different number of columns. Intersection of [1 1 -inf,1 1 15] [1 1 4,1 1 25] is [1 1 4,1 1 15]
-	range1 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(math.MinInt64)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(15)},
-		Collators: collate.GetBinaryCollatorSlice(3),
-	}
-	range2 = ranger.Range{
-		LowVal:    []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(4)},
-		HighVal:   []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1), types.NewIntDatum(25)},
-		Collators: collate.GetBinaryCollatorSlice(3),
-	}
-	intersection1, _ = range1.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range2)
-	actualResult[range1.String()+" "+range2.String()] = rangeToString(intersection1)
-	intersection2, _ = range2.IntersectRange(ctx.GetRangerCtx().TypeCtx, &range1)
-	require.Equal(t, intersection1, intersection2)
-
-	// Compare actual vs expected
-	for k, v := range actualResult {
-		require.Equal(t, expectedResult[k], v)
-	}
-	// cleanup
 	domain.GetDomain(ctx).StatsHandle().Close()
 }


### PR DESCRIPTION
 <!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60556

### Problem Summary:
Current logic of range intersection is broken for a corner case like [5,5] and (5,+inf) where the intersection should be empty.
The logic of considering lower/upper bounds with open/cloxsed intervals is bot working for this case. 
An example is shown below. 

```
create table t (a int, b int, key ab(a, b));
insert into t values (100, 500);
mysql> set @@tidb_opt_fix_control = "54337:OFF";
mysql> select 1 from t where ((a>100) or (a=100 and b>0)) and ((a<100) or (a=100 and b<10));
Empty set (0.00 sec)
mysql> set @@tidb_opt_fix_control = "54337:ON";
Query OK, 0 rows affected (0.00 sec)

mysql> select 1 from t where ((a>100) or (a=100 and b>0)) and ((a<100) or (a=100 and b<10));
+---+
| 1 |
+---+
| 1 |
| 1 |
+---+
```
 

### What changed and how does it work?
The fix is to simplify the code that:
- extend ranges by +/- inf for shorter ranges to simplify the range comparison
- revisit comparison logic for open/closed intervals 
- add extensive tests for corner cases and ranges with different number of columns

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```