### PR TITLE
build: fix build tags for some make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,9 @@ enterprise-docker: init-submodule enterprise-prepare
 enterprise-server-build: TIDB_EDITION=Enterprise
 enterprise-server-build:
 ifeq ($(TARGET), "")
-	CGO_ENABLED=1 $(GOBUILD) -tags=codes,enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o bin/tidb-server cmd/tidb-server/main.go
+	CGO_ENABLED=1 $(GOBUILD_NO_TAGS) -tags=$(BUILD_TAGS),enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o bin/tidb-server cmd/tidb-server/main.go
 else
-	CGO_ENABLED=1 $(GOBUILD) -tags=codes,enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o '$(TARGET)' cmd/tidb-server/main.go
+	CGO_ENABLED=1 $(GOBUILD_NO_TAGS) -tags=$(BUILD_TAGS),enterprise $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG) $(EXTENSION_FLAG)' -o '$(TARGET)' cmd/tidb-server/main.go
 endif
 
 .PHONY: enterprise-server
@@ -263,9 +263,9 @@ enterprise-server:
 .PHONY: server_check
 server_check:
 ifeq ($(TARGET), "")
-	$(GOBUILD) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags deadlock,enableassert -o bin/tidb-server ./cmd/tidb-server
+	$(GOBUILD_NO_TAGS) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags deadlock,enableassert -o bin/tidb-server ./cmd/tidb-server
 else
-	$(GOBUILD) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags deadlock,enableassert -o '$(TARGET)' ./cmd/tidb-server
+	$(GOBUILD_NO_TAGS) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags deadlock,enableassert -o '$(TARGET)' ./cmd/tidb-server
 endif
 
 .PHONY: linux
@@ -407,15 +407,15 @@ lightning_web:
 
 .PHONY: build_br
 build_br:
-	CGO_ENABLED=1 $(GOBUILD) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) ./br/cmd/br
+	CGO_ENABLED=1 $(GOBUILD_NO_TAGS) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) ./br/cmd/br
 
 .PHONY: build_lightning_for_web
 build_lightning_for_web:
-	CGO_ENABLED=1 $(GOBUILD) -tags dev $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) lightning/cmd/tidb-lightning/main.go
+	CGO_ENABLED=1 $(GOBUILD_NO_TAGS) -tags dev $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) lightning/cmd/tidb-lightning/main.go
 
 .PHONY: build_lightning
 build_lightning:
-	CGO_ENABLED=1 $(GOBUILD) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) ./lightning/cmd/tidb-lightning
+	CGO_ENABLED=1 $(GOBUILD_NO_TAGS) -tags codes $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) ./lightning/cmd/tidb-lightning
 
 .PHONY: build_lightning-ctl
 build_lightning-ctl:

--- a/Makefile.common
+++ b/Makefile.common
@@ -41,7 +41,8 @@ ifeq ("${NEXT_GEN}", "1")
 endif
 
 GO              := GO111MODULE=on go
-GOBUILD         := $(GOEXPERIMENT) $(GO) build -tags $(BUILD_TAGS)
+GOBUILD_NO_TAGS := $(GOEXPERIMENT) $(GO) build
+GOBUILD         := $(GOBUILD_NO_TAGS) -tags $(BUILD_TAGS)
 GOBUILDCOVERAGE := GOPATH=$(GOPATH) cd tidb-server; $(GO) test -coverpkg="../..." -c .
 GOTEST          := $(GO) test -p $(P)
 OVERALLS        := GO111MODULE=on overalls

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -92,6 +92,8 @@ func GetTiDBInfo() string {
 	)
 	if kerneltype.IsNextGen() {
 		info += "\nKernel Type: Next Generation"
+	} else {
+		info += "\nKernel Type: Classic"
 	}
 	return info
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418

Problem Summary:

### What changed and how does it work?
- add `GOBUILD_NO_TAGS`, as some make target explicitly specify `-tags` param which will override the `-tags` in `GOBUILD`
- always print kernel type in output of `-V`
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

