### PR TITLE
fix(runaway): ensure DistSQLContext's checker is synchronized with session variables

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2648,7 +2648,7 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 	vars := s.GetSessionVars()
 	sc := vars.StmtCtx
 
-	return sc.GetOrInitDistSQLFromCache(func() *distsqlctx.DistSQLContext {
+	dctx := sc.GetOrInitDistSQLFromCache(func() *distsqlctx.DistSQLContext {
 		return &distsqlctx.DistSQLContext{
 			WarnHandler:     sc.WarnHandler,
 			InRestrictedSQL: sc.InRestrictedSQL,
@@ -2703,6 +2703,16 @@ func (s *session) GetDistSQLCtx() *distsqlctx.DistSQLContext {
 			ExecDetails: &sc.SyncExecDetails,
 		}
 	})
+
+	// Check if the runaway checker is updated. This is to avoid that evaluating a non-correlated subquery
+	// during the optimization phase will cause the `*distsqlctx.DistSQLContext` to be created before the
+	// runaway checker is set later at the execution phase.
+	// Ref: https://github.com/pingcap/tidb/issues/61899
+	if dctx.RunawayChecker != sc.RunawayChecker {
+		dctx.RunawayChecker = sc.RunawayChecker
+	}
+
+	return dctx
 }
 
 // GetRangerCtx returns the context used in `ranger` related functions


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61899.

### What changed and how does it work?

Update `GetDistSQLCtx` to check and align the `RunawayChecker` in the cached DistSQL context with the session's current value.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

Prepare:

```sql
create table t1(a int, b int);
insert into t1 value(rand()*1000, rand()*1000); x 44600

mysql> select count(*) from t1;
+----------+
| count(*) |
+----------+
|    44600 |
+----------+
1 row in set (0.01 sec)

mysql> CREATE RESOURCE GROUP IF NOT EXISTS rg1 RU_PER_SEC = 100 QUERY_LIMIT=(RU=10, ACTION=KILL);
Query OK, 0 rows affected (0.06 sec)

mysql> SET RESOURCE GROUP rg1;
Query OK, 0 rows affected (0.00 sec)
```

Before:

```sql
mysql> explain analyze select * from t1 where b > 36;
ERROR 8253 (HY000): Query execution was interrupted, identified as runaway query [RequestUnit = RRU:13.419626, WRU:0.000000, WaitDuration:0s(10)]

mysql> explain analyze select min(a)+10 from t1 where a < 639;
ERROR 8253 (HY000): Query execution was interrupted, identified as runaway query [RequestUnit = RRU:38.330615, WRU:0.000000, WaitDuration:0s(10)]

mysql> explain analyze select * from t1 where b > (select min(a)+3 from t1 where a < 452);
+--------------------------+----------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------+----------+------+
| id                       | estRows  | actRows | task      | access object | execution info                                                                                                                                                                                                                                                                                                                                                                                                                            | operator info                                    | memory   | disk |
+--------------------------+----------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------+----------+------+
| TableReader_36           | 18466.67 | 44437   | root      |               | time:217.3ms, loops:46, RU:78.809008, cop_task: {num: 9, max: 121.4ms, min: 572.6µs, avg: 24.1ms, p95: 121.4ms, max_proc_keys: 17376, p95_proc_keys: 17376, tot_proc: 25.1ms, tot_wait: 370.2µs, copr_cache_hit_ratio: 0.00, build_task_duration: 8.17µs, max_distsql_concurrency: 1}, rpc_info:{Cop:{num_rpc:9, total_time:217.1ms}}                                                                                                     | data:Selection_35                                | 414.5 KB | N/A  |
| └─Selection_35           | 18466.67 | 44437   | cop[tikv] |               | tikv_task:{proc max:8ms, min:0s, avg: 2.78ms, p80:6ms, p95:8ms, iters:79, tasks:9}, scan_detail: {total_process_keys: 44600, total_process_keys_size: 1906316, total_keys: 44609, get_snapshot_time: 199µs, rocksdb: {key_skipped_count: 44600, block: {cache_hit_count: 93}}}, time_detail: {total_process_time: 25.1ms, total_suspend_time: 45.2µs, total_wait_time: 370.2µs, total_kv_read_wall_time: 25ms, tikv_wall_time: 26.2ms}    | gt(test.t1.b, 3)                                 | N/A      | N/A  |
|   └─TableFullScan_34     | 55400.00 | 44600   | cop[tikv] | table:t1      | tikv_task:{proc max:8ms, min:0s, avg: 2.78ms, p80:6ms, p95:8ms, iters:79, tasks:9}                                                                                                                                                                                                                                                                                                                                                        | keep order:false, stats:partial[b:unInitialized] | N/A      | N/A  |
+--------------------------+----------+---------+-----------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------+----------+------+
3 rows in set (0.24 sec)
```

After:

```sql
mysql> explain analyze select min(a)+10 from t1 where a < 639;
ERROR 8253 (HY000): Query execution was interrupted, identified as runaway query [RequestUnit = RRU:29.563074, WRU:0.000000, WaitDuration:0s(10)]

mysql> explain analyze select * from t1 where b > 36;
ERROR 8253 (HY000): Query execution was interrupted, identified as runaway query [RequestUnit = RRU:10.572321, WRU:0.000000, WaitDuration:0s(10)]

mysql> explain analyze select * from t1 where b > (select min(a)+3 from t1 where a < 452);
ERROR 8253 (HY000): Query execution was interrupted, identified as runaway query [RequestUnit = RRU:30.184085, WRU:0.000000, WaitDuration:0s(10)]
```

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
Fixed an issue where the evaluating of non-correlated subqueries could cause runaway configuration to become invalid.
```
