### PR TITLE
executor: fix INSERT IGNORE + STRICT Mode + DST transition.

### DIFF
--- a/pkg/executor/insert_common.go
+++ b/pkg/executor/insert_common.go
@@ -325,7 +325,8 @@ func (e *InsertValues) handleErr(col *table.Column, val *types.Datum, rowIdx int
 	if col != nil && col.GetType() == mysql.TypeTimestamp &&
 		types.ErrTimestampInDSTTransition.Equal(err) {
 		newErr := exeerrors.ErrTruncateWrongInsertValue.FastGenByArgs(types.TypeStr(col.GetType()), val.GetString(), col.Name.O, rowIdx+1)
-		if e.Ctx().GetSessionVars().SQLMode.HasStrictMode() {
+		// IGNORE takes precedence over STRICT mode.
+		if !e.ignoreErr && e.Ctx().GetSessionVars().SQLMode.HasStrictMode() {
 			return newErr
 		}
 		// timestamp already adjusted to end of DST transition, convert error to warning

--- a/tests/integrationtest/r/executor/insert.result
+++ b/tests/integrationtest/r/executor/insert.result
@@ -2424,3 +2424,27 @@ id	ts	mode
 DROP TABLE t;
 SET @@time_zone = @old_time_zone;
 SET @@sql_mode = @old_sql_mode;
+SET @old_time_zone = @@time_zone;
+SET @@time_zone = 'Europe/Amsterdam';
+SET @old_sql_mode = @@sql_mode;
+create table t (ts timestamp);
+set time_zone = 'Europe/Amsterdam';
+set sql_mode = 'strict_trans_tables,no_zero_date,no_zero_in_date,error_for_division_by_zero';
+insert into t values ('2025-03-30 02:00:00');
+Error 1292 (22007): Incorrect timestamp value: '2025-03-30 02:00:00' for column 'ts' at row 1
+select * from t;
+ts
+insert ignore into t values ('2025-03-30 02:00:00');
+Level	Code	Message
+Warning	1292	Incorrect timestamp value: '2025-03-30 02:00:00' for column 'ts' at row 1
+show warnings;
+Level	Code	Message
+Warning	1292	Incorrect timestamp value: '2025-03-30 02:00:00' for column 'ts' at row 1
+Level	Code	Message
+Warning	1292	Incorrect timestamp value: '2025-03-30 02:00:00' for column 'ts' at row 1
+select * from t;
+ts
+2025-03-30 03:00:00
+DROP TABLE t;
+SET @@time_zone = @old_time_zone;
+SET @@sql_mode = @old_sql_mode;

--- a/tests/integrationtest/t/executor/insert.test
+++ b/tests/integrationtest/t/executor/insert.test
@@ -1765,3 +1765,21 @@ SELECT * FROM t ORDER BY id;
 DROP TABLE t;
 SET @@time_zone = @old_time_zone;
 SET @@sql_mode = @old_sql_mode;
+
+# Testing INSERT IGNORE with STRICT mode, #61439
+SET @old_time_zone = @@time_zone;
+SET @@time_zone = 'Europe/Amsterdam';
+SET @old_sql_mode = @@sql_mode;
+create table t (ts timestamp);
+set time_zone = 'Europe/Amsterdam';
+set sql_mode = 'strict_trans_tables,no_zero_date,no_zero_in_date,error_for_division_by_zero';
+--error 1292
+insert into t values ('2025-03-30 02:00:00');
+select * from t;
+insert ignore into t values ('2025-03-30 02:00:00');
+show warnings;
+select * from t;
+DROP TABLE t;
+SET @@time_zone = @old_time_zone;
+SET @@sql_mode = @old_sql_mode;
+--disable_warnings


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61439

Problem Summary:
In #61337 there was a missed case, where INSERT IGNORE and STRICT mode was combined, which resulted in not inserting a row, when it should have been adjusted and inserted.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When a non-existing timestamp during DST transition is used in INSERT IGNORE with STRICT sql_mode, it is now adjusted to next valid timestamp and inserted with a warning, instead of skipped or set to '0000-00-00'.
```
