### PR TITLE
ddl: refresh TiFlash PlacementRules periodically

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
     deps = [
         "//br/pkg/storage",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl/copr",
         "//pkg/ddl/ingest",
         "//pkg/ddl/label",

--- a/pkg/ddl/ddl_tiflash_api.go
+++ b/pkg/ddl/ddl_tiflash_api.go
@@ -615,7 +615,7 @@ func (d *ddl) refreshTiFlashPlacementRules(sctx sessionctx.Context, tick uint64)
 			logutil.DDLLogger().Warn("get placement rule err", zap.Error(err))
 			continue
 		}
-		// rule is missing
+		// pdhttp.GetPlacementRule returns the zero object instead of nil pointer when not found.
 		ruleIsMissing := rule == nil || len(rule.ID) == 0
 		if ruleIsMissing && replica.TableInfo.TiFlashReplica.Count > 0 {
 			job := &model.Job{

--- a/pkg/ddl/ddl_tiflash_api.go
+++ b/pkg/ddl/ddl_tiflash_api.go
@@ -619,12 +619,15 @@ func (d *ddl) refreshTiFlashPlacementRules(sctx sessionctx.Context, tick uint64)
 		ruleIsMissing := rule == nil || len(rule.ID) == 0
 		if ruleIsMissing && replica.TableInfo.TiFlashReplica.Count > 0 {
 			job := &model.Job{
-				SchemaID:   replica.DBInfo.ID,
-				TableID:    replica.TableInfo.ID,
-				SchemaName: replica.DBInfo.Name.L,
-				TableName:  replica.TableInfo.Name.L,
-				Type:       model.ActionSetTiFlashReplica,
-				BinlogInfo: &model.HistoryInfo{},
+				Version:        model.GetJobVerInUse(),
+				SchemaID:       replica.DBInfo.ID,
+				TableID:        replica.TableInfo.ID,
+				SchemaName:     replica.DBInfo.Name.L,
+				TableName:      replica.TableInfo.Name.L,
+				Type:           model.ActionSetTiFlashReplica,
+				BinlogInfo:     &model.HistoryInfo{},
+				CDCWriteSource: sctx.GetSessionVars().CDCWriteSource,
+				SQLMode:        sctx.GetSessionVars().SQLMode,
 			}
 			args := model.SetTiFlashReplicaArgs{TiflashReplica: ast.TiFlashReplicaSpec{
 				Count:  replica.TableInfo.TiFlashReplica.Count,

--- a/pkg/ddl/ddl_tiflash_api.go
+++ b/pkg/ddl/ddl_tiflash_api.go
@@ -30,12 +30,14 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	ddlutil "github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	infoschemacontext "github.com/pingcap/tidb/pkg/infoschema/context"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/util"
@@ -221,6 +223,8 @@ var (
 	PullTiFlashPdTick = atomicutil.NewUint64(30 * 5)
 	// UpdateTiFlashStoreTick indicates the number of intervals before we fully update TiFlash stores.
 	UpdateTiFlashStoreTick = atomicutil.NewUint64(5)
+	// RefreshRulesTick indicates the number of intervals before we refresh TiFlash rules.
+	RefreshRulesTick = atomicutil.NewUint64(10)
 	// PollTiFlashBackoffMaxTick is the max tick before we try to update TiFlash replica availability for one table.
 	PollTiFlashBackoffMaxTick TiFlashTick = 10
 	// PollTiFlashBackoffMinTick is the min tick before we try to update TiFlash replica availability for one table.
@@ -548,6 +552,95 @@ func (d *ddl) refreshTiFlashTicker(ctx sessionctx.Context, pollTiFlashContext *T
 	return nil
 }
 
+type pending struct {
+	ID        int64
+	TableInfo *model.TableInfo
+	DBInfo    *model.DBInfo
+}
+
+// refreshTiFlashPlacementRules will refresh the placement rules of TiFlash replicas if on tick.
+// 1. It will scan all the meta and check if there is any TiFlash replica.
+// 2. If there is, it will check if the placement rules are missing.
+// 3. If the placement rules are missing, it will add by submit a ActionSetTiFlashReplica job to repair the entire table.
+func (d *ddl) refreshTiFlashPlacementRules(sctx sessionctx.Context, tick uint64) error {
+	if tick%RefreshRulesTick.Load() != 0 {
+		return nil
+	}
+	schema := d.infoCache.GetLatest()
+	if schema == nil {
+		return errors.New("schema is nil")
+	}
+
+	var pendings []pending
+
+	for _, dbResult := range schema.ListTablesWithSpecialAttribute(infoschemacontext.TiFlashAttribute) {
+		db, ok := schema.SchemaByName(dbResult.DBName)
+		if !ok {
+			return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbResult.DBName.O)
+		}
+		for _, tblInfo := range dbResult.TableInfos {
+			if tblInfo.TiFlashReplica == nil {
+				continue
+			}
+
+			if ps := tblInfo.GetPartitionInfo(); ps != nil {
+				collectPendings := func(ps []model.PartitionDefinition) {
+					for _, p := range ps {
+						pendings = append(pendings, pending{
+							ID:        p.ID,
+							TableInfo: tblInfo,
+							DBInfo:    db,
+						})
+					}
+				}
+				collectPendings(ps.Definitions)
+				collectPendings(ps.AddingDefinitions)
+			} else {
+				pendings = append(pendings, pending{
+					ID:        tblInfo.ID,
+					TableInfo: tblInfo,
+					DBInfo:    db,
+				})
+			}
+		}
+	}
+
+	fixed := make(map[int64]struct{})
+	for _, replica := range pendings {
+		if _, ok := fixed[replica.TableInfo.ID]; ok {
+			continue
+		}
+		rule, err := infosync.GetPlacementRule(d.ctx, replica.ID)
+		if err != nil {
+			logutil.DDLLogger().Warn("get placement rule err", zap.Error(err))
+			continue
+		}
+		// rule is missing
+		if rule == nil && replica.TableInfo.TiFlashReplica.Count > 0 {
+			job := &model.Job{
+				SchemaID:   replica.DBInfo.ID,
+				TableID:    replica.TableInfo.ID,
+				SchemaName: replica.DBInfo.Name.L,
+				TableName:  replica.TableInfo.Name.L,
+				Type:       model.ActionSetTiFlashReplica,
+				BinlogInfo: &model.HistoryInfo{},
+			}
+			args := model.SetTiFlashReplicaArgs{TiflashReplica: ast.TiFlashReplicaSpec{
+				Count:  replica.TableInfo.TiFlashReplica.Count,
+				Labels: replica.TableInfo.TiFlashReplica.LocationLabels,
+			}}
+			err = d.executor.doDDLJob2(sctx, job, &args)
+			if err != nil {
+				logutil.DDLLogger().Warn("fix placement rule err", zap.Error(err))
+			} else {
+				logutil.DDLLogger().Info("fix placement rule success", zap.Int64("tableID", replica.TableInfo.ID))
+				fixed[replica.TableInfo.ID] = struct{}{}
+			}
+		}
+	}
+	return nil
+}
+
 func (d *ddl) PollTiFlashRoutine() {
 	pollTiflashContext, err := NewTiFlashManagementContext()
 	if err != nil {
@@ -592,6 +685,11 @@ func (d *ddl) PollTiFlashRoutine() {
 							// If we have not set up MockTiFlash instance, for those tests without TiFlash, just suppress.
 						default:
 							logutil.DDLLogger().Warn("refreshTiFlashTicker returns error", zap.Error(err))
+						}
+					}
+					if kerneltype.IsNextGen() {
+						if err := d.refreshTiFlashPlacementRules(sctx, pollTiflashContext.PollCounter); err != nil {
+							logutil.DDLLogger().Warn("refreshTiFlashPlacementRules returns error", zap.Error(err))
 						}
 					}
 				} else {

--- a/pkg/ddl/ddl_tiflash_api.go
+++ b/pkg/ddl/ddl_tiflash_api.go
@@ -616,7 +616,8 @@ func (d *ddl) refreshTiFlashPlacementRules(sctx sessionctx.Context, tick uint64)
 			continue
 		}
 		// rule is missing
-		if rule == nil && replica.TableInfo.TiFlashReplica.Count > 0 {
+		ruleIsMissing := rule == nil || len(rule.ID) == 0
+		if ruleIsMissing && replica.TableInfo.TiFlashReplica.Count > 0 {
 			job := &model.Job{
 				SchemaID:   replica.DBInfo.ID,
 				TableID:    replica.TableInfo.ID,

--- a/pkg/domain/infosync/info.go
+++ b/pkg/domain/infosync/info.go
@@ -1305,6 +1305,16 @@ func GetTiFlashRegionCountFromPD(ctx context.Context, tableID int64, regionCount
 	return is.tiflashReplicaManager.GetRegionCountFromPD(ctx, tableID, regionCount)
 }
 
+// GetPlacementRule is a helper function to get placement rule by table id.
+func GetPlacementRule(ctx context.Context, tableID int64) (*pdhttp.Rule, error) {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return nil, err
+	}
+
+	return is.tiflashReplicaManager.GetPlacementRule(ctx, tableID)
+}
+
 // GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
 func GetTiFlashStoresStat(ctx context.Context) (*pdhttp.StoresInfo, error) {
 	is, err := getGlobalInfoSyncer()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Close #61864

Problem Summary:
See the issue.

### What changed and how does it work?
Added a `syncer` to placement rules.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. Create a test table.
```sql
create table test(pk varchar(200) PRIMARY KEY CLUSTERED, note text, id int);
```
2. Add TiFlash replica for it.
```sql
alter table test set tiflash replica 1;
```
3. Restore to another keyspace with the backup.
```
/cse-ctl restore keyspace --name 20250620/074700.meta --target-keyspace-name celestial --keyspace-name aqua --pd cse-ks3-pd:2379 --config /etc/tikv/tikv.toml
```
4. Start TiDB in the new keyspace. (path = `.spec`)
```yaml
tidb:
    baseImage: hub-new.pingcap.net/br/tidb/tispace/pick-refresh-tiflash
    config: |
      enable-telemetry = false
      keyspace-name = "celestial"

      [log]
        [log.file]
          max-backups = 3
    version: "250620173342"
```
5. After TiDB started, check whether the placement rule was created:
```console
# /pd-ctl config placement-rules show
[
  {
    "group_id": "pd",
    "id": "default",
    "start_key": "",
    "end_key": "",
    "role": "voter",
    "is_witness": false,
    "count": 3,
    "location_labels": [
      "host"
    ]
  },
  {
    "group_id": "tiflash",
    "id": "keyspace-1-table-118-r",
    "index": 120,
    "start_key": "7800000174800000ff00000000765f7200fe",
    "end_key": "7800000174800000ff0000000077000000fc",
    "role": "learner",
    "is_witness": false,
    "count": 1,
    "label_constraints": [
      {
        "key": "engine",
        "op": "in",
        "values": [
          "tiflash"
        ]
      }
    ]
  },
  {
    "group_id": "tiflash",
    "id": "keyspace-6-table-118-r",
    "index": 120,
    "start_key": "7800000674800000ff00000000765f7200fe",
    "end_key": "7800000674800000ff0000000077000000fc",
    "role": "learner",
    "is_witness": false,
    "count": 1,
    "label_constraints": [
      {
        "key": "engine",
        "op": "in",
        "values": [
          "tiflash"
        ]
      }
    ],
    "create_timestamp": 1750412103
  }
]
```
Also check the log:
```
[2025/06/20 09:35:04.742 +00:00] [INFO] [ddl_tiflash_api.go:640] ["fix placement rule success"] [keyspaceName=celestial] [category=ddl] [tableID=118]
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
