### PR TITLE
store/gcworker: use label to distinguish keylevel GC and unified GC

### DIFF
--- a/pkg/store/gcworker/gc_worker.go
+++ b/pkg/store/gcworker/gc_worker.go
@@ -1384,7 +1384,7 @@ func (w *GCWorker) doGC(ctx context.Context, safePoint uint64, concurrency int) 
 
 func (w *GCWorker) checkLeader(ctx context.Context) (bool, error) {
 	var label string
-	if w.isUnified() {
+	if w.isUnifiedGC() {
 		label = "check_leader"
 	} else {
 		label = "check_leader_keyspace"

--- a/pkg/store/gcworker/gc_worker.go
+++ b/pkg/store/gcworker/gc_worker.go
@@ -372,6 +372,13 @@ func (w *GCWorker) runKeyspaceDeleteRange(ctx context.Context, concurrency gcCon
 	return nil
 }
 
+func (w *GCWorker) isUnifiedGC() bool {
+	const cfgGCManagementType = "gc_management_type"
+	const cfgGCManagementTypeKeyspaceLevel = "keyspace_level"
+	keyspaceMeta := w.store.GetCodec().GetKeyspaceMeta()
+	return keyspaceMeta != nil && keyspaceMeta.Config[cfgGCManagementType] != cfgGCManagementTypeKeyspaceLevel
+}
+
 // leaderTick of GC worker checks if it should start a GC job every tick.
 func (w *GCWorker) leaderTick(ctx context.Context) error {
 	if w.gcIsRunning {
@@ -394,9 +401,7 @@ func (w *GCWorker) leaderTick(ctx context.Context) error {
 	// Note that when `keyspace-name` is set, `checkLeader` will be done within the key space.
 	// Therefore only one TiDB node in each key space will be responsible to do delete range.
 	// TODO: Use result of AdvanceTxnSafePoint instead, which makes it unnecessary to manually check the config.
-	const cfgGCManagementType = "gc_management_type"
-	const cfgGCManagementTypeKeyspaceLevel = "keyspace_level"
-	if keyspaceMeta := w.store.GetCodec().GetKeyspaceMeta(); keyspaceMeta != nil && keyspaceMeta.Config[cfgGCManagementType] != cfgGCManagementTypeKeyspaceLevel {
+	if w.isUnifiedGC() {
 		err = w.runKeyspaceGCJobInUnifiedGCMode(ctx, concurrency)
 		if err != nil {
 			return errors.Trace(err)
@@ -1378,7 +1383,13 @@ func (w *GCWorker) doGC(ctx context.Context, safePoint uint64, concurrency int) 
 }
 
 func (w *GCWorker) checkLeader(ctx context.Context) (bool, error) {
-	metrics.GCWorkerCounter.WithLabelValues("check_leader").Inc()
+	var label string
+	if w.isUnified() {
+		label = "check_leader"
+	} else {
+		label = "check_leader_keyspace"
+	}
+	metrics.GCWorkerCounter.WithLabelValues(label).Inc()
 	se := createSession(w.store)
 	defer se.Close()
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #58720

Problem Summary:

### What changed and how does it work?

Now we have NextGen and classic tidb share the same code by using build flag.
NextGen introduce keyspace level GC, and classic still use unifed GC. Those two GC types should not co-exist in theory (not talking about tidbcloud).

I change the label to distinguish them, not quite useful, but just in case some bad thing really happen, we can diagnose that.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

![image](https://github.com/user-attachments/assets/4ef7444c-bcdd-4178-9469-e963e74971fe)


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
