### PR TITLE
executor: disable tiflash hash join v2 by default

### DIFF
--- a/pkg/executor/join/joinversion/join_version.go
+++ b/pkg/executor/join/joinversion/join_version.go
@@ -28,7 +28,7 @@ const (
 	// HashJoinVersionOptimized means hash join v2
 	HashJoinVersionOptimized = "optimized"
 	// TiFlashHashJoinVersionDefVal means the default value of hash join version in TiFlash
-	TiFlashHashJoinVersionDefVal = HashJoinVersionOptimized
+	TiFlashHashJoinVersionDefVal = HashJoinVersionLegacy
 )
 
 var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/60299

Problem Summary:

### What changed and how does it work?

TiFlash hash join v2 is enabled in master for test purpose. 
Now disable tiflash hash join v2 in the coming release version.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
