### PR TITLE
planner: fix union scan should convert child to be root task type first then we can do the pattern assert 

### DIFF
--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -119,31 +119,34 @@ func (t *CopTask) getStoreType() kv.StoreType {
 
 // Attach2Task implements PhysicalPlan interface.
 func (p *PhysicalUnionScan) Attach2Task(tasks ...base.Task) base.Task {
+	// when it arrives here, physical union scan will absolutely require a root task type,
+	// so convert child to root task type first.
+	task := tasks[0].ConvertToRootTask(p.SCtx())
 	// We need to pull the projection under unionScan upon unionScan.
 	// Since the projection only prunes columns, it's ok the put it upon unionScan.
-	if sel, ok := tasks[0].Plan().(*PhysicalSelection); ok {
+	if sel, ok := task.Plan().(*PhysicalSelection); ok {
 		if pj, ok := sel.Children()[0].(*PhysicalProjection); ok {
 			// Convert unionScan->selection->projection to projection->unionScan->selection.
 			sel.SetChildren(pj.Children()...)
 			p.SetChildren(sel)
-			p.SetStats(tasks[0].Plan().StatsInfo())
-			rt, _ := tasks[0].(*RootTask)
+			p.SetStats(task.Plan().StatsInfo())
+			rt, _ := task.(*RootTask)
 			rt.SetPlan(p)
 			pj.SetChildren(p)
-			return pj.Attach2Task(tasks...)
+			return pj.Attach2Task(task)
 		}
 	}
-	if pj, ok := tasks[0].Plan().(*PhysicalProjection); ok {
+	if pj, ok := task.Plan().(*PhysicalProjection); ok {
 		// Convert unionScan->projection to projection->unionScan, because unionScan can't handle projection as its children.
 		p.SetChildren(pj.Children()...)
-		p.SetStats(tasks[0].Plan().StatsInfo())
-		rt, _ := tasks[0].(*RootTask)
+		p.SetStats(task.Plan().StatsInfo())
+		rt, _ := task.(*RootTask)
 		rt.SetPlan(pj.Children()[0])
 		pj.SetChildren(p)
-		return pj.Attach2Task(p.BasePhysicalPlan.Attach2Task(tasks...))
+		return pj.Attach2Task(p.BasePhysicalPlan.Attach2Task(task))
 	}
-	p.SetStats(tasks[0].Plan().StatsInfo())
-	return p.BasePhysicalPlan.Attach2Task(tasks...)
+	p.SetStats(task.Plan().StatsInfo())
+	return p.BasePhysicalPlan.Attach2Task(task)
 }
 
 // Attach2Task implements PhysicalPlan interface.

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -148,7 +148,7 @@ func (p *PhysicalUnionScan) Attach2Task(tasks ...base.Task) base.Task {
 	p.SetStats(task.Plan().StatsInfo())
 	// once task is copTask type here, it may be converted proj + tablePlan here.
 	// then when it's connected with union-scan here, we may get as: union-scan + proj + tablePlan
-	// while proj is not allowed to be built under uinon-scan in execution layer currently.
+	// while proj is not allowed to be built under union-scan in execution layer currently.
 	return p.BasePhysicalPlan.Attach2Task(task)
 }
 

--- a/pkg/planner/core/task.go
+++ b/pkg/planner/core/task.go
@@ -146,6 +146,9 @@ func (p *PhysicalUnionScan) Attach2Task(tasks ...base.Task) base.Task {
 		return pj.Attach2Task(p.BasePhysicalPlan.Attach2Task(task))
 	}
 	p.SetStats(task.Plan().StatsInfo())
+	// once task is copTask type here, it may be converted proj + tablePlan here.
+	// then when it's connected with union-scan here, we may get as: union-scan + proj + tablePlan
+	// while proj is not allowed to be built under uinon-scan in execution layer currently.
 	return p.BasePhysicalPlan.Attach2Task(task)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/60106

Problem Summary:

### What changed and how does it work?
As said in the title, union scan should convert the child to be the root task type first, then we can do the pattern assert, such as pull the project above the union-scan itself.
But once the task is cop type here, it may be converted as proj + tablePlan here, then when it's attached with union-scan here, we may get as: union-scan + proj + tablePlan, and miss the proj pullup action in the code change, while proj is not allowed to be built under union-scan in the execution layer currently.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
