### PR TITLE
globalsort: use partitioned prefix to store intermediate files | tidb-test=release-8.1.2

### DIFF
--- a/br/pkg/storage/memstore.go
+++ b/br/pkg/storage/memstore.go
@@ -68,9 +68,6 @@ func (s *MemStorage) DeleteFile(ctx context.Context, name string) error {
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
 	if _, ok := s.dataStore[name]; !ok {
@@ -101,9 +98,6 @@ func (s *MemStorage) WriteFile(ctx context.Context, name string, data []byte) er
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	fileData := append([]byte{}, data...)
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
@@ -127,9 +121,6 @@ func (s *MemStorage) ReadFile(ctx context.Context, name string) ([]byte, error) 
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return nil, errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	theFile, ok := s.loadMap(name)
 	if !ok {
 		return nil, errors.Errorf("cannot find the file: %s", name)
@@ -147,9 +138,6 @@ func (s *MemStorage) FileExists(ctx context.Context, name string) (bool, error) 
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return false, errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	_, ok := s.loadMap(name)
 	return ok, nil
 }
@@ -159,9 +147,6 @@ func (s *MemStorage) FileExists(ctx context.Context, name string) (bool, error) 
 func (s *MemStorage) Open(ctx context.Context, filePath string, o *ReaderOption) (ExternalFileReader, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, errors.Trace(err)
-	}
-	if !path.IsAbs(filePath) {
-		return nil, errors.Errorf("file name is not an absolute path: %s", filePath)
 	}
 	theFile, ok := s.loadMap(filePath)
 	if !ok {
@@ -247,9 +232,6 @@ func (s *MemStorage) Create(ctx context.Context, name string, _ *WriterOption) (
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return nil, errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
 	theFile := new(memFile)
@@ -267,9 +249,6 @@ func (s *MemStorage) Rename(ctx context.Context, oldFileName, newFileName string
 		return ctx.Err()
 	default:
 		// continue on
-	}
-	if !path.IsAbs(newFileName) {
-		return errors.Errorf("new file name is not an absolute path: %s", newFileName)
 	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()

--- a/pkg/disttask/importinto/planner_test.go
+++ b/pkg/disttask/importinto/planner_test.go
@@ -314,6 +314,11 @@ func TestGetSortedKVMetas(t *testing.T) {
 	require.Equal(t, []byte("i1_2_c"), allKVMetas["1"].EndKey)
 }
 
+func writeAndGetFiles(t *testing.T, writer *external.Writer, keys [][]byte, values [][]byte) (
+	dataFiles []string, statsFiles []string) {
+	return
+}
+
 func TestSplitForOneSubtask(t *testing.T) {
 	ctx := context.Background()
 	workDir := t.TempDir()
@@ -339,9 +344,11 @@ func TestSplitForOneSubtask(t *testing.T) {
 			multiFileStat = s.MultipleFilesStats
 		}).
 		Build(store, "/mock-test", "0")
-	_, _, err = external.MockExternalEngineWithWriter(
-		store, writer, "/mock-test", keys, values,
-	)
+	for i := range keys {
+		err := writer.WriteRow(ctx, keys[i], values[i], nil)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close(ctx))
 	require.NoError(t, err)
 	kvMeta := &external.SortedKVMeta{
 		StartKey:           keys[0],

--- a/pkg/lightning/backend/external/byte_reader.go
+++ b/pkg/lightning/backend/external/byte_reader.go
@@ -104,6 +104,7 @@ func newByteReader(
 		smallBuf:      make([]byte, bufSize),
 		curBufOffset:  0,
 	}
+	fmt.Println(bufSize)
 	r.curBuf = [][]byte{r.smallBuf}
 	r.logger = logutil.Logger(r.ctx)
 	return r, r.reload()
@@ -309,6 +310,7 @@ func (r *byteReader) reload() error {
 		case io.ErrUnexpectedEOF:
 			// The last batch.
 			r.curBuf[0] = r.curBuf[0][:n]
+			fmt.Println("0", n)
 		case context.Canceled:
 			return err
 		default:

--- a/pkg/lightning/backend/external/byte_reader.go
+++ b/pkg/lightning/backend/external/byte_reader.go
@@ -104,7 +104,6 @@ func newByteReader(
 		smallBuf:      make([]byte, bufSize),
 		curBufOffset:  0,
 	}
-	fmt.Println(bufSize)
 	r.curBuf = [][]byte{r.smallBuf}
 	r.logger = logutil.Logger(r.ctx)
 	return r, r.reload()
@@ -310,7 +309,6 @@ func (r *byteReader) reload() error {
 		case io.ErrUnexpectedEOF:
 			// The last batch.
 			r.curBuf[0] = r.curBuf[0][:n]
-			fmt.Println("0", n)
 		case context.Canceled:
 			return err
 		default:

--- a/pkg/lightning/backend/external/byte_reader_test.go
+++ b/pkg/lightning/backend/external/byte_reader_test.go
@@ -213,10 +213,12 @@ func TestSwitchMode(t *testing.T) {
 	t.Logf("seed: %d", seed)
 	st := storage.NewMemStorage()
 	// Prepare
+	var kvAndStat [2]string
 	ctx := context.Background()
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(st, "/test", "0")
 
 	err := writer.Init(ctx, 5*1024*1024)
@@ -244,9 +246,9 @@ func TestSwitchMode(t *testing.T) {
 	require.NoError(t, err)
 	pool := membuf.NewPool()
 	ConcurrentReaderBufferSizePerConc = rand.Intn(100) + 1
-	kvReader, err := NewKVReader(context.Background(), "/test/0/one-file", st, 0, 64*1024)
+	kvReader, err := NewKVReader(context.Background(), kvAndStat[0], st, 0, 64*1024)
 	require.NoError(t, err)
-	kvReader.byteReader.enableConcurrentRead(st, "/test/0/one-file", 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())
+	kvReader.byteReader.enableConcurrentRead(st, kvAndStat[0], 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())
 	modeUseCon := false
 	i := 0
 	for {

--- a/pkg/lightning/backend/external/iter_test.go
+++ b/pkg/lightning/backend/external/iter_test.go
@@ -305,7 +305,7 @@ func testMergeIterSwitchMode(t *testing.T, f func([]byte, int) []byte) {
 	err := writer.Close(context.Background())
 	require.NoError(t, err)
 
-	dataNames, _, err := GetAllFileNames(context.Background(), st, "")
+	dataNames, _, err := getKVAndStatFilesByScan(context.Background(), st, "testprefix")
 	require.NoError(t, err)
 
 	offsets := make([]uint64, len(dataNames))

--- a/pkg/lightning/backend/external/kv_reader.go
+++ b/pkg/lightning/backend/external/kv_reader.go
@@ -50,6 +50,7 @@ func NewKVReader(
 	bufSize int,
 ) (*KVReader, error) {
 	oneThird := bufSize / 3
+	oneThird = max(oneThird, 1)
 	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset, oneThird*2)
 	if err != nil {
 		return nil, err

--- a/pkg/lightning/backend/external/kv_reader.go
+++ b/pkg/lightning/backend/external/kv_reader.go
@@ -50,6 +50,7 @@ func NewKVReader(
 	bufSize int,
 ) (*KVReader, error) {
 	oneThird := bufSize / 3
+	// some test use very random buf size, might < 3
 	oneThird = max(oneThird, 1)
 	sr, err := openStoreReaderAndSeek(ctx, store, name, initFileOffset, oneThird*2)
 	if err != nil {

--- a/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/pkg/lightning/backend/external/onefile_writer_test.go
@@ -45,9 +45,11 @@ func TestOnefileWriterBasic(t *testing.T) {
 	// 1. write into one file.
 	// 2. read kv file and check result.
 	// 3. read stat file and check result.
+	var kvAndStat [2]string
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/test", "0")
 
 	require.NoError(t, writer.Init(ctx, 5*1024*1024))
@@ -72,7 +74,7 @@ func TestOnefileWriterBasic(t *testing.T) {
 	require.NoError(t, writer.Close(ctx))
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/test/0/one-file", memStore, 0, bufSize)
+	kvReader, err := NewKVReader(ctx, kvAndStat[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := 0; i < kvCnt; i++ {
 		key, value, err := kvReader.NextKV()
@@ -84,7 +86,7 @@ func TestOnefileWriterBasic(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 	require.NoError(t, kvReader.Close())
 
-	statReader, err := newStatsReader(ctx, memStore, "/test/0_stat/one-file", bufSize)
+	statReader, err := newStatsReader(ctx, memStore, kvAndStat[1], bufSize)
 	require.NoError(t, err)
 
 	var keyCnt uint64 = 0
@@ -108,17 +110,21 @@ func TestOnefileWriterStat(t *testing.T) {
 	// 3. read stat file and check result.
 	for _, kvCnt := range kvCntArr {
 		for _, distance := range distanceCntArr {
-			checkOneFileWriterStatWithDistance(t, kvCnt, distance, DefaultMemSizeLimit, "test"+strconv.Itoa(int(distance)))
+			t.Run(fmt.Sprintf("kvCnt=%d, distance=%d", kvCnt, distance), func(t *testing.T) {
+				checkOneFileWriterStatWithDistance(t, kvCnt, distance, DefaultMemSizeLimit, "test"+strconv.Itoa(int(distance)))
+			})
 		}
 	}
 }
 
 func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance uint64, memSizeLimit uint64, prefix string) {
+	var kvAndStat [2]string
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(keysDistance).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/"+prefix, "0")
 
 	require.NoError(t, writer.Init(ctx, 5*1024*1024))
@@ -135,7 +141,7 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 	require.NoError(t, writer.Close(ctx))
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/"+prefix+"/0/one-file", memStore, 0, bufSize)
+	kvReader, err := NewKVReader(ctx, kvAndStat[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := 0; i < kvCnt; i++ {
 		key, value, err := kvReader.NextKV()
@@ -147,7 +153,7 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 	require.Equal(t, io.EOF, err)
 	require.NoError(t, kvReader.Close())
 
-	statReader, err := newStatsReader(ctx, memStore, "/"+prefix+"/0_stat/one-file", bufSize)
+	statReader, err := newStatsReader(ctx, memStore, kvAndStat[1], bufSize)
 	require.NoError(t, err)
 
 	var keyCnt uint64 = 0
@@ -177,11 +183,13 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 	// 2. merge 5 files into one file.
 	// 3. read one file and check result.
 	// 4. check duplicate key.
+	var kvAndStats [][2]string
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(1000).
 		SetKeyDuplicationEncoding(true).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStats = summary.MultipleFilesStats[0].Filenames }).
 		Build(memStore, "/test", "0")
 
 	kvCount := 2000000
@@ -202,22 +210,27 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 	})
 	DefaultReadBufferSize = 100
 	defaultOneWriterMemSizeLimit = 1000
+	dataFiles := make([]string, 0, len(kvAndStats))
+	for _, f := range kvAndStats {
+		dataFiles = append(dataFiles, f[0])
+	}
+	var onefile [2]string
 	require.NoError(t, mergeOverlappingFilesInternal(
 		ctx,
-		[]string{"/test/0/0", "/test/0/1", "/test/0/2", "/test/0/3", "/test/0/4"},
+		dataFiles,
 		memStore,
 		int64(5*size.MB),
 		"/test2",
 		"mergeID",
 		1000,
-		nil,
+		func(summary *WriterSummary) { onefile = summary.MultipleFilesStats[0].Filenames[0] },
 		true,
 		common.OnDuplicateKeyIgnore,
 	))
 
 	kvs := make([]kvPair, 0, kvCount)
 
-	kvReader, err := NewKVReader(ctx, "/test2/mergeID/one-file", memStore, 0, 100)
+	kvReader, err := NewKVReader(ctx, onefile[0], memStore, 0, 100)
 	require.NoError(t, err)
 	for i := 0; i < kvCount; i++ {
 		key, value, err := kvReader.NextKV()
@@ -261,10 +274,12 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	// 2. merge one file.
 	// 3. read kv file and check the result.
 	// 4. check the writeSummary.
+	var kvAndStat [2]string
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(1000).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/test", "0")
 
 	require.NoError(t, writer.Init(ctx, 5*1024*1024))
@@ -309,7 +324,7 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	defaultOneWriterMemSizeLimit = 1000
 	require.NoError(t, mergeOverlappingFilesInternal(
 		ctx,
-		[]string{"/test/0/one-file"},
+		[]string{kvAndStat[0]},
 		memStore,
 		int64(5*size.MB),
 		"/test2",
@@ -321,7 +336,8 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	))
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/test2/mergeID/one-file", memStore, 0, bufSize)
+	kvAndStat2 := resSummary.MultipleFilesStats[0].Filenames[0]
+	kvReader, err := NewKVReader(ctx, kvAndStat2[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := 0; i < kvCnt; i++ {
 		key, value, err := kvReader.NextKV()
@@ -335,11 +351,9 @@ func TestOnefileWriterManyRows(t *testing.T) {
 
 	// check writerSummary.
 	expected := MultipleFilesStat{
-		MinKey: kvs[0].Key,
-		MaxKey: kvs[len(kvs)-1].Key,
-		Filenames: [][2]string{
-			{"/test2/mergeID/one-file", "/test2/mergeID_stat/one-file"},
-		},
+		MinKey:            kvs[0].Key,
+		MaxKey:            kvs[len(kvs)-1].Key,
+		Filenames:         [][2]string{kvAndStat2},
 		MaxOverlappingNum: 1,
 	}
 	require.EqualValues(t, expected.MinKey, resSummary.Min)
@@ -360,11 +374,13 @@ func TestOnefilePropOffset(t *testing.T) {
 
 	// 1. write into one file.
 	// 2. read stat file and check offset ascending.
+	var kvAndStat [2]string
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
 		SetBlockSize(memSizeLimit).
 		SetMemorySizeLimit(uint64(memSizeLimit)).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/test", "0")
 
 	require.NoError(t, writer.Init(ctx, 5*1024*1024))
@@ -388,7 +404,7 @@ func TestOnefilePropOffset(t *testing.T) {
 
 	require.NoError(t, writer.Close(ctx))
 
-	rd, err := newStatsReader(ctx, memStore, "/test/0_stat/one-file", 4096)
+	rd, err := newStatsReader(ctx, memStore, kvAndStat[1], 4096)
 	require.NoError(t, err)
 	lastOffset := uint64(0)
 	for {

--- a/pkg/lightning/backend/external/reader_test.go
+++ b/pkg/lightning/backend/external/reader_test.go
@@ -40,11 +40,13 @@ func TestReadAllDataBasic(t *testing.T) {
 	memStore := storage.NewMemStorage()
 	memSizeLimit := (rand.Intn(10) + 1) * 400
 
+	var summary *WriterSummary
 	w := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
 		SetMemorySizeLimit(uint64(memSizeLimit)).
 		SetBlockSize(memSizeLimit).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, "/test", "0")
 
 	writer := NewEngineWriter(w)
@@ -65,8 +67,7 @@ func TestReadAllDataBasic(t *testing.T) {
 		return bytes.Compare(i.Key, j.Key)
 	})
 
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
-	require.NoError(t, err)
+	datas, stats := getKVAndStatFiles(summary)
 
 	testReadAndCompare(ctx, t, kvs, memStore, datas, stats, kvs[0].Key, memSizeLimit)
 }
@@ -79,10 +80,12 @@ func TestReadAllOneFile(t *testing.T) {
 	memStore := storage.NewMemStorage()
 	memSizeLimit := (rand.Intn(10) + 1) * 400
 
+	var summary *WriterSummary
 	w := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
 		SetMemorySizeLimit(uint64(memSizeLimit)).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		BuildOneFile(memStore, "/test", "0")
 
 	require.NoError(t, w.Init(ctx, int64(5*size.MB)))
@@ -103,8 +106,7 @@ func TestReadAllOneFile(t *testing.T) {
 		return bytes.Compare(i.Key, j.Key)
 	})
 
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
-	require.NoError(t, err)
+	datas, stats := getKVAndStatFiles(summary)
 
 	testReadAndCompare(ctx, t, kvs, memStore, datas, stats, kvs[0].Key, memSizeLimit)
 }
@@ -118,9 +120,11 @@ func TestReadLargeFile(t *testing.T) {
 	})
 	ConcurrentReaderBufferSizePerConc = 512 * 1024
 
+	var summary *WriterSummary
 	w := NewWriterBuilder().
 		SetPropSizeDistance(128*1024).
 		SetPropKeysDistance(1000).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		BuildOneFile(memStore, "/test", "0")
 
 	require.NoError(t, w.Init(ctx, int64(5*size.MB)))
@@ -132,8 +136,7 @@ func TestReadLargeFile(t *testing.T) {
 	}
 	require.NoError(t, w.Close(ctx))
 
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
-	require.NoError(t, err)
+	datas, stats := getKVAndStatFiles(summary)
 	require.Len(t, datas, 1)
 
 	failpoint.Enable("github.com/pingcap/tidb/pkg/lightning/backend/external/assertReloadAtMostOnce", "return()")
@@ -151,7 +154,7 @@ func TestReadLargeFile(t *testing.T) {
 	startKey := []byte("key000000")
 	maxKey := []byte("key004998")
 	endKey := []byte("key004999")
-	err = readAllData(ctx, memStore, datas, stats, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
+	err := readAllData(ctx, memStore, datas, stats, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
 	require.NoError(t, err)
 	output.build(ctx)
 	require.Equal(t, startKey, output.kvs[0].key)

--- a/pkg/lightning/backend/external/sort_test.go
+++ b/pkg/lightning/backend/external/sort_test.go
@@ -134,7 +134,7 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. merge step
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
+	datas, stats, err := getKVAndStatFilesByScan(ctx, memStore, "test")
 	require.NoError(t, err)
 
 	dataGroup, _ := splitDataAndStatFiles(datas, stats)

--- a/pkg/lightning/backend/external/split_test.go
+++ b/pkg/lightning/backend/external/split_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -112,19 +113,54 @@ notExhausted:
 	require.NoError(t, splitter.Close())
 }
 
+func writeKVs(t *testing.T, writer *Writer, keys [][]byte, values [][]byte) {
+	ctx := context.Background()
+	for i := range keys {
+		err := writer.WriteRow(ctx, keys[i], values[i], nil)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close(ctx))
+}
+
+func getKVAndStatFiles(sum *WriterSummary) (dataFiles []string, statsFiles []string) {
+	for _, ms := range sum.MultipleFilesStats {
+		for _, f := range ms.Filenames {
+			dataFiles = append(dataFiles, f[0])
+			statsFiles = append(statsFiles, f[1])
+		}
+	}
+	return
+}
+
+func removePartitionPrefix(t *testing.T, in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		bs := []byte(s)
+		idx := bytes.IndexByte(bs, '/')
+		require.GreaterOrEqual(t, idx, 0)
+		require.True(t, isValidPartition(bs[:idx]))
+		// we include / after partition prefix in the out, as all tests have it.
+		out = append(out, s[idx:])
+	}
+	sort.Strings(out)
+	return out
+}
+
 func TestOnlyOneGroup(t *testing.T) {
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	subDir := "/mock-test"
 
+	var summary *WriterSummary
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(20).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "5")
 
-	dataFiles, statFiles, err := MockExternalEngineWithWriter(memStore, writer, subDir, [][]byte{{1}, {2}}, [][]byte{{1}, {2}})
-	require.NoError(t, err)
+	writeKVs(t, writer, [][]byte{{1}, {2}}, [][]byte{{1}, {2}})
+	dataFiles, statFiles := getKVAndStatFiles(summary)
 	require.Len(t, dataFiles, 1)
 	require.Len(t, statFiles, 1)
 
@@ -199,11 +235,13 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	memStore := storage.NewMemStorage()
 	subDir := "/mock-test"
 
+	var summary *WriterSummary
 	writer1 := NewWriterBuilder().
 		SetMemorySizeLimit(2*(lengthBytes*2+10)).
 		SetBlockSize(2*(lengthBytes*2+10)).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "1")
 	keys1 := [][]byte{
 		[]byte("key01"), []byte("key11"), []byte("key21"),
@@ -211,8 +249,9 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	values1 := [][]byte{
 		[]byte("val01"), []byte("val11"), []byte("val21"),
 	}
-	dataFiles1, statFiles1, err := MockExternalEngineWithWriter(memStore, writer1, subDir, keys1, values1)
-	require.NoError(t, err)
+
+	writeKVs(t, writer1, keys1, values1)
+	dataFiles1, statFiles1 := getKVAndStatFiles(summary)
 	require.Len(t, dataFiles1, 2)
 	require.Len(t, statFiles1, 2)
 
@@ -221,6 +260,7 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 		SetBlockSize(2*(lengthBytes*2+10)).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "2")
 	keys2 := [][]byte{
 		[]byte("key02"), []byte("key12"), []byte("key22"),
@@ -228,16 +268,17 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	values2 := [][]byte{
 		[]byte("val02"), []byte("val12"), []byte("val22"),
 	}
-	dataFiles12, statFiles12, err := MockExternalEngineWithWriter(memStore, writer2, subDir, keys2, values2)
-	require.NoError(t, err)
-	require.Len(t, dataFiles12, 4)
-	require.Len(t, statFiles12, 4)
+	writeKVs(t, writer2, keys2, values2)
+	dataFiles2, statFiles2 := getKVAndStatFiles(summary)
+	require.Len(t, dataFiles2, 2)
+	require.Len(t, statFiles2, 2)
 
 	writer3 := NewWriterBuilder().
 		SetMemorySizeLimit(2*(lengthBytes*2+10)).
 		SetBlockSize(2*(lengthBytes*2+10)).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "3")
 	keys3 := [][]byte{
 		[]byte("key03"), []byte("key13"), []byte("key23"),
@@ -245,23 +286,23 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	values3 := [][]byte{
 		[]byte("val03"), []byte("val13"), []byte("val23"),
 	}
-	dataFiles123, statFiles123, err := MockExternalEngineWithWriter(memStore, writer3, subDir, keys3, values3)
-	require.NoError(t, err)
-	require.Len(t, dataFiles123, 6)
-	require.Len(t, statFiles123, 6)
+	writeKVs(t, writer3, keys3, values3)
+	dataFiles3, statFiles3 := getKVAndStatFiles(summary)
+	require.Len(t, dataFiles3, 2)
+	require.Len(t, statFiles3, 2)
 
 	// "/mock-test/X/0" contains "key0X" and "key1X"
 	// "/mock-test/X/1" contains "key2X"
 	require.Equal(t, []string{
-		"/mock-test/1/0", "/mock-test/1/1",
-		"/mock-test/2/0", "/mock-test/2/1",
 		"/mock-test/3/0", "/mock-test/3/1",
-	}, dataFiles123)
+	}, removePartitionPrefix(t, dataFiles3))
 
-	multi := mockOneMultiFileStat(dataFiles123[:4], statFiles123[:4])
+	dataFiles12 := append(append([]string{}, dataFiles1...), dataFiles2...)
+	statFiles12 := append(append([]string{}, statFiles1...), statFiles2...)
+	multi := mockOneMultiFileStat(dataFiles12, statFiles12)
 	multi[0].MinKey = []byte("key01")
 	multi[0].MaxKey = []byte("key21")
-	multi2 := mockOneMultiFileStat(dataFiles123[4:], statFiles123[4:])
+	multi2 := mockOneMultiFileStat(dataFiles3, statFiles3)
 	multi2[0].MinKey = []byte("key02")
 	multi2[0].MaxKey = []byte("key22")
 	multiFileStat := []MultipleFilesStat{multi2[0], multi[0]}
@@ -279,8 +320,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err := splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key03"), endKey)
-	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0"}, statFiles)
+	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key02")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key02")}, regionSplitKeys)
 
@@ -288,8 +329,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key12"), endKey)
-	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0", "/mock-test/3/0"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0", "/mock-test/3_stat/0"}, statFiles)
+	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0", "/mock-test/3/0"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0", "/mock-test/3_stat/0"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key11")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key11")}, regionSplitKeys)
 
@@ -298,8 +339,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key21"), endKey)
-	require.Equal(t, []string{"/mock-test/2/0", "/mock-test/3/0"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/2_stat/0", "/mock-test/3_stat/0"}, statFiles)
+	require.Equal(t, []string{"/mock-test/2/0", "/mock-test/3/0"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/2_stat/0", "/mock-test/3_stat/0"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key13")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key13")}, regionSplitKeys)
 
@@ -309,8 +350,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key23"), endKey)
-	require.Equal(t, []string{"/mock-test/1/1", "/mock-test/2/1"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/1_stat/1", "/mock-test/2_stat/1"}, statFiles)
+	require.Equal(t, []string{"/mock-test/1/1", "/mock-test/2/1"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/1_stat/1", "/mock-test/2_stat/1"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key22")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key22")}, regionSplitKeys)
 
@@ -318,8 +359,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.Nil(t, endKey)
-	require.Equal(t, []string{"/mock-test/3/1"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/3_stat/1"}, statFiles)
+	require.Equal(t, []string{"/mock-test/3/1"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/3_stat/1"}, removePartitionPrefix(t, statFiles))
 	require.Len(t, rangeJobKeys, 0)
 	require.Len(t, regionSplitKeys, 0)
 
@@ -348,14 +389,16 @@ func TestExactlyKeyNum(t *testing.T) {
 
 	subDir := "/mock-test"
 
+	var summary *WriterSummary
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(15).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "5")
 
-	dataFiles, statFiles, err := MockExternalEngineWithWriter(memStore, writer, subDir, keys, values)
-	require.NoError(t, err)
+	writeKVs(t, writer, keys, values)
+	dataFiles, statFiles := getKVAndStatFiles(summary)
 	multiFileStat := mockOneMultiFileStat(dataFiles, statFiles)
 
 	// maxRangeKeys = 3

--- a/pkg/lightning/backend/external/util_test.go
+++ b/pkg/lightning/backend/external/util_test.go
@@ -183,18 +183,17 @@ func TestGetAllFileNames(t *testing.T) {
 	err = w3.Close(ctx)
 	require.NoError(t, err)
 
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, "/subtask")
+	filenames, err := GetAllFileNames(ctx, store, "subtask")
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
-		"/subtask/12_stat/0", "/subtask/12_stat/1", "/subtask/12_stat/2",
-		"/subtask/3_stat/0", "/subtask/3_stat/1", "/subtask/3_stat/2",
-	}, statFiles)
+	filenames = removePartitionPrefix(t, filenames)
 	require.Equal(t, []string{
 		"/subtask/0/0", "/subtask/0/1", "/subtask/0/2",
+		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
 		"/subtask/12/0", "/subtask/12/1", "/subtask/12/2",
+		"/subtask/12_stat/0", "/subtask/12_stat/1", "/subtask/12_stat/2",
 		"/subtask/3/0", "/subtask/3/1", "/subtask/3/2",
-	}, dataFiles)
+		"/subtask/3_stat/0", "/subtask/3_stat/1", "/subtask/3_stat/2",
+	}, filenames)
 }
 
 func TestCleanUpFiles(t *testing.T) {
@@ -219,21 +218,19 @@ func TestCleanUpFiles(t *testing.T) {
 	err := w.Close(ctx)
 	require.NoError(t, err)
 
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, "/subtask")
+	filenames, err := GetAllFileNames(ctx, store, "subtask")
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
-	}, statFiles)
+	filenames = removePartitionPrefix(t, filenames)
 	require.Equal(t, []string{
 		"/subtask/0/0", "/subtask/0/1", "/subtask/0/2",
-	}, dataFiles)
+		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
+	}, filenames)
 
-	require.NoError(t, CleanUpFiles(ctx, store, "/subtask"))
+	require.NoError(t, CleanUpFiles(ctx, store, "subtask"))
 
-	dataFiles, statFiles, err = GetAllFileNames(ctx, store, "/subtask")
+	filenames, err = GetAllFileNames(ctx, store, "subtask")
 	require.NoError(t, err)
-	require.Equal(t, []string(nil), statFiles)
-	require.Equal(t, []string(nil), dataFiles)
+	require.Equal(t, []string(nil), filenames)
 }
 
 func TestGetMaxOverlapping(t *testing.T) {

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -607,5 +607,12 @@ func TestRandPartitionedPrefix(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	prefix := "write-prefix"
 	partitioned := randPartitionedPrefix(prefix, rnd)
-	require.Equal(t, partitioned[3:], prefix)
+	require.Equal(t, partitionHeaderChar, partitioned[0])
+	require.Equal(t, partitioned[4:], prefix)
+	require.True(t, isValidPartition([]byte(partitioned[:3])))
+
+	require.False(t, isValidPartition([]byte("aa")))
+	require.False(t, isValidPartition([]byte("aaa")))
+	require.False(t, isValidPartition([]byte("paz")))
+	require.False(t, isValidPartition([]byte("pza")))
 }

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -70,11 +70,10 @@ func checkFileCleaned(t *testing.T, jobID, taskID int64, sortStorageURI string) 
 	require.NoError(t, err)
 	for _, id := range []int64{jobID, taskID} {
 		prefix := strconv.Itoa(int(id))
-		dataFiles, statFiles, err := external.GetAllFileNames(context.Background(), extStore, prefix)
+		files, err := external.GetAllFileNames(context.Background(), extStore, prefix)
 		require.NoError(t, err)
 		require.Greater(t, jobID, int64(0))
-		require.Equal(t, 0, len(dataFiles))
-		require.Equal(t, 0, len(statFiles))
+		require.Equal(t, 0, len(files))
 	}
 }
 
@@ -83,7 +82,7 @@ func checkFileExist(t *testing.T, sortStorageURI string, prefix string) {
 	require.NoError(t, err)
 	extStore, err := storage.NewWithDefaultOpt(context.Background(), storeBackend)
 	require.NoError(t, err)
-	dataFiles, _, err := external.GetAllFileNames(context.Background(), extStore, prefix)
+	dataFiles, err := external.GetAllFileNames(context.Background(), extStore, prefix)
 	require.NoError(t, err)
 	require.Greater(t, len(dataFiles), 0)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

on default, S3 have only one partition per bucket, and each partition have it's own request limit, if user want to have larger  upper bound of the limit, they have to ask AWS support to partition manually before accessing, and BTW, from the feedback of S3, the partition is not durable forever, if you don't use the partition too frequently, the partition might be merged automatically, as partition takes additionally resource.

when importing large mount of data with import-into using large number of nodes, during global sort steps, we might many intermediate files to S3, and might meet request throttle, and slows import down.

currently, we are using `cloud_storage_uri/<task-id>/<subtask-id>/<uuid><type-suffix>/<seq>` to store intemediate KV and stat files, the range of `<task-id>/<subtask-id>` is very wide and it's hard to predicate before import, because TiDB caches ID range, so the ID might be like `1 2`, `30001 30002`, `60001 60002`, and we have 2 level of IDs in the prefix, this makes it **harder for customer to ask S3 to pre-partition by prefix**.

so we wound like to make this easier, to make the file prefix more predictable before import start

### What changed and how does it work?

the rule is: generate a random byte in range [0, 256) and encode to hex string,
and append it after `p` as the partitioned prefix. one example:
```
s3://bucket-name/cloud_storage_uri/p00/<task-id>/<subtask-id>/<uuid><type-suffix>/<seq>`
s3://bucket-name/cloud_storage_uri/p01/<task-id>/<subtask-id>/<uuid><type-suffix>/<seq>`
s3://bucket-name/cloud_storage_uri/p02/<task-id>/<subtask-id>/<uuid><type-suffix>/<seq>`
....
....

s3://bucket-name/cloud_storage_uri/pff/<task-id>/<subtask-id>/<uuid><type-suffix>/<seq>`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

partitioned files are like this:
```
[2025-04-25 19:44:05 CST] 2.2KiB STANDARD abc/90001/90001/meta.json
[2025-04-25 19:44:05 CST] 2.3KiB STANDARD abc/90001/90002/meta.json
...
[2025-04-25 19:44:04 CST]   204B STANDARD abc/90001/plan/encode/1/meta.json
[2025-04-25 19:44:04 CST]   209B STANDARD abc/90001/plan/encode/10/meta.json
...
[2025-04-25 19:35:07 CST]     0B STANDARD abc/a.txt
[2025-04-25 19:44:05 CST]   148B STANDARD abc/p00/90001/90002/index/3/963f54f4-0f5b-4ba0-86e4-3137608e29c8_stat/0
[2025-04-25 19:44:05 CST]  94KiB STANDARD abc/p0a/90001/90004/index/2/f7904c13-556b-4ff1-8e2a-7ae5d469f439/0
[2025-04-25 19:44:05 CST]  52KiB STANDARD abc/p0c/90001/90002/data/963f54f4-0f5b-4ba0-86e4-3137608e29c8/0
[2025-04-25 19:44:05 CST]    74B STANDARD abc/p11/90001/90004/data/f7904c13-556b-4ff1-8e2a-7ae5d469f439_stat/0
[2025-04-25 19:44:05 CST]    74B STANDARD abc/p1b/90001/90005/data/2121dd6a-7534-4f16-9a89-ee18a802a2e9_stat/0
[2025-04-25 19:44:05 CST]  94KiB STANDARD abc/p1f/90001/90008/index/2/ae19d0a9-76d9-4b7c-b421-00c257ec270f/0
[2025-04-25 19:44:05 CST]  94KiB STANDARD abc/p21/90001/90008/index/3/ae19d0a9-76d9-4b7c-b421-00c257ec270f/0
[2025-04-25 19:44:05 CST]    74B STANDARD abc/p22/90001/90003/data/c0a54321-53c8-42d8-8d2c-af1b3628c2b7_stat/0
[2025-04-25 19:44:05 CST]  80KiB STANDARD abc/p23/90001/90002/index/1/963f54f4-0f5b-4ba0-86e4-3137608e29c8/0
[2025-04-25 19:44:05 CST]   148B STANDARD abc/p26/90001/90008/index/2/ae19d0a9-76d9-4b7c-b421-00c257ec270f_stat/0
[2025-04-25 19:44:05 CST]   148B STANDARD abc/p27/90001/90003/index/3/c0a54321-53c8-42d8-8d2c-af1b3628c2b7_stat/0
[2025-04-25 19:44:05 CST]  94KiB STANDARD abc/p2a/90001/90006/index/2/73442e32-5653-42ef-9ff4-d40053dc89ec/0
[2025-04-25 19:44:05 CST]  52KiB STANDARD abc/p2b/90001/90005/data/2121dd6a-7534-4f16-9a89-ee18a802a2e9/0
[2025-04-25 19:44:05 CST]  52KiB STANDARD abc/p2b/90001/90006/data/73442e32-5653-42ef-9ff4-d40053dc89ec/0
...
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
