### PR TITLE
planner: Handle NullEQ <=> in range columns partition pruning

### DIFF
--- a/pkg/planner/core/casetest/partition/BUILD.bazel
+++ b/pkg/planner/core/casetest/partition/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/config",
         "//pkg/planner/util/coretestsdk",

--- a/pkg/planner/core/casetest/partition/BUILD.bazel
+++ b/pkg/planner/core/casetest/partition/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 15,
+    shard_count = 16,
     deps = [
         "//pkg/config",
         "//pkg/planner/util/coretestsdk",

--- a/pkg/planner/core/casetest/partition/partition_pruner_test.go
+++ b/pkg/planner/core/casetest/partition/partition_pruner_test.go
@@ -649,3 +649,27 @@ func TestIssue61134(t *testing.T) {
 	tk.MustQuery("explain select * from t where a in ('')").CheckContain("Point_Get")
 	tk.MustQuery("select * from t where a in ('')").Check(testkit.Rows(" 1"))
 }
+
+func TestIssue61176(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE t (a varchar(9), unique index (a)) PARTITION BY RANGE COLUMNS (a) (PARTITION p0 VALUES LESS THAN ('M'), PARTITION p1 VALUES LESS THAN (MAXVALUE))`)
+	tk.MustExec(`insert into t values ('Y'),('A'),(NULL)`)
+	tk.MustQuery(`select a from t where a <=> 'Y'`).Check(testkit.Rows("Y"))
+	tk.MustQuery(`select a from t where a <=> 'A'`).Check(testkit.Rows("A"))
+	tk.MustQuery(`select a from t where a <=> NULL`).Check(testkit.Rows("<nil>"))
+	tk.MustQuery(`explain format=brief select a from t where a <=> 'Y'`).MultiCheckContain([]string{"Point_Get", "partition:p1"})
+	tk.MustQuery(`explain format=brief select a from t where a <=> 'A'`).MultiCheckContain([]string{"Point_Get", "partition:p0"})
+	tk.MustQuery(`explain format=brief select a from t where a <=> NULL`).MultiCheckContain([]string{"IndexRangeScan", "partition:p0"})
+	tk.MustExec(`drop table t`)
+	tk.MustExec(`CREATE TABLE t (a varchar(9) PRIMARY KEY) PARTITION BY RANGE COLUMNS (a) (PARTITION p0 VALUES LESS THAN ('M'), PARTITION p1 VALUES LESS THAN (MAXVALUE))`)
+	tk.MustExec(`insert into t values ('Y'),('A')`)
+	tk.MustContainErrMsg(`insert into t values (NULL)`, "[table:1048]Column 'a' cannot be null")
+	tk.MustQuery(`select a from t where a <=> 'Y'`).Check(testkit.Rows("Y"))
+	tk.MustQuery(`select a from t where a <=> 'A'`).Check(testkit.Rows("A"))
+	tk.MustQuery(`select a from t where a <=> NULL`).Check(testkit.Rows())
+	tk.MustQuery(`explain format=brief select a from t where a <=> 'Y'`).MultiCheckContain([]string{"Point_Get", "partition:p1"})
+	tk.MustQuery(`explain format=brief select a from t where a <=> 'A'`).MultiCheckContain([]string{"Point_Get", "partition:p0"})
+	tk.MustQuery(`explain format=brief select a from t where a <=> NULL`).MultiCheckContain([]string{"TableRangeScan", "partition:p0"})
+}

--- a/pkg/planner/core/casetest/partition/partition_pruner_test.go
+++ b/pkg/planner/core/casetest/partition/partition_pruner_test.go
@@ -650,7 +650,7 @@ func TestIssue61134(t *testing.T) {
 	tk.MustQuery("select * from t where a in ('')").Check(testkit.Rows(" 1"))
 }
 
-func TestIssue61176(t *testing.T) {
+func TestIssue61176Char(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -680,22 +680,78 @@ func TestIssue61176(t *testing.T) {
 	for _, t := range testCase {
 		tk.MustExec(`CREATE TABLE t (a varchar(9), unique index (a))` + t.partitionBy)
 		tk.MustExec(`insert into t values ('Y'),('D'),(NULL)`)
-		tk.MustQuery(`select a from t where a <=> 'Y'`).Check(testkit.Rows("Y"))
 		tk.MustQuery(`select a from t where a <=> 'D'`).Check(testkit.Rows("D"))
+		tk.MustQuery(`select a from t where a <=> 'Y'`).Check(testkit.Rows("Y"))
 		tk.MustQuery(`select a from t where a <=> NULL`).Check(testkit.Rows("<nil>"))
-		tk.MustQuery(`explain format=brief select a from t where a <=> 'Y'`).MultiCheckContain([]string{"Point_Get", "partition:" + t.partY})
 		tk.MustQuery(`explain format=brief select a from t where a <=> 'D'`).MultiCheckContain([]string{"Point_Get", "partition:" + t.partD})
+		tk.MustQuery(`explain format=brief select a from t where a <=> 'Y'`).MultiCheckContain([]string{"Point_Get", "partition:" + t.partY})
 		tk.MustQuery(`explain format=brief select a from t where a <=> NULL`).MultiCheckContain([]string{"IndexRangeScan", "partition:" + t.partNull})
 		tk.MustExec(`drop table t`)
 		tk.MustExec(`CREATE TABLE t (a varchar(9) PRIMARY KEY)` + t.partitionBy)
 		tk.MustExec(`insert into t values ('Y'),('D')`)
 		tk.MustContainErrMsg(`insert into t values (NULL)`, "[table:1048]Column 'a' cannot be null")
-		tk.MustQuery(`select a from t where a <=> 'Y'`).Check(testkit.Rows("Y"))
 		tk.MustQuery(`select a from t where a <=> 'D'`).Check(testkit.Rows("D"))
+		tk.MustQuery(`select a from t where a <=> 'Y'`).Check(testkit.Rows("Y"))
 		tk.MustQuery(`select a from t where a <=> NULL`).Check(testkit.Rows())
-		tk.MustQuery(`explain format=brief select a from t where a <=> 'Y'`).MultiCheckContain([]string{"Point_Get", "partition:" + t.partY})
 		tk.MustQuery(`explain format=brief select a from t where a <=> 'D'`).MultiCheckContain([]string{"Point_Get", "partition:" + t.partD})
+		tk.MustQuery(`explain format=brief select a from t where a <=> 'Y'`).MultiCheckContain([]string{"Point_Get", "partition:" + t.partY})
 		tk.MustQuery(`explain format=brief select a from t where a <=> NULL`).MultiCheckContain([]string{"TableRangeScan", "partition:" + t.partNull})
+		tk.MustExec(`drop table t`)
+	}
+}
+
+func TestIssue61176Int(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	testCase := []struct {
+		partitionBy string
+		part1       string
+		part5       string
+		partNull    string
+	}{
+		{
+			" PARTITION BY RANGE (a) (PARTITION pNULL VALUES LESS THAN (0), PARTITION p0 VALUES LESS THAN (5), PARTITION p1 VALUES LESS THAN (MAXVALUE))",
+			"p0",
+			"p1",
+			"pNULL",
+		}, {
+			" PARTITION BY LIST (a) (PARTITION p0 VALUES IN (1), PARTITION p1 VALUES IN (5), PARTITION pNULL VALUES IN (NULL))",
+			"p0",
+			"p1",
+			"pNULL",
+		}, {
+			" PARTITION BY KEY (a) PARTITIONS 3",
+			"p2",
+			"p1",
+			"p1",
+		}, {
+			" PARTITION BY HASH (a) PARTITIONS 3",
+			"p1",
+			"p2",
+			"p0",
+		},
+	}
+	for _, t := range testCase {
+		tk.MustExec(`CREATE TABLE t (a int, unique index (a))` + t.partitionBy)
+		tk.MustExec(`insert into t values (1),(5),(NULL)`)
+		tk.MustQuery(`select a from t where a <=> 1`).Check(testkit.Rows("1"))
+		tk.MustQuery(`select a from t where a <=> 5`).Check(testkit.Rows("5"))
+		tk.MustQuery(`select a from t where a <=> NULL`).Check(testkit.Rows("<nil>"))
+		tk.MustQuery(`explain format=brief select a from t where a <=> 1`).MultiCheckContain([]string{"Point_Get", "partition:" + t.part1})
+		tk.MustQuery(`explain format=brief select a from t where a <=> 5`).MultiCheckContain([]string{"Point_Get", "partition:" + t.part5})
+		tk.MustQuery(`explain format=brief select a from t where a <=> NULL`).MultiCheckContain([]string{"IndexRangeScan", "partition:" + t.partNull})
+		tk.MustExec(`drop table t`)
+		tk.MustExec(`CREATE TABLE t (a int PRIMARY KEY)` + t.partitionBy)
+		tk.MustExec(`insert into t values (1),(5)`)
+		tk.MustContainErrMsg(`insert into t values (NULL)`, "[table:1048]Column 'a' cannot be null")
+		tk.MustQuery(`select a from t where a <=> 1`).Check(testkit.Rows("1"))
+		tk.MustQuery(`select a from t where a <=> 5`).Check(testkit.Rows("5"))
+		tk.MustQuery(`select a from t where a <=> NULL`).Check(testkit.Rows())
+		tk.MustQuery(`explain format=brief select a from t where a <=> 1`).MultiCheckContain([]string{"Point_Get", "partition:" + t.part1})
+		tk.MustQuery(`explain format=brief select a from t where a <=> 5`).MultiCheckContain([]string{"Point_Get", "partition:" + t.part5})
+		// TODO: Also do this for RANGE COLUMNS? Why is this different?!?
+		tk.MustQuery(`explain format=brief select a from t where a <=> NULL`).CheckContain("TableDual")
 		tk.MustExec(`drop table t`)
 	}
 }

--- a/pkg/testkit/result.go
+++ b/pkg/testkit/result.go
@@ -180,7 +180,7 @@ func (res *Result) String() string {
 func (res *Result) MultiCheckContain(expecteds []string) {
 	result := res.String()
 	for _, expected := range expecteds {
-		res.require.True(strings.Contains(result, expected), "the result doesn't contain the expected %s\n%s", expected, result)
+		res.require.True(strings.Contains(result, expected), "the result doesn't contain the exepected %s\n%s", expected, result)
 	}
 }
 

--- a/pkg/testkit/result.go
+++ b/pkg/testkit/result.go
@@ -180,7 +180,7 @@ func (res *Result) String() string {
 func (res *Result) MultiCheckContain(expecteds []string) {
 	result := res.String()
 	for _, expected := range expecteds {
-		res.require.True(strings.Contains(result, expected), "the result doesn't contain the exepected %s\n%s", expected, result)
+		res.require.True(strings.Contains(result, expected), "the result doesn't contain the expected %s\n%s", expected, result)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61176

Problem Summary:

### What changed and how does it work?
Partition pruning for NullEQ `<=>` of range columns could return more than one partition, resulting in PointGet failed.

Added handling to first check if constant is NULL, then just use first partition, else treat as EQ `=`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed an issue where PointGet could fail when using NullEQ (<=>) for a table partitioned by range column
```
