### PR TITLE
br: add keyspace support for br abort command

### DIFF
--- a/br/cmd/br/abort.go
+++ b/br/cmd/br/abort.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/task"
 	"github.com/pingcap/tidb/br/pkg/trace"
 	"github.com/pingcap/tidb/br/pkg/version/build"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -27,6 +28,8 @@ func NewAbortCommand() *cobra.Command {
 			build.LogInfo(build.BR)
 			logutil.LogEnvVariables()
 			task.LogArguments(c)
+			// disable stats otherwise takes too much memory
+			session.DisableStats4Test()
 			return nil
 		},
 	}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -2582,6 +2582,11 @@ func RunRestoreAbort(c context.Context, g glue.Glue, cmdName string, cfg *Restor
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 
+	// update keyspace to be user specified
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.KeyspaceName = cfg.KeyspaceName
+	})
+
 	keepaliveCfg := GetKeepalive(&cfg.Config)
 	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, keepaliveCfg, cfg.CheckRequirements, true, conn.NormalVersionChecker)
 	if err != nil {

--- a/br/tests/config/pd.toml
+++ b/br/tests/config/pd.toml
@@ -5,3 +5,6 @@ enable-placement-rules = true
 cacert-path = "/tmp/backup_restore_test/certs/ca.pem"
 cert-path = "/tmp/backup_restore_test/certs/pd.pem"
 key-path = "/tmp/backup_restore_test/certs/pd.key"
+
+[keyspace]
+pre-alloc = ["keyspace1", "keyspace2"]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62357

Problem Summary:

### What changed and how does it work?
Update keyspace when user passes in
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
