### PR TITLE
planner: fix get wrong cost with cost tracer 

### DIFF
--- a/pkg/planner/core/casetest/tpch/BUILD.bazel
+++ b/pkg/planner/core/casetest/tpch/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "//pkg/testkit/testdata",
         "//pkg/testkit/testmain",
         "//pkg/testkit/testsetup",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/planner/core/casetest/tpch/tpch_test.go
+++ b/pkg/planner/core/casetest/tpch/tpch_test.go
@@ -252,7 +252,7 @@ func checkCost(t *testing.T, tk *testkit.TestKit, q4 string) {
 	require.Equal(t, len(costTraceRows.Rows()), len(verboseRows.Rows()))
 	for i := 0; i < len(costTraceRows.Rows()); i++ {
 		// check id / estRows / estCost. they should be the same one
-		require.Equal(t, costTraceRows.Rows()[i][:2], verboseRows.Rows()[i][:2])
+		require.Equal(t, costTraceRows.Rows()[i][:3], verboseRows.Rows()[i][:3])
 	}
 }
 

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -1021,16 +1021,6 @@ func (e *Explain) RenderResult() error {
 		}
 	}
 
-	if strings.ToLower(e.Format) == types.ExplainFormatCostTrace {
-		if pp, ok := e.TargetPlan.(base.PhysicalPlan); ok {
-			// trigger getPlanCost again with CostFlagTrace to record all cost formulas
-			if _, err := getPlanCost(pp, property.RootTaskType,
-				optimizetrace.NewDefaultPlanCostOption().WithCostFlag(costusage.CostFlagRecalculate|costusage.CostFlagTrace)); err != nil {
-				return err
-			}
-		}
-	}
-
 	switch strings.ToLower(e.Format) {
 	case types.ExplainFormatROW, types.ExplainFormatBrief, types.ExplainFormatVerbose, types.ExplainFormatTrueCardCost, types.ExplainFormatCostTrace, types.ExplainFormatPlanCache:
 		if e.Rows == nil || e.Analyze {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5549,7 +5549,7 @@ func (b *PlanBuilder) buildExplain(ctx context.Context, explain *ast.ExplainStmt
 
 	var targetPlan base.Plan
 	if explain.Stmt != nil && !explain.Explore {
-		if strings.ToLower(explain.Format) == types.ExplainFormatCostTrace {
+		if strings.EqualFold(explain.Format, types.ExplainFormatCostTrace) {
 			origin := sctx.GetSessionVars().StmtCtx.EnableOptimizeTrace
 			sctx.GetSessionVars().StmtCtx.EnableOptimizeTrace = true
 			defer func() {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5549,6 +5549,13 @@ func (b *PlanBuilder) buildExplain(ctx context.Context, explain *ast.ExplainStmt
 
 	var targetPlan base.Plan
 	if explain.Stmt != nil && !explain.Explore {
+		if strings.ToLower(explain.Format) == types.ExplainFormatCostTrace {
+			origin := sctx.GetSessionVars().StmtCtx.EnableOptimizeTrace
+			sctx.GetSessionVars().StmtCtx.EnableOptimizeTrace = true
+			defer func() {
+				sctx.GetSessionVars().StmtCtx.EnableOptimizeTrace = origin
+			}()
+		}
 		nodeW := resolve.NewNodeWWithCtx(explain.Stmt, b.resolveCtx)
 		targetPlan, _, err = OptimizeAstNode(ctx, sctx, nodeW, b.is)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61155

Problem Summary:

When we use the cost trace's explain, it will calculate the cost twice. Unfortunately, when calculating secondly, the row count has been polluted by the first.

the first calculation:

```
1500000000*math.log2(46.17)*11.6+10000*math.log2(46.17)*11.6 = 96203219945.10272
```

```1500000000``` will become the ```5.645217633333338e+07```, because ```postOptimize```‘s 
```tryEnableLateMaterialization``` can change the ```row count``` in the first plan generate.

https://github.com/pingcap/tidb/blob/7419112ef7bcd6fb0f0acb2e98222487e6616297/pkg/planner/core/tiflash_selection_late_materialization.go#L283-L290

the second calculation:

```
5.645217633333338e+07*math.log2(46.17)*11.6+10000*math.log2(46.17)*11.6 = 3621204637.5523133
```

So two formats have different costs.


### What changed and how does it work?

Generate the cost trace in the first calculation. Remove the second calculation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix get wrong cost with cost tracer

修复使用 cost tracer 得到不正确的 cost 值
```
