### PR TITLE
*: fix a bug using stale read together with autocommit=0

### DIFF
--- a/tests/realtikvtest/txntest/stale_read_test.go
+++ b/tests/realtikvtest/txntest/stale_read_test.go
@@ -1749,7 +1749,7 @@ func TestStaleReadWithNonAutoCommit(t *testing.T) {
 	time.Sleep(time.Second) // to get rid of 'table not exist' error
 
 	done := make(chan struct{})
-	res := make(chan interface{})
+	res := make(chan any)
 	go func() {
 		defer func() {
 			res <- recover()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62384

Problem Summary:

A nasty bug when using stale read and autocommit=0 together.
If the user use:

```
set @@autocommit = 0;
... some other query should be inside a transaction
set @@autocommit = 1;
```

When using stale read, it's not in a transaction.
This cause the query see insistency data because they're not the same transaction.

### What changed and how does it work?

I found the stale read code differ a lot with default setting.

Under default setting, how does "set autocommit = 0" start a transaction? 
There is a txnmanager's `ActivateTxn()` and it will check `!sessVars.IsAutocommit() && sessVars.SnapshotTS == 0` and `SetInTxn(true)`

But for stale read, the code is totally different.

session.go `PrepareTxnCtx()` creates a txn future, but stale read will not use `ActivateTxn()` to activate it.
Instead, in planner preprocess pass, there will be a stale read process to replace the txnmanager `provider` of this transaction, the stale read ts is obtain there and this new stale read provider will have a totally different way to `GetStmtReadTS()`.

In such code path, `!sessVars.IsAutocommit() && sessVars.SnapshotTS == 0` is never checked, so stale read does not handle 'set autocommit=0' correctly.

In this commit, I try to fix it by checking !sessVars.IsAutocommit() condition, and use EnterNewTxnRequest with `EnterNewTxnWithBeginStmt`  type, this is exactly what `executeBegin` do in executor/simple.go 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix a bug of stale read, before this fix, stale read does not work with autocommit=0 correctly
```
