### PR TITLE
statistics: internal sql must have invalid stats

### DIFF
--- a/pkg/statistics/column.go
+++ b/pkg/statistics/column.go
@@ -150,6 +150,10 @@ func ColumnStatsIsInvalid(colStats *Column, sctx planctx.PlanContext, histColl *
 		}()
 	}
 	if sctx != nil {
+		if sctx.GetSessionVars().InRestrictedSQL {
+			inValidForCollPseudo = true
+			return true
+		}
 		stmtctx := sctx.GetSessionVars().StmtCtx
 		if (colStats == nil || !colStats.IsStatsInitialized() || colStats.IsLoadNeeded()) &&
 			stmtctx != nil &&

--- a/pkg/statistics/index.go
+++ b/pkg/statistics/index.go
@@ -140,7 +140,7 @@ func IndexStatsIsInvalid(sctx planctx.PlanContext, idxStats *Index, coll *HistCo
 	}
 	// If the given index statistics is nil or we found that the index's statistics hasn't been fully loaded, we add this index to NeededItems.
 	// Also, we need to check that this HistColl has its physical ID and it is permitted to trigger the stats loading.
-	if (idxStats == nil || !idxStats.IsFullLoad()) && !coll.CanNotTriggerLoad {
+	if (idxStats == nil || !idxStats.IsFullLoad()) && !coll.CanNotTriggerLoad && !sctx.GetSessionVars().InRestrictedSQL {
 		asyncload.AsyncLoadHistogramNeededItems.Insert(model.TableItemID{
 			TableID:          coll.PhysicalID,
 			ID:               cid,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61601

Problem Summary:

### What changed and how does it work?

Internal SQL has no stats. so ```xxxxStatsIsInvailed``` must get the invalid result. so now you directly return invalid when it is a internal sql.


Another major issue is that none of our estimation processes check whether it is a memory or system database (  IsMemOrSysDB  ) or if it is in restricted SQL mode (  InRestrictedSQL  ). This can lead to potential problems in certain checks. Further investigation of the relevant code is still needed.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before the bugfix:

![Image](https://github.com/user-attachments/assets/55566247-1b95-439a-9b17-45efa5aba744)


after the bugfix:

<img width="1524" alt="image" src="https://github.com/user-attachments/assets/4f0ff7a0-8cef-4c98-9120-9e8cda6fe70e" />


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
