### PR TITLE
planner: add check for skew risk ratio within a bucket | tidb-test=pr/2564

### DIFF
--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -575,8 +575,10 @@ func (hg *Histogram) BetweenRowCount(sctx planctx.PlanContext, a, b types.Datum)
 		result := min(lessCountB, hg.NotNullCount()-lessCountA)
 		rangeEst = min(result, lowEqual+ndvAvg)
 	}
+	// LessCounts are equal only if no valid buckets or both values are out of range
+	isInValidBucket := lessCountA != lessCountB
 	// If values in the same bucket, use skewRatio to adjust the range estimate to account for potential skew.
-	if len(hg.Buckets) != 0 && bktIndexA == bktIndexB {
+	if isInValidBucket && bktIndexA == bktIndexB {
 		// sctx may be nil for stats version 1
 		if sctx != nil {
 			skewRatio := sctx.GetSessionVars().RiskRangeSkewRatio


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62093

Problem Summary:

### What changed and how does it work?
Previous usage of tidb_opt_risk_range_skew_ratio for skew within a bucket didn't filter out scenarios where the predicate bounds were out of range. Added check so this skew ratio only applies when at least part of the range predicate is within the histogram range. 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
