### PR TITLE
pkg/config: make UpdateGlobal return its restore function as documented

### DIFF
--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1917,8 +1917,7 @@ func AdjustTablesToRestoreAndCreateTableTracker(
 // tweakLocalConfForRestore tweaks some of configs of TiDB to make the restore progress go well.
 // return a function that could restore the config to origin.
 func tweakLocalConfForRestore() func() {
-	restoreConfig := config.RestoreFunc()
-	config.UpdateGlobal(func(conf *config.Config) {
+	return config.UpdateGlobal(func(conf *config.Config) {
 		// set max-index-length before execute DDLs and create tables
 		// we set this value to max(3072*4), otherwise we might not restore table
 		// when upstream and downstream both set this value greater than default(3072)
@@ -1929,7 +1928,6 @@ func tweakLocalConfForRestore() func() {
 		conf.TableColumnCountLimit = config.DefMaxOfTableColumnCountLimit
 		log.Warn("set table-column-count to max(4096) to skip check column count in DDL")
 	})
-	return restoreConfig
 }
 
 func getTiFlashNodeCount(ctx context.Context, pdClient pd.Client) (uint64, error) {

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -39,7 +39,7 @@ go_test(
     data = glob(["**"]),
     embed = [":config"],
     flaky = True,
-    shard_count = 28,
+    shard_count = 29,
     deps = [
         "//pkg/testkit/testsetup",
         "//pkg/util/logutil",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1398,11 +1398,14 @@ func (c *Config) Valid() error {
 }
 
 // UpdateGlobal updates the global config, and provide a restore function that can be used to restore to the original.
-func UpdateGlobal(f func(conf *Config)) {
+func UpdateGlobal(f func(conf *Config)) (restore func()) {
 	g := GetGlobalConfig()
 	newConf := *g
 	f(&newConf)
 	StoreGlobalConfig(&newConf)
+	return func() {
+		StoreGlobalConfig(g)
+	}
 }
 
 // RestoreFunc gets a function that restore the config to the current value.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1036,6 +1036,14 @@ func TestTxnTotalSizeLimitValid(t *testing.T) {
 }
 
 func TestConflictInstanceConfig(t *testing.T) {
+	// Save original global state
+	originalConflictOptions := ConflictOptions
+	originalDeprecatedOptions := DeprecatedOptions
+	defer func() {
+		ConflictOptions = originalConflictOptions
+		DeprecatedOptions = originalDeprecatedOptions
+	}()
+
 	var expectedNewName string
 	conf := new(Config)
 	storeDir := t.TempDir()
@@ -1094,6 +1102,14 @@ func TestConflictInstanceConfig(t *testing.T) {
 }
 
 func TestDeprecatedConfig(t *testing.T) {
+	// Save original global state
+	originalConflictOptions := ConflictOptions
+	originalDeprecatedOptions := DeprecatedOptions
+	defer func() {
+		ConflictOptions = originalConflictOptions
+		DeprecatedOptions = originalDeprecatedOptions
+	}()
+
 	var expectedNewName string
 	conf := new(Config)
 	storeDir := t.TempDir()
@@ -1434,15 +1450,25 @@ func TestKeyspaceName(t *testing.T) {
 }
 
 func TestUpdateGlobal(t *testing.T) {
-	originalPort := GetGlobalConfig().Port
-	
+	originalConfig := GetGlobalConfig()
+	originalConflictOptions := ConflictOptions
+	originalDeprecatedOptions := DeprecatedOptions
+
+	defer func() {
+		StoreGlobalConfig(originalConfig)
+		ConflictOptions = originalConflictOptions
+		DeprecatedOptions = originalDeprecatedOptions
+	}()
+
+	originalPort := originalConfig.Port
+
 	restore := UpdateGlobal(func(conf *Config) {
 		conf.Port = 9999
 	})
-	
+
 	require.Equal(t, uint(9999), GetGlobalConfig().Port)
-	
+
 	restore()
-	
+
 	require.Equal(t, originalPort, GetGlobalConfig().Port)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1432,3 +1432,17 @@ func TestKeyspaceName(t *testing.T) {
 	conf.KeyspaceName = "abc"
 	require.NoError(t, conf.Valid())
 }
+
+func TestUpdateGlobal(t *testing.T) {
+	originalPort := GetGlobalConfig().Port
+	
+	restore := UpdateGlobal(func(conf *Config) {
+		conf.Port = 9999
+	})
+	
+	require.Equal(t, uint(9999), GetGlobalConfig().Port)
+	
+	restore()
+	
+	require.Equal(t, originalPort, GetGlobalConfig().Port)
+}

--- a/pkg/ddl/db_integration_test.go
+++ b/pkg/ddl/db_integration_test.go
@@ -1412,8 +1412,9 @@ func TestAlterAlgorithm(t *testing.T) {
 }
 
 func TestTreatOldVersionUTF8AsUTF8MB4(t *testing.T) {
-	restoreFunc := config.RestoreFunc()
-	defer restoreFunc()
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		conf.TreatOldVersionUTF8AsUTF8MB4 = config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4
+	})()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/pkg/ddl/db_rename_test.go
+++ b/pkg/ddl/db_rename_test.go
@@ -34,10 +34,9 @@ import (
 // See issue: https://github.com/pingcap/tidb/issues/29752
 // Ref https://dev.mysql.com/doc/refman/8.0/en/rename-table.html
 func TestRenameTableWithLocked(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.EnableTableLock = true
-	})
+	})()
 
 	store := testkit.CreateMockStore(t, mockstore.WithDDLChecker())
 

--- a/pkg/ddl/tests/serial/serial_test.go
+++ b/pkg/ddl/tests/serial/serial_test.go
@@ -90,10 +90,9 @@ func TestChangeMaxIndexLength(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.MaxIndexLength = config.DefMaxOfMaxIndexLength
-	})
+	})()
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t (c1 varchar(3073), index(c1)) charset = ascii")
@@ -843,10 +842,9 @@ func TestTableLocksDisable(t *testing.T) {
 	tk.MustExec("create table t1 (a int)")
 
 	// Test for disable table lock config.
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.EnableTableLock = false
-	})
+	})()
 
 	tk.MustExec("lock tables t1 write")
 	tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1235 LOCK TABLES is not supported. To enable this experimental feature, set 'enable-table-lock' in the configuration file."))

--- a/pkg/executor/cluster_table_test.go
+++ b/pkg/executor/cluster_table_test.go
@@ -95,10 +95,9 @@ select 7;`
 	fileName3 := "tidb-slow-query-2020-02-17T18-00-05.01.log"
 	fileName4 := "tidb-slow-query.log"
 	fileNames := []string{fileName0, fileName1, fileName2, fileName3, fileName4}
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.SlowQueryFile = fileName4
-	})
+	})()
 
 	prepareLogs(t, logData, fileNames)
 	defer func() {
@@ -218,10 +217,9 @@ select 10;`
 	fileName2 := "tidb-slow-20236-2020-02-16T19-04-05.01.log"
 	fileName3 := "tidb-slow-20236-2020-02-17T18-00-05.01.log"
 	fileName4 := "tidb-slow-20236.log"
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.SlowQueryFile = fileName4
-	})
+	})()
 	for k := range 2 {
 		// k = 0 for normal files
 		// k = 1 for compressed files

--- a/pkg/executor/executor_failpoint_test.go
+++ b/pkg/executor/executor_failpoint_test.go
@@ -41,10 +41,9 @@ import (
 )
 
 func TestTiDBLastTxnInfoCommitMode(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = time.Second
-	})
+	})()
 
 	store := testkit.CreateMockStore(t)
 

