### PR TITLE
parser: fix panic when call `json_memberof` without parameters

### DIFF
--- a/pkg/parser/ast/functions.go
+++ b/pkg/parser/ast/functions.go
@@ -529,9 +529,8 @@ func (n *FuncCallExpr) customRestore(ctx *format.RestoreCtx) (bool, error) {
 			}
 			ctx.WritePlain(")")
 			return true, nil
-		} else {
-			return true, errors.WithStack(errors.Errorf("Incorrect parameter count in the call to native function 'json_memberof'"))
 		}
+		return true, errors.WithStack(errors.Errorf("Incorrect parameter count in the call to native function 'json_memberof'"))
 	}
 	return false, nil
 }

--- a/pkg/parser/ast/functions.go
+++ b/pkg/parser/ast/functions.go
@@ -518,16 +518,20 @@ func (n *FuncCallExpr) customRestore(ctx *format.RestoreCtx) (bool, error) {
 		return true, nil
 	}
 	if n.FnName.L == JSONMemberOf {
-		if err := n.Args[0].Restore(ctx); err != nil {
-			return true, errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(MEMBER OF).Args[0]")
+		if len(n.Args) == 2 {
+			if err := n.Args[0].Restore(ctx); err != nil {
+				return true, errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(MEMBER OF).Args[0]")
+			}
+			ctx.WriteKeyWord(" MEMBER OF ")
+			ctx.WritePlain("(")
+			if err := n.Args[1].Restore(ctx); err != nil {
+				return true, errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(MEMBER OF).Args[1]")
+			}
+			ctx.WritePlain(")")
+			return true, nil
+		} else {
+			return true, errors.WithStack(errors.Errorf("Incorrect parameter count in the call to native function 'json_memberof'"))
 		}
-		ctx.WriteKeyWord(" MEMBER OF ")
-		ctx.WritePlain("(")
-		if err := n.Args[1].Restore(ctx); err != nil {
-			return true, errors.Annotatef(err, "An error occurred while restore FuncCallExpr.(MEMBER OF).Args[1]")
-		}
-		ctx.WritePlain(")")
-		return true, nil
 	}
 	return false, nil
 }

--- a/pkg/parser/ast/functions_test.go
+++ b/pkg/parser/ast/functions_test.go
@@ -14,10 +14,12 @@
 package ast_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/parser"
 	. "github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/test_driver"
 	"github.com/stretchr/testify/require"
@@ -243,4 +245,23 @@ func TestGenericFuncRestore(t *testing.T) {
 		return node.(*SelectStmt).Fields.Fields[0].Expr
 	}
 	runNodeRestoreTest(t, testCases, "select %s from t", extractNodeFunc)
+}
+
+func TestRestoreWithError(t *testing.T) {
+	testCases := []string{
+		"json_memberof()",
+	}
+
+	extractNodeFunc := func(node Node) Node {
+		return node.(*SelectStmt).Fields.Fields[0].Expr
+	}
+
+	for _, c := range testCases {
+		sql := "select " + c
+		p := parser.New()
+		stmt, err := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, err)
+		var sb strings.Builder
+		require.Error(t, extractNodeFunc(stmt).Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)))
+	}
 }

--- a/tests/integrationtest/r/expression/json.result
+++ b/tests/integrationtest/r/expression/json.result
@@ -873,3 +873,5 @@ select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
 json_search('{"h": "i"}', 'all', 'i', '\\', NULL)
 NULL
 set tidb_enable_vectorized_expression = default;
+select json_memberof();
+Error 1582 (42000): Incorrect parameter count in the call to native function 'json_memberof'

--- a/tests/integrationtest/t/expression/json.test
+++ b/tests/integrationtest/t/expression/json.test
@@ -576,3 +576,8 @@ select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
 set tidb_enable_vectorized_expression = 'OFF';
 select json_search('{"h": "i"}', 'all', 'i', '\\', NULL);
 set tidb_enable_vectorized_expression = default;
+
+# TestIssue60906
+--error 1582
+select json_memberof();
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60906 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
