### PR TITLE
executor/infoschema_reader: exclude virtual schema in TIKV_REGION_STATUS

### DIFF
--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -367,7 +367,7 @@ func TestTikvRegionStatus(t *testing.T) {
 	))
 
 	// Run the query to ensure virtual schemas are excluded and expect no rows to be returned
-	tk.MustQuery(`SELECT DB_NAME FROM information_schema.TIKV_REGION_STATUS WHERE DB_NAME IN ('information_schema', 'metrics_schema', 'performance_schema')`).Check(testkit.Rows())
+	tk.MustQuery(`SELECT DB_NAME FROM information_schema.TIKV_REGION_STATUS WHERE DB_NAME IN ('INFORMATION_SCHEMA', 'METRICS_SCHEMA', 'PERFORMANCE_SCHEMA')`).Check(testkit.Rows())
 }
 
 func TestTableStorageStats(t *testing.T) {

--- a/pkg/executor/infoschema_cluster_table_test.go
+++ b/pkg/executor/infoschema_cluster_table_test.go
@@ -365,6 +365,9 @@ func TestTikvRegionStatus(t *testing.T) {
 		"1 test test_t2 1 p_a 1 p1",
 		"1 test test_t2 1 p_b 0 <nil>",
 	))
+
+	// Run the query to ensure virtual schemas are excluded and expect no rows to be returned
+	tk.MustQuery(`SELECT DB_NAME FROM information_schema.TIKV_REGION_STATUS WHERE DB_NAME IN ('information_schema', 'metrics_schema', 'performance_schema')`).Check(testkit.Rows())
 }
 
 func TestTableStorageStats(t *testing.T) {

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2095,7 +2095,7 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 	}
 
 	tableInfos := tikvHelper.GetRegionsTableInfo(allRegionsInfo, is, nil)
-	virtualSchemas := []string{"information_schema", "metrics_schema", "performance_schema"}
+	virtualSchemas := []string{util.InformationSchemaName.L, util.PerformanceSchemaName.L, util.MetricSchemaName.L}
 	for i := range allRegionsInfo.Regions {
 		regionTableList := tableInfos[allRegionsInfo.Regions[i].ID]
 		if len(regionTableList) == 0 {

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2095,6 +2095,7 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 	}
 
 	tableInfos := tikvHelper.GetRegionsTableInfo(allRegionsInfo, is, nil)
+	virtualSchemas := []string{"information_schema", "metrics_schema", "performance_schema"}
 	for i := range allRegionsInfo.Regions {
 		regionTableList := tableInfos[allRegionsInfo.Regions[i].ID]
 		if len(regionTableList) == 0 {
@@ -2102,7 +2103,6 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 		}
 		for j, regionTable := range regionTableList {
 			// Exclude virtual schemas
-			var virtualSchemas = []string{"information_schema", "metrics_schema", "performance_schema"}
 			if slices.Contains(virtualSchemas, regionTable.DB.Name.L) {
 				continue
 			}

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2101,6 +2101,11 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 			e.setNewTiKVRegionStatusCol(&allRegionsInfo.Regions[i], nil)
 		}
 		for j, regionTable := range regionTableList {
+			// Exclude virtual schemas
+			var virtualSchemas = []string{"information_schema", "metrics_schema", "performance_schema"}
+			if slices.Contains(virtualSchemas, regionTable.DB.Name.L) {
+				continue
+			}
 			if checker != nil && !checker.RequestVerification(sctx.GetSessionVars().ActiveRoles, regionTable.DB.Name.L, regionTable.Table.Name.L, "", mysql.AllPrivMask) {
 				continue
 			}

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2095,7 +2095,6 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 	}
 
 	tableInfos := tikvHelper.GetRegionsTableInfo(allRegionsInfo, is, nil)
-	virtualSchemas := []string{util.InformationSchemaName.L, util.PerformanceSchemaName.L, util.MetricSchemaName.L}
 	for i := range allRegionsInfo.Regions {
 		regionTableList := tableInfos[allRegionsInfo.Regions[i].ID]
 		if len(regionTableList) == 0 {
@@ -2103,7 +2102,7 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 		}
 		for j, regionTable := range regionTableList {
 			// Exclude virtual schemas
-			if slices.Contains(virtualSchemas, regionTable.DB.Name.L) {
+			if util.IsMemDB(regionTable.DB.Name.L) {
 				continue
 			}
 			if checker != nil && !checker.RequestVerification(sctx.GetSessionVars().ActiveRoles, regionTable.DB.Name.L, regionTable.Table.Name.L, "", mysql.AllPrivMask) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #59698

Problem Summary:

### What changed and how does it work?

Add a check to exclude INFORMATION_SCHEMA, METRICS_SCHEMA and PERFORMANCE_SCHEMA when TIKV_REGION_STATUS is queried.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Previously, when you query TIKV_REGION_STATUS, results will show tables from INFORMATION_SCHEMA, METRICS_SCHEMA and PERFORMANCE_SCHEMA. From now on, it will not be shown as a part of this TIKV_REGION_STATUS results as they are not a part of TiKV data store.
```
