### PR TITLE
dxf: make import job preparation and planning cancelable

### DIFF
--- a/pkg/dxf/framework/scheduler/scheduler.go
+++ b/pkg/dxf/framework/scheduler/scheduler.go
@@ -46,6 +46,8 @@ import (
 const metricStateAll = "all"
 
 var (
+	errTaskChanged = goerrors.New("task state or step changed")
+
 	// CheckTaskFinishedInterval is the interval for scheduler.
 	// exported for testing.
 	CheckTaskFinishedInterval = 500 * time.Millisecond
@@ -174,6 +176,58 @@ func (s *BaseScheduler) refreshTaskIfNeeded() error {
 		s.task.Store(newTask)
 	}
 	return nil
+}
+
+// startTaskStateWatcher cancels long-running prepare or plan work when the
+// persisted task state or step no longer matches the scheduler's task snapshot.
+// The returned stop function must be called after the work finishes. It waits
+// for the watcher to exit and reports whether the task changed.
+func (s *BaseScheduler) startTaskStateWatcher(task *proto.Task) (context.Context, func() bool) {
+	watchCtx, cancel := context.WithCancelCause(s.ctx)
+	done := make(chan struct{})
+	taskBase := task.TaskBase
+	go func() {
+		defer close(done)
+
+		ticker := time.NewTicker(CheckTaskFinishedInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-watchCtx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			newTaskBase, err := s.taskMgr.GetTaskBaseByID(watchCtx, taskBase.ID)
+			if err != nil {
+				if watchCtx.Err() != nil {
+					return
+				}
+				if goerrors.Is(err, storage.ErrTaskNotFound) {
+					cancel(errTaskChanged)
+					return
+				}
+				s.sampleLogger.Warn("check task state during prepare or plan failed", zap.Error(err))
+				continue
+			}
+			if newTaskBase.State != taskBase.State || newTaskBase.Step != taskBase.Step {
+				s.logger.Info("task state or step changed, cancel prepare or plan",
+					zap.Stringer("old-state", taskBase.State),
+					zap.Stringer("new-state", newTaskBase.State),
+					zap.String("old-step", proto.Step2Str(taskBase.Type, taskBase.Step)),
+					zap.String("new-step", proto.Step2Str(taskBase.Type, newTaskBase.Step)))
+				cancel(errTaskChanged)
+				return
+			}
+		}
+	}()
+
+	stop := func() bool {
+		cancel(nil)
+		<-done
+		return goerrors.Is(context.Cause(watchCtx), errTaskChanged)
+	}
+	return watchCtx, stop
 }
 
 // scheduleTask schedule the task execution step by step.
@@ -406,7 +460,12 @@ func (s *BaseScheduler) onPending() error {
 	s.logger.Debug("on pending state", zap.Stringer("state", task.State),
 		zap.String("step", proto.Step2Str(task.Type, task.Step)))
 	if task.Step == proto.StepInit && task.ExtraParams.PrepareMode == proto.PrepareModeRequired {
-		if err := s.OnPrepare(s.ctx, s, task); err != nil {
+		prepareCtx, stopWatcher := s.startTaskStateWatcher(task)
+		err := s.OnPrepare(prepareCtx, s, task)
+		if stopWatcher() {
+			return nil
+		}
+		if err != nil {
 			return s.handlePrepareOrPlanErr(err)
 		}
 		switched, err := s.taskMgr.SwitchTaskStepAfterPrepare(s.ctx, task)
@@ -592,7 +651,11 @@ func (s *BaseScheduler) switch2NextStep() error {
 		return errors.New("no available TiDB node to dispatch subtasks")
 	}
 
-	metas, err := s.OnNextSubtasksBatch(s.ctx, s, task, eligibleNodes, nextStep)
+	planCtx, stopWatcher := s.startTaskStateWatcher(task)
+	metas, err := s.OnNextSubtasksBatch(planCtx, s, task, eligibleNodes, nextStep)
+	if stopWatcher() {
+		return nil
+	}
 	if err != nil {
 		s.logger.Warn("generate part of subtasks failed", zap.Error(err))
 		return s.handlePrepareOrPlanErr(err)

--- a/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
+++ b/pkg/dxf/framework/scheduler/scheduler_nokit_test.go
@@ -748,6 +748,147 @@ func TestSchedulerMaintainTaskFields(t *testing.T) {
 		require.True(t, ctrl.Satisfied())
 	})
 
+	t.Run("test task state change cancels prepare", func(t *testing.T) {
+		originalInterval := CheckTaskFinishedInterval
+		CheckTaskFinishedInterval = 10 * time.Millisecond
+		t.Cleanup(func() {
+			CheckTaskFinishedInterval = originalInterval
+		})
+
+		subCtrl := gomock.NewController(t)
+		defer subCtrl.Finish()
+		subTaskMgr := mock.NewMockTaskManager(subCtrl)
+		subExt := schmock.NewMockExtension(subCtrl)
+		taskWithPrepare := task
+		taskWithPrepare.ExtraParams.PrepareMode = proto.PrepareModeRequired
+		subScheduler := createScheduler(&taskWithPrepare, true, subTaskMgr, subCtrl)
+		subScheduler.Extension = subExt
+
+		prepareStarted := make(chan struct{})
+		prepareCanceled := make(chan struct{})
+		releasePrepare := make(chan struct{})
+		subExt.EXPECT().OnPrepare(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ storage.TaskHandle, _ *proto.Task) error {
+				close(prepareStarted)
+				select {
+				case <-ctx.Done():
+					close(prepareCanceled)
+					return ctx.Err()
+				case <-releasePrepare:
+					return nil
+				}
+			})
+
+		cancelledTask := taskWithPrepare
+		cancelledTask.State = proto.TaskStateCancelling
+		subTaskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).
+			Return(&cancelledTask.TaskBase, nil).
+			AnyTimes()
+
+		preparePersisted := false
+		subTaskMgr.EXPECT().SwitchTaskStepAfterPrepare(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(context.Context, *proto.Task) (bool, error) {
+				preparePersisted = true
+				return false, nil
+			}).
+			AnyTimes()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- subScheduler.onPending()
+		}()
+		<-prepareStarted
+
+		wasCanceled := false
+		select {
+		case <-prepareCanceled:
+			wasCanceled = true
+		case <-time.After(time.Second):
+			close(releasePrepare)
+		}
+
+		require.NoError(t, <-done)
+		require.True(t, wasCanceled)
+		require.False(t, preparePersisted)
+		require.True(t, subCtrl.Satisfied())
+	})
+
+	t.Run("test task state change cancels plan", func(t *testing.T) {
+		originalInterval := CheckTaskFinishedInterval
+		CheckTaskFinishedInterval = 10 * time.Millisecond
+		t.Cleanup(func() {
+			CheckTaskFinishedInterval = originalInterval
+		})
+
+		subCtrl := gomock.NewController(t)
+		defer subCtrl.Finish()
+		subTaskMgr := mock.NewMockTaskManager(subCtrl)
+		subExt := schmock.NewMockExtension(subCtrl)
+		taskForPlan := task
+		subScheduler := createScheduler(&taskForPlan, true, subTaskMgr, subCtrl)
+		subScheduler.Extension = subExt
+
+		subExt.EXPECT().GetNextStep(gomock.Any()).Return(proto.StepOne)
+		subExt.EXPECT().GetEligibleInstances(gomock.Any(), gomock.Any()).Return([]string{":4000"}, nil)
+
+		planStarted := make(chan struct{})
+		planCanceled := make(chan struct{})
+		releasePlan := make(chan struct{})
+		subExt.EXPECT().OnNextSubtasksBatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(
+				ctx context.Context,
+				_ storage.TaskHandle,
+				_ *proto.Task,
+				_ []string,
+				_ proto.Step,
+			) ([][]byte, error) {
+				close(planStarted)
+				select {
+				case <-ctx.Done():
+					close(planCanceled)
+					return nil, ctx.Err()
+				case <-releasePlan:
+					return nil, nil
+				}
+			})
+
+		cancelledTask := taskForPlan
+		cancelledTask.State = proto.TaskStateCancelling
+		subTaskMgr.EXPECT().GetTaskBaseByID(gomock.Any(), task.ID).
+			Return(&cancelledTask.TaskBase, nil).
+			AnyTimes()
+
+		planPersisted := false
+		subTaskMgr.EXPECT().GetUsedSlotsOnNodes(gomock.Any()).
+			DoAndReturn(func(context.Context) (map[string]int, error) {
+				planPersisted = true
+				return nil, nil
+			}).
+			AnyTimes()
+		subTaskMgr.EXPECT().SwitchTaskStep(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil).
+			AnyTimes()
+
+		done := make(chan error, 1)
+		go func() {
+			done <- subScheduler.switch2NextStep()
+		}()
+		<-planStarted
+
+		wasCanceled := false
+		select {
+		case <-planCanceled:
+			wasCanceled = true
+		case <-time.After(time.Second):
+			close(releasePlan)
+		}
+
+		require.NoError(t, <-done)
+		require.True(t, wasCanceled)
+		require.False(t, planPersisted)
+		require.True(t, subCtrl.Satisfied())
+	})
+
 	t.Run("test revertTask", func(t *testing.T) {
 		scheduler.task.Store(&schTask)
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #59834

Problem Summary:

Cancelling an import task cannot interrupt long-running table region generation or subtask planning, so the cancel operation waits until those callbacks finish.

### What changed and how does it work?

The scheduler watches the task's persisted state and step while invoking `OnPrepare` and `OnNextSubtasksBatch`. When either changes, it cancels the callback context and returns to the scheduler refresh loop without persisting a stale callback result.

Unit tests cover cancellation during both callbacks.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operations now stop promptly when a task is cancelled, changed, or deleted during preparation or planning.
  * Prevents outdated preparation or planning results from being saved after a task state change.
  * Handles temporary task-state lookup failures without prematurely stopping operations.

* **Tests**
  * Added coverage for cancellation during preparation and planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->