### PR TITLE
build: add next-gen build flag to pluginpkg command

### DIFF
--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"text/template"
 	"time"
 
@@ -33,6 +34,7 @@ var (
 	pkgDir  string
 	outDir  string
 	pgoFile string
+	nextGen bool
 )
 
 const codeTemplate = `
@@ -76,6 +78,7 @@ func init() {
 	flag.StringVar(&pkgDir, "pkg-dir", "", "plugin package folder path")
 	flag.StringVar(&outDir, "out-dir", "", "plugin packaged folder path")
 	flag.StringVar(&pgoFile, "pgo-file", "", "go profile-guided optimization(pgo) file path")
+	flag.BoolVar(&nextGen, "next-gen", false, "whether to build plugin with next-gen features")
 	flag.Usage = usage
 }
 
@@ -155,8 +158,14 @@ func main() {
 	if pgoFile != "" {
 		flags = append(flags, "-pgo="+pgoFile)
 	}
+
+	buildTags := []string{"codes"}
+	if nextGen {
+		buildTags = append(buildTags, "nextgen")
+	}
+
 	flags = append(flags,
-		"-tags=codes",
+		"-tags="+strings.Join(buildTags, ","),
 		"-buildmode=plugin",
 		"-o", outputFile, pkgDir)
 	buildCmd := exec.CommandContext(ctx, "go", flags...)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61847

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  > go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/audit -out-dir ../plugin-so -next-gen
  > ...
  > ./bin/tidb-server -keyspace-name=test-ks  -plugin-dir=../plugin-so -plugin-load=audit-1,whitelist-1
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
