### PR TITLE
distsql: Add fetch_resp_duration in table reader's execution info

### DIFF
--- a/pkg/distsql/distsql_test.go
+++ b/pkg/distsql/distsql_test.go
@@ -113,6 +113,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 		totalWaitTime:      time.Second,
 		reqStat:            tikv.NewRegionRequestRuntimeStats(),
 		distSQLConcurrency: 15,
+		fetchRspDuration:   time.Second,
 	}
 	s1.copRespTime.Add(execdetails.Duration(time.Second))
 	s1.copRespTime.Add(execdetails.Duration(time.Millisecond))
@@ -123,7 +124,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	stmtStats.RegisterStats(1, s1.Clone())
 	stmtStats.RegisterStats(1, s2)
 	stats := stmtStats.GetRootStats(1)
-	expect := "time:1s, open:0s, close:0s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, backoff{RegionMiss: 2ms}"
+	expect := "time:1s, open:0s, close:0s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, fetch_resp_duration: 2s, backoff{RegionMiss: 2ms}"
 	require.Equal(t, expect, stats.String())
 	// Test for idempotence.
 	require.Equal(t, expect, stats.String())
@@ -133,7 +134,7 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 	s1.reqStat.RecordRPCErrorStats("server_is_busy")
 	stmtStats.RegisterStats(2, s1.Clone())
 	stats = stmtStats.GetRootStats(2)
