### PR TITLE
planner: Enable non-prepared plan cache for queries with hints.

### DIFF
--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -858,11 +858,9 @@ func testRandomPlanCacheCases(t *testing.T,
 		result1 := tk.MustQuery(q).Sort()
 		tk.MustExec("set tidb_enable_non_prepared_plan_cache=1")
 
-		// the first execution caches the plan
 		result2 := tk.MustQuery(q).Sort()
 		require.True(t, result1.Equal(result2.Rows()))
 
-		// the second execution uses the cache
 		result2 = tk.MustQuery(q).Sort()
 		require.True(t, result1.Equal(result2.Rows()))
 	}

--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -852,17 +852,17 @@ func testRandomPlanCacheCases(t *testing.T,
 	tk := testkit.NewTestKit(t, store)
 	prepFunc(tk)
 
-	// non prepared plan cache
+	// nonprepared plan cache
 	for _, q := range queryFunc(true) {
 		tk.MustExec("set tidb_enable_non_prepared_plan_cache=0")
 		result1 := tk.MustQuery(q).Sort()
 		tk.MustExec("set tidb_enable_non_prepared_plan_cache=1")
 
-		// this first execution caches the plan
+		// the first execution caches the plan
 		result2 := tk.MustQuery(q).Sort()
 		require.True(t, result1.Equal(result2.Rows()))
 
-		// this second execution uses the caches
+		// the second execution uses the cache
 		result2 = tk.MustQuery(q).Sort()
 		require.True(t, result1.Equal(result2.Rows()))
 	}

--- a/pkg/planner/core/plan_cache_test.go
+++ b/pkg/planner/core/plan_cache_test.go
@@ -1029,13 +1029,13 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t1 order by a",                              // order by
 		"select * from t3 where full_name = 'a b'",                 // generated column
 		"select * from t3 where a > 1 and full_name = 'a b'",
-		"select * from t1 where a in (1, 2)",                    // Partitioned
-		"select * from t2 where a in (1, 2) and b in (1, 2, 3)", // Partitioned
-		"select * from t1 where a in (1, 2) and b < 15",         // Partitioned
+		"select * from t1 where a in (1, 2)",                                 // Partitioned
+		"select * from t2 where a in (1, 2) and b in (1, 2, 3)",              // Partitioned
+		"select * from t1 where a in (1, 2) and b < 15",                      // Partitioned
+		"select /*+ use_index(t1, idx_b) */ * from t1 where a > 1 and b < 2", // hint
 	}
 
 	unsupported := []string{
-		"select /*+ use_index(t1, idx_b) */ * from t1 where a > 1 and b < 2",               // hint
 		"select a, sum(b) as c from t1 where a > 1 and b < 2 group by a having sum(b) > 1", // having
 		"select * from (select * from t1) t",                                               // sub-query
 		"select * from t1 where a in (select a from t)",                                    // uncorrelated sub-query
@@ -1049,14 +1049,13 @@ func TestNonPreparedPlanExplainWarning(t *testing.T) {
 		"select * from t where bt > 0", // bit
 		"select * from t where a > 1 and bt > 0",
 		"select data_type from INFORMATION_SCHEMA.columns where table_name = 'v'", // memTable
-		"select * from v",                // view
-		"select * from t where a = null", // null
-		"select * from t where false",    // table dual
+		"select * from v",                                                         // view
+		"select * from t where a = null",                                          // null
+		"select * from t where false",                                             // table dual
 	}
 
 	reasons := []string{
-		"skip non-prepared plan-cache: queries that have hints, having-clause, window-function are not supported",
-		"skip non-prepared plan-cache: queries that have hints, having-clause, window-function are not supported",
+		"skip non-prepared plan-cache: queries with HAVING clauses are not supported",
 		"skip non-prepared plan-cache: queries that have sub-queries are not supported",
 		"skip non-prepared plan-cache: query has some unsupported Node",
 		"skip non-prepared plan-cache: query has some unsupported Node",

--- a/pkg/planner/core/plan_cacheable_checker_test.go
+++ b/pkg/planner/core/plan_cacheable_checker_test.go
@@ -391,15 +391,18 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select * from test.t where a+b=13",      // '+'
 		"select * from test.t where mod(a, 3)=1", // mod
 		"select * from test.t where d>now()",     // now
+		"select * from test.t where a > 1 and b < 2",
 		"select a+1 from test.t where a<13",
 		"select mod(a, 10) from test.t where a<13",
-		"select * from test.t limit 1",                                  // limit
-		"select distinct a from test.t where a > 1 and b < 2",           // distinct
-		"select distinct a from test.t1 where a > 1 and b < 2",          // distinct & partitioned
-		"select count(*) from test.t where a > 1 and b < 2 group by a",  // group by
-		"select count(*) from test.t1 where a > 1 and b < 2 group by a", // group by & partitioned
-		"select * from test.t order by a",                               // order by
-		"select * from test.t1 order by a",                              // order by & partitioned
+		"select * from test.t limit 1",                                           // limit
+		"select distinct a from test.t where a > 1 and b < 2",                    // distinct
+		"select distinct a from test.t1 where a > 1 and b < 2",                   // distinct & partitioned
+		"select count(*) from test.t where a > 1 and b < 2 group by a",           // group by
+		"select count(*) from test.t1 where a > 1 and b < 2 group by a",          // group by & partitioned
+		"select * from test.t order by a",                                        // order by
+		"select * from test.t1 order by a",                                       // order by & partitioned
+		"select /*+ use_index(t1, idx_b) */ * from test.t where a > 1 and b < 2", // hint
+		"select /*+ use_index(t, idx_b) */ * from test.t1 where a > 1 and b < 2", // hint & partitioned
 
 		// 2-way joins
 		"select * from test.t inner join test.t3 on test.t.a=test.t3.a",
@@ -415,16 +418,14 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 		"select a, sum(b) as c from test.t where a > 1 and b < 2 group by a having sum(b) > 1",
 		// having & partitioned
 		"select a, sum(b) as c from test.t1 where a > 1 and b < 2 group by a having sum(b) > 1",
-		"select /*+ use_index(t1, idx_b) */ * from t where a > 1 and b < 2", // hint
-		"select /*+ use_index(t, idx_b) */ * from t1 where a > 1 and b < 2", // hint & partitioned
 
 		"select * from (select * from test.t) t",  // sub-query
 		"select * from (select * from test.t1) t", // sub-query & partitioned
 
 		// uncorrelated sub-query
-		"select * from test.t where a in (select a from t)",
+		"select * from test.t where a in (select a from test.t)",
 		// uncorrelated sub-query & partitioned
-		"select * from test.t1 where a in (select a from t)",
+		"select * from test.t1 where a in (select a from test.t)",
 		// correlated sub-query
 		"select * from test.t where a in (select a from test.t where a > t1.a)",
 		// correlated sub-query & partitioned
@@ -432,16 +433,16 @@ func TestNonPreparedPlanCacheable(t *testing.T) {
 	}
 
 	supportedDML := []string{
-		"select * from test.t for update",               // lock
-		"select * from test.t1 for update",              // lock & partitioned
-		"insert into test.t values(1, 1, 1, 1)",         // insert
-		"insert into test.t1 values(1, 1)",              // insert & partitioned
-		"insert into t(a, b) select a, b from test.t",   // insert into select
-		"insert into t1(a, b) select a, b from test.t1", // insert into select & partitioned
-		"update test.t set a = 1 where b = 2",           // update
-		"update test.t1 set a = 1 where b = 2",          // update & partitioned
-		"delete from test.t where b = 1",                // delete
-		"delete from test.t1 where b = 1",               // delete & partitioned
+		"select * from test.t for update",                    // lock
+		"select * from test.t1 for update",                   // lock & partitioned
+		"insert into test.t values(1, 1, 1, 1)",              // insert
+		"insert into test.t1 values(1, 1)",                   // insert & partitioned
+		"insert into test.t(a, b) select a, b from test.t",   // insert into select
+		"insert into test.t1(a, b) select a, b from test.t1", // insert into select & partitioned
+		"update test.t set a = 1 where b = 2",                // update
+		"update test.t1 set a = 1 where b = 2",               // update & partitioned
+		"delete from test.t where b = 1",                     // delete
+		"delete from test.t1 where b = 1",                    // delete & partitioned
 	}
 
 	sctx := tk.Session()

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -296,12 +296,12 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 			sessVars.StmtCtx.StmtHints = curStmtHints
 
 			if sessVars.StmtCtx.StmtHints.HasResourceGroup {
-				sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL")
+				sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL binding")
 			}
 
 			// update session var by hint /set_var/
 			if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
-				sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
+				sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL binding")
 			}
 			for name, val := range sessVars.StmtCtx.StmtHints.SetVars {
 				oldV, err := sessVars.SetSystemVarWithOldValAsRet(name, val)

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -216,12 +216,12 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	}()
 
 	// The SkipPlanCache function doesn't work until EnablePlanCache() is called in GetPlanFromPlanCache.
-	skip_non_prepared_cache := false
+	skipNonPreparedCache := false
 
 	// Disable the plan cache to prevent running the code above twice.
 	if sessVars.StmtCtx.StmtHints.HasResourceGroup {
 		sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL")
-		skip_non_prepared_cache = true
+		skipNonPreparedCache = true
 	}
 
 	warns = warns[:0]
@@ -235,7 +235,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	// Disable the plan cache to prevent running the code above twice.
 	if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
 		sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
-		skip_non_prepared_cache = true
+		skipNonPreparedCache = true
 	}
 
 	if _, isolationReadContainTiKV := sessVars.IsolationReadEngines[kv.TiKV]; isolationReadContainTiKV {
@@ -266,7 +266,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	if sessVars.EnableNonPreparedPlanCache &&
 		isStmtNode &&
 		!useBinding && // TODO: support binding
-		!skip_non_prepared_cache {
+		!skipNonPreparedCache {
 		cachedPlan, names, ok, err := getPlanFromNonPreparedPlanCache(ctx, sctx, stmtNode, is)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -294,6 +294,11 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 				setVarHintChecker, hypoIndexChecker(ctx, is),
 				sessVars.CurrentDB, byte(kv.ReplicaReadFollower))
 			sessVars.StmtCtx.StmtHints = curStmtHints
+
+			if sessVars.StmtCtx.StmtHints.HasResourceGroup {
+				sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL")
+			}
+
 			// update session var by hint /set_var/
 			if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
 				sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
@@ -305,6 +310,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 				}
 				sessVars.StmtCtx.AddSetVarHintRestore(name, oldV)
 			}
