### PR TITLE
planner: fetch and maintain tiflashable flag when preparing possible properties bottom-up.

### DIFF
--- a/pkg/planner/core/base/plan_base.go
+++ b/pkg/planner/core/base/plan_base.go
@@ -253,7 +253,7 @@ type LogicalPlan interface {
 
 	// PreparePossibleProperties is only used for join and aggregation. Like group by a,b,c, all permutation of (a,b,c) is
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.
-	PreparePossibleProperties(schema *expression.Schema, childrenProperties ...[][]*expression.Column) [][]*expression.Column
+	PreparePossibleProperties(schema *expression.Schema, childrenProperties ...*property.PossibleProp) *property.PossibleProp
 
 	// ExhaustPhysicalPlans generates all possible plans that can match the required property.
 	// It will return:

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"math"
 	"slices"
 
@@ -41,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	h "github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/ranger"

--- a/pkg/planner/core/operator/logicalop/base_logical_plan.go
+++ b/pkg/planner/core/operator/logicalop/base_logical_plan.go
@@ -269,7 +269,11 @@ func (*BaseLogicalPlan) ExtractColGroups(_ [][]*expression.Column) [][]*expressi
 }
 
 // PreparePossibleProperties implements LogicalPlan.<13th> interface.
-func (*BaseLogicalPlan) PreparePossibleProperties(_ *expression.Schema, childProps ...*property.PossibleProp) *property.PossibleProp {
+func (p *BaseLogicalPlan) PreparePossibleProperties(_ *expression.Schema, childProps ...*property.PossibleProp) *property.PossibleProp {
+	if len(p.children) == 0 {
+		// it's a leaf node, so we return an empty possible property.
+		return &property.PossibleProp{}
+	}
 	intest.Assert(len(childProps) > 0 && childProps[0] != nil)
 	return &property.PossibleProp{TiFlashable: childProps[0].TiFlashable} // return an empty possible property but with tiFlashable flag.
 }

--- a/pkg/planner/core/operator/logicalop/base_logical_plan.go
+++ b/pkg/planner/core/operator/logicalop/base_logical_plan.go
@@ -269,8 +269,9 @@ func (*BaseLogicalPlan) ExtractColGroups(_ [][]*expression.Column) [][]*expressi
 }
 
 // PreparePossibleProperties implements LogicalPlan.<13th> interface.
-func (*BaseLogicalPlan) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
-	return nil
+func (*BaseLogicalPlan) PreparePossibleProperties(_ *expression.Schema, childProps ...*property.PossibleProp) *property.PossibleProp {
+	intest.Assert(len(childProps) > 0 && childProps[0] != nil)
+	return &property.PossibleProp{TiFlashable: childProps[0].TiFlashable} // return an empty possible property but with tiFlashable flag.
 }
 
 // ExhaustPhysicalPlans implements LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/hash64_equals_generated.go
+++ b/pkg/planner/core/operator/logicalop/hash64_equals_generated.go
@@ -156,18 +156,6 @@ func (op *LogicalAggregation) Hash64(h base.Hasher) {
 			one.Hash64(h)
 		}
 	}
-	if op.PossibleProperties == nil {
-		h.HashByte(base.NilFlag)
-	} else {
-		h.HashByte(base.NotNilFlag)
-		h.HashInt(len(op.PossibleProperties))
-		for _, one := range op.PossibleProperties {
-			h.HashInt(len(one))
-			for _, onee := range one {
-				onee.Hash64(h)
-			}
-		}
-	}
 }
 
 // Equals implements the Hash64Equals interface, only receive *LogicalAggregation pointer.
@@ -199,19 +187,6 @@ func (op *LogicalAggregation) Equals(other any) bool {
 	for i, one := range op.GroupByItems {
 		if !one.Equals(op2.GroupByItems[i]) {
 			return false
-		}
-	}
-	if (op.PossibleProperties == nil && op2.PossibleProperties != nil) || (op.PossibleProperties != nil && op2.PossibleProperties == nil) || len(op.PossibleProperties) != len(op2.PossibleProperties) {
-		return false
-	}
-	for i, one := range op.PossibleProperties {
-		if (one == nil && op2.PossibleProperties[i] != nil) || (one != nil && op2.PossibleProperties[i] == nil) || len(one) != len(op2.PossibleProperties[i]) {
-			return false
-		}
-		for ii, onee := range one {
-			if !onee.Equals(op2.PossibleProperties[i][ii]) {
-				return false
-			}
 		}
 	}
 	return true

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -17,7 +17,6 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"slices"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -34,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace/logicaltrace"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
 	h "github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/intset"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 )

