### PR TITLE
codec: should also return the value even with error because the error may be ignored in the future

### DIFF
--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -1517,7 +1517,7 @@ func HashGroupKey(loc *time.Location, n int, col *chunk.Column, buf [][]byte, ft
 				buf[i] = append(buf[i], decimalFlag)
 				buf[i], err = EncodeDecimal(buf[i], &ds[i], ft.GetFlen(), ft.GetDecimal())
 				if err != nil {
-					return nil, err
+					return buf, err
 				}
 			}
 		}
@@ -1530,7 +1530,7 @@ func HashGroupKey(loc *time.Location, n int, col *chunk.Column, buf [][]byte, ft
 				buf[i] = append(buf[i], uintFlag)
 				buf[i], err = EncodeMySQLTime(loc, ts[i], mysql.TypeUnspecified, buf[i])
 				if err != nil {
-					return nil, err
+					return buf, err
 				}
 			}
 		}

--- a/pkg/util/codec/codec_test.go
+++ b/pkg/util/codec/codec_test.go
@@ -984,14 +984,16 @@ func TestHashGroup(t *testing.T) {
 	tp1 := tp
 	tp1.SetFlen(20)
 	tp1.SetDecimal(5)
-	_, err := HashGroupKey(time.Local, 3, chk1.Column(0), buf1, tp1)
+	buf, err := HashGroupKey(time.Local, 3, chk1.Column(0), buf1, tp1)
 	require.Error(t, err)
+	require.Len(t, buf, 3)
 
 	tp2 := tp
 	tp2.SetFlen(12)
 	tp2.SetDecimal(10)
-	_, err = HashGroupKey(time.Local, 3, chk1.Column(0), buf1, tp2)
+	buf, err = HashGroupKey(time.Local, 3, chk1.Column(0), buf1, tp2)
 	require.Error(t, err)
+	require.Len(t, buf, 3)
 }
 
 func datumsForTest() ([]types.Datum, []*types.FieldType) {

--- a/tests/integrationtest/r/executor/aggregate.result
+++ b/tests/integrationtest/r/executor/aggregate.result
@@ -2059,3 +2059,8 @@ Projection	1.00	root		Column#9, Column#12, Column#15, Column#18
             └─TableFullScan	1000.00	cop[tikv]	table:test	keep order:false, stats:pseudo
 delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
+select distinct avg(nullif(77.15, PI()));
+avg(nullif(77.15, PI()))
+77.1500000000000000000000000000000000
+Level	Code	Message
+Warning	1265	Data truncated for column '%s' at row %d

--- a/tests/integrationtest/t/executor/aggregate.test
+++ b/tests/integrationtest/t/executor/aggregate.test
@@ -1070,3 +1070,7 @@ explain format = 'brief' select /*+ hash_agg() */ sum(a), (select NULL from test
 delete from mysql.opt_rule_blacklist where name = "decorrelate";
 admin reload opt_rule_blacklist;
 
+# TestIssue61735AggregateTruncatedDecimal
+--enable_warnings
+select distinct avg(nullif(77.15, PI()));
+--disable_warnings


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61735 

Problem Summary:

The `HashGroupKey` didn't return a valid `buf` with the error. Therefore, if the error is ignored (or regarded as a warning), the `buf` cannot be accessed. Ref https://github.com/pingcap/tidb/pull/48613/files#diff-6215f2010e82b5ba1c5dd0158b1026512071abe70470ba50eb3055d37b8f5eeeL1262-L1271. Previously, `HashGroupKey` handle the error inside the function, so it'll not have this issue. PR #48613 refactored it to handling the error outside, which cause this issue.

### What changed and how does it work?

Return a valid buf with the error in `HashGroupKey`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
