### PR TITLE
globalsort: support onDup param for writer

### DIFF
--- a/pkg/ingestor/engineapi/engine.go
+++ b/pkg/ingestor/engineapi/engine.go
@@ -88,7 +88,8 @@ type OnDuplicateKey int
 
 const (
 	// OnDuplicateKeyIgnore means ignore the duplicate key.
-	// this is the old behavior as add-index check dup by using DupDetectKeyAdapter.
+	// this is the current behavior, we will keep it before we fully switch to
+	// below 3 options.
 	OnDuplicateKeyIgnore OnDuplicateKey = iota
 	// OnDuplicateKeyRecord means record the duplicate keys to external store.
 	// depends on the step, we might only record when number of duplicates are larger

--- a/pkg/lightning/backend/external/file.go
+++ b/pkg/lightning/backend/external/file.go
@@ -64,12 +64,16 @@ func (s *KeyValueStore) addEncodedData(data []byte) error {
 	}
 
 	s.offset += uint64(len(data))
-	s.rc.onNextEncodedData(data, s.offset)
+	if s.rc != nil {
+		s.rc.onNextEncodedData(data, s.offset)
+	}
 
 	return nil
 }
 
 // finish closes the KeyValueStore and append the last range property.
 func (s *KeyValueStore) finish() {
-	s.rc.onFileEnd()
+	if s.rc != nil {
+		s.rc.onFileEnd()
+	}
 }

--- a/pkg/lightning/backend/external/file.go
+++ b/pkg/lightning/backend/external/file.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	statSuffix = "_stat"
+	dupSuffix  = "_dup"
 	// we use uint64 to store the length of key and value.
 	lengthBytes = 8
 )

--- a/pkg/lightning/backend/external/kv_reader.go
+++ b/pkg/lightning/backend/external/kv_reader.go
@@ -64,6 +64,9 @@ func newKVReader(
 	}, nil
 }
 