--- a/pkg/planner/core/operator/logicalop/logical_aggregation.go
+++ b/pkg/planner/core/operator/logicalop/logical_aggregation.go
@@ -17,6 +17,7 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"slices"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -48,8 +49,8 @@ type LogicalAggregation struct {
 	PreferAggType  uint
 	PreferAggToCop bool
 
-	PossibleProperties [][]*expression.Column `hash64-equals:"true" shallow-ref:"true"`
-	InputCount         float64                // InputCount is the input count of this plan.
+	PossibleProperties *property.PossibleProp
+	InputCount         float64 // InputCount is the input count of this plan.
 
 	// NoCopPushDown indicates if planner must not push this agg down to coprocessor.
 	// It is true when the agg is in the outer child tree of apply.
@@ -271,25 +272,34 @@ func (la *LogicalAggregation) ExtractColGroups(_ [][]*expression.Column) [][]*ex
 }
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (la *LogicalAggregation) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...[][]*expression.Column) [][]*expression.Column {
+func (la *LogicalAggregation) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...*property.PossibleProp) *property.PossibleProp {
+	intest.Assert(len(childrenProperties) > 0 && childrenProperties[0] != nil)
 	childProps := childrenProperties[0]
 	// If there's no group-by item, the stream aggregation could have no order property. So we can add an empty property
 	// when its group-by item is empty.
+	la.PossibleProperties = &property.PossibleProp{}
+	res := &property.PossibleProp{}
 	if len(la.GroupByItems) == 0 {
-		la.PossibleProperties = [][]*expression.Column{nil}
-		return nil
+		return res
 	}
-	resultProperties := make([][]*expression.Column, 0, len(childProps))
+
+	// prepare the order columns for the aggregation.
+	resultOrderCols := make([][]*expression.Column, 0, len(childProps.OrderCols))
 	groupByCols := la.GetGroupByCols()
-	for _, possibleChildProperty := range childProps {
+	for _, possibleChildProperty := range childProps.OrderCols {
 		sortColOffsets := util.GetMaxSortPrefix(possibleChildProperty, groupByCols)
 		if len(sortColOffsets) == len(groupByCols) {
 			prop := possibleChildProperty[:len(groupByCols)]
-			resultProperties = append(resultProperties, prop)
+			resultOrderCols = append(resultOrderCols, prop)
 		}
 	}
-	la.PossibleProperties = resultProperties
-	return resultProperties
+	la.PossibleProperties.OrderCols = resultOrderCols
+	la.PossibleProperties.TiFlashable = childProps.TiFlashable
+
+	// return the result properties.
+	res.OrderCols = resultOrderCols
+	res.TiFlashable = childProps.TiFlashable
+	return res
 }
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/logical_apply.go
+++ b/pkg/planner/core/operator/logicalop/logical_apply.go
@@ -175,6 +175,10 @@ func (la *LogicalApply) ExtractColGroups(colGroups [][]*expression.Column) [][]*
 }
 
 // PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+func (la *LogicalApply) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// apply can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
+}
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.
 func (la *LogicalApply) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {

--- a/pkg/planner/core/operator/logicalop/logical_index_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_index_scan.go
@@ -17,9 +17,9 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/kv"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	ruleutil "github.com/pingcap/tidb/pkg/planner/core/rule/util"

--- a/pkg/planner/core/operator/logicalop/logical_index_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_index_scan.go
@@ -17,6 +17,7 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/kv"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -130,16 +131,29 @@ func (is *LogicalIndexScan) DeriveStats(_ []*property.StatsInfo, selfSchema *exp
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (is *LogicalIndexScan) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
+func (is *LogicalIndexScan) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	res := &property.PossibleProp{}
 	if len(is.IdxCols) == 0 {
-		return nil
+		return res
+	}
+	// fetch the ds tiFlash path info.
+	hasTiFlash := false
+	if is.Source != nil {
+		for _, path := range is.Source.AllPossibleAccessPaths {
+			if path.StoreType == kv.TiFlash {
+				hasTiFlash = true
+				break
+			}
+		}
 	}
 	result := make([][]*expression.Column, 0, is.EqCondCount+1)
 	for i := 0; i <= is.EqCondCount; i++ {
 		result = append(result, make([]*expression.Column, len(is.IdxCols)-i))
 		copy(result[i], is.IdxCols[i:])
 	}
-	return result
+	res.OrderCols = result
+	res.TiFlashable = hasTiFlash
+	return res
 }
 
 // ExhaustPhysicalPlans inherits BaseLogicalPlan.LogicalPlan.<14th> implementation.

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -17,7 +17,6 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"maps"
 	"math"
 	"math/bits"
