### PR TITLE
*: add log for bootstrap part and init USR1 single handler early to help diagnose

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -287,6 +287,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, "invalid config: keyspace name is not supported for classic TiDB")
 		os.Exit(0)
 	}
+
+	signal.SetupUSR1Handler()
 	registerStores()
 	err := metricsutil.RegisterMetrics()
 	terror.MustNil(err)

--- a/pkg/ddl/ddl.go
+++ b/pkg/ddl/ddl.go
@@ -797,7 +797,9 @@ func (d *ddl) Start(startMode StartMode, ctxPool *pools.ResourcePool) error {
 	}
 	logutil.DDLLogger().Info("start DDL", zap.String("ID", d.uuid),
 		zap.Bool("runWorker", campaignOwner),
-		zap.Stringer("jobVersion", model.GetJobVerInUse()))
+		zap.Stringer("jobVersion", model.GetJobVerInUse()),
+		zap.String("startMode", string(startMode)),
+	)
 
 	d.sessPool = sess.NewSessionPool(ctxPool)
 	d.executor.sessPool, d.jobSubmitter.sessPool = d.sessPool, d.sessPool

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -819,6 +819,7 @@ func bootstrap(s sessiontypes.Session) {
 			zap.Error(err))
 	}
 	dom := domain.GetDomain(s)
+	bootLogger := logutil.SampleLoggerFactory(30*time.Second, 1)()
 	for {
 		b, err := checkBootstrapped(s)
 		if err != nil {
@@ -842,6 +843,7 @@ func bootstrap(s sessiontypes.Session) {
 				zap.Duration("take time", time.Since(startTime)))
 			return
 		}
+		bootLogger.Info("bootstrap not done yet, waiting for owner to finish")
 		time.Sleep(200 * time.Millisecond)
 	}
 }

--- a/pkg/util/signal/signal_posix.go
+++ b/pkg/util/signal/signal_posix.go
@@ -11,6 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 //go:build linux || darwin || freebsd || unix
 
 package signal
@@ -26,22 +31,47 @@ import (
 	"go.uber.org/zap"
 )
 
