### PR TITLE
executor: fix data race because of using shared KV requests (#61376)

### DIFF
--- a/pkg/distsql/BUILD.bazel
+++ b/pkg/distsql/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/collate",
         "//pkg/util/dbterror",
         "//pkg/util/execdetails",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "//pkg/util/memory",
         "//pkg/util/ranger",

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
@@ -33,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
@@ -41,10 +43,12 @@ import (
 
 // RequestBuilder is used to build a "kv.Request".
 // It is called before we issue a kv request by "Select".
+// Notice a builder can only be used once unless it returns an error in test.
 type RequestBuilder struct {
 	kv.Request
-	is  infoschema.InfoSchema
-	err error
+	is   infoschema.InfoSchema
+	err  error
+	used bool
 
 	// When SetDAGRequest is called, builder will also this field.
 	dag *tipb.DAGRequest
@@ -52,6 +56,10 @@ type RequestBuilder struct {
 
 // Build builds a "kv.Request".
 func (builder *RequestBuilder) Build() (*kv.Request, error) {
+	if builder.used && intest.InTest {
+		return nil, errors.Errorf("request builder is already used")
+	}
+	builder.used = true
 	if builder.ReadReplicaScope == "" {
 		builder.ReadReplicaScope = kv.GlobalReplicaScope
 	}

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -712,21 +712,6 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 			maxChunkSize:    e.MaxChunkSize(),
 			PushedLimit:     e.PushedLimit,
 		}
-		var builder distsql.RequestBuilder
-		builder.SetDAGRequest(e.dagPB).
-			SetStartTS(e.startTS).
-			SetDesc(e.desc).
-			SetKeepOrder(e.keepOrder).
-			SetPaging(e.indexPaging).
-			SetTxnScope(e.txnScope).
-			SetReadReplicaScope(e.readReplicaScope).
-			SetIsStaleness(e.isStaleness).
-			SetFromSessionVars(e.Ctx().GetSessionVars()).
-			SetFromInfoSchema(e.Ctx().GetInfoSchema()).
-			SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx(), &builder.Request, e.idxNetDataSize/float64(len(kvRanges)))).
-			SetMemTracker(tracker).
-			SetConnID(e.Ctx().GetSessionVars().ConnectionID).
-			SetKilled(&e.Ctx().GetSessionVars().Killed)
 
 		results := make([]distsql.SelectResult, 0, len(kvRanges))
 		for _, kvRange := range kvRanges {
@@ -740,6 +725,22 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<
 			if finished {
 				break
 			}
+
+			var builder distsql.RequestBuilder
+			builder.SetDAGRequest(e.dagPB).
+				SetStartTS(e.startTS).
+				SetDesc(e.desc).
+				SetKeepOrder(e.keepOrder).
+				SetPaging(e.indexPaging).
+				SetTxnScope(e.txnScope).
+				SetReadReplicaScope(e.readReplicaScope).
+				SetIsStaleness(e.isStaleness).
+				SetFromSessionVars(e.Ctx().GetSessionVars()).
+				SetFromInfoSchema(e.Ctx().GetInfoSchema()).
+				SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx(), &builder.Request, e.idxNetDataSize/float64(len(kvRanges)))).
+				SetMemTracker(tracker).
+				SetConnID(e.Ctx().GetSessionVars().ConnectionID).
+				SetKilled(&e.Ctx().GetSessionVars().Killed)
 
 			// init kvReq, result and worker for this partition
 			// The key ranges should be ordered.

--- a/pkg/executor/index_merge_reader.go
+++ b/pkg/executor/index_merge_reader.go
@@ -376,22 +376,6 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 					}
 				}
 
-				var builder distsql.RequestBuilder
-				builder.SetDAGRequest(e.dagPBs[workID]).
-					SetStartTS(e.startTS).
-					SetDesc(e.descs[workID]).
-					SetKeepOrder(e.keepOrder).
-					SetTxnScope(e.txnScope).
-					SetReadReplicaScope(e.readReplicaScope).
-					SetIsStaleness(e.isStaleness).
-					SetFromSessionVars(e.Ctx().GetSessionVars()).
-					SetMemTracker(e.memTracker).
-					SetPaging(e.paging).
-					SetFromInfoSchema(e.Ctx().GetInfoSchema()).
-					SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx(), &builder.Request, e.partialNetDataSizes[workID])).
-					SetConnID(e.Ctx().GetSessionVars().ConnectionID).
-					SetKilled(&e.Ctx().GetSessionVars().Killed)
-
 				tps := worker.getRetTpsForIndexScan(e.handleCols)
 				results := make([]distsql.SelectResult, 0, len(keyRanges))
 				defer func() {
@@ -411,6 +395,22 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 						return
 					default:
 					}