@@ -39,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
 	"github.com/pingcap/tidb/pkg/types"
 	utilhint "github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/intset"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 )

--- a/pkg/planner/core/operator/logicalop/logical_lock.go
+++ b/pkg/planner/core/operator/logicalop/logical_lock.go
@@ -114,6 +114,10 @@ func (p *LogicalLock) PushDownTopN(topNLogicalPlan base.LogicalPlan, opt *optimi
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+func (p *LogicalLock) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// LogicalLock table can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
+}
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.
 func (p *LogicalLock) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {

--- a/pkg/planner/core/operator/logicalop/logical_mem_table.go
+++ b/pkg/planner/core/operator/logicalop/logical_mem_table.go
@@ -156,6 +156,10 @@ func (p *LogicalMemTable) DeriveStats(_ []*property.StatsInfo, selfSchema *expre
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+func (p *LogicalMemTable) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// mem table can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
+}
 
 // ExhaustPhysicalPlans inherits BaseLogicalPlan.LogicalPlan.<14th> implementation.
 

--- a/pkg/planner/core/operator/logicalop/logical_partition_union_all.go
+++ b/pkg/planner/core/operator/logicalop/logical_partition_union_all.go
@@ -15,6 +15,7 @@
 package logicalop
 
 import (
+	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
@@ -37,6 +38,12 @@ func (p LogicalPartitionUnionAll) Init(ctx base.PlanContext, offset int) *Logica
 // ExhaustPhysicalPlans implements LogicalPlan interface.
 func (p *LogicalPartitionUnionAll) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {
 	return utilfuncp.ExhaustPhysicalPlans4LogicalPartitionUnionAll(p, prop)
+}
+
+// PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+func (p *LogicalPartitionUnionAll) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// LogicalLock table can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
 }
 
 // *************************** end implementation of LogicalPlan interface ***************************

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -15,7 +15,6 @@
 package logicalop
 
 import (
-	"github.com/pingcap/tidb/pkg/util/intest"
 	"slices"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace/logicaltrace"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/intset"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 )

--- a/pkg/planner/core/operator/logicalop/logical_projection.go
+++ b/pkg/planner/core/operator/logicalop/logical_projection.go
@@ -15,6 +15,7 @@
 package logicalop
 
 import (
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"slices"
 
 	"github.com/pingcap/tidb/pkg/expression"
@@ -333,19 +334,21 @@ func (p *LogicalProjection) ExtractColGroups(colGroups [][]*expression.Column) [
 }
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (p *LogicalProjection) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...[][]*expression.Column) [][]*expression.Column {
+func (p *LogicalProjection) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...*property.PossibleProp) *property.PossibleProp {
+	intest.Assert(len(childrenProperties) > 0 && childrenProperties[0] != nil)
 	childProperties := childrenProperties[0]
 	oldCols := make([]*expression.Column, 0, p.Schema().Len())
 	newCols := make([]*expression.Column, 0, p.Schema().Len())
 	for i, expr := range p.Exprs {
+		// only consider the column expression, since we need to see original column orders.
 		if col, ok := expr.(*expression.Column); ok {
 			newCols = append(newCols, p.Schema().Columns[i])
 			oldCols = append(oldCols, col)
 		}
 	}
 	tmpSchema := expression.NewSchema(oldCols...)
-	newProperties := make([][]*expression.Column, 0, len(childProperties))
-	for _, childProperty := range childProperties {
+	newProperties := make([][]*expression.Column, 0, len(childProperties.OrderCols))
+	for _, childProperty := range childProperties.OrderCols {
 		newChildProperty := make([]*expression.Column, 0, len(childProperty))
 		for _, col := range childProperty {
 			pos := tmpSchema.ColumnIndex(col)
@@ -358,7 +361,10 @@ func (p *LogicalProjection) PreparePossibleProperties(_ *expression.Schema, chil
 			newProperties = append(newProperties, newChildProperty)
 		}
 	}
-	return newProperties
+	return &property.PossibleProp{
+		OrderCols:   newProperties,
+		TiFlashable: childProperties.TiFlashable,
+	}
 }
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/logical_selection.go
+++ b/pkg/planner/core/operator/logicalop/logical_selection.go
@@ -244,7 +244,7 @@ func (p *LogicalSelection) DeriveStats(childStats []*property.StatsInfo, _ *expr
 // ExtractColGroups inherits BaseLogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (*LogicalSelection) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...[][]*expression.Column) [][]*expression.Column {
+func (*LogicalSelection) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...*property.PossibleProp) *property.PossibleProp {
 	return childrenProperties[0]
 }
 

--- a/pkg/planner/core/operator/logicalop/logical_show.go
+++ b/pkg/planner/core/operator/logicalop/logical_show.go
@@ -123,6 +123,12 @@ func (p *LogicalShow) DeriveStats(_ []*property.StatsInfo, selfSchema *expressio
 	return p.StatsInfo(), true, nil
 }
 
+// PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+func (p *LogicalShow) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// apply can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
+}
+
 // ExtractCorrelatedCols inherits BaseLogicalPlan.LogicalPlan.<15th> implementation.
 
 // MaxOneRow inherits BaseLogicalPlan.LogicalPlan.<16th> implementation.

--- a/pkg/planner/core/operator/logicalop/logical_show_ddl_jobs.go
+++ b/pkg/planner/core/operator/logicalop/logical_show_ddl_jobs.go
@@ -80,6 +80,10 @@ func (p *LogicalShowDDLJobs) DeriveStats(_ []*property.StatsInfo, selfSchema *ex
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+func (p *LogicalShowDDLJobs) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// apply can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
+}
 
 // ExhaustPhysicalPlans inherits BaseLogicalPlan.LogicalPlan.<14th> implementation.
 

--- a/pkg/planner/core/operator/logicalop/logical_sort.go
+++ b/pkg/planner/core/operator/logicalop/logical_sort.go
@@ -17,7 +17,6 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/intest"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -27,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 )
 

--- a/pkg/planner/core/operator/logicalop/logical_sort.go
+++ b/pkg/planner/core/operator/logicalop/logical_sort.go
@@ -17,6 +17,7 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/util/intest"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
@@ -117,12 +118,16 @@ func (ls *LogicalSort) PushDownTopN(topNLogicalPlan base.LogicalPlan, opt *optim
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (ls *LogicalSort) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
+func (ls *LogicalSort) PreparePossibleProperties(_ *expression.Schema, childProps ...*property.PossibleProp) *property.PossibleProp {
+	intest.Assert(len(childProps) > 0 && childProps[0] != nil)
 	propCols := getPossiblePropertyFromByItems(ls.ByItems)
+	res := &property.PossibleProp{}
 	if len(propCols) == 0 {
-		return nil
+		return res
 	}
-	return [][]*expression.Column{propCols}
+	res.OrderCols = [][]*expression.Column{propCols}
+	res.TiFlashable = childProps[0].TiFlashable
+	return res
 }
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/logical_table_dual.go
+++ b/pkg/planner/core/operator/logicalop/logical_table_dual.go
@@ -136,7 +136,11 @@ func (p *LogicalTableDual) DeriveStats(_ []*property.StatsInfo, selfSchema *expr
 
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
-// PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
+// PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
+func (p *LogicalTableDual) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// LogicalTableDual can not be pushed down to TiFlash.
+	return &property.PossibleProp{}
+}
 
 // ExhaustPhysicalPlans inherits BaseLogicalPlan.LogicalPlan.<14th> implementation.
 

--- a/pkg/planner/core/operator/logicalop/logical_table_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_table_scan.go
@@ -17,9 +17,9 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/kv"
 
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"

--- a/pkg/planner/core/operator/logicalop/logical_table_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_table_scan.go
@@ -17,6 +17,7 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/kv"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -94,15 +95,28 @@ func (ts *LogicalTableScan) DeriveStats(_ []*property.StatsInfo, _ *expression.S
 // ExtractColGroups inherits BaseLogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (ts *LogicalTableScan) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
+func (ts *LogicalTableScan) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
 	if ts.HandleCols != nil {
 		cols := make([]*expression.Column, ts.HandleCols.NumCols())
 		for i, c := range ts.HandleCols.IterColumns2() {
 			cols[i] = c
 		}
-		return [][]*expression.Column{cols}
+		// fetch the ds tiFlash path info.
+		hasTiFlash := false
+		if ts.Source != nil {
+			for _, path := range ts.Source.AllPossibleAccessPaths {
+				if path.StoreType == kv.TiFlash {
+					hasTiFlash = true
+					break
+				}
+			}
+		}
+		return &property.PossibleProp{
+			OrderCols:   [][]*expression.Column{cols},
+			TiFlashable: hasTiFlash,
+		}
 	}
-	return nil
+	return &property.PossibleProp{}
 }
 
 // ExhaustPhysicalPlans inherits BaseLogicalPlan.<14th> implementation.

--- a/pkg/planner/core/operator/logicalop/logical_tikv_single_gather.go
+++ b/pkg/planner/core/operator/logicalop/logical_tikv_single_gather.go
@@ -16,6 +16,7 @@ package logicalop
 
 import (
 	"bytes"
+	"github.com/pingcap/tidb/pkg/planner/property"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -86,7 +87,7 @@ func (*TiKVSingleGather) BuildKeyInfo(selfSchema *expression.Schema, childSchema
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (*TiKVSingleGather) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...[][]*expression.Column) [][]*expression.Column {
+func (*TiKVSingleGather) PreparePossibleProperties(_ *expression.Schema, childrenProperties ...*property.PossibleProp) *property.PossibleProp {
 	return childrenProperties[0]
 }
 

--- a/pkg/planner/core/operator/logicalop/logical_tikv_single_gather.go
+++ b/pkg/planner/core/operator/logicalop/logical_tikv_single_gather.go
@@ -16,11 +16,11 @@ package logicalop
 
 import (
 	"bytes"
-	"github.com/pingcap/tidb/pkg/planner/property"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 )
 

--- a/pkg/planner/core/operator/logicalop/logical_top_n.go
+++ b/pkg/planner/core/operator/logicalop/logical_top_n.go
@@ -17,7 +17,6 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/intest"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 )
 

--- a/pkg/planner/core/operator/logicalop/logical_top_n.go
+++ b/pkg/planner/core/operator/logicalop/logical_top_n.go
@@ -17,6 +17,7 @@ package logicalop
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/pkg/util/intest"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
@@ -143,12 +144,16 @@ func (lt *LogicalTopN) DeriveStats(childStats []*property.StatsInfo, _ *expressi
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (lt *LogicalTopN) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
+func (lt *LogicalTopN) PreparePossibleProperties(_ *expression.Schema, childProps ...*property.PossibleProp) *property.PossibleProp {
+	intest.Assert(len(childProps) > 0 && childProps[0] != nil)
+	res := &property.PossibleProp{}
 	propCols := getPossiblePropertyFromByItems(lt.ByItems)
 	if len(propCols) == 0 {
-		return nil
+		return res
 	}
-	return [][]*expression.Column{propCols}
+	res.OrderCols = [][]*expression.Column{propCols}
+	res.TiFlashable = childProps[0].TiFlashable
+	return res
 }
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/logical_union_all.go
+++ b/pkg/planner/core/operator/logicalop/logical_union_all.go
@@ -174,6 +174,11 @@ func (p *LogicalUnionAll) DeriveStats(childStats []*property.StatsInfo, selfSche
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
+func (p *LogicalUnionAll) PreparePossibleProperties(_ *expression.Schema, _ ...*property.PossibleProp) *property.PossibleProp {
+	// UnionAll can not be pushed down to TiFlash.
+	// So we return an empty possible property.
+	return &property.PossibleProp{}
+}
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.
 func (p *LogicalUnionAll) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {

--- a/pkg/planner/core/operator/logicalop/logical_union_scan.go
+++ b/pkg/planner/core/operator/logicalop/logical_union_scan.go
@@ -122,10 +122,12 @@ func (p *LogicalUnionScan) PruneColumns(parentUsedCols []*expression.Column, opt
 // ExtractColGroups inherits BaseLogicalPlan.LogicalPlan.<12th> implementation.
 
 // PreparePossibleProperties inherits BaseLogicalPlan.LogicalPlan.<13th> implementation.
-func (p *LogicalUnionScan) PreparePossibleProperties(schema *expression.Schema, childrenProperties ...[][]*expression.Column) [][]*expression.Column {
+func (p *LogicalUnionScan) PreparePossibleProperties(schema *expression.Schema, childrenProperties ...*property.PossibleProp) *property.PossibleProp {
 	// ref exhaustPhysicalPlans4LogicalUnionScan: it will push down the sort prop directly.
 	// in union scan exec, it will feel the underlying tableReader or indexReader to get the keepOrder.
-	return p.Children()[0].PreparePossibleProperties(schema, childrenProperties...)
+	res := p.Children()[0].PreparePossibleProperties(schema, childrenProperties...)
+	res.TiFlashable = false // UnionScan is not supported by TiFlash, so we set it to false.
+	return res
 }
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/logical_window.go
+++ b/pkg/planner/core/operator/logicalop/logical_window.go
@@ -16,6 +16,7 @@ package logicalop
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/pkg/util/intest"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
@@ -415,7 +416,8 @@ func (p *LogicalWindow) ExtractColGroups(colGroups [][]*expression.Column) [][]*
 }
 
 // PreparePossibleProperties implements base.LogicalPlan.<13th> interface.
-func (p *LogicalWindow) PreparePossibleProperties(_ *expression.Schema, _ ...[][]*expression.Column) [][]*expression.Column {
+func (p *LogicalWindow) PreparePossibleProperties(_ *expression.Schema, childProps ...*property.PossibleProp) *property.PossibleProp {
+	intest.Assert(len(childProps) > 0 && childProps[0] != nil)
 	result := make([]*expression.Column, 0, len(p.PartitionBy)+len(p.OrderBy))
 	for i := range p.PartitionBy {
 		result = append(result, p.PartitionBy[i].Col)
@@ -423,7 +425,10 @@ func (p *LogicalWindow) PreparePossibleProperties(_ *expression.Schema, _ ...[][
 	for i := range p.OrderBy {
 		result = append(result, p.OrderBy[i].Col)
 	}
-	return [][]*expression.Column{result}
+	return &property.PossibleProp{
+		OrderCols:   [][]*expression.Column{result},
+		TiFlashable: childProps[0].TiFlashable,
+	}
 }
 
 // ExhaustPhysicalPlans implements base.LogicalPlan.<14th> interface.

--- a/pkg/planner/core/operator/logicalop/logical_window.go
+++ b/pkg/planner/core/operator/logicalop/logical_window.go
@@ -16,7 +16,6 @@ package logicalop
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/pkg/util/intest"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/expression/aggregation"
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/util/utilfuncp"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tipb/go-tipb"
 )

--- a/pkg/planner/core/operator/logicalop/shallow_ref_generated.go
+++ b/pkg/planner/core/operator/logicalop/shallow_ref_generated.go
@@ -120,20 +120,6 @@ func (op *LogicalAggregation) GroupByItemsShallowRef() []expression.Expression {
 	return op.GroupByItems
 }
 
-// PossiblePropertiesShallowRef implements the copy-on-write usage.
-func (op *LogicalAggregation) PossiblePropertiesShallowRef() [][]*expression.Column {
-	PossiblePropertiesCP := make([][]*expression.Column, 0, len(op.PossibleProperties))
-	for _, one := range op.PossibleProperties {
-		oneCP := make([]*expression.Column, 0, len(one))
-		for _, onee := range one {
-			oneCP = append(oneCP, onee)
-		}
-		PossiblePropertiesCP = append(PossiblePropertiesCP, one)
-	}
-	op.PossibleProperties = PossiblePropertiesCP
-	return op.PossibleProperties
-}
-
 // LogicalSortShallowRef implements the copy-on-write usage.
 func (op *LogicalSort) LogicalSortShallowRef() *LogicalSort {
 	shallow := *op

--- a/pkg/planner/core/property_cols_prune.go
+++ b/pkg/planner/core/property_cols_prune.go
@@ -15,14 +15,14 @@
 package core
 
 import (
-	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
+	"github.com/pingcap/tidb/pkg/planner/property"
 )
 
 // preparePossibleProperties traverses the plan tree by a post-order method,
 // recursively calls base.LogicalPlan PreparePossibleProperties interface.
-func preparePossibleProperties(lp base.LogicalPlan) [][]*expression.Column {
-	childrenProperties := make([][][]*expression.Column, 0, len(lp.Children()))
+func preparePossibleProperties(lp base.LogicalPlan) *property.PossibleProp {
+	childrenProperties := make([]*property.PossibleProp, 0, len(lp.Children()))
 	for _, child := range lp.Children() {
 		childrenProperties = append(childrenProperties, preparePossibleProperties(child))
 	}

--- a/pkg/planner/property/logical_property.go
+++ b/pkg/planner/property/logical_property.go
@@ -35,3 +35,9 @@ func NewLogicalProp() *LogicalProperty {
 }
 
 // todo: ScalarProperty: usedColumns in current scalar expr, null reject, cor-related, subq contained and so on
+
+// PossibleProp is used to store the possible properties of child logical plan.
+type PossibleProp struct {
+	OrderCols   [][]*expression.Column
+	TiFlashable bool
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/62210

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
