### PR TITLE
br: adjust auto analyze

### DIFF
--- a/br/pkg/restore/snap_client/pipeline_items.go
+++ b/br/pkg/restore/snap_client/pipeline_items.go
@@ -90,7 +90,6 @@ type PipelineContext struct {
 	LogProgress         bool
 	ChecksumConcurrency uint
 	StatsConcurrency    uint
-	AutoAnalyze         bool
 
 	// pipeline item tool client
 	KvClient   kv.Client
@@ -108,7 +107,9 @@ func (rc *SnapClient) RestorePipeline(ctx context.Context, plCtx PipelineContext
 	if plCtx.Checksum {
 		progressLen += int64(len(createdTables))
 	}
-	progressLen += int64(len(createdTables)) // for pipeline item - update stats meta
+	if plCtx.LoadStats {
+		progressLen += int64(len(createdTables))
+	}
 	if plCtx.WaitTiflashReady {
 		progressLen += int64(len(createdTables))
 	}
@@ -124,7 +125,9 @@ func (rc *SnapClient) RestorePipeline(ctx context.Context, plCtx PipelineContext
 	}
 
 	// pipeline update meta and load stats
-	rc.registerUpdateMetaAndLoadStats(handlerBuilder, plCtx.ExtStorage, updateCh, plCtx.StatsConcurrency, plCtx.AutoAnalyze, plCtx.LoadStats)
+	if plCtx.LoadStats {
+		rc.registerUpdateMetaAndLoadStats(handlerBuilder, plCtx.ExtStorage, updateCh, plCtx.StatsConcurrency)
+	}
 
 	// pipeline wait Tiflash synced
 	if plCtx.WaitTiflashReady {
@@ -367,8 +370,6 @@ func (rc *SnapClient) registerUpdateMetaAndLoadStats(
 	s storage.ExternalStorage,
 	updateCh glue.Progress,
 	statsConcurrency uint,
-	autoAnalyze bool,
-	loadStats bool,
 ) {
 	statsHandler := rc.dom.StatsHandle()
 	buffer := NewStatsMetaItemBuffer()
@@ -376,7 +377,7 @@ func (rc *SnapClient) registerUpdateMetaAndLoadStats(
 	builder.RegisterPipelineTask("Update Stats", statsConcurrency, func(c context.Context, tbl *CreatedTable) error {
 		oldTable := tbl.OldTable
 		var statsErr error = nil
-		if loadStats && oldTable.Stats != nil {
+		if oldTable.Stats != nil {
 			log.Info("start loads analyze after validate checksum",
 				zap.Int64("old id", oldTable.Info.ID),
 				zap.Int64("new id", tbl.Table.ID),
@@ -390,7 +391,7 @@ func (rc *SnapClient) registerUpdateMetaAndLoadStats(
 				zap.Stringer("table", oldTable.Info.Name),
 				zap.Stringer("db", oldTable.DB.Name),
 				zap.Duration("cost", time.Since(start)))
-		} else if loadStats && len(oldTable.StatsFileIndexes) > 0 {
+		} else if len(oldTable.StatsFileIndexes) > 0 {
 			log.Info("start to load statistic data for each partition",
 				zap.Int64("old id", oldTable.Info.ID),
 				zap.Int64("new id", tbl.Table.ID),
@@ -406,7 +407,7 @@ func (rc *SnapClient) registerUpdateMetaAndLoadStats(
 				zap.Duration("cost", time.Since(start)))
 		}
 
-		if autoAnalyze && (statsErr != nil || !loadStats || (oldTable.Stats == nil && len(oldTable.StatsFileIndexes) == 0)) {
+		if statsErr != nil || (oldTable.Stats == nil && len(oldTable.StatsFileIndexes) == 0) {
 			// Not need to return err when failed because of update analysis-meta
 			log.Info("start update metas", zap.Stringer("table", oldTable.Info.Name), zap.Stringer("db", oldTable.DB.Name))
 			// get the the number of rows of each partition

--- a/br/pkg/task/common_test.go
+++ b/br/pkg/task/common_test.go
@@ -315,7 +315,6 @@ func expectedDefaultRestoreConfig() RestoreConfig {
 		},
 		NoSchema:                 false,
 		LoadStats:                true,
-		AutoAnalyze:              true,
 		PDConcurrency:            0x1,
 		StatsConcurrency:         0xc,
 		BatchFlushInterval:       16000000000,

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -74,8 +74,6 @@ const (
 	FlagPDConcurrency = "pd-concurrency"
 	// FlagStatsConcurrency controls concurrency to restore statistic.
 	FlagStatsConcurrency = "stats-concurrency"
-	// FlagAutoAnalyze corresponds to the column `modify_count` of table `mysql.stats_meta`.
-	FlagAutoAnalyze = "auto-analyze"
 	// FlagBatchFlushInterval controls after how long the restore batch would be auto sended.
 	FlagBatchFlushInterval = "batch-flush-interval"
 	// FlagDdlBatchSize controls batch ddl size to create a batch of tables
@@ -174,7 +172,6 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 		"(deprecated) concurrency pd-relative operations like split & scatter.")
 	flags.Uint(FlagStatsConcurrency, defaultStatsConcurrency,
 		"concurrency to restore statistic")
-	flags.Bool(FlagAutoAnalyze, true, "trigger tidb analyze priority queue to analyze table (must be true if --load-stats is set)")
 	flags.Duration(FlagBatchFlushInterval, defaultBatchFlushInterval,
 		"after how long a restore batch would be auto sent.")
 	flags.Uint(FlagDdlBatchSize, defaultFlagDdlBatchSize,
@@ -244,7 +241,6 @@ type RestoreConfig struct {
 	LoadStats          bool          `json:"load-stats" toml:"load-stats"`
 	PDConcurrency      uint          `json:"pd-concurrency" toml:"pd-concurrency"`
 	StatsConcurrency   uint          `json:"stats-concurrency" toml:"stats-concurrency"`
-	AutoAnalyze        bool          `json:"auto-analyze" toml:"auto-analyze"`
 	BatchFlushInterval time.Duration `json:"batch-flush-interval" toml:"batch-flush-interval"`
 	// DdlBatchSize use to define the size of batch ddl to create tables
 	DdlBatchSize uint `json:"ddl-batch-size" toml:"ddl-batch-size"`
@@ -299,7 +295,7 @@ func (cfg *RestoreConfig) LocalEncryptionEnabled() bool {
 // DefineRestoreFlags defines common flags for the restore tidb command.
 func DefineRestoreFlags(flags *pflag.FlagSet) {
 	flags.Bool(flagNoSchema, false, "skip creating schemas and tables, reuse existing empty ones")
-	flags.Bool(flagLoadStats, true, "Run load stats at end of snapshot restore task")
+	flags.Bool(flagLoadStats, true, "Run load stats or update stats_meta to trigger auto-analyze at end of snapshot restore task")
 	// Do not expose this flag
 	_ = flags.MarkHidden(flagNoSchema)
 	flags.String(FlagWithPlacementPolicy, "STRICT", "correspond to tidb global/session variable with-tidb-placement-mode")
@@ -408,13 +404,6 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 	cfg.StatsConcurrency, err = flags.GetUint(FlagStatsConcurrency)
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", FlagStatsConcurrency)
-	}
-	cfg.AutoAnalyze, err = flags.GetBool(FlagAutoAnalyze)
-	if err != nil {
-		return errors.Annotatef(err, "failed to get flag %s", FlagAutoAnalyze)
-	}
-	if cfg.LoadStats && !cfg.AutoAnalyze {
-		return errors.Errorf("cannot set --auto-analyze to false if --load-stats is set")
 	}
 	cfg.BatchFlushInterval, err = flags.GetDuration(FlagBatchFlushInterval)
 	if err != nil {
@@ -1345,7 +1334,6 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		LogProgress:         cfg.LogProgress,
 		ChecksumConcurrency: cfg.ChecksumConcurrency,
 		StatsConcurrency:    cfg.StatsConcurrency,
-		AutoAnalyze:         cfg.AutoAnalyze,
 
 		KvClient:   mgr.GetStorage().GetClient(),
 		ExtStorage: s,

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -174,7 +174,7 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 		"(deprecated) concurrency pd-relative operations like split & scatter.")
 	flags.Uint(FlagStatsConcurrency, defaultStatsConcurrency,
 		"concurrency to restore statistic")
-	flags.Bool(FlagAutoAnalyze, true, "trigger tidb analyze priority queue to analyze table")
+	flags.Bool(FlagAutoAnalyze, true, "trigger tidb analyze priority queue to analyze table (must be true if --load-stats is set)")
 	flags.Duration(FlagBatchFlushInterval, defaultBatchFlushInterval,
 		"after how long a restore batch would be auto sent.")
 	flags.Uint(FlagDdlBatchSize, defaultFlagDdlBatchSize,
@@ -412,6 +412,9 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 	cfg.AutoAnalyze, err = flags.GetBool(FlagAutoAnalyze)
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", FlagAutoAnalyze)
+	}
+	if cfg.LoadStats && !cfg.AutoAnalyze {
+		return errors.Errorf("cannot set --auto-analyze to false if --load-stats is set")
 	}
 	cfg.BatchFlushInterval, err = flags.GetDuration(FlagBatchFlushInterval)
 	if err != nil {

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -91,9 +91,7 @@ run_sql "DROP DATABASE ${DB}1;"
 rm -f $LOG
 run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" || cat $LOG
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
-cat "$TEST_DIR/sql_res.$TEST_NAME.txt"
-check_not_contains "count"
+check_not_contains "1. row"
 
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
-cat "$TEST_DIR/sql_res.$TEST_NAME.txt"
-check_not_contains "count"
+check_not_contains "1. row"

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -65,7 +65,7 @@ fi
 run_sql "DROP DATABASE ${DB}1;"
 
 rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.*" || cat $LOG
+run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" || cat $LOG
 table_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = 0;" | awk '/count/{print $2}')
 if [ "${table_count}" -ne 9 ]; then
     echo "table stats meta count does not equal to 9, but $count instead"
@@ -86,7 +86,7 @@ fi
 run_sql "DROP DATABASE ${DB}1;"
 
 rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.*" --auto-analyze || cat $LOG
+run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" --auto-analyze || cat $LOG
 table_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;" | awk '/count/{print $2}')
 if [ "${table_count}" -ne 9 ]; then
     echo "table stats meta count does not equal to 9, but $count instead"
@@ -102,3 +102,14 @@ if [ "${p1_count}" -ne 4 ]; then
     echo "partition p1 stats meta count does not equal to 4, but $p1_count instead"
     exit 1
 fi
+
+# test auto analyze
+run_sql "DROP DATABASE ${DB}1;"
+
+rm -f $LOG
+run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" --auto-analyze=false || cat $LOG
+run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
+check_not_contains "count"
+
+run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
+check_not_contains "count"

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -45,6 +45,8 @@ if [ "${dump_mark}" -ne "123" ]; then
     exit 1
 fi
 
+run_br --pd $PD_ADDR backup full -s "local://$TEST_DIR/${DB}2" --log-file $LOG --ignore-stats=true --filter "${DB}1.*"
+
 for i in $(seq $DB_COUNT); do
     run_sql "DROP DATABASE $DB${i};"
 done
@@ -62,31 +64,11 @@ if [ "${load_mark}" -ne "22" ]; then
     exit 1
 fi
 
+# test load stats is true but statistic data is not backed up
 run_sql "DROP DATABASE ${DB}1;"
 
 rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" || cat $LOG
-table_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = 0;" | awk '/count/{print $2}')
-if [ "${table_count}" -ne 9 ]; then
-    echo "table stats meta count does not equal to 9, but $count instead"
-    exit 1
-fi
-p0_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and parts.PARTITION_NAME = 'p0' and modify_count = 0;" | awk '/count/{print $2}')
-if [ "${p0_count}" -ne 5 ]; then
-    echo "partition p0 stats meta count does not equal to 5, but $p0_count instead"
-    exit 1
-fi
-p1_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and parts.PARTITION_NAME = 'p1' and modify_count = 0;" | awk '/count/{print $2}')
-if [ "${p1_count}" -ne 4 ]; then
-    echo "partition p1 stats meta count does not equal to 4, but $p1_count instead"
-    exit 1
-fi
-
-# test auto analyze
-run_sql "DROP DATABASE ${DB}1;"
-
-rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" --auto-analyze || cat $LOG
+run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/${DB}2" --log-file $LOG --load-stats=true --filter "${DB}1.br_stats_partition" || cat $LOG
 table_count=$(run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;" | awk '/count/{print $2}')
 if [ "${table_count}" -ne 9 ]; then
     echo "table stats meta count does not equal to 9, but $count instead"
@@ -103,11 +85,11 @@ if [ "${p1_count}" -ne 4 ]; then
     exit 1
 fi
 
-# test auto analyze
+# test load stats is false
 run_sql "DROP DATABASE ${DB}1;"
 
 rm -f $LOG
-run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" --auto-analyze=false || cat $LOG
+run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" || cat $LOG
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
 check_not_contains "count"
 

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -91,7 +91,9 @@ run_sql "DROP DATABASE ${DB}1;"
 rm -f $LOG
 run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" || cat $LOG
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
+cat $LOG
 check_not_contains "count"
 
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
+cat $LOG
 check_not_contains "count"

--- a/br/tests/br_stats/run.sh
+++ b/br/tests/br_stats/run.sh
@@ -91,9 +91,9 @@ run_sql "DROP DATABASE ${DB}1;"
 rm -f $LOG
 run_br --pd $PD_ADDR restore full -s "local://$TEST_DIR/$DB" --log-file $LOG --load-stats=false --filter "${DB}1.br_stats_partition" || cat $LOG
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.TABLES tables ON meta.table_id = tables.TIDB_TABLE_ID WHERE tables.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
-cat $LOG
+cat "$TEST_DIR/sql_res.$TEST_NAME.txt"
 check_not_contains "count"
 
 run_sql "SELECT meta.count as count FROM mysql.stats_meta meta JOIN INFORMATION_SCHEMA.PARTITIONS parts ON meta.table_id = parts.TIDB_PARTITION_ID WHERE parts.TABLE_SCHEMA = '${DB}1' and modify_count = count and count > 0;"
-cat $LOG
+cat "$TEST_DIR/sql_res.$TEST_NAME.txt"
 check_not_contains "count"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60374

Problem Summary:
If the count of stats_meta is larger than 1000 and the table has not been analyzed yet, the priority_queue also analyze the table in the background.
### What changed and how does it work?
1. remove `--auto-analyze`
2. BR won't update `stats_meta` if `--load-stats=true`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
