### PR TITLE
ddl/dxf: modify param at runtime for add-index with global sort (part 1)

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -828,20 +828,9 @@ func (dc *ddlCtx) addIndexWithLocalIngest(
 }
 
 func adjustWorkerCntAndMaxWriteSpeed(ctx context.Context, pipe *operator.AsyncPipeline, job *model.Job, bcCtx ingest.BackendCtx, avgRowSize int) {
-	opR, opW := pipe.GetLocalIngestModeReaderAndWriter()
-	if opR == nil || opW == nil {
+	reader, writer := pipe.GetReaderAndWriter()
+	if reader == nil || writer == nil {
 		logutil.DDLIngestLogger().Error("failed to get local ingest mode reader or writer", zap.Int64("jobID", job.ID))
-		return
-	}
-	reader, readerOk := opR.(*TableScanOperator)
-	writer, writerOk := opW.(*IndexIngestOperator)
-	if !readerOk || !writerOk {
-		logutil.DDLIngestLogger().Error(
-			"unexpected operator types, config can't be adjusted",
-			zap.Int64("jobID", job.ID),
-			zap.Bool("isReaderValid", readerOk),
-			zap.Bool("isWriterValid", writerOk),
-		)
 		return
 	}
 	ticker := time.NewTicker(UpdateDDLJobReorgCfgInterval)

--- a/pkg/ddl/backfilling_import_cloud.go
+++ b/pkg/ddl/backfilling_import_cloud.go
@@ -177,3 +177,15 @@ func (m *cloudImportExecutor) Cleanup(ctx context.Context) error {
 	m.backend.Close()
 	return nil
 }
+
+// TaskMetaModified changes the max write speed for ingest
+func (m *cloudImportExecutor) TaskMetaModified(ctx context.Context, newMeta []byte) error {
+	// Will be added in the future PR
+	return nil
+}
+
+// ResourceModified change the concurrency for ingest
+func (m *cloudImportExecutor) ResourceModified(ctx context.Context, newResource *proto.StepResource) error {
+	// Will be added in the future PR
+	return nil
+}

--- a/pkg/ddl/backfilling_merge_sort.go
+++ b/pkg/ddl/backfilling_merge_sort.go
@@ -134,3 +134,8 @@ func (m *mergeSortExecutor) onFinished(ctx context.Context, subtask *proto.Subta
 	subtask.Meta = newMeta
 	return nil
 }
+
+func (m *mergeSortExecutor) ResourceModified(_ context.Context, newResource *proto.StepResource) error {
+	// Will be added in the future PR
+	return nil
+}

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -175,11 +175,6 @@ func NewAddIndexIngestPipeline(
 	}
 	srcChkPool := createChunkPool(copCtx, reorgMeta)
 	readerCnt, writerCnt := expectedIngestWorkerCnt(concurrency, avgRowSize)
-	rm := reorgMeta
-	if rm.UseCloudStorage {
-		// param cannot be modified at runtime for global sort right now.
-		rm = nil
-	}
 
 	failpoint.Inject("mockDMLExecutionBeforeScan", func(_ failpoint.Value) {
 		if MockDMLExecutionBeforeScan != nil {
@@ -189,7 +184,7 @@ func NewAddIndexIngestPipeline(
 
 	srcOp := NewTableScanTaskSource(ctx, store, tbl, startKey, endKey, backendCtx)
 	scanOp := NewTableScanOperator(ctx, sessPool, copCtx, srcChkPool, readerCnt,
-		reorgMeta.GetBatchSize(), rm, backendCtx)
+		reorgMeta.GetBatchSize(), reorgMeta, backendCtx)
 	ingestOp := NewIndexIngestOperator(ctx, copCtx, sessPool,
 		tbl, indexes, engines, srcChkPool, writerCnt, reorgMeta)
 	sinkOp := newIndexWriteResultSink(ctx, backendCtx, tbl, indexes, rowCntListener)
@@ -255,7 +250,7 @@ func NewWriteIndexToExternalStoragePipeline(
 
 	srcOp := NewTableScanTaskSource(ctx, store, tbl, startKey, endKey, nil)
 	scanOp := NewTableScanOperator(ctx, sessPool, copCtx, srcChkPool, readerCnt,
-		reorgMeta.GetBatchSize(), nil, nil)
+		reorgMeta.GetBatchSize(), reorgMeta, nil)
 	writeOp := NewWriteExternalStoreOperator(
 		ctx, copCtx, sessPool, jobID, subtaskID,
 		tbl, indexes, extStore, srcChkPool, writerCnt,

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -103,35 +103,36 @@ func (r *readIndexStepExecutor) Init(ctx context.Context) error {
 	return nil
 }
 
-func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.Subtask) error {
-	logutil.DDLLogger().Info("read index executor run subtask",
-		zap.Bool("use cloud", r.isGlobalSort()))
-
-	r.subtaskSummary.Store(subtask.ID, &readIndexSummary{
-		metaGroups: make([]*external.SortedKVMeta, len(r.indexes)),
-	})
-
-	sm, err := decodeBackfillSubTaskMeta(ctx, r.cloudStorageURI, subtask.Meta)
+func (r *readIndexStepExecutor) runGlobalPipeline(
+	ctx context.Context,
+	opCtx *OperatorCtx,
+	subtask *proto.Subtask,
+	sm *BackfillSubTaskMeta,
+	concurrency int,
+) error {
+	pipe, err := r.buildExternalStorePipeline(opCtx, subtask.ID, sm, concurrency)
 	if err != nil {
 		return err
 	}
 
-	opCtx, cancel := NewDistTaskOperatorCtx(ctx, subtask.TaskID, subtask.ID)
-	defer cancel()
-	r.curRowCount.Store(0)
+	r.currPipe.Store(pipe)
+	defer func() {
+		r.currPipe.Store(nil)
+	}()
 
-	concurrency := int(r.GetResource().CPU.Capacity())
-	if r.isGlobalSort() {
-		pipe, err := r.buildExternalStorePipeline(opCtx, subtask.ID, sm, concurrency)
-		if err != nil {
-			return err
-		}
-		if err = executeAndClosePipeline(opCtx, pipe, nil, nil, r.avgRowSize); err != nil {
-			return errors.Trace(err)
-		}
-		return r.onFinished(ctx, subtask)
+	if err = executeAndClosePipeline(opCtx, pipe, nil, nil, r.avgRowSize); err != nil {
+		return errors.Trace(err)
 	}
+	return r.onFinished(ctx, subtask)
+}
 
+func (r *readIndexStepExecutor) runLocalPipeline(
+	ctx context.Context,
+	opCtx *OperatorCtx,
+	subtask *proto.Subtask,
+	sm *BackfillSubTaskMeta,
+	concurrency int,
+) error {
 	// TODO(tangenta): support checkpoint manager that interact with subtask table.
 	bCtx, err := ingest.NewBackendCtxBuilder(ctx, r.d.store, r.job).
 		WithImportDistributedLock(r.d.etcdCli, sm.TS).
@@ -158,11 +159,35 @@ func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.S
 		}
 		return err
 	}
-	err = bCtx.FinishAndUnregisterEngines(ingest.OptCleanData | ingest.OptCheckDup)
-	if err != nil {
+
+	if err = bCtx.FinishAndUnregisterEngines(ingest.OptCleanData | ingest.OptCheckDup); err != nil {
 		return errors.Trace(err)
 	}
 	return r.onFinished(ctx, subtask)
+}
+
+func (r *readIndexStepExecutor) RunSubtask(ctx context.Context, subtask *proto.Subtask) error {
+	logutil.DDLLogger().Info("read index executor run subtask",
+		zap.Bool("use cloud", r.isGlobalSort()))
+
+	r.subtaskSummary.Store(subtask.ID, &readIndexSummary{
+		metaGroups: make([]*external.SortedKVMeta, len(r.indexes)),
+	})
+
+	sm, err := decodeBackfillSubTaskMeta(ctx, r.cloudStorageURI, subtask.Meta)
+	if err != nil {
+		return err
+	}
+
+	opCtx, cancel := NewDistTaskOperatorCtx(ctx, subtask.TaskID, subtask.ID)
+	defer cancel()
+	r.curRowCount.Store(0)
+
+	concurrency := int(r.GetResource().CPU.Capacity())
+	if r.isGlobalSort() {
+		return r.runGlobalPipeline(ctx, opCtx, subtask, sm, concurrency)
+	}
+	return r.runLocalPipeline(ctx, opCtx, subtask, sm, concurrency)
 }
 
 func (r *readIndexStepExecutor) RealtimeSummary() *execute.SubtaskSummary {
@@ -180,9 +205,6 @@ func (r *readIndexStepExecutor) Cleanup(ctx context.Context) error {
 }
 
 func (r *readIndexStepExecutor) TaskMetaModified(_ context.Context, newMeta []byte) error {
-	if r.isGlobalSort() {
-		return goerrors.New("not support modify task meta for global sort")
-	}
 	newTaskMeta := &BackfillTaskMeta{}
 	if err := json.Unmarshal(newMeta, newTaskMeta); err != nil {
 		return errors.Trace(err)
@@ -191,29 +213,26 @@ func (r *readIndexStepExecutor) TaskMetaModified(_ context.Context, newMeta []by
 	if newBatchSize != r.job.ReorgMeta.GetBatchSize() {
 		r.job.ReorgMeta.SetBatchSize(newBatchSize)
 	}
-	newMaxWriteSpeed := newTaskMeta.Job.ReorgMeta.GetMaxWriteSpeed()
-	if newMaxWriteSpeed != r.job.ReorgMeta.GetMaxWriteSpeed() {
-		r.job.ReorgMeta.SetMaxWriteSpeed(newMaxWriteSpeed)
-		if r.backend != nil {
-			r.backend.UpdateWriteSpeedLimit(newMaxWriteSpeed)
+	// Only local sort need modify write speed in this step.
+	if !r.isGlobalSort() {
+		newMaxWriteSpeed := newTaskMeta.Job.ReorgMeta.GetMaxWriteSpeed()
+		if newMaxWriteSpeed != r.job.ReorgMeta.GetMaxWriteSpeed() {
+			r.job.ReorgMeta.SetMaxWriteSpeed(newMaxWriteSpeed)
+			if r.backend != nil {
+				r.backend.UpdateWriteSpeedLimit(newMaxWriteSpeed)
+			}
 		}
 	}
 	return nil
 }
 
 func (r *readIndexStepExecutor) ResourceModified(_ context.Context, newResource *proto.StepResource) error {
-	if r.isGlobalSort() {
-		return goerrors.New("not support modify resource for global sort")
-	}
 	pipe := r.currPipe.Load()
-	// Tune of work pool can only be called after start.
-	if pipe == nil || !pipe.IsStarted() {
+	if pipe == nil {
 		// let framework retry
 		return goerrors.New("no subtask running")
 	}
-	opR, opW := pipe.GetLocalIngestModeReaderAndWriter()
-	reader := opR.(*TableScanOperator)
-	writer := opW.(*IndexIngestOperator)
+	reader, writer := pipe.GetReaderAndWriter()
 	targetReaderCnt, targetWriterCnt := expectedIngestWorkerCnt(int(newResource.CPU.Capacity()), r.avgRowSize)
 	currentReaderCnt, currentWriterCnt := reader.GetWorkerPoolSize(), writer.GetWorkerPoolSize()
 	if int32(targetReaderCnt) != currentReaderCnt {

--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -1273,9 +1273,7 @@ func TestAdminAlterDDLJobUnsupportedCases(t *testing.T) {
 		Type: model.ActionAddColumn,
 	}
 	insertMockJob2Table(tk, &job)
-	// unsupported job type
-	tk.MustGetErrMsg(fmt.Sprintf("admin alter ddl jobs %d thread = 8;", job.ID),
-		"unsupported DDL operation: add column. Supported DDL operations are: ADD INDEX (without global sort), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION")
+	tk.MustExec(fmt.Sprintf("admin alter ddl jobs %d thread = 8;", job.ID))
 	deleteJobMetaByID(tk, 1)
 
 	job = model.Job{
@@ -1288,8 +1286,7 @@ func TestAdminAlterDDLJobUnsupportedCases(t *testing.T) {
 	}
 	insertMockJob2Table(tk, &job)
 	// unsupported job type
-	tk.MustGetErrMsg(fmt.Sprintf("admin alter ddl jobs %d thread = 8;", job.ID),
-		"unsupported DDL operation: add index. Supported DDL operations are: ADD INDEX (without global sort), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION")
+	tk.MustExec(fmt.Sprintf("admin alter ddl jobs %d thread = 8;", job.ID))
 	deleteJobMetaByID(tk, 1)
 }
 

--- a/pkg/disttask/operator/operator.go
+++ b/pkg/disttask/operator/operator.go
@@ -31,6 +31,12 @@ type Operator interface {
 	String() string
 }
 
+// TunableOperator is the operator which supports modifying pool size.
+type TunableOperator interface {
+	TuneWorkerPoolSize(workerNum int32, wait bool)
+	GetWorkerPoolSize() int32
+}
+
 // AsyncOperator process the data in async way.
 //
 // Eg: The sink of AsyncOperator op1 and the source of op2

--- a/pkg/disttask/operator/pipeline.go
+++ b/pkg/disttask/operator/pipeline.go
@@ -77,10 +77,13 @@ func (p *AsyncPipeline) String() string {
 	return "AsyncPipeline[" + strings.Join(opStrs, " -> ") + "]"
 }
 
-// GetLocalIngestModeReaderAndWriter returns the reader and writer in the local ingest mode.
-func (p *AsyncPipeline) GetLocalIngestModeReaderAndWriter() (operator1, operator2 Operator) {
+// GetReaderAndWriter returns the reader and writer in this pipeline.
+// Currently this can only be used in readIndexStepExecutor.
+func (p *AsyncPipeline) GetReaderAndWriter() (operator1, operator2 TunableOperator) {
 	if len(p.ops) != 4 {
 		return nil, nil
 	}
-	return p.ops[1], p.ops[2]
+	r, _ := p.ops[1].(TunableOperator)
+	w, _ := p.ops[2].(TunableOperator)
+	return r, w
 }

--- a/pkg/executor/operate_ddl_jobs.go
+++ b/pkg/executor/operate_ddl_jobs.go
@@ -170,7 +170,7 @@ func (e *AlterDDLJobExec) processAlterDDLJobConfig(
 		}
 		if !job.IsAlterable() {
 			return fmt.Errorf("unsupported DDL operation: %s. "+
-				"Supported DDL operations are: ADD INDEX (without global sort), MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION", job.Type.String())
+				"Supported DDL operations are: ADD INDEX, MODIFY COLUMN, and ALTER TABLE REORGANIZE PARTITION", job.Type.String())
 		}
 		if err = e.updateReorgMeta(job, model.AdminCommandByEndUser); err != nil {
 			continue

--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -244,20 +244,6 @@ func split[T any](in []T, groupNum int) [][]T {
 	return ret
 }
 
-func (e *Engine) getAdjustedConcurrency() int {
-	if e.checkHotspot {
-		// estimate we will open at most 8000 files, so if e.dataFiles is small we can
-		// try to concurrently process ranges.
-		adjusted := maxCloudStorageConnections / len(e.dataFiles)
-		if adjusted == 0 {
-			return 1
-		}
-		return min(adjusted, 8)
-	}
-	adjusted := min(e.workerConcurrency, maxCloudStorageConnections/len(e.dataFiles))
-	return max(adjusted, 1)
-}
-
 func getFilesReadConcurrency(
 	ctx context.Context,
 	storage storage.ExternalStorage,

--- a/pkg/lightning/backend/external/engine_test.go
+++ b/pkg/lightning/backend/external/engine_test.go
@@ -16,7 +16,6 @@ package external
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"testing"
 
@@ -213,32 +212,6 @@ func TestSplit(t *testing.T) {
 		got := split(c.input, c.conc)
 		require.Equal(t, c.expected, got)
 	}
-}
-
-func TestGetAdjustedConcurrency(t *testing.T) {
-	genFiles := func(n int) []string {
-		files := make([]string, 0, n)
-		for i := 0; i < n; i++ {
-			files = append(files, fmt.Sprintf("file%d", i))
-		}
-		return files
-	}
-	e := &Engine{
-		checkHotspot:      true,
-		workerConcurrency: 32,
-		dataFiles:         genFiles(100),
-	}
-	require.Equal(t, 8, e.getAdjustedConcurrency())
-	e.dataFiles = genFiles(8000)
-	require.Equal(t, 1, e.getAdjustedConcurrency())
-
-	e.checkHotspot = false
-	e.dataFiles = genFiles(10)
-	require.Equal(t, 32, e.getAdjustedConcurrency())
-	e.dataFiles = genFiles(100)
-	require.Equal(t, 10, e.getAdjustedConcurrency())
-	e.dataFiles = genFiles(10000)
-	require.Equal(t, 1, e.getAdjustedConcurrency())
 }
 
 func TestTryDecodeEndKey(t *testing.T) {

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -646,7 +646,7 @@ func (job *Job) IsPausable() bool {
 // IsAlterable checks whether the job type can be altered.
 func (job *Job) IsAlterable() bool {
 	// Currently, only non-distributed add index reorg task can be altered
-	return job.Type == ActionAddIndex && !job.ReorgMeta.UseCloudStorage ||
+	return job.Type == ActionAddIndex ||
 		job.Type == ActionModifyColumn ||
 		job.Type == ActionReorganizePartition
 }

--- a/pkg/resourcemanager/pool/workerpool/workerpool.go
+++ b/pkg/resourcemanager/pool/workerpool/workerpool.go
@@ -17,6 +17,7 @@ package workerpool
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/tidb/pkg/resourcemanager/util"
@@ -60,6 +61,7 @@ type WorkerPool[T TaskMayPanic, R any] struct {
 	wg            tidbutil.WaitGroupWrapper
 	createWorker  func() Worker[T, R]
 	lastTuneTs    atomicutil.Time
+	started       atomic.Bool
 	mu            syncutil.RWMutex
 }
 
@@ -124,9 +126,13 @@ func (p *WorkerPool[T, R]) Start(ctx context.Context) {
 
 	p.ctx, p.cancel = context.WithCancel(ctx)
 
-	for i := 0; i < int(p.numWorkers); i++ {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for range p.numWorkers {
 		p.runAWorker()
 	}
+	p.started.Store(true)
 }
 
 func (p *WorkerPool[T, R]) handleTaskWithRecover(w Worker[T, R], task T) {
@@ -200,17 +206,24 @@ func (p *WorkerPool[T, R]) Tune(numWorkers int32, wait bool) {
 	p.lastTuneTs.Store(time.Now())
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	// If the pool is not started, just set the number of workers.
+	if !p.started.Load() {
+		p.numWorkers = numWorkers
+		return
+	}
+
 	diff := numWorkers - p.numWorkers
 	if diff > 0 {
 		// Add workers
-		for i := 0; i < int(diff); i++ {
+		for range diff {
 			p.runAWorker()
 		}
 	} else if diff < 0 {
 		// Remove workers
 		var wg sync.WaitGroup
 	outer:
-		for i := 0; i < int(-diff); i++ {
+		for range int(-diff) {
 			wg.Add(1)
 			select {
 			case p.quitChan <- tuneConfig{wg: &wg}:
@@ -225,6 +238,8 @@ func (p *WorkerPool[T, R]) Tune(numWorkers int32, wait bool) {
 			wg.Wait()
 		}
 	}
+	logutil.BgLogger().Info("tune worker pool",
+		zap.Int32("from", p.numWorkers), zap.Int32("to", numWorkers))
 	p.numWorkers = numWorkers
 }
 

--- a/pkg/resourcemanager/pool/workerpool/workpool_test.go
+++ b/pkg/resourcemanager/pool/workerpool/workpool_test.go
@@ -75,7 +75,7 @@ func TestWorkerPool(t *testing.T) {
 
 	// Add some tasks to the pool.
 	cntWg.Add(10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		pool.AddTask(int64Task(i))
 	}
 
@@ -88,7 +88,7 @@ func TestWorkerPool(t *testing.T) {
 
 	// Add some more tasks to the pool.
 	cntWg.Add(10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		pool.AddTask(int64Task(i))
 	}
 
@@ -101,7 +101,7 @@ func TestWorkerPool(t *testing.T) {
 
 	// Add some more tasks to the pool.
 	cntWg.Add(10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		pool.AddTask(int64Task(i))
 	}
 
@@ -120,7 +120,7 @@ func TestTunePoolSize(t *testing.T) {
 		seed := time.Now().UnixNano()
 		rnd := rand.New(rand.NewSource(seed))
 		t.Logf("seed: %d", seed)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			wait := rnd.Intn(2) == 0
 			larger := pool.Cap() + rnd.Int31n(10) + 2
 			pool.Tune(larger, wait)
@@ -131,6 +131,15 @@ func TestTunePoolSize(t *testing.T) {
 		}
 		pool.Release()
 		pool.Wait()
+	})
+
+	t.Run("change pool size before start", func(t *testing.T) {
+		pool := NewWorkerPool[int64Task]("test", util.UNKNOWN, 10, createMyWorker)
+		pool.Tune(5, true)
+		pool.Start(context.Background())
+		pool.Release()
+		pool.Wait()
+		require.EqualValues(t, 5, pool.Cap())
 	})
 
 	t.Run("context done when reduce pool size and wait", func(t *testing.T) {
@@ -203,7 +212,7 @@ func TestWorkerPoolCustomChan(t *testing.T) {
 	})
 
 	pool.Start(context.Background())
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		taskCh <- int64Task(i)
 	}
 	close(taskCh)

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +31,8 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/disttask/framework/testutil"
+	"github.com/pingcap/tidb/pkg/disttask/operator"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -444,4 +448,84 @@ func TestIngestUseGivenTS(t *testing.T) {
 	require.NotNil(t, mvccResp.Info)
 	require.Greater(t, len(mvccResp.Info.Writes), 0)
 	require.Equal(t, presetTS, mvccResp.Info.Writes[0].CommitTs)
+}
+
+func TestAlterJobOnDXWithGlobalSort(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/util/cpu/mockNumCpu", `return(16)`))
+	testutil.ReduceCheckInterval(t)
+
+	gcsHost, gcsPort, cloudStorageURI := genStorageURI(t)
+	opt := fakestorage.Options{
+		Scheme:     "http",
+		Host:       gcsHost,
+		Port:       gcsPort,
+		PublicHost: gcsHost,
+	}
+	server, err := fakestorage.NewServerWithOptions(opt)
+	require.NoError(t, err)
+	server.CreateBucketWithOpts(fakestorage.CreateBucketOpts{Name: "sorted"})
+	t.Cleanup(server.Stop)
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("set global tidb_enable_dist_task = on;")
+	t.Cleanup(func() {
+		tk.MustExec("set global tidb_enable_dist_task = off;")
+	})
+	tk.MustExec(`set global tidb_ddl_enable_fast_reorg = on;`)
+	tk.MustExec("set @@global.tidb_cloud_storage_uri = '" + cloudStorageURI + "';")
+	t.Cleanup(func() {
+		tk.MustExec("set @@global.tidb_cloud_storage_uri = '';")
+	})
+
+	tk.MustExec("drop database if exists testalter;")
+	tk.MustExec("create database testalter;")
+	tk.MustExec("use testalter;")
+	tk.MustExec("create table gsort(a bigint auto_random primary key);")
+	for range 16 {
+		tk.MustExec("insert into gsort values (), (), (), ()")
+	}
+	tk.MustExec("split table gsort between (3) and (8646911284551352360) regions 50;")
+
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1")
+	tk.MustExec("set @@tidb_ddl_reorg_batch_size = 32")
+	tk.MustExec("set global tidb_ddl_reorg_max_write_speed = 16")
+	t.Cleanup(func() {
+		tk.MustExec("set global tidb_ddl_reorg_max_write_speed = 0")
+	})
+
+	var pipeClosed bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterPipeLineClose", func(pipe *operator.AsyncPipeline) {
+		pipeClosed = true
+		reader, writer := pipe.GetReaderAndWriter()
+		require.EqualValues(t, 4, reader.(*ddl.TableScanOperator).GetWorkerPoolSize())
+		require.EqualValues(t, 6, writer.(*ddl.IndexIngestOperator).GetWorkerPoolSize())
+	})
+
+	// Change the batch size and concurrency during table scanning and check the modified parameters.
+	var modified atomic.Bool
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/afterDetectAndHandleParamModify", func() {
+		require.False(t, modified.Load())
+		modified.Store(true)
+	})
+	var onceScan sync.Once
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/scanRecordExec", func(reorgMeta *model.DDLReorgMeta) {
+		onceScan.Do(func() {
+			tk1 := testkit.NewTestKit(t, store)
+			rows := tk1.MustQuery("select job_id from mysql.tidb_ddl_job").Rows()
+			require.Len(t, rows, 1)
+			tk1.MustExec(fmt.Sprintf("admin alter ddl jobs %s thread = 8, batch_size = 256", rows[0][0]))
+			require.Eventually(t, func() bool {
+				return modified.Load()
+			}, 20*time.Second, 100*time.Millisecond)
+			require.Equal(t, 256, reorgMeta.GetBatchSize())
+			modified.Store(false)
+		})
+	})
+
+	tk.MustExec("alter table t1 add index idx(a);")
+	require.True(t, pipeClosed)
+	require.True(t, modified.Load())
+	tk.MustExec("admin check index t1 idx;")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/57497, ref https://github.com/pingcap/tidb/issues/57229

Problem Summary:

### What changed and how does it work?

This is the first part for supporting dynamic parameters change for add-index on DXF with global sort:

- Remove limitation for `alter ddl jobs` for add index with global sort
- Modify the batch size, as well as thread for read index step.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
