### PR TITLE
planner: add brief format for explain for connection statement

### DIFF
--- a/pkg/executor/explainfor_test.go
+++ b/pkg/executor/explainfor_test.go
@@ -295,12 +295,12 @@ func TestPointGetUserVarPlanCache(t *testing.T) {
 	tkProcess := tk.Session().ShowProcess()
 	ps := []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use idx_a
-		`Projection_9 10.00 root  test.t1.a, test.t1.b, test.t2.a, test.t2.b`,
-		`└─HashJoin_11 10.00 root  CARTESIAN inner join`,
-		`  ├─Point_Get_12(Build) 1.00 root table:t2, index:idx_a(a) `, // use idx_a
-		`  └─TableReader_14(Probe) 10.00 root  data:TableRangeScan_13`,
-		`    └─TableRangeScan_13 10.00 cop[tikv] table:t1 range:[1,1], keep order:false, stats:pseudo`))
+	tk.MustQuery(fmt.Sprintf("explain format='brief' for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use idx_a
+		`Projection 10.00 root  test.t1.a, test.t1.b, test.t2.a, test.t2.b`,
+		`└─HashJoin 10.00 root  CARTESIAN inner join`,
+		`  ├─Point_Get(Build) 1.00 root table:t2, index:idx_a(a) `, // use idx_a
+		`  └─TableReader(Probe) 10.00 root  data:TableRangeScan`,
+		`    └─TableRangeScan 10.00 cop[tikv] table:t1 range:[1,1], keep order:false, stats:pseudo`))
 
 	tk.MustExec("set @a=2")
 	tk.MustQuery("execute stmt using @a").Check(testkit.Rows(
@@ -309,12 +309,12 @@ func TestPointGetUserVarPlanCache(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use idx_a
-		`Projection_9 10.00 root  test.t1.a, test.t1.b, test.t2.a, test.t2.b`,
-		`└─HashJoin_11 10.00 root  CARTESIAN inner join`,
-		`  ├─Point_Get_12(Build) 1.00 root table:t2, index:idx_a(a) `,
-		`  └─TableReader_14(Probe) 10.00 root  data:TableRangeScan_13`,
-		`    └─TableRangeScan_13 10.00 cop[tikv] table:t1 range:[2,2], keep order:false, stats:pseudo`))
+	tk.MustQuery(fmt.Sprintf("explain format='brief' for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use idx_a
+		`Projection 10.00 root  test.t1.a, test.t1.b, test.t2.a, test.t2.b`,
+		`└─HashJoin 10.00 root  CARTESIAN inner join`,
+		`  ├─Point_Get_(Build) 1.00 root table:t2, index:idx_a(a) `,
+		`  └─TableReader(Probe) 10.00 root  data:TableRangeScan`,
+		`    └─TableRangeScan 10.00 cop[tikv] table:t1 range:[2,2], keep order:false, stats:pseudo`))
 	tk.MustQuery("execute stmt using @a").Check(testkit.Rows(
 		"2 4 2 2",
 	))

--- a/pkg/executor/prepared_test.go
+++ b/pkg/executor/prepared_test.go
@@ -91,11 +91,11 @@ func TestIssue29850(t *testing.T) {
 	tkProcess := tk.Session().ShowProcess()
 	ps := []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use PointGet
-		`Projection_7 0.00 root  test.customer.c_discount, test.customer.c_last, test.customer.c_credit, test.warehouse.w_tax`,
-		`└─HashJoin_8 0.00 root  CARTESIAN inner join`,
-		`  ├─Point_Get_11(Build) 1.00 root table:warehouse handle:1262`,
-		`  └─Point_Get_10(Probe) 1.00 root table:customer, clustered index:PRIMARY(c_w_id, c_d_id, c_id) `))
+	tk.MustQuery(fmt.Sprintf("explain format='brief' for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use PointGet
+		`Projection 0.00 root  test.customer.c_discount, test.customer.c_last, test.customer.c_credit, test.warehouse.w_tax`,
+		`└─HashJoin 0.00 root  CARTESIAN inner join`,
+		`  ├─Point_Get(Build) 1.00 root table:warehouse handle:1262`,
+		`  └─Point_Get(Probe) 1.00 root table:customer, clustered index:PRIMARY(c_w_id, c_d_id, c_id) `))
 	tk.MustQuery(`execute stmt using @w_id, @c_d_id, @c_id`).Check(testkit.Rows())
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // can use the cached plan
 
