### PR TITLE
pkg/distsql: Add failpoint so TestIssue48756 can run with and without CopLiteWorker

### DIFF
--- a/pkg/executor/test/executor/BUILD.bazel
+++ b/pkg/executor/test/executor/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//pkg/tablecodec",
         "//pkg/testkit",
         "//pkg/testkit/testdata",
+        "//pkg/testkit/testfailpoint",
         "//pkg/types",
         "//pkg/util",
         "//pkg/util/dbterror/exeerrors",

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
@@ -3053,21 +3054,39 @@ func TestDecimalDivPrecisionIncrement(t *testing.T) {
 }
 
 func TestIssue48756(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("CREATE TABLE t (id INT, a VARBINARY(20), b BIGINT)")
-	tk.MustExec(`INSERT INTO t VALUES(1, _binary '2012-05-19 09:06:07', 20120519090607),
-(1, _binary '2012-05-19 09:06:07', 20120519090607),
-(2, _binary '12012-05-19 09:06:07', 120120519090607),
-(2, _binary '12012-05-19 09:06:07', 120120519090607)`)
-	tk.MustQuery("SELECT SUBTIME(BIT_OR(b), '1 1:1:1.000002') FROM t GROUP BY id").Sort().Check(testkit.Rows(
-		"2012-05-18 08:05:05.999998",
-		"<nil>",
-	))
-	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1292 Incorrect time value: '120120519090607'",
-	))
+	for useCopLiteWorker := range 2 {
+		t.Run(fmt.Sprintf("TryCopLiteWorker=%d", useCopLiteWorker), func(t *testing.T) {
+			// Inject the TryCopLiteWorker value into the current session's DistSQL context
+			testfailpoint.Enable(t,
+				"github.com/pingcap/tidb/pkg/distsql/TryCopLiteWorker",
+				fmt.Sprintf("return(%d)", useCopLiteWorker),
+			)
+
+			store := testkit.CreateMockStore(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("use test")
+			tk.MustExec("CREATE TABLE t (id INT, a VARBINARY(20), b BIGINT)")
+			tk.MustExec(`INSERT INTO t VALUES
+				(1, _binary '2012-05-19 09:06:07', 20120519090607),
+				(1, _binary '2012-05-19 09:06:07', 20120519090607),
+				(2, _binary '12012-05-19 09:06:07', 120120519090607),
+				(2, _binary '12012-05-19 09:06:07', 120120519090607)`)
+
+			tk.MustQuery("SELECT SUBTIME(BIT_OR(b), '1 1:1:1.000002') FROM t GROUP BY id").
+				Sort().
+				Check(testkit.Rows(
+					"2012-05-18 08:05:05.999998",
+					"<nil>",
+				))
+
+			warnings := tk.MustQuery("show warnings").Rows()
+			require.Len(t, warnings, 1)
+			require.Equal(t, "Warning", warnings[0][0], "generates a warning")
+			require.Equal(t, "1292", warnings[0][1], "expected error code")
+			require.Equal(t, "Incorrect time value: '120120519090607'", warnings[0][2],
+				"expected error message")
+		})
+	}
 }
 
 func TestIssue50308(t *testing.T) {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: ref #56311

Problem Summary:

The test TestIssue48756 was reported as failing rarely. Since pull request #57522 was merged, it now fails every time. Originally issue #56311 was prioritized low because the problem was hard to reproduce. Now it's easy to reproduce, but the existing test fails to exercise the "lite" coprocessor path added in that pull request.

### What changed and how does it work?

This commit adds a failpoint that sets the TryCopLiteWorker option in distsql.Select(), and runs test case "TestIssue48756" twice: once with, and once without, the "lite" coprocessor option. One of the two paths consistently fails, as described in issue #56311, so this change reproduces the failure.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility
- [X] No side effects

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility
- [X] No changes needing documentation

### Release note


```release-note
Add a unit test case to help diagnose a bug affecting the error message produced when overly-large integers are truncated and converted to datetime values.
```