### PR TITLE
br: always set ForcePathStyle=false for s3 compatible Tencent Cloud provider

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -199,7 +199,7 @@ func (options *S3BackendOptions) Apply(s3 *backuppb.S3) error {
 	}
 	// In some cases, we need to set ForcePathStyle to false.
 	// Refer to: https://rclone.org/s3/#s3-force-path-style
-	if options.Provider == "alibaba" || options.Provider == "netease" ||
+	if options.Provider == "alibaba" || options.Provider == "netease" || options.Provider == "tencent" ||
 		options.UseAccelerateEndpoint {
 		options.ForcePathStyle = false
 	}

--- a/br/pkg/storage/s3_test.go
+++ b/br/pkg/storage/s3_test.go
@@ -249,6 +249,21 @@ func TestApplyUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "tencent provider",
+			options: S3BackendOptions{
+				Region:         "us-west-2",
+				ForcePathStyle: true,
+				Provider:       "tencent",
+			},
+			s3: &backuppb.S3{
+				Region:         "us-west-2",
+				ForcePathStyle: false,
+				Bucket:         "bucket",
+				Prefix:         "prefix",
+				Provider:       "tencent",
+			},
+		},
+		{
 			name: "useAccelerateEndpoint",
 			options: S3BackendOptions{
 				Region:                "us-west-2",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #55568

Problem Summary:

For buckets created after January 1, 2024, the use of path-style domain is not supported, only virtual-hosted-style domain is permitted.
https://www.tencentcloud.com/document/product/436/57456

### What changed and how does it work?

disable ForcePathStyle and use virtual-hosted-style for Tencent Cloud

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
br: always set ForcePathStyle=false for s3 compatible Tencent Cloud provider
```
