### PR TITLE
expression: refine code in `IsPushDownEnabled`

### DIFF
--- a/pkg/executor/aggfuncs/BUILD.bazel
+++ b/pkg/executor/aggfuncs/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
     deps = [
         "//pkg/expression",
         "//pkg/expression/aggregation",
+        "//pkg/kv",
         "//pkg/parser/ast",
         "//pkg/parser/charset",
         "//pkg/parser/mysql",

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -239,6 +239,11 @@ func CheckAggPushDown(ctx expression.EvalContext, aggFunc *AggFuncDesc, storeTyp
 	if aggFunc.Name == ast.AggFuncApproxPercentile {
 		return false
 	}
+	if storeType != kv.TiFlash && aggFunc.Name == ast.AggFuncApproxCountDistinct {
+		// Can not push down approx_count_distinct to other store except tiflash by now.
+		return false
+	}
+
 	if !checkVectorAggPushDown(ctx, aggFunc) {
 		return false
 	}
@@ -251,7 +256,8 @@ func CheckAggPushDown(ctx expression.EvalContext, aggFunc *AggFuncDesc, storeTyp
 		ret = aggFunc.Name != ast.AggFuncGroupConcat
 	}
 	if ret {
-		ret = expression.IsPushDownEnabled(strings.ToLower(aggFunc.Name), storeType)
+		// don't need to call strings.ToLower because it is ensured by newBaseFuncDesc that aggFunc.Name is already in lower case.
+		ret = expression.IsPushDownEnabled(aggFunc.Name, storeType)
 	}
 	return ret
 }

--- a/pkg/expression/aggregation/aggregation.go
+++ b/pkg/expression/aggregation/aggregation.go
@@ -16,7 +16,6 @@ package aggregation
 
 import (
 	"bytes"
-	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/executor/aggregate"
+	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"

--- a/pkg/expression/expr_to_pb_test.go
+++ b/pkg/expression/expr_to_pb_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/pkg/executor/aggregate"
-	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"

--- a/pkg/expression/infer_pushdown.go
+++ b/pkg/expression/infer_pushdown.go
@@ -449,11 +449,6 @@ func IsPushDownEnabled(name string, storeType kv.StoreType) bool {
 		return !(value&mask == mask)
 	}
 
-	if storeType != kv.TiFlash && name == ast.AggFuncApproxCountDistinct {
-		// Can not push down approx_count_distinct to other store except tiflash by now.
-		return false
-	}
-
 	return true
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61375

Problem Summary:

In current implementation, `IsPushDownEnabled` explicitly check `AggFuncApproxCountDistinct`:
https://github.com/pingcap/tidb/blob/eeccd2e94c23df353ba70919691d65d38ad31805/pkg/expression/infer_pushdown.go#L452-L1455

Actually, this check can be moved to `CheckAggPushDown`

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
