### PR TITLE
expression: deduplicate the args of IN function | tidb-test=pr/2518

### DIFF
--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -211,10 +211,10 @@ type builtinInIntSig struct {
 func (b *builtinInIntSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[int64]bool, len(b.args)-1)
-	
+
 	// Keep track of unique args count for in-place modification
 	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
-	
+
 	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
@@ -223,7 +223,7 @@ func (b *builtinInIntSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
-			
+
 			if isNull {
 				// Only keep one NULL value
 				if !b.hasNull {
@@ -233,7 +233,7 @@ func (b *builtinInIntSig) buildHashMapForConstArgs(ctx BuildContext) error {
 				}
 				continue
 			}
-			
+
 			// Only keep this arg if value wasn't seen before
 			if _, exists := b.hashSet[val]; !exists {
 				b.hashSet[val] = mysql.HasUnsignedFlag(b.args[i].GetType(ctx.GetEvalCtx()).GetFlag())
@@ -254,10 +254,10 @@ func (b *builtinInIntSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			uniqueArgCount++
 		}
 	}
-	
+
 	// Truncate args to only include unique values
 	b.args = b.args[:uniqueArgCount]
-	
+
 	return nil
 }
 
@@ -340,10 +340,10 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewStringSet()
 	collator := collate.GetCollator(b.collation)
-	
+
 	// Keep track of unique args count for in-place modification
 	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
-	
+
 	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
@@ -352,7 +352,7 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
-			
+
 			if isNull {
 				// Only keep one NULL value
 				if !b.hasNull {
@@ -362,7 +362,7 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx BuildContext) error {
 				}
 				continue
 			}
-			
+
 			key := string(collator.Key(val)) // should do memory copy here
 			// Only keep this arg if value wasn't seen before
 			if !b.hashSet.Exist(key) {
@@ -384,10 +384,10 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			uniqueArgCount++
 		}
 	}
-	
+
 	// Truncate args to only include unique values
 	b.args = b.args[:uniqueArgCount]
-	
+
 	return nil
 }
 
@@ -449,10 +449,10 @@ type builtinInRealSig struct {
 func (b *builtinInRealSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewFloat64Set()
-	
+
 	// Keep track of unique args count for in-place modification
 	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
-	
+
 	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
@@ -461,7 +461,7 @@ func (b *builtinInRealSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
-			
+
 			if isNull {
 				// Only keep one NULL value
 				if !b.hasNull {
@@ -471,7 +471,7 @@ func (b *builtinInRealSig) buildHashMapForConstArgs(ctx BuildContext) error {
 				}
 				continue
 			}
-			
+
 			// Only keep this arg if value wasn't seen before
 			if !b.hashSet.Exist(val) {
 				b.hashSet.Insert(val)
@@ -492,10 +492,10 @@ func (b *builtinInRealSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			uniqueArgCount++
 		}
 	}
-	
+
 	// Truncate args to only include unique values
 	b.args = b.args[:uniqueArgCount]
-	
+
 	return nil
 }
 
@@ -555,10 +555,10 @@ type builtinInDecimalSig struct {
 func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewStringSet()
-	
+
 	// Keep track of unique args count for in-place modification
 	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
-	
+
 	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
@@ -567,7 +567,7 @@ func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
-			
+
 			if isNull {
 				// Only keep one NULL value
 				if !b.hasNull {
@@ -577,12 +577,12 @@ func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx BuildContext) error {
 				}
 				continue
 			}
-			
+
 			key, err := val.ToHashKey()
 			if err != nil {
 				return err
 			}
-			
+
 			hashKey := string(key)
 			// Only keep this arg if value wasn't seen before
 			if !b.hashSet.Exist(hashKey) {
@@ -604,10 +604,10 @@ func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			uniqueArgCount++
 		}
 	}
-	
+
 	// Truncate args to only include unique values
 	b.args = b.args[:uniqueArgCount]
-	
+
 	return nil
 }
 
@@ -672,10 +672,10 @@ type builtinInTimeSig struct {
 func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[types.CoreTime]struct{}, len(b.args)-1)
-	
+
 	// Keep track of unique args count for in-place modification
 	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
-	
+
 	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
@@ -684,7 +684,7 @@ func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
-			
+
 			if isNull {
 				// Only keep one NULL value
 				if !b.hasNull {
@@ -694,7 +694,7 @@ func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx BuildContext) error {
 				}
 				continue
 			}
-			
+
 			coreTime := val.CoreTime()
 			// Only keep this arg if value wasn't seen before
 			if _, exists := b.hashSet[coreTime]; !exists {
@@ -716,10 +716,10 @@ func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			uniqueArgCount++
 		}
 	}
-	
+
 	// Truncate args to only include unique values
 	b.args = b.args[:uniqueArgCount]
-	
+
 	return nil
 }
 
