### PR TITLE
fix: better install.sh in dumpling support arm64

### DIFF
--- a/dumpling/install.sh
+++ b/dumpling/install.sh
@@ -3,17 +3,32 @@ set -e
 
 mkdir -p bin/
 
+# Detect architecture
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64)
+        ARCH_SUFFIX="amd64"
+        ;;
+    aarch64|arm64)
+        ARCH_SUFFIX="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
 # download lightning and sync_diff_inspector
 TOOLS_TAG="nightly"
-wget http://download.pingcap.org/tidb-toolkit-$TOOLS_TAG-linux-amd64.tar.gz -O tools.tar.gz
+wget http://download.pingcap.org/tidb-toolkit-$TOOLS_TAG-linux-$ARCH_SUFFIX.tar.gz -O tools.tar.gz
 tar -xzvf tools.tar.gz
-mv tidb-toolkit-$TOOLS_TAG-linux-amd64/bin/* bin/
+mv tidb-toolkit-$TOOLS_TAG-linux-$ARCH_SUFFIX/bin/* bin/
 
 # download minio
-wget https://dl.min.io/server/minio/release/linux-amd64/minio -O bin/minio
+wget https://dl.min.io/server/minio/release/linux-$ARCH_SUFFIX/minio -O bin/minio
 chmod a+x bin/minio
 
-wget https://dl.minio.io/client/mc/release/linux-amd64/mc -O bin/mc
+wget https://dl.minio.io/client/mc/release/linux-$ARCH_SUFFIX/mc -O bin/mc
 chmod a+x bin/mc
 
 go get github.com/ma6174/snappy@15869b0666f67839ecf86cd29ef1452ddcd79cb8


### PR DESCRIPTION
this patch do two things

- support arm64 in dumpling/install.sh
- chmod +x for it


Issue Number: close #62297

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
