### PR TITLE
ddl: fix OOM issue when adding many indexes

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -112,7 +112,6 @@ go_library(
         "//pkg/lightning/backend/local",
         "//pkg/lightning/common",
         "//pkg/lightning/config",
-        "//pkg/lightning/membuf",
         "//pkg/meta",
         "//pkg/meta/autoid",
         "//pkg/meta/metabuild",

--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -112,6 +112,7 @@ go_library(
         "//pkg/lightning/backend/local",
         "//pkg/lightning/common",
         "//pkg/lightning/config",
+        "//pkg/lightning/membuf",
         "//pkg/meta",
         "//pkg/meta/autoid",
         "//pkg/meta/metabuild",

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/operator"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
+	"github.com/pingcap/tidb/pkg/lightning/membuf"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -669,6 +670,7 @@ func NewWriteExternalStoreOperator(
 					SetOnCloseFunc(onClose).
 					SetKeyDuplicationEncoding(hasUnique).
 					SetMemorySizeLimit(memoryQuota).
+					SetBlockSize(getAdjustedIndexBlockSize(memoryQuota)).
 					SetGroupOffset(i)
 				writerID := uuid.New().String()
 				prefix := path.Join(strconv.Itoa(int(jobID)), strconv.Itoa(int(subtaskID)))
@@ -694,6 +696,15 @@ func NewWriteExternalStoreOperator(
 		logger:        logutil.Logger(ctx),
 		totalCount:    totalCount,
 	}
+}
+
+func getAdjustedIndexBlockSize(memSizePerWriter uint64) int {
+	blockSize := external.DefaultBlockSize
+	alignedSize := membuf.GetAlignedSize(memSizePerWriter, uint64(blockSize))
+	if float64(alignedSize)/float64(memSizePerWriter) > 1.1 {
+		return int(memSizePerWriter)
+	}
+	return blockSize
 }
 
 // Close implements operator.Operator interface.

--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -89,7 +89,7 @@ go_test(
     embed = [":importinto"],
     flaky = True,
     race = "on",
-    shard_count = 18,
+    shard_count = 17,
     deps = [
         "//br/pkg/storage",
         "//pkg/ddl",

--- a/pkg/disttask/importinto/BUILD.bazel
+++ b/pkg/disttask/importinto/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//pkg/lightning/common",
         "//pkg/lightning/config",
         "//pkg/lightning/log",
-        "//pkg/lightning/membuf",
         "//pkg/lightning/metric",
         "//pkg/lightning/mydump",
         "//pkg/lightning/verification",

--- a/pkg/disttask/importinto/encode_and_sort_operator_test.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/operator"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/lightning/backend"
-	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -230,12 +229,4 @@ func TestGetKVGroupBlockSize(t *testing.T) {
 	require.Equal(t, 32*units.MiB, getKVGroupBlockSize(dataKVGroup))
 	require.Equal(t, 16*units.MiB, getKVGroupBlockSize(""))
 	require.Equal(t, 16*units.MiB, getKVGroupBlockSize("1"))
-}
-
-func TestGetAdjustedIndexBlockSize(t *testing.T) {
-	require.EqualValues(t, 1*units.MiB, external.GetAdjustedBlockSize(1*units.MiB))
-	require.EqualValues(t, 16*units.MiB, external.GetAdjustedBlockSize(15*units.MiB))
-	require.EqualValues(t, 16*units.MiB, external.GetAdjustedBlockSize(16*units.MiB))
-	require.EqualValues(t, 17*units.MiB, external.GetAdjustedBlockSize(17*units.MiB))
-	require.EqualValues(t, 16*units.MiB, external.GetAdjustedBlockSize(166*units.MiB))
 }

--- a/pkg/disttask/importinto/encode_and_sort_operator_test.go
+++ b/pkg/disttask/importinto/encode_and_sort_operator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/disttask/operator"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/lightning/backend"
+	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -232,9 +233,9 @@ func TestGetKVGroupBlockSize(t *testing.T) {
 }
 
 func TestGetAdjustedIndexBlockSize(t *testing.T) {
-	require.EqualValues(t, 1*units.MiB, getAdjustedIndexBlockSize(1*units.MiB))
-	require.EqualValues(t, 16*units.MiB, getAdjustedIndexBlockSize(15*units.MiB))
-	require.EqualValues(t, 16*units.MiB, getAdjustedIndexBlockSize(16*units.MiB))
-	require.EqualValues(t, 17*units.MiB, getAdjustedIndexBlockSize(17*units.MiB))
-	require.EqualValues(t, 16*units.MiB, getAdjustedIndexBlockSize(166*units.MiB))
+	require.EqualValues(t, 1*units.MiB, external.GetAdjustedBlockSize(1*units.MiB))
+	require.EqualValues(t, 16*units.MiB, external.GetAdjustedBlockSize(15*units.MiB))
+	require.EqualValues(t, 16*units.MiB, external.GetAdjustedBlockSize(16*units.MiB))
+	require.EqualValues(t, 17*units.MiB, external.GetAdjustedBlockSize(17*units.MiB))
+	require.EqualValues(t, 16*units.MiB, external.GetAdjustedBlockSize(166*units.MiB))
 }

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -114,7 +114,7 @@ func (s *importStepExecutor) Init(ctx context.Context) error {
 		}()
 	}
 	s.dataKVMemSizePerCon, s.perIndexKVMemSizePerCon = getWriterMemorySizeLimit(s.GetResource(), s.tableImporter.Plan)
-	s.indexBlockSize = getAdjustedIndexBlockSize(s.perIndexKVMemSizePerCon)
+	s.indexBlockSize = external.GetAdjustedBlockSize(s.perIndexKVMemSizePerCon)
 	s.logger.Info("KV writer memory buf info",
 		zap.String("data-buf-limit", units.BytesSize(float64(s.dataKVMemSizePerCon))),
 		zap.String("per-index-buf-limit", units.BytesSize(float64(s.perIndexKVMemSizePerCon))),

--- a/pkg/lightning/backend/external/writer.go
+++ b/pkg/lightning/backend/external/writer.go
@@ -64,6 +64,23 @@ const (
 	DefaultBlockSize = 16 * units.MiB
 )
 
+// GetAdjustedBlockSize gets the block size after alignment.
+func GetAdjustedBlockSize(memSizePerWriter uint64) int {
+	// the buf size is aligned to block size, and the target table might have many
+	// writers, one writer might take much more memory when the buf size
+	// is slightly larger than the N*block-size.
+	// such as when memSizePerWriter = 2M, block-size = 16M, the aligned size
+	// is 16M, it's 8 times larger.
+	// so we adjust the block size when the aligned size is larger than 1.1 times
+	// of memSizePerWriter, to avoid OOM.
+	blockSize := DefaultBlockSize
+	alignedSize := membuf.GetAlignedSize(memSizePerWriter, uint64(blockSize))
+	if float64(alignedSize)/float64(memSizePerWriter) > 1.1 {
+		return int(memSizePerWriter)
+	}
+	return blockSize
+}
+
 // rangePropertiesCollector collects range properties for each range. The zero
 // value of rangePropertiesCollector is not ready to use, should call reset()
 // first.

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble"
+	"github.com/docker/go-units"
 	"github.com/jfcg/sorty/v2"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	dbkv "github.com/pingcap/tidb/pkg/kv"
@@ -594,4 +595,12 @@ func TestFlushKVsRetry(t *testing.T) {
 		lastKey = append(lastKey[:0], p.firstKey...)
 		p, err = r.nextProp()
 	}
+}
+
+func TestGetAdjustedIndexBlockSize(t *testing.T) {
+	require.EqualValues(t, 1*units.MiB, GetAdjustedBlockSize(1*units.MiB))
+	require.EqualValues(t, 16*units.MiB, GetAdjustedBlockSize(15*units.MiB))
+	require.EqualValues(t, 16*units.MiB, GetAdjustedBlockSize(16*units.MiB))
+	require.EqualValues(t, 17*units.MiB, GetAdjustedBlockSize(17*units.MiB))
+	require.EqualValues(t, 16*units.MiB, GetAdjustedBlockSize(166*units.MiB))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #59508

Problem Summary:

### What changed and how does it work?

Same as #59518, avoid alignment when the aligned size >= 1.1 * calculated-buf-size.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  Adding 64 indexes:
  ![image](https://github.com/user-attachments/assets/6198e819-03e9-4539-b866-28ee082ad8a9)
  ![image](https://github.com/user-attachments/assets/5497eea9-51eb-44dd-a9db-4be8ccff1c14)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
