### PR TITLE
fix(runaway): resolve the dead channel in UpdateNewAndDoneWatch

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1568,7 +1568,8 @@ func (do *Domain) Start(startMode ddl.StartMode) error {
 	do.wg.Run(do.topNSlowQueryLoop, "topNSlowQueryLoop")
 	do.wg.Run(do.infoSyncerKeeper, "infoSyncerKeeper")
 	do.wg.Run(do.globalConfigSyncerKeeper, "globalConfigSyncerKeeper")
-	do.wg.Run(do.runawayStartLoop, "runawayStartLoop")
+	do.wg.Run(do.runawayManager.RunawayRecordFlushLoop, "runawayRecordFlushLoop")
+	do.wg.Run(do.runawayManager.RunawayWatchSyncLoop, "runawayWatchSyncLoop")
 	do.wg.Run(do.requestUnitsWriterLoop, "requestUnitsWriterLoop")
 	skipRegisterToDashboard := gCfg.SkipRegisterToDashboard
 	if !skipRegisterToDashboard {

--- a/pkg/domain/runaway.go
+++ b/pkg/domain/runaway.go
@@ -18,23 +18,14 @@ import (
 	"context"
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/pingcap/tidb/pkg/domain/infosync"
-	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/resourcegroup/runaway"
-	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/tikv/client-go/v2/tikv"
 	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/constants"
 	rmclient "github.com/tikv/pd/client/resource_group/controller"
-	"go.uber.org/zap"
-)
-
-const (
-	runawayWatchSyncInterval         = time.Second
-	runawayLoopLogErrorIntervalCount = 1800
 )
 
 func (do *Domain) initResourceGroupsController(ctx context.Context, pdClient pd.Client, uniqueID uint64) error {
@@ -63,34 +54,4 @@ func (do *Domain) initResourceGroupsController(ctx context.Context, pdClient pd.
 	do.resourceGroupsController = control
 	tikv.SetResourceControlInterceptor(control)
 	return nil
-}
-
-func (do *Domain) runawayStartLoop() {
-	defer util.Recover(metrics.LabelDomain, "runawayStartLoop", nil, false)
-	runawayWatchSyncTicker := time.NewTicker(runawayWatchSyncInterval)
-	count := 0
-	var err error
-	logutil.BgLogger().Info("try to start runaway manager loop")
-	for {
-		select {
-		case <-do.exit:
-			return
-		case <-runawayWatchSyncTicker.C:
-			// Due to the watch and watch done tables is created later than runaway queries table
-			err = do.runawayManager.UpdateNewAndDoneWatch()
-			if err == nil {
-				logutil.BgLogger().Info("preparations for the runaway manager are finished and start runaway manager loop")
-				do.wg.Run(do.runawayManager.RunawayRecordFlushLoop, "runawayRecordFlushLoop")
-				do.wg.Run(do.runawayManager.RunawayWatchSyncLoop, "runawayWatchSyncLoop")
-				do.runawayManager.MarkSyncerInitialized()
-				return
-			}
-		}
-		if count %= runawayLoopLogErrorIntervalCount; count == 0 {
-			logutil.BgLogger().Warn(
-				"failed to start runaway manager loop, please check whether the bootstrap or update is finished",
-				zap.Error(err))
-		}
-		count++
-	}
 }

--- a/pkg/executor/internal/querywatch/query_watch_test.go
+++ b/pkg/executor/internal/querywatch/query_watch_test.go
@@ -33,7 +33,7 @@ func TestQueryWatch(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, _ := testkit.CreateMockStoreAndDomain(t)
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	if vardef.SchemaCacheSize.Load() != 0 {
 		t.Skip("skip this test because the schema cache is enabled")
@@ -189,7 +189,7 @@ func TestQueryWatchIssue56897(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, _ := testkit.CreateMockStoreAndDomain(t)
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustQuery("QUERY WATCH ADD ACTION KILL SQL TEXT SIMILAR TO 'use test';").Check((testkit.Rows("1")))

--- a/pkg/executor/internal/querywatch/query_watch_test.go
+++ b/pkg/executor/internal/querywatch/query_watch_test.go
@@ -33,7 +33,7 @@ func TestQueryWatch(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, dom := testkit.CreateMockStoreAndDomain(t)
+	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	if vardef.SchemaCacheSize.Load() != 0 {
 		t.Skip("skip this test because the schema cache is enabled")
@@ -45,10 +45,6 @@ func TestQueryWatch(t *testing.T) {
 	tk.MustExec("insert into t2 values(1)")
 	tk.MustExec("create table t3(a int)")
 	tk.MustExec("insert into t3 values(1)")
-
-	require.Eventually(t, func() bool {
-		return dom.RunawayManager().IsSyncerInitialized()
-	}, 20*time.Second, 300*time.Millisecond)
 
 	err := tk.QueryToErr("query watch add sql text exact to 'select * from test.t1'")
 	require.ErrorContains(t, err, "must set runaway config for resource group `default`")
@@ -193,12 +189,9 @@ func TestQueryWatchIssue56897(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, dom := testkit.CreateMockStoreAndDomain(t)
+	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	require.Eventually(t, func() bool {
-		return dom.RunawayManager().IsSyncerInitialized()
-	}, 20*time.Second, 300*time.Millisecond)
 	tk.MustQuery("QUERY WATCH ADD ACTION KILL SQL TEXT SIMILAR TO 'use test';").Check((testkit.Rows("1")))
 	time.Sleep(1 * time.Second)
 	_, err := tk.Exec("use test")

--- a/pkg/resourcegroup/runaway/syncer.go
+++ b/pkg/resourcegroup/runaway/syncer.go
@@ -15,6 +15,7 @@
 package runaway
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -24,10 +25,8 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 )
 
-const (
-	// watchSyncInterval is the interval to sync the watch record.
-	watchSyncInterval = time.Second
-)
+// watchSyncInterval is the interval to sync the watch record.
+const watchSyncInterval = time.Second
 
 // Syncer is used to sync the runaway records.
 type syncer struct {
@@ -45,10 +44,28 @@ func newSyncer(sysSessionPool util.SessionPool) *syncer {
 			watchTableName,
 			"start_time",
 			NullTime},
-		deletionWatchReader: &systemTableReader{watchDoneTableName,
+		deletionWatchReader: &systemTableReader{
+			watchDoneTableName,
 			"done_time",
 			NullTime},
 	}
+}
+
+func (s *syncer) checkWatchTableExist() bool {
+	return s.checkTableExist("tidb_runaway_watch")
+}
+
+func (s *syncer) checkWatchDoneTableExist() bool {
+	return s.checkTableExist("tidb_runaway_watch_done")
+}
+
+func (s *syncer) checkTableExist(tableName string) bool {
+	sql := fmt.Sprintf(`SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = '%s'`, tableName)
+	rows, err := ExecRCRestrictedSQL(s.sysSessionPool, sql, nil)
+	if err != nil || len(rows) == 0 {
+		return false
+	}
+	return rows[0].GetInt64(0) > 0
 }
 
 func (s *syncer) getWatchRecordByID(id int64) ([]*QuarantineRecord, error) {

--- a/pkg/resourcegroup/runaway/syncer.go
+++ b/pkg/resourcegroup/runaway/syncer.go
@@ -51,21 +51,21 @@ func newSyncer(sysSessionPool util.SessionPool) *syncer {
 	}
 }
 
-func (s *syncer) checkWatchTableExist() bool {
+func (s *syncer) checkWatchTableExist() (bool, error) {
 	return s.checkTableExist("tidb_runaway_watch")
 }
 
-func (s *syncer) checkWatchDoneTableExist() bool {
+func (s *syncer) checkWatchDoneTableExist() (bool, error) {
 	return s.checkTableExist("tidb_runaway_watch_done")
 }
 
-func (s *syncer) checkTableExist(tableName string) bool {
+func (s *syncer) checkTableExist(tableName string) (bool, error) {
 	sql := fmt.Sprintf(`SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = '%s'`, tableName)
 	rows, err := ExecRCRestrictedSQL(s.sysSessionPool, sql, nil)
 	if err != nil || len(rows) == 0 {
-		return false
+		return false, err
 	}
-	return rows[0].GetInt64(0) > 0
+	return rows[0].GetInt64(0) > 0, nil
 }
 
 func (s *syncer) getWatchRecordByID(id int64) ([]*QuarantineRecord, error) {

--- a/pkg/resourcegroup/tests/resource_group_test.go
+++ b/pkg/resourcegroup/tests/resource_group_test.go
@@ -337,7 +337,7 @@ func TestResourceGroupRunaway(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, dom := testkit.CreateMockStoreAndDomain(t)
+	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
 
@@ -354,10 +354,6 @@ func TestResourceGroupRunaway(t *testing.T) {
 	tk.MustQuery("select /*+ resource_group(rg1) */ * from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select /*+ resource_group(rg2) */ * from t").Check(testkit.Rows("1"))
 	tk.MustQuery("select /*+ resource_group(rg3) */ * from t").Check(testkit.Rows("1"))
-
-	require.Eventually(t, func() bool {
-		return dom.RunawayManager().IsSyncerInitialized()
-	}, 20*time.Second, 300*time.Millisecond)
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/sleepCoprRequest", fmt.Sprintf("return(%d)", 60)))
 	err := tk.QueryToErr("select /*+ resource_group(rg1) */ * from t")
@@ -448,10 +444,6 @@ func TestResourceGroupRunawayExceedTiDBSide(t *testing.T) {
 	tk.MustExec("insert into t values(1)")
 	tk.MustExec("create resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=KILL)")
 
-	require.Eventually(t, func() bool {
-		return dom.RunawayManager().IsSyncerInitialized()
-	}, 20*time.Second, 300*time.Millisecond)
-
 	err := tk.QueryToErr("select /*+ resource_group(rg1) */ sleep(0.5) from t")
 	require.ErrorContains(t, err, "[executor:8253]Query execution was interrupted, identified as runaway query")
 
@@ -468,7 +460,7 @@ func TestResourceGroupRunawayFlood(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, dom := testkit.CreateMockStoreAndDomain(t)
+	store, _ := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
 
@@ -478,9 +470,6 @@ func TestResourceGroupRunawayFlood(t *testing.T) {
 	tk.MustExec("set global tidb_enable_resource_control='on'")
 	tk.MustExec("create resource group rg1 RU_PER_SEC=1000 QUERY_LIMIT=(EXEC_ELAPSED='50ms' ACTION=KILL)")
 	tk.MustQuery("select /*+ resource_group(rg1) */ * from t").Check(testkit.Rows("1"))
-	require.Eventually(t, func() bool {
-		return dom.RunawayManager().IsSyncerInitialized()
-	}, 20*time.Second, 300*time.Millisecond)
 
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/store/copr/sleepCoprRequest", fmt.Sprintf("return(%d)", 60)))
 	defer func() {

--- a/pkg/resourcegroup/tests/resource_group_test.go
+++ b/pkg/resourcegroup/tests/resource_group_test.go
@@ -337,7 +337,7 @@ func TestResourceGroupRunaway(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, _ := testkit.CreateMockStoreAndDomain(t)
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
 
@@ -460,7 +460,7 @@ func TestResourceGroupRunawayFlood(t *testing.T) {
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/resourcegroup/runaway/FastRunawayGC"))
 	}()
-	store, _ := testkit.CreateMockStoreAndDomain(t)
+	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil, nil))
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61782.

Problem Summary:

Revert #52283 and implement a simpler method to prevent error logs.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

Mannually modify `maxWatchRecordChannelSize` to 10 to ensure easier triggering.

<img width="442" alt="image" src="https://github.com/user-attachments/assets/c7067265-46b1-4135-92e7-b4c945fc5ab6" />

Before:

<img width="972" alt="image" src="https://github.com/user-attachments/assets/139fb4a8-ad19-4e4e-a864-14e39d3ef37b" />

After:

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/b7d066d3-3226-49eb-bf12-fc46573f7dfb" />

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Resolve the issue causing system table read/write operations related to runaways to hang after restarting TiDB instance.
```
