### PR TITLE
planner, executor: implement support for broadcasting queries

### DIFF
--- a/docs/design/2025-05-26-refresh-stats-command.md
+++ b/docs/design/2025-05-26-refresh-stats-command.md
@@ -170,7 +170,7 @@ func (e *SimpleExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 
 func (e *SimpleExec) executeRefreshStats(ctx context.Context, s *ast.RefreshStatsStmt) error {
 	if e.IsFromRemote {
-		// TODO: do the real init stats
+		// TODO: do the real refresh stats
 		return nil
 	}
 	return broadcast(ctx, e.Ctx(), s.Text())
@@ -206,7 +206,7 @@ func broadcast(ctx context.Context, sctx sessionctx.Context, sql string) error {
 	}
 
 	logutil.BgLogger().Info("Broadcast query", zap.String("sql", sql))
-	return err
+	return nil
 }
 ```
 

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -2781,7 +2781,7 @@ func broadcast(ctx context.Context, sctx sessionctx.Context, sql string) error {
 		return errors.Trace(err)
 	}
 
-	logutil.BgLogger().Info("Broadcast query", zap.String("sql", sql))
+	logutil.BgLogger().Info("Successfully broadcast query", zap.String("sql", sql))
 	return nil
 }
 

--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -55,6 +55,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
+	statslogutil "github.com/pingcap/tidb/pkg/statistics/handle/logutil"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
@@ -182,6 +183,8 @@ func (e *SimpleExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 		err = e.executeSetSessionStates(ctx, x)
 	case *ast.KillStmt:
 		err = e.executeKillStmt(ctx, x)
+	case *ast.RefreshStatsStmt:
+		err = e.executeRefreshStats(ctx, x)
 	case *ast.BinlogStmt:
 		// We just ignore it.
 		return nil
@@ -2723,6 +2726,63 @@ func killRemoteConn(ctx context.Context, sctx sessionctx.Context, gcid *globalco
 	logutil.BgLogger().Info("Killed remote connection", zap.Uint64("serverID", gcid.ServerID),
 		zap.Uint64("conn", gcid.ToConnID()), zap.Bool("query", query))
 	return err
+}
+
+func (e *SimpleExec) executeRefreshStats(ctx context.Context, s *ast.RefreshStatsStmt) error {
+	if e.IsFromRemote {
+		// TODO: do the real refresh stats
+		statslogutil.StatsLogger().Info("Refresh stats from remote", zap.String("sql", s.Text()))
+		return nil
+	}
+	return broadcast(ctx, e.Ctx(), s.Text())
+}
+
+func broadcast(ctx context.Context, sctx sessionctx.Context, sql string) error {
+	broadcastExec := &tipb.Executor{
+		Tp: tipb.ExecType_TypeBroadcastQuery,
+		BroadcastQuery: &tipb.BroadcastQuery{
+			Query: &sql,
+		},
+	}
+	dagReq := &tipb.DAGRequest{}
+	dagReq.TimeZoneName, dagReq.TimeZoneOffset = timeutil.Zone(sctx.GetSessionVars().Location())
+	sc := sctx.GetSessionVars().StmtCtx
+	if sc.RuntimeStatsColl != nil {
+		collExec := true
+		dagReq.CollectExecutionSummaries = &collExec
+	}
+	dagReq.Flags = sc.PushDownFlags()
+	dagReq.Executors = []*tipb.Executor{broadcastExec}
+
+	var builder distsql.RequestBuilder
+	kvReq, err := builder.
+		SetDAGRequest(dagReq).
+		SetFromSessionVars(sctx.GetDistSQLCtx()).
+		SetFromInfoSchema(sctx.GetInfoSchema()).
+		SetStoreType(kv.TiDB).
+		// Send to all TiDB instances.
+		SetTiDBServerID(0).
+		SetStartTS(math.MaxUint64).
+		Build()
+	if err != nil {
+		return err
+	}
+	resp := sctx.GetClient().Send(ctx, kvReq, sctx.GetSessionVars().KVVars, &kv.ClientSendOption{})
+	if resp == nil {
+		err := errors.New("client returns nil response")
+		return err
+	}
+
+	// Must consume & close the response, otherwise coprocessor task will leak.
+	defer func() {
+		_ = resp.Close()
+	}()
+	if _, err := resp.Next(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
+	logutil.BgLogger().Info("Broadcast query", zap.String("sql", sql))
+	return nil
 }
 
 func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -524,6 +524,8 @@ func (b *PlanBuilder) Build(ctx context.Context, node *resolve.NodeW) (base.Plan
 		return b.buildLoadData(ctx, x)
 	case *ast.LoadStatsStmt:
 		return b.buildLoadStats(x), nil
+	case *ast.RefreshStatsStmt:
+		return b.buildRefreshStats(x), nil
 	case *ast.LockStatsStmt:
 		return b.buildLockStats(x), nil
 	case *ast.UnlockStatsStmt:
@@ -4764,6 +4766,16 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 
 func (*PlanBuilder) buildLoadStats(ld *ast.LoadStatsStmt) base.Plan {
 	p := &LoadStats{Path: ld.Path}
+	return p
+}
+
+func (b *PlanBuilder) buildRefreshStats(ld *ast.RefreshStatsStmt) base.Plan {
+	// TODO: We need to check the select privilege here.
+	p := &Simple{
+		Statement:    ld,
+		IsFromRemote: false,
+		ResolveCtx:   b.resolveCtx,
+	}
 	return p
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4769,10 +4769,10 @@ func (*PlanBuilder) buildLoadStats(ld *ast.LoadStatsStmt) base.Plan {
 	return p
 }
 
-func (b *PlanBuilder) buildRefreshStats(ld *ast.RefreshStatsStmt) base.Plan {
+func (b *PlanBuilder) buildRefreshStats(rs *ast.RefreshStatsStmt) base.Plan {
 	// TODO: We need to check the select privilege here.
 	p := &Simple{
-		Statement:    ld,
+		Statement:    rs,
 		IsFromRemote: false,
 		ResolveCtx:   b.resolveCtx,
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61273

Problem Summary:

### What changed and how does it work?

In this PR, I added a basic framework for distributing SQL queries to different TiDB nodes. I also used a simple log to simulate the real refresh stats. I will add the actual code in my subsequent updates.

I tested it locally, and it can distribute the correct SQL to different TiDB nodes. The core idea is that we need to use the coprocessor to send tasks to each TiDB cluster and execute them correctly.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/61380#issuecomment-2944086220)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