@@ -779,10 +779,10 @@ type builtinInDurationSig struct {
 func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[time.Duration]struct{}, len(b.args)-1)
-	
+
 	// Keep track of unique args count for in-place modification
 	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
-	
+
 	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
@@ -791,7 +791,7 @@ func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx BuildContext) error 
 			if err != nil {
 				return err
 			}
-			
+
 			if isNull {
 				// Only keep one NULL value
 				if !b.hasNull {
@@ -801,7 +801,7 @@ func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx BuildContext) error 
 				}
 				continue
 			}
-			
+
 			// Only keep this arg if value wasn't seen before
 			if _, exists := b.hashSet[val.Duration]; !exists {
 				b.hashSet[val.Duration] = struct{}{}
@@ -822,10 +822,10 @@ func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx BuildContext) error 
 			uniqueArgCount++
 		}
 	}
-	
+
 	// Truncate args to only include unique values
 	b.args = b.args[:uniqueArgCount]
-	
+
 	return nil
 }
 

--- a/pkg/expression/builtin_other.go
+++ b/pkg/expression/builtin_other.go
@@ -211,6 +211,11 @@ type builtinInIntSig struct {
 func (b *builtinInIntSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[int64]bool, len(b.args)-1)
+	
+	// Keep track of unique args count for in-place modification
+	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
+	
+	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
 		case ConstStrict:
@@ -218,21 +223,41 @@ func (b *builtinInIntSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
+			
 			if isNull {
-				b.hasNull = true
+				// Only keep one NULL value
+				if !b.hasNull {
+					b.hasNull = true
+					b.args[uniqueArgCount] = b.args[i]
+					uniqueArgCount++
+				}
 				continue
 			}
-			b.hashSet[val] = mysql.HasUnsignedFlag(b.args[i].GetType(ctx.GetEvalCtx()).GetFlag())
+			
+			// Only keep this arg if value wasn't seen before
+			if _, exists := b.hashSet[val]; !exists {
+				b.hashSet[val] = mysql.HasUnsignedFlag(b.args[i].GetType(ctx.GetEvalCtx()).GetFlag())
+				b.args[uniqueArgCount] = b.args[i]
+				uniqueArgCount++
+			}
 		case ConstOnlyInContext:
 			// Avoid build plans for wrong type.
 			if _, _, err := b.args[i].EvalInt(ctx.GetEvalCtx(), chunk.Row{}); err != nil {
 				return err
 			}
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		default:
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		}
 	}
+	
+	// Truncate args to only include unique values
+	b.args = b.args[:uniqueArgCount]
+	
 	return nil
 }
 
@@ -315,6 +340,11 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewStringSet()
 	collator := collate.GetCollator(b.collation)
+	
+	// Keep track of unique args count for in-place modification
+	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
+	
+	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
 		case ConstStrict:
@@ -322,22 +352,42 @@ func (b *builtinInStringSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
+			
 			if isNull {
-				b.hasNull = true
+				// Only keep one NULL value
+				if !b.hasNull {
+					b.hasNull = true
+					b.args[uniqueArgCount] = b.args[i]
+					uniqueArgCount++
+				}
 				continue
 			}
-			b.hashSet.Insert(string(collator.Key(val))) // should do memory copy here
+			
+			key := string(collator.Key(val)) // should do memory copy here
+			// Only keep this arg if value wasn't seen before
+			if !b.hashSet.Exist(key) {
+				b.hashSet.Insert(key)
+				b.args[uniqueArgCount] = b.args[i]
+				uniqueArgCount++
+			}
 		case ConstOnlyInContext:
 			// Avoid build plans for wrong type.
 			if _, _, err := b.args[i].EvalString(ctx.GetEvalCtx(), chunk.Row{}); err != nil {
 				return err
 			}
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		default:
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		}
 	}
-
+	
+	// Truncate args to only include unique values
+	b.args = b.args[:uniqueArgCount]
+	
 	return nil
 }
 
