### PR TITLE
*: adapt the show columns, show index and rename for column privilege

### DIFF
--- a/pkg/executor/simple.go
+++ b/pkg/executor/simple.go
@@ -2168,6 +2168,12 @@ func (e *SimpleExec) executeRenameUser(s *ast.RenameUserStmt) error {
 			break
 		}
 
+		// rename privileges from mysql.columns_priv
+		if err = renameUserHostInSystemTable(sqlExecutor, mysql.ColumnPrivTable, "User", "Host", userToUser); err != nil {
+			failedUser = oldUser.String() + " TO " + newUser.String() + " " + mysql.ColumnPrivTable + " error"
+			break
+		}
+
 		// rename relationship from mysql.role_edges
 		if err = renameUserHostInSystemTable(sqlExecutor, mysql.RoleEdgeTable, "TO_USER", "TO_HOST", userToUser); err != nil {
 			failedUser = oldUser.String() + " TO " + newUser.String() + " " + mysql.RoleEdgeTable + " (to) error"
@@ -2198,7 +2204,6 @@ func (e *SimpleExec) executeRenameUser(s *ast.RenameUserStmt) error {
 
 		// rename relationship from mysql.global_grants
 		// TODO: add global_grants into the parser
-		// TODO: need update columns_priv once we implement columns_priv functionality.
 		// When that is added, please refactor both executeRenameUser and executeDropUser to use an array of tables
 		// to loop over, so it is easier to maintain.
 		if err = renameUserHostInSystemTable(sqlExecutor, "global_grants", "User", "Host", userToUser); err != nil {
@@ -2391,7 +2396,7 @@ func (e *SimpleExec) executeDropUser(ctx context.Context, s *ast.DropUserStmt) e
 					break
 				}
 			}
-		} // TODO: need delete columns_priv once we implement columns_priv functionality.
+		}
 	}
 
 	if len(failedUsers) != 0 {

--- a/pkg/parser/auth/auth.go
+++ b/pkg/parser/auth/auth.go
@@ -93,3 +93,14 @@ func (role *RoleIdentity) String() string {
 	// TODO: Escape username and hostname.
 	return fmt.Sprintf("`%s`@`%s`", role.Username, role.Hostname)
 }
+
+// GetUserAndHostName returns the user and host name if the given user is not nil.
+func GetUserAndHostName(user *UserIdentity) (username string, hostname string) {
+	if user == nil {
+		return "", ""
+	}
+	if len(user.AuthUsername) > 0 && len(user.AuthHostname) > 0 {
+		return user.AuthUsername, user.AuthHostname
+	}
+	return user.Username, user.Hostname
+}

--- a/tests/integrationtest/r/executor/show.result
+++ b/tests/integrationtest/r/executor/show.result
@@ -1141,3 +1141,51 @@ t	CREATE TABLE `t` (
   `b` int DEFAULT NULL,
   PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T! PRE_SPLIT_REGIONS=2 */
+create database test_show_columns_db;
+create user test_show_columns_user;
+create table test_show_columns_db.t (a int, b int);
+// no grant would report error
+show columns from test_show_columns_db.t;
+Error 1142 (42000): SELECT command denied to user 'test_show_columns_user'@'%' for table 't'
+// with column privilege, specific columns are shown.
+grant select(a) on test_show_columns_db.t to test_show_columns_user;
+show columns from test_show_columns_db.t;
+Field	Type	Null	Key	Default	Extra
+a	int	YES		NULL	
+grant insert(b) on test_show_columns_db.t to test_show_columns_user;
+show columns from test_show_columns_db.t;
+Field	Type	Null	Key	Default	Extra
+a	int	YES		NULL	
+b	int	YES		NULL	
+// with table privilege, all columns are shown.
+revoke select(a),insert(b) on test_show_columns_db.t from test_show_columns_user;
+grant update on test_show_columns_db.t to test_show_columns_user;
+show columns from test_show_columns_db.t;
+Field	Type	Null	Key	Default	Extra
+a	int	YES		NULL	
+b	int	YES		NULL	
+drop database test_show_columns_db;
+drop user test_show_columns_user;
+create database test_show_index_db;
+create user test_show_index_user;
+create table test_show_index_db.t (a int, b int);
+alter table test_show_index_db.t add index i1(b);
+alter table test_show_index_db.t add index i2(b);
+// no grant would report error
+show index from test_show_index_db.t;
+Error 1142 (42000): SELECT command denied to user 'test_show_index_user'@'%' for table 't'
+// with any column privilege, indexes are shown.
+grant update(a) on test_show_index_db.t to test_show_index_user;
+show index from test_show_index_db.t;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression	Clustered	Global
+t	1	i1	1	b	A	0	NULL	NULL	YES	BTREE			YES	NULL	NO	NO
+t	1	i2	1	b	A	0	NULL	NULL	YES	BTREE			YES	NULL	NO	NO
+// with table privilege, indexes are shown.
+revoke update(a) on test_show_index_db.t from test_show_index_user;
+grant references on test_show_index_db.t to test_show_index_user;
+show index from test_show_index_db.t;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression	Clustered	Global
+t	1	i1	1	b	A	0	NULL	NULL	YES	BTREE			YES	NULL	NO	NO
+t	1	i2	1	b	A	0	NULL	NULL	YES	BTREE			YES	NULL	NO	NO
+drop database test_show_index_db;
+drop user test_show_index_user;

--- a/tests/integrationtest/t/executor/show.test
+++ b/tests/integrationtest/t/executor/show.test
@@ -433,3 +433,68 @@ set @@session.default_collation_for_utf8mb4=default;
 DROP TABLE IF EXISTS `t`;
 CREATE TABLE `t` (a BIGINT PRIMARY KEY AUTO_RANDOM(2), b INT) PRE_SPLIT_REGIONS=4;
 SHOW CREATE TABLE `t`;
+
+
+# TestShowColumns
+connection default;
+create database test_show_columns_db;
+create user test_show_columns_user;
+create table test_show_columns_db.t (a int, b int);
+
+--echo // no grant would report error
+connect (test_show_columns_user, localhost, test_show_columns_user,,);
+--error 1142
+show columns from test_show_columns_db.t;
+
+--echo // with column privilege, specific columns are shown.
+connection default;
+grant select(a) on test_show_columns_db.t to test_show_columns_user;
+connection test_show_columns_user;
+show columns from test_show_columns_db.t;
+connection default;
+grant insert(b) on test_show_columns_db.t to test_show_columns_user;
+connection test_show_columns_user;
+show columns from test_show_columns_db.t;
+
+--echo // with table privilege, all columns are shown.
+connection default;
+revoke select(a),insert(b) on test_show_columns_db.t from test_show_columns_user;
+grant update on test_show_columns_db.t to test_show_columns_user;
+connection test_show_columns_user;
+show columns from test_show_columns_db.t;
+
+disconnect test_show_columns_user;
+connection default;
+drop database test_show_columns_db;
+drop user test_show_columns_user;
+
+# TestShowIndex
+connection default;
+create database test_show_index_db;
+create user test_show_index_user;
+create table test_show_index_db.t (a int, b int);
+alter table test_show_index_db.t add index i1(b);
+alter table test_show_index_db.t add index i2(b);
+
+--echo // no grant would report error
+connect (test_show_index_user, localhost, test_show_index_user,,);
+--error 1142
+show index from test_show_index_db.t;
+
+--echo // with any column privilege, indexes are shown.
+connection default;
+grant update(a) on test_show_index_db.t to test_show_index_user;
+connection test_show_index_user;
+show index from test_show_index_db.t;
+
+--echo // with table privilege, indexes are shown.
+connection default;
+revoke update(a) on test_show_index_db.t from test_show_index_user;
+grant references on test_show_index_db.t to test_show_index_user;
+connection test_show_index_user;
+show index from test_show_index_db.t;
+
+disconnect test_show_index_user;
+connection default;
+drop database test_show_index_db;
+drop user test_show_index_user;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Adapt the show columns, show index and rename for column privilege
This PR pick `pkg/executor/show.go`, `pkg/executor/simple.go`, `pkg/parser/auth/auth.go`, `tests/integrationtest/t/executor/show.test` and `tests/integrationtest/r/executor/show.result` in https://github.com/pingcap/tidb/pull/61638

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