@@ -117,8 +117,8 @@ func TestIssue29850(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows( // cannot use PointGet since it contains a or condition
-		`Point_Get_5 1.00 root table:t handle:1`))
+	tk.MustQuery(fmt.Sprintf("explain format='brief' for connection %d", tkProcess.ID)).Check(testkit.Rows( // cannot use PointGet since it contains a or condition
+		`Point_Get 1.00 root table:t handle:1`))
 	tk.MustQuery(`execute stmt using @a1, @a2`).Check(testkit.Rows("1", "2"))
 }
 
@@ -794,11 +794,11 @@ func TestIssue29101(t *testing.T) {
 	tkProcess := tk.Session().ShowProcess()
 	ps := []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use PK
-		`Projection_6 1.00 root  test.customer.c_discount, test.customer.c_last, test.customer.c_credit, test.warehouse.w_tax`,
-		`└─HashJoin_7 1.00 root  CARTESIAN inner join`,
-		`  ├─Point_Get_10(Build) 1.00 root table:warehouse handle:936`,
-		`  └─Point_Get_9(Probe) 1.00 root table:customer, index:PRIMARY(c_w_id, c_d_id, c_id) `))
+	tk.MustQuery(fmt.Sprintf("explain format='brief' for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use PK
+		`Projection 1.00 root  test.customer.c_discount, test.customer.c_last, test.customer.c_credit, test.warehouse.w_tax`,
+		`└─HashJoin 1.00 root  CARTESIAN inner join`,
+		`  ├─Point_Get(Build) 1.00 root table:warehouse handle:936`,
+		`  └─Point_Get(Probe) 1.00 root table:customer, index:PRIMARY(c_w_id, c_d_id, c_id) `))
 	tk.MustQuery(`execute s1 using @a,@b,@c`).Check(testkit.Rows())
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // can use the plan-cache
 
@@ -820,16 +820,16 @@ func TestIssue29101(t *testing.T) {
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}
 	tk.Session().SetSessionManager(&testkit.MockSessionManager{PS: ps})
