### PR TITLE
statistics: avoid the panic during stats load

### DIFF
--- a/pkg/statistics/handle/handle_hist.go
+++ b/pkg/statistics/handle/handle_hist.go
@@ -309,8 +309,15 @@ func (h *Handle) handleOneItemTask(task *NeededItemTask) (err error) {
 		wrapper.idx = index
 	} else {
 		col, ok := tbl.Columns[item.ID]
-		if !ok || col.IsFullLoad() {
-			wrapper.col = nil
+		if !ok {
+			// From `removeHistLoadedColumns`, we can see that if a column is not found in the `tbl`,
+			// we'll directly remove it from the `remainedItems`.
+			// This precondition makes it difficult to tell when we will get here.
+			// But we should not panic here.
+			return nil
+		} else if col.IsFullLoad() {
+			// If this column is fully loaded, we don't need to load it again.
+			return nil
 		} else {
 			wrapper.col = col
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61733 

Problem Summary:

### What changed and how does it work?

We checked the logic. Currently, the panic should only happen when there are no stats in storage.

So this pull request directly makes the function return if it hits the code that causes panic previously.

The comment in codes also updated.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