-	expect = "cop_task: {num: 2, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 1s, tot_wait: 1s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, rpc_info:{Cop:{num_rpc:1, total_time:1s}, rpc_errors:{server_is_busy:2}}, backoff{RegionMiss: 1ms}"
+	expect = "cop_task: {num: 2, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 1s, tot_wait: 1s, copr_cache_hit_ratio: 0.00, max_distsql_concurrency: 15}, fetch_resp_duration: 1s, rpc_info:{Cop:{num_rpc:1, total_time:1s}, rpc_errors:{server_is_busy:2}}, backoff{RegionMiss: 1ms}"
 	require.Equal(t, expect, stats.String())
 	// Test for idempotence.
 	require.Equal(t, expect, stats.String())

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -617,12 +617,12 @@ func (r *selectResult) Close() error {
 		defer func() {
 			if ci, ok := r.resp.(copr.CopInfo); ok {
 				r.stats.buildTaskDuration = ci.GetBuildTaskElapsed()
-				r.stats.fetchRspDuration = r.fetchDuration
 				batched, fallback := ci.GetStoreBatchInfo()
 				if batched != 0 || fallback != 0 {
 					r.stats.storeBatchedNum, r.stats.storeBatchedFallbackNum = batched, fallback
 				}
 			}
+			r.stats.fetchRspDuration = r.fetchDuration
 			r.ctx.RuntimeStatsColl.RegisterStats(r.rootPlanID, r.stats)
 		}()
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61125 

Problem Summary:
Described in #61125 

### What changed and how does it work?
Output fetch response duration in tableReader's execution summary after cop_task item.

```
explain analyze select l_orderkey, max(l_suppkey) from lineitem group by l_orderkey;
+------------------------------+------------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| id                           | estRows    | actRows | task      | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | operator info                                                                                                                          | memory   | disk    |
+------------------------------+------------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| Projection_4                 | 1487616.00 | 1500000 | root      |                | time:851ms, open:27.8µs, close:16.5µs, loops:1468, RU:18822.86, Concurrency:5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | test.lineitem.l_orderkey, Column#17                                                                                                    | 189.8 KB | N/A     |
| └─HashAgg_11                 | 1487616.00 | 1500000 | root      |                | time:850.1ms, open:27.5µs, close:11µs, loops:1468, partial_worker:{wall_time:747.236958ms, concurrency:5, task_num:63, tot_wait:2.828049333s, tot_exec:539.821873ms, tot_time:3.736145125s, max:747.230375ms, p95:747.230375ms}, final_worker:{wall_time:851.055042ms, concurrency:5, task_num:25, tot_wait:14.002µs, tot_exec:373.885666ms, tot_time:4.238890918s, max:851.04425ms, p95:851.04425ms}                                                                                                                                                                                                            | group by:test.lineitem.l_orderkey, funcs:max(Column#18)->Column#17, funcs:firstrow(test.lineitem.l_orderkey)->test.lineitem.l_orderkey | 420.3 MB | 0 Bytes |
|   └─TableReader_12           | 1487616.00 | 1500050 | root      |                | time:742.9ms, open:16.8µs, close:8.29µs, loops:64, cop_task: {num: 71, max: 116.4ms, min: 642.8µs, avg: 42.2ms, p95: 114.5ms, max_proc_keys: 201728, p95_proc_keys: 200704, tot_proc: 2.95s, tot_wait: 2.43ms, copr_cache_hit_ratio: 0.00, build_task_duration: 5.25µs, max_distsql_concurrency: 5}, fetch_resp_duration: 742.1ms, rpc_info:{Cop:{num_rpc:71, total_time:3s}}                                                                                                                                                                                                                                    | data:HashAgg_5                                                                                                                         | 1.53 MB  | N/A     |
|     └─HashAgg_5              | 1487616.00 | 1500050 | cop[tikv] |                | tikv_task:{proc max:115ms, min:1ms, avg: 41.5ms, p80:94ms, p95:112ms, iters:5863, tasks:71}, scan_detail: {total_process_keys: 6001215, total_process_keys_size: 1166860203, total_keys: 6001286, get_snapshot_time: 1.07ms, rocksdb: {delete_skipped_count: 81088, key_skipped_count: 6082303, block: {cache_hit_count: 1312, read_count: 36220, read_byte: 354.0 MB, read_time: 369.2ms}}}, time_detail: {total_process_time: 2.95s, total_suspend_time: 1.91ms, total_wait_time: 2.43ms, total_kv_read_wall_time: 2.74s, tikv_grpc_process_time: 879.9µs, tikv_grpc_wait_time: 2.97s, tikv_wall_time: 2.97s}  | group by:test.lineitem.l_orderkey, funcs:max(test.lineitem.l_suppkey)->Column#18                                                       | N/A      | N/A     |
|       └─TableFullScan_10     | 6001215.00 | 6001215 | cop[tikv] | table:lineitem | tikv_task:{proc max:109ms, min:1ms, avg: 38.6ms, p80:87ms, p95:105ms, iters:5863, tasks:71}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | keep order:false                                                                                                                       | N/A      | N/A     |
+------------------------------+------------+---------+-----------+----------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
```
For MPP Tasks:
```
explain analyze select l_orderkey, max(l_suppkey) from lineitem group by l_orderkey;
+--------------------------------------+------------+---------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| id                                   | estRows    | actRows | task         | access object  | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | operator info                                                                                                                                            | memory  | disk |
+--------------------------------------+------------+---------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------+------+
| TableReader_58                       | 4800972.00 | 1500000 | root         |                | time:58.4ms, open:972.1µs, close:4.96µs, loops:2059, RU:1608.47, cop_task: {num: 1038, max: 0s, min: 0s, avg: 0s, p95: 0s, copr_cache_hit_ratio: 0.00}, fetch_resp_duration: 55.4ms                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | MppVersion: 3, data:ExchangeSender_57                                                                                                                    | 24.4 KB | N/A  |
| └─ExchangeSender_57                  | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:55.4ms, loops:3072, threads:12}, tiflash_network: {inner_zone_send_bytes: 24053616}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | ExchangeType: PassThrough                                                                                                                                | N/A     | N/A  |
|   └─Projection_5                     | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:46.5ms, loops:3072, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | test.lineitem.l_orderkey, Column#17                                                                                                                      | N/A     | N/A  |
|     └─Projection_53                  | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:46.1ms, loops:3072, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Column#17, test.lineitem.l_orderkey                                                                                                                      | N/A     | N/A  |
|       └─HashAgg_54                   | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:45.8ms, loops:3072, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | group by:test.lineitem.l_orderkey, funcs:max(Column#28)->Column#17, funcs:firstrow(test.lineitem.l_orderkey)->test.lineitem.l_orderkey, stream_count: 12 | N/A     | N/A  |
|         └─ExchangeReceiver_56        | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:34.3ms, loops:132, threads:12}, tiflash_wait: {pipeline_queue_wait: 6ms}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | stream_count: 12                                                                                                                                         | N/A     | N/A  |
|           └─ExchangeSender_55        | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:31.1ms, loops:256, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | ExchangeType: HashPartition, Compression: FAST, Hash Cols: [name: test.lineitem.l_orderkey, collate: binary], stream_count: 12                           | N/A     | N/A  |
|             └─HashAgg_51             | 4800972.00 | 1500000 | mpp[tiflash] |                | tiflash_task:{time:30ms, loops:256, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | group by:test.lineitem.l_orderkey, funcs:max(test.lineitem.l_suppkey)->Column#28                                                                         | N/A     | N/A  |
|               └─TableFullScan_31     | 6001215.00 | 6001215 | mpp[tiflash] | table:lineitem | tiflash_task:{time:14.8ms, loops:97, threads:12}, tiflash_wait: {pipeline_queue_wait: 5ms}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:5, remote_regions:0, tot_learner_read:0ms, region_balance:{instance_num: 1, max/min: 5/5=1.000000}, delta_rows:0, delta_bytes:0, segments:21, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:10ms, tot_build_inputstream:47ms, min_local_stream:4ms, max_local_stream:13ms, dtfile:{data_scanned_rows:6001215, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:16ms, tot_read:66ms}} | keep order:false, stats:pseudo                                                                                                                           | N/A     | N/A  |
+--------------------------------------+------------+---------+--------------+----------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------+------+
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
