### PR TITLE
executor: log error in the Close of joinv1 instead of returning it

### DIFF
--- a/pkg/executor/join/hash_table_v1.go
+++ b/pkg/executor/join/hash_table_v1.go
@@ -533,7 +533,7 @@ func (c *hashRowContainer) Len() uint64 {
 }
 
 func (c *hashRowContainer) Close() error {
-	failpoint.Inject("issue60923", nil)
+	failpoint.Inject("issue60926", nil)
 
 	defer c.memTracker.Detach()
 	c.chkBuf = nil

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -787,7 +787,7 @@ func TestIssue60926(t *testing.T) {
 	tk.MustExec("insert into t1 values (0, 10), (1, 10), (2, 10), (3, 10), (4, 10), (5, 10), (6, 10), (7, 10), (8, 10), (9, 10), (10, 10);")
 	tk.MustExec("insert into t2 values (0, 5), (0, 5), (1, 5), (2, 5), (2, 5), (3, 5), (4, 5), (5, 5), (5, 5), (6, 5), (7, 5), (8, 5), (8, 5), (9, 5), (9, 5), (10, 5);")
 
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/join/issue6", "panic")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/join/issue60926", "panic")
 	tk.MustExec("set tidb_hash_join_version=legacy")
 
 	ctx := context.Background()

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -775,7 +775,7 @@ func TestIssue55881(t *testing.T) {
 	}
 }
 
-func TestIssue60923(t *testing.T) {
+func TestIssue60926(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
@@ -787,7 +787,7 @@ func TestIssue60923(t *testing.T) {
 	tk.MustExec("insert into t1 values (0, 10), (1, 10), (2, 10), (3, 10), (4, 10), (5, 10), (6, 10), (7, 10), (8, 10), (9, 10), (10, 10);")
 	tk.MustExec("insert into t2 values (0, 5), (0, 5), (1, 5), (2, 5), (2, 5), (3, 5), (4, 5), (5, 5), (5, 5), (6, 5), (7, 5), (8, 5), (8, 5), (9, 5), (9, 5), (10, 5);")
 
-	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/join/issue60923", "panic")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/join/issue6", "panic")
 	tk.MustExec("set tidb_hash_join_version=legacy")
 
 	ctx := context.Background()

--- a/pkg/executor/test/issuetest/executor_issue_test.go
+++ b/pkg/executor/test/issuetest/executor_issue_test.go
@@ -15,7 +15,6 @@
 package issuetest_test
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -790,19 +789,7 @@ func TestIssue60926(t *testing.T) {
 	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/join/issue60926", "panic")
 	tk.MustExec("set tidb_hash_join_version=legacy")
 
-	ctx := context.Background()
 	join.IsChildCloseCalledForTest = false
-	rs, _ := tk.ExecWithContext(context.Background(), "select * from t1 join (select col0, sum(col1) from t2 group by col0) as r on t1.col0 = r.col0;")
-	req := rs.NewChunk(nil)
-	for {
-		err := rs.Next(ctx, req)
-		require.NoError(t, err)
-		if req.NumRows() == 0 {
-			break
-		}
-	}
-	if rs != nil {
-		require.Error(t, rs.Close())
-	}
+	tk.MustQuery("select * from t1 join (select col0, sum(col1) from t2 group by col0) as r on t1.col0 = r.col0;")
 	require.True(t, join.IsChildCloseCalledForTest)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62351

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
