### PR TITLE
executor: fix the issue during analyze when first col is virtual col

### DIFF
--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/collate"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/ranger"
@@ -148,15 +149,23 @@ func (e *AnalyzeColumnsExecV2) decodeSampleDataWithVirtualColumn(
 	decoder := codec.NewDecoder(chk, e.ctx.GetSessionVars().Location())
 	for _, sample := range collector.Base().Samples {
 		for i, columns := range sample.Columns {
-			if schema.Columns[i].VirtualExpr != nil {
-				continue
-			}
+			// Virtual columns will be decoded as null first.
 			_, err := decoder.DecodeOne(columns.GetBytes(), i, e.schemaForVirtualColEval.Columns[i].RetType)
 			if err != nil {
 				return err
 			}
 		}
 	}
+	intest.AssertFunc(func() bool {
+		// Ensure all columns in the chunk have the same number of rows.
+		// Checking for virtual columns.
+		for i := 1; i < chk.NumCols(); i++ {
+			if chk.Column(i).Rows() != chk.Column(0).Rows() {
+				return false
+			}
+		}
+		return true
+	}, "all columns in chunk should have the same number of rows")
 	err := table.FillVirtualColumnValue(fieldTps, virtualColIdx, schema.Columns, e.colsInfo, e.ctx.GetExprCtx(), chk)
 	if err != nil {
 		return err

--- a/tests/integrationtest/r/executor/analyze.result
+++ b/tests/integrationtest/r/executor/analyze.result
@@ -855,5 +855,13 @@ SELECT * FROM Issue34228;
 id	dt
 1	2022-02-01 00:00:02
 2	2022-02-01 00:00:02
+create table analyze_virtual_col(a int generated always as (1) virtual, b int);
+insert into analyze_virtual_col(b) values(2);
+analyze table analyze_virtual_col all columns;
+select * from analyze_virtual_col where a > 1 and b > 1;
+a	b
+show stats_topn where table_name = 'analyze_virtual_col';
+Db_name	Table_name	Partition_name	Column_name	Is_index	Value	Count
+executor__analyze	analyze_virtual_col		b	0	2	1
 SET @@global.tidb_analyze_version = default;
 SET @@session.tidb_partition_prune_mode = default;

--- a/tests/integrationtest/t/executor/analyze.test
+++ b/tests/integrationtest/t/executor/analyze.test
@@ -931,5 +931,15 @@ SELECT * FROM Issue34228;
 
 connection default;
 disconnect conn1;
+
+
+# https://github.com/pingcap/tidb/issues/61606
+create table analyze_virtual_col(a int generated always as (1) virtual, b int);
+insert into analyze_virtual_col(b) values(2);
+analyze table analyze_virtual_col all columns;
+select * from analyze_virtual_col where a > 1 and b > 1;
+--sorted_result
+show stats_topn where table_name = 'analyze_virtual_col';
+
 SET @@global.tidb_analyze_version = default;
 SET @@session.tidb_partition_prune_mode = default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61606

Problem Summary:

### What changed and how does it work?

The samples should append `null` for the virtual generated column first for later use.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复当表的第一列为虚拟生成列时，统计信息可能出错的问题
Fix the issue that the statistics will be incorrect when the table's first column is virtual generated column
```
