### PR TITLE
planner,range: simple the code for sorting the pointers

### DIFF
--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -694,7 +694,6 @@ func (r *builder) buildFromIn(
 		endPoint := &point{value: endValue}
 		rangePoints = append(rangePoints, startPoint, endPoint)
 	}
-	//sorter := pointSorter{points: rangePoints, tc: tc, collator: }
 	collator := collate.GetCollator(colCollate)
 	slices.SortFunc(rangePoints, func(a, b *point) (cmpare int) {
 		cmpare, r.err = rangePointLess(tc, a, b, collator)

--- a/pkg/util/ranger/points.go
+++ b/pkg/util/ranger/points.go
@@ -87,7 +87,7 @@ func rangePointLess(tc types.Context, a, b *point, collator collate.Collator) (i
 	if cmp != 0 {
 		return cmp, nil
 	}
-	return boolToInt(rangePointEqualValueLess(a, b)), errors.Trace(err)
+	return rangePointEqualValueLess(a, b), errors.Trace(err)
 }
 
 func rangePointEnumLess(a, b *point) (int, error) {
@@ -95,25 +95,24 @@ func rangePointEnumLess(a, b *point) (int, error) {
 	if cmp != 0 {
 		return cmp, nil
 	}
-	return boolToInt(rangePointEqualValueLess(a, b)), nil
+	return rangePointEqualValueLess(a, b), nil
 }
 
-func boolToInt(b bool) int {
-	if b {
-		return 1
+func rangePointEqualValueLess(a, b *point) int {
+	var result bool
+	if a.start && b.start {
+		result = !a.excl && b.excl
+	} else if a.start {
+		result = !a.excl && !b.excl
+	} else if b.start {
+		result = a.excl || b.excl
+	} else {
+		result = a.excl && !b.excl
+	}
+	if result {
+		return -1
 	}
 	return 0
-}
-
-func rangePointEqualValueLess(a, b *point) bool {
-	if a.start && b.start {
-		return !a.excl && b.excl
-	} else if a.start {
-		return !a.excl && !b.excl
-	} else if b.start {
-		return a.excl || b.excl
-	}
-	return a.excl && !b.excl
 }
 
 func pointsConvertToSortKey(sctx *rangerctx.RangerContext, inputPs []*point, newTp *types.FieldType) ([]*point, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61458

Problem Summary:

### What changed and how does it work?
Using `slices.SortFunc` has many advantages

- avoid the boundary check
- simple the code

it can make sort quicker.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
before
BenchmarkDetachCondAndBuildRangeForIndex-8   	    6349	    216681 ns/op

after 
BenchmarkDetachCondAndBuildRangeForIndex-8   	    6542	    205847 ns/op
```

improve the performance 4.99%


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
