### PR TITLE
br: add retry for updating stats meta

### DIFF
--- a/br/pkg/restore/snap_client/pipeline_items.go
+++ b/br/pkg/restore/snap_client/pipeline_items.go
@@ -350,7 +350,7 @@ func (buffer *statsMetaItemBuffer) UpdateMetasRest(ctx context.Context, statsHan
 	if len(metaUpdates) == 0 {
 		return nil
 	}
-	return statsHandler.SaveMetaToStorage("br restore", false, metaUpdates...)
+	return buffer.saveMetaToStorageWithRetry(ctx, statsHandler, metaUpdates)
 }
 
 func (buffer *statsMetaItemBuffer) TryUpdateMetas(ctx context.Context, statsHandler *handle.Handle, physicalID, count int64) error {
@@ -363,7 +363,23 @@ func (buffer *statsMetaItemBuffer) TryUpdateMetas(ctx context.Context, statsHand
 	if len(metaUpdates) == 0 {
 		return nil
 	}
-	return statsHandler.SaveMetaToStorage("br restore", false, metaUpdates...)
+	return buffer.saveMetaToStorageWithRetry(ctx, statsHandler, metaUpdates)
+}
+
+func (buffer *statsMetaItemBuffer) saveMetaToStorageWithRetry(
+	ctx context.Context,
+	statsHandler *handle.Handle,
+	metaUpdates []statstypes.MetaUpdate,
+) error {
+	state := utils.InitialRetryState(8, 500*time.Millisecond, 500*time.Millisecond)
+	err := utils.WithRetry(ctx, func() error {
+		if err := statsHandler.SaveMetaToStorage("br restore", false, metaUpdates...); err != nil {
+			log.Error("failed to save meta to storage", zap.Error(err))
+			return errors.Trace(err)
+		}
+		return nil
+	}, &state)
+	return errors.Trace(err)
 }
 
 func calculateRowCountForPhysicalTable(files []*backuppb.File) int64 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61140

Problem Summary:
After BR starts, the region cache may not be updated in time. Therefore, the pessimistic prewrite batches are sent to follower peer.
However, BR heartbeat for pessimistic lock exceeds 20 seconds, so that the lock is rollbacked by select SQL from other TiDB nodes.
### What changed and how does it work?
add retry for updating stats meta
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
