### PR TITLE
planner: Simplify plan cache code.gi

### DIFF
--- a/pkg/executor/trace.go
+++ b/pkg/executor/trace.go
@@ -112,7 +112,7 @@ func (e *TraceExec) nextOptimizerCEPlanTrace(ctx context.Context, se sessionctx.
 	}()
 
 	nodeW := resolve.NewNodeWWithCtx(e.stmtNode, e.resolveCtx)
-	_, _, err := core.OptimizeAstNode(ctx, se, nodeW, se.GetInfoSchema().(infoschema.InfoSchema))
+	_, _, err := core.OptimizeAstNodeNoCache(ctx, se, nodeW, se.GetInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (e *TraceExec) nextOptimizerDebugPlanTrace(ctx context.Context, se sessionc
 	}()
 
 	nodeW := resolve.NewNodeWWithCtx(e.stmtNode, e.resolveCtx)
-	_, _, err := core.OptimizeAstNode(ctx, se, nodeW, se.GetInfoSchema().(infoschema.InfoSchema))
+	_, _, err := core.OptimizeAstNodeNoCache(ctx, se, nodeW, se.GetInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func (e *TraceExec) nextOptimizerPlanTrace(ctx context.Context, se sessionctx.Co
 		stmtCtx.EnableOptimizeTrace = origin
 	}()
 	nodeW := resolve.NewNodeWWithCtx(e.stmtNode, e.resolveCtx)
-	_, _, err = core.OptimizeAstNode(ctx, se, nodeW, se.GetInfoSchema().(infoschema.InfoSchema))
+	_, _, err = core.OptimizeAstNodeNoCache(ctx, se, nodeW, se.GetInfoSchema().(infoschema.InfoSchema))
 	if err != nil {
 		return err
 	}

--- a/pkg/planner/cardinality/trace_test.go
+++ b/pkg/planner/cardinality/trace_test.go
@@ -85,7 +85,7 @@ func TestTraceCE(t *testing.T) {
 		stmt, err := p.ParseOneStmt(sql, "", "")
 		require.NoError(t, err)
 		nodeW := resolve.NewNodeW(stmt)
-		_, _, err = plannercore.OptimizeAstNode(context.Background(), sctx, nodeW, is)
+		_, _, err = plannercore.OptimizeAstNodeNoCache(context.Background(), sctx, nodeW, is)
 		require.NoError(t, err)
 
 		traceResult := sctx.GetSessionVars().StmtCtx.OptimizerCETrace

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -65,6 +65,7 @@ import (
 
 // OptimizeAstNode optimizes the query to a physical plan directly.
 var OptimizeAstNode func(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW, is infoschema.InfoSchema) (base.Plan, types.NameSlice, error)
+var OptimizeAstNodeNoCache func(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW, is infoschema.InfoSchema) (base.Plan, types.NameSlice, error)
 
 // AllowCartesianProduct means whether tidb allows cartesian join without equal conditions.
 var AllowCartesianProduct = atomic.NewBool(true)

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -340,9 +340,10 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isNonPrepared
 	stmtCtx := sessVars.StmtCtx
 
 	core_metrics.GetPlanCacheMissCounter(isNonPrepared).Inc()
+	// XXX: We should be able to remove InPreparedPlanBuilding.
 	sctx.GetSessionVars().StmtCtx.InPreparedPlanBuilding = true
 	nodeW := resolve.NewNodeWWithCtx(stmtAst.Stmt, stmt.ResolveCtx)
-	p, names, err := OptimizeAstNode(ctx, sctx, nodeW, is)
+	p, names, err := OptimizeAstNodeNoCache(ctx, sctx, nodeW, is)
 	sctx.GetSessionVars().StmtCtx.InPreparedPlanBuilding = false
 	if err != nil {
 		return nil, nil, err

--- a/pkg/planner/core/plan_cache_partition_table_test.go
+++ b/pkg/planner/core/plan_cache_partition_table_test.go
@@ -166,7 +166,7 @@ func TestNonPreparedPlanCachePartitionIndex(t *testing.T) {
 
 	tk.MustQuery(`explain format='plan_cache' select * from t where a = 2`).Check(testkit.Rows("Point_Get_1 1.00 root table:t, partition:p1, index:PRIMARY(a) "))
 	tk.MustQuery(`explain format='plan_cache' select * from t where a = 2`).Check(testkit.Rows("Point_Get_1 1.00 root table:t, partition:p1, index:PRIMARY(a) "))
-	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
 	tk.MustQuery(`select * from t where a = 2`).Check(testkit.Rows("abc 2"))
 	tk.MustExec(`create table tk (a int primary key nonclustered, b varchar(255), key (b)) partition by key (a) partitions 3`)
 	tk.MustExec(`insert into tk select a, b from t`)
@@ -175,7 +175,7 @@ func TestNonPreparedPlanCachePartitionIndex(t *testing.T) {
 	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
 	// PointGet will use Fast Plan, so no Plan Cache, even for Key Partitioned tables.
 	tk.MustQuery(`select * from tk where a = 2`).Check(testkit.Rows("2 abc"))
-	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
 }
 
 func TestFixControl33031(t *testing.T) {
@@ -745,11 +745,10 @@ func preparedStmtBatchPointGet(t *testing.T, ids []any, tk *testkit.TestKit, poi
 func nonPreparedStmtPointGet(t *testing.T, ids []any, tk *testkit.TestKit, testTbl partCoverStruct, seededRand *rand.Rand, rowData map[any]string, filler, comment string, isCaseSensitive bool) {
 	// Test non-prepared statements
 	// FastPlan will be used instead of checking plan cache!
-	usePlanCache := len(testTbl.pointGetExplain) == 0
 	tk.MustExec(`set @@tidb_enable_non_prepared_plan_cache=1`)
 	id := ids[seededRand.Intn(len(ids))]
 	idStr := getIDStr(id)
-	cols, hasSpaceCol := getRandCols(seededRand)
+	cols, _ := getRandCols(seededRand)
 	sql := `select ` + strings.Join(cols, ",") + ` from t where a = `
 	tk.MustQuery(sql + idStr).Check(testkit.Rows(getRowData(rowData, filler, cols, isCaseSensitive, id)...))
 	prevID := id
@@ -757,26 +756,21 @@ func nonPreparedStmtPointGet(t *testing.T, ids []any, tk *testkit.TestKit, testT
 	id = ids[seededRand.Intn(len(ids))]
 	idStr = getIDStr(id)
 	tk.MustQuery(sql + idStr).Check(testkit.Rows(getRowData(rowData, filler, cols, isCaseSensitive, id)...))
-	if usePlanCache != tk.Session().GetSessionVars().FoundInPlanCache {
-		require.Equal(t, usePlanCache || hasSpaceCol, tk.Session().GetSessionVars().FoundInPlanCache, fmt.Sprintf("id: %d, prev id: %d", id, prevID))
-	}
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache, fmt.Sprintf("id: %d, prev id: %d", id, prevID))
 	id = ids[seededRand.Intn(len(ids))]
 	idStr = getIDStr(id)
 	tk.MustQuery(sql + idStr).Check(testkit.Rows(getRowData(rowData, filler, cols, isCaseSensitive, id)...))
-	if usePlanCache || hasSpaceCol != tk.Session().GetSessionVars().FoundInPlanCache {
-		require.Equal(t, usePlanCache || hasSpaceCol, tk.Session().GetSessionVars().FoundInPlanCache)
-	}
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
 	id = ids[seededRand.Intn(len(ids))]
 	idStr = getIDStr(id)
 	tk.MustQuery(sql + idStr).Check(testkit.Rows(getRowData(rowData, filler, cols, isCaseSensitive, id)...))
-	require.Equal(t, usePlanCache || hasSpaceCol, tk.Session().GetSessionVars().FoundInPlanCache)
-	if usePlanCache {
-		tk.MustExec(`set @@tidb_enable_non_prepared_plan_cache=0`)
-		id = ids[seededRand.Intn(len(ids))]
-		idStr = getIDStr(id)
-		tk.MustQuery(sql + idStr).Check(testkit.Rows(getRowData(rowData, filler, cols, isCaseSensitive, id)...))
-		require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
-	}
+	require.True(t, tk.Session().GetSessionVars().FoundInPlanCache)
+
+	tk.MustExec(`set @@tidb_enable_non_prepared_plan_cache=0`)
+	id = ids[seededRand.Intn(len(ids))]
+	idStr = getIDStr(id)
+	tk.MustQuery(sql + idStr).Check(testkit.Rows(getRowData(rowData, filler, cols, isCaseSensitive, id)...))
+	require.False(t, tk.Session().GetSessionVars().FoundInPlanCache)
 }
 
 func nonpreparedStmtBatchPointGet(t *testing.T, ids []any, tk *testkit.TestKit, pointGetExplain []string, seededRand *rand.Rand, rowData map[any]string, filler, currTest string, canUseBatchPointGet, isCaseSensitive bool) {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5614,7 +5614,7 @@ func (b *PlanBuilder) buildSelectInto(ctx context.Context, sel *ast.SelectStmt) 
 		return nil, err
 	}
 	nodeW := resolve.NewNodeWWithCtx(sel, b.resolveCtx)
-	targetPlan, _, err := OptimizeAstNode(ctx, sctx, nodeW, b.is)
+	targetPlan, _, err := OptimizeAstNodeNoCache(ctx, sctx, nodeW, b.is)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -141,10 +141,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	defer tracing.StartRegion(ctx, "planner.Optimize").End()
 	sessVars := sctx.GetSessionVars()
 	pctx := sctx.GetPlanCtx()
-	if sessVars.StmtCtx.EnableOptimizerDebugTrace {
-		debugtrace.EnterContextCommon(pctx)
-		defer debugtrace.LeaveContextCommon(pctx)
-	}
 
 	if !sessVars.InRestrictedSQL && (vardef.RestrictedReadOnly.Load() || vardef.VarTiDBSuperReadOnly.Load()) {
 		allowed, err := allowInReadOnlyMode(pctx, node.Node)
@@ -156,6 +152,104 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 		}
 	}
 
+	defer func() {
+		if retErr == nil {
+			// Override the resource group if the hint is set.
+			if sessVars.StmtCtx.StmtHints.HasResourceGroup {
+				if vardef.EnableResourceControl.Load() {
+					hasPriv := true
+					// only check dynamic privilege when strict-mode is enabled.
+					if vardef.EnableResourceControlStrictMode.Load() {
+						checker := privilege.GetPrivilegeManager(sctx)
+						if checker != nil {
+							hasRgAdminPriv := checker.RequestDynamicVerification(sctx.GetSessionVars().ActiveRoles, "RESOURCE_GROUP_ADMIN", false)
+							hasRgUserPriv := checker.RequestDynamicVerification(sctx.GetSessionVars().ActiveRoles, "RESOURCE_GROUP_USER", false)
+							hasPriv = hasRgAdminPriv || hasRgUserPriv
+						}
+					}
+					if hasPriv {
+						sessVars.StmtCtx.ResourceGroupName = sessVars.StmtCtx.StmtHints.ResourceGroup
+						// if we are in a txn, should update the txn resource name to let the txn
+						// commit with the hint resource group.
+						if txn, err := sctx.Txn(false); err == nil && txn != nil && txn.Valid() {
+							kv.SetTxnResourceGroup(txn, sessVars.StmtCtx.ResourceGroupName)
+						}
+					} else {
+						err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or RESOURCE_GROUP_ADMIN or RESOURCE_GROUP_USER")
+						sessVars.StmtCtx.AppendWarning(err)
+					}
+				} else {
+					err := infoschema.ErrResourceGroupSupportDisabled
+					sessVars.StmtCtx.AppendWarning(err)
+				}
+			}
+
+			// Handle SetVars hints for cached plans.
+			for name, val := range sessVars.StmtCtx.StmtHints.SetVars {
+				oldV, err := sessVars.SetSystemVarWithOldStateAsRet(name, val)
+				if err != nil {
+					sessVars.StmtCtx.AppendWarning(err)
+				}
+				sessVars.StmtCtx.AddSetVarHintRestore(name, oldV)
+			}
+		}
+	}()
+
+	// Handle the execute statement.  This calls into the prepared plan cache.
+	if _, ok := node.Node.(*ast.ExecuteStmt); ok {
+		p, names, err := OptimizeExecStmt(ctx, sctx, node, is)
+		return p, names, err
+	}
+
+	// Call into the non-prepared plan cache.
+	if stmtNode, isStmtNode := node.Node.(ast.StmtNode); sessVars.EnableNonPreparedPlanCache && isStmtNode {
+		cachedPlan, names, ok, err := getPlanFromNonPreparedPlanCache(ctx, sctx, stmtNode, is)
+		if err != nil {
+			return nil, nil, err
+		}
+		if ok {
+			return cachedPlan, names, nil
+		}
+	}
+
+	return optimizeNoCache(ctx, sctx, node, is)
+}
+
+func optimizeNoCache(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW, is infoschema.InfoSchema) (plan base.Plan, slice types.NameSlice, retErr error) {
+	pctx := sctx.GetPlanCtx()
+	sessVars := sctx.GetSessionVars()
+
+	if sessVars.StmtCtx.EnableOptimizerDebugTrace {
+		debugtrace.EnterContextCommon(pctx)
+		defer debugtrace.LeaveContextCommon(pctx)
+	}
+
+	tableHints := hint.ExtractTableHintsFromStmtNode(node.Node, sessVars.StmtCtx)
+	originStmtHints, _, warns := hint.ParseStmtHints(tableHints,
+		setVarHintChecker, hypoIndexChecker(ctx, is),
+		sessVars.CurrentDB, byte(kv.ReplicaReadFollower))
+	sessVars.StmtCtx.StmtHints = originStmtHints
+	for _, warn := range warns {
+		sessVars.StmtCtx.AppendWarning(warn)
+	}
+
+	if sessVars.StmtCtx.StmtHints.HasResourceGroup {
+		sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL")
+	}
+
+	if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
+		sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
+	}
+
+	for name, val := range sessVars.StmtCtx.StmtHints.SetVars {
+		oldV, err := sessVars.SetSystemVarWithOldStateAsRet(name, val)
+		if err != nil {
+			sessVars.StmtCtx.AppendWarning(err)
+		}
+		sessVars.StmtCtx.AddSetVarHintRestore(name, oldV)
+	}
+
+	// XXX: this should be handled after any bindings are setup.
 	if sessVars.SQLMode.HasStrictMode() && !IsReadOnly(node.Node, sessVars) {
 		sessVars.StmtCtx.TiFlashEngineRemovedDueToStrictSQLMode = true
 		_, hasTiFlashAccess := sessVars.IsolationReadEngines[kv.TiFlash]
@@ -168,89 +262,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 				sessVars.IsolationReadEngines[kv.TiFlash] = struct{}{}
 			}
 		}()
-	}
-
-	// handle the execute statement
-	if _, ok := node.Node.(*ast.ExecuteStmt); ok {
-		p, names, err := OptimizeExecStmt(ctx, sctx, node, is)
-		return p, names, err
-	}
-
-	tableHints := hint.ExtractTableHintsFromStmtNode(node.Node, sessVars.StmtCtx)
-	originStmtHints, _, warns := hint.ParseStmtHints(tableHints,
-		setVarHintChecker, hypoIndexChecker(ctx, is),
-		sessVars.CurrentDB, byte(kv.ReplicaReadFollower))
-	sessVars.StmtCtx.StmtHints = originStmtHints
-	for _, warn := range warns {
-		sessVars.StmtCtx.AppendWarning(warn)
-	}
-
-	defer func() {
-		// Override the resource group if the hint is set.
-		if retErr == nil && sessVars.StmtCtx.StmtHints.HasResourceGroup {
-			if vardef.EnableResourceControl.Load() {
-				hasPriv := true
-				// only check dynamic privilege when strict-mode is enabled.
-				if vardef.EnableResourceControlStrictMode.Load() {
-					checker := privilege.GetPrivilegeManager(sctx)
-					if checker != nil {
-						hasRgAdminPriv := checker.RequestDynamicVerification(sctx.GetSessionVars().ActiveRoles, "RESOURCE_GROUP_ADMIN", false)
-						hasRgUserPriv := checker.RequestDynamicVerification(sctx.GetSessionVars().ActiveRoles, "RESOURCE_GROUP_USER", false)
-						hasPriv = hasRgAdminPriv || hasRgUserPriv
-					}
-				}
-				if hasPriv {
-					sessVars.StmtCtx.ResourceGroupName = sessVars.StmtCtx.StmtHints.ResourceGroup
-					// if we are in a txn, should update the txn resource name to let the txn
-					// commit with the hint resource group.
-					if txn, err := sctx.Txn(false); err == nil && txn != nil && txn.Valid() {
-						kv.SetTxnResourceGroup(txn, sessVars.StmtCtx.ResourceGroupName)
-					}
-				} else {
-					err := plannererrors.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or RESOURCE_GROUP_ADMIN or RESOURCE_GROUP_USER")
-					sessVars.StmtCtx.AppendWarning(err)
-				}
-			} else {
-				err := infoschema.ErrResourceGroupSupportDisabled
-				sessVars.StmtCtx.AppendWarning(err)
-			}
-		}
-	}()
-
-	// The SkipPlanCache function doesn't work until EnablePlanCache() is called in GetPlanFromPlanCache.
-	skipNonPreparedCache := false
-
-	if sessVars.StmtCtx.StmtHints.HasResourceGroup {
-		/* If the prepared plan cache is enabled, this SetSkipPlanCache call is
-		needed to insure that the resource_group handling code is run each time
-		the query is executed. */
-		sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL")
-
-		/* If the non-prepared plan cache is enabled, skipNonPreparedCache must
-		be set to true to insure that the resource_group handling code does not
-		run twice for non-prepared statements. */
-		skipNonPreparedCache = true
-	}
-
-	warns = warns[:0]
-	for name, val := range sessVars.StmtCtx.StmtHints.SetVars {
-		oldV, err := sessVars.SetSystemVarWithOldStateAsRet(name, val)
-		if err != nil {
-			sessVars.StmtCtx.AppendWarning(err)
-		}
-		sessVars.StmtCtx.AddSetVarHintRestore(name, oldV)
-	}
-	// Setting skipNonPreparedCache to true to prevent running the code above twice.
-	if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
-		/* If the prepared plan cache is enabled, this SetSkipPlanCache call is
-		needed to insure that the SET_VAR code is run each time the query is
-		executed. */
-		sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL")
-
-		/* If the non-prepared plan cache is enabled, skipNonPreparedCache must
-		be set to true to insure that the SET_VAR code does not run twice for
-		non-prepared statements. */
-		skipNonPreparedCache = true
 	}
 
 	if _, isolationReadContainTiKV := sessVars.IsolationReadEngines[kv.TiKV]; isolationReadContainTiKV {
@@ -277,19 +288,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 		node = node.CloneWithNewNode(stmtNode)
 	}
 
-	// try to get Plan from the NonPrepared Plan Cache
-	if sessVars.EnableNonPreparedPlanCache &&
-		isStmtNode &&
-		!skipNonPreparedCache {
-		cachedPlan, names, ok, err := getPlanFromNonPreparedPlanCache(ctx, sctx, stmtNode, is)
-		if err != nil {
-			return nil, nil, err
-		}
-		if ok {
-			return cachedPlan, names, nil
-		}
-	}
-
 	var (
 		names                      types.NameSlice
 		bestPlan, bestPlanFromBind base.Plan
@@ -299,6 +297,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 	if useBinding {
 		var bindStmtHints hint.StmtHints
 		originHints := hint.CollectHint(stmtNode)
+		var warns []error
 		if binding != nil && binding.IsBindingEnabled() {
 			if sessVars.StmtCtx.EnableOptimizerDebugTrace {
 				core.DebugTraceTryBinding(pctx, binding.Hint)
@@ -313,7 +312,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 				sessVars.StmtCtx.SetSkipPlanCache("resource_group is used in the SQL binding")
 			}
 
-			// update session var by hint /set_var/
 			if len(sessVars.StmtCtx.StmtHints.SetVars) > 0 {
 				sessVars.StmtCtx.SetSkipPlanCache("SET_VAR is used in the SQL binding")
 			}
@@ -346,7 +344,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node *resolve.NodeW,
 			} else {
 				sessVars.StmtCtx.AppendExtraNote(errors.NewNoStackErrorf("Using the bindSQL: %v", chosenBinding.BindSQL))
 			}
-			if len(tableHints) > 0 {
+			if originStmtHints.QueryHasHints {
 				sessVars.StmtCtx.AppendWarning(errors.NewNoStackErrorf("The system ignores the hints in the current query and uses the hints specified in the bindSQL: %v", chosenBinding.BindSQL))
 			}
 		}
@@ -722,6 +720,7 @@ func planIDFunc(plan any) (planID int, ok bool) {
 
 func init() {
 	core.OptimizeAstNode = Optimize
+	core.OptimizeAstNodeNoCache = optimizeNoCache
 	core.IsReadOnly = IsReadOnly
 	indexadvisor.QueryPlanCostHook = queryPlanCost
 	bindinfo.GetBindingHandle = func(sctx sessionctx.Context) bindinfo.BindingHandle {

--- a/pkg/util/hint/hint.go
+++ b/pkg/util/hint/hint.go
@@ -203,6 +203,9 @@ const (
 
 // StmtHints are hints that apply to the entire statement, like 'max_exec_time', 'memory_quota'.
 type StmtHints struct {
+	// This is true iff there were hints in the statement.
+	QueryHasHints bool
+
 	// Hint Information
 	MemQuotaQuery           int64
 	MaxExecutionTime        uint64
@@ -252,6 +255,7 @@ func (sh *StmtHints) Clone() *StmtHints {
 		copy(tableHints, sh.OriginalTableHints)
 	}
 	return &StmtHints{
+		QueryHasHints:                  sh.QueryHasHints,
 		MemQuotaQuery:                  sh.MemQuotaQuery,
 		MaxExecutionTime:               sh.MaxExecutionTime,
 		ReplicaRead:                    sh.ReplicaRead,
@@ -291,9 +295,12 @@ func ParseStmtHints(hints []*ast.TableOptimizerHint,
 	hypoIndexChecker func(db, tbl, col ast.CIStr) (colOffset int, err error),
 	currentDB string, replicaReadFollower byte) ( // to avoid cycle import
 	stmtHints StmtHints, offs []int, warns []error) {
+	stmtHints.QueryHasHints = len(hints) != 0
+
 	if len(hints) == 0 {
 		return
 	}
+
 	hintOffs := make(map[string]int, len(hints))
 	var forceNthPlan *ast.TableOptimizerHint
 	var memoryQuotaHintCnt, useToJAHintCnt, useCascadesHintCnt, noIndexMergeHintCnt, readReplicaHintCnt, maxExecutionTimeCnt, forceNthPlanCnt, straightJoinHintCnt, resourceGroupHintCnt int

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -926,7 +926,7 @@ select a from t where a in (1, 2);
 a
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-0
+1
 explain format='brief' select b from t where b = 1;
 id	estRows	task	access object	operator info
 Point_Get	1.00	root	table:t, index:b(b)	
@@ -936,7 +936,7 @@ select b from t where b = 1;
 b
 select @@last_plan_from_cache;
 @@last_plan_from_cache
-0
+1
 set tidb_enable_non_prepared_plan_cache=DEFAULT;
 drop table if exists t;
 create table t (a int);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61876

Problem Summary:

The existing code for plan cache is convoluted.  Currently, when one of the plan caches is in use, planner.Optimize calls into the plan cache code, which in turn can call back into planner.Optimize. There are also various other places in executor and plan builder code that call back into planner.Optimize.

### What changed and how does it work?
This patch make two changes:
* The code path for the plan cache is simplified, and planner.Optimize() is not called indirectly by plan cache code,
* Point-get plans can now be cached for non-prepared queries,

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
