### PR TITLE
planner: merge the some code of helper func `genPlanWithSCtx` with `Explain` to reduce redundant code

### DIFF
--- a/pkg/bindinfo/binding_auto.go
+++ b/pkg/bindinfo/binding_auto.go
@@ -38,11 +38,11 @@ var CalculatePlanDigest func(sctx sessionctx.Context, stmt ast.StmtNode) (planDi
 // This function will call the optimizer.
 var RecordRelevantOptVarsAndFixes func(sctx sessionctx.Context, stmt ast.StmtNode) (varNames []string, fixIDs []uint64, err error)
 
-// GenPlanWithSCtx generates the plan for the given SQL statement under the given session context.
-// This function will call the optimizer.
+// GenBriefPlanWithSCtx generates the plan for the given SQL statement under the given session context.
+// This function will call the optimizer, the output is same as "EXPLAIN FORMAT='brief' {SQL}".
 // PlanHintStr is a set of hints to reproduce this plan, which is used to create binding.
 // PlanText is the results of EXPLAIN of the current plan.
-var GenPlanWithSCtx func(sctx sessionctx.Context, stmt ast.StmtNode) (planDigest, planHintStr string, planText [][]string, err error)
+var GenBriefPlanWithSCtx func(sctx sessionctx.Context, stmt ast.StmtNode) (planDigest, planHintStr string, planText [][]string, err error)
 
 // BindingPlanInfo contains the binding info and its corresponding plan execution info, which is used by
 // "SHOW PLAN FOR <SQL>" to help users understand the historical plans for a specific SQL.

--- a/pkg/bindinfo/binding_auto_test.go
+++ b/pkg/bindinfo/binding_auto_test.go
@@ -40,7 +40,7 @@ func TestGenPlanWithSCtx(t *testing.T) {
 		p.Reset()
 		stmt, err := p.ParseOneStmt(sql, "", "")
 		require.NoError(t, err)
-		planDigest, planHint, planText, err := bindinfo.GenPlanWithSCtx(sctx, stmt)
+		planDigest, planHint, planText, err := bindinfo.GenBriefPlanWithSCtx(sctx, stmt)
 		require.NoError(t, err)
 		require.True(t, len(planDigest) > 0)
 		require.True(t, strings.Contains(planHint, expectedHint))

--- a/pkg/bindinfo/binding_plan_generation.go
+++ b/pkg/bindinfo/binding_plan_generation.go
@@ -303,7 +303,7 @@ func genPlanUnderState(sctx sessionctx.Context, stmt ast.StmtNode, state *state)
 	}
 	sctx.GetSessionVars().OptimizerFixControl = fixControlMap
 
-	planDigest, planHints, planText, err := GenPlanWithSCtx(sctx, stmt)
+	planDigest, planHints, planText, err := GenBriefPlanWithSCtx(sctx, stmt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindinfo/testdata/binding_auto_suite_out.json
+++ b/pkg/bindinfo/testdata/binding_auto_suite_out.json
@@ -6,48 +6,48 @@
         "SQL": "explain explore select count(1) from t",
         "Plan": [
           [
-            "HashAgg_12  root  1.00    funcs:count(Column#7)->Column#5",
-            "└─IndexReader_13  root  1.00    index:HashAgg_5",
-            "  └─HashAgg_5  cop[tikv]  1.00    funcs:count(1)->Column#7",
-            "    └─IndexFullScan_11  cop[tikv]  10000.00  table:t, index:a(a)  keep order:false, stats:pseudo"
+            "HashAgg  1.00  root    funcs:count(Column#7)->Column#5",
+            "└─IndexReader  1.00  root    index:HashAgg",
+            "  └─HashAgg  1.00  cop[tikv]    funcs:count(1)->Column#7",
+            "    └─IndexFullScan  10000.00  cop[tikv]  table:t, index:a(a)  keep order:false, stats:pseudo"
           ],
           [
-            "HashAgg_7  root  1.00    funcs:count(1)->Column#5",
-            "└─IndexReader_17  root  10000.00    index:IndexFullScan_16",
-            "  └─IndexFullScan_16  cop[tikv]  10000.00  table:t, index:a(a)  keep order:false, stats:pseudo"
+            "HashAgg  1.00  root    funcs:count(1)->Column#5",
+            "└─IndexReader  10000.00  root    index:IndexFullScan",
+            "  └─IndexFullScan  10000.00  cop[tikv]  table:t, index:a(a)  keep order:false, stats:pseudo"
           ],
           [
-            "StreamAgg_20  root  1.00    funcs:count(Column#10)->Column#5",
-            "└─IndexReader_21  root  1.00    index:StreamAgg_8",
-            "  └─StreamAgg_8  cop[tikv]  1.00    funcs:count(1)->Column#10",
-            "    └─IndexFullScan_19  cop[tikv]  10000.00  table:t, index:a(a)  keep order:false, stats:pseudo"
+            "StreamAgg  1.00  root    funcs:count(Column#10)->Column#5",
+            "└─IndexReader  1.00  root    index:StreamAgg",
+            "  └─StreamAgg  1.00  cop[tikv]    funcs:count(1)->Column#10",
+            "    └─IndexFullScan  10000.00  cop[tikv]  table:t, index:a(a)  keep order:false, stats:pseudo"
           ],
           [
-            "StreamAgg_9  root  1.00    funcs:count(1)->Column#5",
-            "└─TableReader_23  root  10000.00    data:TableFullScan_22",
-            "  └─TableFullScan_22  cop[tikv]  10000.00  table:t  keep order:false, stats:pseudo"
+            "StreamAgg  1.00  root    funcs:count(1)->Column#5",
+            "└─TableReader  10000.00  root    data:TableFullScan",
+            "  └─TableFullScan  10000.00  cop[tikv]  table:t  keep order:false, stats:pseudo"
           ],
           [
-            "StreamAgg_20  root  1.00    funcs:count(Column#10)->Column#5",
-            "└─TableReader_21  root  1.00    data:StreamAgg_8",
-            "  └─StreamAgg_8  cop[tikv]  1.00    funcs:count(1)->Column#10",
-            "    └─TableFullScan_18  cop[tikv]  10000.00  table:t  keep order:false, stats:pseudo"
+            "StreamAgg  1.00  root    funcs:count(Column#10)->Column#5",
+            "└─TableReader  1.00  root    data:StreamAgg",
+            "  └─StreamAgg  1.00  cop[tikv]    funcs:count(1)->Column#10",
+            "    └─TableFullScan  10000.00  cop[tikv]  table:t  keep order:false, stats:pseudo"
           ],
           [
-            "HashAgg_7  root  1.00    funcs:count(1)->Column#5",
-            "└─TableReader_15  root  10000.00    data:TableFullScan_14",
-            "  └─TableFullScan_14  cop[tikv]  10000.00  table:t  keep order:false, stats:pseudo"
+            "HashAgg  1.00  root    funcs:count(1)->Column#5",
+            "└─TableReader  10000.00  root    data:TableFullScan",
+            "  └─TableFullScan  10000.00  cop[tikv]  table:t  keep order:false, stats:pseudo"
           ],
           [
-            "StreamAgg_9  root  1.00    funcs:count(1)->Column#5",
-            "└─IndexReader_25  root  10000.00    index:IndexFullScan_24",
-            "  └─IndexFullScan_24  cop[tikv]  10000.00  table:t, index:a(a)  keep order:false, stats:pseudo"
+            "StreamAgg  1.00  root    funcs:count(1)->Column#5",
+            "└─IndexReader  10000.00  root    index:IndexFullScan",
+            "  └─IndexFullScan  10000.00  cop[tikv]  table:t, index:a(a)  keep order:false, stats:pseudo"
           ],
           [
-            "HashAgg_12  root  1.00    funcs:count(Column#7)->Column#5",
-            "└─TableReader_13  root  1.00    data:HashAgg_5",
-            "  └─HashAgg_5  cop[tikv]  1.00    funcs:count(1)->Column#7",
-            "    └─TableFullScan_10  cop[tikv]  10000.00  table:t  keep order:false, stats:pseudo"
+            "HashAgg  1.00  root    funcs:count(Column#7)->Column#5",
+            "└─TableReader  1.00  root    data:HashAgg",
+            "  └─HashAgg  1.00  cop[tikv]    funcs:count(1)->Column#7",
+            "    └─TableFullScan  10000.00  cop[tikv]  table:t  keep order:false, stats:pseudo"
           ]
         ]
       },
@@ -55,22 +55,22 @@
         "SQL": "explain explore select max(b) from t where a=1",
         "Plan": [
           [
-            "StreamAgg_11  root  1.00    funcs:max(test.t.b)->Column#5",
-            "└─TopN_13  root  1.00    test.t.b:desc, offset:0, count:1",
-            "  └─IndexLookUp_21  root  1.00    ",
-            "    ├─IndexRangeScan_17(Build)  cop[tikv]  10.00  table:t, index:a(a)  range:[1,1], keep order:false, stats:pseudo",
-            "    └─TopN_20(Probe)  cop[tikv]  1.00    test.t.b:desc, offset:0, count:1",
-            "      └─Selection_19  cop[tikv]  9.99    not(isnull(test.t.b))",
-            "        └─TableRowIDScan_18  cop[tikv]  10.00  table:t  keep order:false, stats:pseudo"
+            "StreamAgg  1.00  root    funcs:max(test.t.b)->Column#5",
+            "└─TopN  1.00  root    test.t.b:desc, offset:0, count:1",
+            "  └─IndexLookUp  1.00  root    ",
+            "    ├─IndexRangeScan(Build)  10.00  cop[tikv]  table:t, index:a(a)  range:[1,1], keep order:false, stats:pseudo",
+            "    └─TopN(Probe)  1.00  cop[tikv]    test.t.b:desc, offset:0, count:1",
+            "      └─Selection  9.99  cop[tikv]    not(isnull(test.t.b))",
+            "        └─TableRowIDScan  10.00  cop[tikv]  table:t  keep order:false, stats:pseudo"
           ],
           [
-            "HashAgg_10  root  1.00    funcs:max(test.t.b)->Column#5",
-            "└─TopN_13  root  1.00    test.t.b:desc, offset:0, count:1",
-            "  └─IndexLookUp_21  root  1.00    ",
-            "    ├─IndexRangeScan_17(Build)  cop[tikv]  10.00  table:t, index:a(a)  range:[1,1], keep order:false, stats:pseudo",
-            "    └─TopN_20(Probe)  cop[tikv]  1.00    test.t.b:desc, offset:0, count:1",
-            "      └─Selection_19  cop[tikv]  9.99    not(isnull(test.t.b))",
-            "        └─TableRowIDScan_18  cop[tikv]  10.00  table:t  keep order:false, stats:pseudo"
+            "HashAgg  1.00  root    funcs:max(test.t.b)->Column#5",
+            "└─TopN  1.00  root    test.t.b:desc, offset:0, count:1",
+            "  └─IndexLookUp  1.00  root    ",
+            "    ├─IndexRangeScan(Build)  10.00  cop[tikv]  table:t, index:a(a)  range:[1,1], keep order:false, stats:pseudo",
+            "    └─TopN(Probe)  1.00  cop[tikv]    test.t.b:desc, offset:0, count:1",
+            "      └─Selection  9.99  cop[tikv]    not(isnull(test.t.b))",
+            "        └─TableRowIDScan  10.00  cop[tikv]  table:t  keep order:false, stats:pseudo"
           ]
         ]
       }

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
-	"github.com/pingcap/tidb/pkg/planner/planctx"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/costusage"
@@ -1026,7 +1025,7 @@ func (e *Explain) RenderResult() error {
 	case types.ExplainFormatROW, types.ExplainFormatBrief, types.ExplainFormatVerbose, types.ExplainFormatTrueCardCost, types.ExplainFormatCostTrace, types.ExplainFormatPlanCache:
 		if e.Rows == nil || e.Analyze {
 			flat := FlattenPhysicalPlan(e.TargetPlan, true)
-			e.explainFlatPlanInRowFormat(flat)
+			e.Rows = ExplainFlatPlanInRowFormat(flat, e.Format, e.Analyze, e.RuntimeStatsColl, e.ExplainRows)
 			if e.Analyze &&
 				e.SCtx().GetSessionVars().MemoryDebugModeMinHeapInUse != 0 &&
 				e.SCtx().GetSessionVars().MemoryDebugModeAlarmRatio > 0 {
@@ -1069,23 +1068,29 @@ func (e *Explain) RenderResult() error {
 	return nil
 }
 
-func (e *Explain) explainFlatPlanInRowFormat(flat *FlatPhysicalPlan) {
+// ExplainFlatPlanInRowFormat returns the explain result in row format.
+func ExplainFlatPlanInRowFormat(flat *FlatPhysicalPlan, format string, analyze bool,
+	runtimeStatsColl *execdetails.RuntimeStatsColl, explainRows [][]string) (rows [][]string) {
 	if flat == nil || len(flat.Main) == 0 || flat.InExplain {
 		return
 	}
 	for _, flatOp := range flat.Main {
-		e.explainFlatOpInRowFormat(flatOp)
+		rows = prepareOperatorInfo(flatOp, format, analyze,
+			runtimeStatsColl, explainRows, rows)
 	}
 	for _, cte := range flat.CTEs {
 		for _, flatOp := range cte {
-			e.explainFlatOpInRowFormat(flatOp)
+			rows = prepareOperatorInfo(flatOp, format, analyze,
+				runtimeStatsColl, explainRows, rows)
 		}
 	}
 	for _, subQ := range flat.ScalarSubQueries {
 		for _, flatOp := range subQ {
-			e.explainFlatOpInRowFormat(flatOp)
+			rows = prepareOperatorInfo(flatOp, format, analyze,
+				runtimeStatsColl, explainRows, rows)
 		}
 	}
+	return
 }
 
 func (e *Explain) explainFlatPlanInJSONFormat(flat *FlatPhysicalPlan) (encodes []*ExplainInfoForEncode) {
@@ -1121,11 +1126,6 @@ func (e *Explain) explainOpRecursivelyInJSONFormat(flatOp *FlatOperator, flats F
 			e.explainOpRecursivelyInJSONFormat(flats[idx], flats))
 	}
 	return cur
-}
-
-func (e *Explain) explainFlatOpInRowFormat(flatOp *FlatOperator) {
-	taskTp, textTreeExplainID := getExplainIDAndTaskTp(flatOp)
-	e.prepareOperatorInfo(flatOp.Origin, taskTp, textTreeExplainID)
 }
 
 func getExplainIDAndTaskTp(flatOp *FlatOperator) (taskTp, textTreeExplainID string) {
@@ -1196,36 +1196,40 @@ func getRuntimeInfo(ctx base.PlanContext, p base.Plan, runtimeStatsColl *execdet
 
 // prepareOperatorInfo generates the following information for every plan:
 // operator id, estimated rows, task type, access object and other operator info.
-func (e *Explain) prepareOperatorInfo(p base.Plan, taskType, id string) {
+func prepareOperatorInfo(flatOp *FlatOperator, format string, analyze bool,
+	runtimeStatsColl *execdetails.RuntimeStatsColl, explainRows, rows [][]string) [][]string {
+	p := flatOp.Origin
 	if p.ExplainID().String() == "_0" {
-		return
+		return rows
 	}
+	taskType, id := getExplainIDAndTaskTp(flatOp)
 
-	estRows, estCost, costFormula, accessObject, operatorInfo := e.getOperatorInfo(p, id)
+	estRows, estCost, costFormula, accessObject, operatorInfo := getOperatorInfo(p, id, explainRows)
 
 	var row []string
-	if e.Analyze || e.RuntimeStatsColl != nil {
+	if analyze || runtimeStatsColl != nil {
 		row = []string{id, estRows}
-		if e.Format == types.ExplainFormatVerbose || e.Format == types.ExplainFormatTrueCardCost || e.Format == types.ExplainFormatCostTrace {
+		if format == types.ExplainFormatVerbose || format == types.ExplainFormatTrueCardCost || format == types.ExplainFormatCostTrace {
 			row = append(row, estCost)
 		}
-		if e.Format == types.ExplainFormatTrueCardCost || e.Format == types.ExplainFormatCostTrace {
+		if format == types.ExplainFormatTrueCardCost || format == types.ExplainFormatCostTrace {
 			row = append(row, costFormula)
 		}
-		actRows, analyzeInfo, memoryInfo, diskInfo := getRuntimeInfoStr(e.SCtx(), p, e.RuntimeStatsColl)
+		actRows, analyzeInfo, memoryInfo, diskInfo := getRuntimeInfoStr(p.SCtx(), p, runtimeStatsColl)
 		row = append(row, actRows, taskType, accessObject, analyzeInfo, operatorInfo, memoryInfo, diskInfo)
 	} else {
 		row = []string{id, estRows}
-		if e.Format == types.ExplainFormatVerbose || e.Format == types.ExplainFormatTrueCardCost ||
-			e.Format == types.ExplainFormatCostTrace {
+		if format == types.ExplainFormatVerbose || format == types.ExplainFormatTrueCardCost ||
+			format == types.ExplainFormatCostTrace {
 			row = append(row, estCost)
 		}
-		if e.Format == types.ExplainFormatCostTrace {
+		if format == types.ExplainFormatCostTrace {
 			row = append(row, costFormula)
 		}
 		row = append(row, taskType, accessObject, operatorInfo)
 	}
-	e.Rows = append(e.Rows, row)
+	rows = append(rows, row)
+	return rows
 }
 
 func (e *Explain) prepareOperatorInfoForJSONFormat(p base.Plan, taskType, id string, explainID string) *ExplainInfoForEncode {
@@ -1233,7 +1237,7 @@ func (e *Explain) prepareOperatorInfoForJSONFormat(p base.Plan, taskType, id str
 		return nil
 	}
 
-	estRows, _, _, accessObject, operatorInfo := e.getOperatorInfo(p, id)
+	estRows, _, _, accessObject, operatorInfo := getOperatorInfo(p, id, e.ExplainRows)
 	jsonRow := &ExplainInfoForEncode{
 		ID:           explainID,
 		EstRows:      estRows,
@@ -1249,24 +1253,21 @@ func (e *Explain) prepareOperatorInfoForJSONFormat(p base.Plan, taskType, id str
 	return jsonRow
 }
 
-func (e *Explain) getOperatorInfo(p base.Plan, id string) (estRows, estCost, costFormula, accessObject, operatorInfo string) {
+func getOperatorInfo(p base.Plan, operatorID string, explainRows [][]string) (estRows, estCost, costFormula, accessObject, operatorInfo string) {
 	// For `explain for connection` statement, `e.ExplainRows` will be set.
-	for _, row := range e.ExplainRows {
+	for _, row := range explainRows {
 		if len(row) < 5 {
 			panic("should never happen")
 		}
-		if row[0] == id {
+		if row[0] == operatorID {
 			return row[1], "N/A", "N/A", row[3], row[4]
 		}
 	}
-	return getOperatorInfo(e.SCtx(), p)
-}
-
-func getOperatorInfo(sctx planctx.PlanContext, p base.Plan) (estRows, estCost, costFormula, accessObject, operatorInfo string) {
 	pp, isPhysicalPlan := p.(base.PhysicalPlan)
 	estRows = "N/A"
 	estCost = "N/A"
 	costFormula = "N/A"
+	sctx := p.SCtx()
 	if isPhysicalPlan {
 		estRows = strconv.FormatFloat(pp.GetEstRowCountForDisplay(), 'f', 2, 64)
 		if sctx != nil && sctx.GetSessionVars().CostModelVersion == modelVer2 {

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -1228,8 +1228,7 @@ func prepareOperatorInfo(flatOp *FlatOperator, format string, analyze bool,
 		}
 		row = append(row, taskType, accessObject, operatorInfo)
 	}
-	rows = append(rows, row)
-	return rows
+	return append(rows, row)
 }
 
 func (e *Explain) prepareOperatorInfoForJSONFormat(p base.Plan, taskType, id string, explainID string) *ExplainInfoForEncode {

--- a/pkg/planner/core/flat_plan.go
+++ b/pkg/planner/core/flat_plan.go
@@ -162,31 +162,6 @@ func (d OperatorLabel) String() string {
 	return ""
 }
 
-// ExplainFlatPlan returns the explain result of the FlatPhysicalPlan in a slice of string slice.
-func ExplainFlatPlan(flatPlan *FlatPhysicalPlan) (plan [][]string) {
-	plan = make([][]string, 0, 4)
-	for _, flatOp := range flatPlan.Main {
-		plan = append(plan, explainFlatPlanOperator(flatOp))
-	}
-	for _, cte := range flatPlan.CTEs {
-		for _, flatOp := range cte {
-			plan = append(plan, explainFlatPlanOperator(flatOp))
-		}
-	}
-	for _, subQ := range flatPlan.ScalarSubQueries {
-		for _, flatOp := range subQ {
-			plan = append(plan, explainFlatPlanOperator(flatOp))
-		}
-	}
-	return
-}
-
-func explainFlatPlanOperator(flatOp *FlatOperator) []string {
-	taskTp, textTreeExplainID := getExplainIDAndTaskTp(flatOp)
-	estRows, _, _, accessObject, operatorInfo := getOperatorInfo(flatOp.Origin.SCtx(), flatOp.Origin)
-	return []string{textTreeExplainID, taskTp, estRows, accessObject, operatorInfo}
-}
-
 type operatorCtx struct {
 	depth       uint32
 	label       OperatorLabel

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -705,7 +705,8 @@ func genPlanWithSCtx(sctx sessionctx.Context, stmt ast.StmtNode) (planDigest, pl
 	}
 	flat := core.FlattenPhysicalPlan(p, false)
 	_, digest := core.NormalizeFlatPlan(flat)
-	plan := core.ExplainFlatPlan(flat)
+	sctx.GetSessionVars().StmtCtx.IgnoreExplainIDSuffix = true // ignore operatorID to make the output simpler
+	plan := core.ExplainFlatPlanInRowFormat(flat, types.ExplainFormatBrief, false, nil, nil)
 	hints := core.GenHintsFromFlatPlan(flat)
 
 	return digest.String(), hint.RestoreOptimizerHints(hints), plan, nil

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -690,7 +690,7 @@ func recordRelevantOptVarsAndFixes(sctx sessionctx.Context, stmt ast.StmtNode) (
 	return
 }
 
-func genPlanWithSCtx(sctx sessionctx.Context, stmt ast.StmtNode) (planDigest, planHintStr string, planText [][]string, err error) {
+func genBriefPlanWithSCtx(sctx sessionctx.Context, stmt ast.StmtNode) (planDigest, planHintStr string, planText [][]string, err error) {
 	ret := &core.PreprocessorReturn{}
 	nodeW := resolve.NewNodeW(stmt)
 	if err = core.Preprocess(context.Background(), sctx, nodeW,
@@ -721,5 +721,5 @@ func init() {
 	}
 	bindinfo.CalculatePlanDigest = calculatePlanDigestFunc
 	bindinfo.RecordRelevantOptVarsAndFixes = recordRelevantOptVarsAndFixes
-	bindinfo.GenPlanWithSCtx = genPlanWithSCtx
+	bindinfo.GenBriefPlanWithSCtx = genBriefPlanWithSCtx
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60148

Problem Summary: planner: merge the some code of helper func `genPlanWithSCtx` with `Explain` to reduce redundant code

### What changed and how does it work?

Refactor some of of `Explain`, and remove the prior `ExplainFlatPlan` (merged with `ExplainFlatPlanInRowFormat`).
Now `ExplainFlatPlanInRowFormat` is the only function to get a formatted plan in row format:

```
func ExplainFlatPlanInRowFormat(flat *FlatPhysicalPlan, format string, analyze bool,
	runtimeStatsColl *execdetails.RuntimeStatsColl, explainRows [][]string) (rows [][]string) {...}
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
