### PR TITLE
executor: fix goroutine leak when exceeding quota in `Close`

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -290,7 +290,7 @@ func (e *HashAggExec) Close() error {
 			if e.memTracker.BytesConsumed() >= 0 {
 				e.memTracker.ReplaceBytesUsed(0)
 			} else {
-				logutil.BgLogger().Warn("Memory tracking is inaccurate", zap.Int64(e.memTracker.BytesConsumed()))
+				logutil.BgLogger().Warn("Memory tracking is inaccurate", zap.Int64("memory consumption", e.memTracker.BytesConsumed()))
 			}
 		}
 	}

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -286,8 +286,12 @@ func (e *HashAggExec) Close() error {
 		}
 		channel.Clear(e.finalOutputCh)
 		e.executed = false
-		if e.memTracker != nil && e.memTracker.BytesConsumed() > 0 {
-			e.memTracker.ReplaceBytesUsed(0)
+		if e.memTracker != nil {
+			if e.memTracker.BytesConsumed() >= 0 {
+				e.memTracker.ReplaceBytesUsed(0)
+			} else {
+				logutil.BgLogger().Warn("Memory tracking is inaccurate", zap.Int64(e.memTracker.BytesConsumed()))
+			}
 		}
 	}
 	return e.baseExecutor.Close()

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -253,7 +253,7 @@ func (e *HashAggExec) Close() error {
 		e.childResult = nil
 		e.groupSet, _ = set.NewStringSetWithMemoryUsage()
 		e.partialResultMap = nil
-		if e.memTracker != nil {
+		if e.memTracker != nil && e.memTracker.BytesConsumed() > 0 {
 			e.memTracker.ReplaceBytesUsed(0)
 		}
 		if e.listInDisk != nil {
@@ -286,7 +286,7 @@ func (e *HashAggExec) Close() error {
 		}
 		channel.Clear(e.finalOutputCh)
 		e.executed = false
-		if e.memTracker != nil {
+		if e.memTracker != nil && e.memTracker.BytesConsumed() > 0 {
 			e.memTracker.ReplaceBytesUsed(0)
 		}
 	}

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -502,9 +502,7 @@ func (c *hashRowContainer) Len() uint64 {
 }
 
 func (c *hashRowContainer) Close() error {
-	failpoint.Inject("issue60923", func() {
-		panic("panic for test")
-	})
+	failpoint.Inject("issue60923", nil)
 
 	defer c.memTracker.Detach()
 	c.chkBuf = nil

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -23,6 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
@@ -501,6 +502,10 @@ func (c *hashRowContainer) Len() uint64 {
 }
 
 func (c *hashRowContainer) Close() error {
+	failpoint.Inject("issue60923", func() {
+		panic("panic for test")
+	})
+
 	defer c.memTracker.Detach()
 	c.chkBuf = nil
 	return c.rowContainer.Close()

--- a/executor/join.go
+++ b/executor/join.go
@@ -171,7 +171,7 @@ func (e *HashJoinExec) Close() error {
 			channel.Clear(e.probeWorkers[i].joinChkResourceCh)
 		}
 		e.probeSideTupleFetcher.probeChkResourceCh = nil
-		terror.Call(e.rowContainer.Close)
+		terror.CallWithRecover(e.rowContainer.Close)
 		e.hashJoinCtx.sessCtx.GetSessionVars().MemTracker.UnbindActionFromHardLimit(e.rowContainer.ActionSpill())
 		e.waiterWg.Wait()
 	}

--- a/executor/test/issue_test/BUILD.bazel
+++ b/executor/test/issue_test/BUILD.bazel
@@ -3,5 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "issue_test_test",
     srcs = ["executor_issue_test.go"],
-    deps = ["//testkit"],
+    deps = [
+        "//testkit",
+        "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/executor/test/issue_test/executor_issue_test.go
+++ b/executor/test/issue_test/executor_issue_test.go
@@ -51,7 +51,7 @@ func TestIssue60923(t *testing.T) {
 	tk.MustExec("insert into t1 values (0, 10), (1, 10), (2, 10), (3, 10), (4, 10), (5, 10), (6, 10), (7, 10), (8, 10), (9, 10), (10, 10);")
 	tk.MustExec("insert into t2 values (0, 5), (0, 5), (1, 5), (2, 5), (2, 5), (3, 5), (4, 5), (5, 5), (5, 5), (6, 5), (7, 5), (8, 5), (8, 5), (9, 5), (9, 5), (10, 5);")
 
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/issue60923", "return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/issue60923", "panic"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/issue60923"))
 	}()

--- a/executor/test/issue_test/executor_issue_test.go
+++ b/executor/test/issue_test/executor_issue_test.go
@@ -17,7 +17,9 @@ package explain
 import (
 	"testing"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIssue53867(t *testing.T) {
@@ -35,4 +37,23 @@ func TestIssue53867(t *testing.T) {
 
 	// Need no panic
 	tk.MustQuery("select /*+ STREAM_AGG() */ (ref_4.c_k3kss19 / ref_4.c_k3kss19) as c2 from t_bhze93f as ref_4 where (EXISTS (select ref_5.c_wp7o_0sstj as c0 from t_bhze93f as ref_5 where (207007502 < (select distinct ref_6.c_weg as c0 from t_xf1at0 as ref_6 union all (select ref_7.c_xb as c0 from t_b0t as ref_7 where (-16090 != ref_4.c_x393ej_)) limit 1)) limit 1));")
+}
+
+func TestIssue60923(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1 (col0 int, col1 int);")
+	tk.MustExec("create table t2 (col0 int, col1 int);")
+	tk.MustExec("insert into t1 values (0, 10), (1, 10), (2, 10), (3, 10), (4, 10), (5, 10), (6, 10), (7, 10), (8, 10), (9, 10), (10, 10);")
+	tk.MustExec("insert into t2 values (0, 5), (0, 5), (1, 5), (2, 5), (2, 5), (3, 5), (4, 5), (5, 5), (5, 5), (6, 5), (7, 5), (8, 5), (8, 5), (9, 5), (9, 5), (10, 5);")
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/issue60923", "return"))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/executor/issue60923"))
+	}()
+	tk.MustQuery("select * from t1 join (select col0, sum(col1) from t2 group by col0) as r on t1.col0 = r.col0;")
 }

--- a/parser/terror/terror.go
+++ b/parser/terror/terror.go
@@ -309,7 +309,7 @@ func Call(fn func() error) {
 	}
 }
 
-// Call executes a function, checks the returned err and avoids the throw of panic.
+// CallWithRecover executes a function, checks the returned err and avoids the throw of panic.
 func CallWithRecover(fn func() error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/parser/terror/terror.go
+++ b/parser/terror/terror.go
@@ -309,6 +309,21 @@ func Call(fn func() error) {
 	}
 }
 
+// Call executes a function, checks the returned err and avoids the throw of panic.
+func CallWithRecover(fn func() error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err := errors.Errorf("%v", r)
+			log.Error("function call panicked", zap.Error(err), zap.Stack("stack"))
+		}
+	}()
+
+	err := fn()
+	if err != nil {
+		log.Error("function call errored", zap.Error(err), zap.Stack("stack"))
+	}
+}
+
 // Log logs the error if it is not nil.
 func Log(err error) {
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60926

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