+// nextKV reads the next key-value pair from the reader.
+// the returned key and value will be reused in later calls, so if the caller want
+// to save the KV for later use, it should copy the key and value.
 func (r *kvReader) nextKV() (key, val []byte, err error) {
 	lenBytes, err := r.byteReader.readNBytes(8)
 	if err != nil {

--- a/pkg/lightning/backend/external/onefile_writer.go
+++ b/pkg/lightning/backend/external/onefile_writer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/membuf"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -57,6 +58,7 @@ type OneFileWriter struct {
 
 	onClose OnCloseFunc
 	closed  bool
+	onDup   engineapi.OnDuplicateKey
 
 	minKey []byte
 	maxKey []byte

--- a/pkg/lightning/backend/external/writer.go
+++ b/pkg/lightning/backend/external/writer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/backend"
 	"github.com/pingcap/tidb/pkg/lightning/backend/encode"
@@ -142,11 +143,16 @@ type WriterSummary struct {
 	// Min and Max are the min and max key written by this writer, both are
 	// inclusive, i.e. [Min, Max].
 	// will be empty if no key is written.
-	Min                tidbkv.Key
-	Max                tidbkv.Key
-	TotalSize          uint64
+	Min tidbkv.Key
+	Max tidbkv.Key
+	// TotalSize is the total size of the data written by this writer.
+	// depends on onDup setting, duplicates might not be included.
+	TotalSize uint64
+	// TotalCnt is the total count of the KV written by this writer.
+	// depends on onDup setting, duplicates might not be included.
 	TotalCnt           uint64
 	MultipleFilesStats []MultipleFilesStat
+	ConflictInfo       engineapi.ConflictInfo
 }
 
 // OnCloseFunc is the callback function when a writer is closed.
@@ -164,6 +170,7 @@ type WriterBuilder struct {
 	propKeysDist    uint64
 	onClose         OnCloseFunc
 	keyDupeEncoding bool
+	onDup           engineapi.OnDuplicateKey
 }
 
 // NewWriterBuilder creates a WriterBuilder.
@@ -228,6 +235,12 @@ func (b *WriterBuilder) SetGroupOffset(offset int) *WriterBuilder {
 	return b
 }
 
+// SetOnDup set the action when checkDup enabled and a duplicate key is found.
+func (b *WriterBuilder) SetOnDup(onDup engineapi.OnDuplicateKey) *WriterBuilder {
+	b.onDup = onDup
+	return b
+}
+
 // Build builds a new Writer. The files writer will create are under the prefix
 // of "{prefix}/{writerID}".
 func (b *WriterBuilder) Build(
@@ -260,6 +273,7 @@ func (b *WriterBuilder) Build(
 		writerID:       writerID,
 		groupOffset:    b.groupOffset,
 		onClose:        b.onClose,
+		onDup:          b.onDup,
 		closed:         false,
 		multiFileStats: make([]MultipleFilesStat, 1),
 		fileMinKeys:    make([]tidbkv.Key, 0, multiFileStatNum),
@@ -294,6 +308,7 @@ func (b *WriterBuilder) BuildOneFile(
 		kvStore:        nil,
 		onClose:        b.onClose,
 		closed:         false,
+		onDup:          b.onDup,
 	}
 	return ret
 }
@@ -388,6 +403,7 @@ type Writer struct {
 	kvSize      int64
 
 	onClose OnCloseFunc
+	onDup   engineapi.OnDuplicateKey
 	closed  bool
 
 	// Statistic information per batch.
@@ -403,6 +419,8 @@ type Writer struct {
 	maxKey    tidbkv.Key
 	totalSize uint64
 	totalCnt  uint64
+	// duplicate key's statistics.
+	conflictInfo engineapi.ConflictInfo
 }
 
 // WriteRow implements ingest.Writer.
@@ -434,7 +452,6 @@ func (w *Writer) WriteRow(ctx context.Context, key, val []byte, handle tidbkv.Ha
 	w.kvLocations = append(w.kvLocations, loc)
 	w.kvSize += int64(encodedKeyLen + len(val))
 	w.batchSize += uint64(length)
-	w.totalCnt += 1
 	return nil
 }
 
@@ -475,6 +492,7 @@ func (w *Writer) Close(ctx context.Context) error {
 		TotalSize:          w.totalSize,
 		TotalCnt:           w.totalCnt,
 		MultipleFilesStats: w.multiFileStats,
+		ConflictInfo:       w.conflictInfo,
 	})
 	return nil
 }
@@ -501,17 +519,44 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 		zap.Int("sequence-number", w.currentSeq),
 	)
 	sortStart := time.Now()
+	var dupFound bool
 	slices.SortFunc(w.kvLocations, func(i, j membuf.SliceLocation) int {
-		return bytes.Compare(w.getKeyByLoc(i), w.getKeyByLoc(j))
+		res := bytes.Compare(w.getKeyByLoc(&i), w.getKeyByLoc(&j))
+		if res == 0 {
+			dupFound = true
+		}
+		return res
 	})
 	sortDuration := time.Since(sortStart)
 	metrics.GlobalSortWriteToCloudStorageDuration.WithLabelValues("sort").Observe(sortDuration.Seconds())
 	metrics.GlobalSortWriteToCloudStorageRate.WithLabelValues("sort").Observe(float64(w.batchSize) / 1024.0 / 1024.0 / sortDuration.Seconds())
 
+	batchKVCnt := len(w.kvLocations)
+	var (
+		dupLocs []membuf.SliceLocation
+		dupCnt  int
+	)
+	if dupFound {
+		switch w.onDup {
+		case engineapi.OnDuplicateKeyIgnore:
+		case engineapi.OnDuplicateKeyRecord:
+			// we don't have a global view, so need to keep duplicates with duplicate
+			// count <= 2, so later we can find them.
+			w.kvLocations, dupLocs, dupCnt = removeDuplicatesMoreThanTwo(w.kvLocations, w.getKeyByLoc)
+			w.kvSize = w.calculateKVSize()
+		case engineapi.OnDuplicateKeyRemove:
+			w.kvLocations, _, dupCnt = removeDuplicates(w.kvLocations, w.getKeyByLoc, false)
+			w.kvSize = w.calculateKVSize()
+		case engineapi.OnDuplicateKeyError:
+			// not implemented yet, same as ignore.
+			// add-index might need this one later.
+		}
+	}
+
 	writeStartTime := time.Now()
-	var dataFile, statFile string
+	var dataFile, statFile, dupFile string
 	for i := 0; i < flushKVsRetryTimes; i++ {
-		dataFile, statFile, err = w.flushSortedKVs(ctx)
+		dataFile, statFile, dupFile, err = w.flushSortedKVs(ctx, dupLocs)
 		if err == nil || ctx.Err() != nil {
 			break
 		}
@@ -524,29 +569,35 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 		return err
 	}
 	writeDuration := time.Since(writeStartTime)
-	kvCnt := len(w.kvLocations)
 	logger.Info("flush kv",
 		zap.Uint64("bytes", w.batchSize),
-		zap.Int("kv-cnt", kvCnt),
+		zap.Int("kv-cnt", batchKVCnt),
 		zap.Duration("sort-time", sortDuration),
 		zap.Duration("write-time", writeDuration),
-		zap.String("sort-speed(kv/s)", getSpeed(uint64(kvCnt), sortDuration.Seconds(), false)),
+		zap.String("sort-speed(kv/s)", getSpeed(uint64(batchKVCnt), sortDuration.Seconds(), false)),
 		zap.String("writer-id", w.writerID),
+		zap.Stringer("on-dup", w.onDup),
+		zap.Int("dup-cnt", dupCnt),
+		zap.Int("recorded-dup-cnt", len(dupLocs)),
 	)
 	totalDuration := time.Since(sortStart)
 	metrics.GlobalSortWriteToCloudStorageDuration.WithLabelValues("sort_and_write").Observe(totalDuration.Seconds())
 	metrics.GlobalSortWriteToCloudStorageRate.WithLabelValues("sort_and_write").Observe(float64(w.batchSize) / 1024.0 / 1024.0 / totalDuration.Seconds())
 
-	minKey, maxKey := w.getKeyByLoc(w.kvLocations[0]), w.getKeyByLoc(w.kvLocations[len(w.kvLocations)-1])
-	w.recordMinMax(minKey, maxKey, uint64(w.kvSize))
-
 	// maintain 500-batch statistics
 	l := len(w.multiFileStats)
-	w.multiFileStats[l-1].Filenames = append(w.multiFileStats[l-1].Filenames,
-		[2]string{dataFile, statFile},
-	)
-	w.fileMinKeys = append(w.fileMinKeys, tidbkv.Key(minKey).Clone())
-	w.fileMaxKeys = append(w.fileMaxKeys, tidbkv.Key(maxKey).Clone())
+	if len(w.kvLocations) > 0 {
+		w.totalCnt += uint64(len(w.kvLocations))
+
+		minKey, maxKey := w.getKeyByLoc(&w.kvLocations[0]), w.getKeyByLoc(&w.kvLocations[len(w.kvLocations)-1])
+		w.recordMinMax(minKey, maxKey, uint64(w.kvSize))
+
+		w.multiFileStats[l-1].Filenames = append(w.multiFileStats[l-1].Filenames,
+			[2]string{dataFile, statFile},
+		)
+		w.fileMinKeys = append(w.fileMinKeys, tidbkv.Key(minKey).Clone())
+		w.fileMaxKeys = append(w.fileMaxKeys, tidbkv.Key(maxKey).Clone())
+	}
 	if fromClose || len(w.multiFileStats[l-1].Filenames) == multiFileStatNum {
 		w.multiFileStats[l-1].build(w.fileMinKeys, w.fileMaxKeys)
 		w.multiFileStats = append(w.multiFileStats, MultipleFilesStat{
@@ -554,6 +605,14 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 		})
 		w.fileMinKeys = w.fileMinKeys[:0]
 		w.fileMaxKeys = w.fileMaxKeys[:0]
+	}
+
+	// maintain dup statistics
+	if len(dupLocs) > 0 {
+		w.conflictInfo.Merge(&engineapi.ConflictInfo{
+			Count: uint64(len(dupLocs)),
+			Files: []string{dupFile},
+		})
 	}
 
 	w.kvLocations = w.kvLocations[:0]
@@ -564,7 +623,7 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 	return nil
 }
 
