### PR TITLE
br: replace stats tables to accelerate statistic data import in the snapshot restore

### DIFF
--- a/br/pkg/restore/snap_client/BUILD.bazel
+++ b/br/pkg/restore/snap_client/BUILD.bazel
@@ -92,7 +92,7 @@ go_test(
     ],
     embed = [":snap_client"],
     flaky = True,
-    shard_count = 26,
+    shard_count = 31,
     deps = [
         "//br/pkg/errors",
         "//br/pkg/glue",
@@ -108,6 +108,7 @@ go_test(
         "//br/pkg/utils",
         "//pkg/domain",
         "//pkg/kv",
+        "//pkg/meta",
         "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/parser/mysql",

--- a/br/pkg/restore/snap_client/client_test.go
+++ b/br/pkg/restore/snap_client/client_test.go
@@ -35,6 +35,8 @@ import (
 	importclient "github.com/pingcap/tidb/br/pkg/restore/internal/import_client"
 	snapclient "github.com/pingcap/tidb/br/pkg/restore/snap_client"
 	"github.com/pingcap/tidb/br/pkg/restore/split"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -393,4 +395,98 @@ func createTestTable(schemaID, tableID int64) *metautil.Table {
 		DB:   dbInfo,
 		Info: tableInfo,
 	}
+}
+
+func generateMetautilTable(dbName string, tableID int64, partitionIDs ...int64) *metautil.Table {
+	var partition *model.PartitionInfo
+	if len(partitionIDs) > 0 {
+		partition := &model.PartitionInfo{
+			Definitions: make([]model.PartitionDefinition, 0, len(partitionIDs)),
+		}
+		for _, partitionID := range partitionIDs {
+			partition.Definitions = append(partition.Definitions, model.PartitionDefinition{
+				ID: partitionID,
+			})
+		}
+	}
+	return &metautil.Table{
+		DB: &model.DBInfo{
+			Name: ast.NewCIStr(dbName),
+		},
+		Info: &model.TableInfo{
+			ID:        tableID,
+			Partition: partition,
+		},
+	}
+}
+
+func TestAllocTableIDs(t *testing.T) {
+	// cannot use shared `mc`, other parallel case may change it.
+	cluster := getStartedMockedCluster(t)
+	defer cluster.Stop()
+
+	g := gluetidb.New()
+	client := snapclient.NewRestoreClient(cluster.PDClient, cluster.PDHTTPCli, nil, split.DefaultTestKeepaliveCfg)
+	err := client.InitConnections(g, cluster.Storage)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	globalID := int64(0)
+	err = kv.RunInNewTxn(ctx, cluster.Storage, true, func(_ context.Context, txn kv.Transaction) error {
+		id, err := meta.NewMutator(txn).AdvanceGlobalIDs(1000)
+		globalID = id + 1000
+		return err
+	})
+	require.NoError(t, err)
+	err = client.AllocTableIDs(ctx, []*metautil.Table{
+		generateMetautilTable("mysql", globalID-1),
+		generateMetautilTable("__TiDB_BR_Temporary_mysql", globalID-2),
+		generateMetautilTable("mysql", globalID-3),
+		generateMetautilTable("__TiDB_BR_Temporary_mysql", globalID-4),
+	}, true)
+	require.NoError(t, err)
+	err = kv.RunInNewTxn(ctx, cluster.Storage, true, func(_ context.Context, txn kv.Transaction) error {
+		id, err := meta.NewMutator(txn).AdvanceGlobalIDs(1000)
+		globalID = id + 1000
+		return err
+	})
+	require.NoError(t, err)
+	err = client.AllocTableIDs(ctx, []*metautil.Table{
+		generateMetautilTable("mysql", globalID-1, globalID+1),
+		generateMetautilTable("test", globalID+2, globalID+3),
+	}, true)
+	require.NoError(t, err)
+	err = kv.RunInNewTxn(ctx, cluster.Storage, true, func(_ context.Context, txn kv.Transaction) error {
+		id, err := meta.NewMutator(txn).AdvanceGlobalIDs(1000)
+		globalID = id + 1000
+		return err
+	})
+	require.NoError(t, err)
+	err = client.AllocTableIDs(ctx, []*metautil.Table{
+		generateMetautilTable("mysql", globalID-1, globalID+1),
+		generateMetautilTable("test", globalID+2, globalID),
+		generateMetautilTable("test2", globalID+3, globalID+4),
+	}, true)
+	require.Error(t, err)
+}
+
+func TestGetMinUserTableID(t *testing.T) {
+	minUserTableID := snapclient.GetMinUserTableID([]*metautil.Table{
+		generateMetautilTable("mysql", 1),
+		generateMetautilTable("__TiDB_BR_Temporary_mysql", 2),
+		generateMetautilTable("mysql", 4),
+		generateMetautilTable("__TiDB_BR_Temporary_mysql", 3),
+	})
+	require.Equal(t, int64(math.MaxInt64), minUserTableID)
+	minUserTableID = snapclient.GetMinUserTableID([]*metautil.Table{
+		generateMetautilTable("mysql", 3, 1),
+		generateMetautilTable("test", 4, 6),
+	})
+	require.Equal(t, int64(3), minUserTableID)
+	minUserTableID = snapclient.GetMinUserTableID([]*metautil.Table{
+		generateMetautilTable("mysql", 4, 1),
+		generateMetautilTable("test", 3, 2),
+		generateMetautilTable("test2", 5, 6),
+	})
+	require.Equal(t, int64(2), minUserTableID)
 }

--- a/br/pkg/restore/snap_client/export_test.go
+++ b/br/pkg/restore/snap_client/export_test.go
@@ -40,6 +40,7 @@ var (
 	GetKeyRangeByMode       = getKeyRangeByMode
 	GetFileRangeKey         = getFileRangeKey
 	GetSortedPhysicalTables = getSortedPhysicalTables
+	GetMinUserTableID       = getMinUserTableID
 )
 
 // MockClient create a fake Client used to test.
@@ -85,7 +86,7 @@ func (rc *SnapClient) CreateTablesTest(
 	for i, t := range tables {
 		tbMapping[t.Info.Name.String()] = i
 	}
-	rc.AllocTableIDs(context.Background(), tables)
+	rc.AllocTableIDs(context.Background(), tables, false)
 	createdTables, err := rc.CreateTables(context.TODO(), tables, newTS)
 	if err != nil {
 		return nil, nil, err

--- a/br/pkg/utils/schema.go
+++ b/br/pkg/utils/schema.go
@@ -57,7 +57,7 @@ func StripTempDBPrefixIfNeeded(tempDB string) (string, bool) {
 
 // IsSysOrTempSysDB tests whether the database is system DB or prefixed with temp.
 func IsSysOrTempSysDB(db string) bool {
-	if name, ok := StripTempDBPrefixIfNeeded(db); IsSysDB(name) && ok {
+	if name, ok := StripTempDBPrefixIfNeeded(db); ok || IsSysDB(name) {
 		return true
 	}
 	return false

--- a/pkg/executor/brie.go
+++ b/pkg/executor/brie.go
@@ -370,11 +370,13 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 			cfg.FilterStr = append(cfg.FilterStr, table.String())
 		}
 		cfg.TableFilter = filter.NewTablesFilter(tables...)
+		cfg.ExplicitFilter = true
 	case len(s.Schemas) != 0:
 		cfg.TableFilter = filter.NewSchemasFilter(s.Schemas...)
 		for _, schema := range s.Schemas {
 			cfg.FilterStr = append(cfg.FilterStr, fmt.Sprintf("`%s`.*", schema))
 		}
+		cfg.ExplicitFilter = true
 	default:
 		cfg.TableFilter = filter.All()
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60930

Problem Summary:
It is slow to import statistic data.
### What changed and how does it work?
introduce the parameter `--load-stats-physical` to move the statistic system tables
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Introduce the parameter `--load-stats-physical` to move the statistic system tables.
```
