### PR TITLE
localbackend: unify job stage transition during ingest | tidb-test=ccf9f5de6817ed2e54c18f2c1757056d2c8b4e4c

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -471,6 +471,11 @@ error = '''
 server is busy
 '''
 
+["Lightning:KV:StoreDiskFull"]
+error = '''
+store disk full
+'''
+
 ["Lightning:Loader:ErrInvalidSchemaFile"]
 error = '''
 invalid schema file

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -264,8 +264,8 @@ type objStoreRegionJobWorker struct {
 }
 
 func (*objStoreRegionJobWorker) preRunJob(_ context.Context, _ *regionJob) error {
-	// cloud engine use cloud storage, such as S3, to hold data, so no need to check
-	// disk fullness.
+	// cloud engine use cloud storage, such as S3, to hold data, it's assumed to
+	// have unlimited available space, so no need to check disk fullness.
 	return nil
 }
 

--- a/pkg/lightning/backend/local/job_worker.go
+++ b/pkg/lightning/backend/local/job_worker.go
@@ -378,7 +378,7 @@ func (w *objStoreRegionJobWorker) ingest(ctx context.Context, j *regionJob) erro
 			logutil.Key("end", j.keyRange.End))
 
 		// TODO: choose target stage based on error.
-		return err
+		return &ingestAPIError{err: err}
 	}
 	return nil
 }

--- a/pkg/lightning/backend/local/job_worker_test.go
+++ b/pkg/lightning/backend/local/job_worker_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/br/pkg/restore/split"
 	"github.com/pingcap/tidb/pkg/ingestor/ingestcli"
 	ingestclimock "github.com/pingcap/tidb/pkg/ingestor/ingestcli/mock"
 	"github.com/pingcap/tidb/pkg/lightning/common"
@@ -41,7 +43,6 @@ func TestRegionJobBaseWorker(t *testing.T) {
 				return &tikvWriteResult{}, nil
 			},
 			ingestFn: func(ctx context.Context, job *regionJob) error {
-				job.convertStageTo(ingested)
 				return nil
 			},
 			regenerateJobsFn: func(
@@ -74,13 +75,75 @@ func TestRegionJobBaseWorker(t *testing.T) {
 		close(w.jobInCh)
 		require.NoError(t, w.run(context.Background()))
 		require.Equal(t, 1, len(w.jobOutCh))
+		outJob := <-w.jobOutCh
+		require.Equal(t, ingested, outJob.stage)
+	})
+
+	t.Run("empty job", func(t *testing.T) {
+		w := newWorker()
+		w.writeFn = func(ctx context.Context, job *regionJob) (*tikvWriteResult, error) {
+			return &tikvWriteResult{emptyJob: true}, nil
+		}
+		job := &regionJob{stage: regionScanned, ingestData: mockIngestData{}}
+		w.jobInCh <- job
+		close(w.jobInCh)
+		require.NoError(t, w.run(context.Background()))
+		require.Equal(t, 1, len(w.jobOutCh))
+		outJob := <-w.jobOutCh
+		require.Equal(t, ingested, outJob.stage)
+	})
+
+	t.Run("meet non-retryable error during ingest", func(t *testing.T) {
+		w := newWorker()
+		w.ingestFn = func(ctx context.Context, job *regionJob) error {
+			return &ingestAPIError{err: common.ErrKVDiskFull}
+		}
+		job := &regionJob{stage: regionScanned, ingestData: mockIngestData{}}
+		w.jobInCh <- job
+		close(w.jobInCh)
+		require.ErrorIs(t, w.run(context.Background()), common.ErrKVDiskFull)
+		require.Equal(t, 1, len(w.jobOutCh))
+		outJob := <-w.jobOutCh
+		// the job is left in wrote stage
+		require.Equal(t, wrote, outJob.stage)
+		require.Nil(t, outJob.lastRetryableErr)
+	})
+
+	t.Run("retry job from regionScanned", func(t *testing.T) {
+		w := newWorker()
+		w.ingestFn = func(ctx context.Context, job *regionJob) error {
+			return &ingestAPIError{err: common.ErrKVIngestFailed}
+		}
+		job := &regionJob{stage: regionScanned, ingestData: mockIngestData{}}
+		w.jobInCh <- job
+		close(w.jobInCh)
+		require.NoError(t, w.run(context.Background()))
+		require.Equal(t, 1, len(w.jobOutCh))
+		outJob := <-w.jobOutCh
+		require.Equal(t, regionScanned, outJob.stage)
+		require.ErrorIs(t, outJob.lastRetryableErr, common.ErrKVIngestFailed)
+	})
+
+	t.Run("retry job from regionScanned, and region got from the ingest error", func(t *testing.T) {
+		w := newWorker()
+		w.ingestFn = func(ctx context.Context, job *regionJob) error {
+			return &ingestAPIError{err: common.ErrKVEpochNotMatch, newRegion: &split.RegionInfo{Region: &metapb.Region{Id: 123}}}
+		}
+		job := &regionJob{stage: regionScanned, ingestData: mockIngestData{}}
+		w.jobInCh <- job
+		close(w.jobInCh)
+		require.NoError(t, w.run(context.Background()))
+		require.Equal(t, 1, len(w.jobOutCh))
+		outJob := <-w.jobOutCh
+		require.Equal(t, regionScanned, outJob.stage)
+		require.ErrorIs(t, outJob.lastRetryableErr, common.ErrKVEpochNotMatch)
+		require.Equal(t, &split.RegionInfo{Region: &metapb.Region{Id: 123}}, outJob.region)
 	})
 
 	t.Run("regenerate jobs", func(t *testing.T) {
 		w := newWorker()
 		w.ingestFn = func(ctx context.Context, job *regionJob) error {
-			job.convertStageTo(needRescan)
-			return nil
+			return &ingestAPIError{err: common.ErrKVNotLeader}
 		}
 		job := &regionJob{stage: regionScanned, ingestData: mockIngestData{}}
 		w.jobInCh <- job
@@ -200,7 +263,6 @@ func TestCloudRegionJobWorker(t *testing.T) {
 		mockIngestCli.EXPECT().Ingest(gomock.Any(), gomock.Any()).Return(errors.New("mock error"))
 		err := cloudW.ingest(context.Background(), job)
 		require.ErrorContains(t, err, "mock error")
-		require.Equal(t, needRescan, job.stage)
 		require.True(t, ctrl.Satisfied())
 	})
 
@@ -214,7 +276,6 @@ func TestCloudRegionJobWorker(t *testing.T) {
 		mockIngestCli.EXPECT().Ingest(gomock.Any(), gomock.Any()).Return(nil)
 		err := cloudW.ingest(context.Background(), job)
 		require.NoError(t, err)
-		require.Equal(t, ingested, job.stage)
 		require.True(t, ctrl.Satisfied())
 	})
 }

--- a/pkg/lightning/backend/local/local_test.go
+++ b/pkg/lightning/backend/local/local_test.go
@@ -1832,9 +1832,7 @@ func getSuccessInjectedBehaviour() []injectedBehaviour {
 			},
 		},
 		{
-			ingest: injectedIngestBehaviour{
-				nextStage: ingested,
-			},
+			ingest: injectedIngestBehaviour{},
 		},
 	}
 }
@@ -1850,8 +1848,7 @@ func getNeedRescanWhenIngestBehaviour() []injectedBehaviour {
 		},
 		{
 			ingest: injectedIngestBehaviour{
-				nextStage: needRescan,
-				err:       common.ErrKVEpochNotMatch,
+				err: &ingestAPIError{err: common.ErrKVEpochNotMatch},
 			},
 		},
 	}
@@ -1909,9 +1906,7 @@ func TestDoImport(t *testing.T) {
 							},
 						},
 						{
-							ingest: injectedIngestBehaviour{
-								nextStage: ingested,
-							},
+							ingest: injectedIngestBehaviour{},
 						},
 						{
 							write: injectedWriteBehaviour{
@@ -1921,9 +1916,7 @@ func TestDoImport(t *testing.T) {
 							},
 						},
 						{
-							ingest: injectedIngestBehaviour{
-								nextStage: ingested,
-							},
+							ingest: injectedIngestBehaviour{},
 						},
 					},
 				},

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -619,7 +619,8 @@ func (local *Backend) ingest(ctx context.Context, j *regionJob) (err error) {
 			}
 			log.FromContext(ctx).Warn("meet underlying error, will retry ingest",
 				log.ShortError(err), logutil.SSTMetas(j.writeResult.sstMeta),
-				logutil.Region(j.region.Region), logutil.Leader(j.region.Leader))
+				logutil.Region(j.region.Region), logutil.Leader(j.region.Leader),
+				zap.Int("retry", retry))
 			lastRetriedErr = err
 			continue
 		}

--- a/pkg/lightning/backend/local/region_job.go
+++ b/pkg/lightning/backend/local/region_job.go
@@ -592,7 +592,7 @@ func (local *Backend) doWrite(ctx context.Context, j *regionJob) (*tikvWriteResu
 // set job to a proper stage with nil error returned.
 // if any underlying logic has error, ingest will return an error to let caller
 // handle it.
-func (local *Backend) ingest(ctx context.Context, j *regionJob) (err error) {
+func (local *Backend) ingest(ctx context.Context, j *regionJob) (res *ingestResult) {
 	failpoint.Inject("fakeRegionJobs", func() {
 		front := j.injected[0]
 		j.injected = j.injected[1:]
@@ -601,55 +601,43 @@ func (local *Backend) ingest(ctx context.Context, j *regionJob) (err error) {
 	})
 
 	if len(j.writeResult.sstMeta) == 0 {
-		j.convertStageTo(ingested)
-		return nil
+		return &ingestResult{nextStage: ingested}
 	}
 
 	if m, ok := metric.FromContext(ctx); ok {
 		begin := time.Now()
 		defer func() {
-			if err == nil {
+			if res.ingestErr == nil {
 				m.SSTSecondsHistogram.WithLabelValues(metric.SSTProcessIngest).Observe(time.Since(begin).Seconds())
 			}
 		}()
 	}
 
+	var lastRetriedErr error
 	for retry := 0; retry < maxRetryTimes; retry++ {
 		resp, err := local.doIngest(ctx, j)
-		if err == nil && resp.GetError() == nil {
-			j.convertStageTo(ingested)
-			return nil
-		}
 		if err != nil {
 			if common.IsContextCanceledError(err) {
-				return err
+				return &ingestResult{
+					nextStage: wrote,
+					ingestErr: err,
+				}
 			}
 			log.FromContext(ctx).Warn("meet underlying error, will retry ingest",
 				log.ShortError(err), logutil.SSTMetas(j.writeResult.sstMeta),
 				logutil.Region(j.region.Region), logutil.Leader(j.region.Leader))
-			j.lastRetryableErr = err
+			lastRetriedErr = err
 			continue
 		}
-		canContinue, err := j.convertStageOnIngestError(resp)
-		if common.IsContextCanceledError(err) {
-			return err
+		if resp.GetError() == nil {
+			return &ingestResult{nextStage: ingested}
 		}
-		if !canContinue {
-			log.FromContext(ctx).Warn("meet error and handle the job later",
-				zap.Stringer("job stage", j.stage),
-				logutil.ShortError(j.lastRetryableErr),
-				j.region.ToZapFields(),
-				logutil.Key("start", j.keyRange.Start),
-				logutil.Key("end", j.keyRange.End))
-			return nil
-		}
-		log.FromContext(ctx).Warn("meet error and will doIngest region again",
-			logutil.ShortError(j.lastRetryableErr),
-			j.region.ToZapFields(),
-			logutil.Key("start", j.keyRange.Start),
-			logutil.Key("end", j.keyRange.End))
+		return convertPBError2IngestResult(j, resp.GetError())
 	}
-	return nil
+	return &ingestResult{
+		nextStage: wrote,
+		ingestErr: lastRetriedErr,
+	}
 }
 
 func (local *Backend) checkWriteStall(
@@ -765,7 +753,7 @@ func (local *Backend) doIngest(ctx context.Context, j *regionJob) (*sst.IngestRe
 			}
 			resp, err = cli.Ingest(ctx, req)
 		}
-		if resp.GetError() != nil || err != nil {
+		if err != nil || resp.GetError() != nil {
 			// remove finished sstMetas
 			j.writeResult.sstMeta = j.writeResult.sstMeta[start:]
 			return resp, errors.Trace(err)
@@ -784,33 +772,35 @@ func (local *Backend) GetWriteSpeedLimit() int {
 	return local.writeLimiter.Limit()
 }
 
+type ingestResult struct {
+	nextStage jobStageTp
+	// if nextStage = regionScanned, the new region info is extracted from the PB
+	// error
+	newRegion *split.RegionInfo
+	ingestErr error
+}
+
 // convertStageOnIngestError will try to fix the error contained in ingest response.
 // Return (_, error) when another error occurred.
 // Return (true, nil) when the job can retry ingesting immediately.
 // Return (false, nil) when the job should be put back to queue.
-func (j *regionJob) convertStageOnIngestError(
-	resp *sst.IngestResponse,
-) (bool, error) {
-	if resp.GetError() == nil {
-		return true, nil
-	}
-
+func convertPBError2IngestResult(job *regionJob, errPb *errorpb.Error) *ingestResult {
 	var newRegion *split.RegionInfo
-	switch errPb := resp.GetError(); {
+	res := &ingestResult{
+		nextStage: needRescan,
+	}
+	switch {
 	case errPb.NotLeader != nil:
-		j.lastRetryableErr = common.ErrKVNotLeader.GenWithStack(errPb.GetMessage())
-
 		// meet a problem that the region leader+peer are all updated but the return
 		// error is only "NotLeader", we should update the whole region info.
-		j.convertStageTo(needRescan)
-		return false, nil
+		res.ingestErr = common.ErrKVNotLeader.GenWithStack(errPb.GetMessage())
 	case errPb.EpochNotMatch != nil:
-		j.lastRetryableErr = common.ErrKVEpochNotMatch.GenWithStack(errPb.GetMessage())
+		res.ingestErr = common.ErrKVEpochNotMatch.GenWithStack(errPb.GetMessage())
 
 		if currentRegions := errPb.GetEpochNotMatch().GetCurrentRegions(); currentRegions != nil {
 			var currentRegion *metapb.Region
 			for _, r := range currentRegions {
-				if insideRegion(r, j.writeResult.sstMeta) {
+				if insideRegion(r, job.writeResult.sstMeta) {
 					currentRegion = r
 					break
 				}
@@ -818,7 +808,7 @@ func (j *regionJob) convertStageOnIngestError(
 			if currentRegion != nil {
 				var newLeader *metapb.Peer
 				for _, p := range currentRegion.Peers {
-					if p.GetStoreId() == j.region.Leader.GetStoreId() {
+					if p.GetStoreId() == job.region.Leader.GetStoreId() {
 						newLeader = p
 						break
 					}
@@ -832,46 +822,36 @@ func (j *regionJob) convertStageOnIngestError(
 			}
 		}
 		if newRegion != nil {
-			j.region = newRegion
-			j.convertStageTo(regionScanned)
-			return false, nil
+			res.newRegion = newRegion
+			res.nextStage = regionScanned
+			return nil
 		}
-		j.convertStageTo(needRescan)
-		return false, nil
 	case strings.Contains(errPb.Message, "raft: proposal dropped"):
-		j.lastRetryableErr = common.ErrKVRaftProposalDropped.GenWithStack(errPb.GetMessage())
-
-		j.convertStageTo(needRescan)
-		return false, nil
+		res.ingestErr = common.ErrKVRaftProposalDropped.GenWithStack(errPb.GetMessage())
 	case errPb.ServerIsBusy != nil:
-		j.lastRetryableErr = common.ErrKVServerIsBusy.GenWithStack(errPb.GetMessage())
-
-		return false, nil
+		res.ingestErr = common.ErrKVServerIsBusy.GenWithStack(errPb.GetMessage())
+		res.nextStage = wrote
 	case errPb.RegionNotFound != nil:
-		j.lastRetryableErr = common.ErrKVRegionNotFound.GenWithStack(errPb.GetMessage())
-
-		j.convertStageTo(needRescan)
-		return false, nil
+		res.ingestErr = common.ErrKVRegionNotFound.GenWithStack(errPb.GetMessage())
 	case errPb.ReadIndexNotReady != nil:
-		j.lastRetryableErr = common.ErrKVReadIndexNotReady.GenWithStack(errPb.GetMessage())
-
 		// this error happens when this region is splitting, the error might be:
 		//   read index not ready, reason can not read index due to split, region 64037
 		// we have paused schedule, but it's temporary,
 		// if next request takes a long time, there's chance schedule is enabled again
 		// or on key range border, another engine sharing this region tries to split this
 		// region may cause this error too.
-		j.convertStageTo(needRescan)
-		return false, nil
+		res.ingestErr = common.ErrKVReadIndexNotReady.GenWithStack(errPb.GetMessage())
 	case errPb.DiskFull != nil:
-		j.lastRetryableErr = common.ErrKVIngestFailed.GenWithStack(errPb.GetMessage())
-
-		return false, errors.Errorf("non-retryable error: %s", resp.GetError().GetMessage())
+		// TODO ErrKVIngestFailed is an retryable error, but it shouldn't retry
+		// when disk is full. we won't change the old behavior in this PR.
+		res.ingestErr = common.ErrKVIngestFailed.GenWithStack(errPb.GetMessage())
+		res.nextStage = wrote
+	default:
+		// all others doIngest error, such as stale command, etc. we'll retry it again from writeAndIngestByRange
+		res.ingestErr = common.ErrKVIngestFailed.GenWithStack(errPb.GetMessage())
+		res.nextStage = regionScanned
 	}
-	// all others doIngest error, such as stale command, etc. we'll retry it again from writeAndIngestByRange
-	j.lastRetryableErr = common.ErrKVIngestFailed.GenWithStack(resp.GetError().GetMessage())
-	j.convertStageTo(regionScanned)
-	return false, nil
+	return nil
 }
 
 type regionJobRetryHeap []*regionJob

--- a/pkg/lightning/backend/local/region_job_test.go
+++ b/pkg/lightning/backend/local/region_job_test.go
@@ -16,7 +16,9 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -45,143 +47,112 @@ func TestIsIngestRetryable(t *testing.T) {
 		},
 	}
 	metas := []*sst.SSTMeta{
-		{
-			Range: &sst.Range{
-				Start: []byte{1},
-				End:   []byte{2},
-			},
-		},
-		{
-			Range: &sst.Range{
-				Start: []byte{1, 1},
-				End:   []byte{2},
-			},
-		},
+		{Range: &sst.Range{Start: []byte{1}, End: []byte{2}}},
+		{Range: &sst.Range{Start: []byte{1, 1}, End: []byte{2}}},
 	}
-	job := regionJob{
-		stage: wrote,
-		keyRange: common.Range{
-			Start: []byte{1},
-			End:   []byte{3},
-		},
-		region: region,
+	job := &regionJob{
+		stage:    wrote,
+		keyRange: common.Range{Start: []byte{1}, End: []byte{3}},
+		region:   region,
 		writeResult: &tikvWriteResult{
 			sstMeta: metas,
 		},
 	}
-	// NotLeader doesn't mean region peers are changed, so we can retry ingest.
 
-	resp := &sst.IngestResponse{
-		Error: &errorpb.Error{
-			NotLeader: &errorpb.NotLeader{
-				Leader: &metapb.Peer{Id: 2},
-			},
+	newRegion := &metapb.Region{
+		Id:       1,
+		StartKey: []byte{1},
+		EndKey:   []byte{3},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 2,
 		},
+		Peers: []*metapb.Peer{{Id: 1}},
 	}
 
-	clone := job
-	canContinueIngest, err := (&clone).convertStageOnIngestError(resp)
-	require.NoError(t, err)
-	require.False(t, canContinueIngest)
-	require.Equal(t, needRescan, clone.stage)
-	require.Error(t, clone.lastRetryableErr)
-
-	// EpochNotMatch means region is changed, if the new region covers the old, we can restart the writing process.
-	// Otherwise, we should restart from region scanning.
-
-	resp.Error = &errorpb.Error{
-		EpochNotMatch: &errorpb.EpochNotMatch{
-			CurrentRegions: []*metapb.Region{
-				{
-					Id:       1,
-					StartKey: []byte{1},
-					EndKey:   []byte{3},
-					RegionEpoch: &metapb.RegionEpoch{
-						ConfVer: 1,
-						Version: 2,
-					},
-					Peers: []*metapb.Peer{{Id: 1}},
-				},
-			},
+	cases := []struct {
+		pbErr *errorpb.Error
+		res   *ingestAPIError
+	}{
+		// NotLeader doesn't mean region peers are changed, so we can retry ingest.
+		{pbErr: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}, res: &ingestAPIError{err: common.ErrKVNotLeader}},
+		// EpochNotMatch means region is changed, if the new region covers the old, we can restart the writing process.
+		// Otherwise, we should restart from region scanning.
+		{
+			pbErr: &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{
+				CurrentRegions: []*metapb.Region{newRegion},
+			}},
+			res: &ingestAPIError{err: common.ErrKVEpochNotMatch, newRegion: &split.RegionInfo{
+				Region: newRegion,
+				Leader: &metapb.Peer{Id: 1},
+			}},
 		},
-	}
-	clone = job
-	canContinueIngest, err = (&clone).convertStageOnIngestError(resp)
-	require.NoError(t, err)
-	require.False(t, canContinueIngest)
-	require.Equal(t, regionScanned, clone.stage)
-	require.Nil(t, clone.writeResult)
-	require.Equal(t, uint64(2), clone.region.Region.RegionEpoch.Version)
-	require.Error(t, clone.lastRetryableErr)
-
-	resp.Error = &errorpb.Error{
-		EpochNotMatch: &errorpb.EpochNotMatch{
-			CurrentRegions: []*metapb.Region{
-				{
-					Id:       1,
-					StartKey: []byte{1},
-					EndKey:   []byte{1, 2},
-					RegionEpoch: &metapb.RegionEpoch{
-						ConfVer: 1,
-						Version: 2,
-					},
-					Peers: []*metapb.Peer{{Id: 1}},
-				},
-			},
+		{
+			pbErr: &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{CurrentRegions: []*metapb.Region{{
+				Id:          1,
+				StartKey:    []byte{1},
+				EndKey:      []byte{1, 2},
+				RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 2},
+				Peers:       []*metapb.Peer{{Id: 1}},
+			}}}},
+			res: &ingestAPIError{err: common.ErrKVEpochNotMatch},
 		},
+		// TODO: in which case raft layer will drop message?
+		{pbErr: &errorpb.Error{Message: "raft: proposal dropped"}, res: &ingestAPIError{err: common.ErrKVRaftProposalDropped}},
+		{pbErr: &errorpb.Error{ServerIsBusy: &errorpb.ServerIsBusy{}}, res: &ingestAPIError{err: common.ErrKVServerIsBusy}},
+		{pbErr: &errorpb.Error{RegionNotFound: &errorpb.RegionNotFound{}}, res: &ingestAPIError{err: common.ErrKVRegionNotFound}},
+		// ReadIndexNotReady means the region is changed, we need to restart from region scanning
+		{pbErr: &errorpb.Error{ReadIndexNotReady: &errorpb.ReadIndexNotReady{}}, res: &ingestAPIError{err: common.ErrKVReadIndexNotReady}},
+		// TiKV disk full is not retryable
+		{pbErr: &errorpb.Error{DiskFull: &errorpb.DiskFull{}}, res: &ingestAPIError{err: common.ErrKVDiskFull}},
+		// a general error is retryable from writing
+		{pbErr: &errorpb.Error{StaleCommand: &errorpb.StaleCommand{}}, res: &ingestAPIError{err: common.ErrKVIngestFailed}},
 	}
-	clone = job
-	canContinueIngest, err = (&clone).convertStageOnIngestError(resp)
-	require.NoError(t, err)
-	require.False(t, canContinueIngest)
-	require.Equal(t, needRescan, clone.stage)
-	require.Error(t, clone.lastRetryableErr)
 
-	// TODO: in which case raft layer will drop message?
-
-	resp.Error = &errorpb.Error{Message: "raft: proposal dropped"}
-	clone = job
-	canContinueIngest, err = (&clone).convertStageOnIngestError(resp)
-	require.NoError(t, err)
-	require.False(t, canContinueIngest)
-	require.Equal(t, needRescan, clone.stage)
-	require.Error(t, clone.lastRetryableErr)
-
-	// ReadIndexNotReady means the region is changed, we need to restart from region scanning
-
-	resp.Error = &errorpb.Error{
-		ReadIndexNotReady: &errorpb.ReadIndexNotReady{
-			Reason: "test",
-		},
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			err := convertPBError2Error(job, c.pbErr)
+			require.ErrorIs(t, err, c.res.err)
+			if c.res.newRegion == nil {
+				require.Nil(t, err.newRegion)
+			} else {
+				require.EqualValues(t, c.res.newRegion, err.newRegion)
+				require.EqualValues(t, 2, err.newRegion.Region.RegionEpoch.Version)
+			}
+		})
 	}
-	clone = job
-	canContinueIngest, err = (&clone).convertStageOnIngestError(resp)
-	require.NoError(t, err)
-	require.False(t, canContinueIngest)
-	require.Equal(t, needRescan, clone.stage)
-	require.Error(t, clone.lastRetryableErr)
+}
 
-	// TiKV disk full is not retryable
+func TestIngestAPIErrorRetryable(t *testing.T) {
+	require.True(t, common.IsRetryableError(&ingestAPIError{err: common.ErrKVIngestFailed}))
+	require.False(t, common.IsRetryableError(&ingestAPIError{err: common.ErrKVDiskFull}))
+}
 
-	resp.Error = &errorpb.Error{
-		DiskFull: &errorpb.DiskFull{},
+func TestGetNextStageOnIngestError(t *testing.T) {
+	cases := []struct {
+		err    error
+		region *split.RegionInfo
+		stage  jobStageTp
+	}{
+		{err: &net.DNSError{IsTimeout: true}, stage: wrote},
+		{err: &ingestAPIError{err: common.ErrKVNotLeader.GenWithStack("")}, stage: needRescan},
+		{err: &ingestAPIError{err: common.ErrKVEpochNotMatch.GenWithStack("")}, stage: needRescan},
+		{err: &ingestAPIError{err: common.ErrKVEpochNotMatch.GenWithStack(""), newRegion: &split.RegionInfo{}},
+			region: &split.RegionInfo{}, stage: regionScanned},
+		{err: &ingestAPIError{err: common.ErrKVRaftProposalDropped.GenWithStack("")}, stage: needRescan},
+		{err: &ingestAPIError{err: common.ErrKVServerIsBusy.GenWithStack("")}, stage: wrote},
+		{err: &ingestAPIError{err: common.ErrKVRegionNotFound.GenWithStack("")}, stage: needRescan},
+		{err: &ingestAPIError{err: common.ErrKVReadIndexNotReady.GenWithStack("")}, stage: needRescan},
+		// ErrKVDiskFull is not retryable, no need to test it
+		{err: &ingestAPIError{err: common.ErrKVIngestFailed.GenWithStack("")}, stage: regionScanned},
 	}
-	clone = job
-	_, err = (&clone).convertStageOnIngestError(resp)
-	require.ErrorContains(t, err, "non-retryable error")
-
-	// a general error is retryable from writing
-
-	resp.Error = &errorpb.Error{
-		StaleCommand: &errorpb.StaleCommand{},
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			region, stage := getNextStageOnIngestError(c.err)
+			require.Equal(t, c.region, region)
+			require.Equal(t, c.stage, stage)
+		})
 	}
-	clone = job
-	canContinueIngest, err = (&clone).convertStageOnIngestError(resp)
-	require.NoError(t, err)
-	require.False(t, canContinueIngest)
-	require.Equal(t, regionScanned, clone.stage)
-	require.Nil(t, clone.writeResult)
-	require.Error(t, clone.lastRetryableErr)
 }
 
 func TestRegionJobRetryer(t *testing.T) {

--- a/pkg/lightning/common/errors.go
+++ b/pkg/lightning/common/errors.go
@@ -82,6 +82,7 @@ var (
 	ErrKVServerIsBusy        = errors.Normalize("server is busy", errors.RFCCodeText("Lightning:KV:ServerIsBusy"))
 	ErrKVRegionNotFound      = errors.Normalize("region not found", errors.RFCCodeText("Lightning:KV:RegionNotFound"))
 	ErrKVReadIndexNotReady   = errors.Normalize("read index not ready", errors.RFCCodeText("Lightning:KV:ReadIndexNotReady"))
+	ErrKVDiskFull            = errors.Normalize("store disk full", errors.RFCCodeText("Lightning:KV:StoreDiskFull"))
 	ErrKVIngestFailed        = errors.Normalize("ingest tikv failed", errors.RFCCodeText("Lightning:KV:ErrKVIngestFailed"))
 	ErrKVRaftProposalDropped = errors.Normalize("raft proposal dropped", errors.RFCCodeText("Lightning:KV:ErrKVRaftProposalDropped"))
 	ErrNoLeader              = errors.Normalize("write to tikv with no leader returned, region '%d', leader: %d", errors.RFCCodeText("Lightning:KV:ErrNoLeader"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418 

Problem Summary:

### What changed and how does it work?
- split previous `convertStageOnIngestError` into `convertPBError2Error` and `getNextStageOnIngestError`
- unify job stage transition during ingest in `regionJobBaseWorker.runJob`
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
