### PR TITLE
localbackend: fix retry on ingest err 'disk full'

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -471,6 +471,11 @@ error = '''
 server is busy
 '''
 
+["Lightning:KV:StoreDiskFull"]
+error = '''
+store disk full
+'''
+
 ["Lightning:Loader:ErrInvalidSchemaFile"]
 error = '''
 invalid schema file

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -901,8 +901,6 @@ func (j *regionJob) convertStageOnIngestError(
 		j.convertStageTo(needRescan)
 		return false, nil
 	case errPb.DiskFull != nil:
-		j.lastRetryableErr = common.ErrKVDiskFull.GenWithStack(errPb.GetMessage())
-
 		return false, common.ErrKVDiskFull.GenWithStack(errPb.GetMessage())
 	}
 	// all others doIngest error, such as stale command, etc. we'll retry it again from writeAndIngestByRange

--- a/pkg/lightning/backend/local/region_job_test.go
+++ b/pkg/lightning/backend/local/region_job_test.go
@@ -168,7 +168,7 @@ func TestIsIngestRetryable(t *testing.T) {
 	}
 	clone = job
 	_, err = (&clone).convertStageOnIngestError(resp)
-	require.ErrorContains(t, err, "non-retryable error")
+	require.ErrorContains(t, err, "DiskFull")
 
 	// a general error is retryable from writing
 

--- a/pkg/lightning/common/errors.go
+++ b/pkg/lightning/common/errors.go
@@ -82,6 +82,7 @@ var (
 	ErrKVServerIsBusy        = errors.Normalize("server is busy", errors.RFCCodeText("Lightning:KV:ServerIsBusy"))
 	ErrKVRegionNotFound      = errors.Normalize("region not found", errors.RFCCodeText("Lightning:KV:RegionNotFound"))
 	ErrKVReadIndexNotReady   = errors.Normalize("read index not ready", errors.RFCCodeText("Lightning:KV:ReadIndexNotReady"))
+	ErrKVDiskFull            = errors.Normalize("store disk full", errors.RFCCodeText("Lightning:KV:StoreDiskFull"))
 	ErrKVIngestFailed        = errors.Normalize("ingest tikv failed", errors.RFCCodeText("Lightning:KV:ErrKVIngestFailed"))
 	ErrKVRaftProposalDropped = errors.Normalize("raft proposal dropped", errors.RFCCodeText("Lightning:KV:ErrKVRaftProposalDropped"))
 	ErrNoLeader              = errors.Normalize("write to tikv with no leader returned, region '%d', leader: %d", errors.RFCCodeText("Lightning:KV:ErrNoLeader"))

--- a/pkg/lightning/common/retry_test.go
+++ b/pkg/lightning/common/retry_test.go
@@ -59,6 +59,7 @@ func TestIsRetryableError(t *testing.T) {
 	require.True(t, IsRetryableError(ErrKVReadIndexNotReady.GenWithStack("test")))
 	require.True(t, IsRetryableError(ErrKVIngestFailed.GenWithStack("test")))
 	require.True(t, IsRetryableError(ErrKVRaftProposalDropped.GenWithStack("test")))
+	require.False(t, IsRetryableError(ErrKVDiskFull.GenWithStack("test")))
 
 	// tidb error
 	require.True(t, IsRetryableError(drivererr.ErrRegionUnavailable))

--- a/tests/realtikvtest/importintotest2/from_select_test.go
+++ b/tests/realtikvtest/importintotest2/from_select_test.go
@@ -164,3 +164,10 @@ func (s *mockGCSSuite) TestCastNegativeToUnsigned() {
 	s.tk.MustExec("import into dt from select -1")
 	s.tk.MustQuery("select * from dt").Check(testkit.Rows("0"))
 }
+
+func (s *mockGCSSuite) TestDiskFullOnIngestFailFast() {
+	s.prepareAndUseDB("from_select")
+	s.tk.MustExec("create table dt(id int unsigned)")
+	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/pkg/lightning/backend/local/diskFullOnIngest", `return(true)`)
+	s.ErrorContains(s.tk.ExecToErr("import into dt from select 1"), "tikv disk full")
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60678

Problem Summary:

### What changed and how does it work?
add a named `ErrKVDiskFull` and avoid retry on it
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
