### PR TITLE
crossks: forbid cross ks session to access user tables and run DDL

### DIFF
--- a/pkg/domain/crossks/BUILD.bazel
+++ b/pkg/domain/crossks/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/config/kerneltype",
         "//pkg/disttask/framework/storage",
         "//pkg/executor/importer",
+        "//pkg/infoschema",
         "//pkg/keyspace",
         "//pkg/kv",
         "//pkg/sessionctx",

--- a/pkg/domain/crossks/cross_ks.go
+++ b/pkg/domain/crossks/cross_ks.go
@@ -100,7 +100,7 @@ func (m *Manager) GetOrCreate(
 	}()
 
 	infoCache := infoschema.NewCache(store, int(vardef.SchemaVersionCacheLimit.Load()))
-	isLoader := issyncer.NewLoader(store, infoCache)
+	isLoader := issyncer.NewLoaderForCrossKS(store, infoCache)
 	ver, err := store.CurrentVersion(kv.GlobalTxnScope)
 	if err != nil {
 		return nil, err

--- a/pkg/infoschema/issyncer/BUILD.bazel
+++ b/pkg/infoschema/issyncer/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kv",
         "//pkg/meta",
         "//pkg/meta/autoid",
+        "//pkg/meta/metadef",
         "//pkg/meta/model",
         "//pkg/metrics",
         "//pkg/sessionctx",

--- a/pkg/infoschema/issyncer/loader.go
+++ b/pkg/infoschema/issyncer/loader.go
@@ -325,7 +325,7 @@ func (l *Loader) fetchAllSchemasWithTables(m meta.Reader) ([]*model.DBInfo, erro
 		return nil, err
 	}
 	if l.crossKS {
-		filteredSchemas := make([]*model.DBInfo, 0, len(allSchemas))
+		filteredSchemas := make([]*model.DBInfo, 0, 1)
 		for _, di := range allSchemas {
 			if metadef.IsSystemDB(di.Name.L) {
 				filteredSchemas = append(filteredSchemas, di)

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -565,6 +565,9 @@ func (b *PlanBuilder) Build(ctx context.Context, node *resolve.NodeW) (base.Plan
 		*ast.ImportIntoActionStmt, *ast.CalibrateResourceStmt, *ast.AddQueryWatchStmt, *ast.DropQueryWatchStmt, *ast.DropProcedureStmt:
 		return b.buildSimple(ctx, node.Node.(ast.StmtNode))
 	case ast.DDLNode:
+		if b.ctx.IsCrossKS() {
+			return nil, errors.New("DDL is not supported in cross keyspace session")
+		}
 		return b.buildDDL(ctx, x)
 	case *ast.CreateBindingStmt:
 		return b.buildCreateBindPlan(x)

--- a/pkg/planner/planctx/context.go
+++ b/pkg/planner/planctx/context.go
@@ -52,6 +52,8 @@ type PlanContext interface {
 	// GetLatestISWithoutSessExt is same as GetLatestInfoSchema, except that it
 	// does NOT include the temporary table definitions stored in session.
 	GetLatestISWithoutSessExt() infoschema.MetaOnlyInfoSchema
+	// IsCrossKS checks whether the current plan context is cross keyspace.
+	IsCrossKS() bool
 	// GetInfoSchema returns the current infoschema
 	GetInfoSchema() infoschema.MetaOnlyInfoSchema
 	// UpdateColStatsUsage updates the column stats usage.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -192,7 +192,9 @@ type session struct {
 
 	// dom is *domain.Domain, use `any` to avoid import cycle.
 	// cross keyspace session doesn't have domain set.
-	dom             any
+	dom any
+	// we cannot compare dom == nil, as dom is untyped, golang will always return true.
+	crossKS         bool
 	schemaValidator validatorapi.Validator
 	infoCache       *infoschema.InfoCache
 	store           kv.Storage
@@ -3906,8 +3908,10 @@ func createSessionWithOpt(
 		// we don't set dom for cross keyspace access.
 		ddlOwnerMgr = dom.DDL().OwnerManager()
 	}
+	crossKS := dom == nil
 	s := &session{
 		dom:                   dom,
+		crossKS:               crossKS,
 		schemaValidator:       schemaValidator,
 		infoCache:             infoCache,
 		store:                 store,
@@ -4422,6 +4426,10 @@ func (s *session) GetLatestISWithoutSessExt() infoschemactx.MetaOnlyInfoSchema {
 
 func (s *session) GetSQLServer() sqlsvrapi.Server {
 	return s.dom.(sqlsvrapi.Server)
+}
+
+func (s *session) IsCrossKS() bool {
+	return s.crossKS
 }
 
 func (s *session) GetSchemaValidator() validatorapi.Validator {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -193,7 +193,7 @@ type session struct {
 	// dom is *domain.Domain, use `any` to avoid import cycle.
 	// cross keyspace session doesn't have domain set.
 	dom any
-	// we cannot compare dom == nil, as dom is untyped, golang will always return true.
+	// we cannot compare dom == nil, as dom is untyped, golang will always return false.
 	crossKS         bool
 	schemaValidator validatorapi.Validator
 	infoCache       *infoschema.InfoCache

--- a/pkg/sessionctx/context.go
+++ b/pkg/sessionctx/context.go
@@ -122,6 +122,7 @@ type Context interface {
 	GetSchemaValidator() validatorapi.Validator
 	// GetSQLServer returns the sqlsvrapi.Server.
 	GetSQLServer() sqlsvrapi.Server
+	IsCrossKS() bool
 
 	GetSessionVars() *variable.SessionVars
 

--- a/pkg/util/mock/context.go
+++ b/pkg/util/mock/context.go
@@ -372,6 +372,11 @@ func (c *Context) GetSQLServer() sqlsvrapi.Server {
 	return c.dom.(sqlsvrapi.Server)
 }
 
+// IsCrossKS implements sessionctx.Context IsCrossKS interface.
+func (*Context) IsCrossKS() bool {
+	return false
+}
+
 // GetSchemaValidator implements sessionctx.Context GetSchemaValidator interface.
 func (c *Context) GetSchemaValidator() validatorapi.Validator {
 	return c.schValidator


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
cross ks sessions are only allowed to read/write system tables of target ks, we enforce this rule in this pr
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
