### PR TITLE
fix: faster two vector function save two loop

### DIFF
--- a/pkg/types/vector_functions.go
+++ b/pkg/types/vector_functions.go
@@ -169,8 +169,6 @@ func (a VectorFloat32) Add(b VectorFloat32) (VectorFloat32, error) {
 	for i, iMax := 0, a.Len(); i < iMax; i++ {
 		// Hope this can be vectorized.
 		vr[i] = va[i] + vb[i]
-	}
-	for i, iMax := 0, a.Len(); i < iMax; i++ {
 		if math.IsInf(float64(vr[i]), 0) {
 			return ZeroVectorFloat32, errors.Errorf("value out of range: overflow")
 		}
@@ -197,9 +195,6 @@ func (a VectorFloat32) Sub(b VectorFloat32) (VectorFloat32, error) {
 	for i, iMax := 0, a.Len(); i < iMax; i++ {
 		// Hope this can be vectorized.
 		vr[i] = va[i] - vb[i]
-	}
-
-	for i, iMax := 0, a.Len(); i < iMax; i++ {
 		if math.IsInf(float64(vr[i]), 0) {
 			return ZeroVectorFloat32, errors.Errorf("value out of range: overflow")
 		}
@@ -226,18 +221,15 @@ func (a VectorFloat32) Mul(b VectorFloat32) (VectorFloat32, error) {
 	for i, iMax := 0, a.Len(); i < iMax; i++ {
 		// Hope this can be vectorized.
 		vr[i] = va[i] * vb[i]
-	}
-
-	for i, iMax := 0, a.Len(); i < iMax; i++ {
 		if math.IsInf(float64(vr[i]), 0) {
 			return ZeroVectorFloat32, errors.Errorf("value out of range: overflow")
 		}
 		if math.IsNaN(float64(vr[i])) {
 			return ZeroVectorFloat32, errors.Errorf("value out of range: NaN")
 		}
-
-		// TODO: Check for underflow.
-		// See https://github.com/pgvector/pgvector/blob/81d13bd40f03890bb5b6360259628cd473c2e467/src/vector.c#L873
+		if vr[i] == 0 && !(va[i] == 0 || vb[i] == 0) {
+			return ZeroVectorFloat32, errors.Errorf("value out of range: underflow")
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

This patch aim to faster two vector function save the one loop for each

and fix one TODO.

Reason: just saw some of the code idea is from pgvector, but in Pgvector side the reason
why use two loops for vector function  is for  `-ftree-vectorize` for pg, 
it seems no benefits for TiDB correct me if it is wrong~

more can check this close patch for pgvector: https://github.com/pgvector/pgvector/pull/639

also fix a TODO in it.

cc @zimulala  

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
