### PR TITLE
lightning: fix length check may be skipped for first line

### DIFF
--- a/pkg/lightning/mydump/csv_parser.go
+++ b/pkg/lightning/mydump/csv_parser.go
@@ -629,8 +629,6 @@ func (parser *CSVParser) replaceEOF(err error, replaced error) error {
 
 // ReadRow reads a row from the datafile.
 func (parser *CSVParser) ReadRow() error {
-	parser.beginRowLenCheck()
-	defer parser.endRowLenCheck()
 	row := &parser.lastRow
 	row.Length = 0
 	row.RowID++
@@ -643,6 +641,9 @@ func (parser *CSVParser) ReadRow() error {
 		}
 		parser.shouldParseHeader = false
 	}
+
+	parser.beginRowLenCheck()
+	defer parser.endRowLenCheck()
 
 	fields, err := parser.readRecord(parser.lastRecord)
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61873

Problem Summary:

### What changed and how does it work?

We should enable `parser.beginRowLenCheck()` after read column headers, to make the check works.

https://github.com/pingcap/tidb/blob/465b166e2b618d783d4489f1f31a3b3cc6c70a15/pkg/lightning/mydump/csv_parser.go#L631-L647

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
