### PR TITLE
memoryusagealarm: optimize recording goroutine profile in oom record

### DIFF
--- a/pkg/util/memoryusagealarm/BUILD.bazel
+++ b/pkg/util/memoryusagealarm/BUILD.bazel
@@ -31,5 +31,6 @@ go_test(
         "//pkg/util",
         "//pkg/util/memory",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/memoryusagealarm/memoryusagealarm.go
+++ b/pkg/util/memoryusagealarm/memoryusagealarm.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	rpprof "runtime/pprof"
 	"slices"
 	"strings"
@@ -401,14 +402,40 @@ type item struct {
 func (*memoryUsageAlarm) recordProfile(recordDir string) error {
 	items := []item{
 		{Name: "heap"},
-		{Name: "goroutine", Debug: 2},
+		// `goroutine` profile is not recorded, but they'll retry multiple times to extend the profile buffer size,
+		// which may cause long STW pauses. We'll use `recordGoroutineProfile` instead to allocate a large buffer
+		// at the beginning.
+		// {Name: "goroutine", Debug: 2},
 	}
 	for _, item := range items {
 		if err := write(item, recordDir); err != nil {
 			return err
 		}
 	}
-	return nil
+
+	return recordGoroutineProfile(recordDir)
+}
+
+func recordGoroutineProfile(recordDir string) error {
+	itemName := "goroutine"
+	fileName := filepath.Join(recordDir, itemName)
+	f, err := os.Create(fileName)
+	if err != nil {
+		logutil.BgLogger().Error(fmt.Sprintf("create %v profile file fail", itemName), zap.Error(err))
+		return err
+	}
+
+	buf := make([]byte, 1<<26) // 64MB buffer
+	n := runtime.Stack(buf, true)
+	if n >= len(buf) {
+		logutil.BgLogger().Warn("goroutine stack trace is too large, truncating", zap.Int("size", n))
+	}
+
+	_, err = f.Write(buf[:n])
+	if err != nil {
+		logutil.BgLogger().Error(fmt.Sprintf("write %v profile file fail", itemName), zap.Error(err))
+	}
+	return err
 }
 
 func write(item item, recordDir string) error {

--- a/pkg/util/memoryusagealarm/memoryusagealarm_test.go
+++ b/pkg/util/memoryusagealarm/memoryusagealarm_test.go
@@ -16,6 +16,7 @@ package memoryusagealarm
 
 import (
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockConfigProvider implements ConfigProvider for testing
@@ -178,4 +180,61 @@ func TestUpdateVariables(t *testing.T) {
 	assert.Equal(t, 0.6, record.configProvider.GetMemoryUsageAlarmRatio())
 	assert.Equal(t, int64(6), record.configProvider.GetMemoryUsageAlarmKeepRecordNum())
 	assert.Equal(t, uint64(2048), record.serverMemoryLimit)
+}
+
+func TestRecordGoroutineProfileWithBackgroundGoroutine(t *testing.T) {
+	recordDir := t.TempDir()
+	profileFile := recordDir + "/goroutine"
+	err := recordGoroutineProfile(recordDir)
+	require.NoError(t, err)
+
+	// Validate the profile file content
+	content, err := os.ReadFile(profileFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+	// Check if the content contains goroutine stack traces
+	require.Contains(t, string(content), "goroutine ")
+	require.Contains(t, string(content), "created by")
+}
+
+func benchmarkRecordGoroutineProfileWithBackgroundGoroutine(b *testing.B, goroutineCount int) {
+	b.StopTimer()
+
+	// Start many background goroutines
+	stopCh := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	for range goroutineCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			<-stopCh
+		}()
+	}
+
+	// Benchmark the recordGoroutineProfile function
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		err := recordGoroutineProfile(b.TempDir())
+		require.NoError(b, err)
+	}
+	b.StopTimer()
+}
+
+func BenchmarkRecordGoroutineProfile(b *testing.B) {
+	b.Run("WithBackgroundGoroutine/10", func(b *testing.B) {
+		benchmarkRecordGoroutineProfileWithBackgroundGoroutine(b, 10)
+	})
+
+	b.Run("WithBackgroundGoroutine/100", func(b *testing.B) {
+		benchmarkRecordGoroutineProfileWithBackgroundGoroutine(b, 100)
+	})
+
+	b.Run("WithBackgroundGoroutine/1000", func(b *testing.B) {
+		benchmarkRecordGoroutineProfileWithBackgroundGoroutine(b, 1000)
+	})
+
+	b.Run("WithBackgroundGoroutine/10000", func(b *testing.B) {
+		benchmarkRecordGoroutineProfileWithBackgroundGoroutine(b, 1000)
+	})
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62080

Problem Summary:

Previously, the go pprof library will try to extend the buffer multiple times and record the goroutine profile multiple times, which may cause long time STW 5 times. This PR allocates a big enough (I hope) buffer at first, and don't retry multiple times.

Ref 
![image](https://github.com/user-attachments/assets/7dcd01c9-04f5-4f78-94b7-10fffe3ee4d9)

### What changed and how does it work?

Manually implement the `recordGoroutineProfile`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
