### PR TITLE
planner: Make SET_VAR query hints restore the original session variable values.

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -226,6 +226,7 @@ go_test(
         "expression_test.go",
         "find_best_task_test.go",
         "fragment_test.go",
+        "hint_test.go",
         "indexmerge_intersection_test.go",
         "indexmerge_path_test.go",
         "indexmerge_test.go",

--- a/pkg/planner/core/hint_test.go
+++ b/pkg/planner/core/hint_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetVarTimestampHintsWorks(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+
+	// test that the set value is preserved
+	tk.MustExec(`set timestamp=1745862208.446495;`)
+	require.Equal(t, "1745862208.446495", tk.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+	require.Equal(t, "1", tk.MustQuery(`select /*+ set_var(timestamp=1) */ @@timestamp;`).Rows()[0][0].(string))
+	require.Equal(t, "1745862208.446495", tk.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+}
+
+func TestSetVarTimestampHintsWorksWithBindings(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create session binding for select @@timestamp + 41 using select /*+ set_var(timestamp=1) */ @@timestamp + 41;`)
+
+	// test that bindings with hints correctly restore the previous non-default timestamp value
+	tk.MustExec(`set timestamp=1745862208.446495;`)
+	require.Equal(t, "1745862208.446495", tk.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+	require.Equal(t, "42", tk.MustQuery(`select @@timestamp + 41;`).Rows()[0][0].(string))
+	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+	require.Equal(t, "1745862208.446495", tk.MustQuery(`select @@timestamp;`).Rows()[0][0].(string))
+}
+
+func TestSetVarInQueriesAndBindingsWorkTogether(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+
+	tk.MustExec(`set @@max_execution_time=2000;`)
+	tk.MustExec(`create table foo (a int);`)
+	tk.MustExec(`create session binding for select * from foo where a = 1 using select /*+ set_var(max_execution_time=1234) */ * from foo where a = 1;`)
+	tk.MustExec(`select /*+ set_var(max_execution_time=2222) */ * from foo where a = 1;`)
+	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+}
+
+func TestSetVarHintsWithExplain(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec(`use test`)
+
+	tk.MustExec(`set @@max_execution_time=2000;`)
+	tk.MustExec(`explain select /*+ set_var(max_execution_time=100) */ @@max_execution_time;`)
+	tk.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+
+	tk.MustExec(`create table t(a int);`)
+	tk.MustExec(`create global binding for select * from t where a = 1 and sleep(0.1) using select /*+ SET_VAR(max_execution_time=500) */ * from t where a = 1 and sleep(0.1);`)
+	tk.MustExec(`select * from t where a = 1 and sleep(0.1);`)
+	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+
+	tk.MustExec(`explain select * from t where a = 1 and sleep(0.1);`)
+	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@max_execution_time;").Check(testkit.Rows("2000"))
+}

--- a/pkg/sessionctx/stmtctx/stmtctx.go
+++ b/pkg/sessionctx/stmtctx/stmtctx.go
@@ -1218,7 +1218,10 @@ func (sc *StatementContext) AddSetVarHintRestore(name, val string) {
 	if sc.SetVarHintRestore == nil {
 		sc.SetVarHintRestore = make(map[string]string)
 	}
-	sc.SetVarHintRestore[name] = val
+
+	if _, found := sc.SetVarHintRestore[name]; !found {
+		sc.SetVarHintRestore[name] = val
+	}
 }
 
 // GetUsedStatsInfo returns the map for recording the used stats during query.

--- a/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
+++ b/tests/realtikvtest/pipelineddmltest/pipelineddml_test.go
@@ -179,6 +179,8 @@ func TestPipelinedDMLPositive(t *testing.T) {
 	tk.MustExec("insert into t values(1, 1)")
 	tk.MustExec("set session tidb_dml_type = bulk")
 	for _, stmt := range stmts {
+		tk.MustExec("drop global binding for " + stmt)
+
 		// text protocol
 		err := panicToErr(func() error {
 			_, err := tk.Exec(stmt)
@@ -217,12 +219,18 @@ func TestPipelinedDMLPositive(t *testing.T) {
 
 	// enable by hint
 	// Hint works for DELETE and UPDATE, but not for INSERT if the hint is in its select clause.
-	tk.MustExec("set @@tidb_dml_type = standard")
-	dmls := [][2]string{
-		{"update t set b = b + 1", "update /*+ SET_VAR(tidb_dml_type=bulk) */ t set b = b + 1"},
-		{"insert into t select * from t", "insert /*+ SET_VAR(tidb_dml_type=bulk) */ into t select * from t"},
-		{"delete from t", "delete /*+ SET_VAR(tidb_dml_type=bulk) */ from t"},
+	dmls := [][3]string{
+		{"update t set b = b + 1", "update /*+ SET_VAR(tidb_dml_type=bulk) */ t set b = b + 1", "true"},
+		{"insert into t select * from t", "insert /*+ SET_VAR(tidb_dml_type=bulk) */ into t select * from t", "false"},
+		{"delete from t", "delete /*+ SET_VAR(tidb_dml_type=bulk) */ from t", "true"},
 	}
+
+	for _, dmlPair := range dmls {
+		tk.MustExec("drop global binding for " + dmlPair[0])
+	}
+
+	tk.MustExec("set @@tidb_dml_type = standard")
+	tk.MustQuery("select @@tidb_dml_type").Check(testkit.Rows("standard"))
 	for _, dmlPair := range dmls {
 		err := panicToErr(
 			func() error {
@@ -230,14 +238,16 @@ func TestPipelinedDMLPositive(t *testing.T) {
 				return err
 			},
 		)
-		require.Error(t, err)
+		require.Error(t, err, dmlPair[1])
 		require.True(t, strings.Contains(err.Error(), "pipelined memdb is enabled"), err.Error())
+		tk.MustQuery("select @@tidb_dml_type").Check(testkit.Rows("standard"))
 	}
 
 	// test global binding
 	for _, dmlPair := range dmls {
 		tk.MustExec("create global binding for " + dmlPair[0] + " using " + dmlPair[1])
 	}
+
 	for _, dmlPair := range dmls {
 		err := panicToErr(
 			func() error {
@@ -245,8 +255,18 @@ func TestPipelinedDMLPositive(t *testing.T) {
 				return err
 			},
 		)
-		require.Error(t, err, dmlPair[0])
-		require.True(t, strings.Contains(err.Error(), "pipelined memdb is enabled"), err.Error())
+
+		tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
+
+		// The hint in the insert statement binding does not work.
+		if dmlPair[2] == "true" {
+			require.Error(t, err, dmlPair[0])
+			require.True(t, strings.Contains(err.Error(), "pipelined memdb is enabled"), err.Error())
+		} else {
+			require.NoError(t, err, dmlPair[0])
+		}
+
+		tk.MustQuery("select @@tidb_dml_type").Check(testkit.Rows("standard"))
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

The SET_VAR SQL hint does not properly restore the previous session values.
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60905, close #59822

Problem Summary:

When a session variable is set by the SET_VAR hint, it overwrites any value previously saved for restoration.  If there is a SET_VAR hint in a SQL query and a SET_VAR hint (for the same variable) in a matching binding, the binding code will set the value to be restored to the value from the query's hint.  See my comment on issue [#60905](https://github.com/pingcap/tidb/issues/60905#issuecomment-2836026943).  This is also the issue with issue #59822.

### What changed and how does it work?

With this pull request, only the first value to be restored for a session variable will be retained.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