@@ -399,6 +449,11 @@ type builtinInRealSig struct {
 func (b *builtinInRealSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewFloat64Set()
+	
+	// Keep track of unique args count for in-place modification
+	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
+	
+	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
 		case ConstStrict:
@@ -406,22 +461,41 @@ func (b *builtinInRealSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
+			
 			if isNull {
-				b.hasNull = true
+				// Only keep one NULL value
+				if !b.hasNull {
+					b.hasNull = true
+					b.args[uniqueArgCount] = b.args[i]
+					uniqueArgCount++
+				}
 				continue
 			}
-			b.hashSet.Insert(val)
+			
+			// Only keep this arg if value wasn't seen before
+			if !b.hashSet.Exist(val) {
+				b.hashSet.Insert(val)
+				b.args[uniqueArgCount] = b.args[i]
+				uniqueArgCount++
+			}
 		case ConstOnlyInContext:
 			// Avoid build plans for wrong type.
 			if _, _, err := b.args[i].EvalReal(ctx.GetEvalCtx(), chunk.Row{}); err != nil {
 				return err
 			}
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		default:
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		}
 	}
-
+	
+	// Truncate args to only include unique values
+	b.args = b.args[:uniqueArgCount]
+	
 	return nil
 }
 
@@ -481,6 +555,11 @@ type builtinInDecimalSig struct {
 func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = set.NewStringSet()
+	
+	// Keep track of unique args count for in-place modification
+	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
+	
+	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
 		case ConstStrict:
@@ -488,26 +567,47 @@ func (b *builtinInDecimalSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
+			
 			if isNull {
-				b.hasNull = true
+				// Only keep one NULL value
+				if !b.hasNull {
+					b.hasNull = true
+					b.args[uniqueArgCount] = b.args[i]
+					uniqueArgCount++
+				}
 				continue
 			}
+			
 			key, err := val.ToHashKey()
 			if err != nil {
 				return err
 			}
-			b.hashSet.Insert(string(key))
+			
+			hashKey := string(key)
+			// Only keep this arg if value wasn't seen before
+			if !b.hashSet.Exist(hashKey) {
+				b.hashSet.Insert(hashKey)
+				b.args[uniqueArgCount] = b.args[i]
+				uniqueArgCount++
+			}
 		case ConstOnlyInContext:
 			// Avoid build plans for wrong type.
 			if _, _, err := b.args[i].EvalDecimal(ctx.GetEvalCtx(), chunk.Row{}); err != nil {
 				return err
 			}
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		default:
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		}
 	}
-
+	
+	// Truncate args to only include unique values
+	b.args = b.args[:uniqueArgCount]
+	
 	return nil
 }
 
@@ -572,6 +672,11 @@ type builtinInTimeSig struct {
 func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[types.CoreTime]struct{}, len(b.args)-1)
+	
+	// Keep track of unique args count for in-place modification
+	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
+	
+	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
 		case ConstStrict:
@@ -579,22 +684,42 @@ func (b *builtinInTimeSig) buildHashMapForConstArgs(ctx BuildContext) error {
 			if err != nil {
 				return err
 			}
+			
 			if isNull {
-				b.hasNull = true
+				// Only keep one NULL value
+				if !b.hasNull {
+					b.hasNull = true
+					b.args[uniqueArgCount] = b.args[i]
+					uniqueArgCount++
+				}
 				continue
 			}
-			b.hashSet[val.CoreTime()] = struct{}{}
+			
+			coreTime := val.CoreTime()
+			// Only keep this arg if value wasn't seen before
+			if _, exists := b.hashSet[coreTime]; !exists {
+				b.hashSet[coreTime] = struct{}{}
+				b.args[uniqueArgCount] = b.args[i]
+				uniqueArgCount++
+			}
 		case ConstOnlyInContext:
 			// Avoid build plans for wrong type.
 			if _, _, err := b.args[i].EvalTime(ctx.GetEvalCtx(), chunk.Row{}); err != nil {
 				return err
 			}
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		default:
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		}
 	}
-
+	
+	// Truncate args to only include unique values
+	b.args = b.args[:uniqueArgCount]
+	
 	return nil
 }
 
