### PR TITLE
test-only: use_index to support tiflash

### DIFF
--- a/pkg/executor/test/tiflashtest/BUILD.bazel
+++ b/pkg/executor/test/tiflashtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 48,
+    shard_count = 49,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/executor/test/tiflashtest/tiflash_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_test.go
@@ -463,6 +463,23 @@ func TestTiFlashPartitionTableReader(t *testing.T) {
 	}
 }
 
+func TestUseIndexTiFlash(t *testing.T) {
+	store := testkit.CreateMockStore(t, withMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (id int primary key, a int, b int, c int, key(a), key(b), key(c))`)
+	tk.MustExec(`alter table t set tiflash replica 1`)
+	tb := external.GetTableByName(t, tk, "test", "t")
+	err := domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+	require.NoError(t, err)
+
+	tk.MustUseIndex(`select /*+ use_index(t, a, b, c, tiflash) */ 1 from t where a=1`, "a")
+	tk.MustUseIndex(`select /*+ use_index(t, a, b, c, tiflash) */ 1 from t where b=1`, "b")
+	tk.MustUseIndex(`select /*+ use_index(t, a, b, c, tiflash) */ 1 from t where b=1`, "b")
+	plan := tk.MustQuery(`explain select /*+ use_index(t, a, b, c, tiflash) */ 1 from t`).Rows()
+	require.Equal(t, plan[len(plan)-1][2], "mpp[tiflash]")
+}
+
 func TestPartitionTable(t *testing.T) {
 	failpoint.Enable("github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune", `return(true)`)
 	defer failpoint.Disable("github.com/pingcap/tidb/pkg/planner/core/forceDynamicPrune")

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1368,12 +1368,6 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 		available = append(available, tablePath)
 	}
 
-	if strings.Contains(ctx.GetSessionVars().StmtCtx.OriginalSQL, "txx") {
-		for _, p := range available {
-			fmt.Println(">>> ", p.IsTablePath(), p.StoreType, *p)
-		}
-	}
-
 	return available, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

`use_index(t, tiflash)`:
```
mysql> explain select /*+ use_index(txx, a, b, primary, tiflash) */ 1 from txx;
+----------------------------+----------+--------------+---------------+---------------------------------------+
| id                         | estRows  | task         | access object | operator info                         |
+----------------------------+----------+--------------+---------------+---------------------------------------+
| TableReader_16             | 10000.00 | root         |               | MppVersion: 3, data:ExchangeSender_15 |
| └─ExchangeSender_15        | 10000.00 | mpp[tiflash] |               | ExchangeType: PassThrough             |
|   └─Projection_4           | 10000.00 | mpp[tiflash] |               | 1->Column#6                           |
|     └─TableFullScan_14     | 10000.00 | mpp[tiflash] | table:txx     | keep order:false, stats:pseudo        |
+----------------------------+----------+--------------+---------------+---------------------------------------+
4 rows in set (0.00 sec)

mysql> explain select /*+ use_index(txx, a, b, primary, tiflash) */ 1 from txx where a=1;
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| id                       | estRows | task      | access object         | operator info                               |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| Projection_4             | 10.00   | root      |                       | 1->Column#6                                 |
| └─IndexReader_7          | 10.00   | root      |                       | index:IndexRangeScan_6                      |
|   └─IndexRangeScan_6     | 10.00   | cop[tikv] | table:txx, index:a(a) | range:[1,1], keep order:false, stats:pseudo |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
3 rows in set (0.01 sec)

mysql> explain select /*+ use_index(txx, a, b, primary, tiflash) */ 1 from txx where b=1;
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| id                       | estRows | task      | access object         | operator info                               |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| Projection_4             | 10.00   | root      |                       | 1->Column#6                                 |
| └─IndexReader_7          | 10.00   | root      |                       | index:IndexRangeScan_6                      |
|   └─IndexRangeScan_6     | 10.00   | cop[tikv] | table:txx, index:b(b) | range:[1,1], keep order:false, stats:pseudo |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
3 rows in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
