### PR TITLE
executor: skip bad zip file when to load plan replayer

### DIFF
--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -458,7 +458,7 @@ func loadStats(ctx sessionctx.Context, f *zip.File) error {
 		if f == nil || f.Name == "" {
 			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Join(errors.New("fail to read stats file"), err))
 		} else {
-		    ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Join(fmt.Errorf("fail to read stats file %s", f.Name), err))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Join(fmt.Errorf("fail to read stats file %s", f.Name), err))
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61471

Problem Summary:

### What changed and how does it work?

If the stats are bad, it's not a big deal; we could skip them and still load the good parts that follow. Unfortunately, we didn't do anything. We just terminated directly. It will abort the global binding loading.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Sorry, I cannot add this case to the test case. The test case contains the customer's information.

After the bugfix, it should look like this.

<img width="886" alt="image" src="https://github.com/user-attachments/assets/deaf3136-b813-44ac-8b39-d1a91ad6176e" />

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
executor: skip bad zip file when to load plan replayer

加载 plan replayer 的时候，跳过损坏的 zip 文件
```