@@ -654,6 +779,11 @@ type builtinInDurationSig struct {
 func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx BuildContext) error {
 	b.nonConstArgsIdx = make([]int, 0)
 	b.hashSet = make(map[time.Duration]struct{}, len(b.args)-1)
+	
+	// Keep track of unique args count for in-place modification
+	uniqueArgCount := 1 // Start with 1 for the first arg (value to check)
+	
+	// TODO: ConstOnlyInContext and default branch should also prune duplicate ones after expression are managed by memo.
 	for i := 1; i < len(b.args); i++ {
 		switch b.args[i].ConstLevel() {
 		case ConstStrict:
@@ -661,22 +791,41 @@ func (b *builtinInDurationSig) buildHashMapForConstArgs(ctx BuildContext) error 
 			if err != nil {
 				return err
 			}
+			
 			if isNull {
-				b.hasNull = true
+				// Only keep one NULL value
+				if !b.hasNull {
+					b.hasNull = true
+					b.args[uniqueArgCount] = b.args[i]
+					uniqueArgCount++
+				}
 				continue
 			}
-			b.hashSet[val.Duration] = struct{}{}
+			
+			// Only keep this arg if value wasn't seen before
+			if _, exists := b.hashSet[val.Duration]; !exists {
+				b.hashSet[val.Duration] = struct{}{}
+				b.args[uniqueArgCount] = b.args[i]
+				uniqueArgCount++
+			}
 		case ConstOnlyInContext:
 			// Avoid build plans for wrong type.
 			if _, _, err := b.args[i].EvalDuration(ctx.GetEvalCtx(), chunk.Row{}); err != nil {
 				return err
 			}
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		default:
-			b.nonConstArgsIdx = append(b.nonConstArgsIdx, i)
+			b.args[uniqueArgCount] = b.args[i]
+			b.nonConstArgsIdx = append(b.nonConstArgsIdx, uniqueArgCount)
+			uniqueArgCount++
 		}
 	}
-
+	
+	// Truncate args to only include unique values
+	b.args = b.args[:uniqueArgCount]
+	
 	return nil
 }
 

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -140,7 +140,7 @@ func TestTableRange(t *testing.T) {
 		},
 		{
 			exprStr:     `a IN (8,8,81,45)`,
-			accessConds: "[in(test.t.a, 8, 8, 81, 45)]",
+			accessConds: "[in(test.t.a, 8, 81, 45)]",
 			filterConds: "[]",
 			resultStr:   `[[8,8] [45,45] [81,81]]`,
 		},
@@ -224,7 +224,7 @@ func TestTableRange(t *testing.T) {
 		},
 		{
 			exprStr:     "a in (1, 1, 1, 1, 1, 1, 2, 1, 2, 3, 2, 3, 4, 4, 1, 2)",
-			accessConds: "[in(test.t.a, 1, 1, 1, 1, 1, 1, 2, 1, 2, 3, 2, 3, 4, 4, 1, 2)]",
+			accessConds: "[in(test.t.a, 1, 2, 3, 4)]",
 			filterConds: "[]",
 			resultStr:   "[[1,1] [2,2] [3,3] [4,4]]",
 		},
