### PR TITLE
domain: fix the issue where defining FKs in a circular manner causes an infinite loop

### DIFF
--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -131,12 +131,11 @@ func findFK(is infoschema.InfoSchema, dbName, tableName string, tableMap map[tab
 		}
 		if _, ok := tableMap[key]; ok {
 			continue
-		} else {
-			tableMap[key] = struct{}{}
-			err := findFK(is, key.DBName, key.TableName, tableMap)
-			if err != nil {
-				return err
-			}
+		}
+		tableMap[key] = struct{}{}
+		err := findFK(is, key.DBName, key.TableName, tableMap)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -129,10 +129,14 @@ func findFK(is infoschema.InfoSchema, dbName, tableName string, tableMap map[tab
 			TableName: fk.RefTable.L,
 			IsView:    false,
 		}
-		tableMap[key] = struct{}{}
-		err := findFK(is, key.DBName, key.TableName, tableMap)
-		if err != nil {
-			return err
+		if _, ok := tableMap[key]; ok {
+			continue
+		} else {
+			tableMap[key] = struct{}{}
+			err := findFK(is, key.DBName, key.TableName, tableMap)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/domain/plan_replayer_dump.go
+++ b/pkg/domain/plan_replayer_dump.go
@@ -129,6 +129,7 @@ func findFK(is infoschema.InfoSchema, dbName, tableName string, tableMap map[tab
 			TableName: fk.RefTable.L,
 			IsView:    false,
 		}
+		// Skip already visited tables to prevent infinite recursion in case of circular foreign key definitions.
 		if _, ok := tableMap[key]; ok {
 			continue
 		}

--- a/pkg/server/handler/optimizor/plan_replayer_test.go
+++ b/pkg/server/handler/optimizor/plan_replayer_test.go
@@ -490,6 +490,7 @@ func prepareData4Issue56458(t *testing.T, client *testserverclient.TestServerCli
 	tk.MustExec("create table t(a int, b int, INDEX ia (a), INDEX ib (b), author_id int, b_id int, FOREIGN KEY (b_id) REFERENCES B(id),FOREIGN KEY (author_id) REFERENCES planReplayer2.t(a) ON DELETE CASCADE) placement policy p;")
 	err = statstestutil.HandleNextDDLEventWithTxn(h)
 	require.NoError(t, err)
+	// defining FKs in a circular manner
 	tk.MustExec(`CREATE TABLE A (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) NOT NULL,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60985

Problem Summary:

### What changed and how does it work?

Foreign keys cannot form a cycle during the table definition phase. However, it is possible to disable FK checks to force a cycle. When traversing the definitions, we need to skip parts that have already been traversed to avoid an infinite loop

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
domain: fix the issue where defining FKs in a circular manner causes an infinite loop

修复外键定义成环时的死循坏问题
```
