### PR TITLE
Fix nil buffer in basePartialResult4GroupConcat when hash aggregation is spilled

### DIFF
--- a/pkg/executor/aggfuncs/spill_deserialize_helper.go
+++ b/pkg/executor/aggfuncs/spill_deserialize_helper.go
@@ -15,6 +15,8 @@
 package aggfuncs
 
 import (
+	"bytes"
+
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	util "github.com/pingcap/tidb/pkg/util/serialization"
@@ -216,8 +218,13 @@ func (s *deserializeHelper) deserializePartialResult4SumFloat64(dst *partialResu
 func (s *deserializeHelper) deserializeBasePartialResult4GroupConcat(dst *basePartialResult4GroupConcat) bool {
 	if s.readRowIndex < s.totalRowCnt {
 		s.pab.Reset(s.column, s.readRowIndex)
-		dst.valsBuf = util.DeserializeBytesBuffer(s.pab)
-		dst.buffer = util.DeserializeBytesBuffer(s.pab)
+		dst.valsBuf = &bytes.Buffer{}
+		hasBuffer := util.DeserializeBool(s.pab)
+		if hasBuffer {
+			dst.buffer = util.DeserializeBytesBuffer(s.pab)
+		} else {
+			dst.buffer = nil
+		}
 		s.readRowIndex++
 		return true
 	}

--- a/pkg/executor/aggfuncs/spill_helper_test.go
+++ b/pkg/executor/aggfuncs/spill_helper_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testLongStr1 string = getLongString("平p凯k星x辰c")
-var testLongStr2 string = getLongString("123aa啊啊aa")
+var testLongStr1 string = getLongString("平352p凯额6辰c")
+var testLongStr2 string = getLongString("123a啊f24f去rsgvsfg")
 
 func getChunk() *chunk.Chunk {
 	fieldTypes := make([]*types.FieldType, 1)
@@ -746,13 +746,15 @@ func TestPartialResult4SumFloat64(t *testing.T) {
 
 func TestBasePartialResult4GroupConcat(t *testing.T) {
 	var serializeHelper = NewSerializeHelper()
+	serializeHelper.buf = make([]byte, 0)
 	bufSizeChecker := newBufferSizeChecker()
 
 	// Initialize test data
 	expectData := []basePartialResult4GroupConcat{
+		{valsBuf: bytes.NewBufferString("123"), buffer: nil},
 		{valsBuf: bytes.NewBufferString(""), buffer: bytes.NewBufferString("")},
-		{valsBuf: bytes.NewBufferString("xzxx"), buffer: bytes.NewBufferString(testLongStr2)},
-		{valsBuf: bytes.NewBufferString(testLongStr1), buffer: bytes.NewBufferString(testLongStr2)},
+		{valsBuf: bytes.NewBufferString(""), buffer: bytes.NewBufferString(testLongStr1)},
+		{valsBuf: bytes.NewBufferString(""), buffer: bytes.NewBufferString(testLongStr2)},
 	}
 	serializedPartialResults := make([]PartialResult, len(expectData))
 	testDataNum := len(serializedPartialResults)
@@ -787,8 +789,11 @@ func TestBasePartialResult4GroupConcat(t *testing.T) {
 	// Check some results
 	require.Equal(t, testDataNum, index)
 	for i := range testDataNum {
-		require.Equal(t, (*basePartialResult4GroupConcat)(serializedPartialResults[i]).valsBuf.String(), deserializedPartialResults[i].valsBuf.String())
-		require.Equal(t, (*basePartialResult4GroupConcat)(serializedPartialResults[i]).buffer.String(), deserializedPartialResults[i].buffer.String())
+		if (*basePartialResult4GroupConcat)(serializedPartialResults[i]).buffer != nil {
+			require.Equal(t, (*basePartialResult4GroupConcat)(serializedPartialResults[i]).buffer.String(), deserializedPartialResults[i].buffer.String())
+		} else {
+			require.Equal(t, (*bytes.Buffer)(nil), deserializedPartialResults[i].buffer)
+		}
 	}
 }
 

--- a/pkg/executor/aggfuncs/spill_serialize_helper.go
+++ b/pkg/executor/aggfuncs/spill_serialize_helper.go
@@ -131,8 +131,12 @@ func (s *SerializeHelper) serializePartialResult4SumFloat64(value partialResult4
 
 func (s *SerializeHelper) serializeBasePartialResult4GroupConcat(value basePartialResult4GroupConcat) []byte {
 	s.buf = s.buf[:0]
-	s.buf = util.SerializeBytesBuffer(value.valsBuf, s.buf)
-	s.buf = util.SerializeBytesBuffer(value.buffer, s.buf)
+	if value.buffer != nil {
+		s.buf = util.SerializeBool(true, s.buf)
+		s.buf = util.SerializeBytesBuffer(value.buffer, s.buf)
+	} else {
+		s.buf = util.SerializeBool(false, s.buf)
+	}
 	return s.buf
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61749

Problem Summary:

### What changed and how does it work?

When all values that passed in `group_concat` are null, buffer in `basePartialResult4GroupConcat` should be nil, and we need to consider it when serializing and deserializing the `basePartialResult4GroupConcat`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that buffer in basePartialResult4GroupConcat may be nil when hash aggregation is spilled
```
