### PR TITLE
fix: fix golint version in make file to make check-static happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ fmt: ## Format Go code using gofmt
 	@gofmt -s -l -w -r 'interface{} -> any' $(FILES) 2>&1 | $(FAIL_ON_STDOUT)
 
 .PHONY: check-static
+check-static: ## Run static code analysis checks
 check-static: tools/bin/golangci-lint
 	GO111MODULE=on CGO_ENABLED=0 tools/bin/golangci-lint run -v $$($(PACKAGE_DIRECTORIES)) --config .golangci.yml
 
@@ -345,8 +346,8 @@ tools/bin/errdoc-gen:
 
 .PHONY: tools/bin/golangci-lint
 tools/bin/golangci-lint:
-	# Build from source is not recommend. See https://golangci-lint.run/usage/install/
-	GOBIN=$(shell pwd)/tools/bin $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2
+	$(eval GOLANGCI_LINT_VERSION := $(shell grep 'github.com/golangci/golangci-lint/v2' go.mod | awk '{print $$2}'))
+	GOBIN=$(shell pwd)/tools/bin $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: tools/bin/vfsgendev
 tools/bin/vfsgendev:


### PR DESCRIPTION
This patch fix the 61966 that use the same version from go.mod for the same version

make the `make  check-static` work again(but not happy for now)

also this patch get the `version` from go.mod file aim to avoid this kind of issue again
another work is add it to `make help` that can show in `make help`

but for now when run `make check-static` will got bunch of unhappy errror which is I do
not sure need to fix, so just fix the `Make`

cc @zimulala 
 
Issue Number: close #61966

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
