### PR TITLE
br: remove the `--auto-analyze`  parameter

### DIFF
--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -315,7 +315,6 @@ func expectedDefaultRestoreConfig() RestoreConfig {
 		},
 		NoSchema:                 false,
 		LoadStats:                true,
-		AutoAnalyze:              true,
 		PDConcurrency:            0x1,
 		StatsConcurrency:         0xc,
 		BatchFlushInterval:       16000000000,

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -70,8 +70,6 @@ const (
 	FlagPDConcurrency = "pd-concurrency"
 	// FlagStatsConcurrency controls concurrency to restore statistic.
 	FlagStatsConcurrency = "stats-concurrency"
-	// FlagAutoAnalyze corresponds to the column `modify_count` of table `mysql.stats_meta`.
-	FlagAutoAnalyze = "auto-analyze"
 	// FlagBatchFlushInterval controls after how long the restore batch would be auto sended.
 	FlagBatchFlushInterval = "batch-flush-interval"
 	// FlagDdlBatchSize controls batch ddl size to create a batch of tables
@@ -170,7 +168,6 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 		"(deprecated) concurrency pd-relative operations like split & scatter.")
 	flags.Uint(FlagStatsConcurrency, defaultStatsConcurrency,
 		"concurrency to restore statistic")
-	flags.Bool(FlagAutoAnalyze, true, "trigger tidb analyze priority queue to analyze table")
 	flags.Duration(FlagBatchFlushInterval, defaultBatchFlushInterval,
 		"after how long a restore batch would be auto sent.")
 	flags.Uint(FlagDdlBatchSize, defaultFlagDdlBatchSize,
@@ -240,7 +237,6 @@ type RestoreConfig struct {
 	LoadStats          bool          `json:"load-stats" toml:"load-stats"`
 	PDConcurrency      uint          `json:"pd-concurrency" toml:"pd-concurrency"`
 	StatsConcurrency   uint          `json:"stats-concurrency" toml:"stats-concurrency"`
-	AutoAnalyze        bool          `json:"auto-analyze" toml:"auto-analyze"`
 	BatchFlushInterval time.Duration `json:"batch-flush-interval" toml:"batch-flush-interval"`
 	// DdlBatchSize use to define the size of batch ddl to create tables
 	DdlBatchSize uint `json:"ddl-batch-size" toml:"ddl-batch-size"`
@@ -404,10 +400,6 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 	cfg.StatsConcurrency, err = flags.GetUint(FlagStatsConcurrency)
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", FlagStatsConcurrency)
-	}
-	cfg.AutoAnalyze, err = flags.GetBool(FlagAutoAnalyze)
-	if err != nil {
-		return errors.Annotatef(err, "failed to get flag %s", FlagAutoAnalyze)
 	}
 	cfg.BatchFlushInterval, err = flags.GetDuration(FlagBatchFlushInterval)
 	if err != nil {
@@ -1291,7 +1283,6 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		LogProgress:         cfg.LogProgress,
 		ChecksumConcurrency: cfg.ChecksumConcurrency,
 		StatsConcurrency:    cfg.StatsConcurrency,
-		AutoAnalyze:         cfg.AutoAnalyze,
 
 		KvClient:   mgr.GetStorage().GetClient(),
 		ExtStorage: s,

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -65,7 +65,7 @@ fi
 run_sql "DROP DATABASE ${DB}1;"
 
 rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.*" || cat $LOG
+run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false || cat $LOG
 table_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = 0;" | awk '/count/{print $2}')
 if [ "${table_count}" -ne 9 ]; then
     echo "table stats meta count does not equal to 9, but $count instead"
@@ -77,27 +77,6 @@ if [ "${p0_count}" -ne 5 ]; then
     exit 1
 fi
 p1_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and parts.PARTITION_NAME = 'p1' and modify_count = 0;" | awk '/count/{print $2}')
-if [ "${p1_count}" -ne 4 ]; then
-    echo "partition p1 stats meta count does not equal to 4, but $p1_count instead"
-    exit 1
-fi
-
-# test auto analyze
-run_sql "DROP DATABASE ${DB}1;"
-
-rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.*" --auto-analyze || cat $LOG
-table_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;" | awk '/count/{print $2}')
-if [ "${table_count}" -ne 9 ]; then
-    echo "table stats meta count does not equal to 9, but $count instead"
-    exit 1
-fi
-p0_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and parts.PARTITION_NAME = 'p0' and modify_count = count and count > 0;" | awk '/count/{print $2}')
-if [ "${p0_count}" -ne 5 ]; then
-    echo "partition p0 stats meta count does not equal to 5, but $p0_count instead"
-    exit 1
-fi
-p1_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and parts.PARTITION_NAME = 'p1' and modify_count = count and count > 0;" | awk '/count/{print $2}')
 if [ "${p1_count}" -ne 4 ]; then
     echo "partition p1 stats meta count does not equal to 4, but $p1_count instead"
     exit 1


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60374

Problem Summary:

Reverts pingcap/tidb#60687

If you look at the auto-analyze code, you'll see that we perform a basic check to ensure the table is valid for analysis.

```go
// IsEligibleForAnalysis checks whether the table is eligible for analysis.
func (t *Table) IsEligibleForAnalysis() bool {
	// 1. If the statistics are either not loaded or are classified as pseudo, there is no need for analyze.
	//    Pseudo statistics can be created by the optimizer, so we need to double check it.
	// 2. If the table is too small, we don't want to waste time to analyze it.
	//    Leave the opportunity to other bigger tables.
	if t == nil || t.Pseudo || t.RealtimeCount < AutoAnalyzeMinCnt {
		return false
	}

	return true
}
```
https://github.com/pingcap/tidb/blob/24903d6b24674b9a43625ac2d05bf1b033b04407/pkg/statistics/table.go#L745

As you can see, if the table statistics are not pseudo and the real-time row count is greater than 1000, the table becomes eligible for analysis.

Additionally, when calculating the change percentage, if the table has not been analyzed yet, it will be added to the analysis queue.

```go
// CalculateChangePercentage calculates the change percentage of the table
// based on the change count and the analysis count.
func (f *AnalysisJobFactory) CalculateChangePercentage(tblStats *statistics.Table) float64 {
	if !tblStats.IsAnalyzed() {
		return unanalyzedTableDefaultChangePercentage
	}
```
https://github.com/pingcap/tidb/blob/24903d6b24674b9a43625ac2d05bf1b033b04407/pkg/statistics/handle/autoanalyze/priorityqueue/analysis_job_factory.go#L163

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/60863#issuecomment-2832990940)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
