### PR TITLE
domain: log warning when killing auto analyze processes that exceed the time window

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -482,8 +482,8 @@ func (do *Domain) CheckAutoAnalyzeWindows() {
 			statslogutil.StatsLogger().Warn("Kill auto analyze process because it exceeded the window",
 				zap.Uint64("processID", id),
 				zap.Time("now", time.Now()),
-				zap.Time("start", start),
-				zap.Time("end", end),
+				zap.String("start", start),
+				zap.String("end", end),
 			)
 			do.SysProcTracker().KillSysProcess(id)
 		}

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -476,9 +476,15 @@ func (do *Domain) CheckAutoAnalyzeWindows() {
 	// Make sure the session is new.
 	sctx := se.(sessionctx.Context)
 	defer do.sysSessionPool.Put(se)
-	if !autoanalyze.CheckAutoAnalyzeWindow(sctx) {
+	start, end, ok := autoanalyze.CheckAutoAnalyzeWindow(sctx)
+	if !ok {
 		for _, id := range handleutil.GlobalAutoAnalyzeProcessList.All() {
-			statslogutil.StatsLogger().Warn("Kill auto analyze process because it exceeded the window", zap.Uint64("processID", id))
+			statslogutil.StatsLogger().Warn("Kill auto analyze process because it exceeded the window",
+				zap.Uint64("processID", id),
+				zap.Time("now", time.Now()),
+				zap.Time("start", start),
+				zap.Time("end", end),
+			)
 			do.SysProcTracker().KillSysProcess(id)
 		}
 	}

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -478,6 +478,7 @@ func (do *Domain) CheckAutoAnalyzeWindows() {
 	defer do.sysSessionPool.Put(se)
 	if !autoanalyze.CheckAutoAnalyzeWindow(sctx) {
 		for _, id := range handleutil.GlobalAutoAnalyzeProcessList.All() {
+			statslogutil.StatsLogger().Warn("Kill auto analyze process because it exceeded the window", zap.Uint64("processID", id))
 			do.SysProcTracker().KillSysProcess(id)
 		}
 	}

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -375,10 +375,10 @@ func (sa *statsAnalyze) Close() {
 
 // CheckAutoAnalyzeWindow determine the time window for auto-analysis and verify if the current time falls within this range.
 // parameters is a map of auto analyze parameters. it is from GetAutoAnalyzeParameters.
-func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (start, end time.Time, ok bool) {
+func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (string, string, bool) {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
-	start, end, ok = checkAutoAnalyzeWindow(parameters)
-	return
+	start, end, ok := checkAutoAnalyzeWindow(parameters)
+	return start.Format("15:04"), end.Format("15:04"), ok
 }
 
 func checkAutoAnalyzeWindow(parameters map[string]string) (_, _ time.Time, _ bool) {

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -375,10 +375,10 @@ func (sa *statsAnalyze) Close() {
 
 // CheckAutoAnalyzeWindow determine the time window for auto-analysis and verify if the current time falls within this range.
 // parameters is a map of auto analyze parameters. it is from GetAutoAnalyzeParameters.
-func CheckAutoAnalyzeWindow(sctx sessionctx.Context) bool {
+func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (start, end time.Time, ok bool) {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
-	_, _, ok := checkAutoAnalyzeWindow(parameters)
-	return ok
+	start, end, ok = checkAutoAnalyzeWindow(parameters)
+	return
 }
 
 func checkAutoAnalyzeWindow(parameters map[string]string) (_, _ time.Time, _ bool) {

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -375,10 +375,12 @@ func (sa *statsAnalyze) Close() {
 
 // CheckAutoAnalyzeWindow determine the time window for auto-analysis and verify if the current time falls within this range.
 // parameters is a map of auto analyze parameters. it is from GetAutoAnalyzeParameters.
-func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (string, string, bool) {
+func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (startStr, endStr string, ok bool) {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
 	start, end, ok := checkAutoAnalyzeWindow(parameters)
-	return start.Format("15:04"), end.Format("15:04"), ok
+	startStr = start.Format("15:04")
+	endStr = end.Format("15:04")
+	return
 }
 
 func checkAutoAnalyzeWindow(parameters map[string]string) (_, _ time.Time, _ bool) {

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -374,7 +374,6 @@ func (sa *statsAnalyze) Close() {
 }
 
 // CheckAutoAnalyzeWindow determine the time window for auto-analysis and verify if the current time falls within this range.
-// parameters is a map of auto analyze parameters. it is from GetAutoAnalyzeParameters.
 func CheckAutoAnalyzeWindow(sctx sessionctx.Context) (startStr, endStr string, ok bool) {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
 	start, end, ok := checkAutoAnalyzeWindow(parameters)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/59939

Problem Summary:

### What changed and how does it work?

We should provide more information before we conduct the process of killing. Otherwise, it is very difficult to know if it is an active kill or if it was caused by other reasons.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/61434#issuecomment-3106520404)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
在 auto-analyze 被 kill 的时候打印日志
Print logs when auto-analyze is killed
```
