### PR TITLE
ddl: handle PD error from getting timestamp

### DIFF
--- a/pkg/ddl/db_test.go
+++ b/pkg/ddl/db_test.go
@@ -59,7 +59,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -1362,19 +1361,8 @@ func TestGetVersionFailed(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t(a int)")
 
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockGetCurrentVersionFailed", "return(true)")
+	// Simulate the failure of getting the current version twice.
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockGetCurrentVersionFailed", "2*return(true)")
 
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		tk.MustExec("alter table t add column b int")
-		return nil
-	})
-
-	eg.Go(func() error {
-		time.Sleep(2 * time.Second)
-		testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/mockGetCurrentVersionFailed")
-		return nil
-	})
-
-	eg.Wait()
+	tk.MustExec("alter table t add column b int")
 }

--- a/pkg/ddl/schema_version.go
+++ b/pkg/ddl/schema_version.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/metrics"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"go.uber.org/zap"
 )
@@ -407,9 +408,11 @@ func waitVersionSyncedWithoutMDL(ctx context.Context, jobCtx *jobContext, job *m
 	}
 
 	ver, err := jobCtx.store.CurrentVersion(kv.GlobalTxnScope)
-	failpoint.Inject("mockGetCurrentVersionFailed", func() {
-		// ref: https://github.com/tikv/client-go/blob/master/tikv/kv.go#L505-L532
-		ver, err = kv.NewVersion(0), tikverr.NewErrPDServerTimeout("mock PD timeout")
+	failpoint.Inject("mockGetCurrentVersionFailed", func(val failpoint.Value) {
+		if val.(bool) {
+			// ref: https://github.com/tikv/client-go/blob/master/tikv/kv.go#L505-L532
+			ver, err = kv.NewVersion(0), tikverr.NewErrPDServerTimeout("mock PD timeout")
+		}
 	})
 
 	// If we failed to get the current version, caller will retry after one second again.
@@ -423,6 +426,11 @@ func waitVersionSyncedWithoutMDL(ctx context.Context, jobCtx *jobContext, job *m
 	if err != nil {
 		logutil.DDLLogger().Warn("get global version failed", zap.Int64("jobID", job.ID), zap.Error(err))
 		return err
+	}
+
+	// Try adding guard for schema version in test
+	if intest.InTest {
+		intest.Assert(latestSchemaVersion > 0, "latestSchemaVersion should be greater than 0")
 	}
 
 	failpoint.Inject("checkDownBeforeUpdateGlobalVersion", func(val failpoint.Value) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58871

Problem Summary:

When we failed to get timestamp from PD, the returned ver is set to zero. This makes `WaitVersionSynced` pass unexpectedly.

https://github.com/tikv/client-go/blob/557a4986e4c43f7809e0305dde9b30d5e433055a/tikv/kv.go#L527-L530

### What changed and how does it work?

We should check the error returned from client to make caller retry syncing version.

I have checked the repo, and now all places that call this function check the error.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
