### PR TITLE
statistics: update logging in auto-analyze components to use the error verbose logger

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2886,7 +2886,7 @@ func (do *Domain) autoAnalyzeWorker() {
 	analyzeTicker := time.NewTicker(do.statsLease)
 	defer func() {
 		analyzeTicker.Stop()
-		logutil.BgLogger().Info("autoAnalyzeWorker exited.")
+		statslogutil.StatsLogger().Info("autoAnalyzeWorker exited.")
 	}()
 	for {
 		select {

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -298,7 +298,7 @@ func (sa *statsAnalyze) HandleAutoAnalyze() (analyzed bool) {
 		analyzed = sa.handleAutoAnalyze(sctx)
 		return nil
 	}); err != nil {
-		statslogutil.StatsLogger().Error("Failed to handle auto analyze", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Failed to handle auto analyze", zap.Error(err))
 	}
 	return
 }

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -298,7 +298,7 @@ func (sa *statsAnalyze) HandleAutoAnalyze() (analyzed bool) {
 		analyzed = sa.handleAutoAnalyze(sctx)
 		return nil
 	}); err != nil {
-		statslogutil.StatsErrVerboseLogger().Error("Failed to handle auto analyze", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Failed to handle auto analyze", zap.Error(err))
 	}
 	return
 }

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -298,7 +298,7 @@ func (sa *statsAnalyze) HandleAutoAnalyze() (analyzed bool) {
 		analyzed = sa.handleAutoAnalyze(sctx)
 		return nil
 	}); err != nil {
-		statslogutil.StatsErrVerboseSampleLogger().Error("Failed to handle auto analyze", zap.Error(err))
+		statslogutil.StatsErrVerboseLogger().Error("Failed to handle auto analyze", zap.Error(err))
 	}
 	return
 }

