### PR TITLE
statistics: prevent deadlock in SaveAnalyzeResultToStorage by adding a fake table ID for concurrent updates

### DIFF
--- a/pkg/statistics/handle/storage/save.go
+++ b/pkg/statistics/handle/storage/save.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -148,8 +149,8 @@ func SaveAnalyzeResultToStorage(sctx sessionctx.Context,
 	// txn1: lockKeys on point get (index lock)
 	// txn2: lockKeys on batch point get (row lock) — waits for txn1 for index lock
 	// txn1: lockKeys on point get (row lock) — deadlock occurs here and it's not retryable
-	fakeTableID := -1988
-	tableIDStrs := []string{fmt.Sprintf("%d", fakeTableID), fmt.Sprintf("%d", tableID)}
+	fakeID := int64(-1988)
+	tableIDStrs := []string{strconv.FormatInt(fakeID, 10), strconv.FormatInt(tableID, 10)}
 	rs, err = util.Exec(sctx, "select snapshot, count, modify_count from mysql.stats_meta where table_id in (%?) for update", tableIDStrs)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref". 

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/62069

ref https://github.com/pingcap/tidb/issues/62565

Problem Summary:

### What changed and how does it work?

We encountered a stable deadlock issue during the analyze process, where the transaction ultimately failed and the error was propagated to the top layer. From the deadlock records in information_schema.deadlocks, it’s confirmed that this is a non-retryable deadlock. The root cause is that the point get operation involves two separate lock phases: one to lock the index and another to lock the row. If another transaction locks both index and row in a single batch point get, it can lead to a deadlock that is not retryable because the lock keys are not within the same lockKeys call.

The sequence looks like this:

```log
txn1: lockKeys on point get (index)

txn2: lockKeys on batch point get (index & row) — waits for txn1

txn1: lockKeys on point get (row) — deadlock occurs here and it's not retryable
```

This fix is to force the point get to lock both index and row in a single batch get operation, by adding a dummy key (like -1988) to ensure a one-round lock acquisition.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test
	- [x] I tested it in TCMS. 
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复收集统计信息时可能遇到的死锁问题
Fix a potential deadlock issue that may occur when collecting statistics
```
