### PR TITLE
fix: string null value should error close #57143

### DIFF
--- a/pkg/types/vector.go
+++ b/pkg/types/vector.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
@@ -219,6 +220,12 @@ func ZeroCopyDeserializeVectorFloat32(b []byte) (VectorFloat32, []byte, error) {
 
 // ParseVectorFloat32 parses a string into a vector.
 func ParseVectorFloat32(s string) (VectorFloat32, error) {
+	// issue #57143 jsoniter parse null will return as []
+	// Trim whitespace and check for null string and reject it
+	if strings.TrimSpace(s) == "null" {
+		return ZeroVectorFloat32, errors.Errorf("Invalid vector text: %s", s)
+	}
+
 	var values []float32
 	var valueError error
 	// We explicitly use a JSON float parser to reject other JSON types.

--- a/pkg/types/vector_test.go
+++ b/pkg/types/vector_test.go
@@ -61,9 +61,9 @@ func TestVectorParse(t *testing.T) {
 	require.NotNil(t, err)
 	require.True(t, v.IsZeroValue())
 
-	// Note: Currently we will parse "null" into [].
+	// "null" string should return error, not empty vector
 	v, err = types.ParseVectorFloat32(`null`)
-	require.Nil(t, err)
+	require.NotNil(t, err)
 	require.True(t, v.IsZeroValue())
 
 	v, err = types.ParseVectorFloat32(`"json_str"`)


### PR DESCRIPTION
### What problem does this PR solve?

This patch try to fix 57143
the issue desc maybe wrong, for TiDB csv load null value should `\N`

but the error is right, folllow #61836 `jsoniter ` load `js` null as `[]`
that caused the csv load issue, this patch use fast route to check the 
value, that do not need the parser that maybe faster

before this patch:

```sql
mysql> insert into t values("   null");
ERROR 1105 (HY000): vector has 0 dimensions, does not fit VECTOR(4)
mysql> insert into t values("[1,2,3,4.4, null]");
ERROR 1105 (HY000): Invalid vector text: [1,2,3,4.4, null]
mysql> insert into t values("[1,2,3,4.4, NULL]");
ERROR 1105 (HY000): Invalid vector text: [1,2,3,4.4, NULL]
mysql> insert into t values("[1,2,3,4.4, 'null']");
ERROR 1105 (HY000): Invalid vector text: [1,2,3,4.4, 'null']
mysql> insert into t values("[1,2,3,4.4, [null]]");
ERROR 1105 (HY000): Invalid vector text: [1,2,3,4.4, [null]]
mysql> insert into t values("null");
ERROR 1105 (HY000): vector has 0 dimensions, does not fit VECTOR(4)
mysql> ^DBye
```

after this patch

```sql

mysql> use test
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> insert into t values("null");
ERROR 1105 (HY000): Invalid vector text: null
mysql> insert into t values("null");
ERROR 1105 (HY000): Invalid vector text: null
mysql> insert into t values("null   ");
ERROR 1105 (HY000): Invalid vector text: null   
mysql> 
```

also cc @breezewish


Issue Number: close #57143

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
