### PR TITLE
ddl: update row count periodically when running reorg job

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -395,6 +395,8 @@ func (w *backfillWorker) handleBackfillTask(d *ddlCtx, task *reorgBackfillTask, 
 			break
 		}
 	}
+	failpoint.InjectCall("afterHandleBackfillTask", task.jobID)
+
 	logutil.DDLLogger().Info("backfill worker finish task",
 		zap.Stringer("worker", w), zap.Stringer("task", task),
 		zap.Int("added count", result.addedCount),

--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -1024,7 +1024,6 @@ func (dc *ddlCtx) writePhysicalTableRecord(
 				} else {
 					totalAddedCount += int64(result.addedCount)
 				}
-				dc.getReorgCtx(reorgInfo.Job.ID).setRowCount(totalAddedCount)
 
 				keeper.updateNextKey(result.taskID, result.nextKey)
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1568,7 +1568,7 @@ func runReorgJobAndHandleErr(
 	if err != nil {
 		return false, ver, errors.Trace(err)
 	}
-	err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (addIndexErr error) {
+	err = w.runReorgJob(jobCtx, reorgInfo, tbl.Meta(), func() (addIndexErr error) {
 		defer util.Recover(metrics.LabelDDL, "onCreateIndex",
 			func() {
 				addIndexErr = dbterror.ErrCancelledDDLJob.GenWithStack("add table `%v` index `%v` panic", tbl.Meta().Name, allIndexInfos[0].Name)

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -423,11 +422,8 @@ func TestAddIndexRowCountUpdate(t *testing.T) {
 			rs := tk2.MustQuery("admin show ddl jobs 1;").Rows()
 			idStr := rs[0][0].(string)
 			id, err := strconv.Atoi(idStr)
-			assert.NoError(t, err)
-			assert.Equal(t, int64(id), jobID)
-			if t.Failed() {
-				return true
-			}
+			require.NoError(t, err)
+			require.Equal(t, int64(id), jobID)
 			rcStr := rs[0][7].(string)
 			rc, err := strconv.Atoi(rcStr)
 			require.NoError(t, err)

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -16,6 +16,7 @@ package ddl_test
 
 import (
 	"context"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -389,4 +391,54 @@ func checkDropDeleteOnly(ctx sessionctx.Context, writeTbl, delTbl table.Table) e
 		return errors.Trace(err)
 	}
 	return txn.Commit(context.Background())
+}
+
+func TestAddIndexRowCountUpdate(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (c1 int primary key, c2 int)")
+	tk.MustExec("insert t values (1, 1), (2, 2), (3, 3);")
+	tk.MustExec("set @@tidb_ddl_reorg_worker_cnt = 1;")
+	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
+	tk.MustExec("set global tidb_enable_dist_task = 0;")
+
+	var jobID int64
+	rowCntUpdated := make(chan struct{})
+	backfillDone := make(chan struct{})
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/updateProgressIntervalInMs", "return(50)")
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterHandleBackfillTask", func(id int64) {
+		jobID = id
+		backfillDone <- struct{}{}
+		<-rowCntUpdated
+	})
+	go func() {
+		defer func() {
+			rowCntUpdated <- struct{}{}
+		}()
+		<-backfillDone
+		tk2 := testkit.NewTestKit(t, store)
+		tk2.MustExec("use test")
+		times := 0
+		for {
+			times++
+			<-time.After(60 * time.Millisecond)
+			rs := tk2.MustQuery("admin show ddl jobs 1;").Rows()
+			idStr := rs[0][0].(string)
+			id, err := strconv.Atoi(idStr)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(id), jobID)
+			if t.Failed() {
+				break
+			}
+			rcStr := rs[0][7].(string)
+			rc, err := strconv.Atoi(rcStr)
+			require.NoError(t, err)
+			if rc > 0 {
+				t.Logf("job %d get row count %d, times %d", id, rc, times)
+				break
+			}
+		}
+	}()
+	tk.MustExec("alter table t add index idx(c2);")
 }

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -427,10 +427,7 @@ func TestAddIndexRowCountUpdate(t *testing.T) {
 			rcStr := rs[0][7].(string)
 			rc, err := strconv.Atoi(rcStr)
 			require.NoError(t, err)
-			if rc > 0 {
-				return true
-			}
-			return false
+			return rc > 0
 		}, 2*time.Minute, 60*time.Millisecond)
 	}()
 	tk.MustExec("alter table t add index idx(c2);")

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -419,9 +419,7 @@ func TestAddIndexRowCountUpdate(t *testing.T) {
 		<-backfillDone
 		tk2 := testkit.NewTestKit(t, store)
 		tk2.MustExec("use test")
-		times := 0
 		require.Eventually(t, func() bool {
-			times++
 			rs := tk2.MustQuery("admin show ddl jobs 1;").Rows()
 			idStr := rs[0][0].(string)
 			id, err := strconv.Atoi(idStr)
@@ -434,7 +432,6 @@ func TestAddIndexRowCountUpdate(t *testing.T) {
 			rc, err := strconv.Atoi(rcStr)
 			require.NoError(t, err)
 			if rc > 0 {
-				t.Logf("job %d get row count %d, times %d", id, rc, times)
 				return true
 			}
 			return false

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -96,8 +96,11 @@ type jobContext struct {
 	logger   *zap.Logger
 
 	// per job step fields, they will be changed on each call of transitOneJobStep.
+	stepCtx              context.Context
+	stepCtxCancel        context.CancelCauseFunc
+	reorgTimeoutOccurred bool
+	inMultiSchema        bool
 
-	stepCtx context.Context
 	metaMut *meta.Mutator
 	// decoded JobArgs, we store it here to avoid decoding it multiple times and
 	// pass some runtime info specific to some job type.
@@ -106,6 +109,32 @@ type jobContext struct {
 	// TODO reorg part of code couple this struct so much, remove it later.
 	oldDDLCtx     *ddlCtx
 	lockStartTime time.Time
+}
+
+func (c *jobContext) shouldPollDDLJob() bool {
+	// If we are in multi-schema change DDL and this is not the outermost
+	// runOneJobStep, we should not start a goroutine to poll the ddl job.
+	return !c.inMultiSchema
+}
+
+func (c *jobContext) initStepCtx() {
+	if c.stepCtx == nil {
+		stepCtx, cancel := context.WithCancelCause(c.ctx)
+		c.stepCtx = stepCtx
+		c.stepCtxCancel = cancel
+	}
+}
+
+func (c *jobContext) cleanStepCtx() {
+	// reorgTimeoutOccurred indicates whether the current reorganization
+	// process was terminated due to a timeout condition. When set to true,
+	// it prevents premature cleanup of step context.
+	if c.reorgTimeoutOccurred {
+		c.reorgTimeoutOccurred = false
+		return
+	}
+	c.stepCtxCancel(context.Canceled)
+	c.stepCtx = nil // unset stepCtx for the next initialization
 }
 
 func (c *jobContext) getAutoIDRequirement() autoid.Requirement {
@@ -584,7 +613,7 @@ func (w *worker) transitOneJobStep(
 	}()
 	// If running job meets error, we will save this error in job Error and retry
 	// later if the job is not cancelled.
-	schemaVer, updateRawArgs, runJobErr := w.runOneJobStep(jobCtx, job, jobCtx.sysTblMgr)
+	schemaVer, updateRawArgs, runJobErr := w.runOneJobStep(jobCtx, job)
 
 	failpoint.InjectCall("afterRunOneJobStep", job)
 
@@ -774,7 +803,6 @@ func (*worker) processJobPausingRequest(jobCtx *jobContext, job *model.Job) (isR
 func (w *worker) runOneJobStep(
 	jobCtx *jobContext,
 	job *model.Job,
-	sysTblMgr systable.Manager,
 ) (ver int64, updateRawArgs bool, err error) {
 	defer tidbutil.Recover(metrics.LabelDDLWorker, fmt.Sprintf("%s runOneJobStep", w),
 		func() {
@@ -809,13 +837,6 @@ func (w *worker) runOneJobStep(
 		return ver, false, err
 	}
 
-	// when sysTblMgr is nil, clean up the job step context just for clearness.
-	// Otherwise, we are in multi-schema change DDL and this is not the outermost
-	// runOneJobStep, we should keep the job step context.
-	if sysTblMgr != nil {
-		jobCtx.stepCtx = nil
-	}
-
 	// It would be better to do the positive check, but no idea to list all valid states here now.
 	if job.IsRollingback() {
 		// when rolling back, we use worker context to process.
@@ -823,13 +844,12 @@ func (w *worker) runOneJobStep(
 	} else {
 		job.State = model.JobStateRunning
 
-		if sysTblMgr != nil {
+		if jobCtx.shouldPollDDLJob() {
 			stopCheckingJobCancelled := make(chan struct{})
 			defer close(stopCheckingJobCancelled)
 
-			var cancelStep context.CancelCauseFunc
-			jobCtx.stepCtx, cancelStep = context.WithCancelCause(jobCtx.ctx)
-			defer cancelStep(context.Canceled)
+			jobCtx.initStepCtx()
+			defer jobCtx.cleanStepCtx()
 			w.wg.Run(func() {
 				ticker := time.NewTicker(2 * time.Second)
 				defer ticker.Stop()
@@ -840,7 +860,7 @@ func (w *worker) runOneJobStep(
 						return
 					case <-ticker.C:
 						failpoint.InjectCall("checkJobCancelled", job)
-						latestJob, err := sysTblMgr.GetJobByID(w.workCtx, job.ID)
+						latestJob, err := jobCtx.sysTblMgr.GetJobByID(w.workCtx, job.ID)
 						if goerrors.Is(err, systable.ErrNotFound) {
 							logutil.DDLLogger().Info(
 								"job not found, might already finished",
@@ -858,13 +878,13 @@ func (w *worker) runOneJobStep(
 							logutil.DDLLogger().Info("job is cancelled",
 								zap.Int64("job_id", job.ID),
 								zap.Stringer("state", latestJob.State))
-							cancelStep(dbterror.ErrCancelledDDLJob)
+							jobCtx.stepCtxCancel(dbterror.ErrCancelledDDLJob)
 							return
 						case model.JobStatePausing, model.JobStatePaused:
 							logutil.DDLLogger().Info("job is paused",
 								zap.Int64("job_id", job.ID),
 								zap.Stringer("state", latestJob.State))
-							cancelStep(dbterror.ErrPausedDDLJob.FastGenByArgs(job.ID))
+							jobCtx.stepCtxCancel(dbterror.ErrPausedDDLJob.FastGenByArgs(job.ID))
 							return
 						case model.JobStateDone, model.JobStateSynced:
 							return
@@ -1082,6 +1102,9 @@ func updateGlobalVersionAndWaitSynced(
 	var err error
 
 	if latestSchemaVersion == 0 {
+		if jobCtx.stepCtx != nil {
+			return nil // do not print noisy log when a ddl step is not complete (like reorg timeout).
+		}
 		logutil.DDLLogger().Info("schema version doesn't change", zap.Int64("jobID", job.ID))
 		return nil
 	}

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -101,7 +101,7 @@ type jobContext struct {
 	stepCtx              context.Context
 	stepCtxCancel        context.CancelCauseFunc
 	reorgTimeoutOccurred bool
-	inMultiSchema        bool
+	inInnerRunOneJobStep bool // Only used for multi-schema change DDL job.
 
 	metaMut *meta.Mutator
 	// decoded JobArgs, we store it here to avoid decoding it multiple times and
@@ -116,7 +116,7 @@ type jobContext struct {
 func (c *jobContext) shouldPollDDLJob() bool {
 	// If we are in multi-schema change DDL and this is not the outermost
 	// runOneJobStep, we should not start a goroutine to poll the ddl job.
-	return !c.inMultiSchema
+	return !c.inInnerRunOneJobStep
 }
 
 func (c *jobContext) initStepCtx() {

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -814,8 +814,11 @@ func (w *worker) runOneJobStep(
 	// Mock for run ddl job panic.
 	failpoint.Inject("mockPanicInRunDDLJob", func(failpoint.Value) {})
 
-	failpoint.InjectCall("onRunOneJobStep", job)
-	jobCtx.logger.Info("run one job step", zap.String("job", job.String()))
+	failpoint.InjectCall("onRunOneJobStep")
+	if job.Type != model.ActionMultiSchemaChange {
+		jobCtx.logger.Info("run one job step", zap.String("job", job.String()))
+		failpoint.InjectCall("onRunOneJobStep")
+	}
 	timeStart := time.Now()
 	if job.RealStartTS == 0 {
 		job.RealStartTS = jobCtx.metaMut.StartTS
@@ -846,8 +849,7 @@ func (w *worker) runOneJobStep(
 		job.State = model.JobStateRunning
 
 		if jobCtx.shouldPollDDLJob() {
-			failpoint.InjectCall("beforePollDDLJob"))
-			jobCtx.logger.Info("beforePollDDLJob", zap.String("job", job.String())
+			failpoint.InjectCall("beforePollDDLJob")
 			stopCheckingJobCancelled := make(chan struct{})
 			defer close(stopCheckingJobCancelled)
 

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -814,6 +814,7 @@ func (w *worker) runOneJobStep(
 
 	if job.Type != model.ActionMultiSchemaChange {
 		jobCtx.logger.Info("run one job step", zap.String("job", job.String()))
+		failpoint.InjectCall("onRunOneJobStep")
 	}
 	timeStart := time.Now()
 	if job.RealStartTS == 0 {
@@ -845,6 +846,7 @@ func (w *worker) runOneJobStep(
 		job.State = model.JobStateRunning
 
 		if jobCtx.shouldPollDDLJob() {
+			failpoint.InjectCall("beforePollDDLJob")
 			stopCheckingJobCancelled := make(chan struct{})
 			defer close(stopCheckingJobCancelled)
 

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -634,7 +634,7 @@ func doReorgWorkForModifyColumn(w *worker, jobCtx *jobContext, job *model.Job, t
 	// enable: curl -X PUT -d "pause" "http://127.0.0.1:10080/fail/github.com/pingcap/tidb/pkg/ddl/mockDelayInModifyColumnTypeWithData".
 	// disable: curl -X DELETE "http://127.0.0.1:10080/fail/github.com/pingcap/tidb/pkg/ddl/mockDelayInModifyColumnTypeWithData"
 	failpoint.Inject("mockDelayInModifyColumnTypeWithData", func() {})
-	err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (addIndexErr error) {
+	err = w.runReorgJob(jobCtx, reorgInfo, tbl.Meta(), func() (addIndexErr error) {
 		defer util.Recover(metrics.LabelDDL, "onModifyColumn",
 			func() {
 				addIndexErr = dbterror.ErrCancelledDDLJob.GenWithStack("modify table `%v` column `%v` panic", tbl.Meta().Name, oldCol.Name)

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -26,9 +26,9 @@ import (
 )
 
 func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
-	jobCtx.inMultiSchema = true
+	jobCtx.inInnerRunOneJobStep = true
 	defer func() {
-		jobCtx.inMultiSchema = false
+		jobCtx.inInnerRunOneJobStep = false
 	}()
 	metaMut := jobCtx.metaMut
 	if job.MultiSchemaInfo.Revertible {

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -26,6 +26,10 @@ import (
 )
 
 func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	jobCtx.inMultiSchema = true
+	defer func() {
+		jobCtx.inMultiSchema = false
+	}()
 	metaMut := jobCtx.metaMut
 	if job.MultiSchemaInfo.Revertible {
 		// Handle the rolling back job.
@@ -37,7 +41,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 					continue
 				}
 				proxyJob := sub.ToProxyJob(job, i)
-				ver, _, err = w.runOneJobStep(jobCtx, &proxyJob, nil)
+				ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
 				err = handleRollbackException(err, proxyJob.Error)
 				if err != nil {
 					return ver, err
@@ -60,7 +64,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 				continue
 			}
 			proxyJob := sub.ToProxyJob(job, i)
-			ver, _, err = w.runOneJobStep(jobCtx, &proxyJob, nil)
+			ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
 			sub.FromProxyJob(&proxyJob, ver)
 			handleRevertibleException(job, sub, proxyJob.Error)
 			return ver, err
@@ -86,7 +90,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 			if schemaVersionGenerated {
 				proxyJob.MultiSchemaInfo.SkipVersion = true
 			}
-			proxyJobVer, _, err := w.runOneJobStep(jobCtx, &proxyJob, nil)
+			proxyJobVer, _, err := w.runOneJobStep(jobCtx, &proxyJob)
 			if !schemaVersionGenerated && proxyJobVer != 0 {
 				schemaVersionGenerated = true
 				ver = proxyJobVer
@@ -135,7 +139,7 @@ func onMultiSchemaChange(w *worker, jobCtx *jobContext, job *model.Job) (ver int
 			continue
 		}
 		proxyJob := sub.ToProxyJob(job, i)
-		ver, _, err = w.runOneJobStep(jobCtx, &proxyJob, nil)
+		ver, _, err = w.runOneJobStep(jobCtx, &proxyJob)
 		sub.FromProxyJob(&proxyJob, ver)
 		return ver, err
 	}

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -811,7 +811,7 @@ func TestMultiSchemaChangePollJobCount(t *testing.T) {
 	tk.MustExec("set global tidb_enable_dist_task = 0;")
 	runOneJobCounter := 0
 	pollJobCounter := 0
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onRunOneJobStep", func(job *model.Job) {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onRunOneJobStep", func() {
 		runOneJobCounter++
 	})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforePollDDLJob", func() {

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -817,9 +817,10 @@ func TestMultiSchemaChangePollJobCount(t *testing.T) {
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforePollDDLJob", func() {
 		pollJobCounter++
 	})
-	tk.MustExec("alter table t add column b int, add column c char(10), add index idx(a);")
-	require.Equal(t, 27, runOneJobCounter)
-	require.Equal(t, 13, pollJobCounter)
+	// Should not test reorg DDL because the result can be unstable.
+	tk.MustExec("alter table t add column b int,  modify column a bigint, add column c char(10);")
+	require.Equal(t, 29, runOneJobCounter)
+	require.Equal(t, 9, pollJobCounter)
 }
 
 type cancelOnceHook struct {

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -801,6 +801,26 @@ func TestMultiSchemaChangeBlockedByRowLevelChecksum(t *testing.T) {
 	tk.MustGetErrCode("alter table t add (c1 int, c2 int)", errno.ErrUnsupportedDDLOperation)
 }
 
+func TestMultiSchemaChangePollJobCount(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (1);")
+	tk.MustExec("set global tidb_ddl_enable_fast_reorg = 0;")
+	tk.MustExec("set global tidb_enable_dist_task = 0;")
+	runOneJobCounter := 0
+	pollJobCounter := 0
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onRunOneJobStep", func() {
+		runOneJobCounter++
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforePollDDLJob", func() {
+		pollJobCounter++
+	})
+	tk.MustExec("alter table t add column b int, add column c char(10), add index idx(a);")
+	require.Equal(t, runOneJobCounter, pollJobCounter+1)
+}
+
 type cancelOnceHook struct {
 	store     kv.Storage
 	triggered bool

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -811,14 +811,15 @@ func TestMultiSchemaChangePollJobCount(t *testing.T) {
 	tk.MustExec("set global tidb_enable_dist_task = 0;")
 	runOneJobCounter := 0
 	pollJobCounter := 0
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onRunOneJobStep", func() {
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/onRunOneJobStep", func(job *model.Job) {
 		runOneJobCounter++
 	})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforePollDDLJob", func() {
 		pollJobCounter++
 	})
 	tk.MustExec("alter table t add column b int, add column c char(10), add index idx(a);")
-	require.Equal(t, runOneJobCounter, pollJobCounter+1)
+	require.Equal(t, 27, runOneJobCounter)
+	require.Equal(t, 13, pollJobCounter)
 }
 
 type cancelOnceHook struct {

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -2436,7 +2436,7 @@ func (w *worker) cleanGlobalIndexEntriesFromDroppedPartitions(jobCtx *jobContext
 		// and then run the reorg next time.
 		return false, errors.Trace(err)
 	}
-	err = w.runReorgJob(reorgInfo, tbl.Meta(), func() (dropIndexErr error) {
+	err = w.runReorgJob(jobCtx, reorgInfo, tbl.Meta(), func() (dropIndexErr error) {
 		defer tidbutil.Recover(metrics.LabelDDL, "onDropTablePartition",
 			func() {
 				dropIndexErr = dbterror.ErrCancelledDDLJob.GenWithStack("drop partition panic")
@@ -3715,7 +3715,7 @@ func doPartitionReorgWork(w *worker, jobCtx *jobContext, job *model.Job, tbl tab
 		return false, ver, errors.Trace(err)
 	}
 	reorgInfo, err := getReorgInfoFromPartitions(jobCtx.oldDDLCtx.jobContext(job.ID, job.ReorgMeta), jobCtx, rh, job, dbInfo, partTbl, physTblIDs, elements)
-	err = w.runReorgJob(reorgInfo, reorgTbl.Meta(), func() (reorgErr error) {
+	err = w.runReorgJob(jobCtx, reorgInfo, reorgTbl.Meta(), func() (reorgErr error) {
 		defer tidbutil.Recover(metrics.LabelDDL, "doPartitionReorgWork",
 			func() {
 				reorgErr = dbterror.ErrCancelledDDLJob.GenWithStack("reorganize partition for table `%v` panic", tbl.Meta().Name)

--- a/pkg/ddl/reorg.go
+++ b/pkg/ddl/reorg.go
@@ -340,6 +340,7 @@ func (rc *reorgCtx) getRowCount() int64 {
 //
 // After that, we can make sure that the worker goroutine is correctly shut down.
 func (w *worker) runReorgJob(
+	jobCtx *jobContext,
 	reorgInfo *reorgInfo,
 	tblInfo *model.TableInfo,
 	reorgFn func() error,
@@ -381,7 +382,13 @@ func (w *worker) runReorgJob(
 		})
 	}
 
-	updateProcessTicker := time.NewTicker(5 * time.Second)
+	updateProgressInverval := 5 * time.Second
+	failpoint.Inject("updateProgressIntervalInMs", func(val failpoint.Value) {
+		if v, ok := val.(int); ok {
+			updateProgressInverval = time.Duration(v) * time.Millisecond
+		}
+	})
+	updateProcessTicker := time.NewTicker(updateProgressInverval)
 	defer updateProcessTicker.Stop()
 	for {
 		select {
@@ -393,6 +400,7 @@ func (w *worker) runReorgJob(
 				logutil.DDLLogger().Warn("owner ts mismatch, return timeout error and retry",
 					zap.Int64("prevTS", res.ownerTS),
 					zap.Int64("curTS", curTS))
+				jobCtx.reorgTimeoutOccurred = true
 				return dbterror.ErrWaitReorgTimeout
 			}
 			// Since job is cancelled，we don't care about its partial counts.
@@ -428,6 +436,8 @@ func (w *worker) runReorgJob(
 			w.mergeWarningsIntoJob(job)
 
 			rc.resetWarnings()
+			jobCtx.reorgTimeoutOccurred = true
+			return dbterror.ErrWaitReorgTimeout
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60145

Problem Summary:

https://github.com/pingcap/tidb/pull/56404 introduced the step context for each step of a DDL job. `runReorgJob` is changed to a blocking implementation, resulting in the inability to update job's row count.

### What changed and how does it work?

This PR returns `dbterror.ErrWaitReorgTimeout` periodically to let the routine of `runJobOneStep` update job's row count. It also manages `stepCtx` carefully to avoid premature cancelling.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  The previous behavior was to run one job step and then get stuck inside.
  Now the behavior is that it exits periodically, so there are many run one job steps, and the job row count is updated.
  ```
  [2025/04/25 11:14:56.185 +08:00] [INFO] [job_worker.go:816] ["run one job step"] [category=ddl] [jobID=129] [conn=1214251012] [job="ID:129, Type:add index, State:running, SchemaState:write reorganization, SchemaID:2, TableID:112, RowCount:541994, ArgLen:0,   start time: 2025-04-25 11:14:22.977 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:457585685463564289, Version: v2, UniqueWarnings:0"]
  [2025/04/25 11:14:58.377 +08:00] [INFO] [advancer.go:678] ["No tasks yet, skipping advancing."]
  [2025/04/25 11:15:01.212 +08:00] [INFO] [job_worker.go:816] ["run one job step"] [category=ddl] [jobID=129] [conn=1214251012] [job="ID:129, Type:add index, State:running, SchemaState:write reorganization, SchemaID:2, TableID:112, RowCount:631338, ArgLen:0,   start time: 2025-04-25 11:14:22.977 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:457585685463564289, Version: v2, UniqueWarnings:0"]
  [2025/04/25 11:15:05.369 +08:00] [INFO] [backfilling.go:386] ["backfill worker back fill index"] [category=ddl] [worker="backfill-worker 3, tp add index"] [addedCount=360448] [scanCount=360448] ["next key"=7480000000000000705f7280000000000df79600] [speed  (rows/s)=9001.939254991426]
  [2025/04/25 11:15:05.411 +08:00] [INFO] [backfilling.go:386] ["backfill worker back fill index"] [category=ddl] [worker="backfill-worker 1, tp add index"] [addedCount=360448] [scanCount=360448] ["next key"=7480000000000000705f72800000000005b9da00] [speed  (rows/s)=9009.241181952648]
  [2025/04/25 11:15:06.234 +08:00] [INFO] [job_worker.go:816] ["run one job step"] [category=ddl] [jobID=129] [conn=1214251012] [job="ID:129, Type:add index, State:running, SchemaState:write reorganization, SchemaID:2, TableID:112, RowCount:725290, ArgLen:0,   start time: 2025-04-25 11:14:22.977 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:457585685463564289, Version: v2, UniqueWarnings:0"]
  [2025/04/25 11:15:10.377 +08:00] [INFO] [advancer.go:678] ["No tasks yet, skipping advancing."]
  [2025/04/25 11:15:11.254 +08:00] [INFO] [job_worker.go:816] ["run one job step"] [category=ddl] [jobID=129] [conn=1214251012] [job="ID:129, Type:add index, State:running, SchemaState:write reorganization, SchemaID:2, TableID:112, RowCount:818730, ArgLen:0,   start time: 2025-04-25 11:14:22.977 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:457585685463564289, Version: v2, UniqueWarnings:0"]
  ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
