### PR TITLE
executor: update internal mpp tasks waitReport time from 3s to 100ms

### DIFF
--- a/pkg/executor/internal/mpp/local_mpp_coordinator.go
+++ b/pkg/executor/internal/mpp/local_mpp_coordinator.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	receiveReportTimeout = 3 * time.Second
+	receiveReportTimeout = 100 * time.Millisecond
 )
 
 // mppResponse wraps mpp data packet.
@@ -781,7 +781,7 @@ func (c *localMppCoordinator) handleAllReports() error {
 			distsql.FillDummySummariesForTiFlashTasks(c.sessionCtx.GetSessionVars().StmtCtx.RuntimeStatsColl, kv.TiFlash, c.planIDs, recordedPlanIDs)
 		case <-time.After(receiveReportTimeout):
 			metrics.MppCoordinatorStatsReportNotReceived.Inc()
-			logutil.BgLogger().Warn(fmt.Sprintf("Mpp coordinator not received all reports within %d seconds", int(receiveReportTimeout.Seconds())),
+			logutil.BgLogger().Info(fmt.Sprintf("Mpp coordinator not received all reports within %d ms", int(receiveReportTimeout.Milliseconds())),
 				zap.Uint64("txnStartTS", c.startTS),
 				zap.Uint64("gatherID", c.gatherID),
 				zap.Int("expectCount", len(c.mppReqs)),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61233 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Check 
```
explain analyze select o_orderkey, o_custkey from orders where o_comment like "%%" limit 5;
+--------------------------------+---------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+---------+------+
| id                             | estRows | actRows | task         | access object | execution info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | operator info                                                                      | memory  | disk |
+--------------------------------+---------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+---------+------+
| Limit_11                       | 5.00    | 5       | root         |               | time:16.5ms, open:399.1µs, close:8.28ms, loops:2, RU:1031.32                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | offset:0, count:5                                                                  | N/A     | N/A  |
| └─TableReader_26               | 5.00    | 1024    | root         |               | time:16.5ms, open:395.8µs, close:8.24ms, loops:1, cop_task: {num: 1, max: 0s, proc_keys: 0, copr_cache_hit_ratio: 0.00}, fetch_resp_duration: 7.82ms                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | MppVersion: 3, data:ExchangeSender_25                                              | 1.00 MB | N/A  |
|   └─ExchangeSender_25          | 5.00    | 262144  | mpp[tiflash] |               | tiflash_task:{time:15.1ms, loops:4, threads:12}, tiflash_network: {inner_zone_send_bytes: 2100236}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | ExchangeType: PassThrough                                                          | N/A     | N/A  |
|     └─Projection_14            | 5.00    | 262144  | mpp[tiflash] |               | tiflash_task:{time:14ms, loops:4, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | test.orders.o_orderkey, test.orders.o_custkey                                      | N/A     | N/A  |
|       └─Selection_24           | 5.00    | 262144  | mpp[tiflash] |               | tiflash_task:{time:13.9ms, loops:4, threads:12}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | like(test.orders.o_comment, "%%", 92)                                              | N/A     | N/A  |
|         └─TableFullScan_23     | 6.25    | 262144  | mpp[tiflash] | table:orders  | tiflash_task:{time:13.4ms, loops:4, threads:12}, tiflash_scan:{mvcc_input_rows:0, mvcc_input_bytes:0, mvcc_output_rows:0, local_regions:1, remote_regions:0, tot_learner_read:0ms, region_balance:{instance_num: 1, max/min: 1/1=1.000000}, delta_rows:0, delta_bytes:0, segments:3, stale_read_regions:0, tot_build_snapshot:0ms, tot_build_bitmap:0ms, tot_build_inputstream:0ms, min_local_stream:5ms, max_local_stream:12ms, dtfile:{data_scanned_rows:1016672, data_skipped_rows:0, mvcc_scanned_rows:0, mvcc_skipped_rows:0, lm_filter_scanned_rows:0, lm_filter_skipped_rows:0, tot_rs_index_check:0ms, tot_read:23ms}} | pushed down filter:empty, keep order:false, stats:partial[o_comment:unInitialized] | N/A     | N/A  |
+--------------------------------+---------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+---------+------+
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