--- a/pkg/executor/explain_test.go
+++ b/pkg/executor/explain_test.go
@@ -187,10 +187,9 @@ func checkActRows(t *testing.T, tk *testkit.TestKit, sql string, expected []stri
 }
 
 func TestCheckActRowsWithUnistore(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.EnableCollectExecutionInfo = true
-	})
+	})()
 	store := testkit.CreateMockStore(t)
 	// testSuite1 use default mockstore which is unistore
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/join/merge_join_test.go
+++ b/pkg/executor/join/merge_join_test.go
@@ -80,10 +80,9 @@ func TestShuffleMergeJoinInDisk(t *testing.T) {
 }
 
 func TestMergeJoinInDisk(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
-	})
+	})()
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/join/testMergeJoinRowContainerSpill", "return(true)"))
 	defer func() {

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -102,10 +102,9 @@ func mustExecDDL(tk *testkit.TestKit, t *testing.T, sql string, dom *domain.Doma
 }
 
 func TestMemCacheReadLock(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.EnableTableLock = true
-	})
+	})()
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -187,10 +186,9 @@ func TestMemCacheReadLock(t *testing.T) {
 }
 
 func TestPartitionMemCacheReadLock(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.EnableTableLock = true
-	})
+	})()
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/pkg/executor/slow_query_sql_test.go
+++ b/pkg/executor/slow_query_sql_test.go
@@ -183,10 +183,9 @@ func TestLogSlowLogIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.SlowQueryFile = f.Name()
-	})
+	})()
 	require.NoError(t, logutil.InitLogger(config.GetGlobalConfig().Log.ToLogConfig()))
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -393,10 +393,9 @@ select 7;`
 	fileName1 := "tidb-slow-retriever-2020-02-15T19-04-05.01.log"
 	fileName2 := "tidb-slow-retriever-2020-02-16T19-04-05.01.log"
 	fileName3 := "tidb-slow-retriever.log"
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.SlowQueryFile = fileName3
-	})
+	})()
 	for k := range 2 {
 		// k = 0 for normal files
 		// k = 1 for compressed files
@@ -662,10 +661,9 @@ select 9;`
 	fileName2 := "tidb-slow-reverse-scan-2020-02-16T19-04-05.01.log"
 	fileName3 := "tidb-slow-reverse-scan-2020-02-17T19-04-05.01.log"
 	fileName4 := "tidb-slow-reverse-scan.log"
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.SlowQueryFile = fileName4
-	})
+	})()
 	fileNames := []string{fileName0, fileName1, fileName2, fileName3, fileName4}
 	prepareLogs(t, logData, fileNames)
 	defer func() {

--- a/pkg/executor/sortexec/sort_test.go
+++ b/pkg/executor/sortexec/sort_test.go
@@ -38,12 +38,10 @@ func TestSortInDisk(t *testing.T) {
 
 // TODO remove failpoint
 func testSortInDisk(t *testing.T, removeDir bool) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill", "return(true)"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/executor/sortexec/testSortedRowContainerSpill"))
