### PR TITLE
[DNM]*: a demo for no_null_index and use_index(tiflash)

### DIFF
--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -5690,6 +5690,8 @@ func ProcessModifyColumnOptions(ctx sessionctx.Context, col *table.Column, optio
 			return errors.Trace(dbterror.ErrUnsupportedModifyColumn.GenWithStackByArgs("can't modify with check"))
 		// Ignore ColumnOptionAutoRandom. It will be handled later.
 		case ast.ColumnOptionAutoRandom:
+		case ast.ColumnOptionNoNullIndex:
+			col.NoNullIndex = true
 		default:
 			return errors.Trace(dbterror.ErrUnsupportedModifyColumn.GenWithStackByArgs(fmt.Sprintf("unknown column option type: %d", opt.Tp)))
 		}
@@ -5861,6 +5863,10 @@ func GetModifiableColumnJob(
 	}
 
 	if err = checkModifyColumnWithForeignKeyConstraint(is, schema.Name.L, t.Meta(), col.ColumnInfo, newCol.ColumnInfo); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err = checkModifyColumnWithNoNullIndex(t.Meta(), col.ColumnInfo, specNewColumn.Options); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -9517,4 +9523,31 @@ func NewDDLReorgMeta(ctx sessionctx.Context) *model.DDLReorgMeta {
 		ResourceGroupName: ctx.GetSessionVars().StmtCtx.ResourceGroupName,
 		Version:           model.CurrentReorgMetaVersion,
 	}
