### PR TITLE
parser, ddl: Add parser support for default value as column

### DIFF
--- a/pkg/ddl/add_column.go
+++ b/pkg/ddl/add_column.go
@@ -604,7 +604,9 @@ func SetDefaultValue(ctx expression.BuildContext, col *table.Column, option *ast
 		}
 		col.DefaultIsExpr = isSeqExpr
 	}
-
+	if _, ok := option.Expr.(*ast.ColumnNameExpr); ok {
+		return hasDefaultValue, errors.New("column name is not yet supported as a default value")
+	}
 	// When the default value is expression, we skip check and convert.
 	if !col.DefaultIsExpr {
 		if hasDefaultValue, value, err = checkColumnDefaultValue(ctx, col, value); err != nil {

--- a/pkg/parser/README.md
+++ b/pkg/parser/README.md
@@ -44,6 +44,7 @@ found you are one of the users but not listed here:
 - [nooncall/shazam](https://github.com/nooncall/shazam)
 - [bytebase/bytebase](https://github.com/bytebase/bytebase)
 - [kyleconroy/sqlc](https://github.com/kyleconroy/sqlc)
+- [block/spirit](https://github.com/block/spirit)
 
 ## Contributing
 

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -592,6 +592,9 @@ func (n *ColumnOption) Restore(ctx *format.RestoreCtx) error {
 				printOuterParentheses = true
 			}
 		}
+		if _, ok := n.Expr.(*ColumnNameExpr); ok {
+			printOuterParentheses = true
+		}
 		if printOuterParentheses {
 			ctx.WritePlain("(")
 		}

--- a/pkg/parser/ast/ddl_test.go
+++ b/pkg/parser/ast/ddl_test.go
@@ -228,6 +228,7 @@ func TestDDLColumnOptionRestore(t *testing.T) {
 		{"DEFAULT ''", "DEFAULT _UTF8MB4''"},
 		{"DEFAULT TRUE", "DEFAULT TRUE"},
 		{"DEFAULT FALSE", "DEFAULT FALSE"},
+		{"DEFAULT (colA)", "DEFAULT (`colA`)"},
 		{"UNIQUE KEY", "UNIQUE KEY"},
 		{"on update CURRENT_TIMESTAMP", "ON UPDATE CURRENT_TIMESTAMP()"},
 		{"comment 'hello'", "COMMENT 'hello'"},

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -4105,6 +4105,12 @@ DefaultValueExpr:
 |	SignedLiteral
 |	NextValueForSequenceParentheses
 |	BuiltinFunction
+|	'(' Identifier ')'
+	{
+		$$ = &ast.ColumnNameExpr{Name: &ast.ColumnName{
+			Name: ast.NewCIStr($2),
+		}}
+	}
 |	'(' SignedLiteral ')'
 	{
 		$$ = $2

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3032,6 +3032,9 @@ func TestDDL(t *testing.T) {
 		{"create table t (i int default (0))", true, "CREATE TABLE `t` (`i` INT DEFAULT 0)"},
 		{"create table t (i int default (-1))", true, "CREATE TABLE `t` (`i` INT DEFAULT -1)"},
 		{"create table t (i int default (+1))", true, "CREATE TABLE `t` (`i` INT DEFAULT +1)"},
+		// For column default expression with column reference
+		{"create table t (a int, b int, c char(33) default (b))", true, "CREATE TABLE `t` (`a` INT,`b` INT,`c` CHAR(33) DEFAULT (`b`))"},
+		{"create table t (a int, b int, c char(33) default `b`)", false, ""},
 
 		// For table option `ENCRYPTION`
 		{"create table t (a int) encryption = 'n';", true, "CREATE TABLE `t` (`a` INT) ENCRYPTION = 'n'"},


### PR DESCRIPTION

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: https://github.com/pingcap/tidb/issues/61475 (does not close)

Problem Summary:

The default value expression in TiDB is more limited than MySQL.

### What changed and how does it work?

This adds parser support for default values being column references. It does not add tidb-server support.

An error is added to the ddl package so that it does not parse-but-ignore leading users to believe the feature is working.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
