### PR TITLE
planner: support "explain explore analyze" when exploring new plans offline

### DIFF
--- a/pkg/bindinfo/BUILD.bazel
+++ b/pkg/bindinfo/BUILD.bazel
@@ -63,7 +63,7 @@ go_test(
     embed = [":bindinfo"],
     flaky = True,
     race = "on",
-    shard_count = 41,
+    shard_count = 42,
     deps = [
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/bindinfo/binding_auto.go
+++ b/pkg/bindinfo/binding_auto.go
@@ -68,7 +68,7 @@ type BindingPlanEvolution interface {
 	// TODO: RecordHistPlansAsBindings records the history plans as bindings for qualified queries.
 
 	// ExplorePlansForSQL explores plans for this SQL.
-	ExplorePlansForSQL(currentDB, sqlOrDigest, charset, collation string) ([]*BindingPlanInfo, error)
+	ExplorePlansForSQL(currentDB, sqlOrDigest, charset, collation string, analyze bool) ([]*BindingPlanInfo, error)
 }
 
 type bindingAuto struct {
@@ -91,8 +91,8 @@ func newBindingAuto(sPool util.DestroyableSessionPool) BindingPlanEvolution {
 // 1. get historical plan candidates.
 // 2. generate new plan candidates.
 // 3. score all historical and newly-generated plan candidates and recommend the best one.
-func (ba *bindingAuto) ExplorePlansForSQL(currentDB, sqlOrDigest, charset, collation string) ([]*BindingPlanInfo, error) {
-	historicalPlans, err := ba.getHistoricalPlanInfo(currentDB, sqlOrDigest, charset, collation)
+func (ba *bindingAuto) ExplorePlansForSQL(currentDB, sqlOrDigest, charset, collation string, analyze bool) ([]*BindingPlanInfo, error) {
+	historicalPlans, err := ba.getBindingPlanInfo(currentDB, sqlOrDigest, charset, collation)
 	if err != nil {
 		return nil, err
 	}
@@ -100,6 +100,12 @@ func (ba *bindingAuto) ExplorePlansForSQL(currentDB, sqlOrDigest, charset, colla
 	generatedPlans, err := ba.planGenerator.Generate(currentDB, sqlOrDigest, charset, collation)
 	if err != nil {
 		return nil, err
+	}
+
+	if analyze {
+		if err := ba.runToGetExecInfo(generatedPlans); err != nil {
+			return nil, err
+		}
 	}
 
 	planCandidates := append(historicalPlans, generatedPlans...)
@@ -111,7 +117,47 @@ func (ba *bindingAuto) ExplorePlansForSQL(currentDB, sqlOrDigest, charset, colla
 	return planCandidates, err
 }
 
-func (ba *bindingAuto) getHistoricalPlanInfo(currentDB, sqlOrDigest, charset, collation string) ([]*BindingPlanInfo, error) {
+// runToGetExecInfo runs these plans to get their execution info.
+func (ba *bindingAuto) runToGetExecInfo(plans []*BindingPlanInfo) error {
+	// TODO: support setting timeout
+	for _, plan := range plans {
+		if plan.ExecTimes > 0 {
+			// already has execution info, no need to run again.
+			continue
+		}
+
+		if err := callWithSCtx(ba.sPool, false, func(sctx sessionctx.Context) error {
+			sctx.GetSessionVars().CurrentDB = plan.Binding.Db
+			sctx.GetSessionVars().UsePlanBaselines = false
+			defer func() {
+				sctx.GetSessionVars().UsePlanBaselines = true
+			}()
+			_, _, err := execRows(sctx, plan.BindSQL)
+			if err != nil {
+				return err
+			}
+
+			// get the execution info from the sctx.
+			plan.ExecTimes = 1
+			plan.AvgLatency = float64(sctx.GetSessionVars().GetTotalCostDuration())
+			if sctx.GetSessionVars().StmtCtx.GetExecDetails().ScanDetail != nil {
+				plan.AvgScanRows = float64(sctx.GetSessionVars().StmtCtx.GetExecDetails().ScanDetail.ProcessedKeys)
+			}
+			plan.AvgReturnedRows = float64(sctx.GetSessionVars().StmtCtx.GetResultRowsCount())
+			if plan.AvgReturnedRows > 0 {
+				plan.LatencyPerReturnRow = plan.AvgLatency / plan.AvgReturnedRows
+				plan.ScanRowsPerReturnRow = plan.AvgScanRows / plan.AvgReturnedRows
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getBindingPlanInfo retrieves the binding plan info for the given SQL or digest.
+func (ba *bindingAuto) getBindingPlanInfo(currentDB, sqlOrDigest, charset, collation string) ([]*BindingPlanInfo, error) {
 	// parse and normalize sqlOrDigest
 	// if the length is 64 and it has no " ", treat it as a digest.
 	var whereCond string

--- a/pkg/bindinfo/binding_plan_generation.go
+++ b/pkg/bindinfo/binding_plan_generation.go
@@ -60,12 +60,13 @@ func (g *planGenerator) Generate(defaultSchema, sql, charset, collation string) 
 
 		for _, genedPlan := range genedPlans {
 			// TODO: construct bindingSQL in a more strict way.
-			bindingSQL := sql[:len(prefix)] + "/*+ " + genedPlan.planHints + " */ " + sql[len(prefix):]
+			bindingSQL := sql[:len(prefix)] + " /*+ " + genedPlan.planHints + " */ " + sql[len(prefix):]
 			binding := &Binding{
 				OriginalSQL: sql,
 				BindSQL:     bindingSQL,
 				Db:          defaultSchema,
 				Source:      "generated",
+				PlanDigest:  genedPlan.planDigest,
 			}
 			if err := prepareHints(sctx, binding); err != nil {
 				return err

--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1655,7 +1655,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 		}
 	}
 
-	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
+	resultRows := stmtCtx.GetResultRowsCount()
 
 	var (
 		keyspaceName string
@@ -1793,15 +1793,6 @@ func collectWarningsForSlowLog(stmtCtx *stmtctx.StatementContext) []variable.JSO
 		res[len(warnings)+i].IsExtra = true
 	}
 	return res
-}
-
-// GetResultRowsCount gets the count of the statement result rows.
-func GetResultRowsCount(stmtCtx *stmtctx.StatementContext, p base.Plan) int64 {
-	runtimeStatsColl := stmtCtx.RuntimeStatsColl
-	if runtimeStatsColl == nil {
-		return 0
-	}
-	return runtimeStatsColl.GetPlanActRows(p.ID())
 }
 
 func (a *ExecStmt) updateNetworkTrafficStatsAndMetrics() {
@@ -2013,7 +2004,7 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 		execDetail.TimeDetail.WaitTime += stmtCtx.WaitLockLeaseTime
 	}
 
-	resultRows := GetResultRowsCount(stmtCtx, a.Plan)
+	resultRows := stmtCtx.GetResultRowsCount()
 
 	var (
 		keyspaceName string

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -385,7 +385,7 @@ func (e *ShowExec) fetchPlanForSQL() error {
 	bindingHandle := domain.GetDomain(e.Ctx()).BindingHandle()
 	charset, collation := e.Ctx().GetSessionVars().GetCharsetInfo()
 	currentDB := e.Ctx().GetSessionVars().CurrentDB
-	plans, err := bindingHandle.ExplorePlansForSQL(currentDB, e.SQLOrDigest, charset, collation)
+	plans, err := bindingHandle.ExplorePlansForSQL(currentDB, e.SQLOrDigest, charset, collation, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/test/executor/executor_test.go
+++ b/pkg/executor/test/executor/executor_test.go
@@ -1566,9 +1566,7 @@ func TestGetResultRowsCount(t *testing.T) {
 		}
 		info := tk.Session().ShowProcess()
 		require.NotNil(t, info)
-		p, ok := info.Plan.(base.Plan)
-		require.True(t, ok)
-		cnt := executor.GetResultRowsCount(tk.Session().GetSessionVars().StmtCtx, p)
+		cnt := tk.Session().GetSessionVars().StmtCtx.GetResultRowsCount()
 		require.Equal(t, ca.row, cnt, fmt.Sprintf("sql: %v", ca.sql))
 	}
 }

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -5573,6 +5573,25 @@ ExplainStmt:
 			Explore:   true,
 		}
 	}
+|	ExplainSym "EXPLORE" "ANALYZE" SelectStmt
+	{
+		startOffset := parser.startOffset(&yyS[yypt])
+		stmt := $4
+		stmt.SetText(parser.lexer.client, strings.TrimSpace(parser.src[startOffset:]))
+		$$ = &ast.ExplainStmt{
+			Stmt:    stmt,
+			Explore: true,
+			Analyze: true,
+		}
+	}
+|	ExplainSym "EXPLORE" "ANALYZE" stringLit
+	{
+		$$ = &ast.ExplainStmt{
+			SQLDigest: $4,
+			Explore:   true,
+			Analyze:   true,
+		}
+	}
 |	ExplainSym TableName
 	{
 		$$ = &ast.ExplainStmt{

--- a/pkg/planner/BUILD.bazel
+++ b/pkg/planner/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/planner/util/optimizetrace",
         "//pkg/privilege",
         "//pkg/sessionctx",
+        "//pkg/sessionctx/stmtctx",
         "//pkg/sessionctx/vardef",
         "//pkg/sessionctx/variable",
         "//pkg/types",

--- a/pkg/planner/core/common_plans.go
+++ b/pkg/planner/core/common_plans.go
@@ -948,7 +948,7 @@ func (e *Explain) renderResultForExplore() error {
 	if sqlOrDigest == "" {
 		sqlOrDigest = e.ExecStmt.Text()
 	}
-	plans, err := bindingHandle.ExplorePlansForSQL(currentDB, sqlOrDigest, charset, collation)
+	plans, err := bindingHandle.ExplorePlansForSQL(currentDB, sqlOrDigest, charset, collation, e.Analyze)
 	if err != nil {
 		return err
 	}

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 	"github.com/pingcap/tidb/pkg/privilege"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/types"
@@ -712,6 +713,13 @@ func genBriefPlanWithSCtx(sctx sessionctx.Context, stmt ast.StmtNode) (planDiges
 	return digest.String(), hint.RestoreOptimizerHints(hints), plan, nil
 }
 
+func planIDFunc(plan any) (planID int, ok bool) {
+	if p, ok := plan.(base.Plan); ok {
+		return p.ID(), true
+	}
+	return 0, false
+}
+
 func init() {
 	core.OptimizeAstNode = Optimize
 	core.IsReadOnly = IsReadOnly
@@ -722,4 +730,5 @@ func init() {
 	bindinfo.CalculatePlanDigest = calculatePlanDigestFunc
 	bindinfo.RecordRelevantOptVarsAndFixes = recordRelevantOptVarsAndFixes
 	bindinfo.GenBriefPlanWithSCtx = genBriefPlanWithSCtx
+	stmtctx.PlanIDFunc = planIDFunc
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #60148

Problem Summary: planner: support "explain explore analyze" when exploring new plans offline

### What changed and how does it work?

Support "analyze" mode in "explain explore", which will run all generated plans to get their execution info to help users make the plan choice decision.

The main idea is to execute all generated plans when running `explain explore`, and get their execution info from `sctx`.

<img width="925" alt="image" src="https://github.com/user-attachments/assets/0b16e11f-68c0-4f3d-9478-75ec2a1e9217" />


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
