### PR TITLE
expression: avoid copying the hashcode to prevent forgetting to update the hashcode when updating the expression later

### DIFF
--- a/pkg/planner/cascades/old/transformation_rules_test.go
+++ b/pkg/planner/cascades/old/transformation_rules_test.go
@@ -205,7 +205,6 @@ func TestTopNRules(t *testing.T) {
 }
 
 func TestProjectionElimination(t *testing.T) {
-	t.Skip("tmp")
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		pattern.OperandProjection: {
@@ -329,7 +328,6 @@ func TestTransformLimitToTableDual(t *testing.T) {
 }
 
 func TestPostTransformationRules(t *testing.T) {
-	t.Skip("tmp")
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		pattern.OperandLimit: {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62121

Problem Summary:

### What changed and how does it work?

We know that each expression has a cache for its hash code. However, if we update the hash code and then modify the content of the expression without rehashing in time, we may get incorrect results.

so now we refrain from copying the hashcode to prevent forgetting to update the hashcode when updating the expression later

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
