### PR TITLE
fix: shut down test without error

### DIFF
--- a/tests/globalkilltest/run-tests.sh
+++ b/tests/globalkilltest/run-tests.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 set -eu
-trap 'set +e; PIDS=$(jobs -p); [ -n "$PIDS" ] && kill -9 $PIDS' EXIT
+trap 'set +e; PIDS=$(jobs -p); for pid in $PIDS; do kill -9 $pid 2>/dev/null || true; done' EXIT
 
 function help_message()
 {

--- a/tests/graceshutdown/run-tests.sh
+++ b/tests/graceshutdown/run-tests.sh
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 set -eu
-trap 'set +e; PIDS=$(jobs -p); [ -n "$PIDS" ] && kill -9 $PIDS' EXIT
+trap 'set +e; PIDS=$(jobs -p); for pid in $PIDS; do kill -9 $pid 2>/dev/null || true; done' EXIT
 
 go test

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -28,7 +28,7 @@ stats="s"
 collation_opt=2
 
 set -eu
-trap 'set +e; PIDS=$(jobs -p); [ -n "$PIDS" ] && kill -9 $PIDS' EXIT
+trap 'set +e; PIDS=$(jobs -p); for pid in $PIDS; do kill -9 $pid 2>/dev/null || true; done' EXIT
 # make tests stable time zone wise
 export TZ="Asia/Shanghai"
 

--- a/tests/integrationtest2/run-tests.sh
+++ b/tests/integrationtest2/run-tests.sh
@@ -60,7 +60,7 @@ record_case=""
 stats="s"
 
 set -eu
-trap 'set +e; PIDS=$(jobs -p); [ -n "$PIDS" ] && kill -9 $PIDS' EXIT
+trap 'set +e; PIDS=$(jobs -p); for pid in $PIDS; do kill -9 $pid 2>/dev/null || true; done' EXIT
 # make tests stable time zone wise
 export TZ="Asia/Shanghai"
 


### PR DESCRIPTION
for now when run tests  locall there's always  an error after the test

e.g. before this patch
```cli
start tidb-server, log file: ./integration-test.out
tidb-server(PID: 86298) started
record result for case: "executor/issues"
./t/executor/issues.test: ok! 467 test cases passed, take time 5.68635825 s
```

Great, All tests passed
integrationtest passed!
./run-tests.sh: line 332: kill: (86298) - No such process

This patch swallow the `trap` error for better dev experience

after this patch

```cli
# github.com/pingcap/tidb/cmd/tidb-server
building mysql-tester binary: ./mysql_tester
start tidb-server, log file: ./integration-test.out
tidb-server(PID: 95300) started
record result for case: "executor/issues"
./t/executor/issues.test: ok! 465 test cases passed, take time 5.830736958 s

Great, All tests passed
```


Issue Number: close #62230

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
