### PR TITLE
ddl: ignore ingest's disk check in the darwin

### DIFF
--- a/pkg/ddl/ingest/disk_root.go
+++ b/pkg/ddl/ingest/disk_root.go
@@ -17,6 +17,7 @@ package ingest
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 
@@ -169,6 +170,10 @@ func (d *diskRootImpl) PreCheckUsage() error {
 		logutil.DDLIngestLogger().Warn("available disk space is less than 10%, cannot use ingest mode",
 			zap.String("sort path", d.path),
 			zap.String("usage", d.usageInfo()))
+		if runtime.GOOS == "darwin" {
+			// darwin‘s disk is too expensive and we only use it in the development environment. so we ignore the error.
+			return nil
+		}
 		msg := fmt.Sprintf("no enough space in %s", d.path)
 		return dbterror.ErrIngestCheckEnvFailed.FastGenByArgs(msg)
 	}

--- a/pkg/ddl/ingest/disk_root.go
+++ b/pkg/ddl/ingest/disk_root.go
@@ -171,7 +171,7 @@ func (d *diskRootImpl) PreCheckUsage() error {
 			zap.String("sort path", d.path),
 			zap.String("usage", d.usageInfo()))
 		if runtime.GOOS == "darwin" {
-			// darwin‘s disk is too expensive and we only use it in the development environment. so we ignore the error.
+			// darwin's disk is too expensive and we only use it in the development environment. so we ignore the error.
 			return nil
 		}
 		msg := fmt.Sprintf("no enough space in %s", d.path)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60893 

Problem Summary:

### What changed and how does it work?

darwin‘s disk is too expensive and we only use it in the development environment. so we ignore the error.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
