### PR TITLE
fix: add mutex to prevent concurrent btree.Clone() calls in infoschema v2

### DIFF
--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -82,24 +82,32 @@ func (si *schemaItem) Name() string {
 	return si.dbInfo.Name.L
 }
 
-// btree.Clone() is not safe to call from multiple goroutines at once,
-// as stated in the BTree source code. We use a mutex to ensure safety.
-var cloneMu sync.Mutex
-
-// btreeSet updates the btree.
+// btreeSet safely updates the btree by cloning and inserting the new item.
+// It avoids concurrent Clone() calls using atomic.Swap and retries with backoff.
 // Concurrent write is supported, but should be avoided as much as possible.
 func btreeSet[T any](ptr *atomic.Pointer[btree.BTreeG[T]], item T) {
-	succ := false
-	for !succ {
-		var t = ptr.Load()
-		cloneMu.Lock()
-		t2 := t.Clone()
-		cloneMu.Unlock()
-		t2.ReplaceOrInsert(item)
-		succ = ptr.CompareAndSwap(t, t2)
-		if !succ {
+	backoff := time.Microsecond
+
+	for {
+		// Atomically take ownership of the tree for cloning
+		old := ptr.Swap(nil)
+		if old == nil {
+			// Another goroutine is likely cloning; back off and retry
 			logutil.BgLogger().Info("infoschema v2 btree concurrently multiple writes detected, this should be rare")
+			time.Sleep(backoff)
+			if backoff < time.Millisecond {
+				backoff *= 2 // exponential backoff to reduce contention
+			}
+			continue
 		}
+
+		// Clone and modify the tree
+		newTree := old.Clone()
+		newTree.ReplaceOrInsert(item)
+
+		// Publish the updated tree atomically
+		ptr.Store(newTree)
+		return
 	}
 }
 


### PR DESCRIPTION

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62391 

Problem Summary:
`btree.BTree.Clone()` is not safe to call concurrently, as mentioned in the upstream BTree library’s documentation. However, in `btreeSet()` (used in infoschema v2), `Clone()` was being called without synchronization, which could lead to race conditions or memory corruption under concurrent writes.

### What changed and how does it work?
A `sync.Mutex` named `cloneMu` has been introduced to wrap the `Clone()` call within `btreeSet()`. This ensures that `Clone()` is only executed by one goroutine at a time, as required by the BTree implementation.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
