### PR TITLE
fix: let gb18030_bin is a bin collation

### DIFF
--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -335,7 +335,7 @@ func ConvertAndGetBinCollator(collate string) Collator {
 func IsBinCollation(collate string) bool {
 	return collate == charset.CollationASCII || collate == charset.CollationLatin1 ||
 		collate == charset.CollationUTF8 || collate == charset.CollationUTF8MB4 ||
-		collate == charset.CollationBin || collate == "utf8mb4_0900_bin"
+		collate == charset.CollationBin || collate == charset.CollationGB18030Bin || collate == "utf8mb4_0900_bin"
 	// TODO: define a constant to reference collations
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

### What changed and how does it work?
gb18030 is already supported, but the IsBinCollation function does not consider gb18030_bin to be a BinCollation