+
+					var builder distsql.RequestBuilder
+					builder.SetDAGRequest(e.dagPBs[workID]).
+						SetStartTS(e.startTS).
+						SetDesc(e.descs[workID]).
+						SetKeepOrder(e.keepOrder).
+						SetTxnScope(e.txnScope).
+						SetReadReplicaScope(e.readReplicaScope).
+						SetIsStaleness(e.isStaleness).
+						SetFromSessionVars(e.Ctx().GetSessionVars()).
+						SetMemTracker(e.memTracker).
+						SetPaging(e.paging).
+						SetFromInfoSchema(e.Ctx().GetInfoSchema()).
+						SetClosestReplicaReadAdjuster(newClosestReadAdjuster(e.Ctx(), &builder.Request, e.partialNetDataSizes[workID])).
+						SetConnID(e.Ctx().GetSessionVars().ConnectionID).
+						SetKilled(&e.Ctx().GetSessionVars().Killed)
 
 					// init kvReq and worker for this partition
 					// The key ranges should be ordered.

--- a/pkg/executor/test/distsqltest/distsql_test.go
+++ b/pkg/executor/test/distsqltest/distsql_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
@@ -73,5 +74,72 @@ func TestDistsqlPartitionTableConcurrency(t *testing.T) {
 		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s limit 5", tbl))
 		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s limit 1", tbl))
 		tk.MustQueryWithContext(ctx, fmt.Sprintf("select * from %s limit 5", tbl))
+	}
+}
+
+func TestDistSQLSharedKVRequestRace(t *testing.T) {
+	// Test for issue https://github.com/pingcap/tidb/issues/60175
+	store := testkit.CreateMockStore(t)
+	originCfg := config.GetGlobalConfig()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Labels = map[string]string{
+			"zone": "us-east-1a",
+		}
+	})
+	require.Equal(t, "us-east-1a", config.GetGlobalConfig().GetTiKVConfig().TxnScope)
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		*conf = *originCfg
+	})
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set session tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("set session tidb_enable_index_merge = ON")
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec(`create table t (
+			a int,
+			b int,
+			c int,
+			d int,
+			primary key (a, d),
+			index ib(b),
+			index ic(c)
+		)
+		partition by range(d) (
+			partition p1 values less than(1),
+			partition p2 values less than(2),
+			partition p3 values less than(3),
+			partition p4 values less than (4)
+		)`)
+	tk.MustExec("begin")
+	for i := 0; i < 1000; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d, %d, %d);", i*1000, i*1000, i*1000, i%4))
+	}
+	tk.MustExec("commit")
+
+	expects := make([]string, 0, 500)
+	for i := 0; i < 1000; i++ {
+		expect := fmt.Sprintf("%d %d %d %d", i*1000, i*1000, i*1000, i%4)
+		expects = append(expects, expect)
+		if len(expects) == 500 {
+			break
+		}
+	}
+
+	replicaReadModes := []string{
+		"leader",
+		"follower",
+		"leader-and-follower",
+		"closest-adaptive",
+		"closest-replicas",
+	}
+	for _, mode := range replicaReadModes {
+		tk.MustExec(fmt.Sprintf("set session tidb_replica_read = '%s'", mode))
+		for i := 0; i < 20; i++ {
+			// index lookup
+			tk.MustQuery("select * from t force index(ic) order by c asc limit 500").Check(testkit.Rows(expects...))
+			// index merge
+			tk.MustQuery("select * from t where b >= 0 or c >= 0 order by c asc limit 500").Check(testkit.Rows(expects...))
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #61376 to v7.5.6.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60175

Problem Summary:

### What changed and how does it work?

The different coprocessor iterator should run on different KV requests, the share usage can cause data race.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