-	tk.MustQuery(fmt.Sprintf("explain for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use index-join
-		`StreamAgg_9 1.00 root  funcs:count(distinct test.stock.s_i_id)->Column#11`,
-		`└─IndexJoin_14 0.03 root  inner join, inner:IndexLookUp_13, outer key:test.order_line.ol_i_id, inner key:test.stock.s_i_id, equal cond:eq(test.order_line.ol_i_id, test.stock.s_i_id)`,
-		`  ├─IndexLookUp_25(Build) 0.03 root  `,
-		`  │ ├─IndexRangeScan_23(Build) 0.03 cop[tikv] table:order_line, index:PRIMARY(ol_w_id, ol_d_id, ol_o_id, ol_number) range:[391 1 3038,391 1 3058), keep order:false, stats:pseudo`,
-		`  │ └─TableRowIDScan_24(Probe) 0.03 cop[tikv] table:order_line keep order:false, stats:pseudo`,
-		`  └─IndexLookUp_13(Probe) 0.03 root  `,
-		`    ├─IndexRangeScan_10(Build) 0.03 cop[tikv] table:stock, index:PRIMARY(s_w_id, s_i_id) range: decided by [eq(test.stock.s_i_id, test.order_line.ol_i_id) eq(test.stock.s_w_id, 391)], keep order:false, stats:pseudo`,
-		`    └─Selection_12(Probe) 0.03 cop[tikv]  lt(test.stock.s_quantity, 18)`,
-		`      └─TableRowIDScan_11 0.03 cop[tikv] table:stock keep order:false, stats:pseudo`))
+	tk.MustQuery(fmt.Sprintf("explain format='brief' for connection %d", tkProcess.ID)).Check(testkit.Rows( // can use index-join
+		`StreamAgg 1.00 root  funcs:count(distinct test.stock.s_i_id)->Column#11`,
+		`└─IndexJoin 0.03 root  inner join, inner:IndexLookUp, outer key:test.order_line.ol_i_id, inner key:test.stock.s_i_id, equal cond:eq(test.order_line.ol_i_id, test.stock.s_i_id)`,
+		`  ├─IndexLookUp(Build) 0.03 root  `,
+		`  │ ├─IndexRangeScan(Build) 0.03 cop[tikv] table:order_line, index:PRIMARY(ol_w_id, ol_d_id, ol_o_id, ol_number) range:[391 1 3038,391 1 3058), keep order:false, stats:pseudo`,
+		`  │ └─TableRowIDScan(Probe) 0.03 cop[tikv] table:order_line keep order:false, stats:pseudo`,
+		`  └─IndexLookUp(Probe) 0.03 root  `,
+		`    ├─IndexRangeScan(Build) 0.03 cop[tikv] table:stock, index:PRIMARY(s_w_id, s_i_id) range: decided by [eq(test.stock.s_i_id, test.order_line.ol_i_id) eq(test.stock.s_w_id, 391)], keep order:false, stats:pseudo`,
+		`    └─Selection(Probe) 0.03 cop[tikv]  lt(test.stock.s_quantity, 18)`,
+		`      └─TableRowIDScan 0.03 cop[tikv] table:stock keep order:false, stats:pseudo`))
 	tk.MustExec(`execute s1 using @a,@b,@c,@c,@a,@d`)
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1")) // can use the plan-cache
 }

--- a/pkg/executor/select.go
+++ b/pkg/executor/select.go
@@ -1034,6 +1034,9 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	if explainForStmt, ok := s.(*ast.ExplainForStmt); ok {
 		sc.InExplainStmt = true
 		sc.InExplainAnalyzeStmt = true
+		// explain for only fetch other stored ExplainRows from another session in the process list, which
+		// is already stored as ExplainFormatRow with explain id inside. But we can do some trimming for those
+		// stored strings when showing. No need to change IgnoreExplainIDSuffix here.
 		sc.InVerboseExplain = strings.ToLower(explainForStmt.Format) == types.ExplainFormatVerbose
 	}
 

