### PR TITLE
planner: fix the wrong join estimation depending on missing or uninitialized stats

### DIFF
--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -472,7 +472,7 @@ func getGroupNDVs(ds *logicalop.DataSource) []property.GroupNDV {
 					break
 				}
 			}
-			if match {
+			if match && idx.IsEssentialStatsLoaded() {
 				ndv := property.GroupNDV{
 					Cols: idxCols,
 					NDV:  float64(idx.NDV),

--- a/tests/integrationtest/r/executor/index_lookup_merge_join.result
+++ b/tests/integrationtest/r/executor/index_lookup_merge_join.result
@@ -11,14 +11,12 @@ insert into t1 values(1,1,1,1),(2,2,2,2),(3,3,3,3);
 insert into t2 values(1,1,1,1),(2,2,2,2);
 explain format = 'brief' select /*+ inl_merge_join(t1,t2) */ * from t1 left join t2 on t1.a = t2.a and t1.c = t2.c and t1.b = t2.b order by t1.a desc;
 id	estRows	task	access object	operator info
-IndexJoin	100000000.00	root		left outer join, inner:IndexLookUp, left side:Projection, outer key:executor__index_lookup_merge_join.t1.a, executor__index_lookup_merge_join.t1.c, executor__index_lookup_merge_join.t1.b, inner key:executor__index_lookup_merge_join.t2.a, executor__index_lookup_merge_join.t2.c, executor__index_lookup_merge_join.t2.b, equal cond:eq(executor__index_lookup_merge_join.t1.a, executor__index_lookup_merge_join.t2.a), eq(executor__index_lookup_merge_join.t1.b, executor__index_lookup_merge_join.t2.b), eq(executor__index_lookup_merge_join.t1.c, executor__index_lookup_merge_join.t2.c)
-├─Projection(Build)	10000.00	root		executor__index_lookup_merge_join.t1.a, executor__index_lookup_merge_join.t1.b, executor__index_lookup_merge_join.t1.c, executor__index_lookup_merge_join.t1.d
-│ └─IndexLookUp	10000.00	root		
-│   ├─IndexFullScan(Build)	10000.00	cop[tikv]	table:t1, index:PRIMARY(a, b, c)	keep order:true, desc, stats:pseudo
-│   └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	10000.00	root		
-  ├─IndexRangeScan(Build)	10000.00	cop[tikv]	table:t2, index:PRIMARY(a, b, c)	range: decided by [eq(executor__index_lookup_merge_join.t2.a, executor__index_lookup_merge_join.t1.a) eq(executor__index_lookup_merge_join.t2.b, executor__index_lookup_merge_join.t1.b) eq(executor__index_lookup_merge_join.t2.c, executor__index_lookup_merge_join.t1.c)], keep order:false, stats:pseudo
-  └─TableRowIDScan(Probe)	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+Sort	12500.00	root		executor__index_lookup_merge_join.t1.a:desc
+└─HashJoin	12500.00	root		left outer join, left side:TableReader, equal:[eq(executor__index_lookup_merge_join.t1.a, executor__index_lookup_merge_join.t2.a) eq(executor__index_lookup_merge_join.t1.c, executor__index_lookup_merge_join.t2.c) eq(executor__index_lookup_merge_join.t1.b, executor__index_lookup_merge_join.t2.b)]
+  ├─TableReader(Build)	10000.00	root		data:TableFullScan
+  │ └─TableFullScan	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+  └─TableReader(Probe)	10000.00	root		data:TableFullScan
+    └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ inl_merge_join(t1,t2) */ * from t1 left join t2 on t1.a = t2.a and t1.c = t2.c and t1.b = t2.b order by t1.a desc;
 a	b	c	d	a	b	c	d
 3	3	3	3	NULL	NULL	NULL	NULL

--- a/tests/integrationtest/r/explain_complex.result
+++ b/tests/integrationtest/r/explain_complex.result
@@ -153,16 +153,16 @@ Projection	1.00	root		explain_complex.st.cm, explain_complex.st.p1, explain_comp
       └─TableRowIDScan	250.00	cop[tikv]	table:st	keep order:false, stats:pseudo
 explain format = 'brief' select dt.id as id, dt.aid as aid, dt.pt as pt, dt.dic as dic, dt.cm as cm, rr.gid as gid, rr.acd as acd, rr.t as t,dt.p1 as p1, dt.p2 as p2, dt.p3 as p3, dt.p4 as p4, dt.p5 as p5, dt.p6_md5 as p6, dt.p7_md5 as p7 from dt dt join rr rr on (rr.pt = 'ios' and rr.t > 1478185592 and dt.aid = rr.aid and dt.dic = rr.dic) where dt.pt = 'ios' and dt.t > 1478185592 and dt.bm = 0 limit 2000;
 id	estRows	task	access object	operator info
-Projection	3.33	root		explain_complex.dt.id, explain_complex.dt.aid, explain_complex.dt.pt, explain_complex.dt.dic, explain_complex.dt.cm, explain_complex.rr.gid, explain_complex.rr.acd, explain_complex.rr.t, explain_complex.dt.p1, explain_complex.dt.p2, explain_complex.dt.p3, explain_complex.dt.p4, explain_complex.dt.p5, explain_complex.dt.p6_md5, explain_complex.dt.p7_md5
-└─Limit	3.33	root		offset:0, count:2000
-  └─IndexJoin	3.33	root		inner join, inner:IndexLookUp, outer key:explain_complex.rr.aid, explain_complex.rr.dic, inner key:explain_complex.dt.aid, explain_complex.dt.dic, equal cond:eq(explain_complex.rr.aid, explain_complex.dt.aid), eq(explain_complex.rr.dic, explain_complex.dt.dic)
+Projection	1.25	root		explain_complex.dt.id, explain_complex.dt.aid, explain_complex.dt.pt, explain_complex.dt.dic, explain_complex.dt.cm, explain_complex.rr.gid, explain_complex.rr.acd, explain_complex.rr.t, explain_complex.dt.p1, explain_complex.dt.p2, explain_complex.dt.p3, explain_complex.dt.p4, explain_complex.dt.p5, explain_complex.dt.p6_md5, explain_complex.dt.p7_md5
+└─Limit	1.25	root		offset:0, count:2000
+  └─IndexJoin	1.25	root		inner join, inner:IndexLookUp, outer key:explain_complex.rr.aid, explain_complex.rr.dic, inner key:explain_complex.dt.aid, explain_complex.dt.dic, equal cond:eq(explain_complex.rr.aid, explain_complex.dt.aid), eq(explain_complex.rr.dic, explain_complex.dt.dic)
     ├─TableReader(Build)	3.33	root		data:Selection
     │ └─Selection	3.33	cop[tikv]		eq(explain_complex.rr.pt, "ios"), gt(explain_complex.rr.t, 1478185592)
     │   └─TableFullScan	10000.00	cop[tikv]	table:rr	keep order:false, stats:pseudo
-    └─IndexLookUp(Probe)	3.33	root		
+    └─IndexLookUp(Probe)	1.25	root		
       ├─Selection(Build)	3.33	cop[tikv]		not(isnull(explain_complex.dt.dic))
       │ └─IndexRangeScan	3.33	cop[tikv]	table:dt, index:aid(aid, dic)	range: decided by [eq(explain_complex.dt.aid, explain_complex.rr.aid) eq(explain_complex.dt.dic, explain_complex.rr.dic)], keep order:false, stats:pseudo
-      └─Selection(Probe)	3.33	cop[tikv]		eq(explain_complex.dt.bm, 0), eq(explain_complex.dt.pt, "ios"), gt(explain_complex.dt.t, 1478185592)
+      └─Selection(Probe)	1.25	cop[tikv]		eq(explain_complex.dt.bm, 0), eq(explain_complex.dt.pt, "ios"), gt(explain_complex.dt.t, 1478185592)
         └─TableRowIDScan	3.33	cop[tikv]	table:dt	keep order:false, stats:pseudo
 explain format = 'brief' select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	estRows	task	access object	operator info

--- a/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+++ b/tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
@@ -1263,10 +1263,10 @@ PRIMARY KEY (`COL1`,`COL2`) /*T![clustered_index] NONCLUSTERED */
 insert into PK_S_MULTI_31 values(122,100),(124,-22),(124,34),(127,103);
 explain format='brief' SELECT col2 FROM PK_S_MULTI_31 AS T1 WHERE (SELECT count(DISTINCT COL1, COL2) FROM PK_S_MULTI_31 AS T2 WHERE T2.COL1>T1.COL1)>2 order by col2;
 id	estRows	task	access object	operator info
-Sort	0.80	root		planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2
-└─Projection	0.80	root		planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2
-  └─Selection	0.80	root		gt(Column#7, 2)
-    └─HashAgg	1.00	root		group by:planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col1, planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2)->planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2, funcs:count(distinct planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col1, planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2)->Column#7
+Sort	6400.00	root		planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2
+└─Projection	6400.00	root		planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2
+  └─Selection	6400.00	root		gt(Column#7, 2)
+    └─HashAgg	8000.00	root		group by:planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col1, planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2, funcs:firstrow(planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2)->planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2, funcs:count(distinct planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col1, planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col2)->Column#7
       └─HashJoin	100000000.00	root		CARTESIAN left outer join, left side:IndexReader, other cond:gt(planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col1, planner__core__casetest__physicalplantest__physical_plan.pk_s_multi_31.col1)
         ├─IndexReader(Build)	10000.00	root		index:IndexFullScan
         │ └─IndexFullScan	10000.00	cop[tikv]	table:T2, index:PRIMARY(COL1, COL2)	keep order:false, stats:pseudo

--- a/tests/integrationtest/r/planner/core/indexjoin.result
+++ b/tests/integrationtest/r/planner/core/indexjoin.result
@@ -94,14 +94,14 @@ Projection	9990.00	root		planner__core__indexjoin.t.a, Column#4, planner__core__
         └─IndexFullScan	10000.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select a, b from t group by a, b) tmp, t1 where tmp.a=t1.a;
 id	estRows	task	access object	operator info
-Projection	1.25	root		planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
-└─IndexJoin	1.25	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
+Projection	9990.00	root		planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
+└─IndexJoin	9990.00	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
   ├─IndexReader(Build)	9990.00	root		index:IndexFullScan
   │ └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
-  └─StreamAgg(Probe)	1.25	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-    └─IndexReader	1.25	root		index:Selection
-      └─Selection	1.25	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
-        └─IndexRangeScan	1.25	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
+  └─StreamAgg(Probe)	9990.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+    └─IndexReader	9990.00	root		index:Selection
+      └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
+        └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
 select /*+ INL_JOIN(tmp) */ tmp.a, t1.b from (select a, b from t group by a, b) tmp, t1 where tmp.a=t1.a order by tmp.a, t1.b;
 a	b
 1	1
@@ -120,13 +120,13 @@ a	b
 1	2
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select a, b from t where a=1 group by a, b having a>0 ) tmp, t1 where tmp.a=t1.a;
 id	estRows	task	access object	operator info
-IndexJoin	1.25	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
+IndexJoin	10.00	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
 ├─IndexReader(Build)	3333.33	root		index:IndexRangeScan
 │ └─IndexRangeScan	3333.33	cop[tikv]	table:t1, index:idx(a, b)	range:(0,+inf], keep order:false, stats:pseudo
-└─StreamAgg(Probe)	1.25	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-  └─IndexReader	1.25	root		index:Selection
-    └─Selection	1.25	cop[tikv]		eq(planner__core__indexjoin.t.a, 1)
-      └─IndexRangeScan	1250.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
+└─StreamAgg(Probe)	10.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+  └─IndexReader	10.00	root		index:Selection
+    └─Selection	10.00	cop[tikv]		eq(planner__core__indexjoin.t.a, 1)
+      └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
 select /*+ INL_JOIN(tmp) */ tmp.a, t1.b from (select a, b from t where a=1 group by a, b having a>0 ) tmp, t1 where tmp.a=t1.a order by tmp.a, t1.b;
 a	b
 1	1
@@ -145,16 +145,16 @@ a	b
 1	2
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select a +1 as a1, b from t group by a, b ) tmp, t1 where tmp.a1=t1.a;
 id	estRows	task	access object	operator info
-IndexHashJoin	1.25	root		inner join, inner:IndexReader, outer key:Column#4, inner key:planner__core__indexjoin.t1.a, equal cond:eq(Column#4, planner__core__indexjoin.t1.a)
-├─Projection(Build)	1.00	root		plus(planner__core__indexjoin.t.a, 1)->Column#4, planner__core__indexjoin.t.b
-│ └─StreamAgg	1.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-│   └─IndexReader	1.00	root		index:StreamAgg
-│     └─StreamAgg	1.00	cop[tikv]		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, 
-│       └─Selection	8000.00	cop[tikv]		not(isnull(plus(planner__core__indexjoin.t.a, 1)))
-│         └─IndexFullScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	keep order:true, stats:pseudo
-└─IndexReader(Probe)	1.25	root		index:Selection
-  └─Selection	1.25	cop[tikv]		not(isnull(planner__core__indexjoin.t1.a))
-    └─IndexRangeScan	1.25	cop[tikv]	table:t1, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t1.a, Column#4)], keep order:false, stats:pseudo
+Projection	8000.00	root		Column#4, planner__core__indexjoin.t.b, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
+└─HashJoin	8000.00	root		inner join, equal:[eq(planner__core__indexjoin.t1.a, Column#4)]
+  ├─Projection(Build)	6400.00	root		plus(planner__core__indexjoin.t.a, 1)->Column#4, planner__core__indexjoin.t.b
+  │ └─HashAgg	6400.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+  │   └─IndexReader	6400.00	root		index:HashAgg
+  │     └─HashAgg	6400.00	cop[tikv]		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, 
+  │       └─Selection	8000.00	cop[tikv]		not(isnull(plus(planner__core__indexjoin.t.a, 1)))
+  │         └─IndexFullScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	keep order:false, stats:pseudo
+  └─IndexReader(Probe)	9990.00	root		index:IndexFullScan
+    └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
 create table t3 (a int, b float, index idx (b));
 create table t4 (a int, b double);
 insert into t3 values (1, 1.0), (1, 2.0), (2, 3.0);
@@ -174,20 +174,20 @@ select /*+ INL_JOIN(tmp) */ tmp.b, t4.b from (select b from t3 group by b) tmp, 
 b	b
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select a, b from t where a>=1 group by a, b) tmp, t1 where tmp.a=t1.a;
 id	estRows	task	access object	operator info
-IndexJoin	1.25	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
+IndexJoin	3333.33	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
 ├─IndexReader(Build)	9990.00	root		index:IndexFullScan
 │ └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
-└─StreamAgg(Probe)	1.25	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-  └─IndexReader	1.25	root		index:Selection
-    └─Selection	1.25	cop[tikv]		ge(planner__core__indexjoin.t.a, 1), not(isnull(planner__core__indexjoin.t.a))
-      └─IndexRangeScan	3.75	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
+└─StreamAgg(Probe)	3333.33	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+  └─IndexReader	3333.33	root		index:Selection
+    └─Selection	3333.33	cop[tikv]		ge(planner__core__indexjoin.t.a, 1), not(isnull(planner__core__indexjoin.t.a))
+      └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select a+1 as a1, b from t where a>=1 group by a, b having a=1) tmp, t1 where tmp.a1=t1.b;
 id	estRows	task	access object	operator info
-HashJoin	1.25	root		inner join, equal:[eq(Column#4, planner__core__indexjoin.t1.b)]
-├─Projection(Build)	1.00	root		plus(planner__core__indexjoin.t.a, 1)->Column#4, planner__core__indexjoin.t.b
-│ └─StreamAgg	1.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-│   └─IndexReader	1.00	root		index:StreamAgg
-│     └─StreamAgg	1.00	cop[tikv]		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, 
+HashJoin	10.00	root		inner join, equal:[eq(Column#4, planner__core__indexjoin.t1.b)]
+├─Projection(Build)	8.00	root		plus(planner__core__indexjoin.t.a, 1)->Column#4, planner__core__indexjoin.t.b
+│ └─StreamAgg	8.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+│   └─IndexReader	8.00	root		index:StreamAgg
+│     └─StreamAgg	8.00	cop[tikv]		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, 
 │       └─IndexRangeScan	10.00	cop[tikv]	table:t, index:idx(a, b)	range:[1,1], keep order:true, stats:pseudo
 └─IndexReader(Probe)	9990.00	root		index:Selection
   └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t1.b))
@@ -205,15 +205,15 @@ Projection	9990.00	root		planner__core__indexjoin.t.a, Column#4, planner__core__
           └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select /*+ stream_agg() */ b, a from t group by b, a) tmp, t1 where tmp.a=t1.a;
 id	estRows	task	access object	operator info
-Projection	1.25	root		planner__core__indexjoin.t.b, planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
-└─Projection	1.25	root		planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
-  └─IndexJoin	1.25	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
+Projection	9990.00	root		planner__core__indexjoin.t.b, planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
+└─Projection	9990.00	root		planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b
+  └─IndexJoin	9990.00	root		inner join, inner:StreamAgg, outer key:planner__core__indexjoin.t1.a, inner key:planner__core__indexjoin.t.a, equal cond:eq(planner__core__indexjoin.t1.a, planner__core__indexjoin.t.a)
     ├─IndexReader(Build)	9990.00	root		index:IndexFullScan
     │ └─IndexFullScan	9990.00	cop[tikv]	table:t1, index:idx(a, b)	keep order:false, stats:pseudo
-    └─StreamAgg(Probe)	1.25	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
-      └─IndexReader	1.25	root		index:Selection
-        └─Selection	1.25	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
-          └─IndexRangeScan	1.25	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
+    └─StreamAgg(Probe)	9990.00	root		group by:planner__core__indexjoin.t.a, planner__core__indexjoin.t.b, funcs:firstrow(planner__core__indexjoin.t.a)->planner__core__indexjoin.t.a, funcs:firstrow(planner__core__indexjoin.t.b)->planner__core__indexjoin.t.b
+      └─IndexReader	9990.00	root		index:Selection
+        └─Selection	9990.00	cop[tikv]		not(isnull(planner__core__indexjoin.t.a))
+          └─IndexRangeScan	10000.00	cop[tikv]	table:t, index:idx(a, b)	range: decided by [eq(planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a)], keep order:true, stats:pseudo
 explain format='brief' select /*+ INL_JOIN(tmp) */ * from (select /*+ stream_agg() */ b, a from t group by b, a) tmp, t1 where tmp.a=t1.a and tmp.b=t1.b;
 id	estRows	task	access object	operator info
 Projection	9980.01	root		planner__core__indexjoin.t.b, planner__core__indexjoin.t.a, planner__core__indexjoin.t1.a, planner__core__indexjoin.t1.b


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61602

Problem Summary: planner: fix the wrong join estimation depending on missing or uninitialized stats

### What changed and how does it work?

planner: fix the wrong join estimation depending on missing or uninitialized stats

It's hard to construct test cases for this issue since it depends on stats cache's status. So I tested it locally, and this PR can work for this scenario:

<img width="564" alt="image" src="https://github.com/user-attachments/assets/e38a9054-c0ae-4cd2-b371-03b0338930af" />


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
