### PR TITLE
planner: Enable the non-prepared plan cache for queries with bindings.

### DIFF
--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -218,9 +218,15 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	// The SkipPlanCache function doesn't work until EnablePlanCache() is called in GetPlanFromPlanCache.
 	skipNonPreparedCache := false
 
-	// Disable the plan cache to prevent running the code above twice.
 	if sessVars.StmtCtx.StmtHints.HasResourceGroup {
+		/* If the prepared plan cache is enabled, this SetSkipPlanCache call is
+		needed to insure that the resource_group handling code is run each time
+		the query is executed. */
 		sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL")
+
+		/* If the non-prepared plan cache is enabled, skipNonPreparedCache must
+		be set to true to insure that the resource_group handling code does not
+		run twice for non-prepared statements. */
 		skipNonPreparedCache = true
 	}
 
@@ -234,7 +240,14 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	}
 	// Setting skipNonPreparedCache to true to prevent running the code above twice.
 	if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
+		/* If the prepared plan cache is enabled, this SetSkipPlanCache call is
+		needed to insure that the SET_VAR code is run each time the query is
+		executed. */
 		sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
+
+		/* If the non-prepared plan cache is enabled, skipNonPreparedCache must
+		be set to true to insure that the SET_VAR code does not run twice for
+		non-prepared statements. */
 		skipNonPreparedCache = true
 	}
 

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -265,7 +265,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	// try to get Plan from the NonPrepared Plan Cache
 	if sessVars.EnableNonPreparedPlanCache &&
 		isStmtNode &&
-		!useBinding && // TODO: support binding
 		!skipNonPreparedCache {
 		cachedPlan, names, ok, err := getPlanFromNonPreparedPlanCache(ctx, sctx, stmtNode, is)
 		if err != nil {

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -894,19 +894,25 @@ set tidb_enable_non_prepared_plan_cache=1;
 create binding for select * from t where a=1 using select /*+ use_index(t, a) */ * from t where a=1;
 select * from t where a=1;
 a
+select @@last_plan_from_binding, @@last_plan_from_cache;
+@@last_plan_from_binding	@@last_plan_from_cache
+1	0
 select * from t where a=1;
 a
-select @@last_plan_from_cache;
-@@last_plan_from_cache
-0
+select @@last_plan_from_binding, @@last_plan_from_cache;
+@@last_plan_from_binding	@@last_plan_from_cache
+1	1
 drop binding for select * from t where a=1;
 select * from t where a=1;
 a
+select @@last_plan_from_binding, @@last_plan_from_cache;
+@@last_plan_from_binding	@@last_plan_from_cache
+0	0
 select * from t where a=1;
 a
-select @@last_plan_from_cache;
-@@last_plan_from_cache
-1
+select @@last_plan_from_binding, @@last_plan_from_cache;
+@@last_plan_from_binding	@@last_plan_from_cache
+0	1
 set tidb_enable_non_prepared_plan_cache=DEFAULT;
 drop table if exists t;
 create table t (a int primary key, b int, unique key(b));

--- a/tests/integrationtest/t/planner/core/plan_cache.test
+++ b/tests/integrationtest/t/planner/core/plan_cache.test
@@ -622,12 +622,14 @@ create table t(a int, index(a));
 set tidb_enable_non_prepared_plan_cache=1;
 create binding for select * from t where a=1 using select /*+ use_index(t, a) */ * from t where a=1;
 select * from t where a=1;
+select @@last_plan_from_binding, @@last_plan_from_cache;
 select * from t where a=1;
-select @@last_plan_from_cache;
+select @@last_plan_from_binding, @@last_plan_from_cache;
 drop binding for select * from t where a=1;
 select * from t where a=1;
+select @@last_plan_from_binding, @@last_plan_from_cache;
 select * from t where a=1;
-select @@last_plan_from_cache;
+select @@last_plan_from_binding, @@last_plan_from_cache;
 set tidb_enable_non_prepared_plan_cache=DEFAULT;
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61047

Problem Summary:

The non-prepared plan cache does not support queries with SQL bindings.

### What changed and how does it work?
This patch:
* adds support for SQL bindings in the non-prepared plan cache,
* adds some comments in Optimize(),
* adds a test for the SQL bindings in the non-prepared plan cache.
 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The non-prepared cache now supports queries with SQL binding.
```
