### PR TITLE
printer: fix printed kernel type

### DIFF
--- a/pkg/util/printer/BUILD.bazel
+++ b/pkg/util/printer/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     embed = [":printer"],
     flaky = True,
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/testkit/testsetup",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -86,7 +86,7 @@ func GetTiDBInfo() string {
 		config.GetGlobalConfig().Store,
 		enterpriseVersion,
 	)
-	info += "Kernel Type: " + kerneltype.Name()
+	info += "\nKernel Type: " + kerneltype.Name()
 	return info
 }
 

--- a/pkg/util/printer/printer_test.go
+++ b/pkg/util/printer/printer_test.go
@@ -17,6 +17,7 @@ package printer
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,4 +50,13 @@ func TestPrintResult(t *testing.T) {
 	result, ok = GetPrintResult(cols, datas)
 	require.False(t, ok)
 	require.Equal(t, "", result)
+}
+
+func TestGetTiDBInfo(t *testing.T) {
+	info := GetTiDBInfo()
+	if kerneltype.IsNextGen() {
+		require.Contains(t, info, "\nKernel Type: Next Generation")
+	} else {
+		require.Contains(t, info, "\nKernel Type: Classic")
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60418 

Problem Summary:

### What changed and how does it work?
introduced by https://github.com/pingcap/tidb/pull/61697 , forget add new line
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
~/code/pingcap/tidb git:[fix-printer] make server; bin/tidb-server -V; NEXT_GEN=1 make server; bin/tidb-server -V
CGO_ENABLED=1  GO111MODULE=on go build -tags codes   -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-924-gc893db633f-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-06-12 11:46:28" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=c893db633f56e7d9c2ca532f9c50074c831d4950" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=fix-printer" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server
Release Version: v9.0.0-alpha-924-gc893db633f-dirty
Edition: Community
Git Commit Hash: c893db633f56e7d9c2ca532f9c50074c831d4950
Git Branch: fix-printer
UTC Build Time: 2025-06-12 11:46:28
GoVersion: go1.23.10
Race Enabled: false
Check Table Before Drop: false
Store: unistore
Kernel Type: Classic
CGO_ENABLED=1  GO111MODULE=on go build -tags codes,nextgen   -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=v9.0.0-alpha-924-gc893db633f-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-06-12 11:47:34" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=c893db633f56e7d9c2ca532f9c50074c831d4950" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=fix-printer" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o 'bin/tidb-server' ./cmd/tidb-server
Release Version: v9.0.0-alpha-924-gc893db633f-dirty
Edition: Community
Git Commit Hash: c893db633f56e7d9c2ca532f9c50074c831d4950
Git Branch: fix-printer
UTC Build Time: 2025-06-12 11:47:34
GoVersion: go1.23.10
Race Enabled: false
Check Table Before Drop: false
Store: unistore
Kernel Type: Next Generation
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