--- a/pkg/planner/core/testdata/runtime_filter_generator_suite_in.json
+++ b/pkg/planner/core/testdata/runtime_filter_generator_suite_in.json
@@ -2,20 +2,20 @@
   {
     "Name": "TestRuntimeFilterGenerator",
     "Cases": [
-      "select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1 and t2.k2 = 1",
+      "format='brief' select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1 and t2.k2 = 1",
       "format='brief' select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1 and t1.k1=t2.k2",
-      "select /*+ shuffle_join(t1, t2) */ * from t1, t2 where t1.k1=t2.k1; -- Global doesn't support",
-      "select /*+ broadcast_join(t2, t1), hash_join_build(t2) */ * from t2, (select k1 from t1 group by k1) t1 where t1.k1=t2.k1; -- Global doesn't support",
-      "select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1; -- t1 is build side",
-      "select * from t1_tikv as t1, t2 where t1.k1=t2.k1; -- Doesn't support hash join in root",
+      "format='brief' select /*+ shuffle_join(t1, t2) */ * from t1, t2 where t1.k1=t2.k1; -- Global doesn't support",
+      "format='brief' select /*+ broadcast_join(t2, t1), hash_join_build(t2) */ * from t2, (select k1 from t1 group by k1) t1 where t1.k1=t2.k1; -- Global doesn't support",
+      "format='brief' select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1; -- t1 is build side",
+      "format='brief' select * from t1_tikv as t1, t2 where t1.k1=t2.k1; -- Doesn't support hash join in root",
       "format='brief' select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1, t2 where t1.k1+1=t2.k1; -- Support transform src expression t1.k1+1",
       "format='brief' select /*+ broadcast_join(t2, t1), hash_join_build(t2) */ * from t2, (select k1, k1+1 as k11 from t1) t1 where t1.k1=t2.k1; -- Only support origin column k1",
-      "select /*+ hash_join_build(t2) */ * from t2, (select k1, k1+1 as k11 from t1) t1 where t1.k11=t2.k1; -- Doesn't support transform column k11",
+      "format='brief' select /*+ hash_join_build(t2) */ * from t2, (select k1, k1+1 as k11 from t1) t1 where t1.k11=t2.k1; -- Doesn't support transform column k11",
       "format='brief' select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1+1; -- Doesn't support target expression t2.k1+1",
       "format='brief' select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1 right join t2 on t1.k1=t2.k1; -- t2 side couldn't be RF target side, no RF",
     // TO-DO reinstate flaky test that was removed to support enabling fix control 46177 
     // "format='brief' select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1 where t1.k1 not in (select k1 from t2); -- RF could not push to t2 because of anti join",
-      "select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1<=>t2.k1; -- Doesn't support null safe eq predicate"
+      "format='brief' select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1<=>t2.k1; -- Doesn't support null safe eq predicate"
     ]
   }
 ]