-// SetupSignalHandler setup signal handler for TiDB Server
-func SetupSignalHandler(shutdownFunc func()) {
-	usrDefSignalChan := make(chan os.Signal, 1)
+// it's the same function used by "/debug/pprof/goroutine"
+// see https://github.com/golang/go/blob/e515ef8bc271f632bb2ebb94e8e700ab67274268/src/runtime/pprof/pprof.go#L750-L769
+func getGoroutineStacks() string {
+	// We don't know how big the buffer needs to be to collect
+	// all the goroutines. Start with 1 MB and try a few times, doubling each time.
+	// Give up and use a truncated trace if 64 MB is not enough.
+	buf := make([]byte, 1<<20)
+	for i := 0; ; i++ {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		if len(buf) >= 64<<20 {
+			// Filled 64 MB - stop there.
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+	return string(buf)
+}
 
+// SetupUSR1Handler sets up a signal handler for SIGUSR1.
+// When SIGUSR1 is received, it dumps the current goroutine stack to the log, it's
+// useful for debugging issue when the server hasn't started yet or stuck on showdown.
+func SetupUSR1Handler() {
+	usrDefSignalChan := make(chan os.Signal, 1)
 	signal.Notify(usrDefSignalChan, syscall.SIGUSR1)
 	go func() {
-		buf := make([]byte, 1<<17)
 		for {
 			sig := <-usrDefSignalChan
 			if sig == syscall.SIGUSR1 {
-				stackLen := runtime.Stack(buf, true)
-				log.Printf("\n=== Got signal [%s] to dump goroutine stack. ===\n%s\n=== Finished dumping goroutine stack. ===\n", sig, buf[:stackLen])
+				log.Printf("\n=== Got signal [%s] to dump goroutine stack. ===\n%s\n=== Finished dumping goroutine stack. ===\n",
+					sig, getGoroutineStacks())
 			}
 		}
 	}()
+}
 
+// SetupSignalHandler setup signal handler for TiDB Server
+func SetupSignalHandler(shutdownFunc func()) {
 	closeSignalChan := make(chan os.Signal, 1)
 	signal.Notify(closeSignalChan,
 		syscall.SIGHUP,

--- a/pkg/util/signal/signal_wasm.go
+++ b/pkg/util/signal/signal_wasm.go
@@ -14,6 +14,9 @@
 
 package signal
 
+// SetupUSR1Handler sets up a signal handler for SIGUSR1.
+func SetupUSR1Handler() {}
+
 // SetupSignalHandler setup signal handler for TiDB Server
 func SetupSignalHandler(shutdownFunc func(bool)) {
 }

--- a/pkg/util/signal/signal_windows.go
+++ b/pkg/util/signal/signal_windows.go
@@ -24,6 +24,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// SetupUSR1Handler sets up a signal handler for SIGUSR1.
+func SetupUSR1Handler() {}
+
 // SetupSignalHandler setup signal handler for TiDB Server
 func SetupSignalHandler(shutdownFunc func()) {
 	//todo deal with dump goroutine stack on windows


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702 

Problem Summary:

### What changed and how does it work?
when the only instance set `tidb-enable-ddl = false`, it will block on bootstrap, or the keyspace doesn't created on PD, it will block on creating store, but we don't know where, as there is no log, and we cannot get stack as the signal handler hasn't been setup and the server hasn't started yet, so we add this pr to help diagnose.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)


run a single tidb-server for some keyspace, and set `tidb-enable-ddl = false`, we can see from log
```
[2025/06/25 15:26:14.620 +08:00] [INFO] [bootstrap.go:846] ["bootstrap not done yet, waiting for owner to finish"] [keyspaceName=ks1] [sampled=]
[2025/06/25 15:26:44.641 +08:00] [INFO] [bootstrap.go:846] ["bootstrap not done yet, waiting for owner to finish"] [keyspaceName=ks1] [sampled=]
```

run tidb-server with a un-registered keyspace, tidb will retry on get keyspace meta

from log we can see it meet ErrKeyspaceNotFound error, and retry
```
[store.go:96] ["open store failed, retrying"] [keyspaceName=aks1] [path="tikv://localhost:2379?keyspaceName=aks1"] [sampled=]
   [error="Load keyspace aks1 failed: type:ENTRY_NOT_FOUND message:\"[PD:keyspace:ErrKeyspaceNotFound]keyspace does not exist\" "] 
```

`kill -USR1`, we can see the stack
```
=== Got signal [user defined signal 1] to dump goroutine stack. ===
goroutine 38 [running]:
github.com/pingcap/tidb/pkg/util/signal.getGoroutineStacks()
        /Users/jujiajia/code/pingcap/tidb/pkg/util/signal/signal_posix.go:42 +0x60
github.com/pingcap/tidb/pkg/util/signal.SetupUSR1Handler.func1()
        /Users/jujiajia/code/pingcap/tidb/pkg/util/signal/signal_posix.go:67 +0x90
created by github.com/pingcap/tidb/pkg/util/signal.SetupUSR1Handler in goroutine 1
        /Users/jujiajia/code/pingcap/tidb/pkg/util/signal/signal_posix.go:62 +0xf8

goroutine 1 [select]:
github.com/tikv/pd/client/servicediscovery.(*serviceDiscovery).initRetry(0x14001418b00, 0x1400141fe00)
        /Users/jujiajia/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20250623084542-60788950a745/servicediscovery/service_discovery.go:523 +0x188
github.com/tikv/pd/client/servicediscovery.(*serviceDiscovery).Init(0x14001418b00)
        /Users/jujiajia/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20250623084542-60788950a745/servicediscovery/service_discovery.go:496 +0x2e0
github.com/tikv/pd/client.(*innerClient).setup(0x1400100e000)
        /Users/jujiajia/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20250623084542-60788950a745/inner_client.go:261 +0x7c
github.com/tikv/pd/client.(*innerClient).init(0x1400100e000, 0x1400141fe00)
        /Users/jujiajia/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20250623084542-60788950a745/inner_client.go:66 +0x180
github.com/tikv/pd/client.newClientWithKeyspaceName({0x108b3b380, 0x10c57daa8}, {0x1073c1ed7, 0x10}, {0x14001352f83, 0x4}, {0x1400187db80, 0x1, 0x1}, {{0x0, ...}, ...}, ...)
        /Users/jujiajia/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20250623084542-60788950a745/client.go:393 +0x5d4
github.com/tikv/pd/client.NewClientWithAPIContext({0x108b3b380, 0x10c57daa8}, {0x108b17848, 0x1400187db90}, {0x1073c1ed7, 0x10}, {0x1400187db80, 0x1, 0x1}, {{0x0, ...}, ...}, ...)
        /Users/jujiajia/go/pkg/mod/github.com/tikv/pd/client@v0.0.0-20250623084542-60788950a745/client.go:335 +0x1dc
github.com/pingcap/tidb/pkg/store/driver.(*TiKVDriver).OpenWithOptions(0x140008cf200, {0x14001352f60, 0x27}, {0x0, 0x0, 0x0})
        /Users/jujiajia/code/pingcap/tidb/pkg/store/driver/tikv_driver.go:159 +0x6c0
github.com/pingcap/tidb/pkg/store/driver.(*TiKVDriver).Open(0x140008cf200, {0x14001352f60, 0x27})
        /Users/jujiajia/code/pingcap/tidb/pkg/store/driver/tikv_driver.go:108 +0x54
github.com/pingcap/tidb/pkg/store.newStoreWithRetry.func1()
        /Users/jujiajia/code/pingcap/tidb/pkg/store/store.go:94 +0x17c
github.com/pingcap/tidb/pkg/util.RunWithRetry(0x1e, 0x1f4, 0x14001c216b8)
        /Users/jujiajia/code/pingcap/tidb/pkg/util/misc.go:72 +0x60
github.com/pingcap/tidb/pkg/store.newStoreWithRetry({0x14001352f60, 0x27}, 0x1e)
        /Users/jujiajia/code/pingcap/tidb/pkg/store/store.go:92 +0x3c0
github.com/pingcap/tidb/pkg/store.New({0x14001352f60, 0x27})
        /Users/jujiajia/code/pingcap/tidb/pkg/store/store.go:75 +0x44
github.com/pingcap/tidb/pkg/store.mustInitStorage({0x14000188d91, 0x4})
        /Users/jujiajia/code/pingcap/tidb/pkg/store/store.go:172 +0x2c8
github.com/pingcap/tidb/pkg/store.MustInitStorage({0x14000188d91, 0x4})
        /Users/jujiajia/code/pingcap/tidb/pkg/store/store.go:147 +0x30
main.createStoreDDLOwnerMgrAndDomain({0x14000188d91, 0x4})
        /Users/jujiajia/code/pingcap/tidb/cmd/tidb-server/main.go:421 +0x3c
main.main()
        /Users/jujiajia/code/pingcap/tidb/cmd/tidb-server/main.go:339 +0x914
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
