### PR TITLE
server: replace instead of truncate encoded result

### DIFF
--- a/pkg/server/internal/column/result_encoder.go
+++ b/pkg/server/internal/column/result_encoder.go
@@ -125,7 +125,7 @@ func (d *ResultEncoder) EncodeData(src []byte) []byte {
 
 // EncodeWith encodes bytes with the given encoding.
 func (d *ResultEncoder) EncodeWith(src []byte, enc charset.Encoding) []byte {
-	data, err := enc.Transform(d.buffer, src, charset.OpEncode)
+	data, err := enc.Transform(d.buffer, src, charset.OpEncodeReplace)
 	if err != nil {
 		logutil.BgLogger().Debug("encode error", zap.Error(err))
 	}

--- a/tests/integrationtest/r/new_character_set.result
+++ b/tests/integrationtest/r/new_character_set.result
@@ -112,3 +112,16 @@ set names utf8mb4;
 show variables like 'collation_connection';
 Variable_name	Value
 collation_connection	utf8mb4_bin
+set character_set_results = "gbk";
+select cast(0x414141E280A9424242 as char charset utf8mb4);
+cast(0x414141E280A9424242 as char charset utf8mb4)
+AAA?BBB
+SET character_set_results = @undefined_var;
+DROP TABLE if exists t61085;
+create table t61085 (a char(255) charset gbk);
+insert into t61085 values ('AAA');
+set SESSION sql_mode = '';
+select * from t61085 where a = cast(0x41414180424242 as char charset gbk);
+a
+AAA
+DROP TABLE t61085;

--- a/tests/integrationtest/t/new_character_set.test
+++ b/tests/integrationtest/t/new_character_set.test
@@ -83,3 +83,14 @@ show variables like 'collation_connection';
 set default_collation_for_utf8mb4 = default;
 set names utf8mb4;
 show variables like 'collation_connection';
+
+# Bug#61085: https://github.com/pingcap/tidb/issues/61085 should replace instead of truncation for result charset
+set character_set_results = "gbk";
+select cast(0x414141E280A9424242 as char charset utf8mb4);
+SET character_set_results = @undefined_var;
+DROP TABLE if exists t61085;
+create table t61085 (a char(255) charset gbk);
+insert into t61085 values ('AAA');
+set SESSION sql_mode = '';
+select * from t61085 where a = cast(0x41414180424242 as char charset gbk);
+DROP TABLE t61085;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61085

Problem Summary: Change behavior when convert result.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix bug that character_set_results will truncate instead of replace on error char
```
