### PR TITLE
br: replace stats tables update

### DIFF
--- a/br/pkg/restore/internal/prealloc_table_id/alloc.go
+++ b/br/pkg/restore/internal/prealloc_table_id/alloc.go
@@ -200,7 +200,7 @@ func (p *PreallocIDs) PreallocIDs(m Allocator) error {
 	return nil
 }
 
-func (p *PreallocIDs) allocID(originalID int64) (int64, error) {
+func (p *PreallocIDs) AllocID(originalID int64) (int64, error) {
 	if p.unallocedIDs != nil {
 		return 0, errors.Errorf("table ID %d is not allocated yet", originalID)
 	}
@@ -217,7 +217,7 @@ func (p *PreallocIDs) RewriteTableInfo(info *model.TableInfo) (*model.TableInfo,
 	}
 	infoCopy := info.Clone()
 
-	newID, err := p.allocID(info.ID)
+	newID, err := p.AllocID(info.ID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to allocate table ID for %d", info.ID)
 	}
@@ -226,7 +226,7 @@ func (p *PreallocIDs) RewriteTableInfo(info *model.TableInfo) (*model.TableInfo,
 	if infoCopy.Partition != nil {
 		for i := range infoCopy.Partition.Definitions {
 			def := &infoCopy.Partition.Definitions[i]
-			newPartID, err := p.allocID(def.ID)
+			newPartID, err := p.AllocID(def.ID)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to allocate partition ID for %d", def.ID)
 			}

--- a/br/pkg/restore/snap_client/client.go
+++ b/br/pkg/restore/snap_client/client.go
@@ -58,6 +58,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	tidbutil "github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/redact"
@@ -163,6 +164,8 @@ type SnapClient struct {
 
 	checkpointChecksum map[int64]*checkpoint.ChecksumItem
 
+	temporarySystemTablesRenamed bool
+
 	// restoreUUID is the UUID of this restore.
 	// restore from a checkpoint inherits the same restoreUUID.
 	restoreUUID uuid.UUID
@@ -229,6 +232,24 @@ func (rc *SnapClient) SetRateLimit(rateLimit uint64) {
 
 func (rc *SnapClient) SetCrypter(crypter *backuppb.CipherInfo) {
 	rc.cipher = crypter
+}
+
+func (rc *SnapClient) CleanTablesIfTemporarySystemTablesRenamed(loadStatsPhysical, loadSysTablePhysical bool, tables []*metautil.Table) []*metautil.Table {
+	if !rc.temporarySystemTablesRenamed {
+		return tables
+	}
+	newTables := make([]*metautil.Table, 0, len(tables))
+	temporaryTableChecker := &TemporaryTableChecker{
+		loadStatsPhysical:    loadStatsPhysical,
+		loadSysTablePhysical: loadSysTablePhysical,
+	}
+	for _, table := range tables {
+		if _, ok := temporaryTableChecker.CheckTemporaryTables(table.DB.Name.O, table.Info.Name.O); ok {
+			continue
+		}
+		newTables = append(newTables, table)
+	}
+	return newTables
 }
 
 // GetClusterID gets the cluster id from down-stream cluster.
@@ -327,9 +348,15 @@ func getMinUserTableID(tables []*metautil.Table) int64 {
 // AllocTableIDs would pre-allocate the table's origin ID if exists, so that the TiKV doesn't need to rewrite the key in
 // the download stage.
 // It returns whether any user table ID is not reused when need check.
-func (rc *SnapClient) AllocTableIDs(ctx context.Context, tables []*metautil.Table, checkUserTableIDReused bool, reusePreallocIDs *checkpoint.PreallocIDs) (bool, error) {
+func (rc *SnapClient) AllocTableIDs(
+	ctx context.Context,
+	tables []*metautil.Table,
+	loadStatsPhysical, loadSysTablePhysical bool,
+	reusePreallocIDs *checkpoint.PreallocIDs,
+) (bool, error) {
 	var preallocedTableIDs *tidalloc.PreallocIDs
 	var err error
+	var userTableIDNotReusedWhenNeedCheck bool = false
 	if reusePreallocIDs == nil {
 		ctx = kv.WithInternalSourceType(ctx, kv.InternalTxnBR)
 		err := kv.RunInNewTxn(ctx, rc.GetDomain().Store(), true, func(_ context.Context, txn kv.Transaction) error {
@@ -345,12 +372,32 @@ func (rc *SnapClient) AllocTableIDs(ctx context.Context, tables []*metautil.Tabl
 			return false, errors.Trace(err)
 		}
 	}
-	userTableIDNotReusedWhenNeedCheck := false
-	if checkUserTableIDReused {
+	if loadStatsPhysical {
 		minUserTableID := getMinUserTableID(tables)
 		start, _ := preallocedTableIDs.GetIDRange()
 		if minUserTableID != int64(math.MaxInt64) && minUserTableID < start {
 			userTableIDNotReusedWhenNeedCheck = true
+			loadStatsPhysical = false
+		}
+	}
+	if reusePreallocIDs != nil && (loadStatsPhysical || loadSysTablePhysical) {
+		temporaryTableChecker := &TemporaryTableChecker{
+			loadStatsPhysical:    loadStatsPhysical,
+			loadSysTablePhysical: loadSysTablePhysical,
+		}
+		for _, table := range tables {
+			if dbName, ok := temporaryTableChecker.CheckTemporaryTables(table.DB.Name.O, table.Info.Name.O); ok {
+				downstreamId, err := preallocedTableIDs.AllocID(table.Info.ID)
+				if err != nil {
+					return false, errors.Trace(err)
+				}
+				if tableInfo, err := rc.dom.InfoSchema().TableInfoByName(ast.NewCIStr(dbName), table.Info.Name); err == nil {
+					if tableInfo.ID == downstreamId {
+						rc.temporarySystemTablesRenamed = true
+					}
+					break
+				}
+			}
 		}
 	}
 

--- a/br/pkg/restore/snap_client/client_test.go
+++ b/br/pkg/restore/snap_client/client_test.go
@@ -16,6 +16,8 @@ package snapclient_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"slices"
@@ -28,6 +30,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/br/pkg/checkpoint"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/gluetidb"
 	"github.com/pingcap/tidb/br/pkg/metautil"
@@ -42,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -397,6 +401,10 @@ func createTestTable(schemaID, tableID int64) *metautil.Table {
 }
 
 func generateMetautilTable(dbName string, tableID int64, partitionIDs ...int64) *metautil.Table {
+	return generateMetautilTableWithName(dbName, "", tableID, partitionIDs...)
+}
+
+func generateMetautilTableWithName(dbName string, tableName string, tableID int64, partitionIDs ...int64) *metautil.Table {
 	var partition *model.PartitionInfo
 	if len(partitionIDs) > 0 {
 		partition = &model.PartitionInfo{
@@ -414,6 +422,7 @@ func generateMetautilTable(dbName string, tableID int64, partitionIDs ...int64) 
 		},
 		Info: &model.TableInfo{
 			ID:        tableID,
+			Name:      ast.NewCIStr(tableName),
 			Partition: partition,
 		},
 	}
@@ -442,7 +451,7 @@ func TestAllocTableIDs(t *testing.T) {
 		generateMetautilTable("__TiDB_BR_Temporary_mysql", globalID-2),
 		generateMetautilTable("mysql", globalID-3),
 		generateMetautilTable("__TiDB_BR_Temporary_mysql", globalID-4),
-	}, true, nil)
+	}, true, false, nil)
 	require.NoError(t, err)
 	require.False(t, userTableIDNotReusedWhenNeedCheck)
 	err = kv.RunInNewTxn(ctx, cluster.Storage, true, func(_ context.Context, txn kv.Transaction) error {
@@ -454,7 +463,7 @@ func TestAllocTableIDs(t *testing.T) {
 	userTableIDNotReusedWhenNeedCheck, err = client.AllocTableIDs(ctx, []*metautil.Table{
 		generateMetautilTable("mysql", globalID-1, globalID+1),
 		generateMetautilTable("test", globalID+2, globalID+3),
-	}, true, nil)
+	}, true, false, nil)
 	require.NoError(t, err)
 	require.False(t, userTableIDNotReusedWhenNeedCheck)
 	err = kv.RunInNewTxn(ctx, cluster.Storage, true, func(_ context.Context, txn kv.Transaction) error {
@@ -467,9 +476,95 @@ func TestAllocTableIDs(t *testing.T) {
 		generateMetautilTable("mysql", globalID-1, globalID+1),
 		generateMetautilTable("test", globalID+2, globalID),
 		generateMetautilTable("test2", globalID+3, globalID+4),
-	}, true, nil)
+	}, true, false, nil)
 	require.NoError(t, err)
 	require.True(t, userTableIDNotReusedWhenNeedCheck)
+
+	tableInfo, err := cluster.Domain.InfoSchema().TableInfoByName(ast.NewCIStr("mysql"), ast.NewCIStr("user"))
+	require.NoError(t, err)
+	userDownstreamTableID := tableInfo.ID
+	tables := []*metautil.Table{
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "user", userDownstreamTableID),
+		generateMetautilTableWithName("test", "user", 100),
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "test", 200),
+		generateMetautilTableWithName("mysql", "test", 300),
+	}
+	userTableIDNotReusedWhenNeedCheck, err = client.AllocTableIDs(ctx, tables, false, true, &checkpoint.PreallocIDs{
+		Start:          1,
+		ReusableBorder: 10000,
+		End:            20000,
+		Hash:           computeIDsHash([]int64{userDownstreamTableID, 100, 200, 300}),
+	})
+	require.NoError(t, err)
+	newTables := client.CleanTablesIfTemporarySystemTablesRenamed(false, true, tables)
+	require.True(t, mustNoTable(newTables, "mysql", "user"))
+	require.Len(t, newTables, 3)
+
+	tableInfo, err = cluster.Domain.InfoSchema().TableInfoByName(ast.NewCIStr("mysql"), ast.NewCIStr("stats_meta"))
+	require.NoError(t, err)
+	statsMetaDownstreamTableID := tableInfo.ID
+	tables = []*metautil.Table{
+		generateMetautilTableWithName("test", "stats_meta", 100),
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "stats_meta", statsMetaDownstreamTableID),
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "test", 200),
+		generateMetautilTableWithName("mysql", "test", 300),
+	}
+	userTableIDNotReusedWhenNeedCheck, err = client.AllocTableIDs(ctx, tables, true, false, &checkpoint.PreallocIDs{
+		Start:          1,
+		ReusableBorder: 10000,
+		End:            20000,
+		Hash:           computeIDsHash([]int64{statsMetaDownstreamTableID, 100, 200, 300}),
+	})
+	require.NoError(t, err)
+	newTables = client.CleanTablesIfTemporarySystemTablesRenamed(true, false, tables)
+	require.True(t, mustNoTable(newTables, "mysql", "stats_meta"))
+	require.Len(t, newTables, 3)
+
+	tables = []*metautil.Table{
+		generateMetautilTableWithName("test", "stats_meta", 100),
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "stats_meta", statsMetaDownstreamTableID),
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "test", 200),
+		generateMetautilTableWithName("__TiDB_BR_Temporary_mysql", "user", userDownstreamTableID),
+		generateMetautilTableWithName("mysql", "test", 300),
+	}
+	userTableIDNotReusedWhenNeedCheck, err = client.AllocTableIDs(ctx, tables, true, true, &checkpoint.PreallocIDs{
+		Start:          1,
+		ReusableBorder: 10000,
+		End:            20000,
+		Hash:           computeIDsHash([]int64{statsMetaDownstreamTableID, userDownstreamTableID, 100, 200, 300}),
+	})
+	require.NoError(t, err)
+	newTables = client.CleanTablesIfTemporarySystemTablesRenamed(true, true, tables)
+	require.True(t, mustNoTable(newTables, "mysql", "stats_meta"))
+	require.True(t, mustNoTable(newTables, "mysql", "user"))
+	require.Len(t, newTables, 3)
+}
+
+func mustNoTable(tables []*metautil.Table, dbName, tableName string) bool {
+	for _, table := range tables {
+		if table.DB.Name.O == dbName && table.Info.Name.O == tableName {
+			return false
+		}
+	}
+	return true
+}
+
+func computeIDsHash(ids []int64) [32]byte {
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	h := sha256.New()
+	buffer := make([]byte, 8)
+
+	for _, id := range ids {
+		binary.BigEndian.PutUint64(buffer, uint64(id))
+		_, err := h.Write(buffer)
+		if err != nil {
+			panic(errors.Wrapf(err, "failed to write table ID %d to hash", id))
+		}
+	}
+
+	var digest [32]byte
+	copy(digest[:], h.Sum(nil))
+	return digest
 }
 
 func TestGetMinUserTableID(t *testing.T) {

--- a/br/pkg/restore/snap_client/export_test.go
+++ b/br/pkg/restore/snap_client/export_test.go
@@ -87,7 +87,7 @@ func (rc *SnapClient) CreateTablesTest(
 	newTS uint64,
 ) (*restoreutils.RewriteRules, []*model.TableInfo, error) {
 	rc.dom = dom
-	rc.AllocTableIDs(context.TODO(), tables, false, nil)
+	rc.AllocTableIDs(context.TODO(), tables, false, false, nil)
 	rewriteRules := &restoreutils.RewriteRules{
 		Data: make([]*import_sstpb.RewriteRule, 0),
 	}
@@ -96,7 +96,7 @@ func (rc *SnapClient) CreateTablesTest(
 	for i, t := range tables {
 		tbMapping[t.Info.Name.String()] = i
 	}
-	rc.AllocTableIDs(context.Background(), tables, false, nil)
+	rc.AllocTableIDs(context.Background(), tables, false, false, nil)
 	createdTables, err := rc.CreateTables(context.TODO(), tables, newTS)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60930 #58757 #60932

Problem Summary:
BR will create another table with already existing table ID in the next retry if the snapshot restore failed after rename the temporary table.
### What changed and how does it work?
skip restoring the renamed system tables.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
