### PR TITLE
ttl: fix the issue that the TTL execution summary for timeout job is empty

### DIFF
--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -536,41 +536,53 @@ func (m *JobManager) checkNotOwnJob() {
 	}
 }
 
+func (m *JobManager) findAllTasksForJob(se session.Session, jobID string) ([]*cache.TTLTask, error) {
+	timeoutJobCtx, cancel := context.WithTimeout(m.ctx, ttlInternalSQLTimeout)
+	defer cancel()
+
+	sql, args := cache.SelectFromTTLTaskWithJobID(jobID)
+	rows, err := se.ExecuteSQL(timeoutJobCtx, sql, args...)
+	cancel()
+	if err != nil {
+		logutil.Logger(m.ctx).Warn("fail to execute sql", zap.String("sql", sql), zap.Any("args", args), zap.Error(err))
+		return nil, err
+	}
+
+	allTasks := make([]*cache.TTLTask, 0, len(rows))
+	for _, r := range rows {
+		task, err := cache.RowToTTLTask(se.GetSessionVars().Location(), r)
+		if err != nil {
+			logutil.Logger(m.ctx).Warn("fail to read task", zap.Error(err), zap.String("jobID", jobID))
+			return nil, err
+		}
+		allTasks = append(allTasks, task)
+	}
+
+	return allTasks, nil
+}
+
 func (m *JobManager) checkFinishedJob(se session.Session) {
 	// reverse iteration so that we could remove the job safely in the loop
-j:
 	for i := len(m.runningJobs) - 1; i >= 0; i-- {
 		job := m.runningJobs[i]
-
-		timeoutJobCtx, cancel := context.WithTimeout(m.ctx, ttlInternalSQLTimeout)
-
-		sql, args := cache.SelectFromTTLTaskWithJobID(job.id)
-		rows, err := se.ExecuteSQL(timeoutJobCtx, sql, args...)
-		cancel()
+		allTasks, err := m.findAllTasksForJob(se, job.id)
 		if err != nil {
-			logutil.Logger(m.ctx).Warn("fail to execute sql", zap.String("sql", sql), zap.Any("args", args), zap.Error(err))
+			logutil.Logger(m.ctx).Warn("fail to find all tasks for job. Skip check finished", zap.String("jobID", job.id), zap.Error(err))
 			continue
 		}
 
 		allFinished := true
-		allTasks := make([]*cache.TTLTask, 0, len(rows))
-		for _, r := range rows {
-			task, err := cache.RowToTTLTask(se.GetSessionVars().Location(), r)
-			if err != nil {
-				logutil.Logger(m.ctx).Warn("fail to read task", zap.Error(err), zap.String("jobID", job.id))
-				continue j
-			}
-			allTasks = append(allTasks, task)
-
-			if task.Status != "finished" {
+		for _, task := range allTasks {
+			if task.Status != cache.TaskStatusFinished {
 				allFinished = false
+				break
 			}
 		}
 
 		if allFinished {
 			logger := m.jobLogger(job)
 			logger.Info("job has finished")
-			summary, err := summarizeTaskResult(allTasks)
+			summary, err := summarizeTaskResultWithError(allTasks, nil)
 			if err != nil {
 				logger.Info("fail to summarize job", zap.Error(err))
 			}
@@ -584,7 +596,6 @@ j:
 			}
 			m.removeJob(job)
 		}
-		cancel()
 	}
 }
 
@@ -623,7 +634,11 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 
 				logger := m.jobLogger(job)
 				logger.Info(fmt.Sprintf("cancel job because %s", cancelReason))
-				summary, err := summarizeErr(errors.New(cancelReason))
+				allTasks, err := m.findAllTasksForJob(se, job.id)
+				if err != nil {
+					logger.Warn("fail to find all tasks for job. Summarize nothing for cancel job", zap.String("jobID", job.id), zap.Error(err))
+				}
+				summary, err := summarizeTaskResultWithError(allTasks, errors.New(cancelReason))
 				if err != nil {
 					logger.Warn("fail to summarize job", zap.Error(err))
 				}
@@ -651,7 +666,11 @@ func (m *JobManager) rescheduleJobs(se session.Session, now time.Time) {
 		// when the job is locked, it can be found in `infoSchemaCache`. Therefore, it must have been dropped.
 		logger := m.jobLogger(job)
 		logger.Info("cancel job because the table has been dropped or it's no longer TTL table")
-		summary, err := summarizeErr(errors.New("TTL table has been removed or the TTL on this table has been stopped"))
+		allTasks, err := m.findAllTasksForJob(se, job.id)
+		if err != nil {
+			logger.Warn("fail to find all tasks for job. Summarize nothing for cancel job", zap.String("jobID", job.id), zap.Error(err))
+		}
+		summary, err := summarizeTaskResultWithError(allTasks, errors.New("TTL table has been removed or the TTL on this table has been stopped"))
 		if err != nil {
 			logger.Warn("fail to summarize job", zap.Error(err))
 		}
@@ -941,7 +960,12 @@ func (m *JobManager) updateHeartBeat(ctx context.Context, se session.Session, no
 func (m *JobManager) updateHeartBeatForJob(ctx context.Context, se session.Session, now time.Time, job *ttlJob) error {
 	if job.createTime.Add(ttlJobTimeout).Before(now) {
 		m.jobLogger(job).Info("job is timeout")
-		summary, err := summarizeErr(errors.New("job is timeout"))
+		tasks, err := m.findAllTasksForJob(se, job.id)
+		if err != nil {
+			m.jobLogger(job).Warn("fail to find all tasks for job. Summarize nothing for timeout job",
+				zap.String("jobID", job.id), zap.Error(err))
+		}
+		summary, err := summarizeTaskResultWithError(tasks, errors.New("job is timeout"))
 		if err != nil {
 			return errors.Wrapf(err, "fail to summarize job")
 		}
@@ -1021,22 +1045,9 @@ type TTLSummary struct {
 	SummaryText string `json:"-"`
 }
 
-func summarizeErr(err error) (*TTLSummary, error) {
-	summary := &TTLSummary{
-		ScanTaskErr: err.Error(),
-	}
-
-	buf, err := json.Marshal(summary)
-	if err != nil {
-		return nil, err
-	}
-	summary.SummaryText = string(buf)
-	return summary, nil
-}
-
-func summarizeTaskResult(tasks []*cache.TTLTask) (*TTLSummary, error) {
+func summarizeTaskResultWithError(tasks []*cache.TTLTask, err error) (*TTLSummary, error) {
 	summary := &TTLSummary{}
-	var allErr error
+	allErr := err
 	for _, t := range tasks {
 		if t.State != nil {
 			summary.TotalRows += t.State.TotalRows

--- a/pkg/ttl/ttlworker/job_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/job_manager_integration_test.go
@@ -2117,3 +2117,39 @@ func TestIterationOfRunningJob(t *testing.T) {
 	// Now all the jobs should have been removed
 	require.Len(t, m.RunningJobs(), 0)
 }
+
+func TestTTLSummaryForTimeoutJob(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	waitAndStopTTLManager(t, dom)
+	sessionFactory := sessionFactory(t, dom)
+
+	tk := testkit.NewTestKit(t, store)
+	m := ttlworker.NewJobManager("test-job-manager", dom.AdvancedSysSessionPool(), store, nil, func() bool { return true })
+
+	se, closeSe := sessionFactory()
+	defer closeSe()
+
+	testTable := &cache.PhysicalTable{ID: 1, TableInfo: &model.TableInfo{ID: 1, TTLInfo: &model.TTLInfo{IntervalExprStr: "1", IntervalTimeUnit: int(ast.TimeUnitDay), JobInterval: "1h"}}}
+	m.InfoSchemaCache().Tables[testTable.ID] = testTable
+	jobID := uuid.NewString()
+	_, err := m.LockJob(context.Background(), se, testTable, se.Now(), jobID, false)
+	require.NoError(t, err)
+	tk.MustQuery("SELECT current_job_id, current_job_owner_id FROM mysql.tidb_ttl_table_status WHERE table_id = ?", 1).Check(testkit.Rows(fmt.Sprintf("%s %s", jobID, m.ID())))
+
+	// insert some finished task
+	tk.MustExec("INSERT INTO mysql.tidb_ttl_task (scan_id, job_id, table_id, status, state, expire_time, created_time)"+
+		" VALUES (1, ?, 1, 'finished', ?, NOW(), NOW())", jobID, `{"total_rows": 100 ,"success_rows": 100}`)
+
+	// report timeout
+	err = m.UpdateHeartBeatForJob(context.Background(), se, se.Now().Add(8*time.Hour), m.RunningJobs()[0])
+	require.NoError(t, err)
+
+	// the job should contain summary
+	rows := tk.MustQuery("SELECT last_job_summary FROM mysql.tidb_ttl_table_status WHERE table_id = ?", 1).Rows()
+	summary := &ttlworker.TTLSummary{}
+	require.NoError(t, json.Unmarshal([]byte(rows[0][0].(string)), summary))
+	require.Equal(t, uint64(100), summary.TotalRows)
+	require.Equal(t, uint64(100), summary.SuccessRows)
+	require.Equal(t, uint64(0), summary.ErrorRows)
+	require.Equal(t, "job is timeout", summary.ScanTaskErr)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61509 

Problem Summary:

### What changed and how does it work?

1. Create a new function `summarizeTaskResultWithError` to submit summary with error.
2. Find all existing tasks and summary them when the ttl job timeout.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the summary for timeout TTL job is empty
```
