### PR TITLE
globalsort: fix stuck when ingesting small kv

### DIFF
--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -69,7 +69,7 @@ import (
 // very small, the real memory taken by each KV pair might be doubled, so it's
 // only an estimation.
 // such as, for a simple table "create table t(id bigint primary key, v bigint, index(v))",
-// each data KV is 29B, each index KV is 38B.
+// each index KV is 38B, golang need 86B memory to store it.
 //
 // RangeS for different region size and cpu:mem ratio, the number in parentheses
 // is the number of SST files per region:

--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -64,6 +64,13 @@ import (
 //     trailing 1 is for RS divided by odd number.
 //   - else RangeS = floor(TempRangeS / RS) * RS.
 //
+// Note: below calculation only consider the memory taken by the KV pair itself,
+// golang takes 24*2 = 48B for each KV pair, so if the size of KV pair itself is
+// very small, the real memory taken by each KV pair might be doubled, so it's
+// only an estimation.
+// such as, for a simple table "create table t(id bigint primary key, v bigint, index(v))",
+// each data KV is 29B, each index KV is 38B.
+//
 // RangeS for different region size and cpu:mem ratio, the number in parentheses
 // is the number of SST files per region:
 //

--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -279,7 +279,9 @@ func getFilesReadConcurrency(
 			)
 		}
 	}
-	logutil.Logger(ctx).Info("estimated file size, including kv length, of this range group",
+	// Note: this is the file size of the range group, KV size is smaller, as we
+	// need additional 8*2 for each KV.
+	logutil.Logger(ctx).Info("estimated file size of this range group",
 		zap.String("totalSize", units.BytesSize(float64(totalFileSize))))
 	return result, startOffs, nil
 }

--- a/pkg/lightning/backend/external/engine.go
+++ b/pkg/lightning/backend/external/engine.go
@@ -279,7 +279,7 @@ func getFilesReadConcurrency(
 			)
 		}
 	}
-	logutil.Logger(ctx).Info("estimated file size of this range group",
+	logutil.Logger(ctx).Info("estimated file size, including kv length, of this range group",
 		zap.String("totalSize", units.BytesSize(float64(totalFileSize))))
 	return result, startOffs, nil
 }

--- a/pkg/lightning/backend/external/split.go
+++ b/pkg/lightning/backend/external/split.go
@@ -248,7 +248,8 @@ func (r *RangeSplitter) SplitOneRangesGroup() (
 			r.recordRegionSplitAfterNextProp = false
 		}
 
-		// each KV need additional memory for 2 slice
+		// each KV need additional memory for 2 slice.
+		// we can enhance it later using SliceLocation.
 		rangeMemSize := r.curRangeJobSize + r.curRangeJobKeyCnt*size.SizeOfSlice*2
 		if rangeMemSize >= r.rangeJobSize || r.curRangeJobKeyCnt >= r.rangeJobKeyCnt {
 			r.curRangeJobSize = 0

--- a/pkg/lightning/backend/external/split.go
+++ b/pkg/lightning/backend/external/split.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/util/logutil"
+	"github.com/pingcap/tidb/pkg/util/size"
 	"go.uber.org/zap"
 )
 
@@ -247,7 +248,9 @@ func (r *RangeSplitter) SplitOneRangesGroup() (
 			r.recordRegionSplitAfterNextProp = false
 		}
 
-		if r.curRangeJobSize >= r.rangeJobSize || r.curRangeJobKeyCnt >= r.rangeJobKeyCnt {
+		// each KV need additional memory for 2 slice
+		rangeMemSize := r.curRangeJobSize + r.curRangeJobKeyCnt*size.SizeOfSlice*2
+		if rangeMemSize >= r.rangeJobSize || r.curRangeJobKeyCnt >= r.rangeJobKeyCnt {
 			r.curRangeJobSize = 0
 			r.curRangeJobKeyCnt = 0
 			r.recordRangeJobAfterNextProp = true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62388

Problem Summary:

### What changed and how does it work?
consider the memory taken by slice header when splitting range
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

same case in the issue, before this pr, 2 out of 3 runs stuck. after this pr, we run 10 times, all success.

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
