### PR TITLE
tablecodec, executor: fix non unqiue global index work with union scan

### DIFF
--- a/pkg/executor/mem_reader.go
+++ b/pkg/executor/mem_reader.go
@@ -663,9 +663,14 @@ func (m *memIndexReader) getMemRowsHandle() ([]kv.Handle, error) {
 			if err != nil {
 				return err
 			}
-			handle, err = kv.NewCommonHandle(b)
+			newHandle, err := kv.NewCommonHandle(b)
 			if err != nil {
 				return err
+			}
+			if ph, ok := handle.(kv.PartitionHandle); ok {
+				handle = kv.NewPartitionHandle(ph.PartitionID, newHandle)
+			} else {
+				handle = newHandle
 			}
 		}
 		// filter key/value by partitition id

--- a/pkg/tablecodec/tablecodec.go
+++ b/pkg/tablecodec/tablecodec.go
@@ -1017,7 +1017,7 @@ func DecodeIndexHandle(key, value []byte, colsLen int) (kv.Handle, error) {
 		if err != nil {
 			return nil, err
 		}
-		// If len(value) >= 9, it may contains partition id, 9 for partition id.
+		// If len(value) >= 9, it may contains partition id.
 		// We should decode it and return a partition handle.
 		if len(value) >= 9 {
 			seg := SplitIndexValue(value)

--- a/tests/integrationtest/r/globalindex/mem_index_merge_non_unique.result
+++ b/tests/integrationtest/r/globalindex/mem_index_merge_non_unique.result
@@ -1,0 +1,252 @@
+## Test IntHandle
+CREATE TABLE `tpk2` (
+`a` int(11) DEFAULT NULL,
+`b` int(11) DEFAULT NULL,
+`c` int(11) NOT NULL,
+`d` int(11) NOT NULL AUTO_INCREMENT,
+KEY `idx_bc` (`b`,`c`),
+KEY `idx_a` (`a`) GLOBAL,
+UNIQUE KEY `uidx_ac` (`a`, `c`),
+KEY `idx_c` (`c`)
+) PARTITION BY HASH (`c`) PARTITIONS 5;
+insert into tpk2 values (1, 2, 1, 1), (3, 6, 3, 3);
+begin;
+insert into tpk2 values (2, 4, 2, 2);
+## for indexMerge union
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+id	estRows	task	access object	operator info
+Projection_5	19.99	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	19.99	root		or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_11	19.99	root	partition:all	type: union
+    ├─IndexRangeScan_7(Build)	10.00	cop[tikv]	table:tpk2, index:idx_a(a)	range:[1,1], keep order:false, stats:pseudo
+    ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:false, stats:pseudo
+    └─TableRowIDScan_10(Probe)	19.99	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+a	b	c	d
+1	2	1	1
+2	4	2	2
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=2 or b=4;
+a	b	c	d
+2	4	2	2
+## for indexMerge intersection
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+id	estRows	task	access object	operator info
+Projection_5	1111.11	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	1111.11	root		gt(globalindex__mem_index_merge_non_unique.tpk2.a, 1), gt(globalindex__mem_index_merge_non_unique.tpk2.c, 1)
+  └─IndexMerge_11	1111.11	root	partition:all	type: intersection
+    ├─IndexRangeScan_7(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_9(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_c(c)	range:(1,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_10(Probe)	1111.11	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+a	b	c	d
+2	4	2	2
+3	6	3	3
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 0 and c > 0;
+a	b	c	d
+1	2	1	1
+2	4	2	2
+3	6	3	3
+## for indexMerge union with specified PARTITION
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+id	estRows	task	access object	operator info
+Projection_5	19.99	root	NULL	globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	19.99	root	NULL	or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_12	19.99	root	partition:p1	type: union
+    ├─Selection_9(Build)	10.00	cop[tikv]	NULL	in(globalindex__mem_index_merge_non_unique.tpk2._tidb_tid, tid1)
+    │ └─IndexRangeScan_7	10.00	cop[tikv]	table:tpk2, index:idx_a(a)	range:[1,1], keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	10.00	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	19.99	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+a	b	c	d
+1	2	1	1
+## for indexMerge intersection with specified PARTITION
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+id	estRows	task	access object	operator info
+Projection_5	1111.11	root	NULL	globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	1111.11	root	NULL	gt(globalindex__mem_index_merge_non_unique.tpk2.a, 1), gt(globalindex__mem_index_merge_non_unique.tpk2.c, 1)
+  └─IndexMerge_12	1111.11	root	partition:p1	type: intersection
+    ├─Selection_9(Build)	3333.33	cop[tikv]	NULL	in(globalindex__mem_index_merge_non_unique.tpk2._tidb_tid, tid1)
+    │ └─IndexRangeScan_7	3333.33	cop[tikv]	table:tpk2, index:idx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_c(c)	range:(1,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	1111.11	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+a	b	c	d
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 0 and c > 0;
+a	b	c	d
+1	2	1	1
+rollback;
+## Test CommonHandle
+drop table tpk2;
+CREATE TABLE `tpk2` (
+`a` int(11) DEFAULT NULL,
+`b` int(11) DEFAULT NULL,
+`c` int(11) NOT NULL,
+`d` int(11) NOT NULL,
+KEY `idx_bc` (`b`,`c`),
+KEY `idx_a` (`a`) GLOBAL,
+KEY `idx_ac` (`a`, `c`) GLOBAL,
+KEY `idx_c` (`c`),
+PRIMARY KEY(`d`, `c`) clustered
+) PARTITION BY HASH (`d`) PARTITIONS 5;
+insert into tpk2 values (1, 2, 1, 1), (3, 6, 3, 3);
+begin;
+insert into tpk2 values (2, 4, 2, 2);
+## for indexMerge union
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+id	estRows	task	access object	operator info
+Projection_5	19.99	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	19.99	root		or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_11	19.99	root	partition:all	type: union
+    ├─IndexRangeScan_7(Build)	10.00	cop[tikv]	table:tpk2, index:idx_a(a)	range:[1,1], keep order:false, stats:pseudo
+    ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:false, stats:pseudo
+    └─TableRowIDScan_10(Probe)	19.99	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+a	b	c	d
+1	2	1	1
+2	4	2	2
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=2 or b=4;
+a	b	c	d
+2	4	2	2
+## for indexMerge intersection
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+id	estRows	task	access object	operator info
+Projection_5	1111.11	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	1111.11	root		gt(globalindex__mem_index_merge_non_unique.tpk2.a, 1), gt(globalindex__mem_index_merge_non_unique.tpk2.c, 1)
+  └─IndexMerge_12	1111.11	root	partition:all	type: intersection
+    ├─Selection_9(Build)	1111.11	cop[tikv]		gt(globalindex__mem_index_merge_non_unique.tpk2.c, 1)
+    │ └─IndexRangeScan_7	3333.33	cop[tikv]	table:tpk2, index:idx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_c(c)	range:(1,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	1111.11	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+a	b	c	d
+2	4	2	2
+3	6	3	3
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 0 and c > 0;
+a	b	c	d
+1	2	1	1
+2	4	2	2
+3	6	3	3
+## for indexMerge union with specified PARTITION
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+id	estRows	task	access object	operator info
+Projection_5	19.99	root	NULL	globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	19.99	root	NULL	or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_12	19.99	root	partition:p1	type: union
+    ├─Selection_9(Build)	10.00	cop[tikv]	NULL	in(globalindex__mem_index_merge_non_unique.tpk2._tidb_tid, tid1)
+    │ └─IndexRangeScan_7	10.00	cop[tikv]	table:tpk2, index:idx_a(a)	range:[1,1], keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	10.00	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	19.99	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+a	b	c	d
+1	2	1	1
+## for indexMerge intersection with specified PARTITION
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+id	estRows	task	access object	operator info
+Projection_5	1111.11	root	NULL	globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	1111.11	root	NULL	gt(globalindex__mem_index_merge_non_unique.tpk2.a, 1), gt(globalindex__mem_index_merge_non_unique.tpk2.c, 1)
+  └─IndexMerge_12	1111.11	root	partition:p1	type: intersection
+    ├─Selection_9(Build)	1111.11	cop[tikv]	NULL	gt(globalindex__mem_index_merge_non_unique.tpk2.c, 1), in(globalindex__mem_index_merge_non_unique.tpk2._tidb_tid, tid1)
+    │ └─IndexRangeScan_7	3333.33	cop[tikv]	table:tpk2, index:idx_a(a)	range:(1,+inf], keep order:false, stats:pseudo
+    ├─IndexRangeScan_10(Build)	3333.33	cop[tikv]	table:tpk2, index:idx_c(c)	range:(1,+inf], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	1111.11	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+a	b	c	d
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 0 and c > 0;
+a	b	c	d
+1	2	1	1
+## for indexMerge union in txn with order by limit
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+id	estRows	task	access object	operator info
+Limit_15	1.00	root		offset:0, count:1
+└─UnionScan_22	1.00	root		or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_27	1.00	root	partition:all	type: union
+    ├─IndexRangeScan_23(Build)	0.50	cop[tikv]	table:tpk2, index:idx_ac(a, c)	range:[1,1], keep order:true, stats:pseudo
+    ├─IndexRangeScan_25(Build)	0.50	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:true, stats:pseudo
+    └─TableRowIDScan_26(Probe)	1.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+a	b	c	d
+1	2	1	1
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+id	estRows	task	access object	operator info
+Limit_15	1.00	root		offset:0, count:1
+└─UnionScan_22	1.00	root		or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_27	1.00	root	partition:all	type: union
+    ├─IndexRangeScan_23(Build)	0.50	cop[tikv]	table:tpk2, index:idx_ac(a, c)	range:[1,1], keep order:true, desc, stats:pseudo
+    ├─IndexRangeScan_25(Build)	0.50	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:true, desc, stats:pseudo
+    └─TableRowIDScan_26(Probe)	1.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+a	b	c	d
+2	4	2	2
+commit;
+## for indexMerge union with order by limit
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+id	estRows	task	access object	operator info
+Projection_26	1.00	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─IndexMerge_25	1.00	root	partition:all	type: union, limit embedded(offset:0, count:1)
+  ├─Limit_23(Build)	0.50	cop[tikv]		offset:0, count:1
+  │ └─IndexRangeScan_19	0.50	cop[tikv]	table:tpk2, index:idx_ac(a, c)	range:[1,1], keep order:true, stats:pseudo
+  ├─Limit_24(Build)	0.50	cop[tikv]		offset:0, count:1
+  │ └─IndexRangeScan_21	0.50	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:true, stats:pseudo
+  └─TableRowIDScan_22(Probe)	1.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+a	b	c	d
+1	2	1	1
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+id	estRows	task	access object	operator info
+Projection_26	1.00	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─IndexMerge_25	1.00	root	partition:all	type: union, limit embedded(offset:0, count:1)
+  ├─Limit_23(Build)	0.50	cop[tikv]		offset:0, count:1
+  │ └─IndexRangeScan_19	0.50	cop[tikv]	table:tpk2, index:idx_ac(a, c)	range:[1,1], keep order:true, desc, stats:pseudo
+  ├─Limit_24(Build)	0.50	cop[tikv]		offset:0, count:1
+  │ └─IndexRangeScan_21	0.50	cop[tikv]	table:tpk2, index:idx_bc(b, c)	range:[4,4], keep order:true, desc, stats:pseudo
+  └─TableRowIDScan_22(Probe)	1.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+a	b	c	d
+2	4	2	2
+## Test IndexWorker + TableWorker
+drop table tpk2;
+CREATE TABLE `tpk2` (
+`a` int(11) DEFAULT NULL,
+`b` int(11),
+`c` int(11) NOT NULL,
+`d` int(11) NOT NULL AUTO_INCREMENT,
+PRIMARY KEY (`b`),
+KEY `idx_a`(`a`) GLOBAL,
+KEY `idx_b`(`b`) GLOBAL
+) PARTITION BY HASH (`b`) PARTITIONS 5;
+insert into tpk2 values (1, 2, 1, 1), (3, 6, 3, 3);
+begin;
+insert into tpk2 values (2, 4, 2, 2);
+## for indexMerge union
+explain select /*+ use_index_merge(tpk2, idx_a, primary) */ * from tpk2 where a=1 or b=4;
+id	estRows	task	access object	operator info
+Projection_5	11.00	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	11.00	root		or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_11	11.00	root	partition:all	type: union
+    ├─IndexRangeScan_7(Build)	10.00	cop[tikv]	table:tpk2, index:idx_a(a)	range:[1,1], keep order:false, stats:pseudo
+    ├─TableRangeScan_9(Build)	1.00	cop[tikv]	table:tpk2	range:[4,4], keep order:false, stats:pseudo
+    └─TableRowIDScan_10(Probe)	11.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, primary) */ * from tpk2 where a=1 or b=4;
+a	b	c	d
+1	2	1	1
+2	4	2	2
+select /*+ use_index_merge(tpk2, idx_a, primary) */ * from tpk2 where a=2 or b=4;
+a	b	c	d
+2	4	2	2
+## for two global indexes
+explain select /*+ use_index_merge(tpk2, idx_a, idx_b) */ * from tpk2 where a=1 or b=4;
+id	estRows	task	access object	operator info
+Projection_5	11.00	root		globalindex__mem_index_merge_non_unique.tpk2.a, globalindex__mem_index_merge_non_unique.tpk2.b, globalindex__mem_index_merge_non_unique.tpk2.c, globalindex__mem_index_merge_non_unique.tpk2.d
+└─UnionScan_6	11.00	root		or(eq(globalindex__mem_index_merge_non_unique.tpk2.a, 1), eq(globalindex__mem_index_merge_non_unique.tpk2.b, 4))
+  └─IndexMerge_12	11.00	root	partition:all	type: union
+    ├─IndexRangeScan_7(Build)	10.00	cop[tikv]	table:tpk2, index:idx_a(a)	range:[1,1], keep order:false, stats:pseudo
+    ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:tpk2, index:idx_b(b)	range:[4,4], keep order:false, stats:pseudo
+    └─TableRowIDScan_11(Probe)	11.00	cop[tikv]	table:tpk2	keep order:false, stats:pseudo
+select /*+ use_index_merge(tpk2, idx_a, idx_b) */ * from tpk2 where a=1 or b=4;
+a	b	c	d
+1	2	1	1
+2	4	2	2
+select /*+ use_index_merge(tpk2, idx_a, idx_b) */ * from tpk2 where a=2 or b=4;
+a	b	c	d
+2	4	2	2
+rollback;

--- a/tests/integrationtest/r/globalindex/mem_index_non_unique.result
+++ b/tests/integrationtest/r/globalindex/mem_index_non_unique.result
@@ -1,0 +1,114 @@
+# IntHandle
+drop table if exists t;
+CREATE TABLE `t` (
+`a` int(11) DEFAULT NULL,
+`b` int(11) DEFAULT NULL,
+KEY `idx` (`a`) GLOBAL,
+KEY `idx1` (`b`) GLOBAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`a`) PARTITIONS 5;
+insert into t values (1, 2), (2, 3), (3, 4), (4, 5);
+begin;
+insert into t values (5, 1);
+select b from t use index(idx1) where b > 2;
+b
+3
+4
+5
+select * from t use index(idx1) where b > 2;
+a	b
+2	3
+3	4
+4	5
+select b from t partition(p0) use index(idx1) where b <= 2;
+b
+1
+select * from t partition(p0) use index(idx1) where b <= 2;
+a	b
+5	1
+select b from t partition(p0, p1) use index(idx1) where b <= 2;
+b
+1
+2
+select * from t partition(p0, p1) use index(idx1) where b <= 2;
+a	b
+1	2
+5	1
+select a from t use index(idx) where a > 2;
+a
+3
+4
+5
+select * from t use index(idx) where a > 2;
+a	b
+3	4
+4	5
+5	1
+select a from t partition(p0) use index(idx) where a <= 2;
+a
+select * from t partition(p0) use index(idx) where a <= 2;
+a	b
+select a from t partition(p0, p1) use index(idx) where a <= 2;
+a
+1
+select * from t partition(p0, p1) use index(idx) where a <= 2;
+a	b
+1	2
+rollback;
+# CommonHandle
+drop table if exists t;
+CREATE TABLE `t` (
+`a` year(4) primary key CLUSTERED,
+`b` int(11) DEFAULT NULL,
+KEY `idx` (`a`) GLOBAL,
+KEY `idx1` (`b`) GLOBAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`a`) PARTITIONS 5;
+insert into t values (2001, 2), (2002, 3), (2003, 4), (2004, 5);
+begin;
+insert into t values (2005, 1);
+select b from t use index(idx1) where b > 2;
+b
+3
+4
+5
+select * from t use index(idx1) where b > 2;
+a	b
+2002	3
+2003	4
+2004	5
+select b from t partition(p0) use index(idx1) where b <= 2;
+b
+1
+select * from t partition(p0) use index(idx1) where b <= 2;
+a	b
+2005	1
+select b from t partition(p0, p1) use index(idx1) where b <= 2;
+b
+1
+2
+select * from t partition(p0, p1) use index(idx1) where b <= 2;
+a	b
+2001	2
+2005	1
+select a from t use index(idx) where a > 2002;
+a
+2003
+2004
+2005
+select * from t use index(idx) where a > 2002;
+a	b
+2003	4
+2004	5
+2005	1
+select a from t partition(p0) use index(idx) where a <= 2002;
+a
+select * from t partition(p0) use index(idx) where a <= 2002;
+a	b
+select a from t partition(p0, p1) use index(idx) where a <= 2002;
+a
+2001
+select * from t partition(p0, p1) use index(idx) where a <= 2002;
+a	b
+2001	2
+rollback;

--- a/tests/integrationtest/t/globalindex/mem_index_merge_non_unique.test
+++ b/tests/integrationtest/t/globalindex/mem_index_merge_non_unique.test
@@ -1,0 +1,140 @@
+--echo ## Test IntHandle
+CREATE TABLE `tpk2` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL,
+  `c` int(11) NOT NULL,
+  `d` int(11) NOT NULL AUTO_INCREMENT,
+  KEY `idx_bc` (`b`,`c`),
+  KEY `idx_a` (`a`) GLOBAL,
+  UNIQUE KEY `uidx_ac` (`a`, `c`),
+  KEY `idx_c` (`c`)
+) PARTITION BY HASH (`c`) PARTITIONS 5;
+
+insert into tpk2 values (1, 2, 1, 1), (3, 6, 3, 3);
+
+begin;
+insert into tpk2 values (2, 4, 2, 2);
+
+--echo ## for indexMerge union
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=2 or b=4;
+
+--echo ## for indexMerge intersection
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 0 and c > 0;
+
+--echo ## for indexMerge union with specified PARTITION
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+
+--echo ## for indexMerge intersection with specified PARTITION
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 0 and c > 0;
+
+rollback;
+
+--echo ## Test CommonHandle
+drop table tpk2;
+CREATE TABLE `tpk2` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL,
+  `c` int(11) NOT NULL,
+  `d` int(11) NOT NULL,
+  KEY `idx_bc` (`b`,`c`),
+  KEY `idx_a` (`a`) GLOBAL,
+  KEY `idx_ac` (`a`, `c`) GLOBAL,
+  KEY `idx_c` (`c`),
+  PRIMARY KEY(`d`, `c`) clustered
+) PARTITION BY HASH (`d`) PARTITIONS 5;
+
+insert into tpk2 values (1, 2, 1, 1), (3, 6, 3, 3);
+
+begin;
+insert into tpk2 values (2, 4, 2, 2);
+
+--echo ## for indexMerge union
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 where a=2 or b=4;
+
+--echo ## for indexMerge intersection
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 where a > 0 and c > 0;
+
+--echo ## for indexMerge union with specified PARTITION
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
+explain select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_bc) */ * from tpk2 partition(p1) where a=1 or b=4;
+
+--echo ## for indexMerge intersection with specified PARTITION
+--replace_regex /_tidb_tid, [0-9]+\)/_tidb_tid, tid1)/
+explain select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 1 and c > 1;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_c) */ * from tpk2 partition(p1) where a > 0 and c > 0;
+
+--echo ## for indexMerge union in txn with order by limit
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+
+commit;
+
+--echo ## for indexMerge union with order by limit
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c limit 1;
+explain select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+select /*+ use_index_merge(tpk2, idx_ac, idx_bc) */ * from tpk2 where a = 1 or b = 4 order by c desc limit 1;
+
+--echo ## Test IndexWorker + TableWorker
+drop table tpk2;
+CREATE TABLE `tpk2` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11),
+  `c` int(11) NOT NULL,
+  `d` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`b`),
+  KEY `idx_a`(`a`) GLOBAL,
+  KEY `idx_b`(`b`) GLOBAL
+) PARTITION BY HASH (`b`) PARTITIONS 5;
+
+insert into tpk2 values (1, 2, 1, 1), (3, 6, 3, 3);
+
+begin;
+insert into tpk2 values (2, 4, 2, 2);
+
+--echo ## for indexMerge union
+explain select /*+ use_index_merge(tpk2, idx_a, primary) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, primary) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, primary) */ * from tpk2 where a=2 or b=4;
+
+--echo ## for two global indexes
+explain select /*+ use_index_merge(tpk2, idx_a, idx_b) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_b) */ * from tpk2 where a=1 or b=4;
+--sorted_result
+select /*+ use_index_merge(tpk2, idx_a, idx_b) */ * from tpk2 where a=2 or b=4;
+
+rollback;