-func (w *Writer) flushSortedKVs(ctx context.Context) (string, string, error) {
+func (w *Writer) flushSortedKVs(ctx context.Context, dupLocs []membuf.SliceLocation) (string, string, string, error) {
 	logger := logutil.Logger(ctx).With(
 		zap.String("writer-id", w.writerID),
 		zap.Int("sequence-number", w.currentSeq),
@@ -572,7 +631,7 @@ func (w *Writer) flushSortedKVs(ctx context.Context) (string, string, error) {
 	writeStartTime := time.Now()
 	dataFile, statFile, dataWriter, statWriter, err := w.createStorageWriter(ctx)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	defer func() {
 		// close the writers when meet error. If no error happens, writers will
@@ -588,9 +647,9 @@ func (w *Writer) flushSortedKVs(ctx context.Context) (string, string, error) {
 	kvStore := NewKeyValueStore(ctx, dataWriter, w.rc)
 
 	for _, pair := range w.kvLocations {
-		err = kvStore.addEncodedData(w.kvBuffer.GetSlice(pair))
+		err = kvStore.addEncodedData(w.kvBuffer.GetSlice(&pair))
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 	}
 
@@ -599,17 +658,25 @@ func (w *Writer) flushSortedKVs(ctx context.Context) (string, string, error) {
 	statSize := len(encodedStat)
 	_, err = statWriter.Write(ctx, encodedStat)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	err = dataWriter.Close(ctx)
 	dataWriter = nil
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	err = statWriter.Close(ctx)
 	statWriter = nil
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
+	}
+
+	var dupPath string
+	if len(dupLocs) > 0 {
+		dupPath, err = w.writeDupKVs(ctx, dupLocs)
+		if err != nil {
+			return "", "", "", err
+		}
 	}
 
 	writeDuration := time.Since(writeStartTime)
@@ -622,13 +689,49 @@ func (w *Writer) flushSortedKVs(ctx context.Context) (string, string, error) {
 	metrics.GlobalSortWriteToCloudStorageDuration.WithLabelValues("write").Observe(writeDuration.Seconds())
 	metrics.GlobalSortWriteToCloudStorageRate.WithLabelValues("write").Observe(float64(w.batchSize) / 1024.0 / 1024.0 / writeDuration.Seconds())
 
-	return dataFile, statFile, nil
+	return dataFile, statFile, dupPath, nil
 }
 
-func (w *Writer) getKeyByLoc(loc membuf.SliceLocation) []byte {
+func (w *Writer) writeDupKVs(ctx context.Context, kvLocs []membuf.SliceLocation) (string, error) {
+	dupPath, dupWriter, err := w.createDupWriter(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		// close the writers when meet error. If no error happens, writers will
+		// be closed outside and assigned to nil.
+		if dupWriter != nil {
+			_ = dupWriter.Close(ctx)
+		}
+	}()
+	dupStore := NewKeyValueStore(ctx, dupWriter, nil)
+	for _, pair := range kvLocs {
+		err = dupStore.addEncodedData(w.kvBuffer.GetSlice(&pair))
+		if err != nil {
+			return "", err
+		}
+	}
+	dupStore.finish()
+	err = dupWriter.Close(ctx)
+	dupWriter = nil
+	if err != nil {
+		return "", err
+	}
+	return dupPath, nil
+}
+
+func (w *Writer) getKeyByLoc(loc *membuf.SliceLocation) []byte {
 	block := w.kvBuffer.GetSlice(loc)
 	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
 	return block[2*lengthBytes : 2*lengthBytes+keyLen]
+}
+
+func (w *Writer) calculateKVSize() int64 {
+	s := int64(0)
+	for _, loc := range w.kvLocations {
+		s += int64(loc.Length) - 2*lengthBytes
+	}
+	return s
 }
 
 func (w *Writer) createStorageWriter(ctx context.Context) (
@@ -654,6 +757,15 @@ func (w *Writer) createStorageWriter(ctx context.Context) (
 		return "", "", nil, nil, err
 	}
 	return dataPath, statPath, dataWriter, statsWriter, nil
+}
+
+func (w *Writer) createDupWriter(ctx context.Context) (string, storage.ExternalFileWriter, error) {
+	path := filepath.Join(w.filenamePrefix+dupSuffix, strconv.Itoa(w.currentSeq))
+	writer, err := w.store.Create(ctx, path, &storage.WriterOption{
+		Concurrency: 20,
+		PartSize:    MinUploadPartSize,
+	})
+	return path, writer, err
 }
 
 // EngineWriter implements backend.EngineWriter interface.

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/jfcg/sorty/v2"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/ingestor/engineapi"
 	dbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/backend/kv"
 	"github.com/pingcap/tidb/pkg/lightning/common"
@@ -603,4 +604,147 @@ func TestGetAdjustedIndexBlockSize(t *testing.T) {
 	require.EqualValues(t, 16*units.MiB, GetAdjustedBlockSize(16*units.MiB))
 	require.EqualValues(t, 17*units.MiB, GetAdjustedBlockSize(17*units.MiB))
 	require.EqualValues(t, 16*units.MiB, GetAdjustedBlockSize(166*units.MiB))
+}
+
+func readKVFile(t *testing.T, store *writerFirstCloseFailStorage, filename string) []kvPair {
+	t.Helper()
+	reader, err := newKVReader(context.Background(), filename, store, 0, units.KiB)
+	require.NoError(t, err)
+	kvs := make([]kvPair, 0)
+	for {
+		key, value, err := reader.nextKV()
+		if goerrors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		kvs = append(kvs, kvPair{key: slices.Clone(key), value: slices.Clone(value)})
+	}
+	return kvs
+}
+
+func TestWriterOnDupRecord(t *testing.T) {
+	ctx := context.Background()
+	store := &writerFirstCloseFailStorage{ExternalStorage: storage.NewMemStorage(), shouldFail: true}
+	var summary *WriterSummary
+
+	t.Run("all duplicated, flush once", func(t *testing.T) {
+		writer := NewWriterBuilder().SetPropKeysDistance(4).SetMemorySizeLimit(240).SetBlockSize(240).
+			SetOnCloseFunc(func(s *WriterSummary) { summary = s }).SetOnDup(engineapi.OnDuplicateKeyRecord).
+			Build(store, "/test", "0")
+		for range 5 {
+			require.NoError(t, writer.WriteRow(ctx, []byte("1111"), []byte("vvvv"), nil))
+		}
+		require.NoError(t, writer.Close(ctx))
+		require.EqualValues(t, []byte("1111"), summary.Min)
+		require.EqualValues(t, []byte("1111"), summary.Max)
+		require.EqualValues(t, 2, summary.TotalCnt)
+		require.EqualValues(t, 16, summary.TotalSize)
+		require.EqualValues(t, 3, summary.ConflictInfo.Count)
+		require.Len(t, summary.ConflictInfo.Files, 1)
+		kvs := readKVFile(t, store, summary.ConflictInfo.Files[0])
+		require.Len(t, kvs, 3)
+		for _, p := range kvs {
+			require.Equal(t, []byte("1111"), p.key)
+			require.Equal(t, []byte("vvvv"), p.value)
+		}
+	})
+
+	t.Run("with different duplicated kv, flush twice", func(t *testing.T) {
+		// each KV will take 24 bytes, so we flush every 10 KVs
+		writer := NewWriterBuilder().SetPropKeysDistance(4).SetMemorySizeLimit(240).SetBlockSize(240).
+			SetOnCloseFunc(func(s *WriterSummary) { summary = s }).SetOnDup(engineapi.OnDuplicateKeyRecord).
+			Build(store, "/test", "0")
+		for _, p := range []struct {
+			pair *kvPair
+			cnt  int
+		}{
+			{pair: &kvPair{key: []byte("5555"), value: []byte("vvvv")}, cnt: 2},
+			{pair: &kvPair{key: []byte("2222"), value: []byte("vvvv")}, cnt: 3},
+			{pair: &kvPair{key: []byte("1111"), value: []byte("vvvv")}, cnt: 5},
+			{pair: &kvPair{key: []byte("6666"), value: []byte("vvvv")}, cnt: 1},
+			{pair: &kvPair{key: []byte("7777"), value: []byte("vvvv")}, cnt: 1},
+			{pair: &kvPair{key: []byte("4444"), value: []byte("vvvv")}, cnt: 4},
+			{pair: &kvPair{key: []byte("3333"), value: []byte("vvvv")}, cnt: 4},
+		} {
+			for i := 0; i < p.cnt; i++ {
+				require.NoError(t, writer.WriteRow(ctx, p.pair.key, p.pair.value, nil))
+			}
+		}
+		require.NoError(t, writer.Close(ctx))
+		require.EqualValues(t, []byte("1111"), summary.Min)
+		require.EqualValues(t, []byte("7777"), summary.Max)
+		require.EqualValues(t, 12, summary.TotalCnt)
+		require.EqualValues(t, 96, summary.TotalSize)
+		require.EqualValues(t, 8, summary.ConflictInfo.Count)
+		require.Len(t, summary.ConflictInfo.Files, 2)
+		kvs := readKVFile(t, store, summary.ConflictInfo.Files[0])
+		require.EqualValues(t, []kvPair{
+			{key: []byte("1111"), value: []byte("vvvv")},
+			{key: []byte("1111"), value: []byte("vvvv")},
+			{key: []byte("1111"), value: []byte("vvvv")},
+			{key: []byte("2222"), value: []byte("vvvv")},
+		}, kvs)
+		kvs = readKVFile(t, store, summary.ConflictInfo.Files[1])
+		require.EqualValues(t, []kvPair{
+			{key: []byte("3333"), value: []byte("vvvv")},
+			{key: []byte("3333"), value: []byte("vvvv")},
+			{key: []byte("4444"), value: []byte("vvvv")},
+			{key: []byte("4444"), value: []byte("vvvv")},
+		}, kvs)
+	})
+}
+
+func TestWriterOnDupRemove(t *testing.T) {
+	ctx := context.Background()
+	store := &writerFirstCloseFailStorage{ExternalStorage: storage.NewMemStorage(), shouldFail: true}
+	var summary *WriterSummary
+
+	t.Run("all duplicated, flush once", func(t *testing.T) {
+		writer := NewWriterBuilder().SetPropKeysDistance(4).SetMemorySizeLimit(240).SetBlockSize(240).
+			SetOnCloseFunc(func(s *WriterSummary) { summary = s }).SetOnDup(engineapi.OnDuplicateKeyRemove).
+			Build(store, "/test", "0")
+		for range 5 {
+			require.NoError(t, writer.WriteRow(ctx, []byte("1111"), []byte("vvvv"), nil))
+		}
+		require.NoError(t, writer.Close(ctx))
+		require.EqualValues(t, dbkv.Key(nil), summary.Min)
+		require.EqualValues(t, dbkv.Key(nil), summary.Max)
+		require.EqualValues(t, 0, summary.TotalCnt)
+		require.EqualValues(t, 0, summary.TotalSize)
+		require.Empty(t, summary.MultipleFilesStats)
+		require.EqualValues(t, 0, summary.ConflictInfo.Count)
+		require.Empty(t, summary.ConflictInfo.Files)
+	})
+
+	t.Run("with different duplicated kv, flush twice", func(t *testing.T) {
+		// each KV will take 24 bytes, so we flush every 10 KVs
+		writer := NewWriterBuilder().SetPropKeysDistance(4).SetMemorySizeLimit(240).SetBlockSize(240).
+			SetOnCloseFunc(func(s *WriterSummary) { summary = s }).SetOnDup(engineapi.OnDuplicateKeyRemove).
+			Build(store, "/test", "0")
+		for _, p := range []struct {
+			pair *kvPair
+			cnt  int
+		}{
+			{pair: &kvPair{key: []byte("5555"), value: []byte("vvvv")}, cnt: 2},
+			{pair: &kvPair{key: []byte("2222"), value: []byte("vvvv")}, cnt: 3},
+			{pair: &kvPair{key: []byte("1111"), value: []byte("vvvv")}, cnt: 5},
+			{pair: &kvPair{key: []byte("6666"), value: []byte("vvvv")}, cnt: 1},
+			{pair: &kvPair{key: []byte("7777"), value: []byte("vvvv")}, cnt: 1},
+			{pair: &kvPair{key: []byte("4444"), value: []byte("vvvv")}, cnt: 4},
+			{pair: &kvPair{key: []byte("3333"), value: []byte("vvvv")}, cnt: 4},
+		} {
+			for i := 0; i < p.cnt; i++ {
+				require.NoError(t, writer.WriteRow(ctx, p.pair.key, p.pair.value, nil))
+			}
+		}
+		require.NoError(t, writer.Close(ctx))
+		require.EqualValues(t, []byte("6666"), summary.Min)
+		require.EqualValues(t, []byte("7777"), summary.Max)
+		require.EqualValues(t, 2, summary.TotalCnt)
+		require.EqualValues(t, 16, summary.TotalSize)
+		require.Len(t, summary.MultipleFilesStats, 1)
+		require.Len(t, summary.MultipleFilesStats[0].Filenames, 1)
+		require.EqualValues(t, 0, summary.ConflictInfo.Count)
+		require.Empty(t, summary.ConflictInfo.Files)
+	})
 }

--- a/pkg/lightning/membuf/buffer.go
+++ b/pkg/lightning/membuf/buffer.go
@@ -265,7 +265,7 @@ func (b *Buffer) AllocBytes(n int) []byte {
 type SliceLocation struct {
 	bufIdx int32
 	offset int32
-	length int32
+	Length int32
 }
 
 var sizeOfSliceLocation = int(unsafe.Sizeof(SliceLocation{}))
@@ -283,7 +283,7 @@ func (b *Buffer) allocBytesWithSliceLocation(n int) ([]byte, SliceLocation) {
 	}
 	blockIdx := int32(b.curBlockIdx)
 	offset := int32(b.curIdx)
-	loc := SliceLocation{bufIdx: blockIdx, offset: offset, length: int32(n)}
+	loc := SliceLocation{bufIdx: blockIdx, offset: offset, Length: int32(n)}
 
 	idx := b.curIdx
 	b.curIdx += n
@@ -319,8 +319,8 @@ func (b *Buffer) addBlock() {
 }
 
 // GetSlice returns the byte slice for the slice location.
-func (b *Buffer) GetSlice(loc SliceLocation) []byte {
-	return b.blocks[loc.bufIdx][loc.offset : loc.offset+loc.length]
+func (b *Buffer) GetSlice(loc *SliceLocation) []byte {
+	return b.blocks[loc.bufIdx][loc.offset : loc.offset+loc.Length]
 }
 
 // AddBytes adds the bytes into this Buffer's managed memory and return it.

--- a/pkg/lightning/membuf/buffer_test.go
+++ b/pkg/lightning/membuf/buffer_test.go
@@ -256,7 +256,7 @@ func BenchmarkSortLocation(b *testing.B) {
 				rnd.Read(buf)
 			}
 			slices.SortFunc(data, func(a, b SliceLocation) int {
-				return bytes.Compare(bytesBuf.GetSlice(a), bytesBuf.GetSlice(b))
+				return bytes.Compare(bytesBuf.GetSlice(&a), bytesBuf.GetSlice(&b))
 			})
 		}()
 	}
@@ -305,7 +305,7 @@ func BenchmarkSortLocationWithGC(b *testing.B) {
 			}
 			runtime.GC()
 			slices.SortFunc(data, func(a, b SliceLocation) int {
-				return bytes.Compare(bytesBuf.GetSlice(a), bytesBuf.GetSlice(b))
+				return bytes.Compare(bytesBuf.GetSlice(&a), bytesBuf.GetSlice(&b))
 			})
 		}()
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60621 

Problem Summary:

### What changed and how does it work?
implement `record` and `remove` for writer
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
