### PR TITLE
[WIP] statistics, executor: store original value in stat buckets

### DIFF
--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -710,6 +710,7 @@ workLoop:
 						continue
 					}
 					val := row.Columns[task.slicePos]
+					orig := val
 					// If this value is very big, we think that it is not a value that can occur many times. So we don't record it.
 					if len(val.GetBytes()) > statistics.MaxSampleValueLength {
 						continue
@@ -721,8 +722,9 @@ workLoop:
 						e.memTracker.BufferedConsume(&bufferedMemSize, deltaSize)
 					}
 					sampleItems = append(sampleItems, &statistics.SampleItem{
-						Value:   val,
-						Ordinal: j,
+						Value:         val,
+						OriginalValue: orig,
+						Ordinal:       j,
 					})
 					// tmp memory usage
 					deltaSize := val.MemUsage() + 4 // content of SampleItem is copied
@@ -748,12 +750,25 @@ workLoop:
 				collectorMemSize := int64(sampleNum) * (8 + statistics.EmptySampleItemSize + 8)
 				e.memTracker.Consume(collectorMemSize)
 				errCtx := e.ctx.GetSessionVars().StmtCtx.ErrCtx()
+
+				// If any column in the index is not binary collated, we need to store the original value.
+				// Because we need to show the original value in the histogram.
+				needStoreOrig := false
+				for _, col := range idx.Columns {
+					info := e.colsInfo[col.Offset]
+					if info.GetCollate() != "binary" {
+						needStoreOrig = true
+						break
+					}
+				}
+
 			indexSampleCollectLoop:
 				for _, row := range task.rootRowCollector.Base().Samples {
 					if len(idx.Columns) == 1 && row.Columns[idx.Columns[0].Offset].IsNull() {
 						continue
 					}
 					b := make([]byte, 0, 8)
+					orig := make([]byte, 0, 8)
 					for _, col := range idx.Columns {
 						// If the index value contains one value which is too long, we think that it's a value that doesn't occur many times.
 						if len(row.Columns[col.Offset].GetBytes()) > statistics.MaxSampleValueLength {
@@ -770,15 +785,30 @@ workLoop:
 							}
 							continue
 						}
-						b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, row.Columns[col.Offset])
+						d := row.Columns[col.Offset]
+						b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, d)
 						err = errCtx.HandleError(err)
 						if err != nil {
 							resultCh <- err
 							continue workLoop
 						}
+						if needStoreOrig {
+							newD := d
+							newD.SetCollation("binary")
+							orig, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), orig, newD)
+							err = errCtx.HandleError(err)
+							if err != nil {
+								resultCh <- err
+								continue workLoop
+							}
+						}
+					}
+					if !needStoreOrig {
+						orig = b
 					}
 					sampleItems = append(sampleItems, &statistics.SampleItem{
-						Value: types.NewBytesDatum(b),
+						Value:         types.NewBytesDatum(b),
+						OriginalValue: types.NewBytesDatum(orig),
 					})
 					// tmp memory usage
 					deltaSize := sampleItems[len(sampleItems)-1].Value.MemUsage()

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -282,6 +282,14 @@ func ValueToString(vars *variable.SessionVars, value *types.Datum, idxCols int, 
 	if len(remained) > 0 {
 		decodedVals = append(decodedVals, types.NewBytesDatum(remained))
 	}
+
+	for i, tp := range idxColumnTypes {
+		if types.IsTypeString(tp) {
+			b := decodedVals[i].GetBytes()
+			decodedVals[i].SetBytesAsString(b, "binary", uint32(len(b)))
+		}
+	}
+
 	str, err := types.DatumsToString(decodedVals, true)
 	return str, err
 }

--- a/pkg/statistics/sample.go
+++ b/pkg/statistics/sample.go
@@ -40,6 +40,8 @@ import (
 type SampleItem struct {
 	// Value is the sampled column value.
 	Value types.Datum
+	// OriginalValue is the original column value
+	OriginalValue types.Datum
 	// Handle is the handle of the sample in its key.
 	// This property is used to calculate Ordinal in fast analyze.
 	Handle kv.Handle

--- a/pkg/types/etc.go
+++ b/pkg/types/etc.go
@@ -46,6 +46,16 @@ func IsTypeVarchar(tp byte) bool {
 	return tp == mysql.TypeVarString || tp == mysql.TypeVarchar
 }
 
+// IsTypeString returns a boolean indicating whether the tp is a string type.
+func IsTypeString(tp byte) bool {
+	switch tp {
+	case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar,
+		mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
+		return true
+	}
+	return false
+}
+
 // IsTypeUnspecified returns a boolean indicating whether the tp is the Unspecified type.
 func IsTypeUnspecified(tp byte) bool {
 	return tp == mysql.TypeUnspecified


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

Currently, the data stored in stat buckets are collate key, not the original string. These data will also be shown in `SHOW STATS_BUCKETS`.

As sync-diff-inspector relys on these lower/upper bound to split the chunk, we should output the original value for stat buckets, like:

```SQL
......
| test    | feed_entries4 |                | PRIMARY     |        1 |       238 |  4063 |       1 | (989466884, "测试😠，😫")            | (992027338, "测试😠，😫")            |    0 |                          
| test    | feed_entries4 |                | PRIMARY     |        1 |       239 |  4080 |       1 | (992470154, "测试😠，😫")            | (997241007, "测试😠，😫")            |    0 |                          
| test    | feed_entries4 |                | PRIMARY     |        1 |       240 |  4096 |       1 | (997356778, "测试😠，😫")            | (999820923, "测试😠，😫")            |    0 |                          
+---------+---------------+----------------+-------------+----------+-----------+-------+---------+----------------------------------+----------------------------------+------+               
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
