### PR TITLE
ddl: fix cancelling stuck issue during adding index

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -451,6 +451,10 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		var done bool
 		for !done {
 			srcChk := w.getChunk()
+			if srcChk == nil {
+				terror.Call(rs.Close)
+				return err
+			}
 			done, err = fetchTableScanResult(w.ctx, w.copCtx.GetBase(), rs, srcChk)
 			if err != nil || util2.IsContextDone(w.ctx) {
 				w.recycleChunk(srcChk)
@@ -468,13 +472,17 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 }
 
 func (w *tableScanWorker) getChunk() *chunk.Chunk {
-	chk := <-w.srcChkPool
-	newCap := copReadBatchSize()
-	if chk.Capacity() != newCap {
-		chk = chunk.NewChunkWithCapacity(w.copCtx.GetBase().FieldTypes, newCap)
+	select {
+	case <-w.ctx.Done():
+		return nil
+	case chk := <-w.srcChkPool:
+		newCap := copReadBatchSize()
+		if chk.Capacity() != newCap {
+			chk = chunk.NewChunkWithCapacity(w.copCtx.GetBase().FieldTypes, newCap)
+		}
+		chk.Reset()
+		return chk
 	}
-	chk.Reset()
-	return chk
 }
 
 func (w *tableScanWorker) recycleChunk(chk *chunk.Chunk) {

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -486,7 +486,11 @@ func (w *tableScanWorker) getChunk() *chunk.Chunk {
 }
 
 func (w *tableScanWorker) recycleChunk(chk *chunk.Chunk) {
-	w.srcChkPool <- chk
+	select {
+	case <-w.ctx.Done():
+		return
+	case w.srcChkPool <- chk:
+	}
 }
 
 // WriteExternalStoreOperator writes index records to external storage.

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -98,8 +98,6 @@ const (
 	recoverCheckFlagDisableGC
 )
 
-var ddlLogger = logutil.BgLogger().With(zap.String("category", "ddl"))
-
 // OnExist specifies what to do when a new object has a name collision.
 type OnExist uint8
 

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -155,6 +155,7 @@ func scanRecords(p *copReqSenderPool, task *reorgBackfillTask, se *sess.Session)
 		var done bool
 		startTime := time.Now()
 		for !done {
+			failpoint.InjectCall("beforeGetChunk")
 			srcChk := p.getChunk()
 			if srcChk == nil {
 				terror.Call(rs.Close)

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -156,6 +156,10 @@ func scanRecords(p *copReqSenderPool, task *reorgBackfillTask, se *sess.Session)
 		startTime := time.Now()
 		for !done {
 			srcChk := p.getChunk()
+			if srcChk == nil {
+				terror.Call(rs.Close)
+				return err
+			}
 			done, err = fetchTableScanResult(p.ctx, p.copCtx.GetBase(), rs, srcChk)
 			if err != nil {
 				p.recycleChunk(srcChk)
@@ -253,13 +257,17 @@ func (c *copReqSenderPool) close(force bool) {
 }
 
 func (c *copReqSenderPool) getChunk() *chunk.Chunk {
-	chk := <-c.srcChkPool
-	newCap := copReadBatchSize()
-	if chk.Capacity() != newCap {
-		chk = chunk.NewChunkWithCapacity(c.copCtx.GetBase().FieldTypes, newCap)
+	select {
+	case <-c.ctx.Done():
+		return nil
+	case chk := <-c.srcChkPool:
+		newCap := copReadBatchSize()
+		if chk.Capacity() != newCap {
+			chk = chunk.NewChunkWithCapacity(c.copCtx.GetBase().FieldTypes, newCap)
+		}
+		chk.Reset()
+		return chk
 	}
-	chk.Reset()
-	return chk
 }
 
 // recycleChunk puts the index record slice and the chunk back to the pool for reuse.
@@ -267,7 +275,11 @@ func (c *copReqSenderPool) recycleChunk(chk *chunk.Chunk) {
 	if chk == nil {
 		return
 	}
-	c.srcChkPool <- chk
+	select {
+	case <-c.ctx.Done():
+		return
+	case c.srcChkPool <- chk:
+	}
 }
 
 func buildTableScan(ctx context.Context, c *copr.CopContextBase, startTS uint64, start, end kv.Key) (distsql.SelectResult, error) {

--- a/pkg/ddl/ingest/BUILD.bazel
+++ b/pkg/ddl/ingest/BUILD.bazel
@@ -67,7 +67,7 @@ go_test(
     embed = [":ingest"],
     flaky = True,
     race = "on",
-    shard_count = 18,
+    shard_count = 19,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -402,3 +402,41 @@ func TestMultiSchemaAddIndexMerge(t *testing.T) {
 		tk.MustExec("admin check table t;")
 	}
 }
+
+func TestAddIndexGetChunkCancel(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	defer ingesttestutil.InjectMockBackendMgr(t, store)()
+
+	tk.MustExec("create table t (a int primary key, b int);")
+	for i := 0; i < 100; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d);", i*10000, i*10000))
+	}
+	tk.MustExec("split table t between (0) and (1000000) regions 10;")
+	jobID := int64(0)
+	hook := &callback.TestDDLCallback{Do: dom}
+	hook.OnJobRunBeforeExported = func(job *model.Job) {
+		if jobID != 0 {
+			return
+		}
+		if job.Type == model.ActionAddIndex {
+			jobID = job.ID
+		}
+	}
+	dom.DDL().SetHook(hook)
+
+	cancelled := false
+	err := failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/beforeGetChunk", func() {
+		if !cancelled {
+			tk2 := testkit.NewTestKit(t, store)
+			tk2.MustExec(fmt.Sprintf("admin cancel ddl jobs %d", jobID))
+			cancelled = true
+		}
+	})
+	require.NoError(t, err)
+	tk.MustGetErrCode("alter table t add index idx(b);", errno.ErrCancelledDDLJob)
+	require.True(t, cancelled)
+	tk.MustExec("admin check table t;")
+	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/beforeGetChunk"))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61087

Problem Summary: See #61087 and https://github.com/pingcap/tidb/issues/61087#issuecomment-2955027436

### What changed and how does it work?

Check context done when `getChunk`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
   ```
   mysql> admin cancel ddl jobs 213;
   +--------+------------+
   | JOB_ID | RESULT     |
   +--------+------------+
   | 213    | successful |
   +--------+------------+
   1 row in set (0.24 sec)
   
   mysql> admin show ddl jobs 1;
   +--------+---------+--------------------------+------------------------+--------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------------+
   | JOB_ID | DB_NAME | TABLE_NAME               | JOB_TYPE               | SCHEMA_STATE | SCHEMA_ID | TABLE_ID | ROW_COUNT | CREATE_TIME         | START_TIME          | END_TIME            | STATE         |
   +--------+---------+--------------------------+------------------------+--------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------------+
   |    213 | test    | sol_token_latest_balance | add index /* ingest */ | none         |         2 |      102 | 632713583 | 2025-06-09 07:41:50 | 2025-06-09 07:41:50 | 2025-06-09 07:46:29 | rollback done |
   +--------+---------+--------------------------+------------------------+--------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------------+
   1 row in set (1.01 sec)
   ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
