### PR TITLE
planner: fix sql with static partition pruning mode got nil pointer error

### DIFF
--- a/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
+++ b/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     flaky = True,
     race = "on",
-    shard_count = 36,
+    shard_count = 37,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -1594,6 +1594,7 @@ func TestRuleAggElimination4Join(t *testing.T) {
 		}
 	})
 }
+
 func TestIssue62331(t *testing.T) {
 	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
 		tk.MustExec("use test")

--- a/pkg/planner/core/casetest/physicalplantest/testdata/cascades_template_in.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/cascades_template_in.json
@@ -15,5 +15,11 @@
       "SELECT t1.id1, t1.id2, COUNT(t1.id3) FROM t1 left join t2 on t1.id1 = t2.id1 and t1.id2 = t2.id2  inner join t4 on t1.id1 = t4.id1 and t1.id2 = t4.id2 GROUP BY t1.id1, t1.id2;"
 
     ]
-  } 
+  },
+  {
+    "name": "TestIssue62331",
+    "cases": [
+      "select /*+ read_from_storage(tiflash[t1]) */ /*+ use_index(t1) */ /*+ agg_to_cop() hash_agg() */  bit_and(t1.col_2) as r0, bit_xor(t1.col_2) as r1 , substring(t1.col_2 ,4) as r2 from t1 where t1.col_1 in ('04:00:09.00' ,'21:06:18.00' ,'18:43:53.00') group by t1.col_1,t1.col_2  having not(t1.col_1 <> '06:32:23.00');"
+    ]
+  }
 ]

--- a/pkg/planner/core/casetest/physicalplantest/testdata/cascades_template_out.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/cascades_template_out.json
@@ -167,5 +167,20 @@
         "Warn": null
       }
     ]
+  },
+  {
+    "Name": "TestIssue62331",
+    "Cases": [
+      {
+        "SQL": "select /*+ read_from_storage(tiflash[t1]) */ /*+ use_index(t1) */ /*+ agg_to_cop() hash_agg() */  bit_and(t1.col_2) as r0, bit_xor(t1.col_2) as r1 , substring(t1.col_2 ,4) as r2 from t1 where t1.col_1 in ('04:00:09.00' ,'21:06:18.00' ,'18:43:53.00') group by t1.col_1,t1.col_2  having not(t1.col_1 <> '06:32:23.00');",
+        "Plan": [
+          "Projection 1.00 root  ifnull(cast(test.t1.col_2, bigint(21) UNSIGNED BINARY), 18446744073709551615)->Column#7, ifnull(cast(test.t1.col_2, bigint(21) UNSIGNED BINARY), 0)->Column#8, substring(cast(test.t1.col_2, var_string(20)), 4)->Column#9",
+          "└─TableDual 1.00 root  rows:0"
+        ],
+        "Warn": ["[planner:1815]No available path for table test.t1 with the store type tiflash of the hint /*+ read_from_storage */, please check the status of the table replica and variable value of tidb_isolation_read_engines(map[0:{} 1:{} 2:{}])",
+        "[parser:8066]Optimizer hint can only be followed by certain keywords like SELECT, INSERT, etc.",
+        "[parser:8066]Optimizer hint can only be followed by certain keywords like SELECT, INSERT, etc."]
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/physicalplantest/testdata/cascades_template_xut.json
+++ b/pkg/planner/core/casetest/physicalplantest/testdata/cascades_template_xut.json
@@ -167,5 +167,20 @@
           "Warn": null
         }
       ]
+    },
+    {
+      "Name": "TestIssue62331",
+      "Cases": [
+        {
+          "SQL": "select /*+ read_from_storage(tiflash[t1]) */ /*+ use_index(t1) */ /*+ agg_to_cop() hash_agg() */  bit_and(t1.col_2) as r0, bit_xor(t1.col_2) as r1 , substring(t1.col_2 ,4) as r2 from t1 where t1.col_1 in ('04:00:09.00' ,'21:06:18.00' ,'18:43:53.00') group by t1.col_1,t1.col_2  having not(t1.col_1 <> '06:32:23.00');",
+          "Plan": [
+            "Projection 1.00 root  ifnull(cast(test.t1.col_2, bigint(21) UNSIGNED BINARY), 18446744073709551615)->Column#7, ifnull(cast(test.t1.col_2, bigint(21) UNSIGNED BINARY), 0)->Column#8, substring(cast(test.t1.col_2, var_string(20)), 4)->Column#9",
+            "└─TableDual 1.00 root  rows:0"
+          ],
+          "Warn": ["[planner:1815]No available path for table test.t1 with the store type tiflash of the hint /*+ read_from_storage */, please check the status of the table replica and variable value of tidb_isolation_read_engines(map[0:{} 1:{} 2:{}])",
+          "[parser:8066]Optimizer hint can only be followed by certain keywords like SELECT, INSERT, etc.",
+          "[parser:8066]Optimizer hint can only be followed by certain keywords like SELECT, INSERT, etc."]
+        }
+      ]
     }
   ]


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62331 

Problem Summary:
Since PR [#61571](https://github.com/pingcap/tidb/pull/61571), `applyPredicateSimplification` invokes `PropagateConstant`. Then`ds.AllConds` and `ds.PushedDownConds` may not kept in sync after `rule.PartitionProcessor`, it will cause a nil pointer panic.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
