### PR TITLE
planner: deprecate the logical interface CanPushToCop and its implementation canPushToCopImpl.

### DIFF
--- a/pkg/planner/core/base/plan_base.go
+++ b/pkg/planner/core/base/plan_base.go
@@ -280,6 +280,7 @@ type LogicalPlan interface {
 	RollBackTaskMap(TS uint64)
 
 	// CanPushToCop check if we might push this plan to a specific store.
+	// Deprecated: don't depend subtree based push check, see CanSelfBeingPushedToCopImpl based op-self push check.
 	CanPushToCop(store kv.StoreType) bool
 
 	// ExtractFD derive the FDSet from the tree bottom up.

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -1113,25 +1113,10 @@ func checkOpSelfSatisfyPropTaskTypeRequirement(p base.LogicalPlan, prop *propert
 		// when parent operator ask current op to be mppTaskType, check operator itself here.
 		return logicalop.CanSelfBeingPushedToCopImpl(p, kv.TiFlash)
 	case property.CopSingleReadTaskType, property.CopMultiReadTaskType:
-		if isClusterTableDatasource(p) {
-			// Cluster table is also supported to be cop pushed down to peer tidb, which
-			// can be seen as cop[tidb] way of accessing the cluster table. So for cluster
-			// table, to storeTp is not kv.TiKV, actually it's kv.TiDB. Otherwise, the
-			// store type check inside will fail.
-			return logicalop.CanSelfBeingPushedToCopImpl(p, kv.TiDB)
-		}
 		return logicalop.CanSelfBeingPushedToCopImpl(p, kv.TiKV)
 	default:
 		return true
 	}
-}
-
-// isClusterTableDatasource checks whether the given logical plan is a DataSource and its table is a cluster table.
-func isClusterTableDatasource(p base.LogicalPlan) bool {
-	if ds, ok := p.(*logicalop.DataSource); ok {
-		return ds.Table.Type().IsClusterTable()
-	}
-	return false
 }
 
 // admitIndexJoinInnerChildPattern is used to check whether current physical choosing is under an index join's

--- a/pkg/planner/core/exhaust_physical_plans.go
+++ b/pkg/planner/core/exhaust_physical_plans.go
@@ -16,6 +16,9 @@ package core
 
 import (
 	"fmt"
+	"math"
+	"slices"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
@@ -43,8 +46,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/set"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
-	"math"
-	"slices"
 )
 
 func exhaustPhysicalPlans4LogicalUnionScan(lp base.LogicalPlan, prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1475,12 +1475,6 @@ func findBestTask4LogicalDataSource(lp base.LogicalPlan, prop *property.Physical
 		planCounter.Dec(1)
 		return
 	}
-	// check whether the DataSource can satisfy the property.
-	if !checkOpSelfSatisfyPropTaskTypeRequirement(ds, prop) {
-		// Currently all plan cannot totally push down to TiKV.
-		ds.StoreTask(prop, base.InvalidTask)
-		return base.InvalidTask, 0, nil
-	}
 	// if prop is require an index join's probe side, check the inner pattern admission here.
 	if prop.IndexJoinProp != nil {
 		pass := admitIndexJoinInnerChildPattern(lp)

--- a/pkg/planner/core/operator/logicalop/base_logical_plan.go
+++ b/pkg/planner/core/operator/logicalop/base_logical_plan.go
@@ -336,6 +336,7 @@ func (p *BaseLogicalPlan) RollBackTaskMap(ts uint64) {
 // it checks if it can be pushed to some stores. For TiKV, it only checks datasource.
 // For TiFlash, it will check whether the operator is supported, but note that the check
 // might be inaccurate.
+// Deprecated: don't depend subtree based push check, see CanSelfBeingPushedToCopImpl based op-self push check.
 func (p *BaseLogicalPlan) CanPushToCop(storeTp kv.StoreType) bool {
 	return CanPushToCopImpl(p, storeTp)
 }

--- a/pkg/planner/core/operator/logicalop/logical_plans_misc.go
+++ b/pkg/planner/core/operator/logicalop/logical_plans_misc.go
@@ -216,6 +216,7 @@ func CanSelfBeingPushedToCopImpl(lp base.LogicalPlan, storeTp kv.StoreType) bool
 }
 
 // CanPushToCopImpl checks whether the logical plan can be pushed to coprocessor.
+// Deprecated: don't depend on subtree based push check, use prop based `CanSelfBeingPushedToCopImpl` instead.
 func CanPushToCopImpl(lp base.LogicalPlan, storeTp kv.StoreType) bool {
 	p := lp.GetBaseLogicalPlan().(*BaseLogicalPlan)
 	ret := true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/62006

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
