### PR TITLE
txn: also update the `@@tidb_last_txn_info` for readyonly or rollback txns

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -330,6 +330,11 @@ func (a *ExecStmt) PointGet(ctx context.Context) (*recordSet, error) {
 			exec.Recreated(pointGetPlan, a.Ctx)
 			a.PsStmt.PointGet.Executor = exec
 			executor = exec
+			// If reuses the executor, the executor build phase is skipped, and the txn will not be activated that
+			// caused `TxnCtx.StartTS` to be 0.
+			// So we should set the `TxnCtx.StartTS` manually here to make sure it is not 0
+			// to provide the right value for `@@tidb_last_txn_info` or other variables.
+			a.Ctx.GetSessionVars().TxnCtx.StartTS = startTs
 		}
 	}
 

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -564,7 +564,7 @@ func TestTiDBLastTxnInfo(t *testing.T) {
 	tk.MustExec("commit")
 	rows3 := tk.MustQuery("select json_extract(@@tidb_last_txn_info, '$.start_ts'), json_extract(@@tidb_last_txn_info, '$.commit_ts')").Rows()
 	require.Equal(t, strconv.FormatUint(startTS2, 10), rows3[0][0])
-	require.Equal(t, "<nil>", rows3[0][1])
+	require.Equal(t, "0", rows3[0][1])
 
 	// txn explicitly started with begin
 	tk.MustExec("begin")
@@ -590,7 +590,7 @@ func TestTiDBLastTxnInfo(t *testing.T) {
 	tk.MustExec("rollback")
 	rows6 := tk.MustQuery("select json_extract(@@tidb_last_txn_info, '$.start_ts'), json_extract(@@tidb_last_txn_info, '$.commit_ts')").Rows()
 	require.Equal(t, strconv.FormatUint(startTS4, 10), rows6[0][0])
-	require.Equal(t, "<nil>", rows6[0][1])
+	require.Equal(t, "0", rows6[0][1])
 
 	// optimistic txn commit failed
 	tk.MustExec("begin optimistic")

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -130,6 +130,7 @@ go_library(
         "@com_github_tikv_client_go_v2//error",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//tikv",
+        "@com_github_tikv_client_go_v2//txnkv/transaction",
         "@com_github_tikv_client_go_v2//util",
         "@io_etcd_go_etcd_client_v3//:client",
         "@io_etcd_go_etcd_client_v3//concurrency",

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -128,6 +128,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/tracing"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
 	tikvutil "github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -984,10 +985,12 @@ func (s *session) setLastTxnInfoBeforeTxnEnd() {
 		return
 	}
 
-	s.GetSessionVars().LastTxnInfo = fmt.Sprintf(
-		`{"txn_scope": "%s", "start_ts": %d, "for_update_ts": %d}`,
-		txnCtx.TxnScope, txnCtx.StartTS, txnCtx.GetForUpdateTS(),
-	)
+	lastTxnInfo, err := json.Marshal(transaction.TxnInfo{
+		TxnScope: txnCtx.TxnScope,
+		StartTS:  txnCtx.StartTS,
+	})
+	terror.Log(err)
+	s.GetSessionVars().LastTxnInfo = string(lastTxnInfo)
 }
 
 func (s *session) GetClient() kv.Client {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -975,7 +975,7 @@ func (s *session) RollbackTxn(ctx context.Context) {
 
 // setLastTxnInfoBeforeTxnEnd sets the @@last_txn_info variable before commit/rollback the transaction.
 // The `LastTxnInfo` updated with a JSON string that contains start_ts, for_update_ts, etc.
-// It updated `LastTxnInfo` does not contain the `commit_ts` fields because it is unknown
+// The `LastTxnInfo` is updated without the `commit_ts` fields because it is unknown
 // until the commit is done (or do not need to commit for readonly or a rollback transaction).
 // The non-readonly transaction will overwrite the `LastTxnInfo` again after commit to update the `commit_ts` field.
 func (s *session) setLastTxnInfoBeforeTxnEnd() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61056

### What changed and how does it work?

also update the `@@tidb_last_txn_info` for readyonly or rollback transactions

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
@@tidb_last_txn_info will also be updated when readonly transaction ends or transaction rollback
```
