### PR TITLE
planner: fix BatchPointGetPlan cannot redact the explain data

### DIFF
--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -605,12 +605,18 @@ func (p *BatchPointGetPlan) OperatorInfo(normalized bool) string {
 		if normalized {
 			buffer.WriteString("handle:?, ")
 		} else {
+			redactMode := p.SCtx().GetSessionVars().EnableRedactLog
+			redactOn := redactMode == errors.RedactLogEnable
 			buffer.WriteString("handle:[")
 			for i, handle := range p.Handles {
 				if i != 0 {
 					buffer.WriteString(" ")
 				}
-				buffer.WriteString(handle.String())
+				if redactOn {
+					buffer.WriteString("?")
+				} else {
+					redact.WriteRedact(&buffer, handle.String(), redactMode)
+				}
 			}
 			buffer.WriteString("], ")
 		}

--- a/pkg/planner/core/tests/redact/redact_test.go
+++ b/pkg/planner/core/tests/redact/redact_test.go
@@ -45,7 +45,7 @@ func TestRedactExplain(t *testing.T) {
 		Check(testkit.Rows(
 			"Projection 2.50 root  ‹1›->Column#5",
 			"└─HashJoin 2.50 root  left outer join, left side:Batch_Point_Get, equal:[eq(test.t.a, test.tlist.a)]",
-			"  ├─Batch_Point_Get(Build) 2.00 root table:t handle:[12 13], keep order:false, desc:false",
+			"  ├─Batch_Point_Get(Build) 2.00 root table:t handle:[‹12› ‹13›], keep order:false, desc:false",
 			"  └─TableReader(Probe) 20.00 root partition:dual data:Selection",
 			"    └─Selection 20.00 cop[tikv]  in(test.tlist.a, ‹12›, ‹13›), not(isnull(test.tlist.a))",
 			"      └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))
@@ -118,7 +118,7 @@ func TestRedactExplain(t *testing.T) {
 		Check(testkit.Rows(
 			"Projection 2.50 root  ?->Column#5",
 			"└─HashJoin 2.50 root  left outer join, left side:Batch_Point_Get, equal:[eq(test.t.a, test.tlist.a)]",
-			"  ├─Batch_Point_Get(Build) 2.00 root table:t handle:[12 13], keep order:false, desc:false",
+			"  ├─Batch_Point_Get(Build) 2.00 root table:t handle:[? ?], keep order:false, desc:false",
 			"  └─TableReader(Probe) 20.00 root partition:dual data:Selection",
 			"    └─Selection 20.00 cop[tikv]  in(test.tlist.a, ?, ?), not(isnull(test.tlist.a))",
 			"      └─TableFullScan 10000.00 cop[tikv] table:tlist keep order:false, stats:pseudo"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61060 

Problem Summary:

### What changed and how does it work?

when to implement the redact, forget to add the redact into ```BatchPointGetPlan```. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
