### PR TITLE
executor: fix the inappropriate RequiredRows set by `TopNExec`

### DIFF
--- a/pkg/executor/sortexec/topn.go
+++ b/pkg/executor/sortexec/topn.go
@@ -285,8 +285,8 @@ func (e *TopNExec) loadChunksUntilTotalLimit(ctx context.Context) error {
 	e.chkHeap.init(e, e.memTracker, e.Limit.Offset+e.Limit.Count, int(e.Limit.Offset), e.greaterRow, e.RetFieldTypes())
 	for uint64(e.chkHeap.rowChunks.Len()) < e.chkHeap.totalLimit {
 		srcChk := exec.TryNewCacheChunk(e.Children(0))
-		// adjust required rows by total limit
-		srcChk.SetRequiredRows(int(e.chkHeap.totalLimit-uint64(e.chkHeap.rowChunks.Len())), e.MaxChunkSize())
+		// TopN requires its child to return all data, so don't need to set RequiredRows here according to the limit.
+		// See #62135 for more info.
 		err := exec.Next(ctx, e.Children(0), srcChk)
 		if err != nil {
 			return err

--- a/pkg/executor/sortexec/topn.go
+++ b/pkg/executor/sortexec/topn.go
@@ -286,7 +286,8 @@ func (e *TopNExec) loadChunksUntilTotalLimit(ctx context.Context) error {
 	for uint64(e.chkHeap.rowChunks.Len()) < e.chkHeap.totalLimit {
 		srcChk := exec.TryNewCacheChunk(e.Children(0))
 		// TopN requires its child to return all data, so don't need to set RequiredRows here according to the limit.
-		// See #62135 for more info.
+		// Instead, setting RequiredRows here might lead smaller BatchSize in its child operator and cause more
+		// requests to TiKV. Please see #62135 for more info.
 		err := exec.Next(ctx, e.Children(0), srcChk)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62135

Problem Summary: executor: fix the inappropriate RequiredRows set by `TopNExec`

### What changed and how does it work?

When first reading the child data, `TopN` sets the `RequiredRows` to its limit number, which is unnecessary, since `TopN` requires its child to return all data. 
Instead setting `RequiredRows` to the limit number might lead to smaller `BatchSize` in the child operator and causes more cop-tasks in some cases.

Please see a concrete case in #62135.

It's hard to check the `Chunk.RequiredRows` during execution phase, and this is just a one-line fix, so it's unnecessary to write tens of lines for testing this PR. I didn't add UT for it, instead I tested it locally, below is the test results:

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/7151c726-31bc-4e79-969c-cbd60facbfcb" />


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
