### PR TITLE
server: return a default flen when unspecified

### DIFF
--- a/pkg/server/driver_tidb_test.go
+++ b/pkg/server/driver_tidb_test.go
@@ -95,4 +95,47 @@ func TestConvertColumnInfo(t *testing.T) {
 	}
 	colInfo = column.ConvertColumnInfo(&resultField)
 	require.Equal(t, uint32(4), colInfo.ColumnLength)
+
+	// Test unspecified length
+	for _, tp := range []byte{
+		mysql.TypeBit,
+		mysql.TypeTiny,
+		mysql.TypeShort,
+		mysql.TypeLong,
+		mysql.TypeLonglong,
+		mysql.TypeFloat,
+		mysql.TypeDouble,
+		mysql.TypeNewDecimal,
+		mysql.TypeDuration,
+		mysql.TypeDate,
+		mysql.TypeTimestamp,
+		mysql.TypeDatetime,
+		mysql.TypeYear,
+		mysql.TypeString,
+		mysql.TypeVarchar,
+		mysql.TypeVarString,
+		mysql.TypeTinyBlob,
+		mysql.TypeBlob,
+		mysql.TypeMediumBlob,
+		mysql.TypeLongBlob,
+		mysql.TypeJSON,
+	} {
+		ftb = types.NewFieldTypeBuilder()
+		ftb.SetType(tp)
+		resultField = resolve.ResultField{
+			Column: &model.ColumnInfo{
+				Name:      ast.NewCIStr("a"),
+				ID:        0,
+				Offset:    0,
+				FieldType: ftb.Build(),
+				Comment:   "column a is the first column in table dual",
+			},
+			ColumnAsName: ast.NewCIStr("a"),
+			TableAsName:  ast.NewCIStr("dual"),
+			DBName:       ast.NewCIStr("test"),
+		}
+		colInfo = column.ConvertColumnInfo(&resultField)
+		expectedLen, _ := mysql.GetDefaultFieldLengthAndDecimal(tp)
+		require.NotEqual(t, colInfo.ColumnLength, uint32(expectedLen))
+	}
 }

