### PR TITLE
fix(ddl): invalid InvolvingSchemaInfo for AlterTableMode and RefreshM…

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -5776,8 +5776,8 @@ func (e *executor) AlterTableMode(sctx sessionctx.Context, args *model.AlterTabl
 		SQLMode:        sctx.GetSessionVars().SQLMode,
 		InvolvingSchemaInfo: []model.InvolvingSchemaInfo{
 			{
-				Database: schema.Name.O,
-				Table:    table.Meta().Name.O,
+				Database: schema.Name.L,
+				Table:    table.Meta().Name.L,
 			},
 		},
 	}


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62200 

Problem Summary:
An assertion failure occurs in the job scheduler due to uninitialized `InvolvingSchemaInfo` fields in DDL jobs of types `RefreshMeta` and `AlterTableMode`. This causes a panic and crash during job scheduling.

### What changed and how does it work?
Explicitly initialize `InvolvingSchemaInfo` fields (such as Database, Table, Policy, Mode) in the DDL job structs within the `RefreshMeta` and `AlterTableMode` executor functions. This ensures the job scheduler sees valid metadata and prevents the assertion failure and panic.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
