### PR TITLE
*: add new option for auto detecting CSV header | tidb-test=b256656b231ebd8f752e8738e89fc64f5263721a

### DIFF
--- a/lightning/pkg/importer/BUILD.bazel
+++ b/lightning/pkg/importer/BUILD.bazel
@@ -160,6 +160,7 @@ go_test(
         "//pkg/store/mockstore",
         "//pkg/table/tables",
         "//pkg/tablecodec",
+        "//pkg/testkit/testfailpoint",
         "//pkg/types",
         "//pkg/util/codec",
         "//pkg/util/dbutil/dbutiltest",

--- a/lightning/pkg/importer/chunk_process.go
+++ b/lightning/pkg/importer/chunk_process.go
@@ -94,13 +94,16 @@ func openParser(
 	var parser mydump.Parser
 	switch chunk.FileMeta.Type {
 	case mydump.SourceTypeCSV:
-		hasHeader := cfg.Mydumper.CSV.Header && chunk.Chunk.Offset == 0
+		csvHeaderOption := mydump.CSVHeaderFalse
+		if cfg.Mydumper.CSV.Header && chunk.Chunk.Offset == 0 {
+			csvHeaderOption = mydump.CSVHeaderTrue
+		}
 		// Create a utf8mb4 convertor to encode and decode data with the charset of CSV files.
 		charsetConvertor, err := mydump.NewCharsetConvertor(cfg.Mydumper.DataCharacterSet, cfg.Mydumper.DataInvalidCharReplace)
 		if err != nil {
 			return nil, err
 		}
-		parser, err = mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, blockBufSize, ioWorkers, hasHeader, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, blockBufSize, ioWorkers, csvHeaderOption, charsetConvertor)
 		if err != nil {
 			return nil, err
 		}

--- a/lightning/pkg/importer/chunk_process_test.go
+++ b/lightning/pkg/importer/chunk_process_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/mock"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/ddl"
@@ -46,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	tmock "github.com/pingcap/tidb/pkg/util/mock"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
@@ -436,9 +436,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverLimit() {
 	s.cr.parser = p
 
 	rc := &Controller{pauser: DeliverPauser, cfg: cfg}
-	require.NoError(s.T(), failpoint.Enable(
-		"github.com/pingcap/tidb/lightning/pkg/importer/mock-kv-size", "return(110000000)"))
-	defer failpoint.Disable("github.com/pingcap/tidb/lightning/pkg/importer/mock-kv-size")
+	testfailpoint.Enable(s.T(), "github.com/pingcap/tidb/lightning/pkg/importer/mock-kv-size", "return(110000000)")
 	_, _, err = s.cr.encodeLoop(ctx, kvsCh, s.tr, s.tr.logger, kvEncoder, deliverCompleteCh, rc)
 	require.NoError(s.T(), err)
 

--- a/lightning/pkg/importer/chunk_process_test.go
+++ b/lightning/pkg/importer/chunk_process_test.go
@@ -431,7 +431,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverLimit() {
 	reader, err := store.Open(ctx, fileName, nil)
 	require.NoError(s.T(), err)
 	w := worker.NewPool(ctx, 1, "io")
-	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, false, nil)
+	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, mydump.CSVHeaderFalse, nil)
 	require.NoError(s.T(), err)
 	s.cr.parser = p
 
@@ -510,7 +510,7 @@ func (s *chunkRestoreSuite) TestEncodeLoopColumnsMismatch() {
 	reader, err := store.Open(ctx, fileName, nil)
 	require.NoError(s.T(), err)
 	w := worker.NewPool(ctx, 5, "io")
-	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, false, nil)
+	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, mydump.CSVHeaderFalse, nil)
 	require.NoError(s.T(), err)
 
 	err = s.cr.parser.Close()
@@ -609,7 +609,7 @@ func (s *chunkRestoreSuite) testEncodeLoopIgnoreColumnsCSV(
 	reader, err := store.Open(ctx, fileName, nil)
 	require.NoError(s.T(), err)
 	w := worker.NewPool(ctx, 5, "io")
-	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, cfg.Mydumper.CSV.Header, nil)
+	p, err := mydump.NewCSVParser(ctx, &cfg.Mydumper.CSV, reader, 111, w, mydump.GetCSVHeaderOptionFromCfg(cfg), nil)
 	require.NoError(s.T(), err)
 
 	err = s.cr.parser.Close()

--- a/lightning/pkg/importer/get_pre_info.go
+++ b/lightning/pkg/importer/get_pre_info.go
@@ -477,16 +477,12 @@ func (p *PreImportInfoGetterImpl) ReadFirstNRowsByFileMeta(ctx context.Context, 
 	blockBufSize := int64(p.cfg.Mydumper.ReadBlockSize)
 	switch dataFileMeta.Type {
 	case mydump.SourceTypeCSV:
-		csvHeaderOption := mydump.CSVHeaderFalse
-		if p.cfg.Mydumper.CSV.Header {
-			csvHeaderOption = mydump.CSVHeaderTrue
-		}
 		// Create a utf8mb4 convertor to encode and decode data with the charset of CSV files.
 		charsetConvertor, err := mydump.NewCharsetConvertor(p.cfg.Mydumper.DataCharacterSet, p.cfg.Mydumper.DataInvalidCharReplace)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, csvHeaderOption, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, mydump.GetCSVHeaderOptionFromCfg(p.cfg), charsetConvertor)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
@@ -650,16 +646,12 @@ func (p *PreImportInfoGetterImpl) sampleDataFromTable(
 	var parser mydump.Parser
 	switch tableMeta.DataFiles[0].FileMeta.Type {
 	case mydump.SourceTypeCSV:
-		csvHeaderOption := mydump.CSVHeaderFalse
-		if p.cfg.Mydumper.CSV.Header {
-			csvHeaderOption = mydump.CSVHeaderTrue
-		}
 		// Create a utf8mb4 convertor to encode and decode data with the charset of CSV files.
 		charsetConvertor, err := mydump.NewCharsetConvertor(p.cfg.Mydumper.DataCharacterSet, p.cfg.Mydumper.DataInvalidCharReplace)
 		if err != nil {
 			return 0.0, false, errors.Trace(err)
 		}
-		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, csvHeaderOption, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, mydump.GetCSVHeaderOptionFromCfg(p.cfg), charsetConvertor)
 		if err != nil {
 			return 0.0, false, errors.Trace(err)
 		}

--- a/lightning/pkg/importer/get_pre_info.go
+++ b/lightning/pkg/importer/get_pre_info.go
@@ -477,13 +477,16 @@ func (p *PreImportInfoGetterImpl) ReadFirstNRowsByFileMeta(ctx context.Context, 
 	blockBufSize := int64(p.cfg.Mydumper.ReadBlockSize)
 	switch dataFileMeta.Type {
 	case mydump.SourceTypeCSV:
-		hasHeader := p.cfg.Mydumper.CSV.Header
+		csvHeaderOption := mydump.CSVHeaderFalse
+		if p.cfg.Mydumper.CSV.Header {
+			csvHeaderOption = mydump.CSVHeaderTrue
+		}
 		// Create a utf8mb4 convertor to encode and decode data with the charset of CSV files.
 		charsetConvertor, err := mydump.NewCharsetConvertor(p.cfg.Mydumper.DataCharacterSet, p.cfg.Mydumper.DataInvalidCharReplace)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, hasHeader, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, csvHeaderOption, charsetConvertor)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
@@ -647,13 +650,16 @@ func (p *PreImportInfoGetterImpl) sampleDataFromTable(
 	var parser mydump.Parser
 	switch tableMeta.DataFiles[0].FileMeta.Type {
 	case mydump.SourceTypeCSV:
-		hasHeader := p.cfg.Mydumper.CSV.Header
+		csvHeaderOption := mydump.CSVHeaderFalse
+		if p.cfg.Mydumper.CSV.Header {
+			csvHeaderOption = mydump.CSVHeaderTrue
+		}
 		// Create a utf8mb4 convertor to encode and decode data with the charset of CSV files.
 		charsetConvertor, err := mydump.NewCharsetConvertor(p.cfg.Mydumper.DataCharacterSet, p.cfg.Mydumper.DataInvalidCharReplace)
 		if err != nil {
 			return 0.0, false, errors.Trace(err)
 		}
-		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, hasHeader, charsetConvertor)
+		parser, err = mydump.NewCSVParser(ctx, &p.cfg.Mydumper.CSV, reader, blockBufSize, p.ioWorkers, csvHeaderOption, charsetConvertor)
 		if err != nil {
 			return 0.0, false, errors.Trace(err)
 		}

--- a/pkg/executor/importer/chunk_process_testkit_test.go
+++ b/pkg/executor/importer/chunk_process_testkit_test.go
@@ -50,7 +50,7 @@ func getCSVParser(ctx context.Context, t *testing.T, fileName string) mydump.Par
 	file, err := os.Open(fileName)
 	require.NoError(t, err)
 	csvParser, err := mydump.NewCSVParser(ctx, &config.CSVConfig{FieldsTerminatedBy: `,`, FieldsEnclosedBy: `"`},
-		file, importer.LoadDataReadBlockSize, nil, false, nil)
+		file, importer.LoadDataReadBlockSize, nil, mydump.CSVHeaderFalse, nil)
 	require.NoError(t, err)
 	return csvParser
 }

--- a/pkg/executor/importer/chunk_process_testkit_test.go
+++ b/pkg/executor/importer/chunk_process_testkit_test.go
@@ -16,6 +16,7 @@ package importer_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -46,11 +47,11 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func getCSVParser(ctx context.Context, t *testing.T, fileName string) mydump.Parser {
+func getCSVParser(ctx context.Context, t *testing.T, fileName string, csvHeaderOption mydump.CSVHeaderOption) mydump.Parser {
 	file, err := os.Open(fileName)
 	require.NoError(t, err)
 	csvParser, err := mydump.NewCSVParser(ctx, &config.CSVConfig{FieldsTerminatedBy: `,`, FieldsEnclosedBy: `"`},
-		file, importer.LoadDataReadBlockSize, nil, mydump.CSVHeaderFalse, nil)
+		file, importer.LoadDataReadBlockSize, nil, csvHeaderOption, nil)
 	require.NoError(t, err)
 	return csvParser
 }
@@ -99,73 +100,102 @@ func TestFileChunkProcess(t *testing.T) {
 	require.NoError(t, err)
 	diskQuotaLock := &syncutil.RWMutex{}
 
-	t.Run("process success", func(t *testing.T) {
-		var dataKVCnt, indexKVCnt int
+	for _, opt := range []mydump.CSVHeaderOption{mydump.CSVHeaderAuto, mydump.CSVHeaderTrue} {
+		t.Run(fmt.Sprintf("process success with %s", opt), func(t *testing.T) {
+			var dataKVCnt, indexKVCnt int
+			fileName := path.Join(tempDir, "test.csv")
+			sourceData := []byte("a,b,c\n1,2,3\n4,5,6\n7,8,9\n")
+			require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
+			csvParser := getCSVParser(ctx, t, fileName, opt)
+			csvParser.SetColumns([]string{"a", "b", "c"})
+			defer func() {
+				require.NoError(t, csvParser.Close())
+			}()
+			metrics := tidbmetrics.GetRegisteredImportMetrics(promutil.NewDefaultFactory(),
+				prometheus.Labels{
+					proto.TaskIDLabelName: uuid.New().String(),
+				})
+			ctx = metric.WithCommonMetric(ctx, metrics)
+			defer func() {
+				tidbmetrics.UnregisterImportMetrics(metrics)
+			}()
+			bak := importer.MinDeliverRowCnt
+			importer.MinDeliverRowCnt = 2
+			defer func() {
+				importer.MinDeliverRowCnt = bak
+			}()
+
+			dataWriter := mock.NewMockEngineWriter(ctrl)
+			indexWriter := mock.NewMockEngineWriter(ctrl)
+			dataWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, columnNames []string, rows encode.Rows) error {
+					dataKVCnt += len(rows.(*kv.Pairs).Pairs)
+					return nil
+				}).AnyTimes()
+			indexWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, columnNames []string, rows encode.Rows) error {
+					group := rows.(kv.GroupedPairs)
+					for _, pairs := range group {
+						indexKVCnt += len(pairs)
+					}
+					return nil
+				}).AnyTimes()
+
+			chunkInfo := &checkpoints.ChunkCheckpoint{
+				Chunk: mydump.Chunk{EndOffset: int64(len(sourceData)), RowIDMax: 10000},
+			}
+			checksum := verify.NewKVGroupChecksumWithKeyspace(nil)
+			processor := importer.NewFileChunkProcessor(
+				csvParser, encoder, nil,
+				chunkInfo, logger.Logger, diskQuotaLock, dataWriter, indexWriter, checksum,
+			)
+			require.NoError(t, processor.Process(ctx))
+			require.True(t, ctrl.Satisfied())
+			checksumDataKVCnt, checksumIndexKVCnt := checksum.DataAndIndexSumKVS()
+			require.Equal(t, uint64(3), checksumDataKVCnt)
+			require.Equal(t, uint64(6), checksumIndexKVCnt)
+			dataKVSize, indexKVSize := checksum.DataAndIndexSumSize()
+			require.Equal(t, uint64(348), dataKVSize+indexKVSize)
+			require.Equal(t, 3, dataKVCnt)
+			require.Equal(t, 6, indexKVCnt)
+			require.Equal(t, float64(len(sourceData)), metric.ReadCounter(metrics.BytesCounter.WithLabelValues(metric.StateRestored)))
+			require.Equal(t, float64(3), metric.ReadCounter(metrics.RowsCounter.WithLabelValues(metric.StateRestored, "")))
+			require.Equal(t, uint64(2), *metric.ReadHistogram(metrics.RowEncodeSecondsHistogram).Histogram.SampleCount)
+			require.Equal(t, uint64(2), *metric.ReadHistogram(metrics.RowReadSecondsHistogram).Histogram.SampleCount)
+		})
+	}
+
+	t.Run("wrong header", func(t *testing.T) {
 		fileName := path.Join(tempDir, "test.csv")
-		sourceData := []byte("1,2,3\n4,5,6\n7,8,9\n")
+		sourceData := []byte(`a,b,d\n4,5,6\n7,8,9\n`)
 		require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
-		csvParser := getCSVParser(ctx, t, fileName)
+		csvParser := getCSVParser(ctx, t, fileName, mydump.CSVHeaderAuto)
+		csvParser.SetColumns([]string{"a", "b", "c"})
 		defer func() {
 			require.NoError(t, csvParser.Close())
-		}()
-		metrics := tidbmetrics.GetRegisteredImportMetrics(promutil.NewDefaultFactory(),
-			prometheus.Labels{
-				proto.TaskIDLabelName: uuid.New().String(),
-			})
-		ctx = metric.WithCommonMetric(ctx, metrics)
-		defer func() {
-			tidbmetrics.UnregisterImportMetrics(metrics)
-		}()
-		bak := importer.MinDeliverRowCnt
-		importer.MinDeliverRowCnt = 2
-		defer func() {
-			importer.MinDeliverRowCnt = bak
 		}()
 
 		dataWriter := mock.NewMockEngineWriter(ctrl)
 		indexWriter := mock.NewMockEngineWriter(ctrl)
-		dataWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, columnNames []string, rows encode.Rows) error {
-				dataKVCnt += len(rows.(*kv.Pairs).Pairs)
-				return nil
-			}).AnyTimes()
-		indexWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, columnNames []string, rows encode.Rows) error {
-				group := rows.(kv.GroupedPairs)
-				for _, pairs := range group {
-					indexKVCnt += len(pairs)
-				}
-				return nil
-			}).AnyTimes()
+		dataWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		indexWriter.EXPECT().AppendRows(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		chunkInfo := &checkpoints.ChunkCheckpoint{
 			Chunk: mydump.Chunk{EndOffset: int64(len(sourceData)), RowIDMax: 10000},
 		}
-		checksum := verify.NewKVGroupChecksumWithKeyspace(nil)
 		processor := importer.NewFileChunkProcessor(
 			csvParser, encoder, nil,
-			chunkInfo, logger.Logger, diskQuotaLock, dataWriter, indexWriter, checksum,
+			chunkInfo, logger.Logger, diskQuotaLock, dataWriter, indexWriter, nil,
 		)
-		require.NoError(t, processor.Process(ctx))
+		require.ErrorIs(t, processor.Process(ctx), common.ErrEncodeKV)
 		require.True(t, ctrl.Satisfied())
-		checksumDataKVCnt, checksumIndexKVCnt := checksum.DataAndIndexSumKVS()
-		require.Equal(t, uint64(3), checksumDataKVCnt)
-		require.Equal(t, uint64(6), checksumIndexKVCnt)
-		dataKVSize, indexKVSize := checksum.DataAndIndexSumSize()
-		require.Equal(t, uint64(348), dataKVSize+indexKVSize)
-		require.Equal(t, 3, dataKVCnt)
-		require.Equal(t, 6, indexKVCnt)
-		require.Equal(t, float64(len(sourceData)), metric.ReadCounter(metrics.BytesCounter.WithLabelValues(metric.StateRestored)))
-		require.Equal(t, float64(3), metric.ReadCounter(metrics.RowsCounter.WithLabelValues(metric.StateRestored, "")))
-		require.Equal(t, uint64(2), *metric.ReadHistogram(metrics.RowEncodeSecondsHistogram).Histogram.SampleCount)
-		require.Equal(t, uint64(2), *metric.ReadHistogram(metrics.RowReadSecondsHistogram).Histogram.SampleCount)
 	})
 
 	t.Run("encode error", func(t *testing.T) {
 		fileName := path.Join(tempDir, "test.csv")
 		sourceData := []byte(`1,2,3\n4,aa,6\n7,8,9\n`)
 		require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
-		csvParser := getCSVParser(ctx, t, fileName)
+		csvParser := getCSVParser(ctx, t, fileName, mydump.CSVHeaderFalse)
 		defer func() {
 			require.NoError(t, csvParser.Close())
 		}()
@@ -190,7 +220,7 @@ func TestFileChunkProcess(t *testing.T) {
 		fileName := path.Join(tempDir, "test.csv")
 		sourceData := []byte(`1,"`)
 		require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
-		csvParser := getCSVParser(ctx, t, fileName)
+		csvParser := getCSVParser(ctx, t, fileName, mydump.CSVHeaderFalse)
 		defer func() {
 			require.NoError(t, csvParser.Close())
 		}()
@@ -215,7 +245,7 @@ func TestFileChunkProcess(t *testing.T) {
 		fileName := path.Join(tempDir, "test.csv")
 		sourceData := []byte("1,2,3\n4,5,6\n7,8,9\n")
 		require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
-		csvParser := getCSVParser(ctx, t, fileName)
+		csvParser := getCSVParser(ctx, t, fileName, mydump.CSVHeaderFalse)
 		defer func() {
 			require.NoError(t, csvParser.Close())
 		}()
@@ -239,7 +269,7 @@ func TestFileChunkProcess(t *testing.T) {
 		fileName := path.Join(tempDir, "test.csv")
 		sourceData := []byte("1,2,3\n4,5,6\n7,8,9\n")
 		require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
-		csvParser := getCSVParser(ctx, t, fileName)
+		csvParser := getCSVParser(ctx, t, fileName, mydump.CSVHeaderFalse)
 		defer func() {
 			require.NoError(t, csvParser.Close())
 		}()

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -393,6 +393,7 @@ func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.Load
 		NullValueOptEnclosed: nullValueOptEnclosed,
 		LineFieldsInfo:       lineFieldsInfo,
 		IgnoreLines:          ignoreLines,
+		CSVHeaderOption:      mydump.CSVHeaderFalse,
 
 		SQLMode:          userSctx.GetSessionVars().SQLMode,
 		Charset:          charset,

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -89,7 +89,7 @@ const (
 	fieldsEscapedByOption     = "fields_escaped_by"
 	fieldsDefinedNullByOption = "fields_defined_null_by"
 	linesTerminatedByOption   = "lines_terminated_by"
-	skipRowsOption            = "skip_rows"
+	csvHeaderOption           = "csv_header"
 	splitFileOption           = "split_file"
 	diskQuotaOption           = "disk_quota"
 	threadOption              = "thread"
@@ -126,7 +126,7 @@ var (
 		fieldsEscapedByOption:       true,
 		fieldsDefinedNullByOption:   true,
 		linesTerminatedByOption:     true,
-		skipRowsOption:              true,
+		csvHeaderOption:             true,
 		splitFileOption:             false,
 		diskQuotaOption:             true,
 		threadOption:                true,
@@ -149,7 +149,7 @@ var (
 		fieldsEscapedByOption:     {},
 		fieldsDefinedNullByOption: {},
 		linesTerminatedByOption:   {},
-		skipRowsOption:            {},
+		csvHeaderOption:           {},
 		splitFileOption:           {},
 	}
 
@@ -238,7 +238,7 @@ type Plan struct {
 	// LinesStartingBy is not used in IMPORT INTO
 	// FieldsOptEnclosed is not used in either IMPORT INTO or LOAD DATA
 	plannercore.LineFieldsInfo
-	IgnoreLines uint64
+	CSVHeaderOption mydump.CSVHeaderOption
 
 	DiskQuota             config.ByteSize
 	Checksum              config.PostOpLevel
@@ -353,9 +353,9 @@ func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.Load
 	restrictive := userSctx.GetSessionVars().SQLMode.HasStrictMode() &&
 		plan.OnDuplicate != ast.OnDuplicateKeyHandlingIgnore
 
-	var ignoreLines uint64
+	csvHeaderOption := mydump.CSVHeaderFalse
 	if plan.IgnoreLines != nil {
-		ignoreLines = *plan.IgnoreLines
+		csvHeaderOption = mydump.CSVHeaderTrue
 	}
 
 	var (
@@ -386,7 +386,7 @@ func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.Load
 		FieldNullDef:         nullDef,
 		NullValueOptEnclosed: nullValueOptEnclosed,
 		LineFieldsInfo:       lineFieldsInfo,
-		IgnoreLines:          ignoreLines,
+		CSVHeaderOption:      csvHeaderOption,
 
 		SQLMode:          userSctx.GetSessionVars().SQLMode,
 		Charset:          charset,
@@ -410,9 +410,9 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 	// those are the default values for lightning CSV format too
 	lineFieldsInfo := plannercore.LineFieldsInfo{
 		FieldsTerminatedBy: `,`,
-		FieldsEnclosedBy:   `"`,
-		FieldsEscapedBy:    `\`,
-		LinesStartingBy:    ``,
+		// FieldsEnclosedBy:   `"`,
+		// FieldsEscapedBy:    `\`,
+		// LinesStartingBy:    ``,
 		// csv_parser will determine it automatically(either '\r' or '\n' or '\r\n')
 		// But user cannot set this to empty explicitly.
 		LinesTerminatedBy: ``,
@@ -676,12 +676,13 @@ func (p *Plan) initOptions(ctx context.Context, seCtx sessionctx.Context, option
 		}
 		p.LinesTerminatedBy = v
 	}
-	if opt, ok := specifiedOptions[skipRowsOption]; ok {
-		vInt, err := optAsInt64(opt)
-		if err != nil || vInt < 0 {
+	if opt, ok := specifiedOptions[csvHeaderOption]; ok {
+		v, err := optAsString(opt)
+		if err != nil || v == "" {
 			return exeerrors.ErrInvalidOptionVal.FastGenByArgs(opt.Name)
 		}
-		p.IgnoreLines = uint64(vInt)
+		v = strings.ToLower(v)
+		p.CSVHeaderOption = mydump.GetCSVHeaderOption(v)
 	}
 	if _, ok := specifiedOptions[splitFileOption]; ok {
 		p.SplitFile = true
@@ -776,15 +777,6 @@ func (p *Plan) initOptions(ctx context.Context, seCtx sessionctx.Context, option
 		if p.MaxNodeCnt == -1 { // -1 means calculate automatically
 			p.MaxNodeCnt = ddl.GetDXFDefaultMaxNodeCntAuto(seCtx.GetStore())
 		}
-	}
-
-	// when split-file is set, data file will be split into chunks of 256 MiB.
-	// skip_rows should be 0 or 1, we add this restriction to simplify skip_rows
-	// logic, so we only need to skip on the first chunk for each data file.
-	// CSV parser limit each row size to LargestEntryLimit(120M), the first row
-	// will NOT cross file chunk.
-	if p.SplitFile && p.IgnoreLines > 1 {
-		return exeerrors.ErrInvalidOptionVal.FastGenByArgs("skip_rows, should be <= 1 when split-file is enabled")
 	}
 
 	if p.SplitFile && len(p.LinesTerminatedBy) == 0 {
@@ -1222,6 +1214,7 @@ func (e *LoadDataController) GetLoadDataReaderInfos() []LoadDataReaderInfo {
 func (e *LoadDataController) GetParser(
 	ctx context.Context,
 	dataFileInfo LoadDataReaderInfo,
+	isFirstChunk bool,
 ) (parser mydump.Parser, err error) {
 	reader, err2 := dataFileInfo.Opener(ctx)
 	if err2 != nil {
@@ -1246,13 +1239,19 @@ func (e *LoadDataController) GetParser(
 		if err != nil {
 			return nil, err
 		}
+
+		// Only first chunk need process header
+		csvHeaderOption := e.CSVHeaderOption
+		if !isFirstChunk {
+			csvHeaderOption = mydump.CSVHeaderFalse
+		}
 		parser, err = mydump.NewCSVParser(
 			ctx,
 			e.GenerateCSVConfig(),
 			reader,
 			LoadDataReadBlockSize,
 			nil,
-			false,
+			csvHeaderOption,
 			charsetConvertor)
 	case DataFormatSQL:
 		parser = mydump.NewChunkParser(
@@ -1276,32 +1275,6 @@ func (e *LoadDataController) GetParser(
 	parser.SetLogger(litlog.Logger{Logger: logutil.Logger(ctx)})
 
 	return parser, nil
-}
-
-// HandleSkipNRows skips the first N rows of the data file.
-func (e *LoadDataController) HandleSkipNRows(parser mydump.Parser) error {
-	// handle IGNORE N LINES
-	ignoreOneLineFn := parser.ReadRow
-	if csvParser, ok := parser.(*mydump.CSVParser); ok {
-		ignoreOneLineFn = func() error {
-			_, _, err3 := csvParser.ReadUntilTerminator()
-			return err3
-		}
-	}
-
-	ignoreLineCnt := e.IgnoreLines
-	for ignoreLineCnt > 0 {
-		err := ignoreOneLineFn()
-		if err != nil {
-			if errors.Cause(err) == io.EOF {
-				return nil
-			}
-			return err
-		}
-
-		ignoreLineCnt--
-	}
-	return nil
 }
 
 func (e *LoadDataController) toMyDumpFiles() []mydump.FileInfo {

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -89,7 +89,7 @@ const (
 	fieldsEscapedByOption     = "fields_escaped_by"
 	fieldsDefinedNullByOption = "fields_defined_null_by"
 	linesTerminatedByOption   = "lines_terminated_by"
-	csvHeaderOption           = "remove_csv_header"
+	csvHeaderOption           = "has_csv_header"
 	skipRowsOption            = "skip_rows"
 	splitFileOption           = "split_file"
 	diskQuotaOption           = "disk_quota"

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1281,7 +1281,7 @@ func (e *LoadDataController) GetParser(
 			nil,
 			csvHeaderOption,
 			charsetConvertor)
-		if err == nil {
+		if err == nil && csvHeaderOption == mydump.CSVHeaderAuto {
 			columnNames := make([]string, 0, len(e.FieldMappings))
 			for _, fieldMapping := range e.FieldMappings {
 				if fieldMapping.Column != nil {

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -354,7 +354,7 @@ func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.Load
 		plan.OnDuplicate != ast.OnDuplicateKeyHandlingIgnore
 
 	csvHeaderOption := mydump.CSVHeaderFalse
-	if plan.IgnoreLines != nil {
+	if plan.IgnoreLines != nil && *plan.IgnoreLines == 1 {
 		csvHeaderOption = mydump.CSVHeaderTrue
 	}
 
@@ -410,9 +410,9 @@ func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plann
 	// those are the default values for lightning CSV format too
 	lineFieldsInfo := plannercore.LineFieldsInfo{
 		FieldsTerminatedBy: `,`,
-		// FieldsEnclosedBy:   `"`,
-		// FieldsEscapedBy:    `\`,
-		// LinesStartingBy:    ``,
+		FieldsEnclosedBy:   `"`,
+		FieldsEscapedBy:    `\`,
+		LinesStartingBy:    ``,
 		// csv_parser will determine it automatically(either '\r' or '\n' or '\r\n')
 		// But user cannot set this to empty explicitly.
 		LinesTerminatedBy: ``,

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/pkg/expression"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
@@ -38,6 +37,7 @@ import (
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	plannerutil "github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/logutil"
@@ -203,11 +203,7 @@ func TestAdjustOptions(t *testing.T) {
 }
 
 func TestAdjustDiskQuota(t *testing.T) {
-	err := failpoint.Enable("github.com/pingcap/tidb/pkg/lightning/common/GetStorageSize", "return(2048)")
-	require.NoError(t, err)
-	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/tidb/pkg/lightning/common/GetStorageSize")
-	}()
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/lightning/common/GetStorageSize", "return(2048)")
 	d := t.TempDir()
 	require.Equal(t, int64(1638), adjustDiskQuota(0, d, logutil.BgLogger()))
 	require.Equal(t, int64(1), adjustDiskQuota(1, d, logutil.BgLogger()))

--- a/pkg/executor/importer/import_test.go
+++ b/pkg/executor/importer/import_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/expression"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/config"
+	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -68,6 +69,7 @@ func TestInitDefaultOptions(t *testing.T) {
 	require.Equal(t, false, plan.SplitFile)
 	require.Equal(t, int64(100), plan.MaxRecordedErrors)
 	require.Equal(t, false, plan.Detached)
+	require.Equal(t, mydump.CSVHeaderFalse, plan.CSVHeaderOption)
 	require.Equal(t, "utf8mb4", *plan.Charset)
 	require.Equal(t, false, plan.DisableTiKVImportMode)
 	require.Equal(t, config.ByteSize(defaultMaxEngineSize), plan.MaxEngineSize)
@@ -105,7 +107,7 @@ func TestInitOptionsPositiveCase(t *testing.T) {
 		fieldsEscapedByOption+"='', "+
 		fieldsDefinedNullByOption+"='N', "+
 		linesTerminatedByOption+"='END', "+
-		skipRowsOption+"=1, "+
+		csvHeaderOption+"='true', "+
 		diskQuotaOption+"='100gib', "+
 		checksumTableOption+"='optional', "+
 		threadOption+"=100000, "+
@@ -128,7 +130,7 @@ func TestInitOptionsPositiveCase(t *testing.T) {
 	require.Equal(t, "", plan.FieldsEscapedBy, sql)
 	require.Equal(t, []string{"N"}, plan.FieldNullDef, sql)
 	require.Equal(t, "END", plan.LinesTerminatedBy, sql)
-	require.Equal(t, uint64(1), plan.IgnoreLines, sql)
+	require.Equal(t, mydump.CSVHeaderTrue, plan.CSVHeaderOption, sql)
 	require.Equal(t, config.ByteSize(100<<30), plan.DiskQuota, sql)
 	require.Equal(t, config.OpLevelOptional, plan.Checksum, sql)
 	require.Equal(t, runtime.GOMAXPROCS(0), plan.ThreadCnt, sql) // it's adjusted to the number of CPUs

--- a/pkg/executor/importer/precheck.go
+++ b/pkg/executor/importer/precheck.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/streamhelper"
 	tidb "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/lightning/common"
+	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/parser/terror"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/cdcutil"
@@ -63,6 +64,9 @@ func (e *LoadDataController) CheckRequirements(ctx context.Context, conn sqlexec
 		if err := e.checkTotalFileSize(); err != nil {
 			return err
 		}
+	}
+	if e.Plan.CSVHeaderOption == mydump.CSVHeaderAuto && len(e.ASTArgs.ColumnsAndUserVars) != 0 {
+		return exeerrors.ErrLoadDataPreCheckFailed.FastGenByArgs("AUTO remove csv header option does not support column list")
 	}
 	if err := e.checkTableEmpty(ctx, conn); err != nil {
 		return err

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -300,22 +300,15 @@ func (ti *TableImporter) getParser(ctx context.Context, chunk *checkpoints.Chunk
 		},
 		Remote: &chunk.FileMeta,
 	}
-	parser, err := ti.LoadDataController.GetParser(ctx, info)
+
+	parser, err := ti.LoadDataController.GetParser(ctx, info, chunk.Chunk.Offset == 0)
 	if err != nil {
 		return nil, err
 	}
-	if chunk.Chunk.Offset == 0 {
-		// if data file is split, only the first chunk need to do skip.
-		// see check in initOptions.
-		if err = ti.LoadDataController.HandleSkipNRows(parser); err != nil {
-			return nil, err
-		}
-		parser.SetRowID(chunk.Chunk.PrevRowIDMax)
-	} else {
-		// if we reached here, the file must be an uncompressed CSV file.
-		if err = parser.SetPos(chunk.Chunk.Offset, chunk.Chunk.PrevRowIDMax); err != nil {
-			return nil, err
-		}
+
+	if err = parser.SetPos(chunk.Chunk.Offset, chunk.Chunk.PrevRowIDMax); err != nil {
+		_ = parser.Close()
+		return nil, err
 	}
 	return parser, nil
 }

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -306,9 +306,18 @@ func (ti *TableImporter) getParser(ctx context.Context, chunk *checkpoints.Chunk
 		return nil, err
 	}
 
-	if err = parser.SetPos(chunk.Chunk.Offset, chunk.Chunk.PrevRowIDMax); err != nil {
-		_ = parser.Close()
-		return nil, err
+	if chunk.Chunk.Offset == 0 {
+		// if data file is split, only the first chunk need to do skip.
+		// see check in initOptions.
+		if err = ti.LoadDataController.HandleSkipNRows(parser); err != nil {
+			return nil, err
+		}
+		parser.SetRowID(chunk.Chunk.PrevRowIDMax)
+	} else {
+		// if we reached here, the file must be an uncompressed CSV file.
+		if err = parser.SetPos(chunk.Chunk.Offset, chunk.Chunk.PrevRowIDMax); err != nil {
+			return nil, err
+		}
 	}
 	return parser, nil
 }

--- a/pkg/executor/load_data.go
+++ b/pkg/executor/load_data.go
@@ -388,6 +388,9 @@ func (w *encodeWorker) processStream(
 			if err != nil {
 				return err
 			}
+			if err = w.controller.HandleSkipNRows(dataParser); err != nil {
+				return err
+			}
 			err = w.processOneStream(ctx, dataParser, outCh)
 			terror.Log(dataParser.Close())
 			if err != nil {
@@ -716,6 +719,11 @@ func (e *LoadDataWorker) TestLoadLocal(parser mydump.Parser) error {
 	err = sessiontxn.NewTxn(ctx, e.UserSctx)
 	if err != nil {
 		return err
+	}
+
+	for range e.controller.IgnoreLines {
+		//nolint: errcheck
+		_ = parser.ReadRow()
 	}
 
 	err = encoder.readOneBatchRows(ctx, parser)

--- a/pkg/executor/load_data.go
+++ b/pkg/executor/load_data.go
@@ -384,11 +384,8 @@ func (w *encodeWorker) processStream(
 			if !ok {
 				return nil
 			}
-			dataParser, err := w.controller.GetParser(ctx, readerInfo)
+			dataParser, err := w.controller.GetParser(ctx, readerInfo, true)
 			if err != nil {
-				return err
-			}
-			if err = w.controller.HandleSkipNRows(dataParser); err != nil {
 				return err
 			}
 			err = w.processOneStream(ctx, dataParser, outCh)
@@ -719,11 +716,6 @@ func (e *LoadDataWorker) TestLoadLocal(parser mydump.Parser) error {
 	err = sessiontxn.NewTxn(ctx, e.UserSctx)
 	if err != nil {
 		return err
-	}
-
-	for range e.controller.IgnoreLines {
-		//nolint: errcheck
-		_ = parser.ReadRow()
 	}
 
 	err = encoder.readOneBatchRows(ctx, parser)

--- a/pkg/lightning/mydump/csv_parser.go
+++ b/pkg/lightning/mydump/csv_parser.go
@@ -746,6 +746,7 @@ func (parser *CSVParser) TrySkipHeader() ([]field, bool, error) {
 				continue
 			}
 			colNameCSV, _, err := parser.unescapeString(fields[i])
+			colNameCSV = strings.TrimSpace(colNameCSV)
 			if err != nil {
 				return nil, false, errors.Trace(err)
 			}

--- a/pkg/lightning/mydump/csv_parser.go
+++ b/pkg/lightning/mydump/csv_parser.go
@@ -768,7 +768,6 @@ func (parser *CSVParser) TrySkipHeader() ([]field, bool, error) {
 		parser.columns = make([]string, 0, len(fields))
 		for _, colName := range fields {
 			colNameStr, _, err := parser.unescapeString(colName)
-			colNameStr = strings.TrimSpace(colNameStr)
 			if err != nil {
 				return nil, false, errors.Trace(err)
 			}

--- a/pkg/lightning/mydump/csv_parser.go
+++ b/pkg/lightning/mydump/csv_parser.go
@@ -765,7 +765,7 @@ func (parser *CSVParser) trySkipHeader() ([]field, bool, error) {
 			if err != nil {
 				return nil, false, errors.Trace(err)
 			}
-			if strings.ToLower(colName) != strings.ToLower(colNameCSV) {
+			if !strings.EqualFold(colName, colNameCSV) {
 				match = false
 				break
 			}

--- a/pkg/lightning/mydump/csv_parser_test.go
+++ b/pkg/lightning/mydump/csv_parser_test.go
@@ -1388,7 +1388,7 @@ yyy",5,xx"xxxx,8
 			LinesStartingBy:    "x\nxx",
 		},
 	}
-	_, err := mydump.NewCSVParser(context.Background(), &cfg.CSV, nil, 1, ioWorkersForCSV, false, nil)
+	_, err := mydump.NewCSVParser(context.Background(), &cfg.CSV, nil, 1, ioWorkersForCSV, mydump.CSVHeaderFalse, nil)
 	require.ErrorContains(t, err, "STARTING BY 'x\nxx' cannot contain LINES TERMINATED BY '\n'")
 }
 

--- a/pkg/lightning/mydump/region.go
+++ b/pkg/lightning/mydump/region.go
@@ -418,17 +418,16 @@ func SplitLargeCSV(
 			_ = r.Close()
 			return nil, nil, err
 		}
-		parser, err := NewCSVParser(ctx, &cfg.CSV, r, cfg.ReadBlockSize, cfg.IOWorkers, CSVHeaderFalse, charsetConvertor)
+		parser, err := NewCSVParser(ctx, &cfg.CSV, r, cfg.ReadBlockSize, cfg.IOWorkers, CSVHeaderTrue, charsetConvertor)
 		if err != nil {
 			return nil, nil, err
 		}
-		readColumns, err := parser.ReadColumns()
-		if err != nil {
+		if _, _, err = parser.TrySkipHeader(); err != nil {
 			_ = parser.Close()
 			return nil, nil, err
 		}
 		if cfg.CSV.HeaderSchemaMatch {
-			columns = readColumns
+			columns = parser.Columns()
 		}
 		startOffset, _ = parser.Pos()
 		endOffset = min(startOffset+maxRegionSize, dataFile.FileMeta.FileSize)

--- a/pkg/lightning/mydump/region.go
+++ b/pkg/lightning/mydump/region.go
@@ -418,16 +418,17 @@ func SplitLargeCSV(
 			_ = r.Close()
 			return nil, nil, err
 		}
-		parser, err := NewCSVParser(ctx, &cfg.CSV, r, cfg.ReadBlockSize, cfg.IOWorkers, true, charsetConvertor)
+		parser, err := NewCSVParser(ctx, &cfg.CSV, r, cfg.ReadBlockSize, cfg.IOWorkers, CSVHeaderFalse, charsetConvertor)
 		if err != nil {
 			return nil, nil, err
 		}
-		if err = parser.ReadColumns(); err != nil {
+		readColumns, err := parser.ReadColumns()
+		if err != nil {
 			_ = parser.Close()
 			return nil, nil, err
 		}
 		if cfg.CSV.HeaderSchemaMatch {
-			columns = parser.Columns()
+			columns = readColumns
 		}
 		startOffset, _ = parser.Pos()
 		endOffset = min(startOffset+maxRegionSize, dataFile.FileMeta.FileSize)
@@ -448,7 +449,7 @@ func SplitLargeCSV(
 				_ = r.Close()
 				return nil, nil, err
 			}
-			parser, err := NewCSVParser(ctx, &cfg.CSV, r, cfg.ReadBlockSize, cfg.IOWorkers, false, charsetConvertor)
+			parser, err := NewCSVParser(ctx, &cfg.CSV, r, cfg.ReadBlockSize, cfg.IOWorkers, CSVHeaderFalse, charsetConvertor)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/lightning/mydump/region_test.go
+++ b/pkg/lightning/mydump/region_test.go
@@ -544,7 +544,7 @@ func TestSplitLargeFileSeekInsideCRLF(t *testing.T) {
 
 	file, err := os.Open(filePath)
 	require.NoError(t, err)
-	parser, err := NewCSVParser(ctx, &cfg.Mydumper.CSV, file, 128, ioWorker, false, nil)
+	parser, err := NewCSVParser(ctx, &cfg.Mydumper.CSV, file, 128, ioWorker, CSVHeaderFalse, nil)
 	require.NoError(t, err)
 
 	for parser.ReadRow() == nil {
@@ -572,7 +572,7 @@ func TestSplitLargeFileSeekInsideCRLF(t *testing.T) {
 
 	file, err = os.Open(filePath)
 	require.NoError(t, err)
-	parser, err = NewCSVParser(ctx, &cfg.Mydumper.CSV, file, 128, ioWorker, false, nil)
+	parser, err = NewCSVParser(ctx, &cfg.Mydumper.CSV, file, 128, ioWorker, CSVHeaderFalse, nil)
 	require.NoError(t, err)
 
 	for parser.ReadRow() == nil {

--- a/tests/integrationtest/r/executor/import_into.result
+++ b/tests/integrationtest/r/executor/import_into.result
@@ -72,6 +72,12 @@ import into t from '/file.csv' with skip_rows=-1;
 Error 8164 (HY000): Invalid option value for skip_rows
 import into t from '/file.csv' with skip_rows=true;
 Error 8164 (HY000): Invalid option value for skip_rows
+import into t from '/file.csv' with remove_csv_header=null;
+Error 8164 (HY000): Invalid option value for remove_csv_header
+import into t from '/file.csv' with remove_csv_header="None";
+Error 8164 (HY000): Invalid option value for remove_csv_header
+import into t from '/file.csv' with remove_csv_header="auto", skip_rows=1;
+Error 8164 (HY000): Invalid option value for remove_csv_header
 import into t from '/file.csv' with split_file='aa';
 Error 8164 (HY000): Invalid option value for split_file
 import into t from '/file.csv' with split_file;

--- a/tests/integrationtest/r/executor/import_into.result
+++ b/tests/integrationtest/r/executor/import_into.result
@@ -72,12 +72,12 @@ import into t from '/file.csv' with skip_rows=-1;
 Error 8164 (HY000): Invalid option value for skip_rows
 import into t from '/file.csv' with skip_rows=true;
 Error 8164 (HY000): Invalid option value for skip_rows
-import into t from '/file.csv' with remove_csv_header=null;
-Error 8164 (HY000): Invalid option value for remove_csv_header
-import into t from '/file.csv' with remove_csv_header="None";
-Error 8164 (HY000): Invalid option value for remove_csv_header
-import into t from '/file.csv' with remove_csv_header="auto", skip_rows=1;
-Error 8164 (HY000): Invalid option value for remove_csv_header
+import into t from '/file.csv' with has_csv_header=null;
+Error 8164 (HY000): Invalid option value for has_csv_header
+import into t from '/file.csv' with has_csv_header="None";
+Error 8164 (HY000): Invalid option value for has_csv_header
+import into t from '/file.csv' with has_csv_header="auto", skip_rows=1;
+Error 8164 (HY000): Invalid option value for has_csv_header
 import into t from '/file.csv' with split_file='aa';
 Error 8164 (HY000): Invalid option value for split_file
 import into t from '/file.csv' with split_file;

--- a/tests/integrationtest/t/executor/import_into.test
+++ b/tests/integrationtest/t/executor/import_into.test
@@ -76,11 +76,11 @@ import into t from '/file.csv' with skip_rows=-1;
 -- error 8164
 import into t from '/file.csv' with skip_rows=true;
 -- error 8164
-import into t from '/file.csv' with remove_csv_header=null;
+import into t from '/file.csv' with has_csv_header=null;
 -- error 8164
-import into t from '/file.csv' with remove_csv_header="None";
+import into t from '/file.csv' with has_csv_header="None";
 -- error 8164
-import into t from '/file.csv' with remove_csv_header="auto", skip_rows=1;
+import into t from '/file.csv' with has_csv_header="auto", skip_rows=1;
 -- error 8164
 import into t from '/file.csv' with split_file='aa';
 -- error 8164

--- a/tests/integrationtest/t/executor/import_into.test
+++ b/tests/integrationtest/t/executor/import_into.test
@@ -76,6 +76,12 @@ import into t from '/file.csv' with skip_rows=-1;
 -- error 8164
 import into t from '/file.csv' with skip_rows=true;
 -- error 8164
+import into t from '/file.csv' with remove_csv_header=null;
+-- error 8164
+import into t from '/file.csv' with remove_csv_header="None";
+-- error 8164
+import into t from '/file.csv' with remove_csv_header="auto", skip_rows=1;
+-- error 8164
 import into t from '/file.csv' with split_file='aa';
 -- error 8164
 import into t from '/file.csv' with split_file;

--- a/tests/realtikvtest/importintotest/BUILD.bazel
+++ b/tests/realtikvtest/importintotest/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//pkg/executor/importer",
         "//pkg/kv",
         "//pkg/lightning/backend/local",
+        "//pkg/lightning/mydump",
         "//pkg/parser/auth",
         "//pkg/parser/terror",
         "//pkg/session",

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -386,7 +386,7 @@ func (s *mockGCSSuite) TestCSVHeaderOption() {
 	for _, tc := range testCases {
 		s.tk.MustExec("truncate table t")
 		loadDataSQL := fmt.Sprintf(`IMPORT INTO t FROM 'gs://csv-option/%s?endpoint=%s'
-		with remove_csv_header="%s", thread=1`, tc.file, gcsEndpoint, tc.csvOption)
+		with has_csv_header="%s", thread=1`, tc.file, gcsEndpoint, tc.csvOption)
 		if tc.result {
 			s.tk.MustQuery(loadDataSQL)
 			s.tk.MustQuery("SELECT count(*) FROM t;").Check(testkit.Rows(strconv.Itoa(tc.count)))

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -347,7 +347,7 @@ func (s *mockGCSSuite) TestIgnoreNLines() {
 func (s *mockGCSSuite) TestCSVHeaderOption() {
 	s.server.CreateObject(fakestorage.Object{
 		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-multi-load", Name: "csv_with_header.csv"},
-		Content: []byte(`a, b, c
+		Content: []byte(`a,b,c
 1,test1,11
 2,test2,22
 3,test3,33
@@ -376,6 +376,9 @@ func (s *mockGCSSuite) TestCSVHeaderOption() {
 		{mydump.CSVHeaderTrue, "csv_without_header.csv", true, 3}, // the first row is skipped
 		{mydump.CSVHeaderFalse, "csv_with_header.csv", false, -1},
 		{mydump.CSVHeaderFalse, "csv_without_header.csv", true, 4},
+		{mydump.CSVHeaderAuto, "*.csv", true, 8},
+		{mydump.CSVHeaderFalse, "*.csv", false, -1},
+		{mydump.CSVHeaderTrue, "*.csv", true, 7},
 	}
 
 	for _, tc := range testCases {

--- a/tests/realtikvtest/importintotest/import_into_test.go
+++ b/tests/realtikvtest/importintotest/import_into_test.go
@@ -345,8 +345,10 @@ func (s *mockGCSSuite) TestIgnoreNLines() {
 }
 
 func (s *mockGCSSuite) TestCSVHeaderOption() {
+	s.server.CreateBucketWithOpts(fakestorage.CreateBucketOpts{Name: "csv-option"})
+
 	s.server.CreateObject(fakestorage.Object{
-		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-multi-load", Name: "csv_with_header.csv"},
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "csv-option", Name: "csv_with_header.csv"},
 		Content: []byte(`a,b,c
 1,test1,11
 2,test2,22
@@ -354,7 +356,7 @@ func (s *mockGCSSuite) TestCSVHeaderOption() {
 4,test4,44`),
 	})
 	s.server.CreateObject(fakestorage.Object{
-		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-multi-load", Name: "csv_without_header.csv"},
+		ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "csv-option", Name: "csv_without_header.csv"},
 		Content: []byte(`5,test5,55
 6,test6,66
 7,test7,77
@@ -383,7 +385,7 @@ func (s *mockGCSSuite) TestCSVHeaderOption() {
 
 	for _, tc := range testCases {
 		s.tk.MustExec("truncate table t")
-		loadDataSQL := fmt.Sprintf(`IMPORT INTO t FROM 'gs://test-multi-load/%s?endpoint=%s'
+		loadDataSQL := fmt.Sprintf(`IMPORT INTO t FROM 'gs://csv-option/%s?endpoint=%s'
 		with remove_csv_header="%s", thread=1`, tc.file, gcsEndpoint, tc.csvOption)
 		if tc.result {
 			s.tk.MustQuery(loadDataSQL)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61166

Problem Summary:

### What changed and how does it work?

Add new option `remove_csv_header` for `IMPORT INTO` with CSV format.

For now, this option coexists with `skip_rows`, although users can't set both of them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
