### PR TITLE
fix: reflect.SliceHeader is deprecated: Use slice instead.

### DIFF
--- a/pkg/parser/charset/encoding_base.go
+++ b/pkg/parser/charset/encoding_base.go
@@ -123,7 +123,7 @@ func generateEncodingErr(name string, invalidBytes []byte) error {
 // Use at your own risk.
 func HackSlice(s string) (b []byte) {
 	if len(s) == 0 {
-		return nil
+		return []byte{}
 	}
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/pkg/parser/charset/encoding_base.go
+++ b/pkg/parser/charset/encoding_base.go
@@ -16,7 +16,6 @@ package charset
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"strings"
 	"unsafe"
 
@@ -123,12 +122,10 @@ func generateEncodingErr(name string, invalidBytes []byte) error {
 // HackSlice converts string to slice without copy.
 // Use at your own risk.
 func HackSlice(s string) (b []byte) {
-	pBytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	pString := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	pBytes.Data = pString.Data
-	pBytes.Len = pString.Len
-	pBytes.Cap = pString.Len
-	return
+	if len(s) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // HackString converts slice to string without copy.
@@ -137,9 +134,5 @@ func HackString(b []byte) (s string) {
 	if len(b) == 0 {
 		return ""
 	}
-	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	pstring.Data = pbytes.Data
-	pstring.Len = pbytes.Len
-	return
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/pkg/parser/digester.go
+++ b/pkg/parser/digester.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	hash2 "hash"
-	"reflect"
 	"strings"
 	"sync"
 	"unsafe"
@@ -155,12 +154,7 @@ type sqlDigester struct {
 }
 
 func (d *sqlDigester) doDigestNormalized(normalized string) (digest *Digest) {
-	hdr := *(*reflect.StringHeader)(unsafe.Pointer(&normalized))
-	b := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: hdr.Data,
-		Len:  hdr.Len,
-		Cap:  hdr.Len,
-	}))
+	b := unsafe.Slice(unsafe.StringData(normalized), len(normalized))
 	d.hasher.Write(b)
 	digest = NewDigest(d.hasher.Sum(nil))
 	d.hasher.Reset()

--- a/pkg/util/chunk/codec.go
+++ b/pkg/util/chunk/codec.go
@@ -16,7 +16,6 @@ package chunk
 
 import (
 	"encoding/binary"
-	"reflect"
 	"unsafe"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -79,11 +78,7 @@ func i64SliceToBytes(i64s []int64) (b []byte) {
 	if len(i64s) == 0 {
 		return nil
 	}
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Len = len(i64s) * 8
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&i64s[0]))
-	return b
+	return unsafe.Slice((*byte)(unsafe.Pointer(&i64s[0])), len(i64s)*8)
 }
 
 // Decode decodes a Chunk from a byte slice, return the remained unused bytes.
@@ -161,11 +156,7 @@ func bytesToI64Slice(b []byte) (i64s []int64) {
 	if len(b) == 0 {
 		return nil
 	}
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&i64s))
-	hdr.Len = len(b) / 8
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	return i64s
+	return unsafe.Slice((*int64)(unsafe.Pointer(&b[0])), len(b)/8)
 }
 
 // VarElemLen indicates this Column is a variable length Column.

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -19,7 +19,6 @@ import (
 	"math"
 	"math/bits"
 	"math/rand"
-	"reflect"
 	"time"
 	"unsafe"
 
@@ -400,7 +399,7 @@ var (
 func (c *Column) resize(n, typeSize int, isNull bool) {
 	sizeData := n * typeSize
 	if cap(c.data) >= sizeData {
-		(*reflect.SliceHeader)(unsafe.Pointer(&c.data)).Len = sizeData
+		c.data = c.data[:sizeData]
 	} else {
 		c.data = make([]byte, sizeData)
 	}
@@ -413,7 +412,7 @@ func (c *Column) resize(n, typeSize int, isNull bool) {
 	newNulls := false
 	sizeNulls := (n + 7) >> 3
 	if cap(c.nullBitmap) >= sizeNulls {
-		(*reflect.SliceHeader)(unsafe.Pointer(&c.nullBitmap)).Len = sizeNulls
+		c.nullBitmap = c.nullBitmap[:sizeNulls]
 	} else {
 		c.nullBitmap = make([]byte, sizeNulls)
 		newNulls = true
@@ -440,7 +439,7 @@ func (c *Column) resize(n, typeSize int, isNull bool) {
 	}
 
 	if cap(c.elemBuf) >= typeSize {
-		(*reflect.SliceHeader)(unsafe.Pointer(&c.elemBuf)).Len = typeSize
+		c.elemBuf = c.elemBuf[:typeSize]
 	} else {
 		c.elemBuf = make([]byte, typeSize)
 	}
@@ -583,60 +582,61 @@ func (c *Column) ReserveEnum(n int) {
 	c.reserve(n, 8)
 }
 
-func (c *Column) castSliceHeader(header *reflect.SliceHeader, typeSize int) {
-	header.Data = (*reflect.SliceHeader)(unsafe.Pointer(&c.data)).Data
-	header.Len = c.length
-	header.Cap = cap(c.data) / typeSize
-}
-
 // Int64s returns an int64 slice stored in this Column.
 func (c *Column) Int64s() []int64 {
-	var res []int64
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeInt64)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*int64)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // Uint64s returns a uint64 slice stored in this Column.
 func (c *Column) Uint64s() []uint64 {
-	var res []uint64
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeUint64)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*uint64)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // Float32s returns a float32 slice stored in this Column.
 func (c *Column) Float32s() []float32 {
-	var res []float32
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeFloat32)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*float32)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // Float64s returns a float64 slice stored in this Column.
 func (c *Column) Float64s() []float64 {
-	var res []float64
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeFloat64)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*float64)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // GoDurations returns a Golang time.Duration slice stored in this Column.
 // Different from the Row.GetDuration method, the argument Fsp is ignored, so the user should handle it outside.
 func (c *Column) GoDurations() []time.Duration {
-	var res []time.Duration
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeGoDuration)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*time.Duration)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // Decimals returns a MyDecimal slice stored in this Column.
 func (c *Column) Decimals() []types.MyDecimal {
-	var res []types.MyDecimal
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeMyDecimal)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*types.MyDecimal)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // Times returns a Time slice stored in this Column.
 func (c *Column) Times() []types.Time {
-	var res []types.Time
-	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeTime)
-	return res
+	if len(c.data) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*types.Time)(unsafe.Pointer(&c.data[0])), c.length)
 }
 
 // GetInt64 returns the int64 in the specific row.

