### PR TITLE
lightning: fix panic on checksum manager close when checksum is off

### DIFF
--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -1375,7 +1375,10 @@ func (rc *Controller) importTables(ctx context.Context) (finalErr error) {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		defer manager.Close()
+		// it's nil when checksum=off
+		if manager != nil {
+			defer manager.Close()
+		}
 		ctx = context.WithValue(ctx, &checksumManagerKey, manager)
 
 		undo, err := rc.registerTaskToPD(ctx)

--- a/lightning/tests/lightning_csv/config-checksum-off.toml
+++ b/lightning/tests/lightning_csv/config-checksum-off.toml
@@ -1,0 +1,14 @@
+[mydumper.csv]
+separator = ','
+delimiter = '"'
+header = false
+not-null = false
+null = '\N'
+backslash-escape = true
+trim-last-separator = false
+
+[tikv-importer]
+send-kv-pairs=10
+region-split-size = 1024
+[post-restore]
+checksum = 'off'

--- a/lightning/tests/lightning_csv/run.sh
+++ b/lightning/tests/lightning_csv/run.sh
@@ -94,6 +94,9 @@ check_contains 'switch tikv mode"] [mode=Import' $TEST_DIR/lightning.log
 check_contains 'switch tikv mode"] [mode=Normal' $TEST_DIR/lightning.log
 
 rm -rf $TEST_DIR/lightning.log
+run_with "local" "$CUR/config-checksum-off.toml"
+
+rm -rf $TEST_DIR/lightning.log
 run_with "tidb" "$CUR/config.toml"
 check_not_contains 'switch tikv mode' $TEST_DIR/lightning.log
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62142

Problem Summary:

### What changed and how does it work?
it's introduced in https://github.com/pingcap/tidb/pull/62143, when checksum=off, the manager is nil
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