+}
+
+func checkModifyColumnWithNoNullIndex(tbInfo *model.TableInfo, col *model.ColumnInfo, options []*ast.ColumnOption) error {
+	if col.NoNullIndex {
+		return nil
+	}
+
+	addNoNullIndex := false
+	for _, opt := range options {
+		if opt.Tp == ast.ColumnOptionNoNullIndex {
+			addNoNullIndex = true
+			break
+		}
+	}
+	if !addNoNullIndex {
+		return nil
+	}
+
+	// cannot add no_null_index if the column is part of an existing index
+	for _, indexInfo := range tbInfo.Indices {
+		for _, idxCol := range indexInfo.Columns {
+			if col.Name.L == idxCol.Name.L && addNoNullIndex {
+				return dbterror.ErrUnsupportedModifyColumn.GenWithStackByArgs("can't modify column to no_null_index with existing index")
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/ddl/ddl_api.go
+++ b/pkg/ddl/ddl_api.go
@@ -1198,6 +1198,8 @@ func columnDefToCol(ctx sessionctx.Context, offset int, colDef *ast.ColumnDef, o
 				col.DelFlag(mysql.NotNullFlag)
 				removeOnUpdateNowFlag(col)
 				hasNullFlag = true
+			case ast.ColumnOptionNoNullIndex:
+				col.NoNullIndex = true
 			case ast.ColumnOptionAutoIncrement:
 				col.AddFlag(mysql.AutoIncrementFlag | mysql.NotNullFlag)
 			case ast.ColumnOptionPrimaryKey:

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -323,6 +323,8 @@ func BuildIndexInfo(
 		MVIndex: mvIndex,
 	}
 
+	idxInfo.NoNullIdxColOffsets = buildNoNullIdxColOffsets(idxInfo.Columns, allTableColumns)
+
 	if indexOption != nil {
 		idxInfo.Comment = indexOption.Comment
 		if indexOption.Visibility == ast.IndexVisibilityInvisible {
@@ -340,6 +342,18 @@ func BuildIndexInfo(
 	}
 
 	return idxInfo, nil
+}
+
+func buildNoNullIdxColOffsets(indexColumns []*model.IndexColumn, allTableColumns []*model.ColumnInfo) []int {
+	var noNullIdxColOffsets []int
+
+	for i, col := range indexColumns {
+		if allTableColumns[col.Offset].NoNullIndex {
+			noNullIdxColOffsets = append(noNullIdxColOffsets, i)
+		}
+	}
+
+	return noNullIdxColOffsets
 }
 
 // AddIndexColumnFlag aligns the column flags of columns in TableInfo to IndexInfo.

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -323,6 +323,7 @@ func BuildIndexInfo(
 		MVIndex: mvIndex,
 	}
 
+	// Primary index is not null, so it's fine to use no_null_index even if it's a primary index (as it'll have no effect).
 	idxInfo.NoNullIdxColOffsets = buildNoNullIdxColOffsets(idxInfo.Columns, allTableColumns)
 
 	if indexOption != nil {

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -29,7 +29,9 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/model"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
@@ -340,6 +342,9 @@ func getRestoreData(tblInfo *model.TableInfo, targetIdx, pkIdx *model.IndexInfo,
 	return dtToRestored
 }
 
+// buildDAGPB builds a DAGRequest for the DDL.
+// Usually, it's a table scan executor. If the `colInfo` contains `NoNullIndex` attribute, it'll attach a selection executor.
+// to only fetch the not null rows.
 func buildDAGPB(sCtx sessionctx.Context, tblInfo *model.TableInfo, colInfos []*model.ColumnInfo) (*tipb.DAGRequest, error) {
 	dagReq := &tipb.DAGRequest{}
 	dagReq.TimeZoneName, dagReq.TimeZoneOffset = timeutil.Zone(sCtx.GetSessionVars().Location())
@@ -348,11 +353,62 @@ func buildDAGPB(sCtx sessionctx.Context, tblInfo *model.TableInfo, colInfos []*m
 	for i := range colInfos {
 		dagReq.OutputOffsets = append(dagReq.OutputOffsets, uint32(i))
 	}
-	execPB, err := constructTableScanPB(sCtx, tblInfo, colInfos)
+	tblScanPB, err := constructTableScanPB(sCtx, tblInfo, colInfos)
 	if err != nil {
 		return nil, err
 	}
-	dagReq.Executors = append(dagReq.Executors, execPB)
+
+	noNullSelection := make([]expression.Expression, 0)
+	for i, colInfo := range colInfos {
+		if colInfo.NoNullIndex {
+			isNullExpr, err := expression.NewFunction(sCtx.GetExprCtx(), ast.IsNull, types.NewFieldType(mysql.TypeTiny),
+				&expression.Column{Index: i, RetType: &colInfo.FieldType},
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			notNullExpr, err := expression.NewFunction(sCtx.GetExprCtx(), ast.UnaryNot, types.NewFieldType(mysql.TypeTiny), isNullExpr)
+			if err != nil {
+				return nil, err
+			}
+
+			noNullSelection = append(noNullSelection, notNullExpr)
+		}
+	}
+	if len(noNullSelection) > 0 {
+		// build an OR for these expressions, because "multi-schema change" will pack all needed column into this selection.
+		// FIXME: this behavior is not correct, because the `colInfos` also contains the dependency of generated columns which are
+		// not used by the index. It's kept here for demo.
+		var expr expression.Expression
+		for _, e := range noNullSelection {
+			if expr == nil {
+				expr = e
+			} else {
+				expr, err = expression.NewFunction(sCtx.GetExprCtx(), ast.LogicOr, types.NewFieldType(mysql.TypeTiny), expr, e)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		conditions, err := expression.ExpressionsToPBList(sCtx.GetExprCtx().GetEvalCtx(), []expression.Expression{expr}, sCtx.GetClient())
+		if err != nil {
+			return nil, err
+		}
+
+		selectionPB := &tipb.Executor{
+			Tp: tipb.ExecType_TypeSelection,
+			Selection: &tipb.Selection{
+				Conditions: conditions,
+				Child:      tblScanPB,
+			},
+		}
+		dagReq.Executors = append(dagReq.Executors, tblScanPB, selectionPB)
+	} else {
+		dagReq.Executors = append(dagReq.Executors, tblScanPB)
+	}
+
 	distsql.SetEncodeType(sCtx.GetDistSQLCtx(), dagReq)
 	return dagReq, nil
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -940,7 +940,7 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 
 	idxNames := make([]string, 0, len(e.indexInfos))
 	for _, idx := range e.indexInfos {
-		if idx.MVIndex {
+		if idx.MVIndex || len(idx.NoNullIdxColOffsets) != 0 {
 			continue
 		}
 		idxNames = append(idxNames, idx.Name.O)
@@ -963,7 +963,7 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	// TODO: Make the value of concurrency adjustable. And we can consider the number of records.
 	if len(e.srcs) == 1 {
 		err = e.checkIndexHandle(ctx, e.srcs[0])
-		if err == nil && e.srcs[0].index.MVIndex {
+		if err == nil && shouldCheckTableRecordForIndex(e.srcs[0].index) {
 			err = e.checkTableRecord(ctx, 0)
 		}
 		if err != nil {
@@ -987,7 +987,7 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 					select {
 					case src := <-taskCh:
 						err1 := e.checkIndexHandle(ctx, src)
-						if err1 == nil && src.index.MVIndex {
+						if err1 == nil && shouldCheckTableRecordForIndex(src.index) {
 							for offset, idx := range e.indexInfos {
 								if idx.ID == src.index.ID {
 									err1 = e.checkTableRecord(ctx, offset)
@@ -1016,6 +1016,10 @@ func (e *CheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 	default:
 		return nil
 	}
+}
+
+func shouldCheckTableRecordForIndex(idx *model.IndexInfo) bool {
+	return idx.MVIndex || len(idx.NoNullIdxColOffsets) != 0
 }
 
 func (e *CheckTableExec) checkTableRecord(ctx context.Context, idxOffset int) error {

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1091,6 +1091,9 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *model.CISt
 		if tableInfo.PKIsHandle && mysql.HasPriKeyFlag(col.GetFlag()) {
 			pkCol = col
 		}
+		if col.NoNullIndex {
+			buf.WriteString(" NO_NULL_INDEX")
+		}
 	}
 
 	if pkCol != nil {

--- a/pkg/executor/test/tiflashtest/BUILD.bazel
+++ b/pkg/executor/test/tiflashtest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 43,
+    shard_count = 44,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -526,6 +526,7 @@ const (
 	ColumnOptionColumnFormat
 	ColumnOptionStorage
 	ColumnOptionAutoRandom
+	ColumnOptionNoNullIndex
 )
 
 var (
@@ -598,6 +599,8 @@ func (n *ColumnOption) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord("UNIQUE KEY")
 	case ColumnOptionNull:
 		ctx.WriteKeyWord("NULL")
+	case ColumnOptionNoNullIndex:
+		ctx.WriteKeyWord("NO_NULL_INDEX")
 	case ColumnOptionOnUpdate:
 		ctx.WriteKeyWord("ON UPDATE ")
 		if err := n.Expr.Restore(ctx); err != nil {

--- a/pkg/parser/misc.go
+++ b/pkg/parser/misc.go
@@ -552,6 +552,7 @@ var tokenMap = map[string]int{
 	"NEXT":                     next,
 	"NEXTVAL":                  nextval,
 	"NO_WRITE_TO_BINLOG":       noWriteToBinLog,
+	"NO_NULL_INDEX":            noNullIndex,
 	"NO":                       no,
 	"NOCACHE":                  nocache,
 	"NOCYCLE":                  nocycle,

--- a/pkg/parser/model/model.go
+++ b/pkg/parser/model/model.go
@@ -117,6 +117,7 @@ type ColumnInfo struct {
 	FieldType           types.FieldType     `json:"type"`
 	State               SchemaState         `json:"state"`
 	Comment             string              `json:"comment"`
+	NoNullIndex         bool                `json:"no_null_index"`
 	// A hidden column is used internally(expression index) and are not accessible by users.
 	Hidden           bool `json:"hidden"`
 	*ChangeStateInfo `json:"change_state_info"`
@@ -1473,19 +1474,20 @@ const (
 // It corresponds to the statement `CREATE INDEX Name ON Table (Column);`
 // See https://dev.mysql.com/doc/refman/5.7/en/create-index.html
 type IndexInfo struct {
-	ID            int64          `json:"id"`
-	Name          CIStr          `json:"idx_name"` // Index name.
-	Table         CIStr          `json:"tbl_name"` // Table name.
-	Columns       []*IndexColumn `json:"idx_cols"` // Index columns.
-	State         SchemaState    `json:"state"`
-	BackfillState BackfillState  `json:"backfill_state"`
-	Comment       string         `json:"comment"`      // Comment
-	Tp            IndexType      `json:"index_type"`   // Index type: Btree, Hash or Rtree
-	Unique        bool           `json:"is_unique"`    // Whether the index is unique.
-	Primary       bool           `json:"is_primary"`   // Whether the index is primary key.
-	Invisible     bool           `json:"is_invisible"` // Whether the index is invisible.
-	Global        bool           `json:"is_global"`    // Whether the index is global.
-	MVIndex       bool           `json:"mv_index"`     // Whether the index is multivalued index.
+	ID                  int64          `json:"id"`
+	Name                CIStr          `json:"idx_name"` // Index name.
+	Table               CIStr          `json:"tbl_name"` // Table name.
+	Columns             []*IndexColumn `json:"idx_cols"` // Index columns.
+	NoNullIdxColOffsets []int          `json:"no_null_idx_cols"`
+	State               SchemaState    `json:"state"`
+	BackfillState       BackfillState  `json:"backfill_state"`
+	Comment             string         `json:"comment"`      // Comment
+	Tp                  IndexType      `json:"index_type"`   // Index type: Btree, Hash or Rtree
+	Unique              bool           `json:"is_unique"`    // Whether the index is unique.
+	Primary             bool           `json:"is_primary"`   // Whether the index is primary key.
+	Invisible           bool           `json:"is_invisible"` // Whether the index is invisible.
+	Global              bool           `json:"is_global"`    // Whether the index is global.
+	MVIndex             bool           `json:"mv_index"`     // Whether the index is multivalued index.
 }
 
 // Clone clones IndexInfo.

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -509,6 +509,7 @@ import (
 	nominvalue            "NOMINVALUE"
 	nonclustered          "NONCLUSTERED"
 	none                  "NONE"
+	noNullIndex           "NO_NULL_INDEX"
 	nowait                "NOWAIT"
 	nulls                 "NULLS"
 	nvarcharType          "NVARCHAR"
@@ -3660,6 +3661,10 @@ ColumnOption:
 |	"AUTO_RANDOM" AutoRandomOpt
 	{
 		$$ = &ast.ColumnOption{Tp: ast.ColumnOptionAutoRandom, AutoRandOpt: $2.(ast.AutoRandomOption)}
+	}
+|	"NO_NULL_INDEX"
+	{
+		$$ = &ast.ColumnOption{Tp: ast.ColumnOptionNoNullIndex}
 	}
 
 AutoRandomOpt:

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -6922,6 +6922,7 @@ UnReservedKeyword:
 |	"OLTP_READ_ONLY"
 |	"OLTP_WRITE_ONLY"
 |	"TPCH_10"
+|	"NO_NULL_INDEX"
 
 TiDBKeyword:
 	"ADMIN"

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1145,6 +1145,37 @@ func (ds *DataSource) skylinePruning(prop *property.PhysicalProperty) []*candida
 			candidates = append(candidates, ds.getIndexMergeCandidate(path, prop))
 			continue
 		}
+		// If the index contains NO_NULL_INDEX column, it may not contain all rows
+		if path.Index != nil && len(path.Index.NoNullIdxColOffsets) > 0 {
+			includeNullRange := false
+
+			for _, col := range path.Index.NoNullIdxColOffsets {
+				for _, ran := range path.Ranges {
+					if len(ran.LowVal) <= col || len(ran.HighVal) <= col ||
+						ran.LowVal[col].IsNull() || ran.HighVal[col].IsNull() {
+						includeNullRange = true
+						break
+					}
+				}
+
+				if includeNullRange {
+					// If the condition can make sure the column is not null, we can also use this index.
+					// TODO: maybe only considering the conditions except accessConds is enough, because the ranges
+					// don't contain NULL.
+					if ranger.CheckColumnIsNotNullWithCNFConditions(ds.SCtx(), path.FullIdxCols[col], ds.allConds) {
+						includeNullRange = false
+						continue
+					}
+
+					break
+				}
+			}
+
+			// conditions that the column is not null
+			if includeNullRange {
+				continue
+			}
+		}
 		// if we already know the range of the scan is empty, just return a TableDual
 		if len(path.Ranges) == 0 {
 			return []*candidatePath{{path: path}}

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1145,37 +1145,7 @@ func (ds *DataSource) skylinePruning(prop *property.PhysicalProperty) []*candida
 			candidates = append(candidates, ds.getIndexMergeCandidate(path, prop))
 			continue
 		}
-		// If the index contains NO_NULL_INDEX column, it may not contain all rows
-		if path.Index != nil && len(path.Index.NoNullIdxColOffsets) > 0 {
-			includeNullRange := false
 
-			for _, col := range path.Index.NoNullIdxColOffsets {
-				for _, ran := range path.Ranges {
-					if len(ran.LowVal) <= col || len(ran.HighVal) <= col ||
-						ran.LowVal[col].IsNull() || ran.HighVal[col].IsNull() {
-						includeNullRange = true
-						break
-					}
-				}
-
-				if includeNullRange {
-					// If the condition can make sure the column is not null, we can also use this index.
-					// TODO: maybe only considering the conditions except accessConds is enough, because the ranges
-					// don't contain NULL.
-					if ranger.CheckColumnIsNotNullWithCNFConditions(ds.SCtx(), path.FullIdxCols[col], ds.allConds) {
-						includeNullRange = false
-						continue
-					}
-
-					break
-				}
-			}
-
-			// conditions that the column is not null
-			if includeNullRange {
-				continue
-			}
-		}
 		// if we already know the range of the scan is empty, just return a TableDual
 		if len(path.Ranges) == 0 {
 			return []*candidatePath{{path: path}}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -973,6 +973,9 @@ func getPathByIndexName(paths []*util.AccessPath, idxName model.CIStr, tblInfo *
 	var primaryIdxPath, indexPrefixPath *util.AccessPath
 	prefixMatches := 0
 	for _, path := range paths {
+		if path.StoreType == kv.TiFlash && idxName.L == "tiflash" {
+			return path
+		}
 		if path.StoreType == kv.TiFlash {
 			continue
 		}

--- a/pkg/table/index.go
+++ b/pkg/table/index.go
@@ -110,6 +110,27 @@ type IndexKVGenerator struct {
 	idxVals []types.Datum
 }
 
+// NewEmptyIndexKVGenerator creates a new IndexKVGenerator for empty indexes.
+func NewEmptyIndexKVGenerator(
+	index Index,
+	ec errctx.Context,
+	loc *time.Location,
+	handle kv.Handle,
+	handleRestoredData []types.Datum,
+	idxData []types.Datum,
+) IndexKVGenerator {
+	return IndexKVGenerator{
+		index:             index,
+		ec:                ec,
+		loc:               loc,
+		handle:            handle,
+		handleRestoreData: handleRestoredData,
+		isMultiValue:      false,
+		idxVals:           idxData,
+		i:                 1, // trick to make Valid() return false
+	}
+}
+
 // NewMultiValueIndexKVGenerator creates a new IndexKVGenerator for multi-value indexes.
 func NewMultiValueIndexKVGenerator(
 	index Index,

--- a/pkg/table/tables/index.go
+++ b/pkg/table/tables/index.go
@@ -106,6 +106,14 @@ func (c *index) GenIndexValue(ec errctx.Context, loc *time.Location, distinct bo
 // 3. (i1, null, i2, ...) ==> [(i1, null, i2, ...)]
 // 4. (i1, [], i2, ...) ==> nothing.
 func (c *index) getIndexedValue(indexedValues []types.Datum) [][]types.Datum {
+	if len(c.idxInfo.NoNullIdxColOffsets) != 0 {
+		for _, offset := range c.idxInfo.NoNullIdxColOffsets {
+			if indexedValues[offset].IsNull() {
+				return nil
+			}
+		}
+	}
+
 	if !c.idxInfo.MVIndex {
 		return [][]types.Datum{indexedValues}
 	}
@@ -501,6 +509,13 @@ func (c *index) GenIndexKVIter(ec errctx.Context, loc *time.Location, indexedVal
 	if c.Meta().MVIndex {
 		mvIndexValues = c.getIndexedValue(indexedValue)
 		return table.NewMultiValueIndexKVGenerator(c, ec, loc, h, handleRestoreData, mvIndexValues)
+	}
+	if len(c.Meta().NoNullIdxColOffsets) != 0 {
+		for _, v := range c.Meta().NoNullIdxColOffsets {
+			if indexedValue[v].Kind() == types.KindNull {
+				return table.NewEmptyIndexKVGenerator(c, ec, loc, h, handleRestoreData, indexedValue)
+			}
+		}
 	}
 	return table.NewPlainIndexKVGenerator(c, ec, loc, h, handleRestoreData, indexedValue)
 }

--- a/pkg/util/ranger/BUILD.bazel
+++ b/pkg/util/ranger/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     timeout = "short",
     srcs = [
         "bench_test.go",
+        "checker_test.go",
         "main_test.go",
         "ranger_test.go",
         "types_test.go",

--- a/pkg/util/ranger/checker_test.go
+++ b/pkg/util/ranger/checker_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ranger_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	plannercore "github.com/pingcap/tidb/pkg/planner/core"
+	"github.com/pingcap/tidb/pkg/session"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/ranger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoNullIndexChecker(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b varchar(60), c decimal(10, 2), d tinyint(2))")
+
+	cases := []struct {
+		column   string
+		exprStrs []string
+		expected bool
+	}{
+		{
+			column:   "a",
+			exprStrs: []string{"a = 1"},
+			expected: true,
+		},
+		{
+			column:   "a",
+			exprStrs: []string{"a is NULL", "a is not NULL"},
+			expected: true,
+		},
+		{
+			column:   "a",
+			exprStrs: []string{"a = NULL"},
+			expected: true,
+		},
+		{
+			column:   "a",
+			exprStrs: []string{"a = 1", "b is not NULL"},
+			expected: true,
+		},
+		{
+			column:   "a",
+			exprStrs: []string{"b is not NULL"},
+			expected: false,
+		},
+		{
+			column:   "b",
+			exprStrs: []string{"b = 'test'"},
+			expected: true,
+		},
+		{
+			column:   "b",
+			exprStrs: []string{"b is NULL"},
+			expected: false,
+		},
+		{
+			column:   "c",
+			exprStrs: []string{"c > 0", "c < 100"},
+			expected: true,
+		},
+		{
+			column:   "c",
+			exprStrs: []string{"c is NULL", "c > 0"},
+			expected: true,
+		},
+		{
+			column:   "d",
+			exprStrs: []string{"d = 1"},
+			expected: true,
+		},
+		{
+			column:   "d",
+			exprStrs: []string{"d is not NULL", "d > 0"},
+			expected: true,
+		},
+		{
+			column:   "d",
+			exprStrs: []string{"d is NULL", "d = 1"},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(strings.Join(c.exprStrs, ","), func(t *testing.T) {
+			// it's a workaround to create `expression.Column` and `expression.Expression` for conditions
+			// and make sure they have the same `UniqueID` for each columns
+			sql := "select " + c.column + " from t where (" + strings.Join(c.exprStrs, ") and (") + ")"
+			stmts, err := session.Parse(tk.Session(), sql)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+			ret := &plannercore.PreprocessorReturn{}
+			err = plannercore.Preprocess(context.Background(), tk.Session(), stmts[0], plannercore.WithPreprocessorReturn(ret))
+			require.NoError(t, err)
+			p, err := plannercore.BuildLogicalPlanForTest(context.Background(), tk.Session(), stmts[0], ret.InfoSchema)
+			require.NoError(t, err)
+			projection := p.(*plannercore.LogicalProjection)
+			column := projection.Schema().Columns[0]
+			selection := projection.Children()[0].(*plannercore.LogicalSelection)
+
+			result := ranger.CheckColumnIsNotNullWithCNFConditions(tk.Session().GetPlanCtx(), column, selection.Conditions)
+			require.Equal(t, c.expected, result)
+		})
+	}
+}

--- a/tests/integrationtest/r/ddl/column.result
+++ b/tests/integrationtest/r/ddl/column.result
@@ -84,3 +84,49 @@ t	CREATE TABLE `t` (
   `a` decimal(10,0) DEFAULT NULL,
   `b` decimal(10,0) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists t;
+create table t(a bit(2) default b'111');
+Error 1067 (42000): Invalid default value for 'a'
+create table t(a bit(65) default b'111');
+Error 1439 (42000): Display width out of range for column 'a' (max = 64)
+create table t(a bit(64) default b'1111111111111111111111111111111111111111111111111111111111111111');
+drop table t;
+create table t(a bit(3) default b'111');
+drop table t;
+create table t(a bit(3) default b'000111');
+drop table t;
+create table t(a bit(32) default b'1111111111111111111111111111111');
+drop table if exists t;
+create table t(col1 int, col2 int);
+alter table t modify column col1 int no_null_index;
+alter table t add index idx(col1, col2);
+alter table t modify column col2 int no_null_index;
+Error 8200 (HY000): Unsupported modify column: can't modify column to no_null_index with existing index
+alter table t modify column col1 int no_null_index;
+alter table t drop index idx;
+alter table t modify column col2 int no_null_index;
+alter table t add index idx(col1, col2);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col1` int(11) DEFAULT NULL NO_NULL_INDEX,
+  `col2` int(11) DEFAULT NULL NO_NULL_INDEX,
+  KEY `idx` (`col1`,`col2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+drop table if exists t;
+create table t(col1 int, col2 int);
+alter table t change column col1 col1 int no_null_index;
+alter table t add index idx(col1, col2);
+alter table t change column col2 col3 int no_null_index;
+Error 8200 (HY000): Unsupported modify column: can't modify column to no_null_index with existing index
+alter table t change column col1 col3 int no_null_index;
+alter table t drop index idx;
+alter table t change column col2 col4 int no_null_index;
+alter table t add index idx(col3, col4);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col3` int(11) DEFAULT NULL NO_NULL_INDEX,
+  `col4` int(11) DEFAULT NULL NO_NULL_INDEX,
+  KEY `idx` (`col3`,`col4`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin

--- a/tests/integrationtest/r/executor/admin.result
+++ b/tests/integrationtest/r/executor/admin.result
@@ -218,3 +218,10 @@ insert into admin_test with recursive cte(a, b) as (select 1, 1 union select a+1
 select /*+ read_from_storage(tikv[`executor__admin`.`admin_test`]) */ bit_xor(crc32(md5(concat_ws(0x2, `c1`, `c2`)))), ((cast(crc32(md5(concat_ws(0x2, `c1`))) as signed) - 9223372036854775807) div 1 % 1024), count(*) from `executor__admin`.`admin_test` use index() where 0 = 0 group by ((cast(crc32(md5(concat_ws(0x2, `c1`))) as signed) - 9223372036854775807) div 1 % 1024);
 select bit_xor(crc32(md5(concat_ws(0x2, `c1`, `c2`)))), ((cast(crc32(md5(concat_ws(0x2, `c1`))) as signed) - 9223372036854775807) div 1 % 1024), count(*) from `executor__admin`.`admin_test` use index(`c2`) where 0 = 0 group by ((cast(crc32(md5(concat_ws(0x2, `c1`))) as signed) - 9223372036854775807) div 1 % 1024);
 set cte_max_recursion_depth=default;
+drop table if exists t;
+create table t (col1 int no_null_index);
+alter table t add index idx(col1);
+insert into t values (NULL);
+insert into t values (1);
+admin check index t idx;
+admin check table t;

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -4445,3 +4445,34 @@ id	estRows	task	access object	operator info
 TableReader	8.00	root		data:Selection
 └─Selection	8.00	cop[tikv]		isnull(planner__core__integration.t.col1), json_contains(json_extract(planner__core__integration.t.col2, "$.path"), cast("1", json BINARY)), json_contains(json_extract(planner__core__integration.t.col3, "$.path"), cast("1", json BINARY))
   └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+create table t (a int, b int, c int no_null_index, key a(a), key b(b), key ac(a, c), key bc(b, c));
+insert into t values (NULL, 1, 1);
+insert into t values (1, NULL, 1);
+insert into t values (1, 1, NULL);
+select * from t where a is null or b is null order by c;
+a	b	c
+NULL	1	1
+1	NULL	1
+explain format='verbose' select * from t where a is null or b is null order by c;
+id	estRows	estCost	task	access object	operator info
+Sort_5	19.99	5431.39	root		planner__core__integration.t.c
+└─IndexMerge_14	19.99	1019.04	root		type: union
+  ├─IndexRangeScan_11(Build)	10.00	2035.00	cop[tikv]	table:t, index:a(a)	range:[NULL,NULL], keep order:false, stats:pseudo
+  ├─IndexRangeScan_12(Build)	10.00	2035.00	cop[tikv]	table:t, index:b(b)	range:[NULL,NULL], keep order:false, stats:pseudo
+  └─TableRowIDScan_13(Probe)	19.99	4881.56	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+create table t (a int no_null_index, b int, c int, key a(a), key b(b), key ac(a, c), key bc(b, c));
+insert into t values (NULL, 1, 1);
+insert into t values (1, NULL, 1);
+insert into t values (1, 1, NULL);
+select * from t where a is null or b is null order by c;
+a	b	c
+NULL	1	1
+1	NULL	1
+explain format='verbose' select * from t where a is null or b is null order by c;
+id	estRows	estCost	task	access object	operator info
+Sort_5	19.99	200732.32	root		planner__core__integration.t.c
+└─TableReader_10	19.99	196319.98	root		data:Selection_9
+  └─Selection_9	19.99	2941000.00	cop[tikv]		or(isnull(planner__core__integration.t.a), isnull(planner__core__integration.t.b))
+    └─TableFullScan_8	10000.00	2442000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -4312,3 +4312,97 @@ case when (
 t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
 ) then 1 else 2 end;
 1
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 int, col3 int no_null_index);
+alter table t add index idx1(col1);
+alter table t add index idx2(col1, col2);
+alter table t add index idx3(col1, col2, col3);
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int(11) NOT NULL,
+  `col1` int(11) DEFAULT NULL NO_NULL_INDEX,
+  `col2` int(11) DEFAULT NULL,
+  `col3` int(11) DEFAULT NULL NO_NULL_INDEX,
+  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
+  KEY `idx1` (`col1`),
+  KEY `idx2` (`col1`,`col2`),
+  KEY `idx3` (`col1`,`col2`,`col3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+insert into t values (1, 1, 1, null);
+insert into t values (2, null, 1, 1);
+insert into t values (3, 1, null, 1);
+select * from t use index (idx1);
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+select * from t use index (idx2);
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+select * from t use index (idx3);
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+select * from t use index (idx1) where col1 is not null;
+id	col1	col2	col3
+1	1	1	NULL
+3	1	NULL	1
+explain format='brief' select * from t use index (idx1) where col1 is not null;
+id	estRows	task	access object	operator info
+IndexLookUp	9990.00	root		
+├─IndexFullScan(Build)	9990.00	cop[tikv]	table:t, index:idx1(col1)	keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	9990.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx1) where col1 > 0;
+id	col1	col2	col3
+1	1	1	NULL
+3	1	NULL	1
+explain format='brief' select * from t use index (idx1) where col1 > 0;
+id	estRows	task	access object	operator info
+IndexLookUp	3333.33	root		
+├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t, index:idx1(col1)	range:(0,+inf], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	3333.33	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx2) where col1 is not null;
+id	col1	col2	col3
+1	1	1	NULL
+3	1	NULL	1
+explain format='brief' select * from t use index (idx2) where col1 is not null;
+id	estRows	task	access object	operator info
+IndexLookUp	9990.00	root		
+├─IndexFullScan(Build)	9990.00	cop[tikv]	table:t, index:idx2(col1, col2)	keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	9990.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx2) where col1 > 0;
+id	col1	col2	col3
+1	1	1	NULL
+3	1	NULL	1
+explain format='brief' select * from t use index (idx2) where col1 > 0;
+id	estRows	task	access object	operator info
+IndexLookUp	3333.33	root		
+├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t, index:idx2(col1, col2)	range:(0,+inf], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	3333.33	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx3) where col1 is not null;
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+select * from t use index (idx1) where col1 is not null and col3 is not null;
+id	col1	col2	col3
+3	1	NULL	1
+explain format='brief' select * from t use index (idx1) where col1 is not null and col3 is not null;
+id	estRows	task	access object	operator info
+IndexLookUp	9980.01	root		
+├─IndexFullScan(Build)	9990.00	cop[tikv]	table:t, index:idx1(col1)	keep order:false, stats:pseudo
+└─Selection(Probe)	9980.01	cop[tikv]		not(isnull(planner__core__integration.t.col3))
+  └─TableRowIDScan	9990.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx1) where col1 > 0 and col3 is not null;
+id	col1	col2	col3
+3	1	NULL	1
+explain format='brief' select * from t use index (idx1) where col1 > 0 and col3 is not null;
+id	estRows	task	access object	operator info
+IndexLookUp	3330.00	root		
+├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t, index:idx1(col1)	range:(0,+inf], keep order:false, stats:pseudo
+└─Selection(Probe)	3330.00	cop[tikv]		not(isnull(planner__core__integration.t.col3))
+  └─TableRowIDScan	3333.33	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx2) where col1 is not null and col3 is not null;
+id	col1	col2	col3
+3	1	NULL	1
+explain format='brief' select * from t use index (idx2) where col1 is not null and col3 is not null;
+id	estRows	task	access object	operator info
+IndexLookUp	9980.01	root		
+├─IndexFullScan(Build)	9990.00	cop[tikv]	table:t, index:idx2(col1, col2)	keep order:false, stats:pseudo
+└─Selection(Probe)	9980.01	cop[tikv]		not(isnull(planner__core__integration.t.col3))
+  └─TableRowIDScan	9990.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select * from t use index (idx3) where col1 is not null and col3 is not null;
+id	col1	col2	col3
+3	1	NULL	1

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -4406,3 +4406,42 @@ IndexLookUp	9980.01	root
 select * from t use index (idx3) where col1 is not null and col3 is not null;
 id	col1	col2	col3
 3	1	NULL	1
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 int, col3 int);
+alter table t add index idx2(col1, col2);
+alter table t add index idx3(col1, col3);
+insert into t values (2, null, 1, 1);
+select * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
+id	col1	col2	col3
+2	NULL	1	1
+select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+explain format='brief' select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
+Error 1815 (HY000): Internal : Can't find a proper physical plan for this query
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 int no_null_index);
+alter table t add index idx1(col1);
+alter table t add index idx2(col2);
+insert into t values (1, 1, NULL);
+insert into t values (2, NULL, 1);
+select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * FROM t WHERE col1 > 5 or col2 > 5;
+id	col1	col2
+explain format='brief' select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * FROM t WHERE col1 > 5 or col2 > 5;
+id	estRows	task	access object	operator info
+IndexMerge	5555.56	root		type: union
+├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t, index:idx1(col1)	range:(5,+inf], keep order:false, stats:pseudo
+├─IndexRangeScan(Build)	3333.33	cop[tikv]	table:t, index:idx2(col2)	range:(5,+inf], keep order:false, stats:pseudo
+└─TableRowIDScan(Probe)	5555.56	cop[tikv]	table:t	keep order:false, stats:pseudo
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 json, col3 json);
+alter table t add index idx2(col1, (CAST(col2->'$.path' AS SIGNED ARRAY)) );
+alter table t add index idx3(col1, (CAST(col3->'$.path' AS SIGNED ARRAY)) );
+insert into t values (2, null, '{"path":[1]}', '{"path":[1]}');
+select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and json_contains(col2->'$.path', '1') and json_contains(col3->'$.path', '1');
+id	col1	col2	col3
+2	NULL	{"path": [1]}	{"path": [1]}
+explain format='brief' select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and json_contains(col2->'$.path', '1') and json_contains(col3->'$.path', '1');
+id	estRows	task	access object	operator info
+TableReader	8.00	root		data:Selection
+└─Selection	8.00	cop[tikv]		isnull(planner__core__integration.t.col1), json_contains(json_extract(planner__core__integration.t.col2, "$.path"), cast("1", json BINARY)), json_contains(json_extract(planner__core__integration.t.col3, "$.path"), cast("1", json BINARY))
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/ddl/column.test
+++ b/tests/integrationtest/t/ddl/column.test
@@ -44,3 +44,44 @@ alter table t1 add column d date default '2024-10';
 drop table if exists t;
 create table t(a decimal(0,0), b decimal(0));
 show create table t;
+
+# TestTooLongDefaultValueForBit
+drop table if exists t;
+-- error 1067
+create table t(a bit(2) default b'111');
+-- error 1439
+create table t(a bit(65) default b'111');
+create table t(a bit(64) default b'1111111111111111111111111111111111111111111111111111111111111111');
+drop table t;
+create table t(a bit(3) default b'111');
+drop table t;
+create table t(a bit(3) default b'000111');
+drop table t;
+create table t(a bit(32) default b'1111111111111111111111111111111');
+
+# TestSetNoNullIndex
+drop table if exists t;
+create table t(col1 int, col2 int);
+alter table t modify column col1 int no_null_index;
+# this grammar doesn't allow remove "no_null_index" from a column, modify it.
+alter table t add index idx(col1, col2);
+-- error 8200
+alter table t modify column col2 int no_null_index;
+alter table t modify column col1 int no_null_index;
+alter table t drop index idx;
+alter table t modify column col2 int no_null_index;
+alter table t add index idx(col1, col2);
+show create table t;
+
+drop table if exists t;
+create table t(col1 int, col2 int);
+alter table t change column col1 col1 int no_null_index;
+# this grammar doesn't allow remove "no_null_index" from a column, modify it.
+alter table t add index idx(col1, col2);
+-- error 8200
+alter table t change column col2 col3 int no_null_index;
+alter table t change column col1 col3 int no_null_index;
+alter table t drop index idx;
+alter table t change column col2 col4 int no_null_index;
+alter table t add index idx(col3, col4);
+show create table t;

--- a/tests/integrationtest/t/executor/admin.test
+++ b/tests/integrationtest/t/executor/admin.test
@@ -226,3 +226,12 @@ select /*+ read_from_storage(tikv[`executor__admin`.`admin_test`]) */ bit_xor(cr
 select bit_xor(crc32(md5(concat_ws(0x2, `c1`, `c2`)))), ((cast(crc32(md5(concat_ws(0x2, `c1`))) as signed) - 9223372036854775807) div 1 % 1024), count(*) from `executor__admin`.`admin_test` use index(`c2`) where 0 = 0 group by ((cast(crc32(md5(concat_ws(0x2, `c1`))) as signed) - 9223372036854775807) div 1 % 1024);
 set cte_max_recursion_depth=default;
 --enable_result_log
+
+# TestAdminCheckNoNullIndex
+drop table if exists t;
+create table t (col1 int no_null_index);
+alter table t add index idx(col1);
+insert into t values (NULL);
+insert into t values (1);
+admin check index t idx;
+admin check table t;

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2377,3 +2377,38 @@ select 1 from (select t.col as c0, 46578369 as c1 from t) as t where
   case when (
     t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
   ) then 1 else 2 end;
+
+# TestNoNullIndex
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 int, col3 int no_null_index);
+alter table t add index idx1(col1);
+alter table t add index idx2(col1, col2);
+alter table t add index idx3(col1, col2, col3);
+show create table t;
+insert into t values (1, 1, 1, null);
+insert into t values (2, null, 1, 1);
+insert into t values (3, 1, null, 1);
+# TODO: it would be better to return TableFullScan instead of returning error
+-- error 1815
+select * from t use index (idx1);
+-- error 1815
+select * from t use index (idx2);
+-- error 1815
+select * from t use index (idx3);
+select * from t use index (idx1) where col1 is not null;
+explain format='brief' select * from t use index (idx1) where col1 is not null;
+select * from t use index (idx1) where col1 > 0;
+explain format='brief' select * from t use index (idx1) where col1 > 0;
+select * from t use index (idx2) where col1 is not null;
+explain format='brief' select * from t use index (idx2) where col1 is not null;
+select * from t use index (idx2) where col1 > 0;
+explain format='brief' select * from t use index (idx2) where col1 > 0;
+-- error 1815
+select * from t use index (idx3) where col1 is not null;
+select * from t use index (idx1) where col1 is not null and col3 is not null;
+explain format='brief' select * from t use index (idx1) where col1 is not null and col3 is not null;
+select * from t use index (idx1) where col1 > 0 and col3 is not null;
+explain format='brief' select * from t use index (idx1) where col1 > 0 and col3 is not null;
+select * from t use index (idx2) where col1 is not null and col3 is not null;
+explain format='brief' select * from t use index (idx2) where col1 is not null and col3 is not null;
+select * from t use index (idx3) where col1 is not null and col3 is not null;

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2419,6 +2419,7 @@ create table t (id int primary key, col1 int no_null_index, col2 int, col3 int);
 alter table t add index idx2(col1, col2);
 alter table t add index idx3(col1, col3);
 insert into t values (2, null, 1, 1);
+-- sorted_result
 select * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
 -- error 1815
 select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
@@ -2431,6 +2432,7 @@ alter table t add index idx1(col1);
 alter table t add index idx2(col2);
 insert into t values (1, 1, NULL);
 insert into t values (2, NULL, 1);
+-- sorted_result
 select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * FROM t WHERE col1 > 5 or col2 > 5;
 explain format='brief' select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * FROM t WHERE col1 > 5 or col2 > 5;
 
@@ -2439,5 +2441,24 @@ create table t (id int primary key, col1 int no_null_index, col2 json, col3 json
 alter table t add index idx2(col1, (CAST(col2->'$.path' AS SIGNED ARRAY)) );
 alter table t add index idx3(col1, (CAST(col3->'$.path' AS SIGNED ARRAY)) );
 insert into t values (2, null, '{"path":[1]}', '{"path":[1]}');
+-- sorted_result
 select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and json_contains(col2->'$.path', '1') and json_contains(col3->'$.path', '1');
 explain format='brief' select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and json_contains(col2->'$.path', '1') and json_contains(col3->'$.path', '1');
+
+drop table if exists t;
+create table t (a int, b int, c int no_null_index, key a(a), key b(b), key ac(a, c), key bc(b, c));
+insert into t values (NULL, 1, 1);
+insert into t values (1, NULL, 1);
+insert into t values (1, 1, NULL);
+-- sorted_result
+select * from t where a is null or b is null order by c;
+explain format='verbose' select * from t where a is null or b is null order by c;
+
+drop table if exists t;
+create table t (a int no_null_index, b int, c int, key a(a), key b(b), key ac(a, c), key bc(b, c));
+insert into t values (NULL, 1, 1);
+insert into t values (1, NULL, 1);
+insert into t values (1, 1, NULL);
+-- sorted_result
+select * from t where a is null or b is null order by c;
+explain format='verbose' select * from t where a is null or b is null order by c;

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2412,3 +2412,32 @@ explain format='brief' select * from t use index (idx1) where col1 > 0 and col3 
 select * from t use index (idx2) where col1 is not null and col3 is not null;
 explain format='brief' select * from t use index (idx2) where col1 is not null and col3 is not null;
 select * from t use index (idx3) where col1 is not null and col3 is not null;
+
+# TestNoNullIndexWithIndexMerge
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 int, col3 int);
+alter table t add index idx2(col1, col2);
+alter table t add index idx3(col1, col3);
+insert into t values (2, null, 1, 1);
+select * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
+-- error 1815
+select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
+-- error 1815
+explain format='brief' select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and col2 < 100 and col3 < 100;
+
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 int no_null_index);
+alter table t add index idx1(col1);
+alter table t add index idx2(col2);
+insert into t values (1, 1, NULL);
+insert into t values (2, NULL, 1);
+select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * FROM t WHERE col1 > 5 or col2 > 5;
+explain format='brief' select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * FROM t WHERE col1 > 5 or col2 > 5;
+
+drop table if exists t;
+create table t (id int primary key, col1 int no_null_index, col2 json, col3 json);
+alter table t add index idx2(col1, (CAST(col2->'$.path' AS SIGNED ARRAY)) );
+alter table t add index idx3(col1, (CAST(col3->'$.path' AS SIGNED ARRAY)) );
+insert into t values (2, null, '{"path":[1]}', '{"path":[1]}');
+select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and json_contains(col2->'$.path', '1') and json_contains(col3->'$.path', '1');
+explain format='brief' select /*+ USE_INDEX_MERGE(t, idx2, idx3) */ * FROM t WHERE col1 is null and json_contains(col2->'$.path', '1') and json_contains(col3->'$.path', '1');


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

no_null_index:
1. Add the parser for column option "no_null_index"
2. Modify the logic of generating index key/value.
3. Modify the skyline pruner to remove invalid path.
4. Add support for CHANGE COLUMN MODIFY COLUMN ADMIN CHECK.

use_index(tiflash):
```
mysql> explain select /*+ use_index(txx, a, b, primary, tiflash) */ 1 from txx;
+----------------------------+----------+--------------+---------------+---------------------------------------+
| id                         | estRows  | task         | access object | operator info                         |
+----------------------------+----------+--------------+---------------+---------------------------------------+
| TableReader_16             | 10000.00 | root         |               | MppVersion: 3, data:ExchangeSender_15 |
| └─ExchangeSender_15        | 10000.00 | mpp[tiflash] |               | ExchangeType: PassThrough             |
|   └─Projection_4           | 10000.00 | mpp[tiflash] |               | 1->Column#6                           |
|     └─TableFullScan_14     | 10000.00 | mpp[tiflash] | table:txx     | keep order:false, stats:pseudo        |
+----------------------------+----------+--------------+---------------+---------------------------------------+
4 rows in set (0.00 sec)

mysql> explain select /*+ use_index(txx, a, b, primary, tiflash) */ 1 from txx where a=1;
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| id                       | estRows | task      | access object         | operator info                               |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| Projection_4             | 10.00   | root      |                       | 1->Column#6                                 |
| └─IndexReader_7          | 10.00   | root      |                       | index:IndexRangeScan_6                      |
|   └─IndexRangeScan_6     | 10.00   | cop[tikv] | table:txx, index:a(a) | range:[1,1], keep order:false, stats:pseudo |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
3 rows in set (0.01 sec)

mysql> explain select /*+ use_index(txx, a, b, primary, tiflash) */ 1 from txx where b=1;
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| id                       | estRows | task      | access object         | operator info                               |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
| Projection_4             | 10.00   | root      |                       | 1->Column#6                                 |
| └─IndexReader_7          | 10.00   | root      |                       | index:IndexRangeScan_6                      |
|   └─IndexRangeScan_6     | 10.00   | cop[tikv] | table:txx, index:b(b) | range:[1,1], keep order:false, stats:pseudo |
+--------------------------+---------+-----------+-----------------------+---------------------------------------------+
3 rows in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