--- a/pkg/planner/core/testdata/runtime_filter_generator_suite_out.json
+++ b/pkg/planner/core/testdata/runtime_filter_generator_suite_out.json
@@ -3,17 +3,17 @@
     "Name": "TestRuntimeFilterGenerator",
     "Cases": [
       {
-        "SQL": "select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1 and t2.k2 = 1",
+        "SQL": "format='brief' select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1 and t2.k2 = 1",
         "Plan": [
-          "TableReader_32 1.00 root  MppVersion: 3, data:ExchangeSender_31",
-          "└─ExchangeSender_31 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─HashJoin_24 1.00 mpp[tiflash]  inner join, equal:[eq(test.t1.k1, test.t2.k1)], runtime filter:0[IN] <- test.t1.k1",
-          "    ├─ExchangeReceiver_28(Build) 1.00 mpp[tiflash]  ",
-          "    │ └─ExchangeSender_27 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
-          "    │   └─Selection_26 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
-          "    │     └─TableFullScan_25 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false",
-          "    └─Selection_30(Probe) 1.00 mpp[tiflash]  eq(test.t2.k2, 1), not(isnull(test.t2.k1))",
-          "      └─TableFullScan_29 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false, runtime filter:0[IN] -> test.t2.k1"
+          "TableReader 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin 1.00 mpp[tiflash]  inner join, equal:[eq(test.t1.k1, test.t2.k1)], runtime filter:0[IN] <- test.t1.k1",
+          "    ├─ExchangeReceiver(Build) 1.00 mpp[tiflash]  ",
+          "    │ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "    │   └─Selection 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
+          "    │     └─TableFullScan 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false",
+          "    └─Selection(Probe) 1.00 mpp[tiflash]  eq(test.t2.k2, 1), not(isnull(test.t2.k1))",
+          "      └─TableFullScan 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false, runtime filter:0[IN] -> test.t2.k1"
         ]
       },
       {
@@ -31,64 +31,64 @@
         ]
       },
       {
-        "SQL": "select /*+ shuffle_join(t1, t2) */ * from t1, t2 where t1.k1=t2.k1; -- Global doesn't support",
+        "SQL": "format='brief' select /*+ shuffle_join(t1, t2) */ * from t1, t2 where t1.k1=t2.k1; -- Global doesn't support",
         "Plan": [
-          "TableReader_21 1.00 root  MppVersion: 3, data:ExchangeSender_20",
-          "└─ExchangeSender_20 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─HashJoin_19 1.00 mpp[tiflash]  inner join, equal:[eq(test.t1.k1, test.t2.k1)]",
-          "    ├─ExchangeReceiver_12(Build) 1.00 mpp[tiflash]  ",
-          "    │ └─ExchangeSender_11 1.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.k1, collate: binary]",
-          "    │   └─Selection_10 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
-          "    │     └─TableFullScan_9 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false",
-          "    └─ExchangeReceiver_16(Probe) 1.00 mpp[tiflash]  ",
-          "      └─ExchangeSender_15 1.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t2.k1, collate: binary]",
-          "        └─Selection_14 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
-          "          └─TableFullScan_13 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false"
+          "TableReader 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin 1.00 mpp[tiflash]  inner join, equal:[eq(test.t1.k1, test.t2.k1)]",
+          "    ├─ExchangeReceiver(Build) 1.00 mpp[tiflash]  ",
+          "    │ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.k1, collate: binary]",
+          "    │   └─Selection 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
+          "    │     └─TableFullScan 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false",
+          "    └─ExchangeReceiver(Probe) 1.00 mpp[tiflash]  ",
+          "      └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t2.k1, collate: binary]",
+          "        └─Selection 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
+          "          └─TableFullScan 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false"
         ]
       },
       {
-        "SQL": "select /*+ broadcast_join(t2, t1), hash_join_build(t2) */ * from t2, (select k1 from t1 group by k1) t1 where t1.k1=t2.k1; -- Global doesn't support",
+        "SQL": "format='brief' select /*+ broadcast_join(t2, t1), hash_join_build(t2) */ * from t2, (select k1 from t1 group by k1) t1 where t1.k1=t2.k1; -- Global doesn't support",
         "Plan": [
-          "TableReader_32 1.00 root  MppVersion: 3, data:ExchangeSender_31",
-          "└─ExchangeSender_31 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─HashJoin_30 1.00 mpp[tiflash]  inner join, equal:[eq(test.t2.k1, test.t1.k1)]",
-          "    ├─ExchangeReceiver_14(Build) 1.00 mpp[tiflash]  ",
-          "    │ └─ExchangeSender_13 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
-          "    │   └─Selection_12 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
-          "    │     └─TableFullScan_11 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false",
-          "    └─Projection_21(Probe) 1.00 mpp[tiflash]  test.t1.k1",
-          "      └─HashAgg_15 1.00 mpp[tiflash]  group by:test.t1.k1, funcs:firstrow(test.t1.k1)->test.t1.k1",
-          "        └─ExchangeReceiver_20 1.00 mpp[tiflash]  ",
-          "          └─ExchangeSender_19 1.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.k1, collate: binary]",
-          "            └─Selection_18 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
-          "              └─TableFullScan_17 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false"
+          "TableReader 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin 1.00 mpp[tiflash]  inner join, equal:[eq(test.t2.k1, test.t1.k1)]",
+          "    ├─ExchangeReceiver(Build) 1.00 mpp[tiflash]  ",
+          "    │ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "    │   └─Selection 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
+          "    │     └─TableFullScan 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false",
+          "    └─Projection(Probe) 1.00 mpp[tiflash]  test.t1.k1",
+          "      └─HashAgg 1.00 mpp[tiflash]  group by:test.t1.k1, funcs:firstrow(test.t1.k1)->test.t1.k1",
+          "        └─ExchangeReceiver 1.00 mpp[tiflash]  ",
+          "          └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.t1.k1, collate: binary]",
+          "            └─Selection 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
+          "              └─TableFullScan 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false"
         ]
       },
       {
-        "SQL": "select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1; -- t1 is build side",
+        "SQL": "format='brief' select /*+ broadcast_join(t1, t2), hash_join_build(t1) */ * from t1, t2 where t1.k1=t2.k1; -- t1 is build side",
         "Plan": [
-          "TableReader_19 1.00 root  MppVersion: 3, data:ExchangeSender_18",
-          "└─ExchangeSender_18 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─HashJoin_17 1.00 mpp[tiflash]  inner join, equal:[eq(test.t1.k1, test.t2.k1)], runtime filter:0[IN] <- test.t1.k1",
-          "    ├─ExchangeReceiver_12(Build) 1.00 mpp[tiflash]  ",
-          "    │ └─ExchangeSender_11 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
-          "    │   └─Selection_10 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
-          "    │     └─TableFullScan_9 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false",
-          "    └─Selection_14(Probe) 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
-          "      └─TableFullScan_13 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false, runtime filter:0[IN] -> test.t2.k1"
+          "TableReader 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin 1.00 mpp[tiflash]  inner join, equal:[eq(test.t1.k1, test.t2.k1)], runtime filter:0[IN] <- test.t1.k1",
+          "    ├─ExchangeReceiver(Build) 1.00 mpp[tiflash]  ",
+          "    │ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "    │   └─Selection 1.00 mpp[tiflash]  not(isnull(test.t1.k1))",
+          "    │     └─TableFullScan 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false",
+          "    └─Selection(Probe) 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
+          "      └─TableFullScan 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false, runtime filter:0[IN] -> test.t2.k1"
         ]
       },
       {
-        "SQL": "select * from t1_tikv as t1, t2 where t1.k1=t2.k1; -- Doesn't support hash join in root",
+        "SQL": "format='brief' select * from t1_tikv as t1, t2 where t1.k1=t2.k1; -- Doesn't support hash join in root",
         "Plan": [
-          "HashJoin_7 1.25 root  inner join, equal:[eq(test.t1_tikv.k1, test.t2.k1)]",
-          "├─TableReader_18(Build) 1.00 root  MppVersion: 3, data:ExchangeSender_17",
-          "│ └─ExchangeSender_17 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "│   └─Selection_16 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
-          "│     └─TableFullScan_15 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false",
-          "└─TableReader_11(Probe) 9990.00 root  data:Selection_10",
-          "  └─Selection_10 9990.00 cop[tikv]  not(isnull(test.t1_tikv.k1))",
-          "    └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "HashJoin 1.25 root  inner join, equal:[eq(test.t1_tikv.k1, test.t2.k1)]",
+          "├─TableReader(Build) 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "│ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "│   └─Selection 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
+          "│     └─TableFullScan 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false",
+          "└─TableReader(Probe) 9990.00 root  data:Selection",
+          "  └─Selection 9990.00 cop[tikv]  not(isnull(test.t1_tikv.k1))",
+          "    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ]
       },
       {
@@ -121,18 +121,18 @@
         ]
       },
       {
-        "SQL": "select /*+ hash_join_build(t2) */ * from t2, (select k1, k1+1 as k11 from t1) t1 where t1.k11=t2.k1; -- Doesn't support transform column k11",
+        "SQL": "format='brief' select /*+ hash_join_build(t2) */ * from t2, (select k1, k1+1 as k11 from t1) t1 where t1.k11=t2.k1; -- Doesn't support transform column k11",
         "Plan": [
-          "TableReader_38 0.80 root  MppVersion: 3, data:ExchangeSender_37",
-          "└─ExchangeSender_37 0.80 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─HashJoin_31 0.80 mpp[tiflash]  inner join, equal:[eq(test.t2.k1, Column#7)]",
-          "    ├─ExchangeReceiver_35(Build) 1.00 mpp[tiflash]  ",
-          "    │ └─ExchangeSender_34 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
-          "    │   └─Selection_33 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
-          "    │     └─TableFullScan_32 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false",
-          "    └─Projection_36(Probe) 0.80 mpp[tiflash]  test.t1.k1, plus(test.t1.k1, 1)->Column#7",
-          "      └─Selection_28 0.80 mpp[tiflash]  not(isnull(plus(test.t1.k1, 1)))",
-          "        └─TableFullScan_27 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false"
+          "TableReader 0.80 root  MppVersion: 3, data:ExchangeSender",
+          "└─ExchangeSender 0.80 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin 0.80 mpp[tiflash]  inner join, equal:[eq(test.t2.k1, Column#7)]",
+          "    ├─ExchangeReceiver(Build) 1.00 mpp[tiflash]  ",
+          "    │ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: Broadcast, Compression: FAST",
+          "    │   └─Selection 1.00 mpp[tiflash]  not(isnull(test.t2.k1))",
+          "    │     └─TableFullScan 1.00 mpp[tiflash] table:t2 pushed down filter:empty, keep order:false",
+          "    └─Projection(Probe) 0.80 mpp[tiflash]  test.t1.k1, plus(test.t1.k1, 1)->Column#7",
+          "      └─Selection 0.80 mpp[tiflash]  not(isnull(plus(test.t1.k1, 1)))",
+          "        └─TableFullScan 1.00 mpp[tiflash] table:t1 pushed down filter:empty, keep order:false"
         ]
       },
       {
@@ -163,15 +163,15 @@
         ]
       },
       {
-        "SQL": "select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1<=>t2.k1; -- Doesn't support null safe eq predicate",
+        "SQL": "format='brief' select /*+ hash_join_build(t1) */ * from t1, t2 where t1.k1<=>t2.k1; -- Doesn't support null safe eq predicate",
         "Plan": [
-          "HashJoin_8 1.00 root  inner join, equal:[nulleq(test.t1.k1, test.t2.k1)]",
-          "├─TableReader_13(Build) 1.00 root  MppVersion: 3, data:ExchangeSender_12",
-          "│ └─ExchangeSender_12 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "│   └─TableFullScan_11 1.00 mpp[tiflash] table:t1 keep order:false",
-          "└─TableReader_18(Probe) 1.00 root  MppVersion: 3, data:ExchangeSender_17",
-          "  └─ExchangeSender_17 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─TableFullScan_16 1.00 mpp[tiflash] table:t2 keep order:false"
+          "HashJoin 1.00 root  inner join, equal:[nulleq(test.t1.k1, test.t2.k1)]",
+          "├─TableReader(Build) 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "│ └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "│   └─TableFullScan 1.00 mpp[tiflash] table:t1 keep order:false",
+          "└─TableReader(Probe) 1.00 root  MppVersion: 3, data:ExchangeSender",
+          "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─TableFullScan 1.00 mpp[tiflash] table:t2 keep order:false"
         ]
       }
     ]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/60965

