### PR TITLE
executor: handle panic for fast admin check

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -465,6 +465,11 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 			return
 		}
 		if str, ok := r.(string); !ok || !strings.Contains(str, memory.PanicMemoryExceedWarnMsg) {
+			// Not sure why panic again after recover, we need to skip this for test.
+			failpoint.Inject("skipExecPanic", func() {
+				err = errors.Errorf("%v", r)
+				failpoint.Return()
+			})
 			panic(r)
 		}
 		err = errors.Errorf("%v", r)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -907,6 +907,11 @@ func (e *CheckTableExec) checkIndexHandle(ctx context.Context, src *IndexLookUpE
 			e.retCh <- errors.Trace(err)
 			break
 		}
+
+		failpoint.Inject("mockAdminCheckPanic", func() {
+			panic("mock admin check panic")
+		})
+
 		if chk.NumRows() == 0 {
 			break
 		}
@@ -2292,6 +2297,7 @@ func (e *FastCheckTableExec) Open(ctx context.Context) error {
 
 type checkIndexTask struct {
 	indexOffset int
+	err         *atomic.Pointer[error]
 }
 
 type checkIndexWorker struct {
@@ -2346,6 +2352,11 @@ func (w *checkIndexWorker) initSessCtx(se sessionctx.Context) (restore func()) {
 
 // HandleTask implements the Worker interface.
 func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.None)) {
+	defer util.Recover("fast_check_table", "handleTableScanTaskWithRecover", func() {
+		err := errors.Errorf("checkIndexTask panicked, indexOffset: %d", task.indexOffset)
+		task.err.CompareAndSwap(nil, &err)
+	}, false)
+
 	defer w.e.wg.Done()
 	idxInfo := w.indexInfos[task.indexOffset]
 	bucketSize := int(CheckTableFastBucketSize.Load())
@@ -2482,6 +2493,11 @@ func (w *checkIndexWorker) HandleTask(task checkIndexTask, _ func(workerpool.Non
 		}
 		slices.SortFunc(indexChecksum, func(i, j groupByChecksum) int {
 			return cmp.Compare(i.bucket, j.bucket)
+		})
+
+		// mock query panic for fast admin check.
+		failpoint.Inject("mockFastAdminCheckPanic", func() {
+			panic("mock fast admin check panic")
 		})
 
 		currentOffset := 0
@@ -2711,7 +2727,7 @@ func (e *FastCheckTableExec) Next(ctx context.Context, _ *chunk.Chunk) error {
 
 	e.wg.Add(len(e.indexInfos))
 	for i := range e.indexInfos {
-		workerPool.AddTask(checkIndexTask{indexOffset: i})
+		workerPool.AddTask(checkIndexTask{indexOffset: i, err: e.err})
 	}
 
 	e.wg.Wait()

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -17,6 +17,7 @@ package executor_test
 import (
 	"testing"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
 	"github.com/stretchr/testify/require"
@@ -175,4 +176,39 @@ func TestCompareIssue38361(t *testing.T) {
 	tk.MustQuery("select b = a from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select b > a from t").Check(testkit.Rows("0"))
 	tk.MustQuery("select c > a from t").Check(testkit.Rows("0"))
+}
+
+func TestAdminCheckPanic(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("drop database if exists TEST1")
+	tk.MustExec("create database TEST1")
+	tk.MustExec("use TEST1")
+
+	// Using a known issue from https://github.com/pingcap/tidb/issues/52510, which can cause panic
+	tk.MustExec(`
+		create table t(id varchar(255) PRIMARY KEY, pid varchar(255), created_at datetime NOT NULL)
+		ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`)
+	tk.MustExec(`insert into t values
+		('o', 'productA', '2023-10-01 12:00:00'),
+		('1', 'productB', '2023-10-02 13:30:00'),
+		('oO', 'productC', '2023-10-03 14:45:00'),
+		('0', 'productD', '2023-10-04 15:20:00'),
+		('child5', 'productE', '2023-10-05 16:10:00')`)
+	tk.MustExec("CREATE INDEX t_idx_created_at ON t (created_at)")
+
+	// Some versions may have fixed this bug, so we also manually inject panic.
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockFastAdminCheckPanic", "return"))
+	defer failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockFastAdminCheckPanic")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockAdminCheckPanic", "return"))
+	defer failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockAdminCheckPanic")
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/skipExecPanic", "return"))
+	defer failpoint.Disable("github.com/pingcap/tidb/pkg/executor/skipExecPanic")
+
+	// When there are some bugs in the executor/optimizeradmin check should
+	// return error no matter whether fast admin check is enabled or not.
+	tk.MustExec("set @@tidb_enable_fast_table_check = OFF")
+	tk.MustExecToErr("admin check table t")
+	tk.MustExec("set @@tidb_enable_fast_table_check = 1")
+	tk.MustExecToErr("admin check table t")
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -197,7 +197,7 @@ func TestAdminCheckPanic(t *testing.T) {
 		('child5', 'productE', '2023-10-05 16:10:00')`)
 	tk.MustExec("CREATE INDEX t_idx_created_at ON t (created_at)")
 
-	// Some versions may have fixed this bug, so we also manually inject panic.
+	// Some newer versions may have fixed this bug, so we also manually inject panic.
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockFastAdminCheckPanic", "return"))
 	defer failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockFastAdminCheckPanic")
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockAdminCheckPanic", "return"))
@@ -205,10 +205,10 @@ func TestAdminCheckPanic(t *testing.T) {
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/executor/skipExecPanic", "return"))
 	defer failpoint.Disable("github.com/pingcap/tidb/pkg/executor/skipExecPanic")
 
-	// When there are some bugs in the executor/optimizeradmin check should
-	// return error no matter whether fast admin check is enabled or not.
+	// When there are some critical bugs in the executor/optimizer, admin check
+	// should fail to execute no matter whether fast admin check is enabled or not.
 	tk.MustExec("set @@tidb_enable_fast_table_check = OFF")
 	tk.MustExecToErr("admin check table t")
-	tk.MustExec("set @@tidb_enable_fast_table_check = 1")
+	tk.MustExec("set @@tidb_enable_fast_table_check = ON")
 	tk.MustExecToErr("admin check table t")
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61612

Problem Summary:

### What changed and how does it work?

This is a manual cherry-pick for https://github.com/pingcap/tidb/pull/55537, which add panic handle logic for `WorkerPool`.

This PR only pick codes related to fast admin check back to release7.5, i.e. handle panic for `checkIndexTask`, to avoid check pass when underlying SQLs meet panic.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
