### PR TITLE
br: set keepalive for switch import mode client

### DIFF
--- a/br/pkg/restore/BUILD.bazel
+++ b/br/pkg/restore/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "@org_golang_google_grpc//backoff",
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//keepalive",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",

--- a/br/pkg/restore/import_mode_switcher.go
+++ b/br/pkg/restore/import_mode_switcher.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 type ImportModeSwitcher struct {
@@ -99,8 +100,10 @@ func (switcher *ImportModeSwitcher) switchTiKVMode(
 					grpc.WithBlock(),
 					grpc.FailOnNonTempDialError(true),
 					grpc.WithConnectParams(grpc.ConnectParams{Backoff: bfConf}),
-					// we don't need to set keepalive timeout here, because the connection lives
-					// at most 5s. (shorter than minimal value for keepalive time!)
+					grpc.WithKeepaliveParams(keepalive.ClientParameters{
+						Time:    10 * time.Second,
+						Timeout: 20 * time.Second,
+					}),
 				)
 				cancel()
 				if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60232

Problem Summary:
tikv sends `keepalive watchdog timeout` to BR
### What changed and how does it work?
set keepalive for switch import mode client
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
