### PR TITLE
planner: fix `PointGetPlan.PrunePartitions` function works with non-binary collate

### DIFF
--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -392,9 +392,7 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 		// and the fast path does not convert the values to `sortKey`.
 		for _, col := range p.IdxCols {
 			// TODO: We could check whether `col` belongs to the partition columns to avoid unnecessary ranger building.
-			// However, we currently don't have a safe and reliable way to do that.
-			// `col` is of type `expression.Column`, while the IDs from `pt.GetPartitionColumnIDs()` are derived from `t.Cols()`
-			// which type is `table.Column`. It's not always correctly to compare them.
+			// https://github.com/pingcap/tidb/pull/62002#discussion_r2171420731
 			if !collate.IsBinCollation(col.GetType(evalCtx).GetCollate()) {
 				// If a non-binary collation is used, the values in `p.IndexValues` are sort keys and cannot be used for partition pruning.
 				r, err := ranger.DetachCondAndBuildRangeForPartition(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -387,7 +387,6 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 	row := make([]types.Datum, len(p.TblInfo.Columns))
 	if p.HandleConstant == nil && len(p.IndexValues) > 0 {
 		indexValues := p.IndexValues
-
 		evalCtx := sctx.GetExprCtx().GetEvalCtx()
 		for _, col := range p.IdxCols {
 			if !collate.IsBinCollation(col.GetType(evalCtx).GetCollate()) {

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -359,7 +359,6 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 			if def.Name.L == p.PartitionNames[0].L {
 				idx := i
 				p.PartitionIdx = &idx
-				break
 			}
 		}
 		return false, nil
@@ -388,8 +387,12 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 	if p.HandleConstant == nil && len(p.IndexValues) > 0 {
 		hasNonBinaryCollate := false
 		for _, col := range p.IdxCols {
-			if !collate.IsBinCollation(col.GetType(sctx.GetExprCtx().GetEvalCtx()).GetCollate()) {
+			switch col.GetType(sctx.GetExprCtx().GetEvalCtx()).GetCollate() {
+			case "utf8mb4_bin", "binary", "ascii_bin", "latin1_bin", "utf8_bin", "utf8mb4_0900_bin":
+			default:
 				hasNonBinaryCollate = true
+			}
+			if hasNonBinaryCollate {
 				break
 			}
 		}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -389,16 +389,8 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 		indexValues := p.IndexValues
 
 		evalCtx := sctx.GetExprCtx().GetEvalCtx()
-		binaryCollations := map[string]struct{}{
-			"utf8mb4_bin":      {},
-			"binary":           {},
-			"ascii_bin":        {},
-			"latin1_bin":       {},
-			"utf8_bin":         {},
-			"utf8mb4_0900_bin": {},
-		}
 		for _, col := range p.IdxCols {
-			if _, exists := binaryCollations[col.GetType(evalCtx).GetCollate()]; !exists {
+			if !collate.IsBinCollation(col.GetType(evalCtx).GetCollate()) {
 				// If a non-binary collation is used, the values in `p.IndexValues` are sort keys and cannot be used for partition pruning.
 				r, err := ranger.DetachCondAndBuildRangeForPartition(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize)
 				if err != nil {

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -388,13 +388,13 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 	if p.HandleConstant == nil && len(p.IndexValues) > 0 {
 		indexValues := p.IndexValues
 		evalCtx := sctx.GetExprCtx().GetEvalCtx()
-		pColIDs := pt.GetPartitionColumnIDs()
 		// If the plan is created via the fast path, `IdxCols` will be nil here,
 		// and the fast path does not convert the values to `sortKey`.
 		for _, col := range p.IdxCols {
-			if !slices.Contains(pColIDs, col.ID) {
-				continue
-			}
+			// TODO: We could check whether `col` belongs to the partition columns to avoid unnecessary ranger building.
+			// However, we currently don't have a safe and reliable way to do that.
+			// `col` is of type `expression.Column`, while the IDs from `pt.GetPartitionColumnIDs()` are derived from `t.Cols()`
+			// which type is `table.Column`. It's not always correctly to compare them.
 			if !collate.IsBinCollation(col.GetType(evalCtx).GetCollate()) {
 				// If a non-binary collation is used, the values in `p.IndexValues` are sort keys and cannot be used for partition pruning.
 				r, err := ranger.DetachCondAndBuildRangeForPartition(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize)

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -386,16 +386,16 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 	}
 	row := make([]types.Datum, len(p.TblInfo.Columns))
 	if p.HandleConstant == nil && len(p.IndexValues) > 0 {
-		containsNonBinaryCollate := false
+		hasNonBinaryCollate := false
 		for _, col := range p.IdxCols {
 			if !collate.IsBinCollation(col.GetType(sctx.GetExprCtx().GetEvalCtx()).GetCollate()) {
-				containsNonBinaryCollate = true
+				hasNonBinaryCollate = true
 				break
 			}
 		}
 		indexValues := p.IndexValues
 		// If a non-binary collation is used, the values in `p.IndexValues` are sort keys and cannot be used for partition pruning.
-		if containsNonBinaryCollate {
+		if hasNonBinaryCollate {
 			r, err := ranger.DetachCondAndBuildRange(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize, false, true)
 			if err != nil {
 				return false, err

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -359,6 +359,7 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 			if def.Name.L == p.PartitionNames[0].L {
 				idx := i
 				p.PartitionIdx = &idx
+				break
 			}
 		}
 		return false, nil
@@ -401,7 +402,7 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 		}
 		// If a non-binary collation is used, the values in `p.IndexValues` are sort keys and cannot be used for partition pruning.
 		if hasNonBinaryCollate {
-			r, err := ranger.DetachCondAndBuildRange(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize, false, true)
+			r, err := ranger.DetachCondAndBuildRangeForPartition(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -389,15 +389,15 @@ func (p *PointGetPlan) PrunePartitions(sctx sessionctx.Context) (bool, error) {
 		indexValues := p.IndexValues
 
 		evalCtx := sctx.GetExprCtx().GetEvalCtx()
+		binaryCollations := map[string]struct{}{
+			"utf8mb4_bin":      {},
+			"binary":           {},
+			"ascii_bin":        {},
+			"latin1_bin":       {},
+			"utf8_bin":         {},
+			"utf8mb4_0900_bin": {},
+		}
 		for _, col := range p.IdxCols {
-			binaryCollations := map[string]struct{}{
-				"utf8mb4_bin":      {},
-				"binary":           {},
-				"ascii_bin":        {},
-				"latin1_bin":       {},
-				"utf8_bin":         {},
-				"utf8mb4_0900_bin": {},
-			}
 			if _, exists := binaryCollations[col.GetType(evalCtx).GetCollate()]; !exists {
 				// If a non-binary collation is used, the values in `p.IndexValues` are sort keys and cannot be used for partition pruning.
 				r, err := ranger.DetachCondAndBuildRangeForPartition(sctx.GetRangerCtx(), p.AccessConditions, p.IdxCols, p.IdxColLens, sctx.GetSessionVars().RangeMaxSize)

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -322,7 +322,7 @@ func extractBestCNFItemRanges(sctx *rangerctx.RangerContext, conds []expression.
 		// We build ranges for `(a,b) in ((1,1),(1,2))` and get `[1 1, 1 1] [1 2, 1 2]`, which are point ranges and we can
 		// append `c = 1` to the point ranges. However, if we choose to merge consecutive ranges here, we get `[1 1, 1 2]`,
 		// which are not point ranges, and we cannot append `c = 1` anymore.
-		res, err := DetachCondAndBuildRange(sctx, tmpConds, cols, lengths, rangeMaxSize, convertToSortKey, false)
+		res, err := detachCondAndBuildRange(sctx, tmpConds, cols, lengths, rangeMaxSize, convertToSortKey, false)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -502,7 +502,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		if eqOrInCount > 0 {
 			newCols := d.cols[eqOrInCount:]
 			newLengths := d.lengths[eqOrInCount:]
-			tailRes, err := DetachCondAndBuildRange(d.sctx, newConditions, newCols, newLengths, d.rangeMaxSize, d.convertToSortKey, d.mergeConsecutive)
+			tailRes, err := detachCondAndBuildRange(d.sctx, newConditions, newCols, newLengths, d.rangeMaxSize, d.convertToSortKey, d.mergeConsecutive)
 			if err != nil {
 				return nil, err
 			}
@@ -1030,8 +1030,8 @@ func DetachCondAndBuildRangeForIndex(sctx *rangerctx.RangerContext, conditions [
 	return d.detachCondAndBuildRangeForCols()
 }
 
-// DetachCondAndBuildRange detaches the index filters from table filters and uses them to build ranges.
-func DetachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
+// detachCondAndBuildRange detaches the index filters from table filters and uses them to build ranges.
+func detachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int, rangeMaxSize int64, convertToSortKey bool, mergeConsecutive bool) (*DetachRangeResult, error) {
 	d := &rangeDetacher{
 		sctx:             sctx,
@@ -1051,7 +1051,7 @@ func DetachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []express
 // The returned values are encapsulated into a struct DetachRangeResult, see its comments for explanation.
 func DetachCondAndBuildRangeForPartition(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int, rangeMaxSize int64) (*DetachRangeResult, error) {
-	return DetachCondAndBuildRange(sctx, conditions, cols, lengths, rangeMaxSize, false, false)
+	return detachCondAndBuildRange(sctx, conditions, cols, lengths, rangeMaxSize, false, false)
 }
 
 type rangeDetacher struct {

--- a/pkg/util/ranger/detacher.go
+++ b/pkg/util/ranger/detacher.go
@@ -322,7 +322,7 @@ func extractBestCNFItemRanges(sctx *rangerctx.RangerContext, conds []expression.
 		// We build ranges for `(a,b) in ((1,1),(1,2))` and get `[1 1, 1 1] [1 2, 1 2]`, which are point ranges and we can
 		// append `c = 1` to the point ranges. However, if we choose to merge consecutive ranges here, we get `[1 1, 1 2]`,
 		// which are not point ranges, and we cannot append `c = 1` anymore.
-		res, err := detachCondAndBuildRange(sctx, tmpConds, cols, lengths, rangeMaxSize, convertToSortKey, false)
+		res, err := DetachCondAndBuildRange(sctx, tmpConds, cols, lengths, rangeMaxSize, convertToSortKey, false)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -502,7 +502,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expressi
 		if eqOrInCount > 0 {
 			newCols := d.cols[eqOrInCount:]
 			newLengths := d.lengths[eqOrInCount:]
-			tailRes, err := detachCondAndBuildRange(d.sctx, newConditions, newCols, newLengths, d.rangeMaxSize, d.convertToSortKey, d.mergeConsecutive)
+			tailRes, err := DetachCondAndBuildRange(d.sctx, newConditions, newCols, newLengths, d.rangeMaxSize, d.convertToSortKey, d.mergeConsecutive)
 			if err != nil {
 				return nil, err
 			}
@@ -1030,8 +1030,8 @@ func DetachCondAndBuildRangeForIndex(sctx *rangerctx.RangerContext, conditions [
 	return d.detachCondAndBuildRangeForCols()
 }
 
-// detachCondAndBuildRange detaches the index filters from table filters and uses them to build ranges.
-func detachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
+// DetachCondAndBuildRange detaches the index filters from table filters and uses them to build ranges.
+func DetachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int, rangeMaxSize int64, convertToSortKey bool, mergeConsecutive bool) (*DetachRangeResult, error) {
 	d := &rangeDetacher{
 		sctx:             sctx,
@@ -1051,7 +1051,7 @@ func detachCondAndBuildRange(sctx *rangerctx.RangerContext, conditions []express
 // The returned values are encapsulated into a struct DetachRangeResult, see its comments for explanation.
 func DetachCondAndBuildRangeForPartition(sctx *rangerctx.RangerContext, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int, rangeMaxSize int64) (*DetachRangeResult, error) {
-	return detachCondAndBuildRange(sctx, conditions, cols, lengths, rangeMaxSize, false, false)
+	return DetachCondAndBuildRange(sctx, conditions, cols, lengths, rangeMaxSize, false, false)
 }
 
 type rangeDetacher struct {

--- a/tests/integrationtest/r/planner/core/casetest/partition/partition_pruner.result
+++ b/tests/integrationtest/r/planner/core/casetest/partition/partition_pruner.result
@@ -928,3 +928,19 @@ Point_Get	1.00	root	table:t, partition:p4, index:idx_3(col_4)
 select * from t where col_4 in ( 'u^D92@_4' ,null );
 col_4
 u^D92@_4
+drop table if exists t;
+CREATE TABLE `t` (
+`col_95` char(181) COLLATE gbk_bin NOT NULL DEFAULT 'SaMKHTyg+nlID-X3Y',
+PRIMARY KEY (`col_95`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_bin
+PARTITION BY RANGE COLUMNS(`col_95`)
+(PARTITION `p0` VALUES LESS THAN ('6)nvX^uj0UGxqX'),
+PARTITION `p1` VALUES LESS THAN ('BHSluf6'),
+PARTITION `p2` VALUES LESS THAN (MAXVALUE));
+insert into t values ('58y-j)84-&Y*'), ('WNe(rS5uwmvIvFnHw'), ('j9FsMawX5uBro%$p'), ('C(#EQm@J');
+explain format='brief' select t.col_95 as r0 from t where t.col_95 between 'Dyw=*7nigCMh' and 'Im0*7sZ' or t.col_95 in ( '58y-j)84-&Y*' ,'WNe(rS5uwmvIvFnHw' ,'j9FsMawX5uBro%$p' ,'C(#EQm@J' ) group by t.col_95  having t.col_95 between '%^2' and '38ABfC-' or t.col_95 between 'eKCAE$d2x_hxscj' and 'zcw35^ATEEp1md=L';
+id	estRows	task	access object	operator info
+Point_Get	1.00	root	table:t, partition:p2, clustered index:PRIMARY(col_95)	
+select t.col_95 as r0 from t where t.col_95 between 'Dyw=*7nigCMh' and 'Im0*7sZ' or t.col_95 in ( '58y-j)84-&Y*' ,'WNe(rS5uwmvIvFnHw' ,'j9FsMawX5uBro%$p' ,'C(#EQm@J' ) group by t.col_95  having t.col_95 between '%^2' and '38ABfC-' or t.col_95 between 'eKCAE$d2x_hxscj' and 'zcw35^ATEEp1md=L';
+r0
+j9FsMawX5uBro%$p

--- a/tests/integrationtest/t/planner/core/casetest/partition/partition_pruner.test
+++ b/tests/integrationtest/t/planner/core/casetest/partition/partition_pruner.test
@@ -330,3 +330,19 @@ insert into t values ('u^D92@_4'), (null);
 explain format='brief' select * from t where col_4 in ( 'u^D92@_4' ,null );
 select * from t where col_4 in ( 'u^D92@_4' ,null );
 
+# Test issue 61965
+drop table if exists t;
+CREATE TABLE `t` (
+  `col_95` char(181) COLLATE gbk_bin NOT NULL DEFAULT 'SaMKHTyg+nlID-X3Y',
+  PRIMARY KEY (`col_95`) /*T![clustered_index] CLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_bin
+PARTITION BY RANGE COLUMNS(`col_95`)
+(PARTITION `p0` VALUES LESS THAN ('6)nvX^uj0UGxqX'),
+ PARTITION `p1` VALUES LESS THAN ('BHSluf6'),
+ PARTITION `p2` VALUES LESS THAN (MAXVALUE));
+
+insert into t values ('58y-j)84-&Y*'), ('WNe(rS5uwmvIvFnHw'), ('j9FsMawX5uBro%$p'), ('C(#EQm@J');
+
+explain format='brief' select t.col_95 as r0 from t where t.col_95 between 'Dyw=*7nigCMh' and 'Im0*7sZ' or t.col_95 in ( '58y-j)84-&Y*' ,'WNe(rS5uwmvIvFnHw' ,'j9FsMawX5uBro%$p' ,'C(#EQm@J' ) group by t.col_95  having t.col_95 between '%^2' and '38ABfC-' or t.col_95 between 'eKCAE$d2x_hxscj' and 'zcw35^ATEEp1md=L';
+select t.col_95 as r0 from t where t.col_95 between 'Dyw=*7nigCMh' and 'Im0*7sZ' or t.col_95 in ( '58y-j)84-&Y*' ,'WNe(rS5uwmvIvFnHw' ,'j9FsMawX5uBro%$p' ,'C(#EQm@J' ) group by t.col_95  having t.col_95 between '%^2' and '38ABfC-' or t.col_95 between 'eKCAE$d2x_hxscj' and 'zcw35^ATEEp1md=L';
+


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61965, close https://github.com/pingcap/tidb/issues/59827

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
