### PR TITLE
batch load regions when region miss

### DIFF
--- a/pkg/store/copr/region_cache.go
+++ b/pkg/store/copr/region_cache.go
@@ -174,7 +174,20 @@ func (c *RegionCache) SplitKeyRangesByLocationsWithBuckets(bo *Backoffer, ranges
 		if limit != UnspecifiedLimit && len(res) >= limit {
 			break
 		}
-		loc, err := c.LocateKey(bo.TiKVBackoffer(), ranges.At(0).StartKey)
+		var (
+			loc *tikv.KeyLocation
+			err error
+		)
+		loc = c.TryLocateKey(ranges.At(0).StartKey)
+		if loc == nil {
+			// load the regions in the key range into region cache, we don't use the returned locations for minimal change.
+			_, err = c.LoadRegionsInKeyRange(bo.TiKVBackoffer(), ranges.RefAt(0).StartKey, ranges.RefAt(0).EndKey)
+			if err != nil {
+				logutil.Logger(bo.GetCtx()).Warn("Failed to load regions in key range", zap.Error(err))
+			}
+			loc, err = c.LocateKey(bo.TiKVBackoffer(), ranges.At(0).StartKey)
+		}
+
 		if err != nil {
 			return res, derr.ToTiDBErr(err)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53850

Problem Summary:

### What changed and how does it work?

Batch load regions into the region cache when building cop tasks encounters a region miss.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

1. Prepare data `sysbench --config-file=config oltp_point_select --tables=1 --table-size=1000000 --auto_inc=false prepare`
2. Split table into 1000 regions by `SPLIT TABLE sbtest1 BETWEEN (0) AND (1000000) REGIONS 1000;`
3. Restart TiDB to clean the region cache.
4. Run a simple query `explain analyze select * from sbtest1 limit 1;`

- v8.1.2: 0.23ms
- this pr: 0.02ms

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
accelerate building coprocessor tasks by batch loading.
```
