### PR TITLE
cgmon: fix the issue that CPU quota is 0 if it's not limited by cgroup

### DIFF
--- a/pkg/util/cgmon/BUILD.bazel
+++ b/pkg/util/cgmon/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cgmon",
@@ -12,5 +12,17 @@ go_library(
         "@com_github_pingcap_log//:log",
         "@com_github_shirou_gopsutil_v3//mem",
         "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "cgmon_test",
+    timeout = "short",
+    srcs = ["cgmon_test.go"],
+    embed = [":cgmon"],
+    flaky = True,
+    deps = [
+        "@com_github_shirou_gopsutil_v3//mem",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/cgmon/cgmon_test.go
+++ b/pkg/util/cgmon/cgmon_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgmon
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadDefaultValueWithoutCgroup(t *testing.T) {
+	getCgroupCPUPeriodAndQuota = func() (period int64, quota int64, err error) {
+		return 0, 0, errors.New("mock error")
+	}
+	getCgroupMemoryLimit = func() (uint64, error) {
+		return 0, errors.New("mock error")
+	}
+
+	require.Error(t, refreshCgroupCPU())
+	require.Error(t, refreshCgroupMemory())
+
+	require.Equal(t, runtime.NumCPU(), lastCPU)
+	vmem, err := mem.VirtualMemory()
+	require.NoError(t, err)
+	require.Equal(t, vmem.Total, lastMemoryLimit)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61223

Problem Summary:

The cpu quota will always be 0 if it failed to get the cgroup limit. The same issue also exists for memory. 

### What changed and how does it work?

Change the logic of error handling in cgmon. Make the cpu quota defaults to the count of CPU, and the memory quota defaults to the memory get from `/proc/meminfo`. Then update these values according to the cgroup settings.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

1. Deploy master branch of tidb in rockylinux 9. Open the grafana. The cpu quota is 0.

![image](https://github.com/user-attachments/assets/f3ac5de0-e43b-46d4-84e3-29bacd97c670)

2. Deploy this branch of TiDB in rockylinux 9. Open the grafana. The cpu quota is 16.

![image](https://github.com/user-attachments/assets/27fb1e21-5598-4d36-8012-2a1f01a87013)

3. Modify the tiup config of TiDB. Set CPU quota to 800 and memory quota to 8G. The value is correct.

![image](https://github.com/user-attachments/assets/5e43fd81-5640-4faf-98a0-6a8d80f62cc4)
![image](https://github.com/user-attachments/assets/a2ddc3cd-ef1b-49c6-b3a7-50e08e27d7d9)

4. Manually remove the memory controller from related cgroup, so that TiDB will get error when it's reading the memory quota, then the memory quota goes to the memory of the whole machine (16G).

![image](https://github.com/user-attachments/assets/716c28bb-f7b0-4353-a348-81928239177c)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the cpu quota is always 0 if `cpu.max` doesn't exist
```