--- a/pkg/util/context/warn_test.go
+++ b/pkg/util/context/warn_test.go
@@ -17,7 +17,6 @@ package context
 import (
 	"encoding/json"
 	"io"
-	"reflect"
 	"testing"
 	"unsafe"
 
@@ -179,7 +178,5 @@ func warnSliceInnerArrayEqual(a []SQLWarn, b []SQLWarn) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	header1 := (*reflect.SliceHeader)(unsafe.Pointer(&a))
-	header2 := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	return header1.Data == header2.Data
+	return unsafe.SliceData(a) == unsafe.SliceData(b)
 }

--- a/pkg/util/rowcodec/common.go
+++ b/pkg/util/rowcodec/common.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"hash/crc32"
 	"math"
-	"reflect"
 	"time"
 	"unsafe"
 
@@ -61,48 +60,28 @@ func bytesToU32Slice(b []byte) []uint32 {
 	if len(b) == 0 {
 		return nil
 	}
-	var u32s []uint32
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u32s))
-	hdr.Len = len(b) / 4
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	return u32s
+	return unsafe.Slice((*uint32)(unsafe.Pointer(&b[0])), len(b)/4)
 }
 
 func bytes2U16Slice(b []byte) []uint16 {
 	if len(b) == 0 {
 		return nil
 	}
-	var u16s []uint16
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u16s))
-	hdr.Len = len(b) / 2
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	return u16s
+	return unsafe.Slice((*uint16)(unsafe.Pointer(&b[0])), len(b)/2)
 }
 
 func u16SliceToBytes(u16s []uint16) []byte {
 	if len(u16s) == 0 {
 		return nil
 	}
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Len = len(u16s) * 2
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&u16s[0]))
-	return b
+	return unsafe.Slice((*byte)(unsafe.Pointer(&u16s[0])), len(u16s)*2)
 }
 
 func u32SliceToBytes(u32s []uint32) []byte {
 	if len(u32s) == 0 {
 		return nil
 	}
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Len = len(u32s) * 4
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&u32s[0]))
-	return b
+	return unsafe.Slice((*byte)(unsafe.Pointer(&u32s[0])), len(u32s)*4)
 }
 
 func encodeInt(buf []byte, iVal int64) []byte {


### PR DESCRIPTION

follow #61952 another part

fix: reflect.SliceHeader is deprecated: Use unsafe.Slice or unsafe.SliceData instead.

Issue Number: close #62129

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
