### PR TITLE
fix: close #61880 by fixing the blob type

### DIFF
--- a/pkg/server/internal/column/result_encoder.go
+++ b/pkg/server/internal/column/result_encoder.go
@@ -96,7 +96,7 @@ func (d *ResultEncoder) ColumnTypeInfoCharsetID(info *Info) uint16 {
 	if d.isNull || len(d.chsName) == 0 || !isStringColumnType(info.Type) {
 		return charset
 	}
-	if charset == mysql.BinaryDefaultCollationID {
+	if charset == mysql.BinaryDefaultCollationID && !isBlobColumnType(info.Type) {
 		return mysql.BinaryDefaultCollationID
 	}
 	return uint16(mysql.CharsetNameToID(d.chsName))
@@ -130,6 +130,14 @@ func (d *ResultEncoder) EncodeWith(src []byte, enc charset.Encoding) []byte {
 		logutil.BgLogger().Debug("encode error", zap.Error(err))
 	}
 	return data
+}
+
+func isBlobColumnType(tp byte) bool {
+	switch tp {
+	case mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
+		return true
+	}
+	return false
 }
 
 func isStringColumnType(tp byte) bool {

--- a/tests/integrationtest/r/executor/issues.result
+++ b/tests/integrationtest/r/executor/issues.result
@@ -1017,3 +1017,8 @@ result
 select ((exists (select 1)) * -5) as c1;
 c1
 -5
+CREATE TABLE test_61880 (c1 blob);
+insert into test_61880 (c1) values(0);
+select * from test_61880;
+c1
+0

--- a/tests/integrationtest/t/executor/issues.test
+++ b/tests/integrationtest/t/executor/issues.test
@@ -779,3 +779,8 @@ select from_unixtime( if(col2 >9999999999, col2/1000, col2), '%Y-%m-%d %H:%i:%s'
 
 # TestIssue56641
 select ((exists (select 1)) * -5) as c1;
+
+# TestIssue61880
+CREATE TABLE test_61880 (c1 blob);
+insert into test_61880 (c1) values(0);
+select * from test_61880;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

This patch close 61880 by fix the blob type when int
the old code use 0 as ascii and save so it is `0x30`

also this patch is the first part to fix #60260 (this is a two 
issues query)

but it still wrong for that issue, it needs another fix


Issue Number: close #61880

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
