### PR TITLE
types: fix `decodeEscapedUnicode` func work with `surrogate pair`

### DIFF
--- a/pkg/types/json_binary_functions.go
+++ b/pkg/types/json_binary_functions.go
@@ -176,7 +176,7 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 	}
 	size = utf8.RuneLen(r1)
 	if size < 0 {
-		return char, size, errors.Errorf("not a valid Unicode character")
+		return char, size, errors.Errorf("Invalid unicode: %s", s)
 	}
 	utf8.EncodeRune(char[0:size], r1)
 	return

--- a/pkg/types/json_binary_functions.go
+++ b/pkg/types/json_binary_functions.go
@@ -172,8 +172,7 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 
 	r1 := rune(binary.BigEndian.Uint16(char[0:2]))
 	if size == 4 {
-		r2 := binary.BigEndian.Uint16(char[2:4])
-		r1 = utf16.DecodeRune(rune(r1), rune(r2))
+		r1 = utf16.DecodeRune(r1, rune(binary.BigEndian.Uint16(char[2:4])))
 	}
 	size = utf8.RuneLen(r1)
 	if size < 0 {

--- a/pkg/types/json_binary_functions.go
+++ b/pkg/types/json_binary_functions.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"slices"
 	"sort"
+	"unicode/utf16"
 	"unicode/utf8"
 
 	"github.com/pingcap/errors"
@@ -134,6 +135,16 @@ func unquoteJSONString(s string) (string, error) {
 				}
 				char, size, err := decodeEscapedUnicode(hack.Slice(s[i+1 : i+5]))
 				if err != nil {
+					// For `surrogate pair`, it uses two `\\uxxx` to encode a character.
+					if size < 0 && len(s) >= i+10 && s[i+5] == '\\' && s[i+6] == 'u' {
+						char, size, err = decodeEscapedUnicode(append(hack.Slice(s[i+1:i+5]), hack.Slice(s[i+7:i+11])...))
+						if err != nil {
+							return "", errors.Trace(err)
+						}
+						ret.Write(char[0:size])
+						i += 10
+						continue
+					}
 					return "", errors.Trace(err)
 				}
 				ret.Write(char[0:size])
@@ -153,15 +164,22 @@ func unquoteJSONString(s string) (string, error) {
 // According RFC 3629, the max length of utf8 characters is 4 bytes.
 // And MySQL use 4 bytes to represent the unicode which must be in [0, 65536).
 func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
-	size, err = hex.Decode(char[0:2], s)
-	if err != nil || size != 2 {
-		// The unicode must can be represented in 2 bytes.
+	size, err = hex.Decode(char[0:4], s)
+	if err != nil || (size != 2 && size != 4) {
+		// The unicode must can be represented in 2 bytes or 4 bytes.
 		return char, 0, errors.Trace(err)
 	}
 
-	unicode := binary.BigEndian.Uint16(char[0:2])
-	size = utf8.RuneLen(rune(unicode))
-	utf8.EncodeRune(char[0:size], rune(unicode))
+	r1 := rune(binary.BigEndian.Uint16(char[0:2]))
+	if size == 4 {
+		r2 := binary.BigEndian.Uint16(char[2:4])
+		r1 = utf16.DecodeRune(rune(r1), rune(r2))
+	}
+	size = utf8.RuneLen(r1)
+	if size < 0 {
+		return char, size, errors.Errorf("not a valid Unicode character")
+	}
+	utf8.EncodeRune(char[0:size], r1)
 	return
 }
 

--- a/pkg/types/json_binary_functions_test.go
+++ b/pkg/types/json_binary_functions_test.go
@@ -25,6 +25,12 @@ func TestDecodeEscapedUnicode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "好\x00", string(r[:]))
 	require.Equal(t, 3, size)
+
+	in = "d83edd21"
+	r, size, err = decodeEscapedUnicode([]byte(in))
+	require.NoError(t, err)
+	require.Equal(t, "🤡", string(r[:]))
+	require.Equal(t, 4, size)
 }
 
 func BenchmarkDecodeEscapedUnicode(b *testing.B) {

--- a/pkg/types/json_binary_functions_test.go
+++ b/pkg/types/json_binary_functions_test.go
@@ -20,23 +20,73 @@ import (
 )
 
 func TestDecodeEscapedUnicode(t *testing.T) {
-	in := "597d"
-	r, size, err := decodeEscapedUnicode([]byte(in))
-	require.NoError(t, err)
-	require.Equal(t, "好\x00", string(r[:]))
-	require.Equal(t, 3, size)
+	testCases := []struct {
+		input            string
+		expectedResult   string
+		size             int
+		inSurrogateRange bool
+		expectedValid    bool
+	}{
+		{"597d", "好\x00", 3, false, true},
+		{"fffd", "�\x00", 3, false, true},
+		{"D83DDE0A", "😊", 4, false, true},
+		{"D83D", "", 0, true, false},
+		{"D83D11", "", 0, false, false},
+		{"ZZZZ", "", 0, false, false},
+		{"D83DDE0A597d", "", 0, false, false},
+	}
 
-	in = "d83edd21"
-	r, size, err = decodeEscapedUnicode([]byte(in))
-	require.NoError(t, err)
-	require.Equal(t, "🤡", string(r[:]))
-	require.Equal(t, 4, size)
+	for _, tc := range testCases {
+		result, size, inSurrogateRange, err := decodeOneEscapedUnicode([]byte(tc.input))
+		require.Equal(t, tc.inSurrogateRange, inSurrogateRange)
+		if tc.expectedValid {
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedResult, string(result[:]))
+			require.Equal(t, tc.size, size)
+		} else {
+			require.Error(t, err)
+		}
+	}
+}
+
+func TestUnquoteJSONString(t *testing.T) {
+	var testCases = []struct {
+		input          string
+		expectedResult string
+		expectedValid  bool
+	}{
+		{"\\b", "\b", true},
+		{"\\f", "\f", true},
+		{"\\n", "\n", true},
+		{"\\r", "\r", true},
+		{"\\t", "\t", true},
+		{"\\\\", "\\", true},
+		{"\\u597d", "好", true},
+		{"0\\u597d0", "0好0", true},
+		{"\\a", "a", true},
+		{"[", "[", true},
+		{"\\ud83e\\udd21", "🤡", true},
+		{"\\ufffd", "�", true},
+		// invalid input
+		{"\\", "", false},
+		{"\\u59", "", false},
+	}
+
+	for _, tc := range testCases {
+		result, err := unquoteJSONString(tc.input)
+		if tc.expectedValid {
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedResult, result)
+		} else {
+			require.Error(t, err)
+		}
+	}
 }
 
 func BenchmarkDecodeEscapedUnicode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		in := "597d"
