### PR TITLE
*: support building coverage image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,12 +202,24 @@ race: failpoint-enable
 	@$(CLEAN_UT_BINARY)
 
 .PHONY: server
-server:
-ifeq ($(TARGET), "")
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/tidb-server ./cmd/tidb-server
+ifeq ($(GOCOVER), )
+    COVER_FLAG :=
 else
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' ./cmd/tidb-server
+    COVER_FLAG := -cover
 endif
+
+ifeq ($(TARGET), "")
+    SERVER_OUT := bin/tidb-server
+else
+    SERVER_OUT := $(TARGET)
+endif
+
+SERVER_BUILD_CMD := \
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) $(COVER_FLAG) \
+	-ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(SERVER_OUT)' ./cmd/tidb-server
+
+server:
+	$(SERVER_BUILD_CMD)
 
 .PHONY: server_debug
 server_debug:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60814

Problem Summary:
We want to support getting coverage information on our integration tests.
To do it in GoLang, we just need to add a build flag -cover.
Our internal building platform uses make server to build the image.
So we must let make server build the coverage image if we want.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
``` 
➜  tidb git:(build_cover) make server
CGO_ENABLED=1  GO111MODULE=on go build -tags codes   -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-619-g18f3b949e8" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-04-24 12:25:44" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=18f3b949e8d89b62dd376decaac87ea8e1adcee7" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=build_cover" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server

➜  tidb git:(build_cover) export GOCOVER=""
➜  tidb git:(build_cover) make server
CGO_ENABLED=1  GO111MODULE=on go build -tags codes   -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-619-g18f3b949e8" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-04-24 12:25:56" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=18f3b949e8d89b62dd376decaac87ea8e1adcee7" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=build_cover" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server

➜  tidb git:(build_cover) export GOCOVER="1"
➜  tidb git:(build_cover) make server
CGO_ENABLED=1  GO111MODULE=on go build -tags codes  -cover -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-619-g18f3b949e8" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-04-24 12:26:01" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=18f3b949e8d89b62dd376decaac87ea8e1adcee7" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=build_cover" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
