### PR TITLE
executor: add an unalignment load test for hash join v2

### DIFF
--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -608,6 +608,46 @@ func TestBalanceOfFilteredRows(t *testing.T) {
 	}
 }
 
+func TestUnalignmentLoad(t *testing.T) {
+	unalignData := make([]byte, 0)
+	for i := range 20 {
+		unalignData = append(unalignData, byte(i))
+	}
+	alignData := make([]byte, 0) 
+	for i := range 10 {
+		alignData = append(alignData, byte(i))
+		alignData = append(alignData, byte(i+1))
+		alignData = append(alignData, byte(i+2))
+		alignData = append(alignData, byte(i+3))
+		alignData = append(alignData, byte(i+4))
+		alignData = append(alignData, byte(i+5))
+		alignData = append(alignData, byte(i+6))
+		alignData = append(alignData, byte(i+7))
+	}
+	require.True(t, uintptr(unsafe.Pointer(&alignData[0])) % 4 == 0)
+
+	// loadUint64
+	for i := range 10 {
+		v1 := *(*uint64)(unsafe.Pointer(&unalignData[i]))
+		v2 := *(*uint64)(unsafe.Pointer(&alignData[i*8]))
+		require.Equal(t, v1, v2)
+	}
+
+	// loadUint32
+	for i := range 10 {
+		v1 := *(*uint32)(unsafe.Pointer(&unalignData[i]))
+		v2 := *(*uint32)(unsafe.Pointer(&alignData[i*8]))
+		require.Equal(t, v1, v2)
+	}
+
+	// loadUint8
+	for i := range 10 {
+		v1 := *(*uint8)(unsafe.Pointer(&unalignData[i]))
+		v2 := *(*uint8)(unsafe.Pointer(&alignData[i*8]))
+		require.Equal(t, v1, v2)
+	}
+}
+
 func TestSetupPartitionInfo(t *testing.T) {
 	type testCase struct {
 		concurrency         uint

--- a/pkg/executor/join/row_table_builder_test.go
+++ b/pkg/executor/join/row_table_builder_test.go
@@ -613,7 +613,7 @@ func TestUnalignmentLoad(t *testing.T) {
 	for i := range 20 {
 		unalignData = append(unalignData, byte(i))
 	}
-	alignData := make([]byte, 0) 
+	alignData := make([]byte, 0)
 	for i := range 10 {
 		alignData = append(alignData, byte(i))
 		alignData = append(alignData, byte(i+1))
@@ -624,7 +624,7 @@ func TestUnalignmentLoad(t *testing.T) {
 		alignData = append(alignData, byte(i+6))
 		alignData = append(alignData, byte(i+7))
 	}
-	require.True(t, uintptr(unsafe.Pointer(&alignData[0])) % 4 == 0)
+	require.True(t, uintptr(unsafe.Pointer(&alignData[0]))%4 == 0)
 
 	// loadUint64
 	for i := range 10 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127

Problem Summary:

Hash join v2 use unalignment load during join probe, this pr add an unalignment load test.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
