### PR TITLE
[DNM]executor: support tidb_store_batch_size for index_scan rpc

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -229,6 +229,12 @@ func (builder *RequestBuilder) SetKeyRanges(keyRanges []kv.KeyRange) *RequestBui
 	return builder
 }
 
+// SetIndexScanKeyRanges sets "KeyRanges" for "kv.Request".
+func (builder *RequestBuilder) SetIndexScanKeyRanges(keyRanges []kv.KeyRange, hints []int) *RequestBuilder {
+	builder.Request.KeyRanges = kv.NewNonParitionedKeyRangesWithHint(keyRanges, hints)
+	return builder
+}
+
 // SetKeyRangesWithHints sets "KeyRanges" for "kv.Request" with row count hints.
 func (builder *RequestBuilder) SetKeyRangesWithHints(keyRanges []kv.KeyRange, hints []int) *RequestBuilder {
 	builder.Request.KeyRanges = kv.NewNonParitionedKeyRangesWithHint(keyRanges, hints)

--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -362,8 +362,8 @@ func extractTableNames(node ast.ResultSetNode, names []*ast.TableName) ([]*ast.T
 	default:
 		return names, false, "queries that have sub-queries are not supported"
 	}
-	if len(names) > 2 {
-		return names, false, "queries that have more than 2 tables are not supported"
+	if len(names) > 5 {
+		return names, false, "queries that have more than 5 tables are not supported"
 	}
 	return names, true, ""
 }

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2155,6 +2155,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		EnableClusteredIndex:          DefTiDBEnableClusteredIndex,
 		EnableParallelApply:           DefTiDBEnableParallelApply,
 		ShardAllocateStep:             DefTiDBShardAllocateStep,
+		EnablePointGetCache:           DefTiDBPointGetCache,
 		PartitionPruneMode:            *atomic2.NewString(DefTiDBPartitionPruneMode),
 		TxnScope:                      kv.NewDefaultTxnScopeVar(),
 		EnabledRateLimitAction:        DefTiDBEnableRateLimitAction,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -809,6 +809,10 @@ var defaultSysVars = []*SysVar{
 		SetMaxDeltaSchemaCount(TidbOptInt64(val, DefTiDBMaxDeltaSchemaCount))
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnablePointGetCache, Value: BoolToOnOff(DefTiDBPointGetCache), Hidden: true, Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnablePointGetCache = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBScatterRegion, Value: DefTiDBScatterRegion, PossibleValues: []string{ScatterOff, ScatterTable, ScatterGlobal}, Type: TypeStr,
 		SetSession: func(vars *SessionVars, val string) error {
 			vars.ScatterRegion = val

--- a/pkg/sessionctx/variable/tidb_vars.go
+++ b/pkg/sessionctx/variable/tidb_vars.go
@@ -539,6 +539,8 @@ const (
 	// deltaSchemaInfos is a queue that maintains the history of schema changes.
 	TiDBMaxDeltaSchemaCount = "tidb_max_delta_schema_count"
 
+	// TiDBEnablePointGetCache is used to control whether to enable the point get cache for special scenario.
+	TiDBEnablePointGetCache = "tidb_enable_point_get_cache"
 	// TiDBScatterRegion will scatter the regions for DDLs when it is "table" or "global", "" indicates not trigger scatter.
 	TiDBScatterRegion = "tidb_scatter_region"
 
@@ -1371,6 +1373,7 @@ const (
 	DefTiDBRestrictedReadOnly               = false
 	DefTiDBSuperReadOnly                    = false
 	DefTiDBShardAllocateStep                = math.MaxInt64
+	DefTiDBPointGetCache                    = false
 	DefTiDBEnableTelemetry                  = false
 	DefTiDBEnableParallelApply              = false
 	DefTiDBPartitionPruneMode               = "dynamic"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?
- #60700
- support tidb_store_batch_size for index_scan rpc

**Manual Test**

- prepare table.

```sql
create table user (id int, sn int, index(id));
insert into user value (1,1),(1,3),(1,5),(1,7),(1,9),(1,11),(1,13),(1,15),(1,17),(1,19);
create table item (sn int, b int, index(sn));
split table item index sn by (2),(4),(6),(8),(10),(12),(14),(16),(18),(20);
explain analyze select * from user join item on user.sn=item.sn where user.id=1;
```

**Before**

`IndexLookUp_12(Probe)` will send 10 cop rpc request, since `tidb_store_batch_size` not suit for `IndexRangeScan`.

```sql
> explain analyze select * from user join item on user.sn=item.sn where user.id=1;
+------------------------------+---------+---------+-----------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| id                           | estRows | actRows | task      | access object            | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | operator info                                                                                                                   | memory    | disk |
+------------------------------+---------+---------+-----------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| IndexHashJoin_15             | 0.01    | 0       | root      |                          | time:2.94ms, open:14µs, close:3.13µs, loops:1, RU:5.83, inner:{total:1.46ms, concurrency:5, task:1, construct:18.9µs, fetch:1.44ms, build:14.9µs, join:1.29µs}                                                                                                                                                                                                                                                                                                                                                       | inner join, inner:IndexLookUp_12, outer key:test3.user.sn, inner key:test3.item.sn, equal cond:eq(test3.user.sn, test3.item.sn) | 19.3 KB   | N/A  |
| ├─IndexLookUp_28(Build)      | 0.01    | 10      | root      |                          | time:1.36ms, open:11.5µs, close:917ns, loops:3, index_task: {total_time: 801µs, fetch_handle: 792.9µs, build: 1.75µs, wait: 6.38µs}, table_task: {total_time: 480.6µs, num: 1, concurrency: 5}, next: {wait_index: 852.1µs, wait_table_lookup_build: 25µs, wait_table_lookup_resp: 451.9µs}                                                                                                                                                                                                                          |                                                                                                                                 | 2.08 KB   | N/A  |
| │ ├─IndexRangeScan_25(Build) | 0.01    | 10      | cop[tikv] | table:user, index:id(id) | time:790.4µs, open:0s, close:0s, loops:3, cop_task: {num: 1, max: 738.4µs, proc_keys: 10, tot_proc: 68.7µs, tot_wait: 202.1µs, copr_cache_hit_ratio: 0.00, build_task_duration: 9.33µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:725µs}}, tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 10, total_process_keys_size: 460, total_keys: 11, get_snapshot_time: 171.6µs, rocksdb: {key_skipped_count: 10, block: {}}}, time_detail: {total_process_time: 68.7µs, total_wa... | range:[1,1], keep order:false, stats:pseudo                                                                                     | N/A       | N/A  |
| │ └─Selection_27(Probe)      | 0.01    | 10      | cop[tikv] |                          | time:442.6µs, open:0s, close:1.54µs, loops:2, cop_task: {num: 1, max: 420.2µs, proc_keys: 10, tot_proc: 52.8µs, tot_wait: 48.9µs, copr_cache_hit_ratio: 0.00, build_task_duration: 9µs, max_distsql_concurrency: 1, max_extra_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:413.9µs}}, tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 10, total_process_keys_size: 410, total_keys: 11, get_snapshot_time: 22.1µs, rocksdb: {key_skipped_count: 10, block: {}}}, time_detail: {total_pro... | not(isnull(test3.user.sn))                                                                                                      | N/A       | N/A  |
| │   └─TableRowIDScan_26      | 0.01    | 10      | cop[tikv] | table:user               | tikv_task:{time:0s, loops:1}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | keep order:false, stats:pseudo                                                                                                  | N/A       | N/A  |
| └─IndexLookUp_12(Probe)      | 0.01    | 0       | root      |                          | time:1.38ms, open:0s, close:2.29µs, loops:1                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |                                                                                                                                 | 272 Bytes | N/A  |
|   ├─Selection_11(Build)      | 0.01    | 0       | cop[tikv] |                          | time:1.27ms, open:0s, close:0s, loops:1, cop_task: {num: 10, max: 1.11ms, min: 729.5µs, avg: 877.9µs, p95: 1.11ms, tot_proc: 236µs, tot_wait: 3.43ms, copr_cache_hit_ratio: 0.00, build_task_duration: 14.5µs, max_distsql_concurrency: 10}, rpc_info:{Cop:{num_rpc:10, total_time:8.46ms}}, tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:10, tasks:10}, scan_detail: {total_keys: 10, get_snapshot_time: 3.11ms, rocksdb: {block: {}}}, time_detail: {total_process_time: 236µs, total_wait_ti... | not(isnull(test3.item.sn))                                                                                                      | N/A       | N/A  |
|   │ └─IndexRangeScan_9       | 0.01    | 0       | cop[tikv] | table:item, index:sn(sn) | tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:10, tasks:10}                                                                                                                                                                                                                                                                                                                                                                                                                                         | range: decided by [eq(test3.item.sn, test3.user.sn)], keep order:false, stats:pseudo                                            | N/A       | N/A  |
|   └─TableRowIDScan_10(Probe) | 0.01    | 0       | cop[tikv] | table:item               |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | keep order:false, stats:pseudo                                                                                                  | N/A       | N/A  |
+------------------------------+---------+---------+-----------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------+-----------+------+
9 rows in set
Time: 0.018s
```

**This PR**

`IndexLookUp_12(Probe)` will only send 2 cop rpc request, since `tidb_store_batch_size` worked.

```sql
> explain analyze select * from user join item on user.sn=item.sn where user.id=1;
+------------------------------+---------+---------+-----------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| id                           | estRows | actRows | task      | access object            | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | operator info                                                                                                                   | memory    | disk |
+------------------------------+---------+---------+-----------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------+-----------+------+
| IndexHashJoin_15             | 0.01    | 0       | root      |                          | time:4.12ms, loops:1, RU:1.974844, inner:{total:2.01ms, concurrency:5, task:1, construct:12.1µs, fetch:2ms, build:67.3µs, join:1.79µs}                                                                                                                                                                                                                                                                                                                                                                               | inner join, inner:IndexLookUp_12, outer key:test3.user.sn, inner key:test3.item.sn, equal cond:eq(test3.user.sn, test3.item.sn) | 19.6 KB   | N/A  |
| ├─IndexLookUp_28(Build)      | 0.01    | 10      | root      |                          | time:1.79ms, loops:3, index_task: {total_time: 584.3µs, fetch_handle: 579.7µs, build: 1.42µs, wait: 3.21µs}, table_task: {total_time: 751.3µs, num: 1, concurrency: 5}, next: {wait_index: 1.02ms, wait_table_lookup_build: 78.8µs, wait_table_lookup_resp: 667.7µs}                                                                                                                                                                                                                                                 |                                                                                                                                 | 18.0 KB   | N/A  |
| │ ├─IndexRangeScan_25(Build) | 0.01    | 10      | cop[tikv] | table:user, index:id(id) | time:572.9µs, loops:3, cop_task: {num: 1, max: 500.8µs, proc_keys: 10, tot_proc: 50.8µs, tot_wait: 51.1µs, copr_cache_hit_ratio: 0.00, build_task_duration: 388.7µs, max_distsql_concurrency: 1, max_extra_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:487.1µs}}, tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 10, total_process_keys_size: 460, total_keys: 11, get_snapshot_time: 26.1µs, rocksdb: {key_skipped_count: 10, block: {}}}, time_detail: {total_process_time: 50.8µs, ... | range:[1,1], keep order:false, stats:pseudo                                                                                     | N/A       | N/A  |
| │ └─Selection_27(Probe)      | 0.01    | 10      | cop[tikv] |                          | time:654.8µs, loops:2, cop_task: {num: 1, max: 597.8µs, proc_keys: 10, tot_proc: 81µs, tot_wait: 32.6µs, copr_cache_hit_ratio: 0.00, build_task_duration: 38.9µs, max_distsql_concurrency: 1, max_extra_concurrency: 1}, rpc_info:{Cop:{num_rpc:1, total_time:591.5µs}}, tikv_task:{time:0s, loops:1}, scan_detail: {total_process_keys: 10, total_process_keys_size: 410, total_keys: 11, get_snapshot_time: 15.5µs, rocksdb: {key_skipped_count: 10, block: {}}}, time_detail: {total_process_time: 81µs, total... | not(isnull(test3.user.sn))                                                                                                      | N/A       | N/A  |
| │   └─TableRowIDScan_26      | 0.01    | 10      | cop[tikv] | table:user               | tikv_task:{time:0s, loops:1}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | keep order:false, stats:pseudo                                                                                                  | N/A       | N/A  |
| └─IndexLookUp_12(Probe)      | 0.01    | 0       | root      |                          | time:1.93ms, loops:1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |                                                                                                                                 | 656 Bytes | N/A  |
|   ├─Selection_11(Build)      | 0.01    | 0       | cop[tikv] |                          | time:1.42ms, loops:1, cop_task: {num: 10, max: 672.4µs, min: 0s, avg: 124.7µs, p95: 672.4µs, tot_proc: 250.4µs, tot_wait: 910.2µs, copr_cache_hit_ratio: 0.00, build_task_duration: 434.3µs, max_distsql_concurrency: 1, max_extra_concurrency: 1, store_batch_num: 8}, rpc_info:{Cop:{num_rpc:2, total_time:1.23ms}}, tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:10, tasks:10}, scan_detail: {total_keys: 10, get_snapshot_time: 649.9µs, rocksdb: {block: {}}}, time_detail: {total_process... | not(isnull(test3.item.sn))                                                                                                      | N/A       | N/A  |
|   │ └─IndexRangeScan_9       | 0.01    | 0       | cop[tikv] | table:item, index:sn(sn) | tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:10, tasks:10}                                                                                                                                                                                                                                                                                                                                                                                                                                         | range: decided by [eq(test3.item.sn, test3.user.sn)], keep order:false, stats:pseudo                                            | N/A       | N/A  |
|   └─TableRowIDScan_10(Probe) | 0.01    | 0       | cop[tikv] | table:item               |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | keep order:false, stats:pseudo                                                                                                  | N/A       | N/A  |
+------------------------------+---------+---------+-----------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------+-----------+------+
9 rows in set
Time: 0.029s
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
