### PR TITLE
*: ensure keyspace name is set for nextgen

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/domain",
         "//pkg/executor",

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor"
@@ -275,6 +276,12 @@ func main() {
 	if *version {
 		setVersions()
 		fmt.Println(printer.GetTiDBInfo())
+		os.Exit(0)
+	}
+	// we cannot add this check inside config.Valid(), as previous '-V' also relies
+	// on initialized global config.
+	if kerneltype.IsNextGen() && len(config.GetGlobalConfig().KeyspaceName) == 0 {
+		fmt.Fprintln(os.Stderr, "invalid config: keyspace name is required for nextgen TiDB")
 		os.Exit(0)
 	}
 	registerStores()

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -47,6 +47,11 @@ func PrintTiDBInfo() {
 		zap.Bool("Race Enabled", israce.RaceEnabled),
 		zap.Bool("Check Table Before Drop", config.CheckTableBeforeDrop),
 	}
+	if kerneltype.IsNextGen() {
+		fields = append(fields, zap.String("Kernel Type", "Next Generation"))
+	} else {
+		fields = append(fields, zap.String("Kernel Type", "Classic"))
+	}
 	if versioninfo.TiDBEnterpriseExtensionGitHash != "" {
 		fields = append(fields, zap.String("Enterprise Extension Commit Hash", versioninfo.TiDBEnterpriseExtensionGitHash))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418

Problem Summary:

### What changed and how does it work?
as title, also add log
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

without keyspace name
```
# bin/tidb-server
invalid config: keyspace name is required for nextgen TiDB
```

on success start
```
[.....] ["Welcome to TiDB."] [keyspaceName=a] .... ["Kernel Type"="Next Generation"]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
