### PR TITLE
types: fix parse vector type which have left string

### DIFF
--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
@@ -246,6 +247,17 @@ func ParseVectorFloat32(s string) (VectorFloat32, error) {
 	}
 	if valueError != nil {
 		return ZeroVectorFloat32, valueError
+	}
+
+	// Check if there are any remaining characters after the JSON array
+	// This ensures we reject strings like "[1,2,3]extra"
+	remaining := parser.SkipAndReturnBytes()
+	if len(remaining) > 0 {
+		// Check if the remaining bytes are only whitespace
+		trimmed := strings.TrimSpace(string(remaining))
+		if len(trimmed) > 0 {
+			return ZeroVectorFloat32, errors.Errorf("Invalid vector text: %s", s)
+		}
 	}
 
 	dim := len(values)

--- a/pkg/types/vector_test.go
+++ b/pkg/types/vector_test.go
@@ -104,6 +104,17 @@ func TestVectorParse(t *testing.T) {
 
 	v, err = types.ParseVectorFloat32(`[-1e39, 1e39]`)
 	require.EqualError(t, err, "value -1e+39 out of range for float32")
+
+	// Test invalid vector with extra characters
+	v, err = types.ParseVectorFloat32(`[1,2,3,4.4]ddddddddddddfasfa`)
+	require.NotNil(t, err)
+	require.True(t, v.IsZeroValue())
+	require.Contains(t, err.Error(), "Invalid vector text")
+
+	v, err = types.ParseVectorFloat32(`[1,2,3]extra`)
+	require.NotNil(t, err)
+	require.True(t, v.IsZeroValue())
+	require.Contains(t, err.Error(), "Invalid vector text")
 }
 
 func TestVectorDatum(t *testing.T) {


### PR DESCRIPTION
This patch fix vector parse, that maybe have left string

TiDB now use jsoniter as vector string parse vector string

but that method maybe have left string, that is wrong text.
more to check the diff and isssue.

for pgvector is right:
https://pglite.dev/repl/
![image](https://github.com/user-attachments/assets/ab6c0f34-7875-4b77-9469-b3308b087541)

cc @breezewish  @lance6716


Issue Number: close #61835

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