community build
```
➜  tidb git:(close-idle-conn) ✗ make server; bin/tidb-server -V
CGO_ENABLED=1  GO111MODULE=on go build -tags codes   -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-857-gca89c94ed0-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-06-04 02:59:37" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=ca89c94ed07a7eaec7ce71113fbbfc40245e0275" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=close-idle-conn" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server
Release Version: v9.0.0-alpha-857-gca89c94ed0-dirty
Edition: Community
Git Commit Hash: ca89c94ed07a7eaec7ce71113fbbfc40245e0275
Git Branch: close-idle-conn
UTC Build Time: 2025-06-04 02:59:37
GoVersion: go1.23.9
Race Enabled: false
Check Table Before Drop: false
Store: unistore
Kernel Type: Classic

➜  tidb git:(close-idle-conn) ✗ NEXT_GEN=1 make server; bin/tidb-server -V
CGO_ENABLED=1  GO111MODULE=on go build -tags codes,nextgen   -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-857-gca89c94ed0-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-06-04 02:59:11" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=ca89c94ed07a7eaec7ce71113fbbfc40245e0275" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=close-idle-conn" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server
Release Version: v9.0.0-alpha-857-gca89c94ed0-dirty
Edition: Community
Git Commit Hash: ca89c94ed07a7eaec7ce71113fbbfc40245e0275
Git Branch: close-idle-conn
UTC Build Time: 2025-06-04 02:59:11
GoVersion: go1.23.9
Race Enabled: false
Check Table Before Drop: false
Store: unistore
Kernel Type: Next Generation
```

for enterprise build
```
➜  tidb git:(close-idle-conn) make enterprise-server-build
CGO_ENABLED=1  GO111MODULE=on go build -tags=codes,enterprise  -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-857-gca89c94ed0-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-06-04 02:57:09" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=ca89c94ed07a7eaec7ce71113fbbfc40245e0275" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=close-idle-conn" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Enterprise"  -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEnterpriseExtensionGitHash=dc633aae52eb11b4e3549e3a7ef5b0ed14e159b1"' -o bin/tidb-server cmd/tidb-server/main.go
➜  tidb git:(close-idle-conn) ✗ bin/tidb-server -V
Release Version: v9.0.0-alpha-857-gca89c94ed0-dirty
Edition: Enterprise
Git Commit Hash: ca89c94ed07a7eaec7ce71113fbbfc40245e0275
Git Branch: close-idle-conn
UTC Build Time: 2025-06-04 02:57:09
GoVersion: go1.23.9
Race Enabled: false
Check Table Before Drop: false
Store: unistore
Enterprise Extension Commit Hash: dc633aae52eb11b4e3549e3a7ef5b0ed14e159b1
Kernel Type: Classic

➜  tidb git:(close-idle-conn) ✗ NEXT_GEN=1 make enterprise-server-build
CGO_ENABLED=1  GO111MODULE=on go build -tags=codes,nextgen,enterprise  -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-857-gca89c94ed0-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-06-04 02:58:00" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=ca89c94ed07a7eaec7ce71113fbbfc40245e0275" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=close-idle-conn" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Enterprise"  -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEnterpriseExtensionGitHash=dc633aae52eb11b4e3549e3a7ef5b0ed14e159b1"' -o bin/tidb-server cmd/tidb-server/main.go
➜  tidb git:(close-idle-conn) ✗ bin/tidb-server -V
Release Version: v9.0.0-alpha-857-gca89c94ed0-dirty
Edition: Enterprise
Git Commit Hash: ca89c94ed07a7eaec7ce71113fbbfc40245e0275
Git Branch: close-idle-conn
UTC Build Time: 2025-06-04 02:58:00
GoVersion: go1.23.9
Race Enabled: false
Check Table Before Drop: false
Store: unistore
Enterprise Extension Commit Hash: dc633aae52eb11b4e3549e3a7ef5b0ed14e159b1
Kernel Type: Next Generation
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
