### PR TITLE
localbackend: release the service safe point on finish checksum

### DIFF
--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -1375,6 +1375,7 @@ func (rc *Controller) importTables(ctx context.Context) (finalErr error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		defer manager.Close()
 		ctx = context.WithValue(ctx, &checksumManagerKey, manager)
 
 		undo, err := rc.registerTaskToPD(ctx)

--- a/lightning/pkg/importer/meta_manager_test.go
+++ b/lightning/pkg/importer/meta_manager_test.go
@@ -442,10 +442,14 @@ type testChecksumMgr struct {
 	callCnt  int
 }
 
+var _ local.ChecksumManager = (*testChecksumMgr)(nil)
+
 func (t *testChecksumMgr) Checksum(ctx context.Context, tableInfo *checkpoints.TidbTableInfo) (*local.RemoteChecksum, error) {
 	t.callCnt++
 	return &t.checksum, nil
 }
+
+func (*testChecksumMgr) Close() {}
 
 func TestSingleTaskMetaMgr(t *testing.T) {
 	metaBuilder := singleMgrBuilder{

--- a/pkg/disttask/importinto/subtask_executor.go
+++ b/pkg/disttask/importinto/subtask_executor.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
 	"github.com/pingcap/tidb/pkg/executor/importer"
@@ -124,9 +123,6 @@ func postProcess(ctx context.Context, store kv.Storage, taskMeta *TaskMeta, subt
 	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
 	if err != nil {
 		return err
-	}
-	if kerneltype.IsNextGen() {
-
 	}
 	return taskManager.WithNewSession(func(se sessionctx.Context) error {
 		return importer.VerifyChecksum(ctx, &taskMeta.Plan, localChecksum.MergedChecksum(), se, logger)

--- a/pkg/disttask/importinto/subtask_executor.go
+++ b/pkg/disttask/importinto/subtask_executor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/storage"
 	"github.com/pingcap/tidb/pkg/executor/importer"
@@ -123,6 +124,9 @@ func postProcess(ctx context.Context, store kv.Storage, taskMeta *TaskMeta, subt
 	ctx = util.WithInternalSourceType(ctx, kv.InternalDistTask)
 	if err != nil {
 		return err
+	}
+	if kerneltype.IsNextGen() {
+
 	}
 	return taskManager.WithNewSession(func(se sessionctx.Context) error {
 		return importer.VerifyChecksum(ctx, &taskMeta.Plan, localChecksum.MergedChecksum(), se, logger)

--- a/pkg/lightning/backend/local/checksum.go
+++ b/pkg/lightning/backend/local/checksum.go
@@ -529,7 +529,7 @@ func (m *gcTTLManager) start(ctx context.Context) {
 				// we will use the last safe point, as after all job removed, we
 				// will set currentTS to 0.
 				if err := m.doUpdateGCTTL(ctx, 0, m.lastSP.Load()); err != nil {
-					log.FromContext(ctx).Warn("failed to update service safe point, checksum may fail if gc triggered", zap.Error(err))
+					log.FromContext(ctx).Warn("failed to remove service safe point", zap.Error(err))
 				}
 				return
 			}

--- a/pkg/lightning/backend/local/checksum.go
+++ b/pkg/lightning/backend/local/checksum.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/metric"
 	"github.com/pingcap/tidb/pkg/lightning/verification"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
+	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tipb/go-tipb"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/oracle"
@@ -46,6 +47,7 @@ const (
 	preUpdateServiceSafePointFactor = 3
 	maxErrorRetryCount              = 3
 	defaultGCLifeTime               = 100 * time.Hour
+	lightningServicePrefix          = "lightning"
 )
 
 var (
@@ -84,6 +86,7 @@ func (rc *RemoteChecksum) IsEqual(other *verification.KVChecksum) bool {
 // ChecksumManager is a manager that manages checksums.
 type ChecksumManager interface {
 	Checksum(ctx context.Context, tableInfo *checkpoints.TidbTableInfo) (*RemoteChecksum, error)
+	Close()
 }
 
 // fetch checksum for tidb sql client
@@ -159,6 +162,8 @@ func (e *tidbChecksumExecutor) Checksum(ctx context.Context, tableInfo *checkpoi
 	}
 	return &cs, nil
 }
+
+func (*tidbChecksumExecutor) Close() {}
 
 type gcLifeTimeManager struct {
 	runningJobsLock sync.Mutex
@@ -286,7 +291,20 @@ var _ ChecksumManager = &TiKVChecksumManager{}
 func NewTiKVChecksumManager(client kv.Client, pdClient pd.Client, distSQLScanConcurrency uint, backoffWeight int, resourceGroupName, explicitRequestSourceType string) *TiKVChecksumManager {
 	return &TiKVChecksumManager{
 		client:                    client,
-		manager:                   newGCTTLManager(pdClient),
+		manager:                   newGCTTLManager(pdClient, lightningServicePrefix),
+		distSQLScanConcurrency:    distSQLScanConcurrency,
+		backoffWeight:             backoffWeight,
+		resourceGroupName:         resourceGroupName,
+		explicitRequestSourceType: explicitRequestSourceType,
+	}
+}
+
+// NewTiKVChecksumManagerForImportInto return a new tikv checksum manager used
+// by import-into.
+func NewTiKVChecksumManagerForImportInto(store kv.Storage, distSQLScanConcurrency uint, backoffWeight int, resourceGroupName, explicitRequestSourceType string) *TiKVChecksumManager {
+	return &TiKVChecksumManager{
+		client:                    store.GetClient(),
+		manager:                   newGCTTLManager(store.(kv.StorageWithPD).GetPDClient(), "import-into"),
 		distSQLScanConcurrency:    distSQLScanConcurrency,
 		backoffWeight:             backoffWeight,
 		resourceGroupName:         resourceGroupName,
@@ -376,6 +394,14 @@ func (e *TiKVChecksumManager) Checksum(ctx context.Context, tableInfo *checkpoin
 	return e.checksumDB(ctx, tableInfo, ts)
 }
 
+// Close closes the TiKVChecksumManager and releases resources.
+// This function cannot be called concurrently with Checksum.
+// Note: this manager doesn't manage the lifecycle of inner client fields, it only
+// closes the gcTTLManager.
+func (e *TiKVChecksumManager) Close() {
+	e.manager.close()
+}
+
 type tableChecksumTS struct {
 	table    string
 	gcSafeTS uint64
@@ -414,12 +440,16 @@ type gcTTLManager struct {
 	serviceID     string
 	// 0 for not start, otherwise started
 	started atomic.Bool
+	lastSP  atomic.Uint64
+	closeCh chan struct{}
+	wg      util.WaitGroupWrapper
 }
 
-func newGCTTLManager(pdClient pd.Client) gcTTLManager {
+func newGCTTLManager(pdClient pd.Client, prefix string) gcTTLManager {
 	return gcTTLManager{
 		pdClient:  pdClient,
-		serviceID: fmt.Sprintf("lightning-%s", uuid.New()),
+		serviceID: fmt.Sprintf("%s-%s", prefix, uuid.New()),
+		closeCh:   make(chan struct{}),
 	}
 }
 
@@ -438,7 +468,7 @@ func (m *gcTTLManager) addOneJob(ctx context.Context, table string, ts uint64) e
 	heap.Fix(m, len(m.tableGCSafeTS)-1)
 	m.currentTS = m.tableGCSafeTS[0].gcSafeTS
 	if curTS == 0 || m.currentTS < curTS {
-		return m.doUpdateGCTTL(ctx, m.currentTS)
+		return m.doUpdateGCTTL(ctx, serviceSafePointTTL, m.currentTS)
 	}
 	return nil
 }
@@ -470,20 +500,13 @@ func (m *gcTTLManager) removeOneJob(table string) {
 	m.currentTS = newTS
 }
 
-func (m *gcTTLManager) updateGCTTL(ctx context.Context) error {
-	m.lock.Lock()
-	currentTS := m.currentTS
-	m.lock.Unlock()
-	return m.doUpdateGCTTL(ctx, currentTS)
-}
-
-func (m *gcTTLManager) doUpdateGCTTL(ctx context.Context, ts uint64) error {
+func (m *gcTTLManager) doUpdateGCTTL(ctx context.Context, ttl int64, ts uint64) error {
 	log.FromContext(ctx).Debug("update PD safePoint limit with TTL",
 		zap.Uint64("currnet_ts", ts))
 	var err error
 	if ts > 0 {
-		_, err = m.pdClient.UpdateServiceGCSafePoint(ctx,
-			m.serviceID, serviceSafePointTTL, ts)
+		m.lastSP.Store(ts)
+		_, err = m.pdClient.UpdateServiceGCSafePoint(ctx, m.serviceID, ttl, ts)
 	}
 	return err
 }
@@ -494,15 +517,18 @@ func (m *gcTTLManager) start(ctx context.Context) {
 
 	updateTick := time.NewTicker(updateGapTime)
 
-	updateGCTTL := func() {
-		if err := m.updateGCTTL(ctx); err != nil {
+	updateGCTTL := func(ttl int64) {
+		m.lock.Lock()
+		currentTS := m.currentTS
+		m.lock.Unlock()
+		if err := m.doUpdateGCTTL(ctx, ttl, currentTS); err != nil {
 			log.FromContext(ctx).Warn("failed to update service safe point, checksum may fail if gc triggered", zap.Error(err))
 		}
 	}
 
 	// trigger a service gc ttl at start
-	updateGCTTL()
-	go func() {
+	updateGCTTL(serviceSafePointTTL)
+	m.wg.RunWithLog(func() {
 		defer updateTick.Stop()
 		for {
 			select {
@@ -510,8 +536,23 @@ func (m *gcTTLManager) start(ctx context.Context) {
 				log.FromContext(ctx).Info("service safe point keeper exited")
 				return
 			case <-updateTick.C:
-				updateGCTTL()
+				updateGCTTL(serviceSafePointTTL)
+			case <-m.closeCh:
+				// when ttl=0, PD will remove the service safe point.
+				// we will use the last safe point, as after all job removed, we
+				// will set currentTS to 0.
+				if err := m.doUpdateGCTTL(ctx, 0, m.lastSP.Load()); err != nil {
+					log.FromContext(ctx).Warn("failed to update service safe point, checksum may fail if gc triggered", zap.Error(err))
+				}
+				return
 			}
 		}
-	}()
+	})
+}
+
+func (m *gcTTLManager) close() {
+	if m.started.CompareAndSwap(true, false) {
+		close(m.closeCh)
+		m.wg.Wait()
+	}
 }

--- a/pkg/lightning/backend/local/checksum.go
+++ b/pkg/lightning/backend/local/checksum.go
@@ -278,7 +278,7 @@ func updateGCLifeTime(ctx context.Context, db *sql.DB, gcLifeTime string) error 
 // TiKVChecksumManager is a manager that can compute checksum of a table using TiKV.
 type TiKVChecksumManager struct {
 	client                    kv.Client
-	manager                   gcTTLManager
+	manager                   *gcTTLManager
 	distSQLScanConcurrency    uint
 	backoffWeight             int
 	resourceGroupName         string
@@ -432,8 +432,8 @@ type gcTTLManager struct {
 	wg      util.WaitGroupWrapper
 }
 
-func newGCTTLManager(pdClient pd.Client, prefix string) gcTTLManager {
-	return gcTTLManager{
+func newGCTTLManager(pdClient pd.Client, prefix string) *gcTTLManager {
+	return &gcTTLManager{
 		pdClient:  pdClient,
 		serviceID: fmt.Sprintf("%s-%s", prefix, uuid.New()),
 		closeCh:   make(chan struct{}),

--- a/pkg/lightning/backend/local/checksum.go
+++ b/pkg/lightning/backend/local/checksum.go
@@ -299,19 +299,6 @@ func NewTiKVChecksumManager(client kv.Client, pdClient pd.Client, distSQLScanCon
 	}
 }
 
-// NewTiKVChecksumManagerForImportInto return a new tikv checksum manager used
-// by import-into.
-func NewTiKVChecksumManagerForImportInto(store kv.Storage, distSQLScanConcurrency uint, backoffWeight int, resourceGroupName, explicitRequestSourceType string) *TiKVChecksumManager {
-	return &TiKVChecksumManager{
-		client:                    store.GetClient(),
-		manager:                   newGCTTLManager(store.(kv.StorageWithPD).GetPDClient(), "import-into"),
-		distSQLScanConcurrency:    distSQLScanConcurrency,
-		backoffWeight:             backoffWeight,
-		resourceGroupName:         resourceGroupName,
-		explicitRequestSourceType: explicitRequestSourceType,
-	}
-}
-
 func (e *TiKVChecksumManager) checksumDB(ctx context.Context, tableInfo *checkpoints.TidbTableInfo, ts uint64) (*RemoteChecksum, error) {
 	executor, err := checksum.NewExecutorBuilder(tableInfo.Core, ts).
 		SetConcurrency(e.distSQLScanConcurrency).

--- a/pkg/lightning/backend/local/checksum_test.go
+++ b/pkg/lightning/backend/local/checksum_test.go
@@ -17,6 +17,7 @@ package local
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -194,12 +195,13 @@ func TestDoChecksumWithTikv(t *testing.T) {
 		kvClient.onSendReq = func(req *kv.Request) {
 			checksumTS = req.StartTs
 		}
-		checksumExec := &TiKVChecksumManager{manager: newGCTTLManager(pdClient), client: kvClient}
+		checksumExec := &TiKVChecksumManager{manager: newGCTTLManager(pdClient, lightningServicePrefix), client: kvClient}
 		physicalTS, logicalTS, err := pdClient.GetTS(ctx)
 		require.NoError(t, err)
 		_, err = checksumExec.Checksum(ctx, &TidbTableInfo{DB: "test", Name: "t", Core: tableInfo})
 		// with max error retry < maxErrorRetryCount, the checksum can success
 		if i >= maxErrorRetryCount {
+			checksumExec.Close()
 			continue
 		}
 		require.NoError(t, err)
@@ -213,6 +215,8 @@ func TestDoChecksumWithTikv(t *testing.T) {
 		require.True(t, checksumExec.manager.started.Load())
 		require.Zero(t, checksumExec.manager.currentTS)
 		require.Equal(t, 0, len(checksumExec.manager.tableGCSafeTS))
+		checksumExec.Close()
+		require.False(t, checksumExec.manager.started.Load())
 	}
 
 	// test PD leader change error
@@ -223,9 +227,13 @@ func TestDoChecksumWithTikv(t *testing.T) {
 	})
 	pdClient.leaderChanging = true
 	kvClient.maxErrCount = 0
-	checksumExec := &TiKVChecksumManager{manager: newGCTTLManager(pdClient), client: kvClient}
+	ttlManager := newGCTTLManager(pdClient, lightningServicePrefix)
+	checksumExec := &TiKVChecksumManager{manager: ttlManager, client: kvClient}
 	_, err := checksumExec.Checksum(ctx, &TidbTableInfo{DB: "test", Name: "t", Core: tableInfo})
 	require.NoError(t, err)
+	require.True(t, pdClient.isServiceGCSafePointExist(ttlManager.serviceID))
+	checksumExec.Close()
+	require.False(t, pdClient.isServiceGCSafePointExist(ttlManager.serviceID))
 }
 
 func TestDoChecksumWithErrorAndLongOriginalLifetime(t *testing.T) {
@@ -290,6 +298,7 @@ func TestSetGCLifetime(t *testing.T) {
 }
 
 type safePointTTL struct {
+	serviceID string
 	safePoint uint64
 	expiredAt int64
 }
@@ -329,13 +338,36 @@ func (c *testPDClient) UpdateServiceGCSafePoint(ctx context.Context, serviceID s
 		panic("service ID must start with 'lightning'")
 	}
 	c.count.Add(1)
+	c.doUpdateServiceGCSafePoint(ctx, serviceID, ttl, safePoint)
+	return c.currentSafePoint(), nil
+}
+
+func (c *testPDClient) doUpdateServiceGCSafePoint(ctx context.Context, serviceID string, ttl int64, safePoint uint64) {
 	c.Lock()
+	defer c.Unlock()
+	// see https://github.com/tikv/pd/blob/29ead019cd0982a3120bc79d4a4d19199dab2279/server/grpc_service.go#L2280-L2284
+	if ttl <= 0 {
+		newS := make([]safePointTTL, 0, len(c.gcSafePoint))
+		for _, p := range c.gcSafePoint {
+			if p.serviceID == serviceID {
+				continue
+			}
+			newS = append(newS, p)
+		}
+		c.gcSafePoint = newS
+		return
+	}
+	// below code doesn't consider serviceID, but it's test, doesn't matter.
 	idx := sort.Search(len(c.gcSafePoint), func(i int) bool {
 		return c.gcSafePoint[i].safePoint >= safePoint
 	})
 	sp := c.gcSafePoint
 	ttlEnd := time.Now().Unix() + ttl
-	spTTL := safePointTTL{safePoint: safePoint, expiredAt: ttlEnd}
+	spTTL := safePointTTL{
+		serviceID: serviceID,
+		safePoint: safePoint,
+		expiredAt: ttlEnd,
+	}
 	switch {
 	case idx >= len(sp):
 		c.gcSafePoint = append(c.gcSafePoint, spTTL)
@@ -346,13 +378,19 @@ func (c *testPDClient) UpdateServiceGCSafePoint(ctx context.Context, serviceID s
 	default:
 		c.gcSafePoint = append(append(sp[:idx], spTTL), sp[idx:]...)
 	}
-	c.Unlock()
-	return c.currentSafePoint(), nil
+}
+
+func (c *testPDClient) isServiceGCSafePointExist(serviceID string) bool {
+	c.Lock()
+	defer c.Unlock()
+	return slices.ContainsFunc(c.gcSafePoint, func(s safePointTTL) bool {
+		return s.serviceID == serviceID
+	})
 }
 
 func TestGcTTLManagerSingle(t *testing.T) {
 	pdClient := &testPDClient{}
-	manager := newGCTTLManager(pdClient)
+	manager := newGCTTLManager(pdClient, lightningServicePrefix)
 	require.NotEqual(t, "", manager.serviceID)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -374,15 +412,14 @@ func TestGcTTLManagerSingle(t *testing.T) {
 
 	// after remove the job, there are no job remain, gc ttl needn't to be updated
 	manager.removeOneJob("test")
-	cancel()
-	time.Sleep(10 * time.Millisecond)
-	val = pdClient.count.Load()
-	time.Sleep(1*time.Second + 10*time.Millisecond)
-	require.Equal(t, val, pdClient.count.Load())
+	require.True(t, pdClient.isServiceGCSafePointExist(manager.serviceID))
+	manager.close()
+	require.False(t, pdClient.isServiceGCSafePointExist(manager.serviceID))
 }
 
 func TestGcTTLManagerMulti(t *testing.T) {
-	manager := newGCTTLManager(&testPDClient{})
+	pdClient := &testPDClient{}
+	manager := newGCTTLManager(pdClient, lightningServicePrefix)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -406,16 +443,16 @@ func TestGcTTLManagerMulti(t *testing.T) {
 
 	manager.removeOneJob("test5")
 	require.Equal(t, uint64(0), manager.currentTS)
-	cancel()
-	// GCTTLManager don't wait its goroutine to exit, so we need to wait awhile.
-	time.Sleep(time.Second)
+	require.True(t, pdClient.isServiceGCSafePointExist(manager.serviceID))
+	manager.close()
+	require.False(t, pdClient.isServiceGCSafePointExist(manager.serviceID))
 }
 
 func TestPdServiceID(t *testing.T) {
 	pdCli := &testPDClient{}
-	gcTTLManager1 := newGCTTLManager(pdCli)
+	gcTTLManager1 := newGCTTLManager(pdCli, lightningServicePrefix)
 	require.Regexp(t, "lightning-.*", gcTTLManager1.serviceID)
-	gcTTLManager2 := newGCTTLManager(pdCli)
+	gcTTLManager2 := newGCTTLManager(pdCli, lightningServicePrefix)
 	require.Regexp(t, "lightning-.*", gcTTLManager2.serviceID)
 
 	require.True(t, gcTTLManager1.serviceID != gcTTLManager2.serviceID)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702, close #62142

Problem Summary:

### What changed and how does it work?
send a request with TTL=0 to remove it, see https://github.com/tikv/pd/blob/29ead019cd0982a3120bc79d4a4d19199dab2279/server/grpc_service.go#L2280-L2284 too
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

with master, we can see the service safe point still exist after lightning exist, it will expire after 10m
```
➜  lightning /Users/user/code/pingcap/tidb/bin/tidb-lightning-master --config test.toml
Verbose debug logs will be written to lightning.log

tidb lightning exit successfully
➜  lightning etcdctl --endpoints localhost:2379 get --prefix ""|grep -a lightning
/pd/7522392937985088901/gc/safe_point/service/lightning-c8a20fff-07bd-4744-bfa5-a12e529847c5
{"service_id":"lightning-c8a20fff-07bd-4744-bfa5-a12e529847c5","expired_at":1751444458,"safe_point":459130498717057084}
```

with this PR, it's removed after exist
```
➜  lightning /Users/user/code/pingcap/tidb/bin/tidb-lightning -V
Release Version: v9.0.0-beta.2.pre-22-ga116ca4c78
Git Commit Hash: a116ca4c789a3c751fdee29bebada13594668312
Git Branch: imp-checksum-task-ks
Go Version: go1.23.10
UTC Build Time: 2025-07-02 08:16:00
Race Enabled: false
➜  lightning /Users/user/code/pingcap/tidb/bin/tidb-lightning --config test.toml
Verbose debug logs will be written to lightning.log

tidb lightning exit successfully
➜  lightning etcdctl --endpoints localhost:2379 get --prefix ""|grep -a lightning
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
