### PR TITLE
release-8.1: Fix prefetch buffer and GCS EOF retry (#59496, #59851)

### DIFF
--- a/br/pkg/storage/gcs_test.go
+++ b/br/pkg/storage/gcs_test.go
@@ -574,6 +574,6 @@ func TestSpeedReadManyFiles(t *testing.T) {
 }
 
 func TestGCSShouldRetry(t *testing.T) {
-	require.True(t, shouldRetry(&url.Error{Err: goerrors.New("http2: server sent GOAWAY and closed the connectiont"), Op: "Get", URL: "https://storage.googleapis.com/storage/v1/"}))
 	require.True(t, shouldRetry(&url.Error{Err: goerrors.New("http2: client connection lost"), Op: "Get", URL: "https://storage.googleapis.com/storage/v1/"}))
+	require.True(t, shouldRetry(&url.Error{Err: io.EOF, Op: "Get", URL: "https://storage.googleapis.com/storage/v1/"}))
 }

--- a/pkg/util/prefetch/reader.go
+++ b/pkg/util/prefetch/reader.go
@@ -16,6 +16,7 @@ package prefetch
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"sync"
 )
@@ -54,7 +55,7 @@ func (r *Reader) run() {
 	for {
 		r.bufIdx = (r.bufIdx + 1) % 2
 		buf := r.buf[r.bufIdx]
-		n, err := r.r.Read(buf)
+		n, err := io.ReadFull(r.r, buf)
 		buf = buf[:n]
 		select {
 		case <-r.closedCh:
@@ -62,6 +63,12 @@ func (r *Reader) run() {
 		case r.bufCh <- buf:
 		}
 		if err != nil {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				// this is caused by io.ReadFull. Because we are prefetching, the buffer size may
+				// be larger that caller's need. So we return io.EOF instead. Let caller check
+				// its needed size to convert io.EOF to io.ErrUnexpectedEOF.
+				err = io.EOF
+			}
 			r.err = err
 			close(r.bufCh)
 			return


### PR DESCRIPTION
This PR manually cherry-picks two PRs to `release-8.1` to resolve a dependency.

---

cherry-pick #59496
cherry-pick #59851

### What problem does this PR solve?

Issue Number: close #59495, close #59754

Problem Summary:
This PR addresses two separate but related issues:
1. The prefetch buffer was not always being fully filled, potentially leading to inefficient reads.
2. A bug in Go's `net/http` library can cause `io.EOF` errors when using GCS, which were not being retried, causing operations to fail.

### What changed and how does it work?

1.  **Prefetch Buffer Fix:** Switched to using `io.ReadFull` to ensure the prefetch buffer is always filled completely.
2.  **GCS EOF Retry:** Added a workaround in the GCS storage layer to specifically retry on `io.EOF` errors, making the connection more resilient to the underlying library bug.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

### Release note

```release-note
None
```
