### PR TITLE
ttl: fix ut failure after using advanced session

### DIFF
--- a/pkg/session/syssession/session_test_util.go
+++ b/pkg/session/syssession/session_test_util.go
@@ -55,3 +55,9 @@ func (s *Session) IsInternalClosed() bool {
 func (p *AdvancedSessionPool) Size() int {
 	return len(p.pool)
 }
+
+// IsAvoidReuse returns whether the internal session avoids re-use
+// It is only used in testing
+func (s *Session) IsAvoidReuse() bool {
+	return s.internal.IsAvoidReuse()
+}

--- a/pkg/timer/tablestore/store.go
+++ b/pkg/timer/tablestore/store.go
@@ -375,13 +375,13 @@ func (s *tableTimerStoreCore) withSession(fn func(*syssession.Session) error) er
 				// Though `pool.WithSession` will discard a not committed transaction.
 				// We still rollback back here to make sure the assertion passes in `Pool.Put`.
 				terror.Log(err)
-				se.Close()
+				se.AvoidReuse()
 				return
 			}
 
 			if _, err = executeSQL(ctx, se, "SET @@time_zone=%?", originalTimeZone); err != nil {
 				terror.Log(err)
-				se.Close()
+				se.AvoidReuse()
 				return
 			}
 		}()

--- a/pkg/ttl/ttlworker/task_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/task_manager_integration_test.go
@@ -50,7 +50,11 @@ func TestParallelLockNewTask(t *testing.T) {
 	testTable, err := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema).TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 
-	sessionFactory := sessionFactory(t, dom)
+	sessionTimeout := time.Minute
+	if testflag.Long() {
+		sessionTimeout = 10 * time.Minute
+	}
+	sessionFactory := sessionFactoryWithTimeout(t, dom, sessionTimeout)
 	se, closeSe := sessionFactory()
 	defer closeSe()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61175

Problem Summary:

1. Timeout error for session in long tests.
2. Fail in `ResetSctxForTest` because the owner is nil.

Both of them are not likely to occur in production environment. For the second issue, it'll occur only when the `SET @@time_zone = ...` failed.

### What changed and how does it work?

1. Don't call `.Close()` in `withSession`.
4. Extend the timeout of a session for test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
