### PR TITLE
planner: distinguish the index join probe as indexScan or tableScan from indexJoinProp side.

### DIFF
--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1024,14 +1024,26 @@ func enumerateIndexJoinByOuterIdx(p *logicalop.LogicalJoin, prop *property.Physi
 	if count := outerChild.StatsInfo().RowCount; count > 0 {
 		avgInnerRowCnt = p.EqualCondOutCnt / count
 	}
-	indexJoinProp := &property.IndexJoinRuntimeProp{
+	// for pk path
+	indexJoinPropTS := &property.IndexJoinRuntimeProp{
 		OtherConditions: p.OtherConditions,
 		InnerJoinKeys:   innerJoinKeys,
 		OuterJoinKeys:   outerJoinKeys,
 		AvgInnerRowCnt:  avgInnerRowCnt,
+		TableRangeScan:  true,
 	}
-	indexJoins := constructIndexJoinStatic(p, prop, outerIdx, indexJoinProp)
-	indexJoins = append(indexJoins, constructIndexHashJoinStatic(p, prop, outerIdx, indexJoinProp)...)
+	// for normal index path
+	indexJoinPropIS := &property.IndexJoinRuntimeProp{
+		OtherConditions: p.OtherConditions,
+		InnerJoinKeys:   innerJoinKeys,
+		OuterJoinKeys:   outerJoinKeys,
+		AvgInnerRowCnt:  avgInnerRowCnt,
+		TableRangeScan:  false,
+	}
+	indexJoins := constructIndexJoinStatic(p, prop, outerIdx, indexJoinPropTS)
+	indexJoins = append(indexJoins, constructIndexJoinStatic(p, prop, outerIdx, indexJoinPropIS)...)
+	indexJoins = append(indexJoins, constructIndexHashJoinStatic(p, prop, outerIdx, indexJoinPropTS)...)
+	indexJoins = append(indexJoins, constructIndexHashJoinStatic(p, prop, outerIdx, indexJoinPropIS)...)
 	return indexJoins
 }
 
@@ -1190,10 +1202,14 @@ func buildDataSource2IndexScanByIndexJoinProp(
 		}
 	}
 	var innerTask base.Task