@@ -98,11 +96,10 @@ func testSortInDisk(t *testing.T, removeDir bool) {
 }
 
 func TestIssue16696(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	alarmRatio := vardef.MemoryUsageAlarmRatio.Load()
 	vardef.MemoryUsageAlarmRatio.Store(0.0)
 	defer vardef.MemoryUsageAlarmRatio.Store(alarmRatio)

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -351,10 +351,9 @@ func TestIndexJoin31494(t *testing.T) {
 
 // Details at https://github.com/pingcap/tidb/issues/31038
 func TestFix31038(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Instance.EnableCollectExecutionInfo.Store(false)
-	})
+	})()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/pkg/executor/test/seqtest/seq_executor_test.go
+++ b/pkg/executor/test/seqtest/seq_executor_test.go
@@ -1103,10 +1103,9 @@ func TestCoprocessorPriority(t *testing.T) {
 	// Insert some data to make sure plan build IndexLookup for t.
 	tk.MustExecWithContext(ctx, "insert into t values (1), (2)")
 
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.ExpensiveThreshold = 0
-	})
+	})()
 
 	cli.setCheckPriority(kvrpcpb.CommandPri_High)
 	tk.MustQueryWithContext(ctx, "select id from t where id = 1")

--- a/pkg/executor/test/simpletest/simple_test.go
+++ b/pkg/executor/test/simpletest/simple_test.go
@@ -554,10 +554,9 @@ func TestFlushPrivilegesPanic(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SkipGrantTable = true
-	})
+	})()
 
 	dom, err := session.BootstrapSession(store)
 	require.NoError(t, err)

