### PR TITLE
ddl: double check collation compatibility before modifying column

### DIFF
--- a/pkg/ddl/ddl_test.go
+++ b/pkg/ddl/ddl_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
-	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/generic"
 	"github.com/pingcap/tidb/pkg/util/mock"
@@ -110,7 +109,7 @@ func TestGetIntervalFromPolicy(t *testing.T) {
 	require.False(t, changed)
 }
 
-func colDefStrToFieldType(t *testing.T, str string, ctx *metabuild.Context) *types.FieldType {
+func colDefStrToColInfo(t *testing.T, str string, ctx *metabuild.Context) *model.ColumnInfo {
 	sqlA := "alter table t modify column a " + str
 	stmt, err := parser.New().ParseOneStmt(sqlA, "", "")
 	require.NoError(t, err)
@@ -118,7 +117,7 @@ func colDefStrToFieldType(t *testing.T, str string, ctx *metabuild.Context) *typ
 	chs, coll := charset.GetDefaultCharsetAndCollate()
 	col, _, err := buildColumnAndConstraint(ctx, 0, colDef, nil, chs, coll)
 	require.NoError(t, err)
-	return &col.FieldType
+	return col.ToInfo()
 }
 
 func TestModifyColumn(t *testing.T) {
@@ -151,9 +150,9 @@ func TestModifyColumn(t *testing.T) {
 		{"varchar(10) character set gbk", "varchar(255) character set gbk", nil},
 	}
 	for _, tt := range tests {
-		ftA := colDefStrToFieldType(t, tt.origin, ctx)
-		ftB := colDefStrToFieldType(t, tt.to, ctx)
-		err := checkModifyTypes(ftA, ftB, false)
+		colA := colDefStrToColInfo(t, tt.origin, ctx)
+		colB := colDefStrToColInfo(t, tt.to, ctx)
+		err := checkModifyTypes(colA, colB, false)
 		if err == nil {
 			require.NoErrorf(t, tt.err, "origin:%v, to:%v", tt.origin, tt.to)
 		} else {

--- a/pkg/ddl/ingest/BUILD.bazel
+++ b/pkg/ddl/ingest/BUILD.bazel
@@ -74,7 +74,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         ":ingest",
         "//pkg/config",

--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -571,3 +571,43 @@ func TestAddIndexValidateRangesFailed(t *testing.T) {
 	tk.MustExec("alter table t add index idx(b);")
 	tk.MustExec("admin check table t;")
 }
+
+func TestIndexChangeWithModifyColumn(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	defer ingesttestutil.InjectMockBackendCtx(t, store)()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (b int, c varchar(100) collate utf8mb4_unicode_ci)")
+	tk.MustExec("insert t values (1, 'aa'), (2, 'bb'), (3, 'cc');")
+
+	tkddl := testkit.NewTestKit(t, store)
+	tkddl.MustExec("use test")
+
+	var checkErr error
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	runModifyColumn := false
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
+		switch job.SchemaState {
+		case model.StateNone:
+			if runModifyColumn {
+				return
+			}
+			runModifyColumn = true
+			go func() {
+				_, checkErr = tkddl.Exec("alter table t modify column c varchar(120) default 'aaaaa' collate utf8mb4_general_ci first;")
+				wg.Done()
+			}()
+		default:
+			return
+		}
+	})
+
+	tk.MustExec("alter table t add index idx(c);")
+	wg.Wait()
+	require.ErrorContains(t, checkErr, "when index is defined")
+	tk.MustExec("admin check table t")
+	tk.MustExec("delete from t;")
+}

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -105,6 +105,10 @@ func (w *worker) onModifyColumn(jobCtx *jobContext, job *model.Job) (ver int64, 
 		return ver, errors.Trace(err)
 	}
 
+	if err = checkModifyTypes(oldCol, args.Column, isColumnWithIndex(oldCol.Name.L, tblInfo.Indices)); err != nil {
+		return ver, errors.Trace(err)
+	}
+
 	if !needChangeColumnData(oldCol, args.Column) {
 		return w.doModifyColumn(jobCtx, job, dbInfo, tblInfo, args.Column, oldCol, args.Position)
 	}
@@ -797,11 +801,7 @@ func GetModifiableColumnJob(
 		return nil, errors.Trace(err)
 	}
 
-	if err = checkModifyTypes(&col.FieldType, &newCol.FieldType, isColumnWithIndex(col.Name.L, t.Meta().Indices)); err != nil {
-		if strings.Contains(err.Error(), "Unsupported modifying collation") {
-			colErrMsg := "Unsupported modifying collation of column '%s' from '%s' to '%s' when index is defined on it."
-			err = dbterror.ErrUnsupportedModifyCollation.GenWithStack(colErrMsg, col.Name.L, col.GetCollate(), newCol.GetCollate())
-		}
+	if err = checkModifyTypes(col.ColumnInfo, newCol.ColumnInfo, isColumnWithIndex(col.Name.L, t.Meta().Indices)); err != nil {
 		return nil, errors.Trace(err)
 	}
 	needChangeColData := needChangeColumnData(col.ColumnInfo, newCol.ColumnInfo)
@@ -1192,24 +1192,31 @@ func checkIndexInModifiableColumns(columns []*model.ColumnInfo, idxColumns []*mo
 // checkModifyTypes checks if the 'origin' type can be modified to 'to' type no matter directly change
 // or change by reorg. It returns error if the two types are incompatible and correlated change are not
 // supported. However, even the two types can be change, if the "origin" type contains primary key, error will be returned.
-func checkModifyTypes(origin *types.FieldType, to *types.FieldType, needRewriteCollationData bool) error {
-	canReorg, err := types.CheckModifyTypeCompatible(origin, to)
+func checkModifyTypes(from, to *model.ColumnInfo, needRewriteCollationData bool) error {
+	fromFt := &from.FieldType
+	toFt := &to.FieldType
+	canReorg, err := types.CheckModifyTypeCompatible(fromFt, toFt)
 	if err != nil {
 		if !canReorg {
 			return errors.Trace(dbterror.ErrUnsupportedModifyColumn.GenWithStackByArgs(err.Error()))
 		}
-		if mysql.HasPriKeyFlag(origin.GetFlag()) {
+		if mysql.HasPriKeyFlag(fromFt.GetFlag()) {
 			msg := "this column has primary key flag"
 			return dbterror.ErrUnsupportedModifyColumn.GenWithStackByArgs(msg)
 		}
 	}
 
-	err = checkModifyCharsetAndCollation(to.GetCharset(), to.GetCollate(), origin.GetCharset(), origin.GetCollate(), needRewriteCollationData)
+	err = checkModifyCharsetAndCollation(toFt.GetCharset(), toFt.GetCollate(), fromFt.GetCharset(), fromFt.GetCollate(), needRewriteCollationData)
 
 	if err != nil {
-		if to.GetCharset() == charset.CharsetGBK || origin.GetCharset() == charset.CharsetGBK {
+		if toFt.GetCharset() == charset.CharsetGBK || fromFt.GetCharset() == charset.CharsetGBK {
 			return errors.Trace(err)
 		}
+		if strings.Contains(err.Error(), "Unsupported modifying collation") {
+			colErrMsg := "Unsupported modifying collation of column '%s' from '%s' to '%s' when index is defined on it."
+			err = dbterror.ErrUnsupportedModifyCollation.GenWithStack(colErrMsg, from.Name.L, from.GetCollate(), to.GetCollate())
+		}
+
 		// column type change can handle the charset change between these two types in the process of the reorg.
 		if dbterror.ErrUnsupportedModifyCharset.Equal(err) && canReorg {
 			return nil

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -106,6 +106,7 @@ func (w *worker) onModifyColumn(jobCtx *jobContext, job *model.Job) (ver int64, 
 	}
 
 	if err = checkModifyTypes(oldCol, args.Column, isColumnWithIndex(oldCol.Name.L, tblInfo.Indices)); err != nil {
+		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
 

--- a/pkg/metrics/ddl.go
+++ b/pkg/metrics/ddl.go
@@ -293,6 +293,9 @@ func RegisterLightningCommonMetricsForDDL(jobID int64) *metric.Common {
 
 // UnregisterLightningCommonMetricsForDDL unregisters the registered common metrics.
 func UnregisterLightningCommonMetricsForDDL(jobID int64, metrics *metric.Common) {
+	if metrics == nil {
+		return
+	}
 	mu.Lock()
 	defer mu.Unlock()
 	metrics.UnregisterFrom(prometheus.DefaultRegisterer)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61668

Problem Summary:

There are two roles for DDL execution:
- DDL submitter: the node that accepts DDL SQL submitted from users.
- DDL owner: the node that runs real DDL workers.

It is a TOCTOU issue. The problem is that DDL submitter checks the collation of MODIFY COLUMN job and make sure there is no index defined on the target column. However, an ADD INDEX job is finished, before DDL owner runs the MODIFY COLUMN job.

### What changed and how does it work?

Add double check at DDL owner side (in `onModifyColumn`).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
