### PR TITLE
fix(runaway): prevent marking quarantine when settings expired

### DIFF
--- a/pkg/resourcegroup/runaway/BUILD.bazel
+++ b/pkg/resourcegroup/runaway/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/generic",
         "//pkg/util/logutil",
         "//pkg/util/sqlexec",
+        "@com_github_gogo_protobuf//proto",
         "@com_github_jellydator_ttlcache_v3//:ttlcache",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61834

### What changed and how does it work?

Introduced a check to ensure that quarantine marking only proceeds if the current resource group settings match the existing settings.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

Slow SQL will be killed after 10s:

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/de21cf70-b698-4f9a-b065-beafd3dbcb58" />

Before:

![image](https://github.com/user-attachments/assets/53eeb78c-165c-47ab-9c1e-2d0f7e2d4d81)

After:

![image](https://github.com/user-attachments/assets/56dbe394-5899-44a8-856d-91e7bc695e3a)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue where expired `WATCH` rule still take effect after the `QUERY_LIMIT` setting is modified.
```
