### PR TITLE
planner: fix the issue that the group by check not allow `cast` expr in both projection and group by | tidb-test=pr/2555

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -3480,9 +3480,13 @@ func allColFromExprNode(p base.LogicalPlan, n ast.Node, names map[*types.FieldNa
 	n.Accept(extractor)
 }
 
-func (b *PlanBuilder) resolveGbyExprs(ctx context.Context, p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) (base.LogicalPlan, []expression.Expression, bool, error) {
+// resolveGbyExprs resolves group by expressions from the group by clause of a select statement.
+// The returned `[]ast.Node` may differ from the original `gby.Items` in the group by clause for params. For params, the
+// `gby.Items[].Expr` will not be overwritten. However, the resolved expression is still needed for further processing, so
+// it's returned out.
+func (b *PlanBuilder) resolveGbyExprs(p base.LogicalPlan, gby *ast.GroupByClause, fields []*ast.SelectField) ([]ast.ExprNode, error) {
 	b.curClause = groupByClause
-	exprs := make([]expression.Expression, 0, len(gby.Items))
+	exprs := make([]ast.ExprNode, 0, len(gby.Items))
 	schema := p.Schema()
 	names := p.OutputNames()
 	if join, ok := p.(*logicalop.LogicalJoin); ok && join.FullSchema != nil {
@@ -3502,14 +3506,22 @@ func (b *PlanBuilder) resolveGbyExprs(ctx context.Context, p base.LogicalPlan, g
 		resolver.isParam = false
 		retExpr, _ := item.Expr.Accept(resolver)
 		if resolver.err != nil {
-			return nil, nil, false, errors.Trace(resolver.err)
+			return exprs, errors.Trace(resolver.err)
 		}
 		if !resolver.isParam {
 			item.Expr = retExpr.(ast.ExprNode)
 		}
 
-		itemExpr := retExpr.(ast.ExprNode)
-		expr, np, err := b.rewrite(ctx, itemExpr, p, nil, true)
+		exprs = append(exprs, retExpr.(ast.ExprNode))
+	}
+	return exprs, nil
+}
+
+func (b *PlanBuilder) rewriteGbyExprs(ctx context.Context, p base.LogicalPlan, gby *ast.GroupByClause, items []ast.ExprNode) (base.LogicalPlan, []expression.Expression, bool, error) {
+	exprs := make([]expression.Expression, 0, len(gby.Items))
+
+	for _, item := range items {
+		expr, np, err := b.rewrite(ctx, item, p, nil, true)
 		if err != nil {
 			return nil, nil, false, err
 		}
@@ -3788,15 +3800,25 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p b
 		originalFields = sel.Fields.Fields
 	}
 
+	var gbyExprs []ast.ExprNode
 	if sel.GroupBy != nil {
-		p, gbyCols, rollup, err = b.resolveGbyExprs(ctx, p, sel.GroupBy, sel.Fields.Fields)
+		gbyExprs, err = b.resolveGbyExprs(p, sel.GroupBy, sel.Fields.Fields)
 		if err != nil {
 			return nil, err
 		}
 	}
 
+	// `checkOnlyFullGroupBy` should be executed before rewrite gbyExprs, because the field type of the fields
+	// may change. For example, the length of a string field may change in `adjustRetFtForCastString`
 	if b.ctx.GetSessionVars().SQLMode.HasOnlyFullGroupBy() && sel.From != nil && !b.ctx.GetSessionVars().OptimizerEnableNewOnlyFullGroupByCheck {
 		err = b.checkOnlyFullGroupBy(p, sel)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if sel.GroupBy != nil {
+		p, gbyCols, rollup, err = b.rewriteGbyExprs(ctx, p, sel.GroupBy, gbyExprs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/table/tables/tables_test.go
+++ b/pkg/table/tables/tables_test.go
@@ -488,7 +488,7 @@ func TestHiddenColumn(t *testing.T) {
 	tk.MustGetErrMsg("select d, b from t;", "[planner:1054]Unknown column 'd' in 'field list'")
 	tk.MustGetErrMsg("select * from t where b > 1;", "[planner:1054]Unknown column 'b' in 'where clause'")
 	tk.MustGetErrMsg("select * from t order by b;", "[planner:1054]Unknown column 'b' in 'order clause'")
-	tk.MustGetErrMsg("select * from t group by b;", "[planner:1054]Unknown column 'b' in 'group statement'")
+	tk.MustGetErrMsg("select sum(a) from t group by b;", "[planner:1054]Unknown column 'b' in 'group statement'")
 
 	// Can't use hidden columns in `INSERT` statement
 	// 1. insert into ... values ...
@@ -529,7 +529,7 @@ func TestHiddenColumn(t *testing.T) {
 	tk.MustGetErrMsg("insert into t1 select d, b from t;", "[planner:1054]Unknown column 'd' in 'field list'")
 	tk.MustGetErrMsg("insert into t1 select a from t where b > 1;", "[planner:1054]Unknown column 'b' in 'where clause'")
 	tk.MustGetErrMsg("insert into t1 select a from t order by b;", "[planner:1054]Unknown column 'b' in 'order clause'")
-	tk.MustGetErrMsg("insert into t1 select a from t group by b;", "[planner:1054]Unknown column 'b' in 'group statement'")
+	tk.MustGetErrMsg("insert into t1 select sum(a) from t group by b;", "[planner:1054]Unknown column 'b' in 'group statement'")
 	tk.MustExec("drop table t1")
 
 	// `UPDATE` statement

--- a/tests/integrationtest/r/planner/core/integration.result
+++ b/tests/integrationtest/r/planner/core/integration.result
@@ -4295,3 +4295,12 @@ case when (
 t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
 ) then 1 else 2 end;
 1
+drop table if exists t;
+create table t (col timestamp);
+explain format='brief' select cast(col as char) from t group by cast(col as char);
+id	estRows	task	access object	operator info
+Projection	8000.00	root		cast(planner__core__integration.t.col, var_string(19))->Column#3
+└─HashAgg	8000.00	root		group by:Column#5, funcs:firstrow(Column#6)->planner__core__integration.t.col
+  └─TableReader	8000.00	root		data:HashAgg
+    └─HashAgg	8000.00	cop[tikv]		group by:cast(planner__core__integration.t.col, var_string(19)), funcs:firstrow(planner__core__integration.t.col)->Column#6
+      └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/planner/core/integration.test
+++ b/tests/integrationtest/t/planner/core/integration.test
@@ -2372,3 +2372,8 @@ select 1 from (select t.col as c0, 46578369 as c1 from t) as t where
   case when (
     t.c0 in (t.c0, cast((cast(1 as unsigned) - cast(t.c1 as signed)) as char))
   ) then 1 else 2 end;
+
+# TestIssue62350
+drop table if exists t;
+create table t (col timestamp);
+explain format='brief' select cast(col as char) from t group by cast(col as char);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62350

Problem Summary:

The following sql will fail to execute

```
create table t (col timestamp);
select cast(col as char) from t group by cast(col as char);
```

### What changed and how does it work?

1. Split the function `resolveGbyExpr` into two parts, the first one to do the resolve and the second one to rewrite the expression

Previously, the order of check and resolve is like this:

```
                                                                   
 ┌───────────────────────────────────────────────────────────┐     
 │SELECT CAST(col as char) FROM t GROUP BY CAST(col as char);│     
 └──┬────────────────────────────────────────────────────────┘     
    │                                                              
    │RESOLVE                                                       
    │                                                              
    ▼                                                              
 ┌───────────────────────────────────────────────────────────────┐ 
 │SELECT CAST(col as char) FROM t GROUP BY CAST(col as char(19));│ 
 └──┬────────────────────────────────────────────────────────────┘ 
    │                                                              
    │CHECK                                                         
    │                                                              
    ▼                                                              
 ┌───────────┐                                                     
 │FAILED!!!!!│                                                     
 └───────────┘                                                     
```

After this PR:

```
 ┌───────────────────────────────────────────────────────────┐   
 │SELECT CAST(col as char) FROM t GROUP BY CAST(col as char);│   
 └──┬────────────────────────────────────────────────────────┘   
    │                                                            
    │RESOLVE                                                     
    │                                                            
    ▼                                                            
 ┌───────────────────────────────────────────────────────────┐   
 │SELECT CAST(col as char) FROM t GROUP BY CAST(col as char);│   
 └──┬────────────────────────────────────────────────────────┘   
    │                                                            
    │CHECK                                                       
    │                                                            
    ▼                                                            
 ┌───────────┐                                                   
 │SUCCESS!!!!│                                                   
 └──┬────────┘                                                   
    │                                                            
    │REWRITE                                                     
    │                                                            
    ▼                                                            
┌───────────────────────────────────────────────────────────────┐
│SELECT CAST(col as char) FROM t GROUP BY CAST(col as char(19));│
└───────────────────────────────────────────────────────────────┘
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
