### PR TITLE
statistics: log schema not found for table in updateGlobalTableStats functions

### DIFF
--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -17,6 +17,7 @@ package priorityqueue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
@@ -45,6 +46,12 @@ func (pq *AnalysisPriorityQueue) HandleDDLEvent(_ context.Context, sctx sessionc
 
 	defer func() {
 		if err != nil {
+			intest.Assert(
+				errors.ErrorEqual(err, context.Canceled) ||
+					strings.Contains(err.Error(), "mock handleTaskOnce error") ||
+					strings.Contains(err.Error(), "session pool closed"),
+				fmt.Sprintf("handle ddl event failed, err: %+v", err),
+			)
 			actionType := event.GetType().String()
 			statslogutil.StatsLogger().Error(fmt.Sprintf("Failed to handle %s event", actionType),
 				zap.Error(err),

--- a/pkg/statistics/handle/ddl/BUILD.bazel
+++ b/pkg/statistics/handle/ddl/BUILD.bazel
@@ -32,7 +32,7 @@ go_test(
     timeout = "short",
     srcs = ["ddl_test.go"],
     flaky = True,
-    shard_count = 22,
+    shard_count = 24,
     deps = [
         ":ddl",
         "//pkg/ddl/notifier",

--- a/pkg/statistics/handle/ddl/ddl.go
+++ b/pkg/statistics/handle/ddl/ddl.go
@@ -60,9 +60,9 @@ func (h *ddlHandlerImpl) HandleDDLEvent(ctx context.Context, sctx sessionctx.Con
 			errors.ErrorEqual(err, context.Canceled) ||
 				strings.Contains(err.Error(), "mock handleTaskOnce error") ||
 				strings.Contains(err.Error(), "session pool closed"),
-			fmt.Sprintf("handle ddl event failed, err: %v", err),
+			fmt.Sprintf("handle ddl event failed, err: %+v", err),
 		)
-		statslogutil.StatsLogger().Warn(
+		statslogutil.StatsErrVerboseSampleLogger().Warn(
 			"Failed to handle DDL event",
 			zap.String("event", s.String()),
 			zap.Error(err),

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -418,6 +418,10 @@ func updateGlobalTableStats4DropPartition(
 	))
 }
 
+const (
+	schemaNotFound = "Not Found"
+)
+
 func updateGlobalTableStats4ExchangePartition(
 	ctx context.Context,
 	sctx sessionctx.Context,
@@ -453,7 +457,7 @@ func updateGlobalTableStats4ExchangePartition(
 
 	// Update the global stats.
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-	globalTableSchemaName := "Not Found"
+	globalTableSchemaName := schemaNotFound
 	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
 	if ok {
 		globalTableSchemaName = globalTableSchema.Name.O
@@ -569,7 +573,7 @@ func updateGlobalTableStats4TruncatePartition(
 	}
 
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
-	globalTableSchemaName := "Not Found"
+	globalTableSchemaName := schemaNotFound
 	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
 	if ok {
 		globalTableSchemaName = globalTableSchema.Name.O

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -453,9 +453,12 @@ func updateGlobalTableStats4ExchangePartition(
 
 	// Update the global stats.
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	globalTableSchemaName := "Not Found"
 	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
-	if !ok {
-		return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
+	if ok {
+		globalTableSchemaName = globalTableSchema.Name.O
+	} else {
+		logutil.StatsSampleLogger().Info("Schema not found for table, it may have been dropped", zap.Int64("tableID", globalTableInfo.ID))
 	}
 	if err = updateStatsWithCountDeltaAndModifyCountDelta(
 		ctx,
@@ -463,7 +466,7 @@ func updateGlobalTableStats4ExchangePartition(
 		globalTableInfo.ID, countDelta, modifyCountDelta,
 	); err != nil {
 		fields := exchangePartitionLogFields(
-			globalTableSchema.Name.O,
+			globalTableSchemaName,
 			globalTableInfo,
 			originalPartInfo.Definitions[0],
 			originalTableInfo,
@@ -483,7 +486,7 @@ func updateGlobalTableStats4ExchangePartition(
 	logutil.StatsLogger().Info(
 		"Update global stats after exchange partition",
 		exchangePartitionLogFields(
-			globalTableSchema.Name.O,
+			globalTableSchemaName,
 			globalTableInfo,
 			originalPartInfo.Definitions[0],
 			originalTableInfo,
@@ -566,9 +569,12 @@ func updateGlobalTableStats4TruncatePartition(
 	}
 
 	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	globalTableSchemaName := "Not Found"
 	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
-	if !ok {
-		return errors.Errorf("schema not found for table %s", globalTableInfo.Name.O)
+	if ok {
+		globalTableSchemaName = globalTableSchema.Name.O
+	} else {
+		logutil.StatsSampleLogger().Info("Schema not found for table, it may have been dropped", zap.Int64("tableID", globalTableInfo.ID))
 	}
 	lockedTables, err := lockstats.QueryLockedTables(ctx, sctx)
 	if err != nil {
@@ -600,7 +606,7 @@ func updateGlobalTableStats4TruncatePartition(
 	)
 	if err != nil {
 		fields := truncatePartitionsLogFields(
-			globalTableSchema,
+			globalTableSchemaName,
 			globalTableInfo,
 			partitionIDs,
 			partitionNames,
@@ -618,7 +624,7 @@ func updateGlobalTableStats4TruncatePartition(
 
 	logutil.StatsLogger().Info("Update global stats after truncate partition",
 		truncatePartitionsLogFields(
-			globalTableSchema,
+			globalTableSchemaName,
 			globalTableInfo,
 			partitionIDs,
 			partitionNames,
@@ -632,7 +638,7 @@ func updateGlobalTableStats4TruncatePartition(
 }
 
 func truncatePartitionsLogFields(
-	globalTableSchema *model.DBInfo,
+	globalTableSchemaName string,
 	globalTableInfo *model.TableInfo,
 	partitionIDs []int64,
 	partitionNames []string,
@@ -642,7 +648,7 @@ func truncatePartitionsLogFields(
 	isLocked bool,
 ) []zap.Field {
 	return []zap.Field{
-		zap.String("schema", globalTableSchema.Name.O),
+		zap.String("schema", globalTableSchemaName),
 		zap.Int64("tableID", globalTableInfo.ID),
 		zap.String("tableName", globalTableInfo.Name.O),
 		zap.Int64s("partitionIDs", partitionIDs),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60729

Problem Summary:

### What changed and how does it work?

We shouldn't require this schema name since it's only used for logging purposes.
In this PR, I’ve made it optional and added a log message in case it’s not found.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
消除 TiDB 在处理 exchange partition 和 truncate partition 事件时可能遇到的无效日志
Eliminate invalid logs that TiDB may encounter when processing exchange partition and truncate partition DDL events
```
