### PR TITLE
planner: add back children's `Schema` when checking `LogicalJoin`'s used columns in column pruning

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1081,25 +1081,29 @@ func (p *LogicalJoin) ExtractUsedCols(parentUsedCols []*expression.Column) (left
 	rChild := p.Children()[1]
 	lSchema := lChild.Schema()
 	rSchema := rChild.Schema()
+	var lFullSchema, rFullSchema *expression.Schema
 	// parentused col = t2.a
 	// leftChild schema = t1.a(t2.a) + and others
 	// rightChild schema = t3 related + and others
 	if join, ok := lChild.(*LogicalJoin); ok {
 		if join.FullSchema != nil {
-			lSchema = join.FullSchema
+			lFullSchema = join.FullSchema
 		}
 	}
 	if join, ok := rChild.(*LogicalJoin); ok {
 		if join.FullSchema != nil {
-			rSchema = join.FullSchema
+			rFullSchema = join.FullSchema
 		}
 	}
 	for _, col := range parentUsedCols {
-		if lSchema != nil && lSchema.Contains(col) {
+		if (lSchema != nil && lSchema.Contains(col)) ||
+			(lFullSchema != nil && lFullSchema.Contains(col)) {
 			leftCols = append(leftCols, col)
-		} else if rSchema != nil && rSchema.Contains(col) {
+		} else if (rSchema != nil && rSchema.Contains(col)) ||
+			(rFullSchema != nil && rFullSchema.Contains(col)) {
 			rightCols = append(rightCols, col)
 		}
+
 	}
 	return leftCols, rightCols
 }

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1087,11 +1087,9 @@ func (p *LogicalJoin) ExtractUsedCols(parentUsedCols []*expression.Column) (left
 	// rightChild schema = t3 related + and others
 	if join, ok := lChild.(*LogicalJoin); ok {
 		lFullSchema = join.FullSchema
-
 	}
 	if join, ok := rChild.(*LogicalJoin); ok {
 		rFullSchema = join.FullSchema
-
 	}
 	for _, col := range parentUsedCols {
 		if (lSchema != nil && lSchema.Contains(col)) ||

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1086,14 +1086,12 @@ func (p *LogicalJoin) ExtractUsedCols(parentUsedCols []*expression.Column) (left
 	// leftChild schema = t1.a(t2.a) + and others
 	// rightChild schema = t3 related + and others
 	if join, ok := lChild.(*LogicalJoin); ok {
-		if join.FullSchema != nil {
-			lFullSchema = join.FullSchema
-		}
+		lFullSchema = join.FullSchema
+
 	}
 	if join, ok := rChild.(*LogicalJoin); ok {
-		if join.FullSchema != nil {
-			rFullSchema = join.FullSchema
-		}
+		rFullSchema = join.FullSchema
+
 	}
 	for _, col := range parentUsedCols {
 		if (lSchema != nil && lSchema.Contains(col)) ||
@@ -1103,7 +1101,6 @@ func (p *LogicalJoin) ExtractUsedCols(parentUsedCols []*expression.Column) (left
 			(rFullSchema != nil && rFullSchema.Contains(col)) {
 			rightCols = append(rightCols, col)
 		}
-
 	}
 	return leftCols, rightCols
 }

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -910,3 +910,40 @@ IndexLookUp	1.00	root
 └─Selection(Probe)	1.00	cop[tikv]		eq(test_59427.t.a, 1)
   └─TableRowIDScan	10.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
 drop database if exists test_59427;
+drop table if exists t1,t2,t3,t4,t5;
+create table t1(a int, b int, c int, d int, e int);
+create table t2(a int, b int, c int, d int, e int);
+create table t3(a int, b int, c int, d int, e int);
+create table t4(a int, b int, c int, d int, e int);
+create table t5(a int, b int, c int, d int, e int);
+explain format = brief select tmp4.b
+from t1 join t2 on t1.a = t2.b
+join t3 on t1.b = t3.b
+left join
+(select a, b, c, (row_number() over (partition by b order by e asc)) from t4) tmp4 on tmp4.b = t2.c and tmp4.c = t3.c
+join t5 on t5.a = t1.e;
+id	estRows	task	access object	operator info
+HashJoin	19472.71	root		inner join, equal:[eq(test.t5.a, test.t1.e)]
+├─TableReader(Build)	9990.00	root		data:Selection
+│ └─Selection	9990.00	cop[tikv]		not(isnull(test.t5.a))
+│   └─TableFullScan	10000.00	cop[tikv]	table:t5	keep order:false, stats:pseudo
+└─HashJoin(Probe)	15578.17	root		left outer join, left side:HashJoin, equal:[eq(test.t2.c, test.t4.b) eq(test.t3.c, test.t4.c)]
+  ├─Selection(Build)	7992.00	root		not(isnull(test.t4.c))
+  │ └─Shuffle	9990.00	root		execution info: concurrency:100, data sources:[TableReader]
+  │   └─Window	9990.00	root		row_number()->Column#26 over(partition by test.t4.b order by test.t4.e rows between current row and current row)
+  │     └─Sort	9990.00	root		test.t4.b, test.t4.e
+  │       └─ShuffleReceiver	9990.00	root		
+  │         └─TableReader	9990.00	root		data:Selection
+  │           └─Selection	9990.00	cop[tikv]		not(isnull(test.t4.b))
+  │             └─TableFullScan	10000.00	cop[tikv]	table:t4	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	15578.17	root		inner join, equal:[eq(test.t1.b, test.t3.b)]
+    ├─HashJoin(Build)	12462.54	root		inner join, equal:[eq(test.t1.a, test.t2.b)]
+    │ ├─TableReader(Build)	9990.00	root		data:Selection
+    │ │ └─Selection	9990.00	cop[tikv]		not(isnull(test.t2.b))
+    │ │   └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+    │ └─TableReader(Probe)	9970.03	root		data:Selection
+    │   └─Selection	9970.03	cop[tikv]		not(isnull(test.t1.a)), not(isnull(test.t1.b)), not(isnull(test.t1.e))
+    │     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+    └─TableReader(Probe)	9990.00	root		data:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(test.t3.b))
+        └─TableFullScan	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -588,3 +588,16 @@ explain format = brief select * from test_59427.t as tt use index (ib) where a =
 explain format = brief select /*+ use_index(test_59427.tt, ib) */ * from test_59427.t as tt where a = 1 and b = 1;
 drop database if exists test_59427;
 
+# TestIssue60692
+drop table if exists t1,t2,t3,t4,t5;
+create table t1(a int, b int, c int, d int, e int);
+create table t2(a int, b int, c int, d int, e int);
+create table t3(a int, b int, c int, d int, e int);
+create table t4(a int, b int, c int, d int, e int);
+create table t5(a int, b int, c int, d int, e int);
+explain format = brief select tmp4.b
+  from t1 join t2 on t1.a = t2.b
+  join t3 on t1.b = t3.b
+  left join
+    (select a, b, c, (row_number() over (partition by b order by e asc)) from t4) tmp4 on tmp4.b = t2.c and tmp4.c = t3.c
+  join t5 on t5.a = t1.e;


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #60692

Problem Summary:

As said in the issue, sometimes the `FullSchema` may contain outdated `Column`s after the projection elimination. 

We should have fixed the `FullSchema`, but considering the long-standing problems in schema maintenance and column pruning in tidb, we can't make sure we won't introduce any new risk.
This PR is likely to be cherry-picked to the LTS version quickly. So it's better to just restore the previous checking logic, i.e., use the `Schema()` to do the check.

### What changed and how does it work?

Add back what's been removed in #51057 in `(*LogicalJoin).ExtractUsedCols()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
