### PR TITLE
tests: adjust test scripts for next-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dev: checklist check integrationtest gogenerate br_unit_test test_part_parser_de
 # Install the check tools.
 .PHONY: check-setup
 check-setup: ## Install development and checking tools
-check-setup:tools/bin/revive 
+check-setup:tools/bin/revive
 
 .PHONY: precheck
 precheck: ## Run pre-commit checks
@@ -51,7 +51,7 @@ precheck: fmt bazel_prepare
 
 .PHONY: check
 check: ## Run comprehensive code quality checks
-check: check-bazel-prepare parser_yacc check-parallel lint tidy testSuite errdoc license 
+check: check-bazel-prepare parser_yacc check-parallel lint tidy testSuite errdoc license
 
 .PHONY: fmt
 fmt: ## Format Go code using gofmt
@@ -126,7 +126,7 @@ clean: failpoint-disable ## Clean build artifacts and test binaries
 # Split tests for CI to run `make test` in parallel.
 .PHONY: test
 test: ## Run all tests (split into parts for parallel execution)
-test: test_part_1 test_part_2 
+test: test_part_1 test_part_2
 	@>&2 echo "Great, all tests passed."
 
 .PHONY: test_part_1
@@ -272,9 +272,9 @@ enterprise-server: ## Build TiDB server with enterprise features
 .PHONY: server_check
 server_check:
 ifeq ($(TARGET), "")
-	$(GOBUILD_NO_TAGS) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags deadlock,enableassert -o bin/tidb-server ./cmd/tidb-server
+	$(GOBUILD_NO_TAGS) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags=$(CHECK_BUILD_TAGS) -o bin/tidb-server ./cmd/tidb-server
 else
-	$(GOBUILD_NO_TAGS) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags deadlock,enableassert -o '$(TARGET)' ./cmd/tidb-server
+	$(GOBUILD_NO_TAGS) -cover $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' --tags=$(CHECK_BUILD_TAGS) -o '$(TARGET)' ./cmd/tidb-server
 endif
 
 .PHONY: linux

--- a/Makefile
+++ b/Makefile
@@ -652,21 +652,21 @@ check-bazel-prepare:
 
 .PHONY: bazel_test
 bazel_test: failpoint-enable bazel_prepare ## Run all tests using Bazel
-	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --build_tests_only --test_keep_going=false \
-		--define gotags=deadlock,intest \
+	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --build_tests_only --test_keep_going=true \
+		--define gotags=$(UNIT_TEST_TAGS) \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
 .PHONY: bazel_coverage_test
 bazel_coverage_test: failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=false \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=true \
 		--@io_bazel_rules_go//go/config:cover_format=go_cover --define gotags=$(UNIT_TEST_TAGS) \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...
 
 .PHONY: bazel_coverage_test_ddlargsv1
 bazel_coverage_test_ddlargsv1: failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=false \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=true \
 		--@io_bazel_rules_go//go/config:cover_format=go_cover --define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...

--- a/Makefile
+++ b/Makefile
@@ -666,7 +666,7 @@ bazel_coverage_test: failpoint-enable bazel_ci_simple_prepare
 
 .PHONY: bazel_coverage_test_ddlargsv1
 bazel_coverage_test_ddlargsv1: failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=true \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=false \
 		--@io_bazel_rules_go//go/config:cover_format=go_cover --define gotags=$(UNIT_TEST_TAGS),ddlargsv1 \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...

--- a/Makefile
+++ b/Makefile
@@ -659,7 +659,7 @@ bazel_test: failpoint-enable bazel_prepare ## Run all tests using Bazel
 
 .PHONY: bazel_coverage_test
 bazel_coverage_test: failpoint-enable bazel_ci_simple_prepare
-	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=true \
+	bazel $(BAZEL_GLOBAL_CONFIG) --nohome_rc coverage $(BAZEL_CMD_CONFIG) $(BAZEL_INSTRUMENTATION_FILTER) --jobs=35 --build_tests_only --test_keep_going=false \
 		--@io_bazel_rules_go//go/config:cover_format=go_cover --define gotags=$(UNIT_TEST_TAGS) \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...

--- a/Makefile
+++ b/Makefile
@@ -652,7 +652,7 @@ check-bazel-prepare:
 
 .PHONY: bazel_test
 bazel_test: failpoint-enable bazel_prepare ## Run all tests using Bazel
-	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --build_tests_only --test_keep_going=true \
+	bazel $(BAZEL_GLOBAL_CONFIG) test $(BAZEL_CMD_CONFIG) --build_tests_only --test_keep_going=false \
 		--define gotags=$(UNIT_TEST_TAGS) \
 		-- //... -//cmd/... -//tests/graceshutdown/... \
 		-//tests/globalkilltest/... -//tests/readonlytest/... -//tests/realtikvtest/...

--- a/Makefile.common
+++ b/Makefile.common
@@ -28,6 +28,7 @@ path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
 export PATH := $(path_to_add):$(PATH)
 
 BUILD_TAGS          := codes
+CHECK_BUILD_TAGS    := deadlock,enableassert
 UNIT_TEST_TAGS      := deadlock,intest
 REAL_TIKV_TEST_TAGS := deadlock,intest
 GOEXPERIMENT=
@@ -38,6 +39,7 @@ endif
 
 ifeq ("${NEXT_GEN}", "1")
 	BUILD_TAGS := $(BUILD_TAGS),nextgen
+	CHECK_BUILD_TAGS := $(CHECK_BUILD_TAGS),nextgen
 	UNIT_TEST_TAGS := $(UNIT_TEST_TAGS),nextgen
 	REAL_TIKV_TEST_TAGS := $(REAL_TIKV_TEST_TAGS),nextgen
 endif

--- a/ci.md
+++ b/ci.md
@@ -27,3 +27,4 @@ The CI pipeline will automatically trigger when you submit a PR or push new comm
 | pull-sqllogic-test              | `/test pull-sqllogic-test`              | SQL logic tests in PingCAP-QE/tidb-test                      | No           |
 | pull-tiflash-test               | `/test pull-tiflash-test`               | TiFlash tests in pingcap/tiflash `tests/docker/`             | No           |
 