+
 			plan, curNames, _, err := optimize(ctx, pctx, node, is)
 			if err != nil {
 				sessVars.StmtCtx.AppendWarning(errors.Errorf("binding %s failed: %v", binding.BindSQL, err))

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -232,7 +232,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 		}
 		sessVars.StmtCtx.AddSetVarHintRestore(name, oldV)
 	}
-	// Disable the plan cache to prevent running the code above twice.
+	// Setting skipNonPreparedCache to true to prevent running the code above twice.
 	if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
 		sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
 		skipNonPreparedCache = true

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -865,7 +865,7 @@ select /*+ use_index(t, a) */ * from t where a=1;
 a
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-0
+1
 select * from t where a=1;
 a
 select * from t where a=1;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60920

Problem Summary:

The non-prepared plan cache does not presently support queries with hints.

### What changed and how does it work?

This pull request:
 * enables the non-prepared plan cache for queries with all hint types except for RESOURCE_GROUP and SET_VAR,
 * disables prepared plan cache for queries with the RESOURCE_GROUP hints,
 * disables the caching of queries with bindings that use SET_VAR hints.
 * makes minor improvements to TestPlanCacheRandomCases in pkg/planner/core/plan_cache_test.go
 * adds a test (TestNonPreparedPlanSupportsHints) to validate that SELECT queries with hints are cached.
 * and patches the tests in plan_cacheable_checker_test.go for the changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
