### PR TITLE
session: rename GetDomainInfoSchema to GetLatestInfoSchema

### DIFF
--- a/pkg/ddl/cluster.go
+++ b/pkg/ddl/cluster.go
@@ -374,7 +374,7 @@ func mergeContinuousKeyRanges(schemaKeyRanges []keyRangeMayExclude) []kv.KeyRang
 // It contains all non system table key ranges and meta data key ranges.
 // The time complexity is O(nlogn).
 func getFlashbackKeyRanges(ctx context.Context, sess sessionctx.Context, flashbackTS uint64) ([]kv.KeyRange, error) {
-	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	schemas := is.AllSchemas()
 
 	// get snapshot schema IDs.

--- a/pkg/ddl/metabuild.go
+++ b/pkg/ddl/metabuild.go
@@ -32,7 +32,7 @@ func NewMetaBuildContextWithSctx(sctx sessionctx.Context, otherOpts ...metabuild
 		metabuild.WithClusteredIndexDefMode(sessVars.EnableClusteredIndex),
 		metabuild.WithShardRowIDBits(sessVars.ShardRowIDBits),
 		metabuild.WithPreSplitRegions(sessVars.PreSplitRegions),
-		metabuild.WithInfoSchema(sctx.GetDomainInfoSchema()),
+		metabuild.WithInfoSchema(sctx.GetLatestInfoSchema()),
 	}
 
 	if len(otherOpts) > 0 {

--- a/pkg/ddl/metabuild_test.go
+++ b/pkg/ddl/metabuild_test.go
@@ -133,7 +133,7 @@ func TestNewMetaBuildContextWithSctx(t *testing.T) {
 		{
 			field: "is",
 			check: func(ctx *metabuild.Context) {
-				sctxInfoSchema := sctx.GetDomainInfoSchema()
+				sctxInfoSchema := sctx.GetLatestInfoSchema()
 				require.NotNil(t, sctxInfoSchema)
 				is, ok := ctx.GetInfoSchema()
 				require.True(t, ok)

--- a/pkg/ddl/tests/multivaluedindex/multi_valued_index_test.go
+++ b/pkg/ddl/tests/multivaluedindex/multi_valued_index_test.go
@@ -29,7 +29,7 @@ func TestCreateMultiValuedIndexHasBinaryCollation(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 
 	tk.MustExec("create table test.t (pk varchar(4) primary key clustered, j json, str varchar(255), value int, key idx((cast(j as char(100) array)), str));")
-	is := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.NotNil(t, is)
 
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -1026,7 +1026,7 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) exec.Executor {
 
 func (b *executorBuilder) buildImportInto(v *plannercore.ImportInto) exec.Executor {
 	// see planBuilder.buildImportInto for detail why we use the latest schema here.
-	latestIS := b.ctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	latestIS := b.ctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbl, ok := latestIS.TableByID(context.Background(), v.Table.TableInfo.ID)
 	if !ok {
 		b.err = errors.Errorf("Can not get table %d", v.Table.TableInfo.ID)

--- a/pkg/executor/distribute_table_test.go
+++ b/pkg/executor/distribute_table_test.go
@@ -126,7 +126,7 @@ func TestDistributeTable(t *testing.T) {
 	recoverCli := infosync.SetPDHttpCliForTest(cli)
 	defer recoverCli()
 	mockCreateSchedulerWithInput := func(tblName string, config map[string]any, partitions []string) *mock.Call {
-		is := tk.Session().GetDomainInfoSchema()
+		is := tk.Session().GetLatestInfoSchema()
 		tbl, err := is.TableInfoByName(ast.NewCIStr(database), ast.NewCIStr(tblName))
 		require.NoError(t, err)
 		tblID := tbl.ID
@@ -227,7 +227,7 @@ func TestShowTableDistributions(t *testing.T) {
 	recoverCli := infosync.SetPDHttpCliForTest(cli)
 	defer recoverCli()
 	mockGetDistributions := func(tblName, partition string, distributions *pdhttp.RegionDistributions) *mock.Call {
-		is := tk.Session().GetDomainInfoSchema()
+		is := tk.Session().GetLatestInfoSchema()
 		tbl, err := is.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr(tblName))
 		require.NoError(t, err)
 		tblID := tbl.ID

--- a/pkg/executor/executor_failpoint_test.go
+++ b/pkg/executor/executor_failpoint_test.go
@@ -679,7 +679,7 @@ func TestGetMvccByEncodedKeyRegionError(t *testing.T) {
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	schemaVersion := tk.Session().GetDomainInfoSchema().SchemaMetaVersion()
+	schemaVersion := tk.Session().GetLatestInfoSchema().SchemaMetaVersion()
 	key := m.EncodeSchemaDiffKey(schemaVersion)
 
 	resp, err := h.GetMvccByEncodedKey(key)

--- a/pkg/executor/importer/precheck_test.go
+++ b/pkg/executor/importer/precheck_test.go
@@ -74,7 +74,7 @@ func TestCheckRequirements(t *testing.T) {
 
 	_, err := conn.Execute(ctx, "create table test.t(id int primary key)")
 	require.NoError(t, err)
-	is := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema)
 	tableObj, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2062,7 +2062,7 @@ func (e *memtableRetriever) setDataForTiKVRegionStatus(ctx context.Context, sctx
 	}
 	requestByTableRange := false
 	var allRegionsInfo *pd.RegionsInfo
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	if e.extractor != nil {
 		extractor, ok := e.extractor.(*plannercore.TiKVRegionStatusExtractor)
 		if ok && len(extractor.GetTablesID()) > 0 {

--- a/pkg/executor/show_placement_test.go
+++ b/pkg/executor/show_placement_test.go
@@ -505,7 +505,7 @@ func TestShowPlacementHandleRegionStatus(t *testing.T) {
 	defer recoverCli()
 
 	mockGetState := func(tblName, partition string, state string) *mock.Call {
-		is := tk.Session().GetDomainInfoSchema()
+		is := tk.Session().GetLatestInfoSchema()
 		tbl, err := is.TableInfoByName(ast.NewCIStr("test"), ast.NewCIStr(tblName))
 		require.NoError(t, err)
 		tblID := tbl.ID

--- a/pkg/executor/write.go
+++ b/pkg/executor/write.go
@@ -436,7 +436,7 @@ func resetErrDataTooLong(colName string, rowIdx int, _ error) error {
 // checkRowForExchangePartition is only used for ExchangePartition by non-partitionTable during write only state.
 // It check if rowData inserted or updated violate partition definition or checkConstraints of partitionTable.
 func checkRowForExchangePartition(sctx sessionctx.Context, row []types.Datum, tbl *model.TableInfo) error {
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	pt, tableFound := is.TableByID(context.Background(), tbl.ExchangePartitionInfo.ExchangePartitionTableID)
 	if !tableFound {
 		return errors.Errorf("exchange partition process table by id failed")

--- a/pkg/expression/builtin_info.go
+++ b/pkg/expression/builtin_info.go
@@ -1051,7 +1051,7 @@ func (b *builtinTiDBEncodeRecordKeySig) Clone() builtinFunc {
 
 // evalString evals a builtinTiDBEncodeRecordKeySig.
 func (b *builtinTiDBEncodeRecordKeySig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	is, err := b.GetDomainInfoSchema(ctx)
+	is, err := b.GetLatestInfoSchema(ctx)
 	if err != nil {
 		return "", true, err
 	}
@@ -1123,7 +1123,7 @@ func (b *builtinTiDBEncodeIndexKeySig) Clone() builtinFunc {
 
 // evalString evals a builtinTiDBEncodeIndexKeySig.
 func (b *builtinTiDBEncodeIndexKeySig) evalString(ctx EvalContext, row chunk.Row) (string, bool, error) {
-	is, err := b.GetDomainInfoSchema(ctx)
+	is, err := b.GetLatestInfoSchema(ctx)
 	if err != nil {
 		return "", true, err
 	}
@@ -1199,7 +1199,7 @@ func (b *builtinTiDBDecodeKeySig) evalString(ctx EvalContext, row chunk.Row) (st
 	if isNull || err != nil {
 		return "", isNull, err
 	}
-	is, err := b.GetDomainInfoSchema(ctx)
+	is, err := b.GetLatestInfoSchema(ctx)
 	if err != nil {
 		return "", true, err
 	}

--- a/pkg/expression/builtin_info_vec.go
+++ b/pkg/expression/builtin_info_vec.go
@@ -425,7 +425,7 @@ func (b *builtinTiDBDecodeKeySig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	}
 	result.ReserveString(n)
 
-	is, err := b.GetDomainInfoSchema(ctx)
+	is, err := b.GetLatestInfoSchema(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/expression/expropt/infoschema.go
+++ b/pkg/expression/expropt/infoschema.go
@@ -44,8 +44,8 @@ func (InfoSchemaPropReader) GetSessionInfoSchema(ctx exprctx.EvalContext) (infos
 	return p(false), nil
 }
 
-// GetDomainInfoSchema return domain information schema.
-func (InfoSchemaPropReader) GetDomainInfoSchema(ctx exprctx.EvalContext) (infoschema.MetaOnlyInfoSchema, error) {
+// GetLatestInfoSchema return domain information schema.
+func (InfoSchemaPropReader) GetLatestInfoSchema(ctx exprctx.EvalContext) (infoschema.MetaOnlyInfoSchema, error) {
 	p, err := getPropProvider[InfoSchemaPropProvider](ctx, exprctx.OptPropInfoSchema)
 	if err != nil {
 		return nil, err

--- a/pkg/expression/expropt/optional_test.go
+++ b/pkg/expression/expropt/optional_test.go
@@ -123,7 +123,7 @@ func TestOptionalEvalPropProviders(t *testing.T) {
 			reader = r
 			verifyNoProvider = func(ctx exprctx.EvalContext) {
 				assertReaderFuncReturnErr(t, ctx, r.GetSessionInfoSchema)
-				assertReaderFuncReturnErr(t, ctx, r.GetDomainInfoSchema)
+				assertReaderFuncReturnErr(t, ctx, r.GetLatestInfoSchema)
 			}
 			verifyProvider = func(ctx exprctx.EvalContext, val exprctx.OptionalEvalPropProvider) {
 				is, ok := val.(InfoSchemaPropProvider)(true).(*mockIsType)
@@ -134,7 +134,7 @@ func TestOptionalEvalPropProviders(t *testing.T) {
 				require.True(t, ok)
 				require.Same(t, &is2, is)
 
-				require.Same(t, &is1, assertReaderFuncValue(t, ctx, r.GetDomainInfoSchema))
+				require.Same(t, &is1, assertReaderFuncValue(t, ctx, r.GetLatestInfoSchema))
 				require.Same(t, &is2, assertReaderFuncValue(t, ctx, r.GetSessionInfoSchema))
 			}
 		case exprctx.OptPropKVStore:

--- a/pkg/expression/sessionexpr/sessionctx.go
+++ b/pkg/expression/sessionexpr/sessionctx.go
@@ -362,7 +362,7 @@ func currentUserProp(sctx sessionctx.Context) exprctx.OptionalEvalPropProvider {
 func infoSchemaProp(sctx sessionctx.Context) expropt.InfoSchemaPropProvider {
 	return func(isDomain bool) infoschema.MetaOnlyInfoSchema {
 		if isDomain {
-			return sctx.GetDomainInfoSchema()
+			return sctx.GetLatestInfoSchema()
 		}
 		return sctx.GetInfoSchema()
 	}

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -434,7 +434,7 @@ func refineCETrace(sctx base.PlanContext) {
 		return cmp.Compare(i.RowCount, j.RowCount)
 	})
 	traceRecords := stmtCtx.OptimizerCETrace
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	for _, rec := range traceRecords {
 		tbl, _ := infoschema.FindTableByTblOrPartID(is, rec.TableID)
 		if tbl != nil {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4718,7 +4718,7 @@ func (b *PlanBuilder) buildImportInto(ctx context.Context, ld *ast.ImportIntoStm
 	//
 	// tidb_read_staleness can be used to do stale read too, it's allowed as long as
 	// TableInfo.ID matches with the latest schema.
-	latestIS := b.ctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	latestIS := b.ctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tableInPlan, ok := latestIS.TableByID(ctx, tableInfo.ID)
 	if !ok {
 		// adaptor.handleNoDelayExecutor has a similar check, but we want to give

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -54,7 +54,7 @@ func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.Log
 
 	// Prepare the table metadata to avoid repeatedly fetching from the infoSchema below, and trigger extra sync/async
 	// stats loading for the determinate mode.
-	is := plan.SCtx().GetDomainInfoSchema()
+	is := plan.SCtx().GetLatestInfoSchema()
 	tblID2TblInfo := make(map[int64]*model.TableInfo)
 	visitedPhysTblIDs.ForEach(func(physicalTblID int) {
 		tblInfo, _ := is.TableInfoByID(int64(physicalTblID))
@@ -440,7 +440,7 @@ func recordTableRuntimeStats(sctx base.PlanContext, tbls map[int64]struct{}) {
 func recordSingleTableRuntimeStats(sctx base.PlanContext, tblID int64) (stats *statistics.Table, skip bool, err error) {
 	dom := domain.GetDomain(sctx)
 	statsHandle := dom.StatsHandle()
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbl, ok := is.TableByID(context.Background(), tblID)
 	if !ok {
 		return nil, false, nil

--- a/pkg/planner/indexadvisor/optimizer.go
+++ b/pkg/planner/indexadvisor/optimizer.go
@@ -69,7 +69,7 @@ func NewOptimizer(sctx sessionctx.Context) Optimizer {
 }
 
 func (opt *optimizerImpl) is() infoschema.InfoSchema {
-	return opt.sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	return opt.sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 }
 
 // IndexNameExist returns whether the specified index name exists in the specified table.

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -622,7 +622,7 @@ func hypoIndexChecker(ctx context.Context, is infoschema.InfoSchema) func(db, tb
 // queryPlanCost returns the plan cost of this node, which is mainly for the Index Advisor.
 func queryPlanCost(sctx sessionctx.Context, stmt ast.StmtNode) (float64, error) {
 	nodeW := resolve.NewNodeW(stmt)
-	plan, _, err := Optimize(context.Background(), sctx, nodeW, sctx.GetDomainInfoSchema().(infoschema.InfoSchema))
+	plan, _, err := Optimize(context.Background(), sctx, nodeW, sctx.GetLatestInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return 0, err
 	}
@@ -647,7 +647,7 @@ func calculatePlanDigestFunc(sctx sessionctx.Context, stmt ast.StmtNode) (planDi
 		return "", err
 	}
 
-	p, _, err := Optimize(context.Background(), sctx, nodeW, sctx.GetDomainInfoSchema().(infoschema.InfoSchema))
+	p, _, err := Optimize(context.Background(), sctx, nodeW, sctx.GetLatestInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return "", err
 	}
@@ -672,7 +672,7 @@ func recordRelevantOptVarsAndFixes(sctx sessionctx.Context, stmt ast.StmtNode) (
 		return nil, nil, err
 	}
 
-	_, _, err = Optimize(context.Background(), sctx, nodeW, sctx.GetDomainInfoSchema().(infoschema.InfoSchema))
+	_, _, err = Optimize(context.Background(), sctx, nodeW, sctx.GetLatestInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -700,7 +700,7 @@ func genBriefPlanWithSCtx(sctx sessionctx.Context, stmt ast.StmtNode) (planDiges
 		return "", "", nil, err
 	}
 
-	p, _, err := Optimize(context.Background(), sctx, nodeW, sctx.GetDomainInfoSchema().(infoschema.InfoSchema))
+	p, _, err := Optimize(context.Background(), sctx, nodeW, sctx.GetLatestInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/planner/planctx/context.go
+++ b/pkg/planner/planctx/context.go
@@ -45,10 +45,10 @@ type PlanContext interface {
 	GetStore() kv.Storage
 	// GetSessionVars gets the session variables.
 	GetSessionVars() *variable.SessionVars
-	// GetDomainInfoSchema returns the latest information schema in domain
-	// Different with `domain.InfoSchema()`, the information schema returned by this method
-	// includes the temporary table definitions stored in session
-	GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema
+	// GetLatestInfoSchema returns the latest information schema.
+	// except schema of physical schema objects, the information schema returned
+	// also includes the temporary table definitions stored in session.
+	GetLatestInfoSchema() infoschema.MetaOnlyInfoSchema
 	// GetInfoSchema returns the current infoschema
 	GetInfoSchema() infoschema.MetaOnlyInfoSchema
 	// UpdateColStatsUsage updates the column stats usage.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4346,7 +4346,7 @@ func (s *session) GetInfoSchema() infoschemactx.MetaOnlyInfoSchema {
 	return temptable.AttachLocalTemporaryTableInfoSchema(s, is)
 }
 
-func (s *session) GetDomainInfoSchema() infoschemactx.MetaOnlyInfoSchema {
+func (s *session) GetLatestInfoSchema() infoschemactx.MetaOnlyInfoSchema {
 	is := domain.GetDomain(s).InfoSchema()
 	extIs := &infoschema.SessionExtendedInfoSchema{InfoSchema: is}
 	return temptable.AttachLocalTemporaryTableInfoSchema(s, extIs)
@@ -4619,7 +4619,7 @@ func (s *session) usePipelinedDmlOrWarn(ctx context.Context) bool {
 		)
 		return false
 	}
-	is, ok := s.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is, ok := s.GetLatestInfoSchema().(infoschema.InfoSchema)
 	if !ok {
 		stmtCtx.AppendWarning(errors.New("Pipelined DML failed to get latest InfoSchema. Fallback to standard mode"))
 		return false

--- a/pkg/session/txnmanager.go
+++ b/pkg/session/txnmanager.go
@@ -84,7 +84,7 @@ func (m *txnManager) GetTxnInfoSchema() infoschema.InfoSchema {
 		return m.ctxProvider.GetTxnInfoSchema()
 	}
 
-	if is := m.sctx.GetDomainInfoSchema(); is != nil {
+	if is := m.sctx.GetLatestInfoSchema(); is != nil {
 		return is.(infoschema.InfoSchema)
 	}
 

--- a/pkg/sessionctx/context.go
+++ b/pkg/sessionctx/context.go
@@ -106,13 +106,13 @@ type Context interface {
 
 	// Deprecated: the semantics of session.GetInfoSchema() is ambiguous
 	// If you want to get the infoschema of the current transaction in SQL layer, use sessiontxn.GetTxnManager(ctx).GetTxnInfoSchema()
-	// If you want to get the latest infoschema use `GetDomainInfoSchema`
+	// If you want to get the latest infoschema use `GetLatestInfoSchema`
 	GetInfoSchema() infoschema.MetaOnlyInfoSchema
 
-	// GetDomainInfoSchema returns the latest information schema in domain
-	// Different with `domain.InfoSchema()`, the information schema returned by this method
-	// includes the temporary table definitions stored in session
-	GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema
+	// GetLatestInfoSchema returns the latest information schema.
+	// except schema of physical schema objects, the information schema returned
+	// also includes the temporary table definitions stored in session.
+	GetLatestInfoSchema() infoschema.MetaOnlyInfoSchema
 
 	GetSessionVars() *variable.SessionVars
 

--- a/pkg/sessiontxn/interface.go
+++ b/pkg/sessiontxn/interface.go
@@ -161,7 +161,7 @@ type TxnManager interface {
 	TxnAdvisable
 	// GetTxnInfoSchema returns the information schema used by txn
 	// If the session is not in any transaction, for example: between two autocommit statements,
-	// this method will return the latest information schema in session that is same with `sessionctx.GetDomainInfoSchema()`
+	// this method will return the latest information schema in session that is same with `sessionctx.GetLatestInfoSchema()`
 	GetTxnInfoSchema() infoschema.InfoSchema
 	// GetTxnScope returns the current txn scope
 	GetTxnScope() string

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -119,7 +119,7 @@ func (p *baseTxnContextProvider) OnInitialize(ctx context.Context, tp sessiontxn
 	}
 
 	p.enterNewTxnType = tp
-	p.infoSchema = p.sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	p.infoSchema = p.sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	txnCtx := &variable.TransactionContext{
 		TxnCtxNoNeedToRestore: variable.TxnCtxNoNeedToRestore{
 			CreateTime: time.Now(),

--- a/pkg/sessiontxn/txn_context_test.go
+++ b/pkg/sessiontxn/txn_context_test.go
@@ -591,7 +591,7 @@ func TestTxnContextForStaleReadInPrepare(t *testing.T) {
 	tk.MustExec("use test")
 	se := tk.Session()
 
-	is1 := se.GetDomainInfoSchema()
+	is1 := se.GetLatestInfoSchema()
 	tk.MustExec("do sleep(0.1)")
 	tk.MustExec("set @a=now(6)")
 	tk.MustExec("prepare s1 from 'select * from t1 where id=1'")
@@ -660,7 +660,7 @@ func TestTxnContextForStaleReadInPrepare(t *testing.T) {
 	se.SetValue(sessiontxn.AssertTxnInfoSchemaKey, nil)
 
 	// stale read should not use plan cache
-	is2 := se.GetDomainInfoSchema()
+	is2 := se.GetLatestInfoSchema()
 	se.SetValue(sessiontxn.AssertTxnInfoSchemaKey, nil)
 	tk.MustExec("set @@tx_read_ts=''")
 	tk.MustExec("do sleep(0.1)")

--- a/pkg/sessiontxn/txn_manager_test.go
+++ b/pkg/sessiontxn/txn_manager_test.go
@@ -448,7 +448,7 @@ func TestSnapshotInterceptor(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("create temporary table test.tmp1 (id int primary key)")
-	tbl, err := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema).TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("tmp1"))
+	tbl, err := tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema).TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("tmp1"))
 	require.NoError(t, err)
 	require.Equal(t, model.TempTableLocal, tbl.Meta().TempTableType)
 	tblID := tbl.Meta().ID

--- a/pkg/statistics/handle/autoanalyze/autoanalyze.go
+++ b/pkg/statistics/handle/autoanalyze/autoanalyze.go
@@ -413,7 +413,7 @@ func RandomPickOneTableAndTryAutoAnalyze(
 	pruneMode variable.PartitionPruneMode,
 	start, end time.Time,
 ) bool {
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	dbs := infoschema.AllSchemaNames(is)
 	// Shuffle the database and table slice to randomize the order of analyzing tables.
 	rd := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/dynamic_partitioned_table_analysis_job.go
@@ -162,7 +162,7 @@ func (j *DynamicPartitionedTableAnalysisJob) ValidateAndPrepare(
 			j.failureHook(j, needRetry)
 		}
 	}
-	is := sctx.GetDomainInfoSchema()
+	is := sctx.GetLatestInfoSchema()
 	tableInfo, ok := is.TableInfoByID(j.GlobalTableID)
 	if !ok {
 		callFailureHook(false)

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/non_partitioned_table_analysis_job.go
@@ -136,7 +136,7 @@ func (j *NonPartitionedTableAnalysisJob) ValidateAndPrepare(
 			j.failureHook(j, needRetry)
 		}
 	}
-	is := sctx.GetDomainInfoSchema()
+	is := sctx.GetLatestInfoSchema()
 	tableInfo, ok := is.TableInfoByID(j.TableID)
 	if !ok {
 		callFailureHook(false)

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue.go
@@ -214,7 +214,7 @@ func (pq *AnalysisPriorityQueue) fetchAllTablesAndBuildAnalysisJobs(ctx context.
 			return err
 		}
 
-		is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+		is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 		// Get current timestamp from the session context.
 		currentTs, err := statsutil.GetStartTS(sctx)
 		if err != nil {
@@ -433,7 +433,7 @@ func (pq *AnalysisPriorityQueue) processTableStats(
 		return errors.Trace(err)
 	}
 	jobFactory := NewAnalysisJobFactory(sctx, autoAnalyzeRatio, currentTs)
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	pruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 
 	var job AnalysisJob
@@ -626,7 +626,7 @@ func (pq *AnalysisPriorityQueue) RequeueMustRetryJobs() {
 			}
 		}()
 
-		is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+		is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 		for tableID := range pq.syncFields.mustRetryJobs {
 			// Note: Delete the job first to ensure it can be added back to the queue
 			delete(pq.syncFields.mustRetryJobs, tableID)

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/queue_ddl_handler.go
@@ -128,7 +128,7 @@ func (pq *AnalysisPriorityQueue) recreateAndPushJob(
 		return errors.Trace(err)
 	}
 	jobFactory := NewAnalysisJobFactory(sctx, autoAnalyzeRatio, currentTs)
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	job := pq.tryCreateJob(is, stats, pruneMode, jobFactory, lockedTables)
 	return pq.pushWithoutLock(job)
 }
@@ -183,7 +183,7 @@ func (pq *AnalysisPriorityQueue) handleAddIndexEvent(
 		return errors.Trace(err)
 	}
 	jobFactory := NewAnalysisJobFactory(sctx, autoAnalyzeRatio, currentTs)
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	pruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	partitionInfo := tableInfo.GetPartitionInfo()
 	lockedTables, err := lockstats.QueryLockedTables(statsutil.StatsCtx, sctx)
@@ -336,7 +336,7 @@ func (pq *AnalysisPriorityQueue) handleExchangeTablePartitionEvent(
 	}
 
 	// For non-partitioned tables.
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	// Get the new table info after the exchange.
 	// Note: We should use the ID of the partitioned table to get the new table info after the exchange.
 	tblInfo, ok := pq.statsHandle.TableInfoByID(is, partInfo.Definitions[0].ID)

--- a/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
+++ b/pkg/statistics/handle/autoanalyze/priorityqueue/static_partitioned_table_analysis_job.go
@@ -152,7 +152,7 @@ func (j *StaticPartitionedTableAnalysisJob) ValidateAndPrepare(
 			j.failureHook(j, needRetry)
 		}
 	}
-	is := sctx.GetDomainInfoSchema()
+	is := sctx.GetLatestInfoSchema()
 	tableInfo, ok := is.TableInfoByID(j.GlobalTableID)
 	if !ok {
 		callFailureHook(false)

--- a/pkg/statistics/handle/ddl/subscriber.go
+++ b/pkg/statistics/handle/ddl/subscriber.go
@@ -456,7 +456,7 @@ func updateGlobalTableStats4ExchangePartition(
 	}
 
 	// Update the global stats.
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	globalTableSchemaName := schemaNotFound
 	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
 	if ok {
@@ -572,7 +572,7 @@ func updateGlobalTableStats4TruncatePartition(
 		return nil
 	}
 
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	globalTableSchemaName := schemaNotFound
 	globalTableSchema, ok := infoschema.SchemaByTable(is, globalTableInfo)
 	if ok {

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -669,7 +669,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 	// When lite-init-stats is disabled, we cannot store the column info in the ColAndIdxExistenceMap.
 	// Because we don't want to access all table information when init stats.
 	// Therefore, we need to get the column info from the domain on demand.
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbl, ok := statsHandle.TableInfoByID(is, col.TableID)
 	if !ok {
 		// This could happen when the table is dropped after the async load is triggered.

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -361,7 +361,7 @@ func (s *statsSyncLoad) handleOneItemTask(task *statstypes.NeededItemTask) (err 
 	if !ok {
 		return nil
 	}
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbl, ok := s.statsHandle.TableInfoByID(is, item.TableID)
 	if !ok {
 		return nil

--- a/pkg/statistics/handle/usage/index_usage.go
+++ b/pkg/statistics/handle/usage/index_usage.go
@@ -33,7 +33,7 @@ func (u *statsUsageImpl) NewSessionIndexUsageCollector() *indexusage.SessionInde
 // GCIndexUsage removes unnecessary index usage data.
 func (u *statsUsageImpl) GCIndexUsage() error {
 	return util.CallWithSCtx(u.statsHandle.SPool(), func(sctx sessionctx.Context) error {
-		schema := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+		schema := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 		u.idxUsageCollector.GCIndexUsage(func(id int64) (*model.TableInfo, bool) {
 			tbl, ok := schema.TableByID(context.Background(), id)
 			if !ok {

--- a/pkg/statistics/handle/usage/index_usage_integration_test.go
+++ b/pkg/statistics/handle/usage/index_usage_integration_test.go
@@ -51,7 +51,7 @@ func TestGCIndexUsage(t *testing.T) {
 	}
 
 	c := dom.StatsHandle().NewSessionIndexUsageCollector()
-	is := tk.Session().GetDomainInfoSchema()
+	is := tk.Session().GetLatestInfoSchema()
 	db, ok := is.SchemaByName(ast.NewCIStr("test"))
 	require.True(t, ok)
 

--- a/pkg/statistics/handle/usage/predicatecolumn/predicate_column.go
+++ b/pkg/statistics/handle/usage/predicatecolumn/predicate_column.go
@@ -109,7 +109,7 @@ func GetPredicateColumns(sctx sessionctx.Context, tableID int64) ([]int64, error
 
 // cleanupDroppedColumnStatsUsage deletes the column stats usage information whose column is dropped.
 func cleanupDroppedColumnStatsUsage(sctx sessionctx.Context, tableID int64) error {
-	is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 	table, ok := is.TableByID(context.Background(), tableID)
 	if !ok {
 		// Usually, it should not happen.

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -124,7 +124,7 @@ func (s *statsUsageImpl) DumpStatsDeltaToKV(dumpAll bool) error {
 		)
 		batchStart := time.Now()
 		err := utilstats.CallWithSCtx(s.statsHandle.SPool(), func(sctx sessionctx.Context) error {
-			is := sctx.GetDomainInfoSchema().(infoschema.InfoSchema)
+			is := sctx.GetLatestInfoSchema().(infoschema.InfoSchema)
 			batchUpdates = make([]*storage.DeltaUpdate, 0, len(batchTableIDs))
 			// Collect all updates in the batch.
 			for _, id := range batchTableIDs {

--- a/pkg/table/tblsession/table.go
+++ b/pkg/table/tblsession/table.go
@@ -163,7 +163,7 @@ func (ctx *MutateContext) GetTemporaryTableSupport() (tblctx.TemporaryTableSuppo
 
 // GetInfoSchemaToCheckExchangeConstraint implements the ExchangePartitionDMLSupport interface.
 func (ctx *MutateContext) GetInfoSchemaToCheckExchangeConstraint() infoschema.MetaOnlyInfoSchema {
-	return ctx.Context.GetDomainInfoSchema()
+	return ctx.Context.GetLatestInfoSchema()
 }
 
 // GetExchangePartitionDMLSupport implements the MutateContext interface.

--- a/pkg/table/tblsession/table_test.go
+++ b/pkg/table/tblsession/table_test.go
@@ -156,5 +156,5 @@ func TestSessionMutateContextFields(t *testing.T) {
 	require.Equal(t, int64(332), tmpTblHandler.GetDirtySize())
 	exchange, ok := ctx.GetExchangePartitionDMLSupport()
 	require.True(t, ok)
-	require.Same(t, ctx.GetDomainInfoSchema(), exchange.GetInfoSchemaToCheckExchangeConstraint())
+	require.Same(t, ctx.GetLatestInfoSchema(), exchange.GetInfoSchemaToCheckExchangeConstraint())
 }

--- a/pkg/ttl/cache/infoschema.go
+++ b/pkg/ttl/cache/infoschema.go
@@ -44,7 +44,7 @@ func NewInfoSchemaCache(updateInterval time.Duration) *InfoSchemaCache {
 
 // Update updates the info schema cache
 func (isc *InfoSchemaCache) Update(se session.Session) error {
-	is := se.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := se.GetLatestInfoSchema().(infoschema.InfoSchema)
 
 	if isc.schemaVer == is.SchemaMetaVersion() {
 		return nil

--- a/pkg/ttl/cache/split_test.go
+++ b/pkg/ttl/cache/split_test.go
@@ -376,7 +376,7 @@ func create2PKTTLTable(t *testing.T, tk *testkit.TestKit, name string, option st
 
 func createTTLTableWithSQL(t *testing.T, tk *testkit.TestKit, name string, sql string) *cache.PhysicalTable {
 	tk.MustExec(sql)
-	is, ok := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema)
+	is, ok := tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.True(t, ok)
 	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(name))
 	require.NoError(t, err)

--- a/pkg/ttl/session/session.go
+++ b/pkg/ttl/session/session.go
@@ -49,8 +49,8 @@ type Session interface {
 	variable.SessionVarsProvider
 	// GetStore returns the kv store
 	GetStore() kv.Storage
-	// GetDomainInfoSchema returns information schema of domain
-	GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema
+	// GetLatestInfoSchema returns information schema of latest info schema.
+	GetLatestInfoSchema() infoschema.MetaOnlyInfoSchema
 	// SessionInfoSchema returns information schema of current session
 	SessionInfoSchema() infoschema.MetaOnlyInfoSchema
 	// GetSQLExecutor returns the sql executor
@@ -98,9 +98,8 @@ func (s *session) GetSessionVars() *variable.SessionVars {
 	return s.sctx.GetSessionVars()
 }
 
-// GetDomainInfoSchema returns information schema of domain
-func (s *session) GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema {
-	return s.sctx.GetDomainInfoSchema()
+func (s *session) GetLatestInfoSchema() infoschema.MetaOnlyInfoSchema {
+	return s.sctx.GetLatestInfoSchema()
 }
 
 // SessionInfoSchema returns information schema of current session

--- a/pkg/ttl/ttlworker/job_manager.go
+++ b/pkg/ttl/ttlworker/job_manager.go
@@ -309,7 +309,7 @@ func (m *JobManager) onTimerTick(se session.Session, rt *ttlTimerRuntime, syncer
 		return
 	}
 
-	is := se.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := se.GetLatestInfoSchema().(infoschema.InfoSchema)
 	if is.SchemaMetaVersion() > lastSyncVer || sinceLastSync > 2*time.Minute {
 		// only sync timer when information schema version upgraded, or it has not been synced for more than 2 minutes.
 		syncer.SyncTimers(m.ctx, is)
@@ -1154,7 +1154,7 @@ GROUP BY
 		records[r.TableID] = r
 	}
 
-	isVer := se.GetDomainInfoSchema()
+	isVer := se.GetLatestInfoSchema()
 	is, ok := isVer.(infoschema.InfoSchema)
 	if !ok {
 		logutil.Logger(ctx).Error(fmt.Sprintf("failed to cast information schema for type: %v", isVer))
@@ -1253,7 +1253,7 @@ func (a *managerJobAdapter) CanSubmitJob(tableID, physicalID int64) (ok bool) {
 }
 
 func (a *managerJobAdapter) canSubmitJobWithSession(tableID, physicalID int64, se session.Session) (bool, error) {
-	is := se.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := se.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbl, ok := is.TableByID(context.Background(), tableID)
 	if !ok {
 		return false, nil

--- a/pkg/ttl/ttlworker/session_test.go
+++ b/pkg/ttl/ttlworker/session_test.go
@@ -193,7 +193,7 @@ func (s *mockSession) GetStore() kv.Storage {
 	return nil
 }
 
-func (s *mockSession) GetDomainInfoSchema() infoschemactx.MetaOnlyInfoSchema {
+func (s *mockSession) GetLatestInfoSchema() infoschemactx.MetaOnlyInfoSchema {
 	return s.sessionInfoSchema
 }
 

--- a/pkg/ttl/ttlworker/task_manager_integration_test.go
+++ b/pkg/ttl/ttlworker/task_manager_integration_test.go
@@ -47,7 +47,7 @@ func TestParallelLockNewTask(t *testing.T) {
 	tk.MustExec("set global tidb_ttl_running_tasks = 1000")
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnTTL)
 	tk.MustExec("create table test.t (id int, created_at datetime) TTL= created_at + interval 1 hour")
-	testTable, err := tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema).TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	testTable, err := tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema).TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)
 
 	sessionTimeout := time.Minute

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -351,8 +351,8 @@ func (c *Context) GetInfoSchema() infoschema.MetaOnlyInfoSchema {
 // MockInfoschema only serves for test.
 var MockInfoschema func(tbList []*model.TableInfo) infoschema.MetaOnlyInfoSchema
 
-// GetDomainInfoSchema returns the latest information schema in domain
-func (c *Context) GetDomainInfoSchema() infoschema.MetaOnlyInfoSchema {
+// GetLatestInfoSchema returns the latest information schema in domain
+func (c *Context) GetLatestInfoSchema() infoschema.MetaOnlyInfoSchema {
 	if c.is == nil {
 		c.is = MockInfoschema(nil)
 	}

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -104,7 +104,7 @@ func (w *worker) createAllTables(ctx context.Context, now time.Time) error {
 	_sessctx := w.getSessionWithRetry()
 	sess := _sessctx.(sessionctx.Context)
 	defer w.sesspool.Put(_sessctx)
-	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	if !is.SchemaExists(workloadSchemaCIStr) {
 		_, err := execRetry(ctx, sess, "create database if not exists "+mysql.WorkloadSchema)
 		if err != nil {
@@ -147,7 +147,7 @@ func (w *worker) createAllTables(ctx context.Context, now time.Time) error {
 		}
 	}
 
-	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is = sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	return w.createAllPartitions(ctx, sess, is, now)
 }
 
@@ -155,7 +155,7 @@ func (w *worker) checkTablesExists(ctx context.Context, now time.Time) bool {
 	_sessctx := w.getSessionWithRetry()
 	sess := _sessctx.(sessionctx.Context)
 	defer w.sesspool.Put(_sessctx)
-	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	return slice.AllOf(w.workloadTables, func(i int) bool {
 		return checkTableExistsByIS(ctx, is, w.workloadTables[i].destTable, now)
 	})

--- a/pkg/util/workloadrepo/worker_test.go
+++ b/pkg/util/workloadrepo/worker_test.go
@@ -580,7 +580,7 @@ func validatePartitionsMatchExpected(ctx context.Context, t *testing.T,
 		ep[generatePartitionName(p.AddDate(0, 0, 1))] = struct{}{}
 	}
 
-	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	tbSchema, err := is.TableByName(ctx, workloadSchemaCIStr, ast.NewCIStr(tbl.destTable))
 	require.NoError(t, err)
 	tbInfo := tbSchema.Meta()
@@ -646,15 +646,15 @@ func validatePartitionCreation(ctx context.Context, now time.Time, t *testing.T,
 	tbl := getTable(t, tableName, wrk)
 	createTableWithParts(ctx, t, tk, tbl, sess, partitions)
 
-	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.False(t, firstTestFails == checkTableExistsByIS(ctx, is, tbl.destTable, now))
 
-	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is = sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.NoError(t, createPartition(ctx, is, tbl, sess, now))
 
 	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, expectedParts))
 
-	is = sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is = sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	require.True(t, checkTableExistsByIS(ctx, is, tbl.destTable, now))
 }
 
@@ -723,7 +723,7 @@ func validatePartitionDrop(ctx context.Context, now time.Time, t *testing.T,
 
 	require.True(t, validatePartitionsMatchExpected(ctx, t, sess, tbl, partitions))
 
-	is := sess.GetDomainInfoSchema().(infoschema.InfoSchema)
+	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
 	err := dropOldPartition(ctx, is, tbl, now, retention, sess)
 	if shouldErr {
 		require.Error(t, err)

--- a/tests/realtikvtest/importintotest2/write_after_import_test.go
+++ b/tests/realtikvtest/importintotest2/write_after_import_test.go
@@ -227,7 +227,7 @@ func (s *mockGCSSuite) testWriteAfterImport(importSQL string, sourceType importe
 			querySQL := "SELECT * FROM t;"
 			s.tk.MustQuery(querySQL).Check(testkit.Rows(allData...))
 
-			is := s.tk.Session().GetDomainInfoSchema().(infoschema.InfoSchema)
+			is := s.tk.Session().GetLatestInfoSchema().(infoschema.InfoSchema)
 			dbInfo, ok := is.SchemaByName(ast.NewCIStr("write_after_import"))
 			s.True(ok)
 			tableObj, err := is.TableByName(context.Background(), ast.NewCIStr("write_after_import"), ast.NewCIStr("t"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702 

Problem Summary:

### What changed and how does it work?
we will create sessions of system keyspace inside user keyspace, so `GetDomainInfoSchema` better be called `GetLatestInfoSchema`, as they share the same domain as sessions of user keyspace

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test. **Only rename methods**
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