--- a/pkg/infoschema/test/clustertablestest/tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/tables_test.go
@@ -596,10 +596,9 @@ func TestTableIfHasColumn(t *testing.T) {
 	columnName := variable.SlowLogHasMoreResults
 	store := testkit.CreateMockStore(t)
 	slowLogFileName := "tidb-table-has-column-slow.log"
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.SlowQueryFile = slowLogFileName
-	})
+	})()
 	f, err := os.OpenFile(slowLogFileName, os.O_CREATE|os.O_WRONLY, 0644)
 	require.NoError(t, err)
 	_, err = f.Write([]byte(`# Time: 2019-02-12T19:33:56.571953+08:00

--- a/pkg/planner/core/casetest/planstats/plan_stats_test.go
+++ b/pkg/planner/core/casetest/planstats/plan_stats_test.go
@@ -339,10 +339,9 @@ func TestPlanStatsLoadTimeout(t *testing.T) {
 }
 
 func TestPlanStatsStatusRecord(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/pkg/planner/core/integration_test.go
+++ b/pkg/planner/core/integration_test.go
@@ -64,10 +64,9 @@ func TestNoneAccessPathsFoundByIsolationRead(t *testing.T) {
 
 	tk.MustExec("set @@session.tidb_isolation_read_engines = 'tiflash, tikv'")
 	tk.MustExec("select * from t")
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.IsolationRead.Engines = []string{"tiflash"}
-	})
+	})()
 	// Change instance config doesn't affect isolation read.
 	tk.MustExec("select * from t")
 }
@@ -1134,10 +1133,9 @@ func TestHypoIndexHint(t *testing.T) {
 func TestIssue29503(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Status.RecordQPSbyDB = true
-	})
+	})()
 
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t;")

--- a/pkg/planner/core/logical_plan_trace_test.go
+++ b/pkg/planner/core/logical_plan_trace_test.go
@@ -396,12 +396,10 @@ func TestSingleRuleTraceStep(t *testing.T) {
 			},
 		},
 	}
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		// if true, test will too slow to run.
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	s := createPlannerSuite()
 	defer s.Close()
 	for i, tc := range tt {

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -1525,12 +1525,10 @@ func TestVisitInfo(t *testing.T) {
 			},
 		},
 	}
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		// if true, test will too slow to run.
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	s := createPlannerSuite()
 	defer s.Close()
 	for _, tt := range tests {
@@ -1651,12 +1649,10 @@ func TestUnion(t *testing.T) {
 }
 
 func TestTopNPushDown(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		// if true, test will too slow to run.
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	var input, output []string
 	planSuiteUnexportedData.LoadTestCases(t, &input, &output)
 	s := createPlannerSuite()
@@ -1739,12 +1735,10 @@ func TestNameResolver(t *testing.T) {
 }
 
 func TestOuterJoinEliminator(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		// if true, test will too slow to run.
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	var input, output []string
 	planSuiteUnexportedData.LoadTestCases(t, &input, &output)
 
@@ -1816,12 +1810,10 @@ type plannerSuiteWithOptimizeVars struct {
 }
 
 func TestWindowFunction(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		// if true, test will too slow to run.
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	s := new(plannerSuiteWithOptimizeVars)
 	s.plannerSuite = createPlannerSuite()
 	defer s.plannerSuite.Close()
@@ -1839,12 +1831,10 @@ func TestWindowFunction(t *testing.T) {
 }
 
 func TestWindowParallelFunction(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		// if true, test will too slow to run.
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	s := new(plannerSuiteWithOptimizeVars)
 	s.plannerSuite = createPlannerSuite()
 	defer s.plannerSuite.Close()

--- a/pkg/planner/core/runtime_filter_generator_test.go
+++ b/pkg/planner/core/runtime_filter_generator_test.go
@@ -35,10 +35,9 @@ func TestRuntimeFilterGenerator(t *testing.T) {
 	require.NoError(t, logutil.InitLogger(config.GetGlobalConfig().Log.ToLogConfig()))
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Log.Level = "debug"
-	})
+	})()
 
 	tk.MustExec("use test")
 	tk.MustExec("create table t1 (k1 int)")

--- a/pkg/server/tests/cursor/cursor_test.go
+++ b/pkg/server/tests/cursor/cursor_test.go
@@ -39,11 +39,9 @@ import (
 
 func TestCursorFetchErrorInFetch(t *testing.T) {
 	tmpStoragePath := t.TempDir()
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = tmpStoragePath
-	})
+	})()
 
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	srv := server2.CreateMockServer(t, store)
@@ -93,11 +91,9 @@ func TestCursorFetchErrorInFetch(t *testing.T) {
 }
 
 func TestCursorFetchShouldSpill(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
-	})
+	})()
 
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	srv := server2.CreateMockServer(t, store)

--- a/pkg/session/test/txn/txn_test.go
+++ b/pkg/session/test/txn/txn_test.go
@@ -229,10 +229,9 @@ func TestDisableTxnAutoRetry(t *testing.T) {
 	tk1.Session().ExecuteInternal(ctx, "commit")
 
 	// test for disable transaction local latch
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TxnLocalLatches.Enabled = false
-	})
+	})()
 	tk1.MustExec("begin")
 	tk1.MustExec("update no_retry set id = 9")
 

--- a/pkg/sessionctx/sessionstates/session_states_test.go
+++ b/pkg/sessionctx/sessionstates/session_states_test.go
@@ -1595,10 +1595,9 @@ func TestShowStateFail(t *testing.T) {
 		},
 	}
 
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.EnableTableLock = true
-	})
+	})()
 	for _, tt := range tests {
 		conn1 := server.CreateMockConn(t, sv)
 		conn1.Context().Session.GetSessionVars().User = nil

--- a/pkg/sessionctx/variable/session_test.go
+++ b/pkg/sessionctx/variable/session_test.go
@@ -329,10 +329,9 @@ func TestSlowLogFormat(t *testing.T) {
 }
 
 func TestIsolationRead(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.IsolationRead.Engines = []string{"tiflash", "tidb"}
-	})
+	})()
 	sessVars := variable.NewSessionVars(nil)
 	_, ok := sessVars.IsolationReadEngines[kv.TiDB]
 	require.True(t, ok)

--- a/pkg/statistics/handle/cache/bench_test.go
+++ b/pkg/statistics/handle/cache/bench_test.go
@@ -97,11 +97,9 @@ func benchGet(b *testing.B, c types.StatsCache) {
 }
 
 func BenchmarkStatsCacheLFUCopyAndUpdate(b *testing.B) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	cache, err := NewStatsCacheImplForTest()
 	if err != nil {
 		b.Fail()
@@ -110,11 +108,9 @@ func BenchmarkStatsCacheLFUCopyAndUpdate(b *testing.B) {
 }
 
 func BenchmarkStatsCacheMapCacheCopyAndUpdate(b *testing.B) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	cache, err := NewStatsCacheImplForTest()
 	if err != nil {
 		b.Fail()
@@ -123,11 +119,9 @@ func BenchmarkStatsCacheMapCacheCopyAndUpdate(b *testing.B) {
 }
 
 func BenchmarkLFUCachePutGet(b *testing.B) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	cache, err := NewStatsCacheImplForTest()
 	if err != nil {
 		b.Fail()
@@ -136,11 +130,9 @@ func BenchmarkLFUCachePutGet(b *testing.B) {
 }
 
 func BenchmarkMapCachePutGet(b *testing.B) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	cache, err := NewStatsCacheImplForTest()
 	if err != nil {
 		b.Fail()
@@ -149,11 +141,9 @@ func BenchmarkMapCachePutGet(b *testing.B) {
 }
 
 func BenchmarkLFUCacheGet(b *testing.B) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	cache, err := NewStatsCacheImplForTest()
 	if err != nil {
 		b.Fail()
@@ -162,11 +152,9 @@ func BenchmarkLFUCacheGet(b *testing.B) {
 }
 
 func BenchmarkMapCacheGet(b *testing.B) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = false
-	})
+	})()
 	cache, err := NewStatsCacheImplForTest()
 	if err != nil {
 		b.Fail()

--- a/pkg/statistics/handle/handletest/handle_test.go
+++ b/pkg/statistics/handle/handletest/handle_test.go
@@ -1260,11 +1260,9 @@ func TestRecordHistoricalStatsToStorage(t *testing.T) {
 
 func TestEvictedColumnLoadedStatus(t *testing.T) {
 	t.Skip("skip this test because it is useless")
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	dom.StatsHandle().SetLease(0)
 	tk := testkit.NewTestKit(t, store)

--- a/pkg/statistics/handle/handletest/initstats/load_stats_test.go
+++ b/pkg/statistics/handle/handletest/initstats/load_stats_test.go
@@ -28,11 +28,9 @@ import (
 )
 
 func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-	})
+	})()
 	handle.IsFullCacheFunc = func(cache types.StatsCache, total uint64) bool {
 		return true
 	}
@@ -40,11 +38,9 @@ func TestConcurrentlyInitStatsWithMemoryLimit(t *testing.T) {
 }
 
 func TestConcurrentlyInitStatsWithoutMemoryLimit(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-	})
+	})()
 	handle.IsFullCacheFunc = func(cache types.StatsCache, total uint64) bool {
 		return false
 	}
@@ -102,20 +98,16 @@ func testConcurrentlyInitStats(t *testing.T) {
 }
 
 func TestDropTableBeforeConcurrentlyInitStats(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-	})
+	})()
 	testDropTableBeforeInitStats(t)
 }
 
 func TestDropTableBeforeNonLiteInitStats(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.LiteInitStats = false
-	})
+	})()
 	testDropTableBeforeInitStats(t)
 }
 

--- a/pkg/statistics/handle/handletest/lockstats/lock_table_stats_test.go
+++ b/pkg/statistics/handle/handletest/lockstats/lock_table_stats_test.go
@@ -166,11 +166,9 @@ func TestLockTableAndUnlockTableStatsRepeatedly(t *testing.T) {
 }
 
 func TestLockAndUnlockTablesStats(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Performance.EnableStatsCacheMemQuota = true
-	})
+	})()
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set @@tidb_analyze_version = 1")

--- a/pkg/statistics/handle/handletest/statstest/stats_test.go
+++ b/pkg/statistics/handle/handletest/statstest/stats_test.go
@@ -233,26 +233,30 @@ func testInitStatsMemTrace(t *testing.T) {
 }
 
 func TestInitStatsMemTraceWithLite(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		// Restore to original config
+	})()
 	testInitStatsMemTraceFunc(t, true)
 }
 
 func TestInitStatsMemTraceWithoutLite(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		// Restore to original config
+	})()
 	testInitStatsMemTraceFunc(t, false)
 }
 
 func TestInitStatsMemTraceWithConcurrentLite(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		// Restore to original config
+	})()
 	testInitStatsMemTraceFunc(t, true)
 }
 
 func TestInitStatsMemTraceWithoutConcurrentLite(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		// Restore to original config
+	})()
 	testInitStatsMemTraceFunc(t, false)
 }
 

--- a/pkg/util/chunk/row_container_test.go
+++ b/pkg/util/chunk/row_container_test.go
@@ -336,11 +336,9 @@ func insertBytesRowsIntoRowContainer(t *testing.T, chkCount int, rowPerChk int) 
 }
 
 func TestRowContainerReaderInDisk(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
-	})
+	})()
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 16)
 	rc.SpillToDisk()
@@ -357,11 +355,9 @@ func TestRowContainerReaderInDisk(t *testing.T) {
 }
 
 func TestCloseRowContainerReader(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
-	})
+	})()
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 16)
 	rc.SpillToDisk()
@@ -384,11 +380,9 @@ func TestCloseRowContainerReader(t *testing.T) {
 }
 
 func TestConcurrentSpillWithRowContainerReader(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
-	})
+	})()
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 1024)
 
@@ -413,11 +407,9 @@ func TestConcurrentSpillWithRowContainerReader(t *testing.T) {
 }
 
 func TestReadAfterSpillWithRowContainerReader(t *testing.T) {
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = t.TempDir()
-	})
+	})()
 
 	rc, allRows := insertBytesRowsIntoRowContainer(t, 16, 1024)
 
@@ -564,11 +556,9 @@ func BenchmarkRowContainerReaderInDiskWithRowSize4096(b *testing.B) {
 func benchmarkRowContainerReaderInDiskWithRowLength(b *testing.B, rowLength int) {
 	b.StopTimer()
 
-	restore := config.RestoreFunc()
-	defer restore()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = b.TempDir()
-	})
+	})()
 
 	longVarCharTyp := types.NewFieldTypeBuilder().SetType(mysql.TypeVarchar).SetFlen(rowLength).Build()
 	fields := []*types.FieldType{&longVarCharTyp}

--- a/pkg/util/chunk/row_in_disk_test.go
+++ b/pkg/util/chunk/row_in_disk_test.go
@@ -287,82 +287,72 @@ func BenchmarkDataInDiskByRows_GetChunk(b *testing.B) {
 }
 
 func TestDataInDiskByRowsWithChecksum1(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodPlaintext
-	})
+	})()
 	testDataInDiskByRows(t, 1)
 }
 
 func TestDataInDiskByRowsWithChecksum2(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodPlaintext
-	})
+	})()
 	testDataInDiskByRows(t, 2)
 }
 
 func TestDataInDiskByRowsWithChecksum8(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodPlaintext
-	})
+	})()
 	testDataInDiskByRows(t, 8)
 }
 
 func TestDataInDiskByRowsWithChecksumReaderWithCache(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodPlaintext
-	})
+	})()
 	testReaderWithCache(t)
 }
 
 func TestDataInDiskByRowsWithChecksumReaderWithCacheNoFlush(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodPlaintext
-	})
+	})()
 	testReaderWithCacheNoFlush(t)
 }
 
 func TestDataInDiskByRowsWithChecksumAndEncrypt1(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodAES128CTR
-	})
+	})()
 	testDataInDiskByRows(t, 1)
 }
 
 func TestDataInDiskByRowsWithChecksumAndEncrypt2(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodAES128CTR
-	})
+	})()
 	testDataInDiskByRows(t, 2)
 }
 
 func TestDataInDiskByRowsWithChecksumAndEncrypt8(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodAES128CTR
-	})
+	})()
 	testDataInDiskByRows(t, 8)
 }
 
 func TestDataInDiskByRowsWithChecksumAndEncryptReaderWithCache(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodAES128CTR
-	})
+	})()
 	testReaderWithCache(t)
 }
 
 func TestDataInDiskByRowsWithChecksumAndEncryptReaderWithCacheNoFlush(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Security.SpilledFileEncryptionMethod = config.SpilledFileEncryptionMethodAES128CTR
-	})
+	})()
 	testReaderWithCacheNoFlush(t)
 }
 

--- a/pkg/util/disk/tempDir_test.go
+++ b/pkg/util/disk/tempDir_test.go
@@ -25,10 +25,9 @@ import (
 
 func TestRemoveDir(t *testing.T) {
 	path := t.TempDir()
-	defer config.RestoreFunc()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TempStoragePath = path
-	})
+	})()
 	err := os.RemoveAll(path) // clean the uncleared temp file during the last run.
 	require.NoError(t, err)
 	err = os.MkdirAll(path, 0755)

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -2155,7 +2155,7 @@ func TestAsyncCommitWithSchemaChange(t *testing.T) {
 	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = time.Second
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
-	})
+	})()
 	require.NoError(t, failpoint.Enable("tikvclient/asyncCommitDoNothing", "return"))
 	defer func() { require.NoError(t, failpoint.Disable("tikvclient/asyncCommitDoNothing")) }()
 

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -2105,11 +2105,10 @@ func TestSelectForUpdateWaitSeconds(t *testing.T) {
 }
 
 func TestSelectForUpdateConflictRetry(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = 500 * time.Millisecond
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
-	})
+	})()
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -2153,8 +2152,7 @@ func TestAsyncCommitWithSchemaChange(t *testing.T) {
 		t.Skip("This test is unstable as depending on time.Sleep")
 	}
 
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = time.Second
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
 	})
@@ -2336,11 +2334,10 @@ func TestPlanCacheSchemaChange(t *testing.T) {
 }
 
 func TestAsyncCommitCalTSFail(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = time.Second
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
-	})
+	})()
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 
@@ -2366,11 +2363,10 @@ func TestAsyncCommitCalTSFail(t *testing.T) {
 }
 
 func TestAsyncCommitAndForeignKey(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = time.Second
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
-	})
+	})()
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk := createAsyncCommitTestKit(t, store)
 	tk.MustExec("drop table if exists t_parent, t_child")

--- a/tests/realtikvtest/sessiontest/infoschema_v2_test.go
+++ b/tests/realtikvtest/sessiontest/infoschema_v2_test.go
@@ -30,10 +30,9 @@ import (
 )
 
 func TestGCOldVersion(t *testing.T) {
-	defer config.RestoreFunc()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.CoprCache.CapacityMB = 0
-	})
+	})()
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("set @@global.tidb_schema_cache_size = 512 * 1024 * 1024")

--- a/tests/realtikvtest/sessiontest/paging_test.go
+++ b/tests/realtikvtest/sessiontest/paging_test.go
@@ -29,10 +29,9 @@ import (
 
 func TestPagingActRowsAndProcessKeys(t *testing.T) {
 	// Close copr-cache
-	defer config.RestoreFunc()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.CoprCache.CapacityMB = 0
-	})
+	})()
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	session := testkit.NewTestKit(t, store)
@@ -104,10 +103,9 @@ func TestPagingActRowsAndProcessKeys(t *testing.T) {
 }
 
 func TestIndexReaderWithPaging(t *testing.T) {
-	defer config.RestoreFunc()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.CoprCache.CapacityMB = 0
-	})
+	})()
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test;")

--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -41,12 +41,11 @@ import (
 )
 
 func TestTxnScopeAndValidateReadTs(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.Labels = map[string]string{
 			"zone": "bj",
 		}
-	})
+	})()
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk := testkit.NewTestKit(t, store)

--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -1492,7 +1492,9 @@ func TestStaleReadNoBackoff(t *testing.T) {
 
 func TestStaleReadAllCombinations(t *testing.T) {
 	store := realtikvtest.CreateMockStoreAndSetup(t)
-	defer config.RestoreFunc()()
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		// Restore to original config
+	})()
 
 	tk := testkit.NewTestKit(t, store)
 

--- a/tests/realtikvtest/txntest/txn_test.go
+++ b/tests/realtikvtest/txntest/txn_test.go
@@ -360,11 +360,10 @@ func TestCheckTxnStatusOnOptimisticTxnBreakConsistency(t *testing.T) {
 	}
 
 	// Allow async commit
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = 500 * time.Millisecond
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
-	})
+	})()
 
 	// A helper function to determine whether a KV RPC request is handled on TiKV without RPC error or region error.
 	isRequestHandled := func(resp *tikvrpc.Response, err error) bool {
@@ -537,11 +536,10 @@ func TestCheckTxnStatusOnOptimisticTxnBreakConsistency(t *testing.T) {
 }
 
 func TestDMLWithAddForeignKey(t *testing.T) {
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = 10 * time.Second
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 500 * time.Millisecond
-	})
+	})()
 
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 	tk := testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB!

PR Title Format:
1. pkg/config: fix UpdateGlobal to return its restore function and add test
-->

### What problem does this PR solve?

Issue Number: close #61311

Problem Summary:  
The comment for `UpdateGlobal` says it “provides a restore function,” but the implementation didn’t return anything. This PR updates the function signature and body so that it now returns the restore closure as documented.

### What changed and how does it work?

- **config.go**  
  - Changed  
    ```go
    func UpdateGlobal(f func(conf *Config)) { … }
    ```  
    to  
    ```go
    func UpdateGlobal(f func(conf *Config)) (restore func()) { … }
    ```  
  - Return the restore function at the end of `UpdateGlobal`.

- **pkg/config/BUILD.bazel**  
  - Bump `shard_count` from 28 to 29 so the `go_test` shards stay balanced.

- **config_test.go**  
  - Add `TestUpdateGlobal` (with global-state save/restore scaffolding) to verify that `UpdateGlobal` actually returns a working restore function.

### Check List

Tests <!-- At least one of them must be included. -->
- [ ] No need to test
- [x] Unit tests added  
  > Added `TestUpdateGlobal` to exercise and verify the new restore closure.

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix UpdateGlobal to return its restore function as documented.
```