### PR TITLE
lightning: change the implementation of `ScannedPos`

### DIFF
--- a/lightning/pkg/importer/chunk_process.go
+++ b/lightning/pkg/importer/chunk_process.go
@@ -341,7 +341,6 @@ func (cr *chunkProcessor) encodeLoop(
 		var newOffset, rowID, newScannedOffset int64
 		var scannedOffset int64 = -1
 		var kvSize uint64
-		var scannedOffsetErr error
 	outLoop:
 		for !canDeliver {
 			readDurStart := time.Now()
@@ -349,11 +348,7 @@ func (cr *chunkProcessor) encodeLoop(
 			columnNames := cr.parser.Columns()
 			newOffset, rowID = cr.parser.Pos()
 			if cr.chunk.FileMeta.Compression != mydump.CompressionNone || cr.chunk.FileMeta.Type == mydump.SourceTypeParquet {
-				newScannedOffset, scannedOffsetErr = cr.parser.ScannedPos()
-				if scannedOffsetErr != nil {
-					logger.Warn("fail to get data engine ScannedPos, progress may not be accurate",
-						log.ShortError(scannedOffsetErr), zap.String("file", cr.chunk.FileMeta.Path))
-				}
+				newScannedOffset = cr.parser.ScannedPos()
 				if scannedOffset == -1 {
 					scannedOffset = newScannedOffset
 				}

--- a/lightning/pkg/importer/chunk_process.go
+++ b/lightning/pkg/importer/chunk_process.go
@@ -355,6 +355,9 @@ func (cr *chunkProcessor) encodeLoop(
 					logger.Warn("fail to get data engine ScannedPos, progress may not be accurate",
 						log.ShortError(scannedOffsetErr), zap.String("file", cr.chunk.FileMeta.Path))
 				}
+				if scannedOffset == -1 {
+					scannedOffset = newScannedOffset
+				}
 			}
 
 			switch errors.Cause(err) {

--- a/pkg/executor/importer/chunk_process.go
+++ b/pkg/executor/importer/chunk_process.go
@@ -69,8 +69,7 @@ func parserEncodeReader(parser mydump.Parser, endOffset int64, filename string) 
 		}
 
 		err = parser.ReadRow()
-		// todo: we can implement a ScannedPos which don't return error, will change it later.
-		currOffset, _ := parser.ScannedPos()
+		currOffset := parser.ScannedPos()
 		switch errors.Cause(err) {
 		case nil:
 		case io.EOF:

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -316,6 +316,7 @@ func (ti *TableImporter) getParser(ctx context.Context, chunk *checkpoints.Chunk
 		if err = parser.SetPos(chunk.Chunk.Offset, chunk.Chunk.PrevRowIDMax); err != nil {
 			return nil, err
 		}
+		parser.SetScannedPos(chunk.Chunk.RealOffset)
 	}
 	return parser, nil
 }

--- a/pkg/lightning/mydump/parquet_parser.go
+++ b/pkg/lightning/mydump/parquet_parser.go
@@ -62,6 +62,8 @@ type ParquetParser struct {
 	lastRow     Row
 	logger      log.Logger
 
+	totalReadBytes int64
+
 	readSeekCloser ReadSeekCloser
 }
 
@@ -373,9 +375,10 @@ func (pp *ParquetParser) SetPos(pos int64, rowID int64) error {
 }
 
 // ScannedPos implements the Parser interface.
-// For parquet it's parquet file's reader current position.
-func (pp *ParquetParser) ScannedPos() (int64, error) {
-	return pp.readSeekCloser.Seek(0, io.SeekCurrent)
+// For parquet file, we can't get the exact position of each column reader,
+// so we just return the total read bytes of the parquet file.
+func (pp *ParquetParser) ScannedPos() int64 {
+	return pp.totalReadBytes
 }
 
 // Close closes the parquet file of the parser.
@@ -425,6 +428,7 @@ func (pp *ParquetParser) ReadRow() error {
 			return err
 		}
 	}
+	pp.totalReadBytes += int64(pp.lastRow.Length)
 	return nil
 }
 

--- a/pkg/lightning/mydump/parser.go
+++ b/pkg/lightning/mydump/parser.go
@@ -156,8 +156,9 @@ type Parser interface {
 	// TODO: replace pos with a new structure to specify position offset and rows offset
 	Pos() (pos int64, rowID int64)
 	SetPos(pos int64, rowID int64) error
-	// ScannedPos always returns the current file reader pointer's location
-	ScannedPos() (int64, error)
+	// ScannedPos always returns the current file reader pointer's location.
+	// It's used to track the progress of the reader.
+	ScannedPos() int64
 	Close() error
 	ReadRow() error
 	LastRow() Row
@@ -218,8 +219,8 @@ func (parser *blockParser) SetPos(pos int64, rowID int64) error {
 
 // ScannedPos gets the read position of current reader.
 // this always returns the position of the underlying file, either compressed or not.
-func (parser *blockParser) ScannedPos() (int64, error) {
-	return parser.reader.Seek(0, io.SeekCurrent)
+func (parser *blockParser) ScannedPos() int64 {
+	return parser.pos
 }
 
 // Pos returns the current file offset.

--- a/pkg/lightning/mydump/parser.go
+++ b/pkg/lightning/mydump/parser.go
@@ -156,9 +156,14 @@ type Parser interface {
 	// TODO: replace pos with a new structure to specify position offset and rows offset
 	Pos() (pos int64, rowID int64)
 	SetPos(pos int64, rowID int64) error
+
 	// ScannedPos always returns the current file reader pointer's location.
 	// It's used to track the progress of the reader.
-	ScannedPos() int64
+	ScannedPos() (int64, error)
+	// SetScannedPos sets the current file reader pointer's location.
+	// It's only needed for lightning parquet import.
+	SetScannedPos(pos int64)
+
 	Close() error
 	ReadRow() error
 	LastRow() Row
@@ -219,9 +224,12 @@ func (parser *blockParser) SetPos(pos int64, rowID int64) error {
 
 // ScannedPos gets the read position of current reader.
 // this always returns the position of the underlying file, either compressed or not.
-func (parser *blockParser) ScannedPos() int64 {
-	return parser.pos
+func (parser *blockParser) ScannedPos() (int64, error) {
+	return parser.reader.Seek(0, io.SeekCurrent)
 }
+
+// SetScannedPos does nothing
+func (*blockParser) SetScannedPos(_ int64) {}
 
 // Pos returns the current file offset.
 // Attention: for compressed sql/csv files, pos is the position in uncompressed files


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61088

Problem Summary:

### What changed and how does it work?

In the encode step, we will track the amount of data read and show it on the panel. This is achieved by calling `Parser.ScannedPos` to get the latest read position. However, the current implement is wrong:

https://github.com/pingcap/tidb/blob/11276faa9dc05ed7047f766a4c1fb45cd2b83109/pkg/lightning/mydump/parquet_parser.go#L377-L379

Because we will open one reader for each column, `Seek` can't reflect the actual bytes we read. Below is a simple illustration.

```
File layout (Dict page and meta are ignored)
--------------------------------------------------------------------------------------------------
|   Column 0 Group 0    |    Column 1 Group 0    |   Column 0 Group 1    |   Column 1 Group 1    | 
--------------------------------------------------------------------------------------------------
                ^                       ^
                |                       |
            Reader 0                 Reader 1
```

Since it's hard to retrieve total scanned bytes for the parser, we used the size of read rows instead which is better than using `Seek`.

Additionally, we use `ScannedPos` to update metrics for all types of data.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

As mentioned before, this interface is used to update the metrics, so changes in this PR won't affect the execution of import jobs.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
