### PR TITLE
privileges: fix TiDB panic when `security.skip-grant-table` is true

### DIFF
--- a/pkg/privilege/privileges/privileges.go
+++ b/pkg/privilege/privileges/privileges.go
@@ -323,6 +323,9 @@ func (p *UserPrivileges) isValidHash(record *UserRecord) bool {
 
 // GetUserResources gets the maximum number of connections for the current user
 func (p *UserPrivileges) GetUserResources(user, host string) (int64, error) {
+	if SkipWithGrant {
+		return 0, nil
+	}
 	terror.Log(p.Handle.ensureActiveUser(context.Background(), user))
 	mysqlPriv := p.Handle.Get()
 	record := mysqlPriv.connectionVerification(user, host)

--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -2083,7 +2083,7 @@ func TestVerificationInfoWithSessionTokenPlugin(t *testing.T) {
 	require.ErrorContains(t, err, "Access denied")
 }
 
-func TestNilHandleInConnectionVerification(t *testing.T) {
+func TestNilHandleInSkipWithGrant(t *testing.T) {
 	config.GetGlobalConfig().Security.SkipGrantTable = true
 	privileges.SkipWithGrant = true
 	defer func() {
@@ -2092,7 +2092,13 @@ func TestNilHandleInConnectionVerification(t *testing.T) {
 	}()
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
+	// check ConnectionVerification
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: `%`}, nil, nil, nil))
+	// check GetUserResources
+	pc := privilege.GetPrivilegeManager(tk.Session())
+	userLimit, err := pc.GetUserResources("root", "%")
+	require.NoError(t, err)
+	require.EqualValues(t, 0, userLimit)
 }
 
 func testShowGrantsSQLMode(t *testing.T, tk *testkit.TestKit, expected []string) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61790

Problem Summary:
When `max_user_connections` was introduced in https://github.com/pingcap/tidb/pull/59197, the privilege system didn't consider `skip-grant-table`, which skips loading the privilege system.

### What changed and how does it work?
If `skip-grant-table` is true, do not query `max_user_connections` and directly return.

I've checked other functions in `UserPrivileges`, no other similar problems.
It's introduced in v9.0.0-beta.1 so it doesn't need a release note.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Steps:
1. Start a TiDB instance with configuration `security.skip-grant-table` and OS root privilege.
2. Connect to TiDB with `mysql -h127.1 -uroot -P4000`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