--- a/tests/integrationtest/t/globalindex/mem_index_non_unique.test
+++ b/tests/integrationtest/t/globalindex/mem_index_non_unique.test
@@ -1,0 +1,106 @@
+--echo # IntHandle
+drop table if exists t;
+CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL,
+  KEY `idx` (`a`) GLOBAL,
+  KEY `idx1` (`b`) GLOBAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`a`) PARTITIONS 5;
+
+insert into t values (1, 2), (2, 3), (3, 4), (4, 5);
+
+begin;
+insert into t values (5, 1);
+
+--sorted_result
+select b from t use index(idx1) where b > 2;
+
+--sorted_result
+select * from t use index(idx1) where b > 2;
+
+--sorted_result
+select b from t partition(p0) use index(idx1) where b <= 2;
+
+--sorted_result
+select * from t partition(p0) use index(idx1) where b <= 2;
+
+--sorted_result
+select b from t partition(p0, p1) use index(idx1) where b <= 2;
+
+--sorted_result
+select * from t partition(p0, p1) use index(idx1) where b <= 2;
+
+--sorted_result
+select a from t use index(idx) where a > 2;
+
+--sorted_result
+select * from t use index(idx) where a > 2;
+
+--sorted_result
+select a from t partition(p0) use index(idx) where a <= 2;
+
+--sorted_result
+select * from t partition(p0) use index(idx) where a <= 2;
+
+--sorted_result
+select a from t partition(p0, p1) use index(idx) where a <= 2;
+
+--sorted_result
+select * from t partition(p0, p1) use index(idx) where a <= 2;
+
+rollback;
+
+
+--echo # CommonHandle
+drop table if exists t;
+CREATE TABLE `t` (
+  `a` year(4) primary key CLUSTERED,
+  `b` int(11) DEFAULT NULL,
+  KEY `idx` (`a`) GLOBAL,
+  KEY `idx1` (`b`) GLOBAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH (`a`) PARTITIONS 5;
+
+insert into t values (2001, 2), (2002, 3), (2003, 4), (2004, 5);
+
+begin;
+insert into t values (2005, 1);
+
+--sorted_result
+select b from t use index(idx1) where b > 2;
+
+--sorted_result
+select * from t use index(idx1) where b > 2;
+
+--sorted_result
+select b from t partition(p0) use index(idx1) where b <= 2;
+
+--sorted_result
+select * from t partition(p0) use index(idx1) where b <= 2;
+
+--sorted_result
+select b from t partition(p0, p1) use index(idx1) where b <= 2;
+
+--sorted_result
+select * from t partition(p0, p1) use index(idx1) where b <= 2;
+
+--sorted_result
+select a from t use index(idx) where a > 2002;
+
+--sorted_result
+select * from t use index(idx) where a > 2002;
+
+--sorted_result
+select a from t partition(p0) use index(idx) where a <= 2002;
+
+--sorted_result
+select * from t partition(p0) use index(idx) where a <= 2002;
+
+--sorted_result
+select a from t partition(p0, p1) use index(idx) where a <= 2002;
+
+--sorted_result
+select * from t partition(p0, p1) use index(idx) where a <= 2002;
+
+rollback;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61083

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
