### PR TITLE
planner: fix panic when execute `select 1 for update`

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3837,11 +3837,11 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 	if l != nil && l.LockType != ast.SelectLockNone {
 		var tableList []*ast.TableName
 		var isExplicitSetTablesNames bool
-		if len(l.Tables) == 0 {
+		if len(l.Tables) == 0 && sel.From != nil {
 			// It's for stmt like `select xxx from table t, t1 where t.a = t1.a for update`
 			nodeW := resolve.NewNodeWWithCtx(sel.From, b.resolveCtx)
 			tableList = ExtractTableList(nodeW, false)
-		} else {
+		} else if len(l.Tables) != 0 {
 			// It's for stmt like `select xxx from table t, t1 where t.a = t1.a for update of t`
 			isExplicitSetTablesNames = true
 			tableList = l.Tables

--- a/tests/integrationtest/r/executor/executor.result
+++ b/tests/integrationtest/r/executor/executor.result
@@ -4271,6 +4271,9 @@ commit;
 commit;
 Error 9007 (HY000): Write conflict, <detail> reason=Optimistic [try again later]
 set global tidb_txn_mode=pessimistic;
+select 1 for update;
+1
+1
 drop table if exists t, t1;
 create table t (i int);
 create table t1 (i int);

--- a/tests/integrationtest/t/executor/executor.test
+++ b/tests/integrationtest/t/executor/executor.test
@@ -2563,6 +2563,8 @@ disconnect conn1;
 disconnect conn2;
 set global tidb_txn_mode=pessimistic;
 
+select 1 for update;
+
 # TestSelectForUpdateOf
 drop table if exists t, t1;
 create table t (i int);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60798

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
