### PR TITLE
crossks: fix 'GC life time is shorter than' error

### DIFF
--- a/pkg/ddl/placement_policy_ddl_test.go
+++ b/pkg/ddl/placement_policy_ddl_test.go
@@ -125,7 +125,8 @@ func TestPlacementPolicyInUse(t *testing.T) {
 	t4.State = model.StatePublic
 	db1.Deprecated.Tables = append(db1.Deprecated.Tables, t4)
 
-	builder := infoschema.NewBuilder(dom, nil, infoschema.NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(dom, schemaCacheSize, nil, infoschema.NewData(), schemaCacheSize > 0)
 	err = builder.InitWithDBInfos(
 		[]*model.DBInfo{db1, db2, dbP},
 		[]*model.PolicyInfo{p1, p2, p3, p4, p5},

--- a/pkg/executor/slow_query_test.go
+++ b/pkg/executor/slow_query_test.go
@@ -59,7 +59,8 @@ func parseLog(retriever *slowQueryRetriever, sctx sessionctx.Context, reader *bu
 
 func newSlowQueryRetriever() (*slowQueryRetriever, error) {
 	data := infoschema.NewData()
-	newISBuilder := infoschema.NewBuilder(nil, nil, data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	newISBuilder := infoschema.NewBuilder(nil, schemaCacheSize, nil, data, schemaCacheSize > 0)
 	err := newISBuilder.InitWithDBInfos(nil, nil, nil, 0)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/stmtsummary_test.go
+++ b/pkg/executor/stmtsummary_test.go
@@ -33,7 +33,8 @@ import (
 
 func TestStmtSummaryRetriverV2_TableStatementsSummary(t *testing.T) {
 	data := infoschema.NewData()
-	infoSchemaBuilder := infoschema.NewBuilder(nil, nil, data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	infoSchemaBuilder := infoschema.NewBuilder(nil, schemaCacheSize, nil, data, schemaCacheSize > 0)
 	err := infoSchemaBuilder.InitWithDBInfos(nil, nil, nil, 0)
 	require.NoError(t, err)
 	infoSchema := infoSchemaBuilder.Build(math.MaxUint64)
@@ -78,7 +79,8 @@ func TestStmtSummaryRetriverV2_TableStatementsSummary(t *testing.T) {
 
 func TestStmtSummaryRetriverV2_TableStatementsSummaryEvicted(t *testing.T) {
 	data := infoschema.NewData()
-	infoSchemaBuilder := infoschema.NewBuilder(nil, nil, data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	infoSchemaBuilder := infoschema.NewBuilder(nil, schemaCacheSize, nil, data, schemaCacheSize > 0)
 	err := infoSchemaBuilder.InitWithDBInfos(nil, nil, nil, 0)
 	require.NoError(t, err)
 	infoSchema := infoSchemaBuilder.Build(math.MaxUint64)
@@ -158,7 +160,8 @@ func TestStmtSummaryRetriverV2_TableStatementsSummaryHistory(t *testing.T) {
 	stmtSummary.Add(stmtsummaryv2.GenerateStmtExecInfo4Test("digest3"))
 
 	data := infoschema.NewData()
-	infoSchemaBuilder := infoschema.NewBuilder(nil, nil, data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	infoSchemaBuilder := infoschema.NewBuilder(nil, schemaCacheSize, nil, data, schemaCacheSize > 0)
 	err = infoSchemaBuilder.InitWithDBInfos(nil, nil, nil, 0)
 	require.NoError(t, err)
 	infoSchema := infoSchemaBuilder.Build(math.MaxUint64)

--- a/pkg/infoschema/BUILD.bazel
+++ b/pkg/infoschema/BUILD.bazel
@@ -43,7 +43,6 @@ go_library(
         "//pkg/privilege",
         "//pkg/session/txninfo",
         "//pkg/sessionctx",
-        "//pkg/sessionctx/vardef",
         "//pkg/sessionctx/variable",
         "//pkg/store/helper",
         "//pkg/table",

--- a/pkg/infoschema/builder.go
+++ b/pkg/infoschema/builder.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	"github.com/pingcap/tidb/pkg/sessionctx"
-	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
 	"github.com/pingcap/tidb/pkg/util/domainutil"
@@ -1148,7 +1147,7 @@ func RegisterVirtualTable(dbInfo *model.DBInfo, tableFromMeta tableFromMetaFunc)
 }
 
 // NewBuilder creates a new Builder with a Handle.
-func NewBuilder(r autoid.Requirement, factory func() (pools.Resource, error), infoData *Data, useV2 bool) *Builder {
+func NewBuilder(r autoid.Requirement, schemaCacheSize uint64, factory func() (pools.Resource, error), infoData *Data, useV2 bool) *Builder {
 	builder := &Builder{
 		Requirement:  r,
 		infoschemaV2: NewInfoSchemaV2(r, factory, infoData),
@@ -1157,7 +1156,6 @@ func NewBuilder(r autoid.Requirement, factory func() (pools.Resource, error), in
 		infoData:     infoData,
 		enableV2:     useV2,
 	}
-	schemaCacheSize := vardef.SchemaCacheSize.Load()
 	infoData.tableCache.SetCapacity(schemaCacheSize)
 	return builder
 }

--- a/pkg/infoschema/infoschema_test.go
+++ b/pkg/infoschema/infoschema_test.go
@@ -105,7 +105,8 @@ func TestBasic(t *testing.T) {
 	internal.AddDB(t, re.Store(), dbInfo)
 	internal.AddTable(t, re.Store(), dbInfo.ID, tblInfo)
 
-	builder := infoschema.NewBuilder(re, nil, infoschema.NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(re, schemaCacheSize, nil, infoschema.NewData(), schemaCacheSize > 0)
 	err = builder.InitWithDBInfos(dbInfos, nil, nil, 1)
 	require.NoError(t, err)
 
@@ -335,7 +336,8 @@ func TestInfoTables(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	builder := infoschema.NewBuilder(re, nil, infoschema.NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(re, schemaCacheSize, nil, infoschema.NewData(), schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(nil, nil, nil, 0)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)
@@ -396,7 +398,8 @@ func TestBuildSchemaWithGlobalTemporaryTable(t *testing.T) {
 	dbInfo.Deprecated.Tables = []*model.TableInfo{}
 	dbInfos := []*model.DBInfo{dbInfo}
 	data := infoschema.NewData()
-	builder := infoschema.NewBuilder(re, nil, data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(re, schemaCacheSize, nil, data, schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(dbInfos, nil, nil, 1)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)
@@ -417,7 +420,8 @@ func TestBuildSchemaWithGlobalTemporaryTable(t *testing.T) {
 		err := kv.RunInNewTxn(ctx, re.Store(), true, func(ctx context.Context, txn kv.Transaction) error {
 			m := meta.NewMutator(txn)
 			for _, change := range changes {
-				builder = infoschema.NewBuilder(re, nil, data, vardef.SchemaCacheSize.Load() > 0)
+				schemaCacheSize := vardef.SchemaCacheSize.Load()
+				builder = infoschema.NewBuilder(re, schemaCacheSize, nil, data, schemaCacheSize > 0)
 				err := builder.InitWithOldInfoSchema(curIs)
 				require.NoError(t, err)
 				change(m, builder)
@@ -501,7 +505,8 @@ func TestBuildSchemaWithGlobalTemporaryTable(t *testing.T) {
 	require.NoError(t, err)
 	newDB.Deprecated.Tables = tblInfos
 	require.True(t, ok)
-	builder = infoschema.NewBuilder(re, nil, data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize = vardef.SchemaCacheSize.Load()
+	builder = infoschema.NewBuilder(re, schemaCacheSize, nil, data, schemaCacheSize > 0)
 	err = builder.InitWithDBInfos([]*model.DBInfo{newDB}, newIS.AllPlacementPolicies(), newIS.AllResourceGroups(), newIS.SchemaMetaVersion())
 	require.NoError(t, err)
 	require.True(t, builder.Build(math.MaxUint64).HasTemporaryTable())
@@ -632,7 +637,8 @@ func TestBuildBundle(t *testing.T) {
 		db.Deprecated.Tables, err = is.SchemaTableInfos(context.Background(), db.Name)
 		require.NoError(t, err)
 	}
-	builder := infoschema.NewBuilder(dom, nil, infoschema.NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(dom, schemaCacheSize, nil, infoschema.NewData(), schemaCacheSize > 0)
 	err = builder.InitWithDBInfos([]*model.DBInfo{db}, is.AllPlacementPolicies(), is.AllResourceGroups(), is.SchemaMetaVersion())
 	require.NoError(t, err)
 	is2 := builder.Build(math.MaxUint64)
@@ -1105,7 +1111,8 @@ func (tc *infoschemaTestContext) createSchema() {
 	internal.AddDB(tc.t, tc.re.Store(), dbInfo)
 	tc.dbInfo = dbInfo
 	// init infoschema
-	builder := infoschema.NewBuilder(tc.re, nil, tc.data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(tc.re, schemaCacheSize, nil, tc.data, schemaCacheSize > 0)
 	err := builder.InitWithDBInfos([]*model.DBInfo{}, nil, nil, 1)
 	require.NoError(tc.t, err)
 	tc.is = builder.Build(math.MaxUint64)
@@ -1290,7 +1297,8 @@ func (tc *infoschemaTestContext) applyDiffAndCheck(diff *model.SchemaDiff, check
 	txn, err := tc.re.Store().Begin()
 	require.NoError(tc.t, err)
 
-	builder := infoschema.NewBuilder(tc.re, nil, tc.data, vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := infoschema.NewBuilder(tc.re, schemaCacheSize, nil, tc.data, schemaCacheSize > 0)
 	err = builder.InitWithOldInfoSchema(tc.is)
 	require.NoError(tc.t, err)
 	// applyDiff

--- a/pkg/infoschema/infoschema_v2_test.go
+++ b/pkg/infoschema/infoschema_v2_test.go
@@ -168,7 +168,8 @@ func TestMisc(t *testing.T) {
 		r.Store().Close()
 	}()
 
-	builder := NewBuilder(r, nil, NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := NewBuilder(r, schemaCacheSize, nil, NewData(), schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(nil, nil, nil, 1)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)
@@ -291,7 +292,8 @@ func TestBundles(t *testing.T) {
 
 	schemaName := ast.NewCIStr("testDB")
 	tableName := ast.NewCIStr("test")
-	builder := NewBuilder(r, nil, NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := NewBuilder(r, schemaCacheSize, nil, NewData(), schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(nil, nil, nil, 1)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)
@@ -412,7 +414,8 @@ func TestReferredFKInfo(t *testing.T) {
 
 	schemaName := ast.NewCIStr("testDB")
 	tableName := ast.NewCIStr("testTable")
-	builder := NewBuilder(r, nil, NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := NewBuilder(r, schemaCacheSize, nil, NewData(), schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(nil, nil, nil, 1)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)
@@ -514,7 +517,8 @@ func TestSpecialAttributeCorrectnessInSchemaChange(t *testing.T) {
 
 	schemaName := ast.NewCIStr("testDB")
 	tableName := ast.NewCIStr("testTable")
-	builder := NewBuilder(r, nil, NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := NewBuilder(r, schemaCacheSize, nil, NewData(), schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(nil, nil, nil, 1)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)
@@ -606,7 +610,8 @@ func TestDataStructFieldsCorrectnessInSchemaChange(t *testing.T) {
 
 	schemaName := ast.NewCIStr("testDB")
 	tableName := ast.NewCIStr("testTable")
-	builder := NewBuilder(r, nil, NewData(), vardef.SchemaCacheSize.Load() > 0)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	builder := NewBuilder(r, schemaCacheSize, nil, NewData(), schemaCacheSize > 0)
 	err := builder.InitWithDBInfos(nil, nil, nil, 1)
 	require.NoError(t, err)
 	is := builder.Build(math.MaxUint64)

--- a/pkg/infoschema/issyncer/BUILD.bazel
+++ b/pkg/infoschema/issyncer/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/store/mockstore",
+        "//pkg/util/logutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/infoschema/issyncer/loader.go
+++ b/pkg/infoschema/issyncer/loader.go
@@ -44,8 +44,33 @@ var (
 	LoadSchemaDiffVersionGapThreshold int64 = 10000
 )
 
+// LoadMode represents the mode of loading info schema.
+type LoadMode int
+
+// String implements fmt.Stringer interface.
+func (m LoadMode) String() string {
+	switch m {
+	case LoadModeAuto:
+		return "auto"
+	case LoadModeFull:
+		return "full"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// LoadModeAuto will use v1 or v2 according to vardef.SchemaCacheSize.
+	// this is also the default mode.
+	LoadModeAuto LoadMode = 0
+	// LoadModeFull uses infoschema V1, and loads all matched info schema objects
+	// into memory immediately.
+	LoadModeFull LoadMode = 1
+)
+
 // Loader is the main structure for syncing the info schema.
 type Loader struct {
+	mode      LoadMode
 	store     kv.Storage
 	infoCache *infoschema.InfoCache
 	// deferFn is used to release infoschema object lazily during v1 and v2 switch
@@ -53,6 +78,7 @@ type Loader struct {
 	// if true, it means the loader is used for cross keyspace, we only allow
 	// loading system tables
 	crossKS bool
+	logger  *zap.Logger
 
 	// below fields are set when running background routines
 	// autoidClient is used when there are tables with AUTO_ID_CACHE=1, it is the client to the autoid service.
@@ -64,11 +90,14 @@ type Loader struct {
 
 // NewLoaderForCrossKS creates a new Loader instance.
 func NewLoaderForCrossKS(store kv.Storage, infoCache *infoschema.InfoCache) *Loader {
+	mode := LoadModeFull
 	return &Loader{
+		mode:      mode,
 		store:     store,
 		infoCache: infoCache,
 		deferFn:   &deferFn{},
 		crossKS:   true,
+		logger:    logutil.BgLogger().With(zap.String("targetKS", store.GetKeyspace()), zap.Stringer("mode", mode)),
 	}
 }
 
@@ -107,11 +136,16 @@ func (l *Loader) LoadWithTS(startTS uint64, isSnapshot bool) (infoschema.InfoSch
 	// fetch the commit timestamp of the schema diff
 	schemaTs, err := l.getTimestampForSchemaVersionWithNonEmptyDiff(m, neededSchemaVersion, startTS)
 	if err != nil {
-		logutil.BgLogger().Warn("failed to get schema version", zap.Error(err), zap.Int64("version", neededSchemaVersion))
+		l.logger.Warn("failed to get schema version", zap.Error(err), zap.Int64("version", neededSchemaVersion))
 		schemaTs = 0
 	}
 
-	enableV2 := vardef.SchemaCacheSize.Load() > 0
+	// 0 means LoadModeFull
+	var schemaCacheSize uint64
+	if l.mode == LoadModeAuto {
+		schemaCacheSize = vardef.SchemaCacheSize.Load()
+	}
+	enableV2 := schemaCacheSize > 0
 	currentSchemaVersion := int64(0)
 	oldInfoSchema := l.infoCache.GetLatest()
 	if oldInfoSchema != nil {
@@ -147,12 +181,12 @@ func (l *Loader) LoadWithTS(startTS uint64, isSnapshot bool) (infoschema.InfoSch
 	// 4. No regenerated schema diff.
 	startTime := time.Now()
 	if !isV1V2Switch && currentSchemaVersion != 0 && neededSchemaVersion > currentSchemaVersion && neededSchemaVersion-currentSchemaVersion < LoadSchemaDiffVersionGapThreshold {
-		is, relatedChanges, diffTypes, err := l.tryLoadSchemaDiffs(useV2, m, currentSchemaVersion, neededSchemaVersion, startTS)
+		is, relatedChanges, diffTypes, err := l.tryLoadSchemaDiffs(useV2, m, currentSchemaVersion, neededSchemaVersion, startTS, schemaCacheSize)
 		if err == nil {
 			infoschema_metrics.LoadSchemaDurationLoadDiff.Observe(time.Since(startTime).Seconds())
 			isV2, _ := infoschema.IsV2(is)
 			l.infoCache.Insert(is, schemaTs)
-			logutil.BgLogger().Info("diff load InfoSchema success",
+			l.logger.Info("diff load InfoSchema success",
 				zap.Bool("isV2", isV2),
 				zap.Int64("currentSchemaVersion", currentSchemaVersion),
 				zap.Int64("neededSchemaVersion", neededSchemaVersion),
@@ -164,20 +198,20 @@ func (l *Loader) LoadWithTS(startTS uint64, isSnapshot bool) (infoschema.InfoSch
 			return is, false, currentSchemaVersion, relatedChanges, nil
 		}
 		// We can fall back to full load, don't need to return the error.
-		logutil.BgLogger().Error("failed to load schema diff", zap.Error(err))
+		l.logger.Error("failed to load schema diff", zap.Error(err))
 	}
 
 	// add failpoint to simulate long-running schema loading scenario
 	failpoint.Inject("mock-load-schema-long-time", func(val failpoint.Value) {
 		if val.(bool) {
 			// not ideal to use sleep, but not sure if there is a better way
-			logutil.BgLogger().Error("sleep before doing a full load")
+			l.logger.Error("sleep before doing a full load")
 			time.Sleep(15 * time.Second)
 		}
 	})
 
 	// full load.
-	schemas, err := l.fetchAllSchemasWithTables(m)
+	schemas, err := l.fetchAllSchemasWithTables(m, schemaCacheSize)
 	if err != nil {
 		return nil, false, currentSchemaVersion, nil, err
 	}
@@ -203,14 +237,14 @@ func (l *Loader) LoadWithTS(startTS uint64, isSnapshot bool) (infoschema.InfoSch
 		// Not adding snapshot schema to history can avoid such cases.
 		data = infoschema.NewData()
 	}
-	builder := infoschema.NewBuilder(l, l.sysExecutorFactory, data, useV2)
+	builder := infoschema.NewBuilder(l, schemaCacheSize, l.sysExecutorFactory, data, useV2)
 	err = builder.InitWithDBInfos(schemas, policies, resourceGroups, neededSchemaVersion)
 	if err != nil {
 		return nil, false, currentSchemaVersion, nil, err
 	}
 	is := builder.Build(startTS)
 	isV2, _ := infoschema.IsV2(is)
-	logutil.BgLogger().Info("full load InfoSchema success",
+	l.logger.Info("full load InfoSchema success",
 		zap.Bool("isV2", isV2),
 		zap.Int64("currentSchemaVersion", currentSchemaVersion),
 		zap.Int64("neededSchemaVersion", neededSchemaVersion),
@@ -220,7 +254,7 @@ func (l *Loader) LoadWithTS(startTS uint64, isSnapshot bool) (infoschema.InfoSch
 		// Reset the whole info cache to avoid co-existing of both v1 and v2, causing the memory usage doubled.
 		fn := l.infoCache.Upsert(is, schemaTs)
 		l.deferFn.add(fn, time.Now().Add(10*time.Minute))
-		logutil.BgLogger().Info("infoschema v1/v2 switch")
+		l.logger.Info("infoschema v1/v2 switch")
 	} else {
 		l.infoCache.Insert(is, schemaTs)
 	}
@@ -231,7 +265,7 @@ func (l *Loader) LoadWithTS(startTS uint64, isSnapshot bool) (infoschema.InfoSch
 // Return true if the schema is loaded successfully.
 // Return false if the schema can not be loaded by schema diff, then we need to do full load.
 // The second returned value is the delta updated table and partition IDs.
-func (l *Loader) tryLoadSchemaDiffs(useV2 bool, m meta.Reader, usedVersion, newVersion int64, startTS uint64) (infoschema.InfoSchema, *transaction.RelatedSchemaChange, []string, error) {
+func (l *Loader) tryLoadSchemaDiffs(useV2 bool, m meta.Reader, usedVersion, newVersion int64, startTS, schemaCacheSize uint64) (infoschema.InfoSchema, *transaction.RelatedSchemaChange, []string, error) {
 	var diffs []*model.SchemaDiff
 	for usedVersion < newVersion {
 		usedVersion++
@@ -242,7 +276,7 @@ func (l *Loader) tryLoadSchemaDiffs(useV2 bool, m meta.Reader, usedVersion, newV
 		if diff == nil {
 			// Empty diff means the txn of generating schema version is committed, but the txn of `runDDLJob` is not or fail.
 			// It is safe to skip the empty diff because the infoschema is new enough and consistent.
-			logutil.BgLogger().Info("diff load InfoSchema get empty schema diff", zap.Int64("version", usedVersion))
+			l.logger.Info("diff load InfoSchema get empty schema diff", zap.Int64("version", usedVersion))
 			l.infoCache.InsertEmptySchemaVersion(usedVersion)
 			continue
 		}
@@ -266,7 +300,7 @@ func (l *Loader) tryLoadSchemaDiffs(useV2 bool, m meta.Reader, usedVersion, newV
 		}
 	})
 
-	builder := infoschema.NewBuilder(l, l.sysExecutorFactory, l.infoCache.Data, useV2)
+	builder := infoschema.NewBuilder(l, schemaCacheSize, l.sysExecutorFactory, l.infoCache.Data, useV2)
 	err := builder.InitWithOldInfoSchema(l.infoCache.GetLatest())
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
@@ -319,7 +353,7 @@ func (l *Loader) getTimestampForSchemaVersionWithNonEmptyDiff(m meta.Reader, ver
 }
 
 // fetchAllSchemasWithTables fetches all schemas with their tables.
-func (l *Loader) fetchAllSchemasWithTables(m meta.Reader) ([]*model.DBInfo, error) {
+func (l *Loader) fetchAllSchemasWithTables(m meta.Reader, schemaCacheSize uint64) ([]*model.DBInfo, error) {
 	allSchemas, err := m.ListDatabases()
 	if err != nil {
 		return nil, err
@@ -338,7 +372,7 @@ func (l *Loader) fetchAllSchemasWithTables(m meta.Reader) ([]*model.DBInfo, erro
 		return nil, nil
 	}
 
-	splittedSchemas := l.splitForConcurrentFetch(allSchemas)
+	splittedSchemas := l.splitForConcurrentFetch(allSchemas, schemaCacheSize)
 	concurrency := min(len(splittedSchemas), 128)
 
 	eg, ectx := util.NewErrorGroupWithRecoverWithCtx(context.Background())
@@ -346,7 +380,7 @@ func (l *Loader) fetchAllSchemasWithTables(m meta.Reader) ([]*model.DBInfo, erro
 	for _, schemas := range splittedSchemas {
 		ss := schemas
 		eg.Go(func() error {
-			return l.fetchSchemasWithTables(ectx, ss, m)
+			return l.fetchSchemasWithTables(ectx, ss, m, schemaCacheSize)
 		})
 	}
 	if err := eg.Wait(); err != nil {
@@ -371,7 +405,7 @@ func (*Loader) fetchResourceGroups(m meta.Reader) ([]*model.ResourceGroupInfo, e
 	return allResourceGroups, nil
 }
 
-func (*Loader) fetchSchemasWithTables(ctx context.Context, schemas []*model.DBInfo, m meta.Reader) error {
+func (*Loader) fetchSchemasWithTables(ctx context.Context, schemas []*model.DBInfo, m meta.Reader, schemaCacheSize uint64) error {
 	failpoint.Inject("failed-fetch-schemas-with-tables", func() {
 		failpoint.Return(errors.New("failpoint: failed to fetch schemas with tables"))
 	})
@@ -383,7 +417,7 @@ func (*Loader) fetchSchemasWithTables(ctx context.Context, schemas []*model.DBIn
 		}
 		var tables []*model.TableInfo
 		var err error
-		if vardef.SchemaCacheSize.Load() > 0 && !infoschema.IsSpecialDB(di.Name.L) {
+		if schemaCacheSize > 0 && !infoschema.IsSpecialDB(di.Name.L) {
 			name2ID, specialTableInfos, err := m.GetAllNameToIDAndTheMustLoadedTableInfo(di.ID)
 			if err != nil {
 				return err
@@ -438,10 +472,10 @@ func (*Loader) fetchSchemasWithTables(ctx context.Context, schemas []*model.DBIn
 // so we decrease the concurrency.
 const fetchSchemaConcurrency = 1
 
-func (*Loader) splitForConcurrentFetch(schemas []*model.DBInfo) [][]*model.DBInfo {
+func (*Loader) splitForConcurrentFetch(schemas []*model.DBInfo, schemaCacheSize uint64) [][]*model.DBInfo {
 	groupCnt := fetchSchemaConcurrency
 	schemaCnt := len(schemas)
-	if vardef.SchemaCacheSize.Load() > 0 && schemaCnt > 1000 {
+	if schemaCacheSize > 0 && schemaCnt > 1000 {
 		// TODO: Temporary solution to speed up when too many databases, will refactor it later.
 		groupCnt = 8
 	}

--- a/pkg/infoschema/issyncer/loader.go
+++ b/pkg/infoschema/issyncer/loader.go
@@ -97,7 +97,7 @@ func NewLoaderForCrossKS(store kv.Storage, infoCache *infoschema.InfoCache) *Loa
 		infoCache: infoCache,
 		deferFn:   &deferFn{},
 		crossKS:   true,
-		logger:    logutil.BgLogger().With(zap.String("targetKS", store.GetKeyspace()), zap.Stringer("mode", mode)),
+		logger:    logutil.BgLogger().With(zap.String("targetKS", store.GetKeyspace()), zap.Stringer("mode", mode)).Named("infoschema"),
 	}
 }
 

--- a/pkg/infoschema/issyncer/loader_test.go
+++ b/pkg/infoschema/issyncer/loader_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
+	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +35,7 @@ func TestLoadFromTS(t *testing.T) {
 	l := &Loader{
 		store:     store,
 		infoCache: infoschema.NewCache(nil, 1),
+		logger:    logutil.BgLogger(),
 	}
 	ver, err := store.CurrentVersion(tidbkv.GlobalTxnScope)
 	require.NoError(t, err)
@@ -74,6 +76,7 @@ func TestLoadFromTS(t *testing.T) {
 	l = &Loader{
 		store:     store,
 		infoCache: infoschema.NewCache(nil, 1),
+		logger:    logutil.BgLogger(),
 	}
 	is, hitCache, oldSchemaVersion, changes, err = l.LoadWithTS(ver.Ver, false)
 	require.NoError(t, err)

--- a/pkg/infoschema/issyncer/syncer.go
+++ b/pkg/infoschema/issyncer/syncer.go
@@ -100,11 +100,13 @@ func New(
 		},
 	}
 	do.schemaValidator = isvalidator.New(schemaLease)
+	mode := LoadModeAuto
 	do.loader = &Loader{
+		mode:      mode,
 		store:     store,
 		infoCache: infoCache,
 		deferFn:   &do.deferFn,
-		logger:    logutil.BgLogger().With(zap.Stringer("mode", LoadModeAuto)),
+		logger:    logutil.BgLogger().With(zap.Stringer("mode", mode)),
 	}
 
 	return do

--- a/pkg/infoschema/issyncer/syncer.go
+++ b/pkg/infoschema/issyncer/syncer.go
@@ -104,6 +104,7 @@ func New(
 		store:     store,
 		infoCache: infoCache,
 		deferFn:   &do.deferFn,
+		logger:    logutil.BgLogger().With(zap.Stringer("mode", LoadModeAuto)),
 	}
 
 	return do
@@ -479,7 +480,8 @@ func (s *Syncer) GetSchemaValidator() validatorapi.Validator {
 
 // FetchAllSchemasWithTables fetches all schemas with their tables.
 func (s *Syncer) FetchAllSchemasWithTables(m meta.Reader) ([]*model.DBInfo, error) {
-	return s.loader.fetchAllSchemasWithTables(m)
+	schemaCacheSize := vardef.SchemaCacheSize.Load()
+	return s.loader.fetchAllSchemasWithTables(m, schemaCacheSize)
 }
 
 // ChangeSchemaCacheSize changes the schema cache size.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
on default, we are using infoschema v2, it will load table info lazily with the TS when it's initialized, so if after initialization, we hasn't try to get the table info after the GC life time, it will report this error, such as in below case
- owner schedule dxf task to next task, but before it start runs subtask, it's shutdown
- another node became owner, and start execute subtask, suppose the subtask takes more than 10m which is the default gc life time, it will report the error

we fix it by load cross ks infoschema by infoschema v1， which will load matched tableinfo actively
- unify the usage of `vardef.SchemaCacheSize`
- introduce `LoadMode` to infoschema loader, on default we will auto decide to use v1 or v2, for cross ks we use `LoadModeFull` mode
- log the target ks and mode in the isLoader
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

<details><summary>apply below diff, before start tidb</summary>

```diff
diff --git a/pkg/disttask/importinto/scheduler.go b/pkg/disttask/importinto/scheduler.go
index 7f091de1cd..8856f39b3e 100644
--- a/pkg/disttask/importinto/scheduler.go
+++ b/pkg/disttask/importinto/scheduler.go
@@ -274,6 +274,7 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 	nextStep proto.Step,
 ) (
 	resSubtaskMeta [][]byte, err error) {
+	time.Sleep(90 * time.Second)
 	logger := logutil.BgLogger().With(
 		zap.Stringer("type", task.Type),
 		zap.Int64("task-id", task.ID),
diff --git a/pkg/session/tidb.go b/pkg/session/tidb.go
index 3a66921683..6d2e732986 100644
--- a/pkg/session/tidb.go
+++ b/pkg/session/tidb.go
@@ -86,7 +86,7 @@ func (dm *domainMap) getWithEtcdClient(store kv.Storage, etcdClient *clientv3.Cl
 		return
 	}
 
-	ddlLease := time.Duration(atomic.LoadInt64(&schemaLease))
+	ddlLease := 10 * time.Second
 	statisticLease := time.Duration(atomic.LoadInt64(&statsLease))
 	planReplayerGCLease := GetPlanReplayerGCLease()
 	err = util.RunWithRetry(util.DefaultMaxRetries, util.RetryInterval, func() (retry bool, err1 error) {
diff --git a/pkg/sessionctx/variable/sysvar.go b/pkg/sessionctx/variable/sysvar.go
index dc6e22b69e..7f4a4cf9ab 100644
--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -955,13 +955,13 @@ var defaultSysVars = []*SysVar{
 	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		return setTiDBTableValue(s, "tikv_gc_enable", val, "Current GC enable status")
 	}},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBGCRunInterval, Value: "10m0s", Type: vardef.TypeDuration, MinValue: int64(time.Minute * 10), MaxValue: uint64(time.Hour * 24 * 365), GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
-		return getTiDBTableValue(s, "tikv_gc_run_interval", "10m0s")
+	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBGCRunInterval, Value: "10s", Type: vardef.TypeDuration, MinValue: int64(time.Second * 10), MaxValue: uint64(time.Hour * 24 * 365), GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+		return getTiDBTableValue(s, "tikv_gc_run_interval", "10s")
 	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		return setTiDBTableValue(s, "tikv_gc_run_interval", val, "GC run interval, at least 10m, in Go format.")
 	}},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBGCLifetime, Value: "10m0s", Type: vardef.TypeDuration, MinValue: int64(time.Minute * 10), MaxValue: uint64(time.Hour * 24 * 365), GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
-		return getTiDBTableValue(s, "tikv_gc_life_time", "10m0s")
+	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBGCLifetime, Value: "10s", Type: vardef.TypeDuration, MinValue: int64(time.Second * 10), MaxValue: uint64(time.Hour * 24 * 365), GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+		return getTiDBTableValue(s, "tikv_gc_life_time", "10s")
 	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		return setTiDBTableValue(s, "tikv_gc_life_time", val, "All versions within life time will not be collected by GC, at least 10m, in Go format.")
 	}},
diff --git a/pkg/store/gcworker/gc_worker.go b/pkg/store/gcworker/gc_worker.go
index c267fa228b..e8ba8ff798 100644
--- a/pkg/store/gcworker/gc_worker.go
+++ b/pkg/store/gcworker/gc_worker.go
@@ -138,13 +138,13 @@ const (
 
 	gcLastRunTimeKey       = "tikv_gc_last_run_time"
 	gcRunIntervalKey       = "tikv_gc_run_interval"
-	gcDefaultRunInterval   = time.Minute * 10
+	gcDefaultRunInterval   = time.Second * 10
 	gcWaitTime             = time.Minute * 1
 	gcRedoDeleteRangeDelay = 24 * time.Hour
 
 	gcLifeTimeKey        = "tikv_gc_life_time"
-	gcDefaultLifeTime    = time.Minute * 10
-	gcMinLifeTime        = time.Minute * 10
+	gcDefaultLifeTime    = time.Second * 10
+	gcMinLifeTime        = time.Second * 10
 	gcSafePointKey       = "tikv_gc_safe_point"
 	gcConcurrencyKey     = "tikv_gc_concurrency"
 	gcDefaultConcurrency = 2
```

</details>

before this pr, run import on user keyspace 3 times, all fail with `GC life time is shorter than transaction duration, transaction start ts is`

after this pr, run 3 times again, all success

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