-	if isMatchProp(ds, indexJoinResult.chosenPath, prop) {
-		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, true, !prop.IsSortItemEmpty() && prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+	if !prop.IsSortItemEmpty() && isMatchProp(ds, indexJoinResult.chosenPath, prop) {
+		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
 	} else {
 		innerTask = constructDS2IndexScanTask(ds, indexJoinResult.chosenPath, indexJoinResult.chosenRanges.Range(), indexJoinResult.chosenRemained, indexJoinResult.idxOff2KeyOff, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt, maxOneRow)
+	}
+	// since there is a possibility that inner task can't be built and the returned value is nil, we just return base.InvalidTask.
+	if innerTask == nil {
+		return base.InvalidTask
 	}
 	// prepare the index path chosen information and wrap them as IndexJoinInfo and fill back to CopTask.
 	// here we don't need to construct physical index join here anymore, because we will encapsulate it bottom-up.
@@ -1255,11 +1271,15 @@ func buildDataSource2TableScanByIndexJoinProp(
 			return base.InvalidTask
 		}
 		rangeInfo := indexJoinIntPKRangeInfo(ds.SCtx().GetExprCtx().GetEvalCtx(), newOuterJoinKeys)
-		if isMatchProp(ds, chosenPath, prop) {
-			innerTask = constructDS2TableScanTask(ds, localRanges, rangeInfo, true, !prop.IsSortItemEmpty() && prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt)
+		if !prop.IsSortItemEmpty() && isMatchProp(ds, chosenPath, prop) {
+			innerTask = constructDS2TableScanTask(ds, localRanges, rangeInfo, true, prop.SortItems[0].Desc, prop.IndexJoinProp.AvgInnerRowCnt)
 		} else {
 			innerTask = constructDS2TableScanTask(ds, localRanges, rangeInfo, false, false, prop.IndexJoinProp.AvgInnerRowCnt)
 		}
+	}
+	// since there is a possibility that inner task can't be built and the returned value is nil, we just return base.InvalidTask.
+	if innerTask == nil {
+		return base.InvalidTask
 	}
 	// prepare the index path chosen information and wrap them as IndexJoinInfo and fill back to CopTask.
 	// here we don't need to construct physical index join here anymore, because we will encapsulate it bottom-up.
@@ -2083,8 +2103,8 @@ func tryToEnumerateIndexJoin(p *logicalop.LogicalJoin, prop *property.PhysicalPr
 		stmtCtx.SetHintWarning("Some INL_MERGE_JOIN and NO_INDEX_MERGE_JOIN hints conflict, NO_INDEX_MERGE_JOIN may be ignored")
 	}
 	// previously we will think about force index join hints here, but we have to wait the inner plans to be a valid
-	// physical one/ones. Because indexJoinProp may not be admitted by its inner patterns, so we innovatively move all
-	// hint related handling to the findBestTask function when we see the entire inner physicalized plan tree. See xxx
+	// physical one/ones. Because indexJoinProp may not be admitted by its inner patterns, so we innovative-ly move all
+	// hint related handling to the findBestTask function when we see the entire inner physical-ized plan tree. See xxx
 	// for details.
 	//
 	// handleFilterIndexJoinHints is trying to avoid generating index join or index hash join when no-index-join related
@@ -2197,12 +2217,43 @@ func recordIndexJoinHintWarnings(lp base.LogicalPlan, prop *property.PhysicalPro
 	return nil
 }
 
-// suitLogicalJoinHint is used to handle logic hint/prefer/variable, which is not a strong guide for optimization phase.
+// applyLogicalJoinHint is used to handle logic hint/prefer/variable, which is not a strong guide for optimization phase.
 // It is changed from handleForceIndexJoinHints to handle the preferred join hint among several valid physical plan choices.
 // It will return true if the hint can be applied when saw a real physic plan successfully built and returned up from child.
 // we cache the most preferred one among this valid and preferred physic plans. If there is no preferred physic applicable
 // for the logic hint, we will return false and the optimizer will continue to return the normal low-cost one.
-func suitLogicalJoinHint(lp base.LogicalPlan, physic base.PhysicalPlan) (preferred bool) {
+func applyLogicalJoinHint(lp base.LogicalPlan, physic base.PhysicalPlan) (preferred bool) {
+	return preferMergeJoin(lp, physic) || preferIndexJoinFamily(lp, physic) || preferHashJoin(lp, physic)
+}
+
+func preferHashJoin(lp base.LogicalPlan, physic base.PhysicalPlan) (preferred bool) {
+	p, ok := lp.(*logicalop.LogicalJoin)
+	if !ok {
+		return false
+	}
+	if physic == nil {
+		return false
+	}
+	forceLeftToBuild := ((p.PreferJoinType & h.PreferLeftAsHJBuild) > 0) || ((p.PreferJoinType & h.PreferRightAsHJProbe) > 0)
+	forceRightToBuild := ((p.PreferJoinType & h.PreferRightAsHJBuild) > 0) || ((p.PreferJoinType & h.PreferLeftAsHJProbe) > 0)
+	preferHashJoin := p.PreferJoinType&h.PreferHashJoin > 0 || forceRightToBuild || forceLeftToBuild
+	_, ok = physic.(*PhysicalHashJoin)
+	return ok && preferHashJoin
+}
+
+func preferMergeJoin(lp base.LogicalPlan, physic base.PhysicalPlan) (preferred bool) {
+	p, ok := lp.(*logicalop.LogicalJoin)
+	if !ok {
+		return false
+	}
+	if physic == nil {
+		return false
+	}
+	_, ok = physic.(*PhysicalMergeJoin)
+	return ok && p.PreferJoinType&h.PreferMergeJoin > 0
+}
+
+func preferIndexJoinFamily(lp base.LogicalPlan, physic base.PhysicalPlan) (preferred bool) {
 	p, ok := lp.(*logicalop.LogicalJoin)
 	if !ok {
 		return false

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -2103,7 +2103,7 @@ func tryToEnumerateIndexJoin(p *logicalop.LogicalJoin, prop *property.PhysicalPr
 		stmtCtx.SetHintWarning("Some INL_MERGE_JOIN and NO_INDEX_MERGE_JOIN hints conflict, NO_INDEX_MERGE_JOIN may be ignored")
 	}
 	// previously we will think about force index join hints here, but we have to wait the inner plans to be a valid
-	// physical one/ones. Because indexJoinProp may not be admitted by its inner patterns, so we innovative-ly move all
+	// physical one/ones. Because indexJoinProp may not be admitted by its inner patterns, so we innovatively move all
 	// hint related handling to the findBestTask function when we see the entire inner physical-ized plan tree. See xxx
 	// for details.
 	//

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -623,20 +623,13 @@ func findBestTask(lp base.LogicalPlan, prop *property.PhysicalProperty, planCoun
 		}
 		newProp = prop
 	}
-	var (
-		cnt     int64
-		prefer  bool
-		curTask base.Task
-	)
-	if bestTask, cnt, prefer, err = enumeratePhysicalPlans4Task(p, plansFitsProp, newProp, false, planCounter, opt); err != nil {
+	var cnt int64
+	var curTask base.Task
+	if bestTask, cnt, err = enumeratePhysicalPlans4Task(p, plansFitsProp, newProp, false, planCounter, opt); err != nil {
 		return nil, 0, err
 	}
 	cntPlan += cnt
 	if planCounter.Empty() {
-		goto END
-	}
-	// preferred valid one should have it priority.
-	if bestTask != nil && !bestTask.Invalid() && prefer {
 		goto END
 	}
 

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1464,7 +1464,6 @@ func findBestTask4LogicalDataSource(lp base.LogicalPlan, prop *property.Physical
 		// cache the physical for indexJoinProp
 		defer func() {
 			ds.StoreTask(prop, t)
-			err = validateTableSamplePlan(ds, t, err)
 		}()
 		// when datasource leaf is in index join's inner side, build the task out with old
 		// index join build logic, we can't merge this with normal datasource's index range

--- a/pkg/planner/core/index_join_path.go
+++ b/pkg/planner/core/index_join_path.go
@@ -643,20 +643,16 @@ func getBestIndexJoinInnerTaskByProp(ds *logicalop.DataSource, prop *property.Ph
 	// which one as the copTask here is better, some more possible upper attached operator cost should be
 	// considered, besides the row count, double reader cost for index lookup should also be considered as
 	// a whole, so we leave the cost compare for index join itself just like what it was before.
+	var innerCopTask base.Task
 	if prop.IndexJoinProp.TableRangeScan {
-		innerTSCopTask := buildDataSource2TableScanByIndexJoinProp(ds, prop)
-		if innerTSCopTask.Invalid() {
-			return base.InvalidTask, 0, nil
-		}
-		planCounter.Dec(1)
-		return innerTSCopTask, 1, nil
+		innerCopTask = buildDataSource2TableScanByIndexJoinProp(ds, prop)
 	}
-	innerISCopTask := buildDataSource2IndexScanByIndexJoinProp(ds, prop)
-	if innerISCopTask.Invalid() {
+	innerCopTask = buildDataSource2IndexScanByIndexJoinProp(ds, prop)
+	if innerCopTask.Invalid() {
 		return base.InvalidTask, 0, nil
 	}
 	planCounter.Dec(1)
-	return innerISCopTask, 1, nil
+	return innerCopTask, 1, nil
 }
 
 // getBestIndexJoinPathResultByProp tries to iterate all possible access paths of the inner child and builds

--- a/pkg/planner/core/index_join_path.go
+++ b/pkg/planner/core/index_join_path.go
@@ -639,7 +639,7 @@ func getBestIndexJoinInnerTaskByProp(ds *logicalop.DataSource, prop *property.Ph
 	// reason2: the ranges from TS and IS couldn't be directly used to derive the stats' estimation, it's not real.
 	// reason3: skyline pruning should not prune the possible index path which could feel the runtime EQ access conditions.
 	//
-	// here we build TS and IS separately according to different index join prop is for we couldn't decide
+	// here we build TableScan(TS) and IndexScan(IS) separately according to different index join prop is for we couldn't decide
 	// which one as the copTask here is better, some more possible upper attached operator cost should be
 	// considered, besides the row count, double reader cost for index lookup should also be considered as
 	// a whole, so we leave the cost compare for index join itself just like what it was before.

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1678,7 +1678,11 @@ func (p *PhysicalIndexJoin) Clone(newCtx base.PlanContext) (base.PhysicalPlan, e
 		return nil, err
 	}
 	cloned.basePhysicalJoin = *base
-	cloned.innerPlan, err = p.innerPlan.Clone(newCtx)
+	// after the new refactor of indexJoin, the inner plan field is not a necessary one.
+	// So we need to check if the inner plan is nil before we do some cloning.
+	if p.innerPlan != nil {
+		cloned.innerPlan, err = p.innerPlan.Clone(newCtx)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/planner/core/physical_plans.go
+++ b/pkg/planner/core/physical_plans.go
@@ -1678,13 +1678,11 @@ func (p *PhysicalIndexJoin) Clone(newCtx base.PlanContext) (base.PhysicalPlan, e
 		return nil, err
 	}
 	cloned.basePhysicalJoin = *base
-	// after the new refactor of indexJoin, the inner plan field is not a necessary one.
-	// So we need to check if the inner plan is nil before we do some cloning.
 	if p.innerPlan != nil {
 		cloned.innerPlan, err = p.innerPlan.Clone(newCtx)
-	}
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 	cloned.Ranges = p.Ranges.CloneForPlanCache() // this clone is deep copy
 	cloned.KeyOff2IdxOff = make([]int, len(p.KeyOff2IdxOff))

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -1853,11 +1853,11 @@ explain format = 'brief' select /*+ hash_join_probe(t1) */ sum(t1.a in (select a
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:sum(Column#9)->Column#8
 └─Projection	10000.00	root		cast(Column#7, decimal(3,0) BINARY)->Column#9
-  └─MergeJoin	10000.00	root		left outer semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+  └─HashJoin	10000.00	root		left outer semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
-    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
-      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ hash_join_probe(t1) */ sum(t1.a in (select a from t2)) from t1;
 sum(t1.a in (select a from t2))
 2
@@ -1869,11 +1869,11 @@ explain format = 'brief' select /*+ hash_join_build(t2@sel_2) */ sum(t1.a in (se
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:sum(Column#9)->Column#8
 └─Projection	10000.00	root		cast(Column#7, decimal(3,0) BINARY)->Column#9
-  └─MergeJoin	10000.00	root		left outer semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+  └─HashJoin	10000.00	root		left outer semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
-    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
-      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ hash_join_build(t2@sel_2) */ sum(t1.a in (select a from t2)) from t1;
 sum(t1.a in (select a from t2))
 2
@@ -1917,11 +1917,11 @@ explain format = 'brief' select /*+ hash_join_probe(t1) */ sum(t1.a not in (sele
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:sum(Column#9)->Column#8
 └─Projection	10000.00	root		cast(Column#7, decimal(3,0) BINARY)->Column#9
-  └─MergeJoin	10000.00	root		anti left outer semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+  └─HashJoin	10000.00	root		anti left outer semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
-    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
-      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ hash_join_probe(t1) */ sum(t1.a not in (select a from t2)) from t1;
 sum(t1.a not in (select a from t2))
 0
@@ -1933,11 +1933,11 @@ explain format = 'brief' select /*+ hash_join_build(t2@sel_2) */ sum(t1.a not in
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:sum(Column#9)->Column#8
 └─Projection	10000.00	root		cast(Column#7, decimal(3,0) BINARY)->Column#9
-  └─MergeJoin	10000.00	root		anti left outer semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+  └─HashJoin	10000.00	root		anti left outer semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
     ├─TableReader(Build)	10000.00	root		data:TableFullScan
-    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+    │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
     └─TableReader(Probe)	10000.00	root		data:TableFullScan
-      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+      └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ hash_join_build(t2@sel_2) */ sum(t1.a not in (select a from t2)) from t1;
 sum(t1.a not in (select a from t2))
 0
@@ -2460,11 +2460,11 @@ show warnings;
 Level	Code	Message
 explain format = 'brief' SELECT /*+ hash_join_probe(t1), set_var(tidb_hash_join_version=legacy) */ * FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.a = t1.a);
 id	estRows	task	access object	operator info
-MergeJoin	8000.00	root		semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+HashJoin	8000.00	root		semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
-│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
-  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 SELECT /*+ hash_join_probe(t1), set_var(tidb_hash_join_version=legacy) */ * FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.a = t1.a);
 a	b
 1	1
@@ -2571,11 +2571,11 @@ show warnings;
 Level	Code	Message
 explain format = 'brief' SELECT /*+ hash_join_build(t2@sel_2), set_var(tidb_hash_join_version=legacy) */ * FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.a = t1.a);
 id	estRows	task	access object	operator info
-MergeJoin	8000.00	root		semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+HashJoin	8000.00	root		semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
-│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
-  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 SELECT /*+ hash_join_build(t2@sel_2), set_var(tidb_hash_join_version=legacy) */ * FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.a = t1.a);
 a	b
 1	1
@@ -2798,11 +2798,11 @@ show warnings;
 Level	Code	Message
 explain format = 'brief' SELECT /*+ USE_TOJA(false) hash_join_probe(t1), set_var(tidb_hash_join_version=legacy) */ t1.a, t1.b FROM t1 WHERE t1.a in (SELECT t2.a FROM t2);
 id	estRows	task	access object	operator info
-MergeJoin	8000.00	root		semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+HashJoin	8000.00	root		semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
-│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
-  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 SELECT /*+ USE_TOJA(false) hash_join_probe(t1), set_var(tidb_hash_join_version=legacy) */ t1.a, t1.b FROM t1 WHERE t1.a in (SELECT t2.a FROM t2);
 a	b
 1	1
@@ -2825,11 +2825,11 @@ show warnings;
 Level	Code	Message
 explain format = 'brief' SELECT /*+ USE_TOJA(false) hash_join_build(t2@sel_2), set_var(tidb_hash_join_version=legacy) */ t1.a, t1.b FROM t1 WHERE t1.a in (SELECT t2.a FROM t2);
 id	estRows	task	access object	operator info
-MergeJoin	8000.00	root		semi join, left side:TableReader, left key:planner__core__casetest__physicalplantest__physical_plan.t1.a, right key:planner__core__casetest__physicalplantest__physical_plan.t2.a
+HashJoin	8000.00	root		semi join, left side:TableReader, equal:[eq(planner__core__casetest__physicalplantest__physical_plan.t1.a, planner__core__casetest__physicalplantest__physical_plan.t2.a)]
 ├─TableReader(Build)	10000.00	root		data:TableFullScan
-│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:true, stats:pseudo
+│ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 └─TableReader(Probe)	10000.00	root		data:TableFullScan
-  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:true, stats:pseudo
+  └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 SELECT /*+ USE_TOJA(false) hash_join_build(t2@sel_2), set_var(tidb_hash_join_version=legacy) */ t1.a, t1.b FROM t1 WHERE t1.a in (SELECT t2.a FROM t2);
 a	b
 1	1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/60106

Problem Summary:

### What changed and how does it work?
* previously the tidb will enumerate and build index join‘s inner task as tableRangeScan and indexRangeScan separately, which means two kinds of this index join will compare their total cost from indexJoin itself. 

* obviously, one indexJoinProp couldn't output two kinds of underlying cop tasks, so we just add one more field in the indexJoinProp to guide the underlying datasource to build separate copTask(tableRangeScan or indexRangeScan) out, then leverage the attack2Task to wrap them as TableReader or IndexReader or IndexLookUpReader just like old logic does, consequently, leading to different physical index join and the cost comparing just between them.

* some small fix: 
    * clone function should check whether the inner plan is nil or not. because in the v2, we didn't need this field anymore.
    * innerTask should be checked as nil or not; if yes, we should return an invalid task directly.
    * the hint handling should be able to see the direct built out physical plan, rather then Enforcer operator like sort or exchanger.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