@@ -662,7 +662,7 @@ func TestColumnRange(t *testing.T) {
 		{
 			colPos:      0,
 			exprStr:     `a IN (8,8,81,45)`,
-			accessConds: "[in(test.t.a, 8, 8, 81, 45)]",
+			accessConds: "[in(test.t.a, 8, 81, 45)]",
 			filterConds: "[]",
 			resultStr:   `[[8,8] [45,45] [81,81]]`,
 			length:      types.UnspecifiedLength,

--- a/pkg/util/ranger/ranger_test.go
+++ b/pkg/util/ranger/ranger_test.go
@@ -1222,14 +1222,14 @@ create table t(
 		{
 			indexPos:    1,
 			exprStr:     `c in ('1.1', 1, 1.1) and a in ('1', 'a', NULL)`,
-			accessConds: "[in(test.t.c, 1.1, 1, 1.1) in(test.t.a, 1, a, <nil>)]",
+			accessConds: "[in(test.t.c, 1.1, 1) in(test.t.a, 1, a, <nil>)]",
 			filterConds: "[]",
 			resultStr:   "[[1 \"1\",1 \"1\"] [1 \"a\",1 \"a\"] [1.1 \"1\",1.1 \"1\"] [1.1 \"a\",1.1 \"a\"]]",
 		},
 		{
 			indexPos:    1,
 			exprStr:     "c in (1, 1, 1, 1, 1, 1, 2, 1, 2, 3, 2, 3, 4, 4, 1, 2)",
-			accessConds: "[in(test.t.c, 1, 1, 1, 1, 1, 1, 2, 1, 2, 3, 2, 3, 4, 4, 1, 2)]",
+			accessConds: "[in(test.t.c, 1, 2, 3, 4)]",
 			filterConds: "[]",
 			resultStr:   "[[1,1] [2,2] [3,3] [4,4]]",
 		},

--- a/tests/integrationtest/r/expression/issues.result
+++ b/tests/integrationtest/r/expression/issues.result
@@ -326,6 +326,7 @@ a
 8
 9223372036854775810
 18446744073709551614
+18446744073709551615
 SELECT a FROM t WHERE a NOT IN (-1, -2, 4, 9223372036854775810);
 a
 0
@@ -342,6 +343,7 @@ a
 7
 8
 9223372036854775810
+18446744073709551614
 18446744073709551615
 drop table if exists t1;
 create table t1 (some_id smallint(5) unsigned,key (some_id) );
@@ -3252,3 +3254,57 @@ where (nullif(
 round(case when (((`t0`.`c0`) >= 1) or null) then 91 else 86 end)
 )) in (select `vkey` from `t0` where false);
 vkey	pkey	c0
+use test;
+drop table if exists t;
+create table t(a int);
+insert into t values (1), (2), (3), (4), (5);
+explain format=brief select * from t where a in (1, 1, 1, 1, 1, 2);
+id	estRows	task	access object	operator info
+TableReader	20.00	root		data:Selection
+└─Selection	20.00	cop[tikv]		in(test.t.a, 1, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+create table t_str(s varchar(10));
+insert into t_str values ('test');
+explain format=brief select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
+id	estRows	task	access object	operator info
+TableReader	20.00	root		data:Selection
+└─Selection	20.00	cop[tikv]		in(test.t_str.s, "a", "b")
+  └─TableFullScan	10000.00	cop[tikv]	table:t_str	keep order:false, stats:pseudo
+create table t_dec(d decimal(10,2));
+insert into t_dec values (1.5), (2.5);
+explain format=brief select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
+id	estRows	task	access object	operator info
+TableReader	20.00	root		data:Selection
+└─Selection	20.00	cop[tikv]		in(test.t_dec.d, 1.5, 2.5)
+  └─TableFullScan	10000.00	cop[tikv]	table:t_dec	keep order:false, stats:pseudo
+explain format=brief select * from t where a in (1, NULL, NULL, NULL, 2);
+id	estRows	task	access object	operator info
+TableReader	20.00	root		data:Selection
+└─Selection	20.00	cop[tikv]		in(test.t.a, 1, NULL, 2)
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+create table t_date(dt date);
+insert into t_date values ('2023-01-01'), ('2023-01-02');
+explain format=brief select * from t_date where dt in
+('2023-01-01', '2023-01-01', '2023-01-02');
+id	estRows	task	access object	operator info
+TableReader	20.00	root		data:Selection
+└─Selection	20.00	cop[tikv]		in(test.t_date.dt, 2023-01-01 00:00:00.000000, 2023-01-02 00:00:00.000000)
+  └─TableFullScan	10000.00	cop[tikv]	table:t_date	keep order:false, stats:pseudo
+select * from t where a in (1, 1, 1, 1, 2);
+a
+1
+2
+select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
+s
+select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
+d
+1.50
+2.50
+select * from t where a in (1, NULL, NULL, NULL, 2);
+a
+1
+2
+select * from t_date where dt in ('2023-01-01', '2023-01-01', '2023-01-02');
+dt
+2023-01-01
+2023-01-02

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -3819,7 +3819,7 @@ set @@tidb_opt_range_max_size = 111;
 explain format='brief' select * from planner__core__integration.sbtest1 a where pad in ('1','1','1','1','1') and id in (1,1,1,1,1);
 id	estRows	task	access object	operator info
 TableReader	8000.00	root		data:Selection
-└─Selection	8000.00	cop[tikv]		in(planner__core__integration.sbtest1.id, 1, 1, 1, 1, 1), in(planner__core__integration.sbtest1.pad, "1", "1", "1", "1", "1")
+└─Selection	8000.00	cop[tikv]		in(planner__core__integration.sbtest1.id, 1), in(planner__core__integration.sbtest1.pad, "1")
   └─TableFullScan	10000.00	cop[tikv]	table:a	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1105	Memory capacity of 111 bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -111,9 +111,9 @@ insert into tbl_39 values (1994),(1995),(1996),(1997);
 explain format='brief' select  /*+ use_index_merge( tbl_39) */ col_239  from tbl_39 where not( tbl_39.col_239 not in ( '1994' ) ) and tbl_39.col_239 not in ( '2004' , '2010' , '2010' ) or not( tbl_39.col_239 <= '1996' ) and not( tbl_39.col_239 between '2026' and '2011' ) order by tbl_39.col_239 limit 382;
 id	estRows	task	access object	operator info
 Limit	382.00	root		offset:0, count:382
-└─UnionScan	382.00	root		or(and(not(not(eq(planner__core__issuetest__planner_issue.tbl_39.col_239, 1994))), not(in(planner__core__issuetest__planner_issue.tbl_39.col_239, 2004, 2010, 2010))), and(not(le(planner__core__issuetest__planner_issue.tbl_39.col_239, 1996)), not(and(ge(cast(planner__core__issuetest__planner_issue.tbl_39.col_239, double UNSIGNED BINARY), 2026), le(cast(planner__core__issuetest__planner_issue.tbl_39.col_239, double UNSIGNED BINARY), 2011)))))
+└─UnionScan	382.00	root		or(and(not(not(eq(planner__core__issuetest__planner_issue.tbl_39.col_239, 1994))), not(in(planner__core__issuetest__planner_issue.tbl_39.col_239, 2004, 2010))), and(not(le(planner__core__issuetest__planner_issue.tbl_39.col_239, 1996)), not(and(ge(cast(planner__core__issuetest__planner_issue.tbl_39.col_239, double UNSIGNED BINARY), 2026), le(cast(planner__core__issuetest__planner_issue.tbl_39.col_239, double UNSIGNED BINARY), 2011)))))
   └─IndexMerge	382.00	root		type: union
-    ├─Selection(Build)	0.05	cop[tikv]		not(in(planner__core__issuetest__planner_issue.tbl_39.col_239, 2004, 2010, 2010))
+    ├─Selection(Build)	0.05	cop[tikv]		not(in(planner__core__issuetest__planner_issue.tbl_39.col_239, 2004, 2010))
     │ └─IndexRangeScan	0.14	cop[tikv]	table:tbl_39, index:PRIMARY(col_239)	range:[1994,1994], keep order:true, stats:pseudo
     ├─Selection(Build)	371.85	cop[tikv]		or(lt(cast(planner__core__issuetest__planner_issue.tbl_39.col_239, double UNSIGNED BINARY), 2026), gt(cast(planner__core__issuetest__planner_issue.tbl_39.col_239, double UNSIGNED BINARY), 2011))
     │ └─IndexRangeScan	387.34	cop[tikv]	table:tbl_39, index:idx_223(col_239)	range:(1996,+inf], keep order:true, stats:pseudo

--- a/tests/integrationtest/t/expression/issues.test
+++ b/tests/integrationtest/t/expression/issues.test
@@ -2206,3 +2206,33 @@ where (nullif(
     3 ^ 10 & (abs(-50)) ,
     round(case when (((`t0`.`c0`) >= 1) or null) then 91 else 86 end)
     )) in (select `vkey` from `t0` where false);
+
+# TestIssue61246
+# Test for duplicate constant values in IN expressions
+use test;
+drop table if exists t;
+create table t(a int);
+insert into t values (1), (2), (3), (4), (5);
+
+explain format=brief select * from t where a in (1, 1, 1, 1, 1, 2);
+
+create table t_str(s varchar(10));
+insert into t_str values ('test');
+explain format=brief select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
+
+create table t_dec(d decimal(10,2));
+insert into t_dec values (1.5), (2.5);
+explain format=brief select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
+
+explain format=brief select * from t where a in (1, NULL, NULL, NULL, 2);
+
+create table t_date(dt date);
+insert into t_date values ('2023-01-01'), ('2023-01-02');
+explain format=brief select * from t_date where dt in 
+  ('2023-01-01', '2023-01-01', '2023-01-02');
+
+select * from t where a in (1, 1, 1, 1, 2);
+select * from t_str where s in ('a', 'a', 'a', 'b', 'a');
+select * from t_dec where d in (1.5, 1.5, 2.5, 1.5);
+select * from t where a in (1, NULL, NULL, NULL, 2);
+select * from t_date where dt in ('2023-01-01', '2023-01-01', '2023-01-02');


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61246 

Problem Summary:

### What changed and how does it work?

deduplicate args of the IN when building the hashmap.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
对 IN 的参数列表进行去重，避免给 tikv 发送过大的 grpc 请求
Do deduplication for IN function's arguments, to avoid sending a big GRPC request to TiKV
```