--- a/pkg/statistics/handle/autoanalyze/exec/exec.go
+++ b/pkg/statistics/handle/autoanalyze/exec/exec.go
@@ -60,7 +60,7 @@ func AutoAnalyze(
 		if err1 != nil {
 			escaped = ""
 		}
-		statslogutil.StatsErrVerboseLogger().Error(
+		statslogutil.StatsErrVerboseSampleLogger().Error(
 			"auto analyze failed",
 			zap.String("sql", escaped),
 			zap.Duration("cost_time", dur),

--- a/pkg/statistics/handle/autoanalyze/exec/exec.go
+++ b/pkg/statistics/handle/autoanalyze/exec/exec.go
@@ -60,7 +60,7 @@ func AutoAnalyze(
 		if err1 != nil {
 			escaped = ""
 		}
-		statslogutil.StatsLogger().Error(
+		statslogutil.StatsErrVerboseLogger().Error(
 			"auto analyze failed",
 			zap.String("sql", escaped),
 			zap.Duration("cost_time", dur),

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/job.go
@@ -117,7 +117,7 @@ func isValidToAnalyze(
 	lastFailedAnalysisDuration, err :=
 		GetLastFailedAnalysisDuration(sctx, schema, table, partitionNames...)
 	if err != nil {
-		logutil.StatsSampleLogger().Warn(
+		logutil.StatsErrVerboseSampleLogger().Warn(
 			"Fail to get last failed analysis duration",
 			zap.String("schema", schema),
 			zap.String("table", table),
@@ -130,7 +130,7 @@ func isValidToAnalyze(
 	averageAnalysisDuration, err :=
 		GetAverageAnalysisDuration(sctx, schema, table, partitionNames...)
 	if err != nil {
-		logutil.StatsSampleLogger().Warn(
+		logutil.StatsErrVerboseSampleLogger().Warn(
 			"Fail to get average analysis duration",
 			zap.String("schema", schema),
 			zap.String("table", table),

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -394,7 +394,7 @@ func (pq *AnalysisPriorityQueue) ProcessDMLChanges() {
 			if value.Version > lastFetchTimestamp {
 				err := pq.processTableStats(sctx, value, parameters, lockedTables)
 				if err != nil {
-					statslogutil.StatsLogger().Error(
+					statslogutil.StatsErrVerboseLogger().Error(
 						"Failed to process table stats",
 						zap.Error(err),
 						zap.Int64("tableID", value.PhysicalID),
@@ -410,7 +410,7 @@ func (pq *AnalysisPriorityQueue) ProcessDMLChanges() {
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsLogger().Error("Failed to process DML changes", zap.Error(err))
+		statslogutil.StatsErrVerboseLogger().Error("Failed to process DML changes", zap.Error(err))
 	}
 }
 
@@ -454,7 +454,7 @@ func (pq *AnalysisPriorityQueue) processTableStats(
 			// Clean up the job if the table is locked.
 			err := pq.syncFields.inner.delete(job)
 			if err != nil {
-				statslogutil.StatsLogger().Error(
+				statslogutil.StatsErrVerboseLogger().Error(
 					"Failed to delete job from priority queue",
 					zap.Error(err),
 					zap.String("job", job.String()),
@@ -637,13 +637,13 @@ func (pq *AnalysisPriorityQueue) RequeueMustRetryJobs() {
 			}
 			err := pq.recreateAndPushJobForTable(sctx, tblInfo.Meta())
 			if err != nil {
-				statslogutil.StatsLogger().Error("Failed to recreate and push job for table", zap.Error(err), zap.Int64("tableID", tableID))
+				statslogutil.StatsErrVerboseLogger().Error("Failed to recreate and push job for table", zap.Error(err), zap.Int64("tableID", tableID))
 				continue
 			}
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsLogger().Error("Failed to requeue must retry jobs", zap.Error(err))
+		statslogutil.StatsErrVerboseLogger().Error("Failed to requeue must retry jobs", zap.Error(err))
 	}
 }
 
@@ -680,7 +680,7 @@ func (pq *AnalysisPriorityQueue) RefreshLastAnalysisDuration() {
 				// DDL events should have already cleaned up jobs for dropped tables.
 				err := pq.syncFields.inner.delete(job)
 				if err != nil {
-					statslogutil.StatsLogger().Error("Failed to delete job from priority queue",
+					statslogutil.StatsErrVerboseLogger().Error("Failed to delete job from priority queue",
 						zap.Error(err),
 						zap.String("job", job.String()),
 					)
@@ -691,7 +691,7 @@ func (pq *AnalysisPriorityQueue) RefreshLastAnalysisDuration() {
 			job.SetIndicators(indicators)
 			job.SetWeight(pq.calculator.CalculateWeight(job))
 			if err := pq.syncFields.inner.update(job); err != nil {
-				statslogutil.StatsLogger().Error("Failed to add job to priority queue",
+				statslogutil.StatsErrVerboseLogger().Error("Failed to add job to priority queue",
 					zap.Error(err),
 					zap.String("job", job.String()),
 				)
@@ -699,7 +699,7 @@ func (pq *AnalysisPriorityQueue) RefreshLastAnalysisDuration() {
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsLogger().Error("Failed to refresh last analysis duration", zap.Error(err))
+		statslogutil.StatsErrVerboseLogger().Error("Failed to refresh last analysis duration", zap.Error(err))
 	}
 }
 

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -394,7 +394,7 @@ func (pq *AnalysisPriorityQueue) ProcessDMLChanges() {
 			if value.Version > lastFetchTimestamp {
 				err := pq.processTableStats(sctx, value, parameters, lockedTables)
 				if err != nil {
-					statslogutil.StatsErrVerboseLogger().Error(
+					statslogutil.StatsErrVerboseSampleLogger().Error(
 						"Failed to process table stats",
 						zap.Error(err),
 						zap.Int64("tableID", value.PhysicalID),
@@ -410,7 +410,7 @@ func (pq *AnalysisPriorityQueue) ProcessDMLChanges() {
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsErrVerboseLogger().Error("Failed to process DML changes", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Failed to process DML changes", zap.Error(err))
 	}
 }
 
@@ -454,7 +454,7 @@ func (pq *AnalysisPriorityQueue) processTableStats(
 			// Clean up the job if the table is locked.
 			err := pq.syncFields.inner.delete(job)
 			if err != nil {
-				statslogutil.StatsErrVerboseLogger().Error(
+				statslogutil.StatsErrVerboseSampleLogger().Error(
 					"Failed to delete job from priority queue",
 					zap.Error(err),
 					zap.String("job", job.String()),
@@ -637,13 +637,13 @@ func (pq *AnalysisPriorityQueue) RequeueMustRetryJobs() {
 			}
 			err := pq.recreateAndPushJobForTable(sctx, tblInfo.Meta())
 			if err != nil {
-				statslogutil.StatsErrVerboseLogger().Error("Failed to recreate and push job for table", zap.Error(err), zap.Int64("tableID", tableID))
+				statslogutil.StatsErrVerboseSampleLogger().Error("Failed to recreate and push job for table", zap.Error(err), zap.Int64("tableID", tableID))
 				continue
 			}
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsErrVerboseLogger().Error("Failed to requeue must retry jobs", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Failed to requeue must retry jobs", zap.Error(err))
 	}
 }
 
@@ -680,7 +680,7 @@ func (pq *AnalysisPriorityQueue) RefreshLastAnalysisDuration() {
 				// DDL events should have already cleaned up jobs for dropped tables.
 				err := pq.syncFields.inner.delete(job)
 				if err != nil {
-					statslogutil.StatsErrVerboseLogger().Error("Failed to delete job from priority queue",
+					statslogutil.StatsErrVerboseSampleLogger().Error("Failed to delete job from priority queue",
 						zap.Error(err),
 						zap.String("job", job.String()),
 					)
@@ -691,7 +691,7 @@ func (pq *AnalysisPriorityQueue) RefreshLastAnalysisDuration() {
 			job.SetIndicators(indicators)
 			job.SetWeight(pq.calculator.CalculateWeight(job))
 			if err := pq.syncFields.inner.update(job); err != nil {
-				statslogutil.StatsErrVerboseLogger().Error("Failed to add job to priority queue",
+				statslogutil.StatsErrVerboseSampleLogger().Error("Failed to add job to priority queue",
 					zap.Error(err),
 					zap.String("job", job.String()),
 				)
@@ -699,7 +699,7 @@ func (pq *AnalysisPriorityQueue) RefreshLastAnalysisDuration() {
 		}
 		return nil
 	}, statsutil.FlagWrapTxn); err != nil {
-		statslogutil.StatsErrVerboseLogger().Error("Failed to refresh last analysis duration", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Failed to refresh last analysis duration", zap.Error(err))
 	}
 }
 

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -53,7 +53,7 @@ func (pq *AnalysisPriorityQueue) HandleDDLEvent(_ context.Context, sctx sessionc
 				fmt.Sprintf("handle ddl event failed, err: %+v", err),
 			)
 			actionType := event.GetType().String()
-			statslogutil.StatsLogger().Error(fmt.Sprintf("Failed to handle %s event", actionType),
+			statslogutil.StatsErrVerboseLogger().Error(fmt.Sprintf("Failed to handle %s event", actionType),
 				zap.Error(err),
 				zap.String("event", event.String()),
 			)
@@ -92,7 +92,7 @@ func (pq *AnalysisPriorityQueue) HandleDDLEvent(_ context.Context, sctx sessionc
 func (pq *AnalysisPriorityQueue) getAndDeleteJob(tableID int64) error {
 	job, ok, err := pq.syncFields.inner.getByKey(tableID)
 	if err != nil {
-		statslogutil.StatsLogger().Error(
+		statslogutil.StatsErrVerboseLogger().Error(
 			"Failed to get the job from priority queue",
 			zap.Error(err),
 			zap.Int64("tableID", tableID),
@@ -102,7 +102,7 @@ func (pq *AnalysisPriorityQueue) getAndDeleteJob(tableID int64) error {
 	if ok {
 		err := pq.syncFields.inner.delete(job)
 		if err != nil {
-			statslogutil.StatsLogger().Error(
+			statslogutil.StatsErrVerboseLogger().Error(
 				"Failed to delete table from priority queue",
 				zap.Error(err),
 				zap.Int64("tableID", tableID),
@@ -424,7 +424,7 @@ func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, eve
 		for _, partition := range tbl.Partitions {
 			if err := pq.getAndDeleteJob(partition.ID); err != nil {
 				// Try best to delete as many tables as possible.
-				statslogutil.StatsLogger().Error(
+				statslogutil.StatsErrVerboseLogger().Error(
 					"Failed to delete table from priority queue",
 					zap.Error(err),
 					zap.String("db", miniDBInfo.Name.O),
@@ -438,7 +438,7 @@ func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, eve
 		// For non-partitioned tables or dynamic partitioned tables.
 		if err := pq.getAndDeleteJob(tbl.ID); err != nil {
 			// Try best to delete as many tables as possible.
-			statslogutil.StatsLogger().Error(
+			statslogutil.StatsErrVerboseLogger().Error(
 				"Failed to delete table from priority queue",
 				zap.Error(err),
 				zap.String("db", miniDBInfo.Name.O),

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -53,7 +53,7 @@ func (pq *AnalysisPriorityQueue) HandleDDLEvent(_ context.Context, sctx sessionc
 				fmt.Sprintf("handle ddl event failed, err: %+v", err),
 			)
 			actionType := event.GetType().String()
-			statslogutil.StatsErrVerboseLogger().Error(fmt.Sprintf("Failed to handle %s event", actionType),
+			statslogutil.StatsErrVerboseSampleLogger().Error(fmt.Sprintf("Failed to handle %s event", actionType),
 				zap.Error(err),
 				zap.String("event", event.String()),
 			)
@@ -92,7 +92,7 @@ func (pq *AnalysisPriorityQueue) HandleDDLEvent(_ context.Context, sctx sessionc
 func (pq *AnalysisPriorityQueue) getAndDeleteJob(tableID int64) error {
 	job, ok, err := pq.syncFields.inner.getByKey(tableID)
 	if err != nil {
-		statslogutil.StatsErrVerboseLogger().Error(
+		statslogutil.StatsErrVerboseSampleLogger().Error(
 			"Failed to get the job from priority queue",
 			zap.Error(err),
 			zap.Int64("tableID", tableID),
@@ -102,7 +102,7 @@ func (pq *AnalysisPriorityQueue) getAndDeleteJob(tableID int64) error {
 	if ok {
 		err := pq.syncFields.inner.delete(job)
 		if err != nil {
-			statslogutil.StatsErrVerboseLogger().Error(
+			statslogutil.StatsErrVerboseSampleLogger().Error(
 				"Failed to delete table from priority queue",
 				zap.Error(err),
 				zap.Int64("tableID", tableID),
@@ -424,7 +424,7 @@ func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, eve
 		for _, partition := range tbl.Partitions {
 			if err := pq.getAndDeleteJob(partition.ID); err != nil {
 				// Try best to delete as many tables as possible.
-				statslogutil.StatsErrVerboseLogger().Error(
+				statslogutil.StatsErrVerboseSampleLogger().Error(
 					"Failed to delete table from priority queue",
 					zap.Error(err),
 					zap.String("db", miniDBInfo.Name.O),
@@ -438,7 +438,7 @@ func (pq *AnalysisPriorityQueue) handleDropSchemaEvent(_ sessionctx.Context, eve
 		// For non-partitioned tables or dynamic partitioned tables.
 		if err := pq.getAndDeleteJob(tbl.ID); err != nil {
 			// Try best to delete as many tables as possible.
-			statslogutil.StatsErrVerboseLogger().Error(
+			statslogutil.StatsErrVerboseSampleLogger().Error(
 				"Failed to delete table from priority queue",
 				zap.Error(err),
 				zap.String("db", miniDBInfo.Name.O),

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -94,7 +94,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
 	err := r.setAutoAnalysisTimeWindow(parameters)
 	if err != nil {
-		statslogutil.StatsLogger().Error("Set auto analyze time window failed", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Set auto analyze time window failed", zap.Error(err))
 		return false
 	}
 	if !r.isWithinTimeWindow() {
@@ -104,7 +104,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	currentPruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	if !r.jobs.IsInitialized() {
 		if err := r.jobs.Initialize(r.ctx); err != nil {
-			statslogutil.StatsLogger().Error("Failed to initialize the queue", zap.Error(err))
+			statslogutil.StatsErrVerboseSampleLogger().Error("Failed to initialize the queue", zap.Error(err))
 			return false
 		}
 		r.lastSeenAutoAnalyzeRatio = currentAutoAnalyzeRatio
@@ -116,7 +116,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 			r.lastSeenPruneMode = currentPruneMode
 			err := r.jobs.Rebuild()
 			if err != nil {
-				statslogutil.StatsLogger().Error("Failed to rebuild the queue", zap.Error(err))
+				statslogutil.StatsErrVerboseSampleLogger().Error("Failed to rebuild the queue", zap.Error(err))
 				return false
 			}
 		}

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -94,7 +94,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
 	err := r.setAutoAnalysisTimeWindow(parameters)
 	if err != nil {
-		statslogutil.StatsErrVerboseLogger().Error("Set auto analyze time window failed", zap.Error(err))
+		statslogutil.StatsErrVerboseSampleLogger().Error("Set auto analyze time window failed", zap.Error(err))
 		return false
 	}
 	if !r.isWithinTimeWindow() {
@@ -104,7 +104,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	currentPruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	if !r.jobs.IsInitialized() {
 		if err := r.jobs.Initialize(r.ctx); err != nil {
-			statslogutil.StatsErrVerboseLogger().Error("Failed to initialize the queue", zap.Error(err))
+			statslogutil.StatsErrVerboseSampleLogger().Error("Failed to initialize the queue", zap.Error(err))
 			return false
 		}
 		r.lastSeenAutoAnalyzeRatio = currentAutoAnalyzeRatio
@@ -116,7 +116,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 			r.lastSeenPruneMode = currentPruneMode
 			err := r.jobs.Rebuild()
 			if err != nil {
-				statslogutil.StatsErrVerboseLogger().Error("Failed to rebuild the queue", zap.Error(err))
+				statslogutil.StatsErrVerboseSampleLogger().Error("Failed to rebuild the queue", zap.Error(err))
 				return false
 			}
 		}

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -94,7 +94,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
 	err := r.setAutoAnalysisTimeWindow(parameters)
 	if err != nil {
-		statslogutil.StatsErrVerboseSampleLogger().Error("Set auto analyze time window failed", zap.Error(err))
+		statslogutil.StatsErrVerboseLogger().Error("Set auto analyze time window failed", zap.Error(err))
 		return false
 	}
 	if !r.isWithinTimeWindow() {
@@ -104,7 +104,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	currentPruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	if !r.jobs.IsInitialized() {
 		if err := r.jobs.Initialize(r.ctx); err != nil {
-			statslogutil.StatsErrVerboseSampleLogger().Error("Failed to initialize the queue", zap.Error(err))
+			statslogutil.StatsErrVerboseLogger().Error("Failed to initialize the queue", zap.Error(err))
 			return false
 		}
 		r.lastSeenAutoAnalyzeRatio = currentAutoAnalyzeRatio
@@ -116,7 +116,7 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 			r.lastSeenPruneMode = currentPruneMode
 			err := r.jobs.Rebuild()
 			if err != nil {
-				statslogutil.StatsErrVerboseSampleLogger().Error("Failed to rebuild the queue", zap.Error(err))
+				statslogutil.StatsErrVerboseLogger().Error("Failed to rebuild the queue", zap.Error(err))
 				return false
 			}
 		}

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -100,7 +100,7 @@ func (w *worker) processJob(job priorityqueue.AnalysisJob) {
 	}()
 
 	if err := job.Analyze(w.statsHandle, w.sysProcTracker); err != nil {
-		statslogutil.StatsErrVerboseLogger().Error(
+		statslogutil.StatsErrVerboseSampleLogger().Error(
 			"Auto analyze job execution failed",
 			zap.Stringer("job", job),
 			zap.Error(err),

--- a/pkg/statistics/handle/autoanalyze/refresher/worker.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/worker.go
@@ -100,7 +100,7 @@ func (w *worker) processJob(job priorityqueue.AnalysisJob) {
 	}()
 
 	if err := job.Analyze(w.statsHandle, w.sysProcTracker); err != nil {
-		statslogutil.StatsLogger().Error(
+		statslogutil.StatsErrVerboseLogger().Error(
 			"Auto analyze job execution failed",
 			zap.Stringer("job", job),
 			zap.Error(err),

--- a/pkg/statistics/handle/logutil/logutil.go
+++ b/pkg/statistics/handle/logutil/logutil.go
@@ -27,12 +27,6 @@ func StatsLogger() *zap.Logger {
 	return logutil.BgLogger().With(zap.String("category", "stats"))
 }
 
-// StatsErrVerboseLogger returns a logger that always output error verbose regardless
-// of the log config.
-func StatsErrVerboseLogger() *zap.Logger {
-	return logutil.ErrVerboseLogger().With(zap.String("category", "stats"))
-}
-
 var (
 	sampleLoggerFactory = logutil.SampleLoggerFactory(5*time.Minute, 1, zap.String(logutil.LogFieldCategory, "stats"))
 	// sampleErrVerboseLoggerFactory creates a logger for error messages with a higher

--- a/pkg/statistics/handle/logutil/logutil.go
+++ b/pkg/statistics/handle/logutil/logutil.go
@@ -27,6 +27,12 @@ func StatsLogger() *zap.Logger {
 	return logutil.BgLogger().With(zap.String("category", "stats"))
 }
 
+// StatsErrVerboseLogger returns a logger that always output error verbose regardless
+// of the log config.
+func StatsErrVerboseLogger() *zap.Logger {
+	return logutil.ErrVerboseLogger().With(zap.String("category", "stats"))
+}
+
 var (
 	sampleLoggerFactory = logutil.SampleLoggerFactory(5*time.Minute, 1, zap.String(logutil.LogFieldCategory, "stats"))
 	// sampleErrVerboseLoggerFactory creates a logger for error messages with a higher


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/59939

Problem Summary:

### What changed and how does it work?

We should use the error verbose logger to print the stack of the error. Since every 3 seconds it will try to fetch available tables to analyze, we use the sample logger here to reduce the number of logs.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/60845#issuecomment-2834531537)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
