### PR TITLE
ddl: remove unnecessary `PrefixNext()` during `iterateSnapshotKeys()`

### DIFF
--- a/pkg/ddl/backfilling.go
+++ b/pkg/ddl/backfilling.go
@@ -1137,7 +1137,7 @@ func iterateSnapshotKeys(ctx *ReorgContext, store kv.Storage, priority int, keyP
 	if endKey == nil {
 		upperBound = keyPrefix.PrefixNext()
 	} else {
-		upperBound = endKey.PrefixNext()
+		upperBound = endKey
 	}
 
 	ver := kv.Version{Ver: version}

--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -705,10 +705,6 @@ func (w *updateColumnWorker) fetchRowColVals(txn kv.Transaction, taskRange reorg
 				return false, errors.Trace(err1)
 			}
 			lastAccessedHandle = recordKey
-			if recordKey.Cmp(taskRange.endKey) == 0 {
-				taskDone = true
-				return false, nil
-			}
 			return true, nil
 		})
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61026

Problem Summary: 

See #61026

### What changed and how does it work?

Remove unnecessary PrefixNext() during iterateSnapshotKeys().

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