--- a/pkg/server/driver_tidb_test.go
+++ b/pkg/server/driver_tidb_test.go
@@ -121,7 +121,7 @@ func TestConvertColumnInfo(t *testing.T) {
 		mysql.TypeJSON,
 	} {
 		ftb = types.NewFieldTypeBuilder()
-		ftb.SetType(tp)
+		ftb.SetType(tp).SetFlen(types.UnspecifiedLength)
 		resultField = resolve.ResultField{
 			Column: &model.ColumnInfo{
 				Name:      ast.NewCIStr("a"),
@@ -136,6 +136,7 @@ func TestConvertColumnInfo(t *testing.T) {
 		}
 		colInfo = column.ConvertColumnInfo(&resultField)
 		expectedLen, _ := mysql.GetDefaultFieldLengthAndDecimal(tp)
-		require.NotEqual(t, colInfo.ColumnLength, uint32(expectedLen))
+		require.Equal(t, colInfo.ColumnLength, uint32(expectedLen))
+		require.NotZero(t, colInfo.ColumnLength)
 	}
 }

--- a/pkg/server/internal/column/convert.go
+++ b/pkg/server/internal/column/convert.go
@@ -42,6 +42,9 @@ func ConvertColumnInfo(fld *resolve.ResultField) (ci *Info) {
 	}
 	if fld.Column.GetFlen() != types.UnspecifiedLength {
 		ci.ColumnLength = uint32(fld.Column.GetFlen())
+	} else {
+		clen, _ := mysql.GetDefaultFieldLengthAndDecimal(fld.Column.GetType())
+		ci.ColumnLength = uint32(clen)
 	}
 	if fld.Column.GetType() == mysql.TypeNewDecimal {
 		// Consider the negative sign.

--- a/pkg/server/internal/column/convert.go
+++ b/pkg/server/internal/column/convert.go
@@ -43,6 +43,9 @@ func ConvertColumnInfo(fld *resolve.ResultField) (ci *Info) {
 	if fld.Column.GetFlen() != types.UnspecifiedLength {
 		ci.ColumnLength = uint32(fld.Column.GetFlen())
 	} else {
+		// FIX https://github.com/pingcap/tidb/issues/60503
+		// MySQL will always output a usable length
+		// while we cannot output the same length, we can give a default flen
 		clen, _ := mysql.GetDefaultFieldLengthAndDecimal(fld.Column.GetType())
 		ci.ColumnLength = uint32(clen)
 	}

--- a/pkg/server/internal/column/convert.go
+++ b/pkg/server/internal/column/convert.go
@@ -42,40 +42,42 @@ func ConvertColumnInfo(fld *resolve.ResultField) (ci *Info) {
 	}
 	if fld.Column.GetFlen() != types.UnspecifiedLength {
 		ci.ColumnLength = uint32(fld.Column.GetFlen())
+		if fld.Column.GetType() == mysql.TypeNewDecimal {
+			// Consider the negative sign.
+			ci.ColumnLength++
+			if fld.Column.GetDecimal() > types.DefaultFsp {
+				// Consider the decimal point.
+				ci.ColumnLength++
+			}
+		} else if types.IsString(fld.Column.GetType()) ||
+			fld.Column.GetType() == mysql.TypeEnum || fld.Column.GetType() == mysql.TypeSet { // issue #18870
+			// Fix issue #4540.
+			// The flen is a hint, not a precise value, so most client will not use the value.
+			// But we found in rare MySQL client, like Navicat for MySQL(version before 12) will truncate
+			// the `show create table` result. To fix this case, we must use a large enough flen to prevent
+			// the truncation, in MySQL, it will multiply bytes length by a multiple based on character set.
+			// For examples:
+			// * latin, the multiple is 1
+			// * gb2312, the multiple is 2
+			// * Utf-8, the multiple is 3
+			// * utf8mb4, the multiple is 4
+			// We used to check non-string types to avoid the truncation problem in some MySQL
+			// client such as Navicat. Now we only allow string type enter this branch.
+			charsetDesc, err := charset.GetCharsetInfo(fld.Column.GetCharset())
+			if err != nil {
+				ci.ColumnLength *= 4
+			} else {
+				ci.ColumnLength *= uint32(charsetDesc.Maxlen)
+			}
+		}
 	} else {
 		// FIX https://github.com/pingcap/tidb/issues/60503
 		// MySQL will always output a usable length
 		// while we cannot output the same length, we can give a default flen
+		// it is not placed before two branches above, because default flen here
+		// is already large enough, multiply or anything else may overflow them
 		clen, _ := mysql.GetDefaultFieldLengthAndDecimal(fld.Column.GetType())
 		ci.ColumnLength = uint32(clen)
-	}
-	if fld.Column.GetType() == mysql.TypeNewDecimal {
-		// Consider the negative sign.
-		ci.ColumnLength++
-		if fld.Column.GetDecimal() > types.DefaultFsp {
-			// Consider the decimal point.
-			ci.ColumnLength++
-		}
-	} else if types.IsString(fld.Column.GetType()) ||
-		fld.Column.GetType() == mysql.TypeEnum || fld.Column.GetType() == mysql.TypeSet { // issue #18870
-		// Fix issue #4540.
-		// The flen is a hint, not a precise value, so most client will not use the value.
-		// But we found in rare MySQL client, like Navicat for MySQL(version before 12) will truncate
-		// the `show create table` result. To fix this case, we must use a large enough flen to prevent
-		// the truncation, in MySQL, it will multiply bytes length by a multiple based on character set.
-		// For examples:
-		// * latin, the multiple is 1
-		// * gb2312, the multiple is 2
-		// * Utf-8, the multiple is 3
-		// * utf8mb4, the multiple is 4
-		// We used to check non-string types to avoid the truncation problem in some MySQL
-		// client such as Navicat. Now we only allow string type enter this branch.
-		charsetDesc, err := charset.GetCharsetInfo(fld.Column.GetCharset())
-		if err != nil {
-			ci.ColumnLength *= 4
-		} else {
-			ci.ColumnLength *= uint32(charsetDesc.Maxlen)
-		}
 	}
 
 	if fld.Column.GetDecimal() == types.UnspecifiedLength {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60503 , close #34901

Problem Summary:  MySQL will always output a usable column-type-info length in the returned packet, so do we. While we cannot output the same flen as mysql, we can return a non-zero length, at least.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix that tidb will return zero in the column type info of mysql protocol when flen unspecified
```
