### PR TITLE
planner: outer join pruning for constants

### DIFF
--- a/pkg/planner/core/casetest/plan_test.go
+++ b/pkg/planner/core/casetest/plan_test.go
@@ -358,6 +358,30 @@ func TestOuterJoinElimination(t *testing.T) {
 	tk.MustHavePlan("select count(*) from t1 left join t2_uk on t1.a = t2_uk.a group by t1.a", "Join")
 	tk.MustNotHavePlan("select count(*) from t1 left join t2_nnuk on t1.a = t2_nnuk.a group by t1.a", "Join")
 	tk.MustNotHavePlan("select count(*) from t1 left join t2_pk on t1.a = t2_pk.a group by t1.a", "Join")
+
+	// test distinct aggregation
+	tk.MustNotHavePlan("select distinct t1.a from t1 left join t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct t1.a from t1 left join t2_k t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct t1.a from t1 left join t2_uk t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct t1.a from t1 left join t2_nnuk t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct t1.a from t1 left join t2_pk t2 on t1.a = t2.a", "Join")
+	// test constant columns with distinct
+	tk.MustNotHavePlan("select distinct 1 from t1 left join t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct 1 from t1 left join t2_k t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct 1 from t1 left join t2_uk t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct 1 from t1 left join t2_nnuk t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct 1 from t1 left join t2_pk t2 on t1.a = t2.a", "Join")
+	// test constant columns with distinct
+	tk.MustHavePlan("select 1 from t1 left join t2 on t1.a = t2.a", "Join")
+	tk.MustHavePlan("select 1 from t1 left join t2_k t2 on t1.a = t2.a", "Join")
+	tk.MustHavePlan("select 1 from t1 left join t2_uk t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select 1 from t1 left join t2_nnuk t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select 1 from t1 left join t2_pk t2 on t1.a = t2.a", "Join")
+	// test subqueries
+	tk.MustHavePlan("select 1 from (select distinct a from t1) t1 left join t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct 1 from (select distinct a from t1) t1 left join t2 on t1.a = t2.a", "Join")
+	tk.MustHavePlan("select t1.a from (select distinct a from t1) t1 left join t2 on t1.a = t2.a", "Join")
+	tk.MustNotHavePlan("select distinct t1.a from (select distinct a from t1) t1 left join t2 on t1.a = t2.a", "Join")
 }
 
 func TestCTEErrNotSupportedYet(t *testing.T) {

--- a/pkg/planner/core/rule/util/misc.go
+++ b/pkg/planner/core/rule/util/misc.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"slices"
+
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/util/intset"
 )
