### PR TITLE
privilege: avoid processing the same privilege event twice

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1952,7 +1952,7 @@ func (do *Domain) decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEve
 					break
 				}
 				isNewVersionEvents = true
-				if tmp.ServerID == do.ServerID() {
+				if do.ServerID() != 0 && tmp.ServerID == do.ServerID() {
 					// Skip the events from this TiDB-Server
 					continue
 				}

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1940,7 +1940,7 @@ func (do *Domain) GetPDHTTPClient() pdhttp.Client {
 
 func (do *Domain) decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEvent {
 	var msg PrivilegeEvent
-	isNewVersionTriggers := false
+	isNewVersionEvents := false
 	for _, event := range resp.Events {
 		if event.Kv != nil {
 			val := event.Kv.Value
@@ -1951,7 +1951,7 @@ func (do *Domain) decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEve
 					logutil.BgLogger().Warn("decodePrivilegeEvent unmarshal fail", zap.Error(err))
 					break
 				}
-				isNewVersionTriggers = true
+				isNewVersionEvents = true
 				if tmp.ServerID == do.ServerID() {
 					// Skip the events from this TiDB-Server
 					continue
@@ -1968,7 +1968,7 @@ func (do *Domain) decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEve
 
 	// In case old version triggers the event, the event value is empty,
 	// Then we fall back to the old way: reload all the users.
-	if len(msg.UserList) == 0 && !isNewVersionTriggers {
+	if len(msg.UserList) == 0 && !isNewVersionEvents {
 		msg.All = true
 	}
 	return msg

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1938,8 +1938,9 @@ func (do *Domain) GetPDHTTPClient() pdhttp.Client {
 	return nil
 }
 
-func decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEvent {
+func (do *Domain) decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEvent {
 	var msg PrivilegeEvent
+	isNewVersionTriggers := false
 	for _, event := range resp.Events {
 		if event.Kv != nil {
 			val := event.Kv.Value
@@ -1949,6 +1950,11 @@ func decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEvent {
 				if err != nil {
 					logutil.BgLogger().Warn("decodePrivilegeEvent unmarshal fail", zap.Error(err))
 					break
+				}
+				isNewVersionTriggers = true
+				if tmp.ServerID == do.ServerID() {
+					// Skip the events from this TiDB-Server
+					continue
 				}
 				if tmp.All {
 					msg.All = true
@@ -1962,13 +1968,13 @@ func decodePrivilegeEvent(resp clientv3.WatchResponse) PrivilegeEvent {
 
 	// In case old version triggers the event, the event value is empty,
 	// Then we fall back to the old way: reload all the users.
-	if len(msg.UserList) == 0 {
+	if len(msg.UserList) == 0 && !isNewVersionTriggers {
 		msg.All = true
 	}
 	return msg
 }
 
-func batchReadMoreData(ch clientv3.WatchChan, event PrivilegeEvent) PrivilegeEvent {
+func (do *Domain) batchReadMoreData(ch clientv3.WatchChan, event PrivilegeEvent) PrivilegeEvent {
 	timer := time.NewTimer(5 * time.Millisecond)
 	defer timer.Stop()
 	const maxBatchSize = 128
@@ -1978,7 +1984,7 @@ func batchReadMoreData(ch clientv3.WatchChan, event PrivilegeEvent) PrivilegeEve
 			if !ok {
 				return event
 			}
-			tmp := decodePrivilegeEvent(resp)
+			tmp := do.decodePrivilegeEvent(resp)
 			if tmp.All {
 				event.All = true
 			} else {
@@ -1988,7 +1994,7 @@ func batchReadMoreData(ch clientv3.WatchChan, event PrivilegeEvent) PrivilegeEve
 			}
 			succ := timer.Reset(5 * time.Millisecond)
 			if !succ {
-				break
+				return event
 			}
 		case <-timer.C:
 			return event
@@ -2030,8 +2036,8 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 			case resp, ok := <-watchCh:
 				if ok {
 					count = 0
-					event = decodePrivilegeEvent(resp)
-					event = batchReadMoreData(watchCh, event)
+					event = do.decodePrivilegeEvent(resp)
+					event = do.batchReadMoreData(watchCh, event)
 				} else {
 					if do.ctx.Err() == nil {
 						logutil.BgLogger().Error("load privilege loop watch channel closed")
@@ -2045,7 +2051,11 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 				}
 			case <-time.After(duration):
 				event.All = true
-				event = batchReadMoreData(watchCh, event)
+				event = do.batchReadMoreData(watchCh, event)
+			}
+
+			if !event.All && len(event.UserList) == 0 {
+				continue
 			}
 
 			err := privReloadEvent(do.privHandle, &event)
@@ -3013,6 +3023,7 @@ const (
 // TiDB old version do not use no such message.
 type PrivilegeEvent struct {
 	All      bool
+	ServerID uint64
 	UserList []string
 }
 
@@ -3033,6 +3044,7 @@ func (do *Domain) notifyUpdatePrivilege(event PrivilegeEvent) error {
 	// Because we need to tell other TiDB instances to update privilege data, say, we're changing the
 	// password using a special TiDB instance and want the new password to take effect.
 	if do.etcdClient != nil {
+		event.ServerID = do.serverID
 		data, err := json.Marshal(event)
 		if err != nil {
 			return errors.Trace(err)

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2054,6 +2054,7 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 				event = do.batchReadMoreData(watchCh, event)
 			}
 
+			// All events are from this TiDB-Server, skip them
 			if !event.All && len(event.UserList) == 0 {
 				continue
 			}

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -1587,11 +1587,8 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 	roleList = append(roleList, &auth.RoleIdentity{Username: user, Hostname: host})
 
 	var userPriv, dbPriv, tablePriv, columnPriv mysql.PrivilegeType
-	var userRecord *UserRecord
-	var dbRecord *dbRecord
-	var tableRecord *tablesPrivRecord
 	for _, r := range roleList {
-		userRecord = p.matchUser(r.Username, r.Hostname)
+		userRecord := p.matchUser(r.Username, r.Hostname)
 		if userRecord != nil {
 			userPriv |= userRecord.Privileges
 		}
@@ -1601,7 +1598,7 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 	}
 
 	for _, r := range roleList {
-		dbRecord = p.matchDB(r.Username, r.Hostname, db)
+		dbRecord := p.matchDB(r.Username, r.Hostname, db)
 		if dbRecord != nil {
 			dbPriv |= dbRecord.Privileges
 		}
@@ -1611,7 +1608,7 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 	}
 
 	for _, r := range roleList {
-		tableRecord = p.matchTables(r.Username, r.Hostname, db, table)
+		tableRecord := p.matchTables(r.Username, r.Hostname, db, table)
 		if tableRecord != nil {
 			tablePriv |= tableRecord.TablePriv
 			if column != "" {
@@ -1632,62 +1629,6 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 	}
 	if columnPriv&priv > 0 {
 		return true
-	}
-
-	// For debug on ci, will delete it before 2025/06/01.
-	if priv != 0 {
-		logutil.BgLogger().Info("Request verification failed",
-			zap.Stringers("activeRoles", activeRoles),
-			zap.String("user", user),
-			zap.String("host", host),
-			zap.String("db", db),
-			zap.String("table", table),
-			zap.String("column", column),
-			zap.Uint64("priv", uint64(priv)),
-			zap.Bool("userRecordExits", userRecord != nil),
-			zap.Uint64("userPriv", uint64(userPriv)),
-			zap.Bool("dbRecordExits", dbRecord != nil),
-			zap.Uint64("dbPriv", uint64(dbPriv)),
-			zap.Bool("tableRecordExits", tableRecord != nil),
-			zap.Uint64("tablePriv", uint64(tablePriv)),
-			zap.Uint64("columnPriv", uint64(columnPriv)),
-			zap.Stack("stack"))
-		if userRecord != nil {
-			for _, r := range roleList {
-				item, _ := p.user.Get(itemUser{username: r.Username})
-				var p []mysql.PrivilegeType
-				var host []string
-				for _, d := range item.data {
-					p = append(p, d.Privileges)
-					host = append(host, d.Host)
-				}
-				logutil.BgLogger().Info("userRecord", zap.String("user", item.username), zap.Int("itemLen", len(item.data)), zap.Any("hosts", host), zap.Any("privileges", p))
-			}
-		}
-		if tableRecord != nil {
-			for _, r := range roleList {
-				item, _ := p.tablesPriv.Get(itemTablesPriv{username: r.Username})
-				var p []mysql.PrivilegeType
-				var host []string
-				for _, d := range item.data {
-					p = append(p, d.TablePriv)
-					host = append(host, d.Host)
-				}
-				logutil.BgLogger().Info("tableRecord", zap.String("user", item.username), zap.Int("itemLen", len(item.data)), zap.Any("hosts", host), zap.Any("privileges", p))
-			}
-		}
-		if dbRecord != nil {
-			for _, r := range roleList {
-				item, _ := p.db.Get(itemDB{username: r.Username})
-				var p []mysql.PrivilegeType
-				var host []string
-				for _, d := range item.data {
-					p = append(p, d.Privileges)
-					host = append(host, d.Host)
-				}
-				logutil.BgLogger().Info("dbRecord", zap.String("user", item.username), zap.Int("itemLen", len(item.data)), zap.Any("hosts", host), zap.Any("privileges", p))
-			}
-		}
 	}
 
 	return priv == 0

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -1631,6 +1631,22 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 		return true
 	}
 
+	if priv != 0 {
+		logutil.BgLogger().Info("Request verification failed",
+			zap.Stringers("activeRoles", activeRoles),
+			zap.String("user", user),
+			zap.String("host", host),
+			zap.String("db", db),
+			zap.String("table", table),
+			zap.String("column", column),
+			zap.Uint64("priv", uint64(priv)),
+			zap.Uint64("userPriv", uint64(userPriv)),
+			zap.Uint64("dbPriv", uint64(dbPriv)),
+			zap.Uint64("tablePriv", uint64(tablePriv)),
+			zap.Uint64("columnPriv", uint64(columnPriv)),
+			zap.Stack("stack"))
+	}
+
 	return priv == 0
 }
 

--- a/pkg/privilege/privileges/cache.go
+++ b/pkg/privilege/privileges/cache.go
@@ -1632,6 +1632,7 @@ func (p *MySQLPrivilege) RequestVerification(activeRoles []*auth.RoleIdentity, u
 	}
 
 	if priv != 0 {
+		// For debug on ci, will delete it later.
 		logutil.BgLogger().Info("Request verification failed",
 			zap.Stringers("activeRoles", activeRoles),
 			zap.String("user", user),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61206

Problem Summary:

The root case is:

Two SQL statements are executed consecutively:  
1. `CREATE USER tcd1, tcd2;`  
2. `GRANT ALL ON *.* to tcd2 WITH GRANT OPTION;`  

**Normal sequence:**  
`notifyUpdatePrivilege()` → priv 0  
`etcd` → `LoadPrivilegeLoop()` → priv 0  
`notifyUpdatePrivilege()` → priv all  
`etcd` → `LoadPrivilegeLoop()` → priv all  

**After adding a sleep between `LoadAll` and `h.priv.Store` in `UpdateAll` for the etcd case, it becomes:**  
`notifyUpdatePrivilege()` → priv 0  
`notifyUpdatePrivilege()` → priv all  
`etcd` → `LoadPrivilegeLoop()` → priv 0  
*(At this point, executing some SQL on tcd2 will result in permission denied errors.)*  
`etcd` → `LoadPrivilegeLoop()` → priv all  

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Add logs in `func privReloadEvent(h *privileges.Handle, event *PrivilegeEvent)` function, use the command below to create a cluster
```
tiup playground nightly --db 2 --db.binpath bin/tidb-server --kv 1 --tiflash 0 --without-monitor
```

Then execute the SQLs below
```sql
CREATE USER tcd1, tcd2;
GRANT ALL ON *.* to tcd2 WITH GRANT OPTION;
```

You can see two logs in each TiDB-Server's log file. Before this PR, it had 4 logs on the execution node and 2 logs on the other node.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