-		_, _, _ = decodeEscapedUnicode([]byte(in))
+		_, _, _, _ = decodeOneEscapedUnicode([]byte(in))
 	}
 }
 

--- a/tests/integrationtest/r/types/json_binary_functions.result
+++ b/tests/integrationtest/r/types/json_binary_functions.result
@@ -1,0 +1,16 @@
+drop table if exists t;
+CREATE TABLE `t` (
+`id` int NOT NULL AUTO_INCREMENT,
+`value` json DEFAULT NULL,
+`value_custom` json DEFAULT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+INSERT INTO `t` (`value`, `value_custom`) VALUES ('{\"emo\\ud83e\\udd21\'ji\": \"some value\", \"escape\\uffff\'seq\'\\uffffue\\uffff\'nce\": \"some value\"}', NULL);
+SELECT 1 FROM `t` WHERE JSON_CONTAINS_PATH(`t`.`value`, 'one', '$."emo\\ud83e\\udd21\'ji"');
+1
+1
+SELECT 1 FROM `t` WHERE JSON_CONTAINS_PATH(`t`.`value`, 'one', '$."escape\\uffff\'seq\'\\uffffue\\uffff\'nce"');
+1
+1
+SELECT 1 FROM `t` WHERE JSON_CONTAINS_PATH(`t`.`value`, 'one', '$."escape\\uffff\'seq\'\\ufffdue\\uffff\'nce"');
+1

--- a/tests/integrationtest/t/types/json_binary_functions.test
+++ b/tests/integrationtest/t/types/json_binary_functions.test
@@ -1,0 +1,14 @@
+drop table if exists t;
+CREATE TABLE `t` (
+    `id` int NOT NULL AUTO_INCREMENT,
+    `value` json DEFAULT NULL,
+    `value_custom` json DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+INSERT INTO `t` (`value`, `value_custom`) VALUES ('{\"emo\\ud83e\\udd21\'ji\": \"some value\", \"escape\\uffff\'seq\'\\uffffue\\uffff\'nce\": \"some value\"}', NULL);
+
+SELECT 1 FROM `t` WHERE JSON_CONTAINS_PATH(`t`.`value`, 'one', '$."emo\\ud83e\\udd21\'ji"');
+
+SELECT 1 FROM `t` WHERE JSON_CONTAINS_PATH(`t`.`value`, 'one', '$."escape\\uffff\'seq\'\\uffffue\\uffff\'nce"');
+
+SELECT 1 FROM `t` WHERE JSON_CONTAINS_PATH(`t`.`value`, 'one', '$."escape\\uffff\'seq\'\\ufffdue\\uffff\'nce"');


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61091

Problem Summary: For some special charactesrs, such like some emoji, it uses two `\\uxxxx` to present. The `decodeEscapedUnicode` func didn't deal with it correctly before. This PR fix it.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
