### PR TITLE
dumpling/dump: fallback to lock tables when timeout from ftwrl

### DIFF
--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -1427,7 +1427,7 @@ func resolveAutoConsistency(d *Dumper) error {
 		err = FlushTableWithReadLock(d.tctx, conn)
 		//nolint: errcheck
 		defer UnlockTables(d.tctx, conn)
-		if err != nil {
+		if err != nil || ctx.Err() == context.DeadlineExceeded {
 			// fallback to ConsistencyTypeLock
 			d.tctx.L().Warn("error when use FLUSH TABLE WITH READ LOCK, fallback to LOCK TABLES",
 				zap.Error(err))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56838

Problem Summary:

### What changed and how does it work?

Fallback to lock tables when FTWRL times out.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Let dumpling fallback to LOCK TABLES if FTWRL is blocked for a long time
```
