### PR TITLE
dumpling: Using stdout for -V and --help, and stderr for errors in main

### DIFF
--- a/dumpling/tests/basic/run.sh
+++ b/dumpling/tests/basic/run.sh
@@ -9,6 +9,16 @@ DB_NAME="basic"
 TABLE_NAME="t"
 SEQUENCE_NAME="s"
 
+tmpfile=$(mktemp)
+bin/dumpling -V > ${tmpfile}.stdout.log 2> ${tmpfile}.stderr.log
+[ -s ${tmpfile}.stdout.log ]
+[ -e ${tmpfile}.stderr.log -a ! -s ${tmpfile}.stderr.log ]
+rm -f ${tmpfile}*
+bin/dumpling --help > ${tmpfile}.stdout.log 2> ${tmpfile}.stderr.log
+[ -s ${tmpfile}.stdout.log ]
+[ -e ${tmpfile}.stderr.log -a ! -s ${tmpfile}.stderr.log ]
+rm -f ${tmpfile}*
+
 echo "Test for simple case."
 run_sql "drop database if exists \`$DB_NAME\`;"
 run_sql "create database \`$DB_NAME\` DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;"


### PR DESCRIPTION
…in().

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #53591

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
dumpling -V and --help now outputs to stdout instead of stderr.
```
