### PR TITLE
meta/autoid:  reduce get autoID's backoff

### DIFF
--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -109,12 +109,10 @@ retry:
 	if len(resp.Kvs) == 0 {
 		// If the key is not found, it means the autoid service leader is not elected yet.
 		// We can retry to get the leader.
-		select {
-		case <-ctx.Done():
-			return nil, 0, errors.Trace(ctx.Err())
-		default:
-			bo.Backoff()
+		if err := ctx.Err(); err != nil {
+			return nil, 0, errors.Trace(err)
 		}
+		bo.Backoff()
 		goto retry
 	}
 	bo.Reset()
@@ -179,12 +177,10 @@ retry:
 	if err != nil {
 		if strings.Contains(err.Error(), "rpc error") {
 			sp.resetConn(ver, err)
-			select {
-			case <-ctx.Done():
-				return 0, 0, errors.Trace(ctx.Err())
-			default:
-				bo.Backoff()
+			if err := ctx.Err(); err != nil {
+				return 0, 0, errors.Trace(err)
 			}
+			bo.Backoff()
 			goto retry
 		}
 		return 0, 0, errors.Trace(err)

--- a/pkg/meta/autoid/autoid_service.go
+++ b/pkg/meta/autoid/autoid_service.go
@@ -117,6 +117,7 @@ retry:
 		}
 		goto retry
 	}
+	bo.Reset()
 
 	addr := string(resp.Kvs[0].Value)
 	opt := grpc.WithTransportCredentials(insecure.NewCredentials())
@@ -150,6 +151,8 @@ func (sp *singlePointAlloc) Alloc(ctx context.Context, n uint64, increment, offs
 	r, ctx := tracing.StartRegionEx(ctx, "autoid.Alloc")
 	defer r.End()
 
+	logutil.BgLogger().Info("alloc autoid",
+		zap.Int64("dbID", sp.dbID))
 	if !validIncrementAndOffset(increment, offset) {
 		return 0, 0, errInvalidIncrementAndOffset.GenWithStackByArgs(increment, offset)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61987

Problem Summary:

### What changed and how does it work?
reducing backoff from 250 ms to 5 ms and adding retry if leader is not assigned in etcd.
### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
test results
<img width="1709" alt="Screenshot 2025-06-24 at 11 09 30 PM" src="https://github.com/user-attachments/assets/a8555d03-97d5-4e06-a574-ef2c55819085" />
