### PR TITLE
*: Update metrics and slow log keyspace info for next gen

### DIFF
--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -101,7 +101,6 @@ go_library(
         "//br/pkg/utils",
         "//pkg/bindinfo",
         "//pkg/config",
-        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/ddl/label",
         "//pkg/ddl/placement",

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor/internal/exec"
@@ -1664,12 +1663,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	)
 	keyspaceName = keyspace.GetKeyspaceNameBySettings()
 	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
-		if kerneltype.IsNextGen() {
-			keyspaceIDU64, _ := strconv.ParseUint(keyspaceName, 10, 32) //nolint:errcheck
-			keyspaceID = uint32(keyspaceIDU64)
-		} else {
-			keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
-		}
+		keyspaceID = uint32(a.Ctx.GetStore().GetCodec().GetKeyspaceID())
 	}
 	if txnTS == 0 {
 		// TODO: txnTS maybe ambiguous, consider logging stale-read-ts with a new field in the slow log.

--- a/pkg/util/metricsutil/common.go
+++ b/pkg/util/metricsutil/common.go
@@ -136,10 +136,10 @@ func initMetrics() {
 	}
 }
 
-// registerMetricsForNextGen registers metrics for next gen. Currently we assume keyspace_name equals keyspace_id, and is globally unique.
+// registerMetricsForNextGen registers metrics for next gen.
 func registerMetricsForNextGen(keyspaceName string) {
 	if !keyspace.IsKeyspaceNameEmpty(keyspaceName) {
-		metrics.SetConstLabels("keyspace_id", keyspaceName)
+		metrics.SetConstLabels("keyspace_name", keyspaceName)
 	}
 	initMetrics()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60864 

Problem Summary:
Confirmed that we should expose keyspace_name from kernerl instead of keyspace_id for metrics. Set real keyspace_id instead of keyspace_name for slow log.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
