### PR TITLE
importinto: forbid set external-id explicitly and set it to keyspace name when sem enabled on nextgen

### DIFF
--- a/br/pkg/storage/parse.go
+++ b/br/pkg/storage/parse.go
@@ -226,3 +226,8 @@ func IsLocalPath(p string) (bool, error) {
 func IsLocal(u *url.URL) bool {
 	return u.Scheme == "local" || u.Scheme == "file" || u.Scheme == ""
 }
+
+// IsS3 returns true if the URL is an S3 URL.
+func IsS3(u *url.URL) bool {
+	return u.Scheme == "s3"
+}

--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -43,6 +43,9 @@ import (
 var hardcodedS3ChunkSize = 5 * 1024 * 1024
 
 const (
+	// S3ExternalID is the key for the external ID used in S3 operations.
+	S3ExternalID = "external-id"
+
 	s3EndpointOption     = "s3.endpoint"
 	s3RegionOption       = "s3.region"
 	s3StorageClassOption = "s3.storage-class"
@@ -51,7 +54,7 @@ const (
 	s3ACLOption          = "s3.acl"
 	s3ProviderOption     = "s3.provider"
 	s3RoleARNOption      = "s3.role-arn"
-	s3ExternalIDOption   = "s3.external-id"
+	s3ExternalIDOption   = "s3." + S3ExternalID
 	notFound             = "NotFound"
 	// number of retries to make of operations.
 	maxRetries = 7

--- a/pkg/config/kerneltype/BUILD.bazel
+++ b/pkg/config/kerneltype/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kerneltype",
@@ -9,4 +9,13 @@ go_library(
     ],
     importpath = "github.com/pingcap/tidb/pkg/config/kerneltype",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "kerneltype_test",
+    timeout = "short",
+    srcs = ["type_test.go"],
+    embed = [":kerneltype"],
+    flaky = True,
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/config/kerneltype/classic.go
+++ b/pkg/config/kerneltype/classic.go
@@ -21,3 +21,8 @@ package kerneltype
 func IsNextGen() bool {
 	return false
 }
+
+// IsClassic returns true if the current kernel type is Classic.
+func IsClassic() bool {
+	return !IsNextGen()
+}

--- a/pkg/config/kerneltype/type_test.go
+++ b/pkg/config/kerneltype/type_test.go
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build nextgen
-
 package kerneltype
 
-// IsNextGen returns true if the current kernel type is NextGen.
-// see doc.go for more info.
-func IsNextGen() bool {
-	return true
-}
+import (
+	"testing"
 
-// IsClassic returns true if the current kernel type is Classic.
-func IsClassic() bool {
-	return !IsNextGen()
+	"github.com/stretchr/testify/require"
+)
+
+func TestKernelType(t *testing.T) {
+	require.Equal(t, !IsClassic(), IsNextGen())
+	require.Equal(t, IsClassic(), !IsNextGen())
 }

--- a/pkg/executor/BUILD.bazel
+++ b/pkg/executor/BUILD.bazel
@@ -396,6 +396,7 @@ go_test(
     deps = [
         "//br/pkg/storage",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/ddl/util",
         "//pkg/distsql",

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -45,8 +45,100 @@ func TestSecurityEnhancedMode(t *testing.T) {
 	// When SEM is enabled these features are restricted to all users
 	// regardless of what privileges they have available.
 	tk.MustGetErrMsg("IMPORT INTO test.t FROM '/file.csv'", "[planner:8132]Feature 'IMPORT INTO from server disk' is not supported when security enhanced mode is enabled")
+}
+
+func TestClassicS3ExternalID(t *testing.T) {
 	if kerneltype.IsNextGen() {
+		t.Skip("only for classic")
+	}
+	store := testkit.CreateMockStore(t)
+	outerTK := testkit.NewTestKit(t, store)
+	outerTK.MustExec("create table test.t (id int);")
+
+	bak := config.GetGlobalKeyspaceName()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = "aaa"
+	})
+	t.Cleanup(func() {
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.KeyspaceName = bak
+		})
+	})
+
+	t.Run("SEM enabled, explicit external ID is allowed, and we don't change it", func(t *testing.T) {
+		sem.Enable()
+		t.Cleanup(func() {
+			sem.Disable()
+		})
+		tk := testkit.NewTestKit(t, store)
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
+			u, err := url.Parse(plan.Path)
+			require.NoError(t, err)
+			require.Contains(t, u.Query(), storage.S3ExternalID)
+			require.Equal(t, "allowed", u.Query().Get(storage.S3ExternalID))
+			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
+		})
+		tk.MustExec("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'")
+		tk.MustQuery("select * from test.t").Check(testkit.Rows())
+	})
+
+	t.Run("SEM disabled, explicit external ID is also allowed, and we don't change it", func(t *testing.T) {
+		tk := testkit.NewTestKit(t, store)
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
+			u, err := url.Parse(plan.Path)
+			require.NoError(t, err)
+			require.Contains(t, u.Query(), storage.S3ExternalID)
+			require.Equal(t, "allowed", u.Query().Get(storage.S3ExternalID))
+			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
+		})
+		tk.MustExec("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=allowed'")
+		tk.MustQuery("select * from test.t").Check(testkit.Rows())
+	})
+}
+
+func TestNextGenS3ExternalID(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("only for nextgen")
+	}
+	store := testkit.CreateMockStore(t)
+	outerTK := testkit.NewTestKit(t, store)
+	outerTK.MustExec("create table test.t (id int);")
+
+	t.Run("SEM enabled, forbid set S3 external ID", func(t *testing.T) {
+		tk := testkit.NewTestKit(t, store)
+		sem.Enable()
+		t.Cleanup(func() {
+			sem.Disable()
+		})
 		tk.MustGetErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=abc'", "[planner:8132]Feature 'IMPORT INTO with S3 external ID' is not supported when security enhanced mode is enabled")
+	})
+
+	t.Run("SEM enabled, set S3 external ID to keyspace name", func(t *testing.T) {
+		sem.Enable()
+		bak := config.GetGlobalKeyspaceName()
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.KeyspaceName = "aaa"
+		})
+		t.Cleanup(func() {
+			config.UpdateGlobal(func(conf *config.Config) {
+				conf.KeyspaceName = bak
+			})
+			sem.Disable()
+		})
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
+			u, err := url.Parse(plan.Path)
+			require.NoError(t, err)
+			require.Contains(t, u.Query(), storage.S3ExternalID)
+			require.Equal(t, "aaa", u.Query().Get(storage.S3ExternalID))
+			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
+		})
+		tk := testkit.NewTestKit(t, store)
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket'")
+		require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
+	})
+
+	t.Run("SEM disabled, allow explicit S3 external id, should not change it", func(t *testing.T) {
+		tk := testkit.NewTestKit(t, store)
 
 		bak := config.GetGlobalKeyspaceName()
 		config.UpdateGlobal(func(conf *config.Config) {
@@ -61,40 +153,10 @@ func TestSecurityEnhancedMode(t *testing.T) {
 			u, err := url.Parse(plan.Path)
 			require.NoError(t, err)
 			require.Contains(t, u.Query(), storage.S3ExternalID)
-			require.Equal(t, "aaa", u.Query().Get(storage.S3ExternalID))
+			require.Equal(t, "allowed", u.Query().Get(storage.S3ExternalID))
 			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
 		})
-		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket'")
-		require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
-	}
-}
-
-func TestWithoutSecurityEnhancedMode(t *testing.T) {
-	if !kerneltype.IsNextGen() {
-		t.Skip("only for nextgen")
-	}
-	store := testkit.CreateMockStore(t)
-
-	t.Run("should not set S3 external ID when SEM is disabled", func(t *testing.T) {
-		tk := testkit.NewTestKit(t, store)
-		tk.MustExec("create table test.t (id int);")
-
-		bak := config.GetGlobalKeyspaceName()
-		config.UpdateGlobal(func(conf *config.Config) {
-			conf.KeyspaceName = "aaa"
-		})
-		t.Cleanup(func() {
-			config.UpdateGlobal(func(conf *config.Config) {
-				conf.KeyspaceName = bak
-			})
-		})
-		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
-			u, err := url.Parse(plan.Path)
-			require.NoError(t, err)
-			require.NotContains(t, u.Query(), storage.S3ExternalID)
-			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
-		})
-		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket'")
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket?external-id=allowed'")
 		require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
 	})
 }

