### PR TITLE
testkit: make ut works in nextgen after introduce SYSTEM ks

### DIFF
--- a/pkg/disttask/importinto/job_testkit_test.go
+++ b/pkg/disttask/importinto/job_testkit_test.go
@@ -46,7 +46,7 @@ func TestSubmitTaskNextgen(t *testing.T) {
 	}
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/domain/MockDisableDistTask", "return(true)")
 	require.NoError(t, kvstore.Register(config.StoreTypeUniStore, mockstore.EmbedUnistoreDriver{}))
-	sysKSStore, _ := testkit.CreateNextgenMockStoreAndDomain(t, keyspace.System)
+	sysKSStore, _ := testkit.CreateMockStoreAndDomainForKS(t, keyspace.System)
 	sysKSTK := testkit.NewTestKit(t, sysKSStore)
 	// in uni-store, Store instances are completely isolated, even they have the
 	// same keyspace name, so we store them here and mock the GetStore
@@ -60,7 +60,7 @@ func TestSubmitTaskNextgen(t *testing.T) {
 			}
 		},
 	)
-	userKSStore, _ := testkit.CreateNextgenMockStoreAndDomain(t, "ks")
+	userKSStore, _ := testkit.CreateMockStoreAndDomainForKS(t, "ks")
 	storeMap["ks"] = userKSStore
 	userKSTK := testkit.NewTestKit(t, userKSStore)
 

--- a/pkg/domain/crossks/cross_ks_test.go
+++ b/pkg/domain/crossks/cross_ks_test.go
@@ -49,7 +49,7 @@ func TestManager(t *testing.T) {
 		t.Skip("cross keyspace is not supported in classic kernel")
 	}
 	require.NoError(t, kvstore.Register(config.StoreTypeUniStore, mockstore.EmbedUnistoreDriver{}))
-	sysKSStore, sysKSDom := testkit.CreateNextgenMockStoreAndDomain(t, keyspace.System)
+	sysKSStore, sysKSDom := testkit.CreateMockStoreAndDomainForKS(t, keyspace.System)
 
 	t.Run("same keyspace access", func(t *testing.T) {
 		_, err := sysKSDom.GetKSSessPool(keyspace.System)
@@ -83,7 +83,7 @@ func TestManager(t *testing.T) {
 		)
 
 		for _, ks := range []string{"ks1", "ks2", "ks3"} {
-			userKSStore, _ := testkit.CreateNextgenMockStoreAndDomain(t, ks)
+			userKSStore, _ := testkit.CreateMockStoreAndDomainForKS(t, ks)
 			storeMap[ks] = userKSStore
 
 			// must switch back to SYSTEM keyspace before creating a cross keyspace session


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
```
	// in nextgen, SYSTEM ks must be bootstrapped first, to make UT easier, we
	// always run them inside SYSTEM keyspace, if your test requires bootstrapping
	// multiple keyspace, you should use CreateMockStoreAndDomainForKS instead.
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

choose random test that uses `CreateMockStoreAndDomain` and `CreateMockStoreWithSchemaLease`, and run with `nextgen` tags, all success

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
