### PR TITLE
planner: use full schema to resolve and rewrite group by item and to build table dual's schema in building where clause | tidb-test=pr/2508

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -243,8 +243,13 @@ func (b *PlanBuilder) rewriteWithPreprocess(
 func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p base.LogicalPlan) (rewriter *expressionRewriter) {
 	defer func() {
 		if p != nil {
-			rewriter.schema = p.Schema()
-			rewriter.names = p.OutputNames()
+			if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
+				rewriter.schema = join.FullSchema
+				rewriter.names = join.FullNames
+			} else {
+				rewriter.schema = p.Schema()
+				rewriter.names = p.OutputNames()
+			}
 		}
 	}()
 

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -954,8 +954,14 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p base.LogicalPlan, wh
 				}
 				// If there is condition which is always false, return dual plan directly.
 				dual := logicalop.LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
-				dual.SetOutputNames(p.OutputNames())
-				dual.SetSchema(p.Schema())
+				if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
+					dual.SetOutputNames(join.FullNames)
+					dual.SetSchema(join.FullSchema)
+				} else {
+					dual.SetOutputNames(p.OutputNames())
+					dual.SetSchema(p.Schema())
+				}
+
 				return dual, nil
 			}
 			cnfExpres = append(cnfExpres, item)
@@ -3474,11 +3480,17 @@ func allColFromExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldNa
 func (b *PlanBuilder) resolveGbyExprs(ctx context.Context, p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) (base.LogicalPlan, []expression.Expression, bool, error) {
 	b.curClause = groupByClause
 	exprs := make([]expression.Expression, 0, len(gby.Items))
+	schema := p.Schema()
+	names := p.OutputNames()
+	if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
+		schema = join.FullSchema
+		names = join.FullNames
+	}
 	resolver := &gbyResolver{
 		ctx:        b.ctx,
 		fields:     fields,
-		schema:     p.Schema(),
-		names:      p.OutputNames(),
+		schema:     schema,
+		names:      names,
 		skipAggMap: b.correlatedAggMapper,
 	}
 	for _, item := range gby.Items {

--- a/tests/integrationtest/r/planner/core/casetest/predicate_simplification.result
+++ b/tests/integrationtest/r/planner/core/casetest/predicate_simplification.result
@@ -243,9 +243,9 @@ CREATE TABLE t1 (code varchar(10)) charset utf8mb4;
 CREATE TABLE t2 (id varchar(10) ) charset utf8mb4;
 EXPLAIN format='brief' SELECT * FROM t1 INNER JOIN t2 ON code=id WHERE id='a12' AND (LENGTH(code)=5 OR code < 'a00');
 id	estRows	task	access object	operator info
-HashJoin	10.00	root		inner join, equal:[eq(planner__core__casetest__predicate_simplification.t1.code, planner__core__casetest__predicate_simplification.t2.id)], other cond:or(eq(length(planner__core__casetest__predicate_simplification.t1.code), 5), lt(planner__core__casetest__predicate_simplification.t2.id, "a00"))
-├─TableReader(Build)	8.00	root		data:Selection
-│ └─Selection	8.00	cop[tikv]		eq(length(planner__core__casetest__predicate_simplification.t1.code), 5), eq(planner__core__casetest__predicate_simplification.t1.code, "a12"), not(isnull(planner__core__casetest__predicate_simplification.t1.code))
+HashJoin	10.83	root		inner join, equal:[eq(planner__core__casetest__predicate_simplification.t1.code, planner__core__casetest__predicate_simplification.t2.id)], other cond:or(eq(length(planner__core__casetest__predicate_simplification.t1.code), 5), lt(planner__core__casetest__predicate_simplification.t2.id, "a00"))
+├─TableReader(Build)	8.66	root		data:Selection
+│ └─Selection	8.66	cop[tikv]		eq(planner__core__casetest__predicate_simplification.t1.code, "a12"), not(isnull(planner__core__casetest__predicate_simplification.t1.code)), or(eq(length(planner__core__casetest__predicate_simplification.t1.code), 5), lt(planner__core__casetest__predicate_simplification.t1.code, "a00"))
 │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 └─TableReader(Probe)	10.00	root		data:Selection
   └─Selection	10.00	cop[tikv]		eq(planner__core__casetest__predicate_simplification.t2.id, "a12"), not(isnull(planner__core__casetest__predicate_simplification.t2.id))
@@ -283,10 +283,10 @@ and t2. col1 in ("2021-07-14 09:28:16", "1982-01-09 03:36:39", "1970-12-18 10:53
 id	estRows	task	access object	operator info
 HashJoin_9	12.50	root		inner join, equal:[eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, planner__core__casetest__predicate_simplification.idt_mc21780.col1)]
 ├─TableReader_16(Build)	10.00	root		data:Selection_15
-│ └─Selection_15	10.00	cop[tikv]		eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1970-12-18 10:53:28.000000), lt(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1976-09-09 20:21:11.000000), not(isnull(planner__core__casetest__predicate_simplification.idt_mc21780.col1))
+│ └─Selection_15	10.00	cop[tikv]		lt(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1976-09-09 20:21:11.000000), not(isnull(planner__core__casetest__predicate_simplification.idt_mc21780.col1)), or(eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 2021-07-14 09:28:16.000000), or(eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1982-01-09 03:36:39.000000), eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1970-12-18 10:53:28.000000)))
 │   └─TableFullScan_14	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader_13(Probe)	10.00	root		data:Selection_12
-  └─Selection_12	10.00	cop[tikv]		eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1970-12-18 10:53:28.000000), lt(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1976-09-09 20:21:11.000000), not(isnull(planner__core__casetest__predicate_simplification.idt_mc21780.col1))
+  └─Selection_12	10.00	cop[tikv]		lt(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1976-09-09 20:21:11.000000), not(isnull(planner__core__casetest__predicate_simplification.idt_mc21780.col1)), or(eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 2021-07-14 09:28:16.000000), or(eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1982-01-09 03:36:39.000000), eq(planner__core__casetest__predicate_simplification.idt_mc21780.col1, 1970-12-18 10:53:28.000000)))
     └─TableFullScan_11	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 drop table if exists t1;
 drop table if exists t2;

--- a/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
+++ b/tests/integrationtest/r/planner/core/casetest/rule/rule_join_reorder.result
@@ -7199,7 +7199,8 @@ Warning	1815	leading hint is inapplicable, check if the leading hint table is va
 Warning	1815	leading hint is inapplicable, check the join type or the join algorithm hint
 explain format = 'brief' select /*+ leading(t4) */ * from t1 left join t2 on t1.a=t2.a right join t4 on t1.b = t4.b where exists (select t3.a from t3);
 id	estRows	task	access object	operator info
-TableDual	0.00	root		rows:0
+Projection	0.00	root		planner__core__casetest__rule__rule_join_reorder.t1.a, planner__core__casetest__rule__rule_join_reorder.t1.b, planner__core__casetest__rule__rule_join_reorder.t2.a, planner__core__casetest__rule__rule_join_reorder.t2.b, planner__core__casetest__rule__rule_join_reorder.t4.a, planner__core__casetest__rule__rule_join_reorder.t4.b
+└─TableDual	0.00	root		rows:0
 explain format = 'brief' select /*+ leading(t3@sel_2) */ * from t1 left join t2 on t1.a=t2.a where exists (select t3.a from t3);
 id	estRows	task	access object	operator info
 TableDual	0.00	root		rows:0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60608

Problem Summary:

### What changed and how does it work?
* resolve group by should use the full schema if any
* rewrite group by item should use the full schema if any
* build selection converted to table dual should use full schema if any

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
