### PR TITLE
*: Support metrics and slowlog with keyspace info for next gen

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -101,6 +101,7 @@ go_library(
         "//br/pkg/utils",
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/ddl/label",
         "//pkg/ddl/placement",

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1660,7 +1660,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	keyspaceName = keyspace.GetKeyspaceNameBySettings()
 	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
 		if kerneltype.IsNextGen() {
-			keyspaceIDU64, _ := strconv.ParseUint(keyspaceName, 10, 32)
+			keyspaceIDU64, _ := strconv.ParseUint(keyspaceName, 10, 32) //nolint:errcheck
 			keyspaceID = uint32(keyspaceIDU64)
 		} else {
 			keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -1658,7 +1659,12 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	)
 	keyspaceName = keyspace.GetKeyspaceNameBySettings()
 	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
-		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
+		if kerneltype.IsNextGen() {
+			keyspaceIDU64, _ := strconv.ParseUint(keyspaceName, 10, 32)
+			keyspaceID = uint32(keyspaceIDU64)
+		} else {
+			keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
+		}
 	}
 	if txnTS == 0 {
 		// TODO: txnTS maybe ambiguous, consider logging stale-read-ts with a new field in the slow log.

--- a/pkg/util/metricsutil/BUILD.bazel
+++ b/pkg/util/metricsutil/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/domain/metrics",
         "//pkg/executor/metrics",
         "//pkg/infoschema/metrics",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60864 Doesn't close this issue, keep it to track possible keyspace_id/keyspace_name logic changes, since it is not settle down now.

Problem Summary:
Currently, we assume global unique keyspace_id is passed as keyspace_name config for next gen tidb. Thus, for next gen, we can use the keyspace_name directly as keyspace_id now. 
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
There is already slow_log test covering keyspace_name/keyspace_id.
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Hack code to set keyspace_name to "987654321", hack code because just setting tidb config's keyspace_name value doesn't work(pd can't find responding keyspace_id). Then check slow log and grafana：
![img_v3_02lo_67f6a88d-43e4-4cae-a38a-1a4926b8362g](https://github.com/user-attachments/assets/b56defc1-1807-4d08-8cd5-1a0ab173be7e)
![img_v3_02lo_381ef7ec-7c5e-4503-bd6e-05e9dbe10bcg](https://github.com/user-attachments/assets/f4b748e5-e03a-4ec2-af3b-17d70cc1f4a4)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
