### PR TITLE
*: Set keyspace_name const labels for client-go related metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -324,7 +324,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(KVApplyBatchSize)
 	prometheus.MustRegister(KVApplyRegionFiles)
 
-	tikvmetrics.InitMetrics(TiDB, TiKVClient)
+	tikvmetrics.InitMetricsWithConstLabels(TiDB, TiKVClient, GetConstLabels())
 	tikvmetrics.RegisterMetrics()
 	tikvmetrics.TiKVPanicCounter = PanicCounter // reset tidb metrics for tikv metrics
 }

--- a/pkg/metrics/wrapper.go
+++ b/pkg/metrics/wrapper.go
@@ -23,6 +23,11 @@ import (
 
 var constLabels prometheus.Labels
 
+// GetConstLabels returns constant labels for metrics.
+func GetConstLabels() prometheus.Labels {
+	return constLabels
+}
+
 // SetConstLabels sets constant labels for metrics.
 func SetConstLabels(kv ...string) {
 	if len(kv)%2 == 1 {

--- a/pkg/util/metricsutil/common.go
+++ b/pkg/util/metricsutil/common.go
@@ -71,7 +71,7 @@ func RegisterMetrics() error {
 		CAPath:   cfg.Security.ClusterSSLCA,
 		CertPath: cfg.Security.ClusterSSLCert,
 		KeyPath:  cfg.Security.ClusterSSLKey,
-	}, opt.WithCustomTimeoutOption(timeoutSec))
+	}, opt.WithCustomTimeoutOption(timeoutSec), opt.WithMetricsLabels(metrics.GetConstLabels()))
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func RegisterMetricsForBR(pdAddrs []string, tls task.TLSConfig, keyspaceName str
 		securityOpt = tls.ToPDSecurityOption()
 	}
 	pdCli, err := pd.NewClient(componentName, pdAddrs, securityOpt,
-		opt.WithCustomTimeoutOption(timeoutSec))
+		opt.WithCustomTimeoutOption(timeoutSec), opt.WithMetricsLabels(metrics.GetConstLabels()))
 	if err != nil {
 		return err
 	}

--- a/pkg/util/metricsutil/common.go
+++ b/pkg/util/metricsutil/common.go
@@ -66,6 +66,7 @@ func RegisterMetrics() error {
 	}
 
 	timeoutSec := time.Duration(cfg.PDClient.PDServerTimeout) * time.Second
+	// Note: for NextGen, pdCli is created to init the metrics' const labels
 	pdCli, err := pd.NewClient(componentName, pdAddrs, pd.SecurityOption{
 		CAPath:   cfg.Security.ClusterSSLCA,
 		CertPath: cfg.Security.ClusterSSLCert,
@@ -104,6 +105,7 @@ func RegisterMetricsForBR(pdAddrs []string, tls task.TLSConfig, keyspaceName str
 	if tls.IsEnabled() {
 		securityOpt = tls.ToPDSecurityOption()
 	}
+	// Note: for NextGen, pdCli is created to init the metrics' const labels
 	pdCli, err := pd.NewClient(componentName, pdAddrs, securityOpt,
 		opt.WithCustomTimeoutOption(timeoutSec), opt.WithMetricsLabels(metrics.GetConstLabels()))
 	if err != nil {

--- a/pkg/util/metricsutil/common.go
+++ b/pkg/util/metricsutil/common.go
@@ -66,7 +66,7 @@ func RegisterMetrics() error {
 	}
 
 	timeoutSec := time.Duration(cfg.PDClient.PDServerTimeout) * time.Second
-	// Note: for NextGen, pdCli is created to init the metrics' const labels
+	// Note: for NextGen, we need to use the side effect of `NewClient` to init the metrics' builtin const labels
 	pdCli, err := pd.NewClient(componentName, pdAddrs, pd.SecurityOption{
 		CAPath:   cfg.Security.ClusterSSLCA,
 		CertPath: cfg.Security.ClusterSSLCert,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60864 

Problem Summary:

### What changed and how does it work?
In this PR, init tikv_client and pd_client metrics with keyspace_name const labels. Note, pd client uses init-only-once mechanism to init metrics, thus create a temporary pd client for this usage.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Hack code to set const labels manually, and verify the metrics got from http API.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