+<!-- test -->

--- a/ci.md
+++ b/ci.md
@@ -27,4 +27,3 @@ The CI pipeline will automatically trigger when you submit a PR or push new comm
 | pull-sqllogic-test              | `/test pull-sqllogic-test`              | SQL logic tests in PingCAP-QE/tidb-test                      | No           |
 | pull-tiflash-test               | `/test pull-tiflash-test`               | TiFlash tests in pingcap/tiflash `tests/docker/`             | No           |
 
-<!-- test -->

--- a/tests/integrationtest/README.md
+++ b/tests/integrationtest/README.md
@@ -1,90 +1,153 @@
 # IntegrationTest
 
-IntegrationTest is a integration test command tool, also with some useful test cases for TiDB execute plan logic, we can run case via `run-tests.sh`.
+This directory contains the integration test suite for TiDB, including tools and test cases for validating TiDB's execution plan logic and end-to-end behavior. You can run these tests using either the classic `run-tests.sh` script or the next-generation `run-tests-next-gen.sh` script, which runs tests against a real TiKV cluster.
+
+---
+
+## Quick Start
+
+### 1. Classic Integration Test Runner
+
+Run all integration tests with the default configuration:
+
+```sh
+./run-tests.sh
+```
+
+### 2. Next-Generation Runner (with Real TiKV Cluster)
+
+To run integration tests against a real TiKV cluster, use:
+
+```sh
+./run-tests-next-gen.sh [run-tests.sh options]
+```
+
+This script sets up a real cluster environment and then invokes `run-tests.sh` with your provided options.
+
+---
+
+## Script Options
+
+### `run-tests.sh` Options
 
 ```
 Usage: ./run-tests.sh [options]
 
     -h: Print this help message.
 
-    -s <tidb-server-path>: Use tidb-server in <tidb-server-path> for testing.
-                           eg. "./run-tests.sh -s ./integrationtest_tidb-server"
+    -d <y|Y|n|N|b|B>: Control new collation feature:
+        "y" or "Y": Only enable new collation during test.
+        "n" or "N": Only disable new collation during test.
+        "b" or "B": For tests prefixed with `collation`, run both enable/disable; for others, only enable [default].
 
-    -b <y|Y|n|N>: "y" or "Y" for building test binaries [default "y" if this option is not specified].
-                  "n" or "N" for not to build.
-                  The building of tidb-server will be skiped if "-s <tidb-server-path>" is provided.
+    -s <tidb-server-path>: Use the specified tidb-server binary for testing.
+        Example: ./run-tests.sh -s ./integrationtest_tidb-server
 
-    -r <test-name>|all: Run tests in file "t/<test-name>.test" and record result to file "r/<test-name>.result".
-                        "all" for running all tests and record their results.
+    -b <y|Y|n|N>: Build test binaries:
+        "y" or "Y": Build binaries [default].
+        "n" or "N": Do not build.
+        (Building is skipped if -s is provided.)
 
-    -t <test-name>: Run tests in file "t/<test-name>.test".
-                    This option will be ignored if "-r <test-name>" is provided.
-                    Run all tests if this option is not provided.
+    -r <test-name>|all: Run and record results for the specified test case(s).
+        Example: ./run-tests.sh -r select
+        Use "all" to record results for all tests.
+
+    -t <test-name>: Run the specified test case(s) (ignored if -r is provided).
+        Example: ./run-tests.sh -t select
 
     -v <vendor-path>: Add <vendor-path> to $GOPATH.
 
-    -p <portgenerator-path>: Use port generator in <portgenerator-path> for generating port numbers.
+    -p <portgenerator-path>: Use the specified port generator for port allocation.
 ```
 
-## How it works
+### `run-tests-next-gen.sh` Notes
 
-IntegrationTest will read test case in `t/*.test`, and execute them in TiDB server with `s/*.json` stat, and compare integration result in `r/*.result`.
+- This script bootstraps a real TiKV cluster and then runs `run-tests.sh`.
+- It requires several TCP ports to be available:
+    - pd: 2379, 2380, 2381, 2383, 2384
+    - tikv: 20160, 20161, 20162, 20180, 20181, 20182
+    - tikv-worker: 19000
+- All options supported by `run-tests.sh` can be passed to `run-tests-next-gen.sh`.
 
-For convenience, we can generate new `*.result` and `*.json` from execute by use `-r` parameter for `run-tests.sh`
+---
 
-## Usage
+## How It Works
 
-### Regression Execute Plan Modification
+- Test cases are defined in `t/*.test`.
+- Each test is executed against a TiDB server (with or without a real TiKV backend).
+- Results are compared with expected outputs in `r/*.result`.
+- Statistics are loaded from `s/*.json`.
+- To generate new `.result` and `.json` files from execution, use the `-r` parameter.
 
-After modify code and before commit, please run this command under TiDB root folder.
+---
+
+## Typical Workflows
+
+### Regression Testing After Code Changes
+
+After modifying TiDB code, run:
 
 ```sh
 make dev
 ```
-
 or
-
 ```sh
 make integrationtest
 ```
 
-It will identify execute plan change.
+This will run the integration tests and help you identify any changes in execution plans.
 
-### Generate New Result from Execute
+### Adding or Updating Test Cases
 
-Add a new test file in `t/` folder, file name should ended with `.test`. Or add new test queries at the end of some files. Then run shell below, it will generate results based on last execution.
+1. Add a new `.test` file to the `t/` directory, or append queries to an existing file.
+2. Generate new expected results by running:
 
-```sh
-cd tests/integrationtest
-./run-tests.sh -r [casename]
-```
+    ```sh
+    cd tests/integrationtest
+    ./run-tests.sh -r [casename]
+    ```
 
-## How to debug integration test
+---
+
+## Debugging Integration Tests
 
 ### Visual Studio Code
 
