### PR TITLE
executor, planner: do not fetch row data for PointGet when covering index have enough data

### DIFF
--- a/bazel-tidb_62423_imporove_point_get
+++ b/bazel-tidb_62423_imporove_point_get
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_taka-h/e278be9bdf33248df7a59714e647c5ba/execroot/_main

--- a/bazel-tidb_62423_imporove_point_get
+++ b/bazel-tidb_62423_imporove_point_get
@@ -1,0 +1,1 @@
+/private/var/tmp/_bazel_taka-h/e278be9bdf33248df7a59714e647c5ba/execroot/_main

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -411,8 +411,11 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 	sctx := e.BaseExecutor.Ctx()
 	schema := e.Schema()
 
-	// If the index covers all required columns, build result directly from index values
-	if e.idxInfo != nil && e.coveredByIndex && !isCommonHandleRead(e.tblInfo, e.idxInfo) {
+	// If the index covers all required columns, build result directly from index values.
+	// Skip this fast path under SELECT ... FOR UPDATE: the row-key lock is acquired only
+	// by getAndLock below, and MySQL/InnoDB semantics require locking the clustered row
+	// regardless of which columns are projected.
+	if e.idxInfo != nil && e.coveredByIndex && !e.lock && !isCommonHandleRead(e.tblInfo, e.idxInfo) {
 		return e.buildResultFromIndex(ctx, req, schema, sctx)
 	}
 

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -904,20 +904,29 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		return nil
 	}
 
