### PR TITLE
Planner: fix panic when getting Top SQL without runtime stats

### DIFF
--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -1029,7 +1029,7 @@ func (e *Explain) RenderResult() error {
 		if strings.ToLower(e.Format) != types.ExplainFormatBrief && strings.ToLower(e.Format) != types.ExplainFormatROW && strings.ToLower(e.Format) != types.ExplainFormatVerbose {
 			return errors.Errorf("explain format '%s' for connection is not supported now", e.Format)
 		}
-		rows, err := plancodec.DecodeBinaryPlan4Connection(e.BriefBinaryPlan, strings.ToLower(e.Format))
+		rows, err := plancodec.DecodeBinaryPlan4Connection(e.BriefBinaryPlan, strings.ToLower(e.Format), false)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/memoryusagealarm/memoryusagealarm.go
+++ b/pkg/util/memoryusagealarm/memoryusagealarm.go
@@ -291,10 +291,13 @@ func (record *memoryUsageAlarm) tryRemoveRedundantRecords() {
 
 func getPlanString(info *util.ProcessInfo) string {
 	var buf strings.Builder
-	rows, _ := plancodec.DecodeBinaryPlan4Connection(info.BriefBinaryPlan, types.ExplainFormatVerbose)
+	rows, _ := plancodec.DecodeBinaryPlan4Connection(info.BriefBinaryPlan, types.ExplainFormatROW, true)
 	buf.WriteString(fmt.Sprintf("|%v|%v|%v|%v|%v|", "id", "estRows", "task", "access object", "operator info"))
 	for _, row := range rows {
-		buf.WriteString(fmt.Sprintf("\n|%v|%v|%v|%v|%v|", row[0], row[1], row[4], row[5], row[7]))
+		buf.WriteString("\n|")
+		for _, col := range row {
+			buf.WriteString(fmt.Sprintf("%v|", col))
+		}
 	}
 	return buf.String()
 }

--- a/pkg/util/plancodec/binary_plan_decode.go
+++ b/pkg/util/plancodec/binary_plan_decode.go
@@ -106,7 +106,7 @@ func DecodeBinaryPlan(binaryPlan string) (string, error) {
 
 // DecodeBinaryPlan4Connection decodes a binary execution plan for the `EXPLAIN FOR CONNECTION` statement.
 // This function is also used by TopSQL for plan analysis.
-func DecodeBinaryPlan4Connection(binaryPlan string, format string) ([][]string, error) {
+func DecodeBinaryPlan4Connection(binaryPlan string, format string, forTopsql bool) ([][]string, error) {
 	protoBytes, err := decompress(binaryPlan)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func DecodeBinaryPlan4Connection(binaryPlan string, format string) ([][]string, 
 
 	// Define column indices for each format
 	var columnIndices []int
-	if pb.WithRuntimeStats {
+	if pb.WithRuntimeStats && !forTopsql {
 		switch format {
 		case types.ExplainFormatBrief, types.ExplainFormatROW:
 			columnIndices = []int{0, 1, 3, 4, 5, 6, 7, 8, 9}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61693


Problem Summary:
TOP SQL sometimes retrieves a plan without runtime information, which may cause an index out of range error.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