-1. Add or create a configuration to `.vscode/launch.json`, an example is shown below. If you want to change some configurations, such as using `TiKV` to run integration tests or others, you can modify `pkg/config/config.toml.example`.
+1. Add a configuration to `.vscode/launch.json` (example below). You can adjust the config file or backend as needed.
+> If you want to change some configurations, such as using `TiKV` to run integration tests or others, you can modify `pkg/config/config.toml.example`.
+    ```json
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Debug TiDB With Default Config",
+                "type": "go",
+                "request": "launch",
+                "mode": "auto",
+                "program": "${fileWorkspaceFolder}/cmd/tidb-server",
+                "args": ["--config=${fileWorkspaceFolder}/pkg/config/config.toml.example"]
+            }
+        ]
+    }
+    ```
 
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Debug TiDB With Default Config",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "program": "${fileWorkspaceFolder}/cmd/tidb-server",
-            "args": ["--config=${fileWorkspaceFolder}/pkg/config/config.toml.example"]
-        }
-    ]
-}
-```
+2. Start TiDB-Server using the **Run and Debug** view or press **F5**.
+3. Connect with any MySQL client (default: port 4000, user `root`, no password):
 
-2. To run `TiDB-Server`, you could bring up **Run and Debug** view, select the **Run and Debug** icon in the **Activity Bar** on the side of VS Code. You can also use shortcut **F5**.
-
-3. Use any mysql client application you like to run SQLs in integration test, the default port is `4000` and default user is `root` without password. Taking `mysql` as an example, you can use `mysql --comments --host 127.0.0.1 --port 4000 -u root` command to do this.
+    ```sh
+    mysql --comments --host 127.0.0.1 --port 4000 -u root
+    ```
 
 ### Goland
 
-You could follow <https://pingcap.github.io/tidb-dev-guide/get-started/setup-an-ide.html#run-or-debug> to run a `TiDB-Server` with or without `TiKV`. Then use any mysql client application you like to run SQLs.
+See the [TiDB Dev Guide](https://pingcap.github.io/tidb-dev-guide/get-started/setup-an-ide.html#run-or-debug) for instructions on running or debugging TiDB-Server with or without TiKV. Use any MySQL client to run SQLs.
+
+---
+
+## Notes
+
+- Use `run-tests-next-gen.sh` for testing with a real TiKV cluster.
+- Use `run-tests.sh` for classic or local integration testing.
+- For more details on test case structure and contributing new tests, see the comments and examples in the `t/` directory.
+
+---

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -19,10 +19,11 @@
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
 # - tikv-worker: 1900
 function main() {
-    local make_test_task="$1"
-
-    local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-    "${self_dir}/bootstrap-test-with-cluster" make ${make_test_task}
+    local self_dir=$(realpath $(dirname $(dirname "${BASH_SOURCE[0]}")))
+    export TIDB_TEST_STORE_NAME="tikv"
+    export TIKV_PATH="127.0.0.1:2379"
+    "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster" "${self_dir}/run-tests.sh" "$@"
 }
 
 main "$@"
+    

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -18,11 +18,16 @@
 # - pd: 2379, 2380, 2381, 2383, 2384
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
 # - tikv-worker: 1900
+
+set -euo pipefail
+
 function main() {
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
     export TIDB_TEST_STORE_NAME="tikv"
     export TIKV_PATH="127.0.0.1:2379"
-    "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh" "${self_dir}/run-tests.sh" "$@"
+    pushd "${self_dir}"
+        ../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh run-tests.sh "$@"
+    popd
 }
 
 main "$@"

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -25,7 +25,13 @@ function main() {
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
     export TIDB_TEST_STORE_NAME="tikv"
     export TIKV_PATH="127.0.0.1:2379"
-    "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh" "${self_dir}/run-tests.sh" "$@"
+
+    if [ -d bin ]; then
+        ln -s "$(realpath bin)" "${self_dir}/bin"
+    fi
+    pushd "${self_dir}"
+        ../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh ./run-tests.sh "$@"
+    popd
 }
 
 main "$@"

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -22,8 +22,7 @@ function main() {
     local self_dir=$(realpath $(dirname $(dirname "${BASH_SOURCE[0]}")))
     export TIDB_TEST_STORE_NAME="tikv"
     export TIKV_PATH="127.0.0.1:2379"
-    "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster" "${self_dir}/run-tests.sh" "$@"
+    "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh" "${self_dir}/run-tests.sh" "$@"
 }
 
 main "$@"
-    

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -19,7 +19,7 @@
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
 # - tikv-worker: 1900
 function main() {
-    local self_dir=$(realpath $(dirname $(dirname "${BASH_SOURCE[0]}")))
+    local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
     export TIDB_TEST_STORE_NAME="tikv"
     export TIKV_PATH="127.0.0.1:2379"
     "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh" "${self_dir}/run-tests.sh" "$@"

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -25,9 +25,7 @@ function main() {
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
     export TIDB_TEST_STORE_NAME="tikv"
     export TIKV_PATH="127.0.0.1:2379"
-    pushd "${self_dir}"
-        ../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh run-tests.sh "$@"
-    popd
+    "${self_dir}/../realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh" "${self_dir}/run-tests.sh" "$@"
 }
 
 main "$@"

--- a/tests/integrationtest/run-tests-next-gen.sh
+++ b/tests/integrationtest/run-tests-next-gen.sh
@@ -17,7 +17,7 @@
 # It need TCP ports:
 # - pd: 2379, 2380, 2381, 2383, 2384
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
-# - tikv-worker: 1900
+# - tikv-worker: 19000
 
 set -euo pipefail
 

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -101,13 +101,13 @@ function find_multiple_available_ports() {
 
 function build_tidb_server()
 {
-    tidb_server="./integrationtest_tidb-server"
+    tidb_server="$(pwd)/integrationtest_tidb-server"
     echo "building tidb-server binary: $tidb_server"
     rm -rf $tidb_server
     if [ "${TIDB_TEST_STORE_NAME}" = "tikv" ]; then
-        GO111MODULE=on go build -o $tidb_server github.com/pingcap/tidb/cmd/tidb-server
+        make -C ../.. server SERVER_OUT=$tidb_server
     else
-        GO111MODULE=on go build -race -o $tidb_server github.com/pingcap/tidb/cmd/tidb-server
+        make -C ../.. server SERVER_OUT=$tidb_server RACE_FLAG="-race"
     fi
 }
 

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -215,9 +215,10 @@ status=${ports[1]}
 
 function start_tidb_server()
 {
-    config_file="config.toml"
+    self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+    config_file="${self_dir}/config.toml"
     if [[ $enabled_new_collation = 0 ]]; then
-        config_file="disable_new_collation.toml"
+        config_file="${self_dir}/disable_new_collation.toml"
     fi
     echo "start tidb-server, log file: $mysql_tester_log"
     if [ "${TIDB_TEST_STORE_NAME}" = "tikv" ]; then

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -226,7 +226,7 @@ function start_tidb_server()
         start_options="$start_options -store unistore -path ''"
     fi
 
-    if [ -n "$NEXT_GEN" ] && [ "$NEXT_GEN" != "0" ] && [ "$NEXT_GEN" != "false" ]; then
+    if [ -n "$NEXT_GEN:-" ] && [ "$NEXT_GEN:-" != "0" ] && [ "$NEXT_GEN:-" != "false" ]; then
         start_options="$start_options -keyspace-name SYSTEM"
     fi
 

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -15,6 +15,7 @@
 
 TIDB_TEST_STORE_NAME=$TIDB_TEST_STORE_NAME
 TIKV_PATH=$TIKV_PATH
+NEXT_GEN=$NEXT_GEN
 
 build=1
 mysql_tester="./mysql_tester"
@@ -226,7 +227,7 @@ function start_tidb_server()
         start_options="$start_options -store unistore -path ''"
     fi
 
-    if [ -n "$NEXT_GEN:-" ] && [ "$NEXT_GEN:-" != "0" ] && [ "$NEXT_GEN:-" != "false" ]; then
+    if [ -n "$NEXT_GEN" ] && [ "$NEXT_GEN" != "0" ] && [ "$NEXT_GEN" != "false" ]; then
         start_options="$start_options -keyspace-name SYSTEM"
     fi
 

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -215,10 +215,9 @@ status=${ports[1]}
 
 function start_tidb_server()
 {
-    self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-    config_file="${self_dir}/config.toml"
+    config_file="config.toml"
     if [[ $enabled_new_collation = 0 ]]; then
-        config_file="${self_dir}/disable_new_collation.toml"
+        config_file="disable_new_collation.toml"
     fi
     echo "start tidb-server, log file: $mysql_tester_log"
     if [ "${TIDB_TEST_STORE_NAME}" = "tikv" ]; then

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -220,18 +220,18 @@ function start_tidb_server()
         config_file="disable_new_collation.toml"
     fi
     start_options="-P $port -status $status -config $config_file"
-    echo "start tidb-server, log file: $mysql_tester_log"
     if [ "${TIDB_TEST_STORE_NAME}" = "tikv" ]; then
-        $start_options="$start_options -store tikv -path ${TIKV_PATH}"
+        start_options="$start_options -store tikv -path ${TIKV_PATH}"
     else
-        $start_options="$start_options -store unistore -path ''"
+        start_options="$start_options -store unistore -path ''"
     fi
 
     if [ -n "$NEXT_GEN" ] && [ "$NEXT_GEN" != "0" ] && [ "$NEXT_GEN" != "false" ]; then
         start_options="$start_options -keyspace-name SYSTEM"
     fi
 
-    $tidb_server $start_options  > $mysql_tester_log 2>&1 &
+    echo "start tidb-server, log file: $mysql_tester_log"
+    $tidb_server $start_options > $mysql_tester_log 2>&1 &
     SERVER_PID=$!
     echo "tidb-server(PID: $SERVER_PID) started"
 }

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -219,14 +219,20 @@ function start_tidb_server()
     if [[ $enabled_new_collation = 0 ]]; then
         config_file="disable_new_collation.toml"
     fi
+    start_options="-P $port -status $status -config $config_file"
     echo "start tidb-server, log file: $mysql_tester_log"
     if [ "${TIDB_TEST_STORE_NAME}" = "tikv" ]; then
-        $tidb_server -P "$port" -status "$status" -config $config_file -store tikv -path "${TIKV_PATH}" > $mysql_tester_log 2>&1 &
-        SERVER_PID=$!
+        $start_options="$start_options -store tikv -path ${TIKV_PATH}"
     else
-        $tidb_server -P "$port" -status "$status" -config $config_file -store unistore -path "" > $mysql_tester_log 2>&1 &
-        SERVER_PID=$!
+        $start_options="$start_options -store unistore -path ''"
     fi
+
+    if [ -n "$NEXT_GEN" ] && [ "$NEXT_GEN" != "0" ] && [ "$NEXT_GEN" != "false" ]; then
+        start_options="$start_options -keyspace-name SYSTEM"
+    fi
+
+    $tidb_server $start_options  > $mysql_tester_log 2>&1 &
+    SERVER_PID=$!
     echo "tidb-server(PID: $SERVER_PID) started"
 }
 

--- a/tests/realtikvtest/configs/next-gen/tikv.toml
+++ b/tests/realtikvtest/configs/next-gen/tikv.toml
@@ -12,7 +12,7 @@ s3-bucket = "next-gen-test"
 s3-region = "local"
 
 [kvengine]
-remote-coprocessor-addr = "http://127.0.0.1:20001/coprocessor"
+remote-coprocessor-addr = "http://127.0.0.1:19000/coprocessor"
 remote-coprocessor-min-blocks-size = 32768                     # 32MB by default
 
 [ia]

--- a/tests/realtikvtest/scripts/classic/README.md
+++ b/tests/realtikvtest/scripts/classic/README.md
@@ -1,0 +1,97 @@
+# Classic TiDB Testing Scripts
+
+This directory contains scripts for testing the classic TiDB architecture with a local test cluster. These scripts help set up and run tests against a real TiKV cluster with traditional components.
+
+## Overview
+
+The scripts in this directory facilitate testing the classic architecture of TiDB by:
+
+1. Setting up a local test cluster with PD and TiKV components
+2. Running test suites against this cluster
+
+## Scripts
+
+### bootstrap-test-with-cluster.sh
+
+This script sets up a complete local test cluster with:
+- 3 PD nodes
+- 3 TiKV servers
+
+It creates temporary data directories, configures the components using the configuration files in `tests/realtikvtest/configs/classic/`, and starts all services required for testing.
+
+Usage:
+```bash
+./bootstrap-test-with-cluster.sh <command>
+```
+
+The script will execute `<command>` after the cluster is set up.
+
+### run-tests-with-gotest.sh
+
+This script runs a specific Go test suite against the classic cluster.
+
+Usage:
+```bash
+./run-tests-with-gotest.sh <test_suite> [<timeout>]
+```
+
+Arguments:
+- `<test_suite>`: The test suite directory under `./tests/realtikvtest/`
+- `<timeout>`: Optional timeout for the test suite (default: 40m)
+
+Example:
+```bash
+./run-tests-with-gotest.sh addindextest 60m
+```
+
+### run-tests.sh
+
+This script runs a make test task against the classic cluster.
+
+Usage:
+```bash
+./run-tests.sh <make_test_task>
+```
+
+Example:
+```bash
+./run-tests.sh bazel_addindextest
+```
+
+## Configuration Files
+
+The test cluster uses configuration files from `tests/realtikvtest/configs/classic/`:
+
+- `tikv.toml`: Configuration for TiKV servers with transaction and storage settings
+
+## Required Ports
+
+The test cluster requires the following TCP ports to be available:
+
+- PD: 2379, 2380, 2381, 2383, 2384
+- TiKV: 20160, 20161, 20162, 20180, 20181, 20182
+
+## Cleanup
+
+The scripts automatically clean up processes on exit. Different cleanup approaches are used depending on the operating system:
+- On macOS: `killall -9 -q <process>`
+- On Linux: `killall -9 -r -q <process>` (with regex support)
+
+Temporary data directories created during test runs are not automatically removed.
+
+## Requirements
+
+- Go development environment
+- TiDB development environment with compiled binaries in `bin/` directory
+- Available ports as listed above
+- Sufficient disk space for temporary data directories
+
+## Classic vs Next-Gen Testing
+
+The classic architecture is the traditional TiDB architecture, which differs from the next-gen architecture in several ways:
+
+- No distributed file system (DFS) integration
+- No TiKV-Worker component
+- Simplified configuration without S3 storage requirements
+
+To test the next-gen architecture instead, see the scripts in the `next-gen` directory.

--- a/tests/realtikvtest/scripts/classic/bootstrap-test-with-cluster.sh
+++ b/tests/realtikvtest/scripts/classic/bootstrap-test-with-cluster.sh
@@ -1,0 +1,66 @@
+#! /usr/bin/env bash
+#
+# Copyright 2025 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# It need TCP ports:
+# - pd: 2379, 2380, 2381, 2383, 2384
+# - tikv: 20160, 20161, 20162, 20180, 20181, 20182
+function main() {
+    local data_base_dir=$(mktemp -d)
+    mkdir -pv ${data_base_dir}/pd-{0,1,2}/data
+    mkdir -pv ${data_base_dir}/tikv-{0,1,2}/data
+
+    local config_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../configs/classic")"
+    if [[ ! -d "${config_dir}" ]]; then
+        echo "Error: config_dir '${config_dir}' does not exist." >&2
+        exit 1
+    fi
+
+    # start the servers.
+    bin/pd-server --name=pd-0 --data-dir=${data_base_dir}/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd0.log &
+    bin/pd-server --name=pd-1 --data-dir=${data_base_dir}/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd1.log &
+    bin/pd-server --name=pd-2 --data-dir=${data_base_dir}/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd2.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
+
+    sleep 10
+    "$@"
+}
+
+function cleanup() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS: no -r option
+        killall -9 -q tikv-server || true
+        killall -9 -q pd-server || true
+    else
+        # Linux: supports -r for regex
+        killall -9 -r -q tikv-server || true
+        killall -9 -r -q pd-server || true
+    fi
+}
+
+exit_code=0
+{ # try block
+    main "$@"
+} || { # catch block
+   exit_code="$?"  # exit code of last command which is 44
+}
+# finally block:
+cleanup
+
+if [[ "$exit_code" != '0' ]]; then
+   exit ${exit_code}
+fi

--- a/tests/realtikvtest/scripts/classic/run-tests-with-gotest.sh
+++ b/tests/realtikvtest/scripts/classic/run-tests-with-gotest.sh
@@ -20,49 +20,9 @@
 function main() {
     local test_suite="$1"
     local suite_timeout="${2:-40m}"
-    local data_base_dir=$(mktemp -d)
-    mkdir -pv ${data_base_dir}/pd-{0,1,2}/data
-    mkdir -pv ${data_base_dir}/tikv-{0,1,2}/data
 
-    local config_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../configs/classic")"
-    if [[ ! -d "${config_dir}" ]]; then
-        echo "Error: config_dir '${config_dir}' does not exist." >&2
-        exit 1
-    fi
-
-    # start the servers.
-    bin/pd-server --name=pd-0 --data-dir=${data_base_dir}/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd0.log &
-    bin/pd-server --name=pd-1 --data-dir=${data_base_dir}/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd1.log &
-    bin/pd-server --name=pd-2 --data-dir=${data_base_dir}/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd2.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
-
-    sleep 10
-    go test ./tests/realtikvtest/${test_suite} -v --tags=intest  -with-real-tikv -timeout ${suite_timeout}
+    local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+    "${self_dir}/bootstrap-test-with-cluster" go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}
 }
 
-function cleanup() {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS: no -r option
-        killall -9 -q tikv-server || true
-        killall -9 -q pd-server || true
-    else
-        # Linux: supports -r for regex
-        killall -9 -r -q tikv-server || true
-        killall -9 -r -q pd-server || true
-    fi
-}
-
-exit_code=0
-{ # try block
-    main "$@"
-} || { # catch block
-   exit_code="$?"  # exit code of last command which is 44
-}
-# finally block:
-cleanup
-
-if [[ "$exit_code" != '0' ]]; then
-   exit ${exit_code}
-fi
+main "$@"

--- a/tests/realtikvtest/scripts/classic/run-tests-with-gotest.sh
+++ b/tests/realtikvtest/scripts/classic/run-tests-with-gotest.sh
@@ -22,7 +22,7 @@ function main() {
     local suite_timeout="${2:-40m}"
 
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-    "${self_dir}/bootstrap-test-with-cluster" go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}
+    "${self_dir}/bootstrap-test-with-cluster.sh" go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}
 }
 
 main "$@"

--- a/tests/realtikvtest/scripts/classic/run-tests.sh
+++ b/tests/realtikvtest/scripts/classic/run-tests.sh
@@ -19,49 +19,9 @@
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
 function main() {
     local make_test_task="$1"
-    local data_base_dir=$(mktemp -d)
-    mkdir -pv ${data_base_dir}/pd-{0,1,2}/data
-    mkdir -pv ${data_base_dir}/tikv-{0,1,2}/data
 
-    local config_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../configs/classic")"
-    if [[ ! -d "${config_dir}" ]]; then
-        echo "Error: config_dir '${config_dir}' does not exist." >&2
-        exit 1
-    fi
-
-    # start the servers.
-    bin/pd-server --name=pd-0 --data-dir=${data_base_dir}/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd0.log &
-    bin/pd-server --name=pd-1 --data-dir=${data_base_dir}/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd1.log &
-    bin/pd-server --name=pd-2 --data-dir=${data_base_dir}/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd2.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
-
-    sleep 10
-    make ${make_test_task}
+    local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+    "${self_dir}/bootstrap-test-with-cluster" make ${make_test_task}
 }
 
-function cleanup() {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS: no -r option
-        killall -9 -q tikv-server || true
-        killall -9 -q pd-server || true
-    else
-        # Linux: supports -r for regex
-        killall -9 -r -q tikv-server || true
-        killall -9 -r -q pd-server || true
-    fi
-}
-
-exit_code=0
-{ # try block
-    main "$@"
-} || { # catch block
-   exit_code="$?"  # exit code of last command which is 44
-}
-# finally block:
-cleanup
-
-if [[ "$exit_code" != '0' ]]; then
-   exit ${exit_code}
-fi
+main "$@"

--- a/tests/realtikvtest/scripts/classic/run-tests.sh
+++ b/tests/realtikvtest/scripts/classic/run-tests.sh
@@ -21,7 +21,7 @@ function main() {
     local make_test_task="$1"
 
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-    "${self_dir}/bootstrap-test-with-cluster" make ${make_test_task}
+    "${self_dir}/bootstrap-test-with-cluster.sh" make ${make_test_task}
 }
 
 main "$@"

--- a/tests/realtikvtest/scripts/next-gen/README.md
+++ b/tests/realtikvtest/scripts/next-gen/README.md
@@ -1,0 +1,108 @@
+# Next-Gen TiDB Testing Scripts
+
+This directory contains scripts for testing the next-generation TiDB architecture with a local test cluster. These scripts help set up and run tests against a real TiKV cluster with next-generation components.
+
+## Overview
+
+The scripts in this directory facilitate testing the next-generation architecture of TiDB by:
+
+1. Setting up a local test cluster with PD, TiKV, and TiKV-Worker components
+2. Configuring MinIO as an S3-compatible storage for DFS (Distributed File System) features
+3. Running test suites against this cluster
+
+## Scripts
+
+### bootstrap-test-with-cluster.sh
+
+This script sets up a complete local test cluster with:
+- 3 PD nodes
+- 3 TiKV servers
+- 1 TiKV-Worker node
+- MinIO server for S3-compatible storage
+
+It creates temporary data directories, configures the components using the configuration files in `tests/realtikvtest/configs/next-gen/`, and starts all services required for testing.
+
+Usage:
+```bash
+./bootstrap-test-with-cluster.sh <command>
+```
+
+The script will execute `<command>` with the `NEXT_GEN=1` environment variable set.
+
+### run-tests-with-gotest.sh
+
+This script runs a specific Go test suite against the next-gen cluster.
+
+Usage:
+```bash
+./run-tests-with-gotest.sh <test_suite> [<timeout>]
+```
+
+Arguments:
+- `<test_suite>`: The test suite directory under `./tests/realtikvtest/`
+- `<timeout>`: Optional timeout for the test suite (default: 40m)
+
+Example:
+```bash
+./run-tests-with-gotest.sh addindextest 60m
+```
+
+### run-tests.sh
+
+This script runs a make test task against the next-gen cluster.
+
+Usage:
+```bash
+./run-tests.sh <make_test_task>
+```
+
+Example:
+```bash
+./run-tests.sh bazel_addindextest
+```
+
+## Configuration Files
+
+The test cluster uses configuration files from `tests/realtikvtest/configs/next-gen/`:
+
+- `pd.toml`: Configuration for PD servers with keyspace settings
+- `tikv.toml`: Configuration for TiKV servers with storage, DFS and IA settings
+- `tikv-worker.toml`: Configuration for TiKV-Worker with DFS and IA settings
+
+## Required Ports
+
+The test cluster requires the following TCP ports to be available:
+
+- PD: 2379, 2380, 2381, 2383, 2384
+- TiKV: 20160, 20161, 20162, 20180, 20181, 20182
+- TiKV-Worker: 19000
+- MinIO: 9000 (configurable via MINIO_PORT environment variable)
+
+## Environment Variables
+
+You can customize the MinIO setup using these environment variables:
+
+- `MINIO_BIN_PATH`: Path to the MinIO binary (defaults to searching in PATH)
+- `MINIO_PORT`: Port for the MinIO server (default: 9000)
+- `MINIO_ACCESS_KEY`: MinIO access key (default: minioadmin)
+- `MINIO_SECRET_KEY`: MinIO secret key (default: minioadmin)
+
+## Cleanup
+
+The scripts automatically clean up processes on exit. However, temporary data directories created during test runs are not automatically removed.
+
+## Requirements
+
+- Go development environment
+- TiDB development environment with compiled binaries in `bin/` directory
+- Available ports as listed above
+- Sufficient disk space for temporary data directories
+
+## Next-Gen Testing
+
+The next-gen architecture includes:
+- Distributed File System (DFS) integration with S3-compatible storage
+- TiKV-Worker for offloading coprocessor tasks
+- Enhanced Intelligent Architecture (IA) capabilities
+
+The tests are run with the `NEXT_GEN=1` environment variable to enable next-gen specific test paths.

--- a/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
+++ b/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
@@ -17,7 +17,7 @@
 # It need TCP ports:
 # - pd: 2379, 2380, 2381, 2383, 2384
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
-# - tikv-worker: 20001
+# - tikv-worker: 19000
 function main() {
     local data_base_dir=$(mktemp -d)
     mkdir -pv ${data_base_dir}/pd-{0,1,2}/data

--- a/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
+++ b/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
@@ -1,0 +1,117 @@
+#! /usr/bin/env bash
+#
+# Copyright 2025 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# It need TCP ports:
+# - pd: 2379, 2380, 2381, 2383, 2384
+# - tikv: 20160, 20161, 20162, 20180, 20181, 20182
+# - tikv-worker: 20001
+function main() {
+    local data_base_dir=$(mktemp -d)
+    mkdir -pv ${data_base_dir}/pd-{0,1,2}/data
+    mkdir -pv ${data_base_dir}/tikv-{0,1,2}/data
+    mkdir -pv ${data_base_dir}/tikv-worker/data
+
+    local config_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../configs/next-gen")"
+    if [[ ! -d "${config_dir}" ]]; then
+        echo "Error: config_dir '${config_dir}' does not exist." >&2
+        exit 1
+    fi
+
+    # init a bucket "next-gen-test", the bucket will be used for testing, do not change it.
+    mkdir -pv ${data_base_dir}/minio/data/next-gen-test
+    start_minio ${data_base_dir}/minio/data
+
+    # start the servers.
+    bin/pd-server --name=pd-0 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd0.log &
+    bin/pd-server --name=pd-1 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd1.log &
+    bin/pd-server --name=pd-2 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd2.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
+    bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:19000 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
+
+    sleep 10
+    NEXT_GEN=1 "$@"
+}
+
+function start_minio() {
+    local data_base_dir="$1"
+
+    # Ensure MinIO binary exists, download if not exists.
+    MINIO_BIN_PATH=${MINIO_BIN_PATH:-$(which minio)}
+    if [[ -z "$MINIO_BIN_PATH" || ! -x "$MINIO_BIN_PATH" ]]; then
+        echo "MinIO binary not found, downloading..."
+        MINIO_BIN_PATH="bin/minio"
+        # Determine OS and ARCH for MinIO download URL
+        OS=$(uname | tr '[:upper:]' '[:lower:]')
+        ARCH=$(uname -m)
+        case "$ARCH" in
+            x86_64) ARCH="amd64" ;;
+            aarch64 | arm64) ARCH="arm64" ;;
+            *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+        esac
+        curl -sSL -o "$MINIO_BIN_PATH" "https://dl.min.io/server/minio/release/${OS}-${ARCH}/minio"
+        chmod +x "$MINIO_BIN_PATH"
+    fi
+
+    MINIO_PORT=${MINIO_PORT:-9000}
+    MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
+    MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
+
+    # Start MinIO server in background
+    export MINIO_ROOT_USER="$MINIO_ACCESS_KEY"
+    export MINIO_ROOT_PASSWORD="$MINIO_SECRET_KEY"
+    echo "🚀 Starting MinIO server..."
+    "$MINIO_BIN_PATH" server "$data_base_dir" --address ":$MINIO_PORT" > minio.log 2>&1 &
+    MINIO_PID=$!
+
+    # Wait for MinIO to be ready (simple check)
+    for i in {1..10}; do
+        if curl -s "http://127.0.0.1:$MINIO_PORT/minio/health/ready" | grep -q "OK"; then
+            echo "MinIO is up"
+            break
+        fi
+        sleep 1
+    done
+    echo "🎉 MinIO server started successfully"
+}
+
+function cleanup() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS: no -r option
+        killall -9 -q tikv-worker || true
+        killall -9 -q tikv-server || true
+        killall -9 -q pd-server || true
+    else
+        # Linux: supports -r for regex
+        killall -9 -r -q tikv-worker || true
+        killall -9 -r -q tikv-server || true
+        killall -9 -r -q pd-server || true
+    fi
+}
+
+exit_code=0
+{ # try block
+    main "$@"
+} || { # catch block
+   exit_code="$?"  # exit code of last command which is 44
+}
+# finally block:
+cleanup
+
+if [[ "$exit_code" != '0' ]]; then
+   exit ${exit_code}
+fi

--- a/tests/realtikvtest/scripts/next-gen/run-tests-with-gotest.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests-with-gotest.sh
@@ -17,103 +17,13 @@
 # It need TCP ports:
 # - pd: 2379, 2380, 2381, 2383, 2384
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
-# - tikv-worker: 20001
+# - tikv-worker: 1900
 function main() {
     local test_suite="$1"
     local suite_timeout="${2:-40m}"
-    local data_base_dir=$(mktemp -d)
-    mkdir -pv ${data_base_dir}/pd-{0,1,2}/data
-    mkdir -pv ${data_base_dir}/tikv-{0,1,2}/data
-    mkdir -pv ${data_base_dir}/tikv-worker/data
 
-    local config_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../../configs/next-gen")"
-    if [[ ! -d "${config_dir}" ]]; then
-        echo "Error: config_dir '${config_dir}' does not exist." >&2
-        exit 1
-    fi
-
-    # init a bucket "next-gen-test", the bucket will be used for testing, do not change it.
-    mkdir -pv ${data_base_dir}/minio/data/next-gen-test
-    start_minio ${data_base_dir}/minio/data
-
-    # start the servers.
-    bin/pd-server --name=pd-0 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd0.log &
-    bin/pd-server --name=pd-1 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd1.log &
-    bin/pd-server --name=pd-2 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd2.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
-    bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:19000 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
-
-    sleep 10
-    NEXT_GEN=1 go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}
+    local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+    "${self_dir}/bootstrap-test-with-cluster" go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}
 }
 
-function start_minio() {
-    local data_base_dir="$1"
-
-    # Ensure MinIO binary exists, download if not exists.
-    MINIO_BIN_PATH=${MINIO_BIN_PATH:-$(which minio)}
-    if [[ -z "$MINIO_BIN_PATH" || ! -x "$MINIO_BIN_PATH" ]]; then
-        echo "MinIO binary not found, downloading..."
-        MINIO_BIN_PATH="bin/minio"
-        # Determine OS and ARCH for MinIO download URL
-        OS=$(uname | tr '[:upper:]' '[:lower:]')
-        ARCH=$(uname -m)
-        case "$ARCH" in
-            x86_64) ARCH="amd64" ;;
-            aarch64 | arm64) ARCH="arm64" ;;
-            *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-        esac
-        curl -sSL -o "$MINIO_BIN_PATH" "https://dl.min.io/server/minio/release/${OS}-${ARCH}/minio"
-        chmod +x "$MINIO_BIN_PATH"
-    fi
-
-    MINIO_PORT=${MINIO_PORT:-9000}
-    MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
-    MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
-
-    # Start MinIO server in background
-    export MINIO_ROOT_USER="$MINIO_ACCESS_KEY"
-    export MINIO_ROOT_PASSWORD="$MINIO_SECRET_KEY"
-    echo "🚀 Starting MinIO server..."
-    "$MINIO_BIN_PATH" server "$data_base_dir" --address ":$MINIO_PORT" > minio.log 2>&1 &
-    MINIO_PID=$!
-
-    # Wait for MinIO to be ready (simple check)
-    for i in {1..10}; do
-        if curl -s "http://127.0.0.1:$MINIO_PORT/minio/health/ready" | grep -q "OK"; then
-            echo "MinIO is up"
-            break
-        fi
-        sleep 1
-    done
-    echo "🎉 MinIO server started successfully"
-}
-
-function cleanup() {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        # macOS: no -r option
-        killall -9 -q tikv-worker || true
-        killall -9 -q tikv-server || true
-        killall -9 -q pd-server || true
-    else
-        # Linux: supports -r for regex
-        killall -9 -r -q tikv-worker || true
-        killall -9 -r -q tikv-server || true
-        killall -9 -r -q pd-server || true
-    fi
-}
-
-exit_code=0
-{ # try block
-    main "$@"
-} || { # catch block
-   exit_code="$?"  # exit code of last command which is 44
-}
-# finally block:
-cleanup
-
-if [[ "$exit_code" != '0' ]]; then
-   exit ${exit_code}
-fi
+main "$@"

--- a/tests/realtikvtest/scripts/next-gen/run-tests-with-gotest.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests-with-gotest.sh
@@ -17,13 +17,13 @@
 # It need TCP ports:
 # - pd: 2379, 2380, 2381, 2383, 2384
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
-# - tikv-worker: 1900
+# - tikv-worker: 19000
 function main() {
     local test_suite="$1"
     local suite_timeout="${2:-40m}"
 
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-    "${self_dir}/bootstrap-test-with-cluster" go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}
+    "${self_dir}/bootstrap-test-with-cluster.sh" go test ./tests/realtikvtest/${test_suite} -v --tags=intest,nextgen -with-real-tikv -timeout ${suite_timeout}
 }
 
 main "$@"

--- a/tests/realtikvtest/scripts/next-gen/run-tests-with-gotest.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests-with-gotest.sh
@@ -43,7 +43,7 @@ function main() {
     bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
     bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
     bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
-    bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:20001 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
+    bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:19000 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
 
     sleep 10
     NEXT_GEN=1 go test ./tests/realtikvtest/${test_suite} -v --tags=intest -with-real-tikv -timeout ${suite_timeout}

--- a/tests/realtikvtest/scripts/next-gen/run-tests.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests.sh
@@ -42,7 +42,7 @@ function main() {
     bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
     bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
     bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
-    bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:20001 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
+    bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:19000 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
 
     sleep 10
     NEXT_GEN=1 make ${make_test_task}

--- a/tests/realtikvtest/scripts/next-gen/run-tests.sh
+++ b/tests/realtikvtest/scripts/next-gen/run-tests.sh
@@ -17,12 +17,12 @@
 # It need TCP ports:
 # - pd: 2379, 2380, 2381, 2383, 2384
 # - tikv: 20160, 20161, 20162, 20180, 20181, 20182
-# - tikv-worker: 1900
+# - tikv-worker: 19000
 function main() {
     local make_test_task="$1"
 
     local self_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
-    "${self_dir}/bootstrap-test-with-cluster" make ${make_test_task}
+    "${self_dir}/bootstrap-test-with-cluster.sh" make ${make_test_task}
 }
 
 main "$@"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62803

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

> in `pull_integration_realcluster_test_next_gen` job: <img width="1086" height="186" alt="image" src="https://github.com/user-attachments/assets/e8f0edec-d054-4392-844a-dcdca9b5ddf6" /><img width="1080" height="201" alt="image" src="https://github.com/user-attachments/assets/ce10c66f-9aa6-4562-b3ef-8300a58fd5ec" /><img width="1073" height="194" alt="image" src="https://github.com/user-attachments/assets/6b02d6ac-6528-47a3-a292-f4a9fd4b40f6" />

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