-	// For indexed columns with case-insensitive collations in the result set,
-	// we need to fetch row data to get the correct case of the stored value.
-	// This is because e.idxVals contains the search values, not the stored values.
+	// For string columns, the search value in e.idxVals may legitimately differ from the
+	// stored value under two collation rules that both normalise before comparing:
+	//   - Case-insensitive collations ('foo' matches stored 'Foo'): IsCICollation.
+	//   - PAD SPACE collations ('foo' matches stored 'foo '), which covers every collation
+	//     except truly binary ones (binary, utf8mb4_0900_bin) and the NO-PAD
+	//     utf8mb4_0900_ai_ci — note that utf8mb4_bin is PAD SPACE but case-sensitive, so
+	//     the CI-only check used to miss it. IsPadSpaceCollation is the same helper used
+	//     by pkg/util/ranger for the trailing-space case.
+	// In either case returning e.idxVals[i] directly would return what the user searched
+	// for rather than what the table actually stores, diverging silently from MySQL
+	// behaviour. Fall back to the row-fetch path so the stored value is decoded.
 	for _, col := range schema.Columns {
-		// Check if this column is part of the index
 		for _, idxCol := range e.idxInfo.Columns {
-			if e.tblInfo.Columns[idxCol.Offset].ID == col.ID {
-				// This column is in the index
-				if col.RetType.EvalType() == types.ETString && collate.IsCICollation(col.RetType.GetCollate()) {
-					// For CI collation, the search value might differ from stored value
+			if e.tblInfo.Columns[idxCol.Offset].ID != col.ID {
+				continue
+			}
+			if col.RetType.EvalType() == types.ETString {
+				collation := col.RetType.GetCollate()
+				if collate.IsCICollation(collation) || collate.IsPadSpaceCollation(collation) {
 					return e.buildResultFromRowData(ctx, req, schema, sctx)
 				}
-				break
 			}
+			break
 		}
 	}
 

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/codec"
+	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -888,6 +889,17 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 	// First verify that index key exists
 	if len(e.handleVal) == 0 {
 		return nil
+	}
+
+	// For columns with case-insensitive collations, we need to fetch row data
+	// to get the correct case of the stored value
+	for _, col := range schema.Columns {
+		if col.RetType.EvalType() == types.ETString {
+			// Check if this column uses a case-insensitive collation
+			if collate.IsCICollation(col.RetType.GetCollate()) {
+				return e.buildResultFromRowData(ctx, req, schema, sctx)
+			}
+		}
 	}
 
 	// Map index columns to their positions in the schema

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -891,13 +891,19 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		return nil
 	}
 
-	// For columns with case-insensitive collations, we need to fetch row data
-	// to get the correct case of the stored value
+	// For indexed columns with case-insensitive collations in the result set,
+	// we need to fetch row data to get the correct case of the stored value.
+	// This is because e.idxVals contains the search values, not the stored values.
 	for _, col := range schema.Columns {
-		if col.RetType.EvalType() == types.ETString {
-			// Check if this column uses a case-insensitive collation
-			if collate.IsCICollation(col.RetType.GetCollate()) {
-				return e.buildResultFromRowData(ctx, req, schema, sctx)
+		// Check if this column is part of the index
+		for _, idxCol := range e.idxInfo.Columns {
+			if e.tblInfo.Columns[idxCol.Offset].ID == col.ID {
+				// This column is in the index
+				if col.RetType.EvalType() == types.ETString && collate.IsCICollation(col.RetType.GetCollate()) {
+					// For CI collation, the search value might differ from stored value
+					return e.buildResultFromRowData(ctx, req, schema, sctx)
+				}
+				break
 			}
 		}
 	}

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -890,7 +890,6 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		return nil
 	}
 
-
 	// Map index columns to their positions in the schema
 	idxColMap := make(map[int64]types.Datum)
 	for i, idxCol := range e.idxInfo.Columns {

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -416,7 +416,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 	// by getAndLock below, and MySQL/InnoDB semantics require locking the clustered row
 	// regardless of which columns are projected.
 	if e.idxInfo != nil && e.coveredByIndex && !e.lock && !isCommonHandleRead(e.tblInfo, e.idxInfo) {
-		return e.buildResultFromIndex(ctx, req, schema, sctx)
+		return e.buildResultFromIndex(ctx, req, schema, sctx, tblID)
 	}
 
 	key := tablecodec.EncodeRowKeyWithHandle(tblID, e.handle)
@@ -898,7 +898,7 @@ func (*runtimeStatsWithSnapshot) Tp() int {
 //     checkIndexCoveringColumns never marks that column as covered (it is not stored in
 //     the index), so if it is selected we never reach this fast path and fall back to
 //     buildResultFromRowData, which does call fillRowChecksum.
-func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context) error {
+func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context, tblID int64) error {
 	// First verify that index key exists
 	if len(e.handleVal) == 0 {
 		return nil
@@ -923,7 +923,7 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 			if col.RetType.EvalType() == types.ETString {
 				collation := col.RetType.GetCollate()
 				if collate.IsCICollation(collation) || collate.IsPadSpaceCollation(collation) {
-					return e.buildResultFromRowData(ctx, req, schema, sctx)
+					return e.buildResultFromRowData(ctx, req, schema, sctx, tblID)
 				}
 			}
 			break
@@ -947,7 +947,7 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 				if !e.handle.IsInt() {
 					// For common handle, we need to decode the handle value
 					// This is more complex and for now we'll fall back to row fetch
-					return e.buildResultFromRowData(ctx, req, schema, sctx)
+					return e.buildResultFromRowData(ctx, req, schema, sctx, tblID)
 				}
 				idxColMap[col.ID] = types.NewIntDatum(e.handle.IntValue())
 			}
@@ -960,7 +960,7 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		if !ok {
 			// If column is not in index map, this shouldn't happen with proper covering index detection
 			// Fall back to row data fetch for safety
-			return e.buildResultFromRowData(ctx, req, schema, sctx)
+			return e.buildResultFromRowData(ctx, req, schema, sctx, tblID)
 		}
 		req.AppendDatum(i, &datum)
 	}
@@ -975,9 +975,10 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 	return nil
 }
 
-// buildResultFromRowData builds the result by fetching and decoding row data (fallback method)
-func (e *PointGetExecutor) buildResultFromRowData(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context) error {
-	tblID := GetPhysID(e.tblInfo, e.partitionDefIdx)
+// buildResultFromRowData builds the result by fetching and decoding row data (fallback method).
+// Callers must pass the effective tblID computed in Next — for global indexes this includes
+// the partition ID decoded from the index value, which differs from GetPhysID output.
+func (e *PointGetExecutor) buildResultFromRowData(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context, tblID int64) error {
 	key := tablecodec.EncodeRowKeyWithHandle(tblID, e.handle)
 	val, err := e.getAndLock(ctx, key)
 	if err != nil {

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -145,6 +145,10 @@ type PointGetExecutor struct {
 	// virtualColumnRetFieldTypes records the RetFieldTypes of virtual columns.
 	virtualColumnRetFieldTypes []*types.FieldType
 
+	// coveredByIndex indicates whether the index covers all required columns,
+	// so we don't need to fetch row data from the table
+	coveredByIndex bool
+
 	stats *runtimeStatsWithSnapshot
 }
 
@@ -214,6 +218,7 @@ func (e *PointGetExecutor) Init(p *physicalop.PointGetPlan) {
 	e.rowDecoder = decoder
 	e.partitionDefIdx = p.PartitionIdx
 	e.columns = p.Columns
+	e.coveredByIndex = p.CoveredByIndex
 	e.buildVirtualColumnInfo()
 
 	sessVars := e.Ctx().GetSessionVars()
@@ -402,6 +407,14 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		}
 	}
 
+	sctx := e.BaseExecutor.Ctx()
+	schema := e.Schema()
+
+	// If the index covers all required columns, build result directly from index values
+	if e.idxInfo != nil && e.coveredByIndex && !isCommonHandleRead(e.tblInfo, e.idxInfo) {
+		return e.buildResultFromIndex(ctx, req, schema, sctx)
+	}
+
 	key := tablecodec.EncodeRowKeyWithHandle(tblID, e.handle)
 	val, err := e.getAndLock(ctx, key)
 	if err != nil {
@@ -431,8 +444,6 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		return nil
 	}
 
-	sctx := e.BaseExecutor.Ctx()
-	schema := e.Schema()
 	err = DecodeRowValToChunk(sctx, schema, e.tblInfo, e.handle, val, req, e.rowDecoder)
 	if err != nil {
 		return err
@@ -870,4 +881,108 @@ func (e *runtimeStatsWithSnapshot) Merge(other execdetails.RuntimeStats) {
 // Tp implements the RuntimeStats interface.
 func (*runtimeStatsWithSnapshot) Tp() int {
 	return execdetails.TpRuntimeStatsWithSnapshot
+}
+
+// buildResultFromIndex builds the result directly from index values when the index covers all required columns
+func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context) error {
+	// First verify that index key exists
+	if len(e.handleVal) == 0 {
+		return nil
+	}
+
+	// Map index columns to their positions in the schema
+	idxColMap := make(map[int64]types.Datum)
+	for i, idxCol := range e.idxInfo.Columns {
+		if i < len(e.idxVals) {
+			idxColMap[e.tblInfo.Columns[idxCol.Offset].ID] = e.idxVals[i]
+		}
+	}
+
+	// Add handle column if needed
+	if e.handle != nil {
+		// Find handle column in schema
+		for _, col := range schema.Columns {
+			if col.ID == model.ExtraHandleID ||
+				(e.tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.GetFlag())) {
+				if e.handle.IsInt() {
+					idxColMap[col.ID] = types.NewIntDatum(e.handle.IntValue())
+				} else {
+					// For common handle, we need to decode the handle value
+					// This is more complex and for now we'll fall back to row fetch
+					return e.buildResultFromRowData(ctx, req, schema, sctx)
+				}
+			}
+		}
+	}
+
+	// Build the row from index values
+	for i, col := range schema.Columns {
+		if datum, ok := idxColMap[col.ID]; ok {
+			req.AppendDatum(i, &datum)
+		} else {
+			// If column is not in index map, this shouldn't happen with proper covering index detection
+			// Fall back to row data fetch for safety
+			return e.buildResultFromRowData(ctx, req, schema, sctx)
+		}
+	}
+
+	// Handle virtual columns
+	err := table.FillVirtualColumnValue(e.virtualColumnRetFieldTypes, e.virtualColumnIndex,
+		schema.Columns, e.columns, sctx.GetExprCtx(), req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// buildResultFromRowData builds the result by fetching and decoding row data (fallback method)
+func (e *PointGetExecutor) buildResultFromRowData(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context) error {
+	tblID := GetPhysID(e.tblInfo, e.partitionDefIdx)
+	key := tablecodec.EncodeRowKeyWithHandle(tblID, e.handle)
+	val, err := e.getAndLock(ctx, key)
+	if err != nil {
+		return err
+	}
+	if len(val) == 0 {
+		if e.idxInfo != nil && !isCommonHandleRead(e.tblInfo, e.idxInfo) &&
+			!e.Ctx().GetSessionVars().StmtCtx.WeakConsistency {
+			return (&consistency.Reporter{
+				HandleEncode: func(kv.Handle) kv.Key {
+					return key
+				},
+				IndexEncode: func(*consistency.RecordData) kv.Key {
+					return e.idxKey
+				},
+				Tbl:             e.tblInfo,
+				Idx:             e.idxInfo,
+				EnableRedactLog: e.Ctx().GetSessionVars().EnableRedactLog,
+				Storage:         e.Ctx().GetStore(),
+			}).ReportLookupInconsistent(ctx,
+				1, 0,
+				[]kv.Handle{e.handle},
+				[]kv.Handle{e.handle},
+				[]consistency.RecordData{{}},
+			)
+		}
+		return nil
+	}
+
+	err = DecodeRowValToChunk(sctx, schema, e.tblInfo, e.handle, val, req, e.rowDecoder)
+	if err != nil {
+		return err
+	}
+
+	err = fillRowChecksum(sctx, 0, 1, schema, e.tblInfo, [][]byte{val}, []kv.Handle{e.handle}, req, nil)
+	if err != nil {
+		return err
+	}
+
+	err = table.FillVirtualColumnValue(e.virtualColumnRetFieldTypes, e.virtualColumnIndex,
+		schema.Columns, e.columns, sctx.GetExprCtx(), req)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -904,26 +904,25 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		for _, col := range schema.Columns {
 			if col.ID == model.ExtraHandleID ||
 				(e.tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.GetFlag())) {
-				if e.handle.IsInt() {
-					idxColMap[col.ID] = types.NewIntDatum(e.handle.IntValue())
-				} else {
+				if !e.handle.IsInt() {
 					// For common handle, we need to decode the handle value
 					// This is more complex and for now we'll fall back to row fetch
 					return e.buildResultFromRowData(ctx, req, schema, sctx)
 				}
+				idxColMap[col.ID] = types.NewIntDatum(e.handle.IntValue())
 			}
 		}
 	}
 
 	// Build the row from index values
 	for i, col := range schema.Columns {
-		if datum, ok := idxColMap[col.ID]; ok {
-			req.AppendDatum(i, &datum)
-		} else {
+		datum, ok := idxColMap[col.ID]
+		if !ok {
 			// If column is not in index map, this shouldn't happen with proper covering index detection
 			// Fall back to row data fetch for safety
 			return e.buildResultFromRowData(ctx, req, schema, sctx)
 		}
+		req.AppendDatum(i, &datum)
 	}
 
 	// Handle virtual columns

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -887,7 +887,17 @@ func (*runtimeStatsWithSnapshot) Tp() int {
 	return execdetails.TpRuntimeStatsWithSnapshot
 }
 
-// buildResultFromIndex builds the result directly from index values when the index covers all required columns
+// buildResultFromIndex builds the result directly from index values when the index covers
+// all required columns. It intentionally skips two things the legacy row-fetch path does:
+//
+//   - consistency.Reporter.ReportLookupInconsistent: we never read the row, so a dangling
+//     index entry (index exists but row is gone) is not surfaced as a consistency error.
+//     The trade-off is accepted because detecting dangling indexes is a diagnostic concern
+//     and reviving the row fetch would eliminate the entire performance benefit.
+//   - fillRowChecksum: only relevant when ExtraRowChecksumID is projected, but
+//     checkIndexCoveringColumns never marks that column as covered (it is not stored in
+//     the index), so if it is selected we never reach this fast path and fall back to
+//     buildResultFromRowData, which does call fillRowChecksum.
 func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.Chunk, schema *expression.Schema, sctx sessionctx.Context) error {
 	// First verify that index key exists
 	if len(e.handleVal) == 0 {

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -890,15 +890,6 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		return nil
 	}
 
-	// For string columns with collations, we should fall back to row data fetch
-	// because the index values might not preserve the original case/format
-	for _, col := range schema.Columns {
-		if col.RetType.EvalType() == types.ETString {
-			// For string columns, especially with case-insensitive collations,
-			// the index key values may not match the stored values exactly
-			return e.buildResultFromRowData(ctx, req, schema, sctx)
-		}
-	}
 
 	// Map index columns to their positions in the schema
 	idxColMap := make(map[int64]types.Datum)

--- a/pkg/executor/point_get.go
+++ b/pkg/executor/point_get.go
@@ -890,6 +890,16 @@ func (e *PointGetExecutor) buildResultFromIndex(ctx context.Context, req *chunk.
 		return nil
 	}
 
+	// For string columns with collations, we should fall back to row data fetch
+	// because the index values might not preserve the original case/format
+	for _, col := range schema.Columns {
+		if col.RetType.EvalType() == types.ETString {
+			// For string columns, especially with case-insensitive collations,
+			// the index key values may not match the stored values exactly
+			return e.buildResultFromRowData(ctx, req, schema, sctx)
+		}
+	}
+
 	// Map index columns to their positions in the schema
 	idxColMap := make(map[int64]types.Datum)
 	for i, idxCol := range e.idxInfo.Columns {

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -377,3 +377,30 @@ func TestWithTiDBSnapshot(t *testing.T) {
 
 	tk.MustQuery("select * from xx").Check(testkit.Rows("1", "7"))
 }
+
+func TestPointGetCoveringIndex(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Create test table as described in issue #37765
+	tk.MustExec("create table t1(id1 int, id2 int, id3 int, PRIMARY KEY(id1), UNIQUE KEY udx_id2 (id2))")
+	tk.MustExec("insert into t1 values (1, 10, 100), (2, 20, 200), (3, 30, 300)")
+
+	// Test case 1: Point get with covering index (id2 is both in WHERE and SELECT)
+	// This should use the covering index optimization to avoid fetching row data
+	tk.MustQuery("SELECT id2 FROM t1 WHERE id2 = 10").Check(testkit.Rows("10"))
+	tk.MustQuery("SELECT id2 FROM t1 WHERE id2 = 20").Check(testkit.Rows("20"))
+	tk.MustQuery("SELECT id2 FROM t1 WHERE id2 = 30").Check(testkit.Rows("30"))
+
+	// Test case 2: Point get with non-covering index (selecting id3 which is not in index)
+	// This should still work but may need to fetch row data
+	tk.MustQuery("SELECT id3 FROM t1 WHERE id2 = 10").Check(testkit.Rows("100"))
+	tk.MustQuery("SELECT id3 FROM t1 WHERE id2 = 20").Check(testkit.Rows("200"))
+
+	// Test case 3: Multiple columns including covering case
+	tk.MustQuery("SELECT id1, id2, id3 FROM t1 WHERE id2 = 10").Check(testkit.Rows("1 10 100"))
+
+	// Test case 4: Verify the optimization doesn't affect non-point-get queries
+	tk.MustQuery("SELECT COUNT(*) FROM t1").Check(testkit.Rows("3"))
+}

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -404,3 +404,34 @@ func TestPointGetCoveringIndex(t *testing.T) {
 	// Test case 4: Verify the optimization doesn't affect non-point-get queries
 	tk.MustQuery("SELECT COUNT(*) FROM t1").Check(testkit.Rows("3"))
 }
+
+// TestPointGetCoveringIndexForUpdateLocks verifies that SELECT ... FOR UPDATE on a covering
+// unique index still locks the underlying row, so another session cannot acquire a conflicting
+// lock while the first transaction is open. The covering-index fast path must not be taken
+// when e.lock is true.
+func TestPointGetCoveringIndexForUpdateLocks(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("use test")
+	tk2.MustExec("use test")
+
+	tk1.MustExec("create table t_cover_lock(id1 int, id2 int, id3 int, PRIMARY KEY(id1), UNIQUE KEY udx_id2 (id2))")
+	tk1.MustExec("insert into t_cover_lock values (1, 10, 100)")
+
+	tk1.MustExec("set @@tidb_txn_mode = 'pessimistic'")
+	tk2.MustExec("set @@tidb_txn_mode = 'pessimistic'")
+
+	tk1.MustExec("begin pessimistic")
+	// Covering-index point get with FOR UPDATE — fast path must be disabled.
+	tk1.MustQuery("SELECT id2 FROM t_cover_lock WHERE id2 = 10 FOR UPDATE").Check(testkit.Rows("10"))
+
+	// Another session trying to update the same row must block; use a short lock-wait
+	// timeout so the test fails fast if the row was not locked.
+	tk2.MustExec("set @@innodb_lock_wait_timeout = 1")
+	tk2.MustExec("begin pessimistic")
+	_, err := tk2.Exec("update t_cover_lock set id3 = 999 where id1 = 1")
+	require.Error(t, err, "expected lock-wait timeout because tk1's FOR UPDATE must lock the row even on covering-index fast path")
+	tk2.MustExec("rollback")
+	tk1.MustExec("commit")
+}

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -459,3 +459,54 @@ func TestPointGetCoveringIndexForUpdateLocks(t *testing.T) {
 	tk2.MustExec("rollback")
 	tk1.MustExec("commit")
 }
+
+// TestPointGetCoveringIndexPartitioned verifies the covering-index fast path produces
+// correct results on a partitioned table, both for a local unique index (on the partition
+// key) and for a global unique index (on a non-partition-key column).
+func TestPointGetCoveringIndexPartitioned(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Local unique index: the unique key is on the partition-key column, so each partition
+	// owns its own index entries and the PointGet executor uses GetPhysID to resolve the
+	// partition at execution time.
+	tk.MustExec(`create table t_part_local (
+		id int,
+		val int,
+		UNIQUE KEY uk_id (id)
+	) partition by hash(id) partitions 4`)
+	tk.MustExec("insert into t_part_local values (1, 100), (2, 200), (3, 300), (11, 1100)")
+
+	tk.MustQuery("select id from t_part_local where id = 1").Check(testkit.Rows("1"))
+	tk.MustQuery("select id from t_part_local where id = 11").Check(testkit.Rows("11"))
+	tk.MustQuery("select val from t_part_local where id = 1").Check(testkit.Rows("100"))
+
+	covering := sumNumRPC(t, tk, "explain analyze select id from t_part_local where id = 1")
+	nonCovering := sumNumRPC(t, tk, "explain analyze select val from t_part_local where id = 1")
+	require.Less(t, covering, nonCovering,
+		"partitioned local-unique covering case (%d RPCs) should issue fewer RPCs than non-covering (%d RPCs)",
+		covering, nonCovering)
+
+	// Global unique index on a non-partition-key column: the index value carries the
+	// partition ID. Results must still be correct when the fast path is taken.
+	tk.MustExec("set tidb_enable_global_index=true")
+	defer tk.MustExec("set tidb_enable_global_index=default")
+	tk.MustExec(`create table t_part_global (
+		id int PRIMARY KEY,
+		gval int,
+		other int,
+		UNIQUE KEY udx_gval (gval) GLOBAL
+	) partition by hash(id) partitions 4`)
+	tk.MustExec("insert into t_part_global values (1, 10, 100), (2, 20, 200), (3, 30, 300), (11, 40, 400)")
+
+	tk.MustQuery("select gval from t_part_global where gval = 10").Check(testkit.Rows("10"))
+	tk.MustQuery("select gval from t_part_global where gval = 40").Check(testkit.Rows("40"))
+	tk.MustQuery("select other from t_part_global where gval = 10").Check(testkit.Rows("100"))
+
+	coveringG := sumNumRPC(t, tk, "explain analyze select gval from t_part_global where gval = 10")
+	nonCoveringG := sumNumRPC(t, tk, "explain analyze select other from t_part_global where gval = 10")
+	require.Less(t, coveringG, nonCoveringG,
+		"partitioned global-unique covering case (%d RPCs) should issue fewer RPCs than non-covering (%d RPCs)",
+		coveringG, nonCoveringG)
+}

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -17,6 +17,8 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -387,22 +389,44 @@ func TestPointGetCoveringIndex(t *testing.T) {
 	tk.MustExec("create table t1(id1 int, id2 int, id3 int, PRIMARY KEY(id1), UNIQUE KEY udx_id2 (id2))")
 	tk.MustExec("insert into t1 values (1, 10, 100), (2, 20, 200), (3, 30, 300)")
 
-	// Test case 1: Point get with covering index (id2 is both in WHERE and SELECT)
-	// This should use the covering index optimization to avoid fetching row data
+	// Result-correctness checks.
 	tk.MustQuery("SELECT id2 FROM t1 WHERE id2 = 10").Check(testkit.Rows("10"))
 	tk.MustQuery("SELECT id2 FROM t1 WHERE id2 = 20").Check(testkit.Rows("20"))
 	tk.MustQuery("SELECT id2 FROM t1 WHERE id2 = 30").Check(testkit.Rows("30"))
-
-	// Test case 2: Point get with non-covering index (selecting id3 which is not in index)
-	// This should still work but may need to fetch row data
 	tk.MustQuery("SELECT id3 FROM t1 WHERE id2 = 10").Check(testkit.Rows("100"))
 	tk.MustQuery("SELECT id3 FROM t1 WHERE id2 = 20").Check(testkit.Rows("200"))
-
-	// Test case 3: Multiple columns including covering case
 	tk.MustQuery("SELECT id1, id2, id3 FROM t1 WHERE id2 = 10").Check(testkit.Rows("1 10 100"))
-
-	// Test case 4: Verify the optimization doesn't affect non-point-get queries
 	tk.MustQuery("SELECT COUNT(*) FROM t1").Check(testkit.Rows("3"))
+
+	// Prove the covering-index fast path is actually taken: a point get that projects only
+	// indexed columns must issue strictly fewer Snapshot.Get RPCs than one that projects a
+	// non-indexed column on the same row (which still needs the row-key fetch).
+	coveringRPCs := sumNumRPC(t, tk, "explain analyze select id2 from t1 where id2 = 10")
+	nonCoveringRPCs := sumNumRPC(t, tk, "explain analyze select id3 from t1 where id2 = 10")
+	require.Greater(t, coveringRPCs, 0, "covering-index query should still issue the index-key Get")
+	require.Less(t, coveringRPCs, nonCoveringRPCs,
+		"covering-index query (%d RPCs) should issue fewer Snapshot.Get RPCs than non-covering query (%d RPCs); "+
+			"otherwise the buildResultFromIndex fast path is not being taken",
+		coveringRPCs, nonCoveringRPCs)
+}
+
+// sumNumRPC runs `explain analyze` and totals every `num_rpc:<N>` field across all operator
+// rows. It is intentionally coarse: we only need to compare relative counts between two
+// queries to prove whether the covering-index fast path skipped the row-key Get.
+func sumNumRPC(t *testing.T, tk *testkit.TestKit, explainSQL string) int {
+	t.Helper()
+	re := regexp.MustCompile(`num_rpc:(\d+)`)
+	total := 0
+	for _, row := range tk.MustQuery(explainSQL).Rows() {
+		for _, field := range row {
+			for _, m := range re.FindAllStringSubmatch(fmt.Sprint(field), -1) {
+				n, err := strconv.Atoi(m[1])
+				require.NoError(t, err, "parse num_rpc in %q", field)
+				total += n
+			}
+		}
+	}
+	return total
 }
 
 // TestPointGetCoveringIndexForUpdateLocks verifies that SELECT ... FOR UPDATE on a covering

--- a/pkg/executor/point_get_test.go
+++ b/pkg/executor/point_get_test.go
@@ -460,6 +460,28 @@ func TestPointGetCoveringIndexForUpdateLocks(t *testing.T) {
 	tk1.MustExec("commit")
 }
 
+// TestPointGetCoveringIndexPadSpace verifies the covering-index fast path does not return
+// the search value instead of the stored value for PAD SPACE collations. utf8mb4_bin is
+// PAD SPACE but case-sensitive — the earlier IsCICollation-only check missed it. The fast
+// path must fall back to a row fetch so the trailing space from the stored value is
+// preserved.
+func TestPointGetCoveringIndexPadSpace(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_pad (c varchar(10) collate utf8mb4_bin, unique key uk_c (c))")
+	// Stored value has a trailing space; PAD SPACE semantics make 'foo' equal 'foo ' in
+	// comparisons, so the unique-index lookup for WHERE c = 'foo' matches this row.
+	tk.MustExec("insert into t_pad values ('foo ')")
+
+	// Row-fetch behaviour: the executor must return the stored value, trailing space
+	// included. If the fast path fired without the PAD SPACE guard, it would return
+	// 'foo' instead.
+	tk.MustQuery("select c, length(c) from t_pad where c = 'foo'").Check(testkit.Rows("foo  4"))
+	tk.MustQuery("select c, length(c) from t_pad where c = 'foo '").Check(testkit.Rows("foo  4"))
+}
+
 // TestPointGetCoveringIndexPartitioned verifies the covering-index fast path produces
 // correct results on a partitioned table, both for a local unique index (on the partition
 // key) and for a global unique index (on a non-partition-key column).

--- a/pkg/planner/core/operator/logicalop/logical_datasource.go
+++ b/pkg/planner/core/operator/logicalop/logical_datasource.go
@@ -726,7 +726,7 @@ func (ds *DataSource) indexCoveringColumn(column *expression.Column, indexColumn
 		return true
 	}
 	evalCtx := ds.SCtx().GetExprCtx().GetEvalCtx()
-	coveredByPlainIndex := isIndexColsCoveringCol(evalCtx, column, indexColumns, idxColLens, ignoreLen)
+	coveredByPlainIndex := IsIndexColsCoveringCol(evalCtx, column, indexColumns, idxColLens, ignoreLen)
 	if !coveredByPlainIndex && handleCoveringState != stateCoveredByCommonHandle {
 		return false
 	}
@@ -748,14 +748,18 @@ func (ds *DataSource) handleCoveringColumn(column *expression.Column, ignoreLen 
 		return stateCoveredByIntHandle
 	}
 	evalCtx := ds.SCtx().GetExprCtx().GetEvalCtx()
-	coveredByClusteredIndex := isIndexColsCoveringCol(evalCtx, column, ds.CommonHandleCols, ds.CommonHandleLens, ignoreLen)
+	coveredByClusteredIndex := IsIndexColsCoveringCol(evalCtx, column, ds.CommonHandleCols, ds.CommonHandleLens, ignoreLen)
 	if coveredByClusteredIndex {
 		return stateCoveredByCommonHandle
 	}
 	return stateNotCoveredByHandle
 }
 
-func isIndexColsCoveringCol(sctx expression.EvalContext, col *expression.Column, indexCols []*expression.Column, idxColLens []int, ignoreLen bool) bool {
+// IsIndexColsCoveringCol reports whether the given column is covered by the index columns,
+// with prefix-index length taken into account (pass ignoreLen=true to skip the length check).
+// A prefix index does not cover the full column value for projection, so the caller must not
+// treat it as covering unless ignoreLen is explicitly true.
+func IsIndexColsCoveringCol(sctx expression.EvalContext, col *expression.Column, indexCols []*expression.Column, idxColLens []int, ignoreLen bool) bool {
 	for i, indexCol := range indexCols {
 		if indexCol == nil || !col.EqualByExprAndID(sctx, indexCol) {
 			continue

--- a/pkg/planner/core/operator/physicalop/physical_batch_point_get.go
+++ b/pkg/planner/core/operator/physicalop/physical_batch_point_get.go
@@ -91,6 +91,9 @@ type PointGetPlan struct {
 	PlanCostVer2 costusage.CostVer2 `plan-cache-clone:"shallow"`
 	// accessCols represents actual columns the PointGet will access, which are used to calculate row-size
 	accessCols []*expression.Column
+	// CoveredByIndex indicates whether the index covers all required columns,
+	// so we don't need to fetch row data from the table
+	CoveredByIndex bool
 
 	// NOTE: please update FastClonePointGetForPlanCache accordingly if you add new fields here.
 }

--- a/pkg/planner/core/plan_clone_utils.go
+++ b/pkg/planner/core/plan_clone_utils.go
@@ -68,6 +68,7 @@ func FastClonePointGetForPlanCache(newCtx base.PlanContext, src, dst *physicalop
 	dst.SetOutputNames(src.OutputNames())
 	dst.LockWaitTime = src.LockWaitTime
 	dst.Columns = src.Columns
+	dst.CoveredByIndex = src.CoveredByIndex
 
 	// remaining fields are unnecessary to clone:
 	// cost, planCostInit, planCost, planCostVer2, accessCols

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -664,7 +664,7 @@ func checkTblIndexForPointPlan(ctx base.PlanContext, tblName *resolve.TableNameW
 		p.PartitionNames = tblName.PartitionNames
 
 		// Check if the index covers all required columns
-		p.CoveredByIndex = checkIndexCoveringColumns(p, schema.Columns, idxInfo)
+		p.CoveredByIndex = checkIndexCoveringColumns(ctx, p, schema.Columns, idxInfo)
 		return p
 	}
 	return nil
@@ -1466,15 +1466,17 @@ func getHashOrKeyPartitionColumnName(ctx base.PlanContext, tbl *model.TableInfo)
 	return &col.Name.Name
 }
 
-// checkIndexCoveringColumns checks if the index covers all required columns
-func checkIndexCoveringColumns(p *physicalop.PointGetPlan, columns []*expression.Column, idxInfo *model.IndexInfo) bool {
-	// Get index columns
+// checkIndexCoveringColumns reports whether idxInfo covers every projected column of a
+// point get. It reuses logicalop.IsIndexColsCoveringCol (the same primitive that drives
+// LogicalDataSource.indexCoveringColumn) so prefix indexes and generated-column equality
+// are handled consistently with the rest of the optimizer.
+func checkIndexCoveringColumns(ctx base.PlanContext, p *physicalop.PointGetPlan, columns []*expression.Column, idxInfo *model.IndexInfo) bool {
 	indexColumns := make([]*expression.Column, 0, len(idxInfo.Columns))
 	idxColLens := make([]int, 0, len(idxInfo.Columns))
-
 	for _, idxCol := range idxInfo.Columns {
+		colInfo := p.TblInfo.Columns[idxCol.Offset]
 		for _, col := range columns {
-			if col.ID == p.TblInfo.Columns[idxCol.Offset].ID {
+			if col.ID == colInfo.ID {
 				indexColumns = append(indexColumns, col)
 				idxColLens = append(idxColLens, idxCol.Length)
 				break
@@ -1482,39 +1484,22 @@ func checkIndexCoveringColumns(p *physicalop.PointGetPlan, columns []*expression
 		}
 	}
 
-	// Check if all required columns are covered by the index
+	evalCtx := ctx.GetExprCtx().GetEvalCtx()
 	for _, col := range columns {
-		if !isColumnCoveredByIndex(p, col, indexColumns, idxColLens) {
+		// Integer primary key: the value is already encoded in the handle, so the executor
+		// synthesizes it without reading row data.
+		if p.TblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.GetFlag()) {
+			continue
+		}
+		// ExtraHandleID / ExtraPhysTblID are synthesized from the handle/partition, not read
+		// from row data. buildResultFromIndex fills the former; if the latter is requested
+		// and not otherwise reconstructable, buildResultFromIndex falls back to a row fetch.
+		if col.ID == model.ExtraHandleID || col.ID == model.ExtraPhysTblID {
+			continue
+		}
+		if !logicalop.IsIndexColsCoveringCol(evalCtx, col, indexColumns, idxColLens, false) {
 			return false
 		}
 	}
-
 	return true
-}
-
-// isColumnCoveredByIndex checks if a column is covered by the index
-func isColumnCoveredByIndex(p *physicalop.PointGetPlan, column *expression.Column, indexColumns []*expression.Column, idxColLens []int) bool {
-	// Handle primary key
-	if p.TblInfo.PKIsHandle && mysql.HasPriKeyFlag(column.RetType.GetFlag()) {
-		return true
-	}
-
-	// Handle row ID
-	if column.ID == model.ExtraHandleID || column.ID == model.ExtraPhysTblID {
-		return true
-	}
-
-	// Check if column is in the index
-	for i, idxCol := range indexColumns {
-		if idxCol.ID == column.ID {
-			// For string columns with prefix index, we need to check if length is sufficient
-			if column.RetType.EvalType() == types.ETString && idxColLens[i] != types.UnspecifiedLength {
-				// For point get, prefix index should be sufficient since we're doing equality comparison
-				return true
-			}
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1491,11 +1491,17 @@ func checkIndexCoveringColumns(ctx base.PlanContext, p *physicalop.PointGetPlan,
 		if p.TblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.GetFlag()) {
 			continue
 		}
-		// ExtraHandleID / ExtraPhysTblID are synthesized from the handle/partition, not read
-		// from row data. buildResultFromIndex fills the former; if the latter is requested
-		// and not otherwise reconstructable, buildResultFromIndex falls back to a row fetch.
-		if col.ID == model.ExtraHandleID || col.ID == model.ExtraPhysTblID {
+		// ExtraHandleID is synthesized from the handle value and does not need to be read
+		// from row data.
+		if col.ID == model.ExtraHandleID {
 			continue
+		}
+		// ExtraPhysTblID is only filled by the legacy row-fetch path; if it's projected,
+		// reporting "covered" here would be misleading since buildResultFromIndex would
+		// immediately fall back. Treat it as non-covering so the planner and executor
+		// agree that the fast path cannot run.
+		if col.ID == model.ExtraPhysTblID {
+			return false
 		}
 		if !logicalop.IsIndexColsCoveringCol(evalCtx, col, indexColumns, idxColLens, false) {
 			return false

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -662,6 +662,9 @@ func checkTblIndexForPointPlan(ctx base.PlanContext, tblName *resolve.TableNameW
 		p.IndexConstants = idxConstant
 		p.ColsFieldType = colsFieldType
 		p.PartitionNames = tblName.PartitionNames
+
+		// Check if the index covers all required columns
+		p.CoveredByIndex = checkIndexCoveringColumns(p, schema.Columns, idxInfo)
 		return p
 	}
 	return nil
@@ -1461,4 +1464,57 @@ func getHashOrKeyPartitionColumnName(ctx base.PlanContext, tbl *model.TableInfo)
 		return nil
 	}
 	return &col.Name.Name
+}
+
+// checkIndexCoveringColumns checks if the index covers all required columns
+func checkIndexCoveringColumns(p *physicalop.PointGetPlan, columns []*expression.Column, idxInfo *model.IndexInfo) bool {
+	// Get index columns
+	indexColumns := make([]*expression.Column, 0, len(idxInfo.Columns))
+	idxColLens := make([]int, 0, len(idxInfo.Columns))
+
+	for _, idxCol := range idxInfo.Columns {
+		for _, col := range columns {
+			if col.ID == p.TblInfo.Columns[idxCol.Offset].ID {
+				indexColumns = append(indexColumns, col)
+				idxColLens = append(idxColLens, idxCol.Length)
+				break
+			}
+		}
+	}
+
+	// Check if all required columns are covered by the index
+	for _, col := range columns {
+		if !isColumnCoveredByIndex(p, col, indexColumns, idxColLens) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isColumnCoveredByIndex checks if a column is covered by the index
+func isColumnCoveredByIndex(p *physicalop.PointGetPlan, column *expression.Column, indexColumns []*expression.Column, idxColLens []int) bool {
+	// Handle primary key
+	if p.TblInfo.PKIsHandle && mysql.HasPriKeyFlag(column.RetType.GetFlag()) {
+		return true
+	}
+
+	// Handle row ID
+	if column.ID == model.ExtraHandleID || column.ID == model.ExtraPhysTblID {
+		return true
+	}
+
+	// Check if column is in the index
+	for i, idxCol := range indexColumns {
+		if idxCol.ID == column.ID {
+			// For string columns with prefix index, we need to check if length is sufficient
+			if column.RetType.EvalType() == types.ETString && idxColLens[i] != types.UnspecifiedLength {
+				// For point get, prefix index should be sufficient since we're doing equality comparison
+				return true
+			}
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37765
https://github.com/pingcap/tidb/issues/37765

Problem Summary:

The point-get statement above used covered index udx_id2 , but TiDB still needs to get the row data

### What changed and how does it work?

If the index covers all required columns, build result directly from index values

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
executor, planner: do not fetch row data for PointGet when covering index have enough data
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point-get (single-row) queries can take an index-only fast path when the chosen index covers all requested columns, letting execution build results directly from index data and reducing latency and internal RPCs.

* **Correctness**
  * Preserves stored string collation and PAD-SPACE semantics by falling back to row fetch when index-only results would alter stored values.

* **Tests**
  * Added tests for correctness, RPC-count improvements, FOR UPDATE lock behavior, partitioned/global indexes, and pad-space cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->