### PR TITLE
ci: Support ut run-multi for CSE

### DIFF
--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -37,6 +37,7 @@ import (
 
 	// Set the correct value when it runs inside docker.
 	_ "go.uber.org/automaxprocs"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/cover"
 )
 
@@ -67,6 +68,9 @@ ut run $package $test
 
 // run test cases that match a pattern
 ut run $package 'r:$regex'
+
+// run test cases of multiple packages
+ut run-multi $package1 $package2 ...
 
 // build all test package
 ut build
@@ -194,6 +198,30 @@ func cmdBuild(args ...string) bool {
 	return true
 }
 
+func cmdRunMulti(pkgs ...string) bool {
+	var err error
+	if len(pkgs) == 0 {
+		return true
+	}
+
+	// Build tasks
+	var tasks []task
+	start := time.Now()
+	err = buildTestBinaryMulti(pkgs)
+	if err != nil {
+		log.Println("build package error", pkgs, err)
+		return false
+	}
+
+	if tasks, err = listTestCasesForPkgs(pkgs); err != nil {
+		log.Println("run existing test cases error", err)
+		return false
+	}
+
+	fmt.Printf("building task finish, maxproc=%d, count=%d, takes=%v\n", buildParallel, len(tasks), time.Since(start))
+	return runTestCases(tasks)
+}
+
 func cmdRun(args ...string) bool {
 	var err error
 	pkgs, err := listPackages()
@@ -221,7 +249,7 @@ func cmdRun(args ...string) bool {
 				tasks = listLongTasks(pkg, tasks)
 			}
 		} else {
-			if tasks, err = runExistingTestCases(pkgs); err != nil {
+			if tasks, err = listTestCasesForPkgs(pkgs); err != nil {
 				log.Println("run existing test cases error", err)
 				return false
 			}
@@ -319,7 +347,10 @@ func cmdRun(args ...string) bool {
 	}
 
 	fmt.Printf("building task finish, parallelism=%d, count=%d, takes=%v\n", buildParallel, len(tasks), time.Since(start))
+	return runTestCases(tasks)
+}
 
+func runTestCases(tasks []task) bool {
 	testWorkerCount := p
 	if long {
 		testWorkerCount = longTestWorkerCount
@@ -334,7 +365,7 @@ func cmdRun(args ...string) bool {
 
 	shuffle(tasks)
 
-	start = time.Now()
+	start := time.Now()
 	for _, task := range tasks {
 		taskCh <- task
 	}
@@ -368,8 +399,8 @@ func cmdRun(args ...string) bool {
 	return true
 }
 
-func runExistingTestCases(pkgs []string) (tasks []task, err error) {
-	wg := &sync.WaitGroup{}
+func listTestCasesForPkgs(pkgs []string) (tasks []task, err error) {
+	g := new(errgroup.Group)
 	tasksChannel := make(chan []task, len(pkgs))
 	for _, pkg := range pkgs {
 		exist, err := testBinaryExist(pkg)
@@ -381,12 +412,22 @@ func runExistingTestCases(pkgs []string) (tasks []task, err error) {
 			fmt.Println("no test case in ", pkg)
 			continue
 		}
-
-		wg.Add(1)
-		go listTestCasesConcurrent(wg, pkg, tasksChannel)
+		pkgCopy := pkg
+		g.Go(func() error {
+			tasks, err := listTestCases(pkgCopy, nil)
+			if err != nil {
+				log.Println("list test cases error", pkgCopy, err)
+				return withTrace(err)
+			}
+			tasksChannel <- tasks
+			return nil
+		})
 	}
 
-	wg.Wait()
+	if err := g.Wait(); err != nil {
+		return nil, withTrace(err)
+	}
+
 	close(tasksChannel)
 	for t := range tasksChannel {
 		tasks = append(tasks, t...)
@@ -518,6 +559,8 @@ func main() {
 			isSucceed = cmdBuild(os.Args[2:]...)
 		case "run":
 			isSucceed = cmdRun(os.Args[2:]...)
+		case "run-multi":
+			isSucceed = cmdRunMulti(os.Args[2:]...)
 		default:
 			isSucceed = usage()
 		}
@@ -678,6 +721,7 @@ func (b blocksByStart) Less(i, j int) bool {
 	return bi.StartLine < bj.StartLine || bi.StartLine == bj.StartLine && bi.StartCol < bj.StartCol
 }
 
+// listTestCases list all test cases of a package and append to a slice.
 func listTestCases(pkg string, tasks []task) ([]task, error) {
 	newCases, err := listNewTestCases(pkg)
 	if err != nil {
@@ -689,20 +733,6 @@ func listTestCases(pkg string, tasks []task) ([]task, error) {
 	}
 
 	return tasks, nil
-}
-
-func listTestCasesConcurrent(wg *sync.WaitGroup, pkg string, tasksChannel chan<- []task) {
-	defer wg.Done()
-	newCases, err := listNewTestCases(pkg)
-	if err != nil {
-		log.Println("list test case error", pkg, err)
-		return
-	}
-	tasks := make([]task, 0, len(newCases))
-	for _, c := range newCases {
-		tasks = append(tasks, task{pkg, c})
-	}
-	tasksChannel <- tasks
 }
 
 func filterTestCases(tasks []task, arg1 string) ([]task, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/30822

Problem Summary:

### What changed and how does it work?

Support `run-multi`, which is a necessary part for TiDB Cloud CSE CICD.

Also removed listTestCasesConcurrent and just based on listTestCases(.., nil).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```shell
./tools/bin/ut run-multi --junitfile ./junit.xml ./pkg/util/topsql/collector ./pkg/util/topsql/reporter
2025/05/27 17:39:40 maxprocs: Leaving GOMAXPROCS=14: CPU quota undefined
ok  	github.com/pingcap/tidb/pkg/util/topsql/collector	0.012s
ok  	github.com/pingcap/tidb/pkg/util/topsql/reporter	0.012s
building task finish, maxproc=14, count=39, takes=3.464729583s
run all tasks takes 3.294060709s
```

Junitfile is used to verify whether multi-packages are indeed involved:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
	<testsuite tests="36" failures="0" time="7.175927" name="github.com/pingcap/tidb/pkg/util/topsql/reporter">
		<properties>
			<property name="go.version" value="go1.24.2 darwin/arm64"></property>
		</properties>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_records_Sort" time="0.029574"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_collecting_appendOthers" time="0.021887"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_record_merge" time="0.020928"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_tsItems_Sort" time="0.016645"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_cpuRecords_topN" time="0.031020"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestPubSubDataSink" time="1.026566"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestReporterWorker" time="3.131159"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_record_append" time="0.033773"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestSingleTargetDataSink" time="0.026104"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestCollectInternal" time="0.020073"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_record_Sort" time="0.030052"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_normalizedPlanMap_take" time="0.022878"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_tsItem_toProto" time="0.020576"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_normalizedSQLMap_take" time="0.015433"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_normalizedPlanMap_register" time="0.030038"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_records_toProto" time="0.026304"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_normalizedSQLMap_toProto" time="0.020832"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestRemoveInvalidPlanRecord" time="0.031565"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_normalizedSQLMap_register" time="0.023717"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestCollectAndTopN" time="0.021479"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestCollectAndSendBatch" time="0.770082"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_collecting_take" time="0.032054"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestDefaultDataSinkRegisterer" time="0.023119"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_collecting_getReportRecords" time="0.020192"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestCollectAndEvicted" time="1.417170"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_records_topN" time="0.030420"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestMultipleDataSinks" time="0.024757"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="TestCollectCapacity" time="0.054373"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_collecting_markAsEvicted_hasEvicted" time="0.030239"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_cpuRecords_Sort" time="0.024815"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_tsItems_toProto" time="0.019612"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_collecting_getOrCreateRecord" time="0.031571"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_record_rebuildTsIndex" time="0.023099"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_normalizedPlanMap_toProto" time="0.021236"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_encodeKey" time="0.031703"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/reporter" name="Test_record_toProto" time="0.020884"></testcase>
	</testsuite>
	<testsuite tests="3" failures="0" time="5.719882" name="github.com/pingcap/tidb/pkg/util/topsql/collector">
		<properties>
			<property name="go.version" value="go1.24.2 darwin/arm64"></property>
		</properties>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/collector" name="TestPProfCPUProfile" time="2.478646"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/collector" name="TestProcessProfCPUProfile" time="3.217943"></testcase>
		<testcase classname="github.com/pingcap/tidb/pkg/util/topsql/collector" name="TestSQLStatsTune" time="0.023293"></testcase>
	</testsuite>
</testsuites>
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
