### PR TITLE
meta: Fix vector incompatibility with old version and TiFlash

### DIFF
--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -139,7 +139,7 @@ type IndexInfo struct {
 	State         SchemaState        `json:"state"`
 	BackfillState BackfillState      `json:"backfill_state"`
 	Comment       string             `json:"comment"`        // Comment
-	Tp            ast.IndexType      `json:"index_type"`     // Index type: Btree, Hash, Rtree or HNSW
+	Tp            ast.IndexType      `json:"index_type"`     // Index type: Btree, Hash, Rtree or Vector
 	Unique        bool               `json:"is_unique"`      // Whether the index is unique.
 	Primary       bool               `json:"is_primary"`     // Whether the index is primary key.
 	Invisible     bool               `json:"is_invisible"`   // Whether the index is invisible.

--- a/pkg/parser/ast/model.go
+++ b/pkg/parser/ast/model.go
@@ -217,17 +217,19 @@ func (t IndexType) String() string {
 }
 
 // IndexTypes
+// Warning: 1) Also used in TiFlash 2) May come from a previous version persisted in TableInfo.
+// So you must keep it compatible when modifying it.
 const (
 	IndexTypeInvalid IndexType = iota
 	IndexTypeBtree
 	IndexTypeHash
 	IndexTypeRtree
 	IndexTypeHypo
+	IndexTypeVector
+	IndexTypeInverted
 	// IndexTypeHNSW is only used in AST.
 	// It will be rewritten into IndexTypeVector after preprocessor phase.
 	IndexTypeHNSW
-	IndexTypeInverted
-	IndexTypeVector
 )
 
 // ReferOptionType is the type for refer options.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/54245

Problem Summary:

### What changed and how does it work?

In https://github.com/pingcap/tidb/pull/60663 we wrongly changed the Tp value of a vector index from HNSW=5 to HNSW=7. This is wrong, because tp is persisted in schema and also used in TiFlash.

This mistake is discovered by TiFlash integration test.

This PR reverts back Tp from 7 to 5. Only the code name changes (HNSW=5 -> Vector=5), and this is compatible.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
