### PR TITLE
executor: Remove useless error logs for indexLoopUp executor when context canceled

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -869,7 +869,9 @@ func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, task *lookup
 	tableReaderExec.buildVirtualColumnInfo()
 	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, task.handles, true)
 	if err != nil {
-		logutil.Logger(ctx).Error("build table reader from handles failed", zap.Error(err))
+		if ctx.Err() != context.Canceled {
+			logutil.Logger(ctx).Error("build table reader from handles failed", zap.Error(err))
+		}
 		return nil, err
 	}
 	return tableReader, nil
@@ -1531,7 +1533,9 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 	tableReader, err := w.idxLookup.buildTableReader(ctx, task)
 	task.buildDoneTime = time.Now()
 	if err != nil {
-		logutil.Logger(ctx).Error("build table reader failed", zap.Error(err))
+		if ctx.Err() != context.Canceled {
+			logutil.Logger(ctx).Error("build table reader failed", zap.Error(err))
+		}
 		return err
 	}
 	defer func() { terror.Log(exec.Close(tableReader)) }()
@@ -1562,7 +1566,9 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 		chk := exec.TryNewCacheChunk(tableReader)
 		err = exec.Next(ctx, tableReader, chk)
 		if err != nil {
-			logutil.Logger(ctx).Error("table reader fetch next chunk failed", zap.Error(err))
+			if ctx.Err() != context.Canceled {
+				logutil.Logger(ctx).Error("table reader fetch next chunk failed", zap.Error(err))
+			}
 			return err
 		}
 		if chk.NumRows() == 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61072 

Problem Summary:
Problem described in #61072

### What changed and how does it work?
In this PR, when index/table work failed, we first check if context is cancelled. And only log errors when context is not cancelled. Doesn't use WithCancelCause function to pass cancel cause here, since the actual root cause is limit executor quit quitely, by returning empty data.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Use tpch, sf=1 benchmark, add index for orders table: 
```alter table orders add index(o_orderdate);```
Then execute the following sql and check tidb.log to see if "table reader fetch next chunk failed" log doesn't exists any more:
```
+----------------------------------+---------+---------+-----------+-----------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+---------+------+
| id                               | estRows | actRows | task      | access object                           | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | operator info                                                                           | memory  | disk |
+----------------------------------+---------+---------+-----------+-----------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+---------+------+
| Limit_9                          | 1.00    | 1       | root      |                                         | time:1.21ms, open:4.29µs, close:123.8µs, loops:2, RU:6.39                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | offset:0, count:1                                                                       | N/A     | N/A  |
| └─IndexLookUp_18                 | 1.00    | 1       | root      |                                         | time:1.2ms, open:2.13µs, close:111.9µs, loops:1, index_task: {total_time: 638.4µs, fetch_handle: 633.6µs, build: 1.5µs, wait: 3.29µs}, table_task: {total_time: 2.83ms, num: 6, concurrency: 5}, next: {wait_index: 275µs, wait_table_lookup_build: 14.3µs, wait_table_lookup_resp: 788.6µs}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |                                                                                         | 80.4 KB | N/A  |
|   ├─IndexRangeScan_14(Build)     | 3.00    | 1696    | cop[tikv] | table:b, index:o_orderdate(O_ORDERDATE) | time:1.09ms, open:0s, close:0s, loops:9, cop_task: {num: 3, max: 461.5µs, min: 238.7µs, avg: 347.2µs, p95: 461.5µs, max_proc_keys: 992, p95_proc_keys: 992, tot_proc: 401.6µs, tot_wait: 72.1µs, copr_cache_hit_ratio: 0.00, build_task_duration: 2.54µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:3, total_time:1.03ms}}, tikv_task:{proc max:1ms, min:0s, avg: 333.3µs, p80:1ms, p95:1ms, iters:12, tasks:3}, scan_detail: {total_process_keys: 1696, total_process_keys_size: 78016, total_keys: 1699, get_snapshot_time: 17µs, rocksdb: {key_skipped_count: 1696, block: {cache_hit_count: 12}}}, time_detail: {total_process_time: 401.6µs, total_wait_time: 72.1µs, total_kv_read_wall_time: 1ms, tikv_grpc_process_time: 20.5µs, tikv_grpc_wait_time: 668µs, tikv_wall_time: 689.8µs}                      | range:(1992-01-01,1992-01-31), keep order:false, stats:partial[o_custkey:unInitialized] | N/A     | N/A  |
|   └─Limit_17(Probe)              | 1.00    | 2       | cop[tikv] |                                         | total_time:2.44ms, total_open:0s, total_close:79.8µs, loops:8, cop_task: {num: 4, max: 555.9µs, min: 0s, avg: 263.3µs, p95: 555.9µs, max_proc_keys: 32, p95_proc_keys: 32, tot_proc: 508.3µs, tot_wait: 51.5µs, copr_cache_hit_ratio: 0.00, build_task_duration: 19.5µs, max_distsql_concurrency: 1, max_extra_concurrency: 1}, rpc_info:{Cop:{num_rpc:4, total_time:1.48ms}, rpc_errors:{context canceled:2}}, tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:2, tasks:2}, scan_detail: {total_process_keys: 64, total_process_keys_size: 9545, total_keys: 64, get_snapshot_time: 24.4µs, rocksdb: {block: {cache_hit_count: 128}}}, time_detail: {total_process_time: 508.3µs, total_wait_time: 51.5µs, tikv_grpc_process_time: 33.8µs, tikv_grpc_wait_time: 676.5µs, tikv_wall_time: 711µs}              | offset:0, count:1                                                                       | N/A     | N/A  |
|     └─Selection_16               | 1.00    | 24      | cop[tikv] |                                         | tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:2, tasks:2}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | gt(test.orders.o_custkey, 100000)                                                       | N/A     | N/A  |
|       └─TableRowIDScan_15        | 3.00    | 64      | cop[tikv] | table:b                                 | tikv_task:{proc max:0s, min:0s, avg: 0s, p80:0s, p95:0s, iters:2, tasks:2}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | keep order:false, stats:partial[o_custkey:unInitialized]                                | N/A     | N/A  |
+----------------------------------+---------+---------+-----------+-----------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+---------+------+
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
