### PR TITLE
executor: update stats table row cache in batch

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -624,14 +624,36 @@ func (e *memtableRetriever) setDataFromReferConst(ctx context.Context, sctx sess
 	return nil
 }
 
-func (e *memtableRetriever) updateStatsCacheIfNeed() bool {
+func (e *memtableRetriever) updateStatsCacheIfNeed(sctx sessionctx.Context, tbls []*model.TableInfo) {
+	needUpdate := false
 	for _, col := range e.columns {
 		// only the following columns need stats cache.
 		if col.Name.O == "AVG_ROW_LENGTH" || col.Name.O == "DATA_LENGTH" || col.Name.O == "INDEX_LENGTH" || col.Name.O == "TABLE_ROWS" {
-			return true
+			needUpdate = true
+			break
 		}
 	}
-	return false
+	if !needUpdate {
+		return
+	}
+
+	tableIDs := make([]int64, 0, len(tbls))
+	for _, tbl := range tbls {
+		if pi := tbl.GetPartitionInfo(); pi != nil {
+			for _, def := range pi.Definitions {
+				tableIDs = append(tableIDs, def.ID)
+			}
+		} else {
+			tableIDs = append(tableIDs, tbl.ID)
+		}
+	}
+	// Even for partitioned tables, we must update the stats cache for the main table itself.
+	// This is necessary because the global index length from the table also needs to be included.
+	// For further details, see: https://github.com/pingcap/tidb/issues/54173
+	err := cache.TableRowStatsCache.UpdateByID(sctx, tableIDs)
+	if err != nil {
+		logutil.BgLogger().Warn("cannot update stats cache for tables", zap.Error(err))
+	}
 }
 
 func (e *memtableRetriever) setDataFromOneTable(
@@ -641,7 +663,6 @@ func (e *memtableRetriever) setDataFromOneTable(
 	schema ast.CIStr,
 	table *model.TableInfo,
 	rows [][]types.Datum,
-	useStatsCache bool,
 ) ([][]types.Datum, error) {
 	collation := table.Collate
 	if collation == "" {
@@ -682,26 +703,7 @@ func (e *memtableRetriever) setDataFromOneTable(
 			policyName = table.PlacementPolicyRef.Name.O
 		}
 
-		var rowCount, avgRowLength, dataLength, indexLength uint64
-		if useStatsCache {
-			// Even for partitioned tables, we must update the stats cache for the main table itself.
-			// This is necessary because the global index length from the table also needs to be included.
-			// For further details, see: https://github.com/pingcap/tidb/issues/54173
-			err := cache.TableRowStatsCache.UpdateByID(sctx, table.ID)
-			if err != nil {
-				return rows, err
-			}
-			if table.GetPartitionInfo() != nil {
-				// needs to update all partitions for partition table.
-				for _, pi := range table.GetPartitionInfo().Definitions {
-					err := cache.TableRowStatsCache.UpdateByID(sctx, pi.ID)
-					if err != nil {
-						return rows, err
-					}
-				}
-			}
-			rowCount, avgRowLength, dataLength, indexLength = cache.TableRowStatsCache.EstimateDataLength(table)
-		}
+		rowCount, avgRowLength, dataLength, indexLength := cache.TableRowStatsCache.EstimateDataLength(table)
 
 		record := types.MakeDatums(
 			infoschema.CatalogVal, // TABLE_CATALOG
@@ -881,13 +883,13 @@ func (e *memtableRetriever) setDataFromTables(ctx context.Context, sctx sessionc
 	if err != nil {
 		return errors.Trace(err)
 	}
-	useStatsCache := e.updateStatsCacheIfNeed()
+	e.updateStatsCacheIfNeed(sctx, tables)
 	loc := sctx.GetSessionVars().TimeZone
 	if loc == nil {
 		loc = time.Local
 	}
 	for i, table := range tables {
-		rows, err = e.setDataFromOneTable(sctx, loc, checker, schemas[i], table, rows, useStatsCache)
+		rows, err = e.setDataFromOneTable(sctx, loc, checker, schemas[i], table, rows)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1267,7 +1269,6 @@ func calcCharOctLength(lenInChar int, cs string) int {
 }
 
 func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sessionctx.Context) error {
-	useStatsCache := e.updateStatsCacheIfNeed()
 	checker := privilege.GetPrivilegeManager(sctx)
 	var rows [][]types.Datum
 	createTimeTp := mysql.TypeDatetime
@@ -1283,6 +1284,7 @@ func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sess
 	if err != nil {
 		return errors.Trace(err)
 	}
+	e.updateStatsCacheIfNeed(sctx, tables)
 	for i, table := range tables {
 		schema := schemas[i]
 		if checker != nil && !checker.RequestVerification(sctx.GetSessionVars().ActiveRoles, schema.L, table.Name.L, "", mysql.SelectPriv) {
@@ -1295,22 +1297,6 @@ func (e *memtableRetriever) setDataFromPartitions(ctx context.Context, sctx sess
 		}
 
 		var rowCount, dataLength, indexLength uint64
-		if useStatsCache {
-			if table.GetPartitionInfo() == nil {
-				err := cache.TableRowStatsCache.UpdateByID(sctx, table.ID)
-				if err != nil {
-					return err
-				}
-			} else {
-				// needs to update needed partitions for partition table.
-				for _, pi := range table.GetPartitionInfo().Definitions {
-					err := cache.TableRowStatsCache.UpdateByID(sctx, pi.ID)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
 		if table.GetPartitionInfo() == nil {
 			rowCount = cache.TableRowStatsCache.GetTableRows(table.ID)
 			dataLength, indexLength = cache.TableRowStatsCache.GetDataAndIndexLength(table, table.ID, rowCount)

--- a/pkg/statistics/handle/cache/stats_table_row_cache.go
+++ b/pkg/statistics/handle/cache/stats_table_row_cache.go
@@ -62,18 +62,18 @@ func (c *StatsTableRowCache) GetColLength(id tableHistID) uint64 {
 }
 
 // UpdateByID tries to update the cache by table ID.
-func (c *StatsTableRowCache) UpdateByID(sctx sessionctx.Context, id int64) error {
-	tableRows, err := getRowCountTables(sctx, id)
+func (c *StatsTableRowCache) UpdateByID(sctx sessionctx.Context, ids []int64) error {
+	tableRows, err := getRowCountTables(sctx, ids...)
 	if err != nil {
 		return err
 	}
-	colLength, err := getColLengthTables(sctx, id)
+	colLength, err := getColLengthTables(sctx, ids...)
 	if err != nil {
 		return err
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.tableRows[id] = tableRows[id]
+	maps.Copy(c.tableRows, tableRows)
 	maps.Copy(c.colLength, colLength)
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62020

Problem Summary:

Previously, the stats row cache is updated one by one for each table. If each update takes 1ms, 1000 tables takes 1s to complete.

### What changed and how does it work?

Update the stats table row cache in batch.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  sysbench oltp_common --mysql-port=4000 --mysql-user=root --mysql-host=127.0.0.1 --mysql-db=test --threads=300 --db-driver=mysql --tables=1000 --table-size=1 prepare
  
  Before this PR:
  ```
  mysql> trace select * from information_schema.tables where table_schema = 'test';
  +-------------------------------------------+-----------------+--------------+
  | operation                                 | startTS         | duration     |
  +-------------------------------------------+-----------------+--------------+
  | trace                                     | 11:12:06.567197 | 2.148556268s |
  |   ├─session.ExecuteStmt                   | 11:12:06.567202 | 346.749µs    |
  |   │ ├─executor.Compile                    | 11:12:06.567215 | 257.758µs    |
  |   │ │ ├─planner.Preprocess                | 11:12:06.567216 | 10.281µs     |
  |   │ │ └─planner.Optimize                  | 11:12:06.567244 | 221.328µs    |
  |   │ └─session.runStmt                     | 11:12:06.567476 | 53.028µs     |
  |   ├─*executor.MemTableReaderExec.Next     | 11:12:06.567586 | 2.147435809s |
  |   └─*executor.MemTableReaderExec.Next     | 11:12:08.715046 | 2.663µs      |
  +-------------------------------------------+-----------------+--------------+
  8 rows in set (2.15 sec)
  ```
  
  After this PR:
  ```
  mysql> trace select * from information_schema.tables where table_schema = 'test';
  +-------------------------------------------+-----------------+-------------+
  | operation                                 | startTS         | duration    |
  +-------------------------------------------+-----------------+-------------+
  | trace                                     | 11:10:47.520650 | 30.419448ms |
  |   ├─session.ExecuteStmt                   | 11:10:47.520655 | 312.578µs   |
  |   │ ├─executor.Compile                    | 11:10:47.520667 | 231.332µs   |
  |   │ │ ├─planner.Preprocess                | 11:10:47.520669 | 5.266µs     |
  |   │ │ └─planner.Optimize                  | 11:10:47.520689 | 203.404µs   |
  |   │ └─session.runStmt                     | 11:10:47.520903 | 48.49µs     |
  |   ├─*executor.MemTableReaderExec.Next     | 11:10:47.520979 | 30.02937ms  |
  |   └─*executor.MemTableReaderExec.Next     | 11:10:47.551034 | 3.146µs     |
  +-------------------------------------------+-----------------+-------------+
  8 rows in set (0.03 sec)
  ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