--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -16,14 +16,20 @@ package executor_test
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/executor/importer"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	plannercore "github.com/pingcap/tidb/pkg/planner/core"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/sem"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +45,58 @@ func TestSecurityEnhancedMode(t *testing.T) {
 	// When SEM is enabled these features are restricted to all users
 	// regardless of what privileges they have available.
 	tk.MustGetErrMsg("IMPORT INTO test.t FROM '/file.csv'", "[planner:8132]Feature 'IMPORT INTO from server disk' is not supported when security enhanced mode is enabled")
+	if kerneltype.IsNextGen() {
+		tk.MustGetErrMsg("IMPORT INTO test.t FROM 's3://bucket?EXTERNAL-ID=abc'", "[planner:8132]Feature 'IMPORT INTO with S3 external ID' is not supported when security enhanced mode is enabled")
+
+		bak := config.GetGlobalKeyspaceName()
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.KeyspaceName = "aaa"
+		})
+		t.Cleanup(func() {
+			config.UpdateGlobal(func(conf *config.Config) {
+				conf.KeyspaceName = bak
+			})
+		})
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
+			u, err := url.Parse(plan.Path)
+			require.NoError(t, err)
+			require.Contains(t, u.Query(), storage.S3ExternalID)
+			require.Equal(t, "aaa", u.Query().Get(storage.S3ExternalID))
+			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
+		})
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket'")
+		require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
+	}
+}
+
+func TestWithoutSecurityEnhancedMode(t *testing.T) {
+	if !kerneltype.IsNextGen() {
+		t.Skip("only for nextgen")
+	}
+	store := testkit.CreateMockStore(t)
+
+	t.Run("should not set S3 external ID when SEM is disabled", func(t *testing.T) {
+		tk := testkit.NewTestKit(t, store)
+		tk.MustExec("create table test.t (id int);")
+
+		bak := config.GetGlobalKeyspaceName()
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.KeyspaceName = "aaa"
+		})
+		t.Cleanup(func() {
+			config.UpdateGlobal(func(conf *config.Config) {
+				conf.KeyspaceName = bak
+			})
+		})
+		testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/executor/importer/NewImportPlan", func(plan *plannercore.ImportInto) {
+			u, err := url.Parse(plan.Path)
+			require.NoError(t, err)
+			require.NotContains(t, u.Query(), storage.S3ExternalID)
+			panic("FAIL IT, AS WE CANNOT RUN IT HERE")
+		})
+		err := tk.QueryToErr("IMPORT INTO test.t FROM 's3://bucket'")
+		require.ErrorContains(t, err, "FAIL IT, AS WE CANNOT RUN IT HERE")
+	})
 }
 
 func TestImportIntoValidateColAssignmentsWithEncodeCtx(t *testing.T) {

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -29,6 +29,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	tidb "github.com/pingcap/tidb/pkg/config"
@@ -408,6 +409,7 @@ func NewPlanFromLoadDataPlan(userSctx sessionctx.Context, plan *plannercore.Load
 
 // NewImportPlan creates a new import into plan.
 func NewImportPlan(ctx context.Context, userSctx sessionctx.Context, plan *plannercore.ImportInto, tbl table.Table) (*Plan, error) {
+	failpoint.InjectCall("NewImportPlan", plan)
 	var format string
 	if plan.Format != nil {
 		format = strings.ToLower(*plan.Format)

--- a/pkg/lightning/backend/local/region_job_test.go
+++ b/pkg/lightning/backend/local/region_job_test.go
@@ -131,7 +131,7 @@ func TestConvertPBError2Error(t *testing.T) {
 }
 
 func TestExtractRegionFromErrForNextGen(t *testing.T) {
-	if !kerneltype.IsNextGen() {
+	if kerneltype.IsClassic() {
 		t.Skip("only run in next gen")
 	}
 	region := &split.RegionInfo{

--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -94,6 +94,7 @@ go_library(
         "//br/pkg/storage",
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/distsql",
         "//pkg/domain",
         "//pkg/errctx",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -6149,7 +6149,10 @@ func checkAlterDDLJobOptValue(opt *AlterDDLJobOpt) error {
 }
 
 // for nextgen import-into with SEM, we disallow user to set S3 external ID explicitly,
-// and we will use the global keyspace name as the S3 external ID.
+// and we will use the keyspace name as the S3 external ID.
+// a nextgen cluster might be shared by multiple tenants, and they might share the
+// same AWS role to access import-into source data bucket, this external ID can
+// be used to restrict the access only to the current tenant.
 func processSemNextGenS3Path(u *url.URL) (string, error) {
 	values := u.Query()
 	for k := range values {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"net/url"
 	"reflect"
 	"slices"
 	"strconv"
@@ -30,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -4608,14 +4610,23 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 	)
 
 	if ld.Select == nil {
-		importFromServer, err = storage.IsLocalPath(ld.Path)
+		u, err := url.Parse(ld.Path)
 		if err != nil {
 			return nil, exeerrors.ErrLoadDataInvalidURI.FastGenByArgs(ImportIntoDataSource, err.Error())
 		}
-	}
-
-	if importFromServer && sem.IsEnabled() {
-		return nil, plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from server disk")
+		importFromServer = storage.IsLocal(u)
+		if sem.IsEnabled() {
+			if importFromServer {
+				return nil, plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from server disk")
+			}
+			if kerneltype.IsNextGen() && storage.IsS3(u) {
+				newPath, err := processSemNextGenS3Path(u)
+				if err != nil {
+					return nil, err
+				}
+				ld.Path = newPath
+			}
+		}
 	}
 
 	for _, opt := range ld.Options {
@@ -6135,6 +6146,22 @@ func checkAlterDDLJobOptValue(opt *AlterDDLJobOpt) error {
 		}
 	}
 	return nil
+}
+
+// for nextgen import-into with SEM, we disallow user to set S3 external ID explicitly,
+// and we will use the global keyspace name as the S3 external ID.
+func processSemNextGenS3Path(u *url.URL) (string, error) {
+	values := u.Query()
+	for k := range values {
+		lowerK := strings.ToLower(k)
+		if lowerK == storage.S3ExternalID {
+			return "", plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO with S3 external ID")
+		}
+	}
+	values.Set(storage.S3ExternalID, config.GetGlobalKeyspaceName())
+	u.RawQuery = values.Encode()
+
+	return u.String(), nil
 }
 
 // GetThreadOrBatchSizeFromExpression gets the numeric value of the thread or batch size from the expression.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418 

Problem Summary:

### What changed and how does it work?
for import into on nextgen with sem enabled:
- forbid user set `external-id` explicitly in the data source S3 url
- set `external-id` to keyspace name for S3

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

with nextgen and SEM
```
mysql> import into t from 's3://mybucket/a.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2flocalhost%3a9000&force-path-style=true&external-id=aaa';
ERROR 8132 (HY000): Feature 'IMPORT INTO with S3 external ID' is not supported when security enhanced mode is enabled


mysql> import into t from 's3://mybucket/a.csv?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2flocalhost%3a9000&force-path-style=true';
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
| Job_ID | Data_Source                                                                                                                                        | Target_Table | Table_ID | Phase | Status   | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time                   | Created_By |
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
|  60001 | s3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2Flocalhost%3A9000&external-id=mykeyspace&force-path-style=true&secret-access-key=xxxxxx | `test`.`t`   |      114 |       | finished | 4B               |             1 |                | 2025-05-26 12:22:59.181178 | 2025-05-26 12:22:59.727514 | 2025-05-26 12:23:01.751417 | root@%     |
+--------+----------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----------+-------+----------+------------------+---------------+----------------+----------------------------+----------------------------+----------------------------+------------+
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