Problem Summary:

### What changed and how does it work?
explain for connection didn't feel the explain with brief format, because session 1 couldn't do the explaining completely for session 2. example: session2 has the @param to do the explain, while session1 couldn't feel what the @param is, so complete eval explain info sometimes will get an error. 

The current situation is, session 2 will store the explainInfo with the default ROW format into the process list. And session 1 will try to explain the plan flat.Main with the same ROW format, then use the ID column to locate the corresponding real detail in the processlist info. For example: tableReader_1 will get the exact row inside processlist <tableReader_1, 11, root, table:t, xxx>, next it will show the real detail in session 1 env rather than explain the raw plan again.

So under this background, we don't want to store another copy of the BRIEF format into the process list. we still let the session 1's explain format as the default ROW format, which is necessary to locate the corresponding row inside pthe rocess list. Otherwise, without an ID suffix, two same "tableReader" will have no idea where the corresponding row is.

The main brief logic is about the trim, mainly about two columns: ID & OperatorInfo.
* ID column is quite simple:
    * like " └─IndexReader_12(Probe)", we only need to find the last index of "_" and trim the number followed.
* OperatorInfo is a little bit complex:
    * like "left outer join, inner:IndexReader_12, left side:IndexReader_24," the target we want to brief is IndexReader_12 and IndexReader_24, which must exactly occur in the ID column at the lower level. so first we collect all the ids into Explain operator itself (IndexReader_12, IndexReader_24), then replace the target operatorInfo strings inside the iteration of all ids collected from ID column before. The replacement here means: the operator info has referred to the exact ID item from the ID column, we should wipe the num suffix of them as well. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