@@ -77,12 +79,9 @@ func IsColsAllFromOuterTable(cols []*expression.Column, outerUniqueIDs *intset.F
 
 // IsColFromInnerTable check whether a column exists in the inner plan
 func IsColFromInnerTable(cols []*expression.Column, innerUniqueIDs *intset.FastIntSet) bool {
-	for _, col := range cols {
-		if innerUniqueIDs.Has(int(col.UniqueID)) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(cols, func(col *expression.Column) bool {
+		return innerUniqueIDs.Has(int(col.UniqueID))
+	})
 }
 
 // SetPredicatePushDownFlag is a hook for other packages to set rule flag.

--- a/pkg/planner/core/rule/util/misc.go
+++ b/pkg/planner/core/rule/util/misc.go
@@ -68,6 +68,9 @@ func IsColsAllFromOuterTable(cols []*expression.Column, outerUniqueIDs *intset.F
 		return false
 	}
 	for _, col := range cols {
+		if col.ID == 0 {
+			continue
+		}
 		if !outerUniqueIDs.Has(int(col.UniqueID)) {
 			return false
 		}

--- a/pkg/planner/core/rule/util/misc.go
+++ b/pkg/planner/core/rule/util/misc.go
@@ -68,9 +68,6 @@ func IsColsAllFromOuterTable(cols []*expression.Column, outerUniqueIDs *intset.F
 		return false
 	}
 	for _, col := range cols {
-		if col.ID == 0 {
-			continue
-		}
 		if !outerUniqueIDs.Has(int(col.UniqueID)) {
 			return false
 		}

--- a/pkg/planner/core/rule/util/misc.go
+++ b/pkg/planner/core/rule/util/misc.go
@@ -75,5 +75,15 @@ func IsColsAllFromOuterTable(cols []*expression.Column, outerUniqueIDs *intset.F
 	return true
 }
 
+// IsColFromInnerTable check whether a column exists in the inner plan
+func IsColFromInnerTable(cols []*expression.Column, innerUniqueIDs *intset.FastIntSet) bool {
+	for _, col := range cols {
+		if innerUniqueIDs.Has(int(col.UniqueID)) {
+			return true
+		}
+	}
+	return false
+}
+
 // SetPredicatePushDownFlag is a hook for other packages to set rule flag.
 var SetPredicatePushDownFlag func(uint64) uint64

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -74,6 +74,11 @@ func (o *OuterJoinEliminator) tryToEliminateOuterJoin(p *logicalop.LogicalJoin, 
 		appendOuterJoinEliminateAggregationTraceStep(p, outerPlan, aggCols, opt)
 		return outerPlan, true, nil
 	}
+	// if we have a single column that is not from any table - we can prune
+	if len(aggCols) == 1 && aggCols[0].ID == 0 && !p.Schema().Contains(aggCols[0]) {
+		appendOuterJoinEliminateAggregationTraceStep(p, outerPlan, aggCols, opt)
+		return outerPlan, true, nil
+	}
 	// outer join elimination without duplicate agnostic aggregate functions
 	innerJoinKeys := o.extractInnerJoinKeys(p, innerChildIdx)
 	contain, err := o.isInnerJoinKeysContainUniqueKey(innerPlan, innerJoinKeys)

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -76,17 +76,20 @@ func (o *OuterJoinEliminator) tryToEliminateOuterJoin(p *logicalop.LogicalJoin, 
 		}
 		nonConstCols = append(nonConstCols, col)
 	}
-	// if nonConstCols is empty, it means all columns are constants
-	if len(nonConstCols) == 0 {
-		appendOuterJoinEliminateAggregationTraceStep(p, outerPlan, aggCols, opt)
-		return outerPlan, true, nil
-	}
-	// outer join elimination with duplicate agnostic aggregate functions
-	// Uses "nonConstCols" as this is aggCols after filtering out constant columns.
-	matched := ruleutil.IsColsAllFromOuterTable(nonConstCols, &outerUniqueIDs)
-	if matched {
-		appendOuterJoinEliminateAggregationTraceStep(p, outerPlan, aggCols, opt)
-		return outerPlan, true, nil
+
+	if len(aggCols) > 0 {
+		// if nonConstCols is empty, it means all columns are constants
+		if len(nonConstCols) == 0 {
+			appendOuterJoinEliminateAggregationTraceStep(p, outerPlan, aggCols, opt)
+			return outerPlan, true, nil
+		}
+		// outer join elimination with duplicate agnostic aggregate functions
+		// Uses "nonConstCols" as this is aggCols after filtering out constant columns.
+		matched := ruleutil.IsColsAllFromOuterTable(nonConstCols, &outerUniqueIDs)
+		if matched {
+			appendOuterJoinEliminateAggregationTraceStep(p, outerPlan, aggCols, opt)
+			return outerPlan, true, nil
+		}
 	}
 	// outer join elimination without duplicate agnostic aggregate functions
 	innerJoinKeys := o.extractInnerJoinKeys(p, innerChildIdx)

--- a/pkg/planner/core/rule_join_elimination.go
+++ b/pkg/planner/core/rule_join_elimination.go
@@ -69,7 +69,7 @@ func (o *OuterJoinEliminator) tryToEliminateOuterJoin(p *logicalop.LogicalJoin, 
 	}
 
 	// Filter out constant columns from aggCols
-	var nonConstCols []*expression.Column
+	nonConstCols := make([]*expression.Column, 0, len(aggCols))
 	for _, col := range aggCols {
 		if col.ID == 0 && !p.Schema().Contains(col) && col.VirtualExpr == nil {
 			continue

--- a/tests/integrationtest/r/planner/core/rule_constant_propagation.result
+++ b/tests/integrationtest/r/planner/core/rule_constant_propagation.result
@@ -162,7 +162,7 @@ create table s (id int, name varchar(10));
 explain format='brief' select * from (select * from (select t.id+1 as id1, t.name from t, (select * from s where s.id>1) s1 where t.id=s1.id ) tmp order by id1) a union (select tmp.* from (select * from t where t.id <3) tmp left join s on tmp.id=s.id); -- match twice;
 id	estRows	task	access object	operator info
 HashAgg	5325.33	root		group by:Column#14, Column#15, funcs:firstrow(Column#14)->Column#14, funcs:firstrow(Column#15)->Column#15
-└─Union	8320.83	root		
+└─Union	7490.00	root		
   ├─Projection	4166.67	root		plus(planner__core__rule_constant_propagation.t.id, 1)->Column#14, planner__core__rule_constant_propagation.t.name->Column#15
   │ └─HashJoin	4166.67	root		inner join, equal:[eq(planner__core__rule_constant_propagation.t.id, planner__core__rule_constant_propagation.s.id)]
   │   ├─TableReader(Build)	3333.33	root		data:Selection
@@ -171,11 +171,7 @@ HashAgg	5325.33	root		group by:Column#14, Column#15, funcs:firstrow(Column#14)->
   │   └─TableReader(Probe)	3333.33	root		data:Selection
   │     └─Selection	3333.33	cop[tikv]		gt(planner__core__rule_constant_propagation.t.id, 1), not(isnull(planner__core__rule_constant_propagation.t.id))
   │       └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
-  └─Projection	4154.17	root		cast(planner__core__rule_constant_propagation.t.id, bigint BINARY)->Column#14, planner__core__rule_constant_propagation.t.name->Column#15
-    └─HashJoin	4154.17	root		left outer join, left side:TableReader, equal:[eq(planner__core__rule_constant_propagation.t.id, planner__core__rule_constant_propagation.s.id)]
-      ├─TableReader(Build)	3323.33	root		data:Selection
-      │ └─Selection	3323.33	cop[tikv]		lt(planner__core__rule_constant_propagation.s.id, 3), not(isnull(planner__core__rule_constant_propagation.s.id))
-      │   └─TableFullScan	10000.00	cop[tikv]	table:s	keep order:false, stats:pseudo
-      └─TableReader(Probe)	3323.33	root		data:Selection
-        └─Selection	3323.33	cop[tikv]		lt(planner__core__rule_constant_propagation.t.id, 3)
-          └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+  └─Projection	3323.33	root		cast(planner__core__rule_constant_propagation.t.id, bigint BINARY)->Column#14, planner__core__rule_constant_propagation.t.name->Column#15
+    └─TableReader	3323.33	root		data:Selection
+      └─Selection	3323.33	cop[tikv]		lt(planner__core__rule_constant_propagation.t.id, 3)
+        └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61305

Problem Summary:

### What changed and how does it work?

Issue 61305 exposed limitations in the outer join pruning if constants are in the select list. If a constant is in the select list, then we don't recognize that this column is irrelvant - and thus if you ONLY otherwise have columns from the left side, we don't prune right side tables due to the constant.

Enhanced outer join pruning to cover these cases.

An example is - before:
``` 
EXPLAIN SELECT DISTINCT 1, t3.parent_id as w1
    -> FROM t3
    ->          LEFT OUTER JOIN t1 ON t1.parent_id = t3.parent_id
    ->       WHERE t3.search_field = 'Find me'
    -> LIMIT 101;
+---------------------------------+------------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------+
| id                              | estRows    | task      | access object                              | operator info                                                                                                 |
+---------------------------------+------------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------+
| Limit_13                        | 8.00       | root      |                                            | offset:0, count:101                                                                                           |
| └─HashAgg_14                    | 8.00       | root      |                                            | group by:test.t3.parent_id, funcs:firstrow(1)->Column#6, funcs:firstrow(test.t3.parent_id)->test.t3.parent_id |
|   └─HashJoin_24                 | 10.00      | root      |                                            | left outer join, left side:IndexReader_26, equal:[eq(test.t3.parent_id, test.t1.parent_id)]                   |
|     ├─IndexReader_26(Build)     | 8.00       | root      |                                            | index:IndexRangeScan_25                                                                                       |
|     │ └─IndexRangeScan_25       | 8.00       | cop[tikv] | table:t3, index:search_field(search_field) | range:["Find me","Find me"], keep order:false                                                                 |
|     └─TableReader_28(Probe)     | 1116372.00 | root      |                                            | data:TableFullScan_27                                                                                         |
|       └─TableFullScan_27        | 1116372.00 | cop[tikv] | table:t1                                   | keep order:false                                                                                              |
+---------------------------------+------------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------+
```

Example after this enhancement:
```
EXPLAIN SELECT DISTINCT 1, t3.parent_id as w1
    -> FROM t3
    ->          LEFT OUTER JOIN t1 ON t1.parent_id = t3.parent_id
    ->       WHERE t3.search_field = 'Find me'
    -> LIMIT 101;
+-----------------------------+---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------+
| id                          | estRows | task      | access object                              | operator info                                                                                                 |
+-----------------------------+---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------+
| Limit_12                    | 8.00    | root      |                                            | offset:0, count:101                                                                                           |
| └─StreamAgg_17              | 8.00    | root      |                                            | group by:test.t3.parent_id, funcs:firstrow(1)->Column#6, funcs:firstrow(test.t3.parent_id)->test.t3.parent_id |
|   └─IndexReader_29          | 8.00    | root      |                                            | index:IndexRangeScan_28                                                                                       |
|     └─IndexRangeScan_28     | 8.00    | cop[tikv] | table:t3, index:search_field(search_field) | range:["Find me","Find me"], keep order:true                                                                  |
+-----------------------------+---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
