### PR TITLE
br: allow append migration to work with restore

### DIFF
--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -652,18 +652,19 @@ type LockedMigrations struct {
 	ReadLock storage.RemoteLock
 }
 
-func (rc *LogClient) GetMigrations(ctx context.Context) (*LockedMigrations, error) {
+func (rc *LogClient) GetLockedMigrations(ctx context.Context) (*LockedMigrations, error) {
 	ext := stream.MigrationExtension(rc.storage)
+	readLock, err := ext.GetReadLock(ctx, "restore stream")
+	if err != nil {
+		return nil, err
+	}
+
 	migs, err := ext.Load(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	ms := migs.ListAll()
-	readLock, err := ext.GetReadLock(ctx, "restore stream")
-	if err != nil {
-		return nil, err
-	}
 
 	lms := &LockedMigrations{
 		Migs:     ms,

--- a/br/pkg/storage/local.go
+++ b/br/pkg/storage/local.go
@@ -131,13 +131,20 @@ func (l *LocalStorage) WalkDir(_ context.Context, opt *WalkOption, fn func(strin
 				// we should return nil to continue.
 				return nil
 			}
+			relativeToBase, err := filepath.Rel(base, path)
+			if err != nil {
+				log.Panic("filepath.Walk returns a path that isn't a subdir of the base dir.",
+					zap.String("path", path), zap.String("base", base), logutil.ShortError(err))
+			}
+			if !strings.HasPrefix(relativeToBase, opt.ObjPrefix) {
+				return nil
+			}
+
+			// Convert to relative path from l.base for consistency with cloud storage
 			path, err = filepath.Rel(l.base, path)
 			if err != nil {
 				log.Panic("filepath.Walk returns a path that isn't a subdir of the base dir.",
 					zap.String("path", path), zap.String("base", l.base), logutil.ShortError(err))
-			}
-			if !strings.HasPrefix(path, opt.ObjPrefix) {
-				return nil
 			}
 			// NOTE: This may cause a tombstone of the dir emit to the caller when
 			// call `Walk` in a non-exist dir.
@@ -158,12 +165,14 @@ func (l *LocalStorage) WalkDir(_ context.Context, opt *WalkOption, fn func(strin
 			return nil
 		}
 		// in mac osx, the path parameter is absolute path; in linux, the path is relative path to execution base dir,
-		// so use Rel to convert to relative path to l.base
-		path, _ = filepath.Rel(l.base, path)
-
-		if !strings.HasPrefix(path, opt.ObjPrefix) {
+		// so use Rel to convert to relative path to the directory being walked (base)
+		relativeToBase, _ := filepath.Rel(base, path)
+		if !strings.HasPrefix(relativeToBase, opt.ObjPrefix) {
 			return nil
 		}
+
+		// Convert to relative path from l.base for consistency with cloud storage
+		path, _ = filepath.Rel(l.base, path)
 
 		size := f.Size()
 		// if not a regular file, we need to use os.stat to get the real file size

--- a/br/pkg/storage/storage.go
+++ b/br/pkg/storage/storage.go
@@ -20,7 +20,7 @@ type Permission string
 
 // StrongConsistency is a marker interface that indicates the storage is strong consistent
 // over its `Read`, `Write` and `WalkDir` APIs.
-type StrongConsisency interface {
+type StrongConsistency interface {
 	MarkStrongConsistency()
 }
 

--- a/br/pkg/stream/stream_metas.go
+++ b/br/pkg/stream/stream_metas.go
@@ -47,6 +47,7 @@ const (
 	metaSuffix        = ".meta"
 	migrationPrefix   = "v1/migrations"
 	lockPrefix        = "v1/LOCK"
+	appendLockPrefix  = "v1/APPEND_LOCK"
 
 	SupportedMigVersion = pb.MigrationVersion_M2
 )
@@ -463,9 +464,9 @@ func (m MigrationExt) AddMigrationToTable(ctx context.Context, mig *pb.Migration
 // MigrationExt is an extension to the `ExternalStorage` type.
 // This added some support methods for the "migration" system of log backup.
 //
-// Migrations are idempontent batch modifications (adding a compaction, delete a file, etc..) to the backup files.
+// Migrations are idempotent batch modifications (adding a compaction, delete a file, etc..) to the backup files.
 // You may check the protocol buffer message `Migration` for more details.
-// Idempontence is important for migrations, as they may be executed multi times due to retry or racing.
+// Idempotence is important for migrations, as they may be executed multiple times due to retry or racing.
 //
 // The encoded migrations will be put in a folder in the external storage,
 // they are ordered by a series number.
@@ -473,7 +474,7 @@ func (m MigrationExt) AddMigrationToTable(ctx context.Context, mig *pb.Migration
 // Not all migrations can be applied to the storage then removed from the migration.
 // Small "additions" will be inlined into the migration, for example, a `Compaction`.
 // Small "deletions" will also be delayed, for example, deleting a span in a file.
-// Such operations will be save to a special migration, the first migration, named "BASE".
+// Such operations will be saved to a special migration, the first migration, named "BASE".
 //
 // A simple list of migrations (loaded by `Load()`):
 /*
@@ -592,7 +593,7 @@ func (NoHooks) StartHandlingMetaEdits([]*pb.MetaEdit)                           
 func (NoHooks) HandledAMetaEdit(*pb.MetaEdit)                                      {}
 func (NoHooks) HandingMetaEditDone()                                               {}
 
-// MigrateionExtnsion installs the extension methods to an `ExternalStorage`.
+// MigrationExtension installs the extension methods to an `ExternalStorage`.
 func MigrationExtension(s storage.ExternalStorage) MigrationExt {
 	return MigrationExt{
 		s:      s,
@@ -601,7 +602,7 @@ func MigrationExtension(s storage.ExternalStorage) MigrationExt {
 	}
 }
 
-// Merge merges two migrations.
+// MergeMigrations merges two migrations.
 // The merged migration contains all operations from the two arguments.
 func MergeMigrations(m1 *pb.Migration, m2 *pb.Migration) *pb.Migration {
 	out := NewMigration()
@@ -650,7 +651,7 @@ type Migrations struct {
 
 // GetReadLock locks the storage and make sure there won't be other one modify this backup.
 func (m *MigrationExt) GetReadLock(ctx context.Context, hint string) (storage.RemoteLock, error) {
-	return storage.LockWith(ctx, storage.TryLockRemoteRead, m.s, lockPrefix, hint)
+	return storage.LockWithRetry(ctx, storage.TryLockRemoteRead, m.s, lockPrefix, hint)
 }
 
 // OrderedMigration is a migration with its path and sequence number.
@@ -762,12 +763,35 @@ func (m MigrationExt) DryRun(f func(MigrationExt)) []storage.Effect {
 	return batchSelf.s.(*storage.Batched).ReadOnlyEffects()
 }
 
+// lockForAppend implements two-phase locking for append migration operations:
+// 1. Acquire read lock on main path (allows coexistence with restore)
+// 2. Acquire write lock on append path (prevents concurrent appends)
+func (m MigrationExt) lockForAppend(ctx context.Context, hint string) (readLock, appendLock storage.RemoteLock, err error) {
+	// Phase 1: Acquire read lock on main path to coexist with restore but conflict with truncate
+	readLock, err = storage.LockWithRetry(ctx, storage.TryLockRemoteRead, m.s, lockPrefix, hint+" (read)")
+	if err != nil {
+		return storage.RemoteLock{}, storage.RemoteLock{}, errors.Annotate(err, "failed to acquire read lock for append operation")
+	}
+
+	// Phase 2: Acquire write lock on append path to prevent concurrent appends
+	appendLock, err = storage.LockWithRetry(ctx, storage.TryLockRemoteWrite, m.s, appendLockPrefix, hint+" (append)")
+	if err != nil {
+		// If append lock fails, release the read lock
+		readLock.UnlockOnCleanUp(ctx)
+		return storage.RemoteLock{}, storage.RemoteLock{}, errors.Annotate(err, "failed to acquire append lock")
+	}
+
+	return readLock, appendLock, nil
+}
+
 func (m MigrationExt) AppendMigration(ctx context.Context, mig *pb.Migration) (int, error) {
-	lock, err := storage.LockWith(ctx, storage.TryLockRemoteWrite, m.s, lockPrefix, "AppendMigration")
+	log.Info("appending migration, trying to acquire two-phase lock")
+	readLock, appendLock, err := m.lockForAppend(ctx, "AppendMigration")
 	if err != nil {
 		return 0, err
 	}
-	defer lock.UnlockOnCleanUp(ctx)
+	defer readLock.UnlockOnCleanUp(ctx)
+	defer appendLock.UnlockOnCleanUp(ctx)
 
 	migs, err := m.Load(ctx)
 	if err != nil {
@@ -856,7 +880,8 @@ func MMOptAppendPhantomMigration(migs ...pb.Migration) MergeAndMigrateToOpt {
 }
 
 // MergeAndMigrateTo will merge the migrations from BASE until the specified SN, then migrate to it.
-// Finally it writes the new BASE and remove stale migrations from the storage.
+// Finally, it writes the new BASE and remove stale migrations from the storage.
+// It's used by Stream Truncation.
 func (m MigrationExt) MergeAndMigrateTo(
 	ctx context.Context,
 	targetSpec int,
@@ -868,7 +893,8 @@ func (m MigrationExt) MergeAndMigrateTo(
 	}
 
 	if !config.skipLockingInTest {
-		lock, err := storage.LockWith(ctx, storage.TryLockRemoteWrite, m.s, lockPrefix, "AppendMigration")
+		lock, err := storage.LockWithRetry(ctx, storage.TryLockRemoteWrite, m.s, lockPrefix,
+			"StreamTruncation: MergeMigration")
 		if err != nil {
 			result.MigratedTo = MigratedTo{
 				Warnings: []error{
@@ -939,7 +965,7 @@ func (m MigrationExt) MergeAndMigrateTo(
 	}
 
 	for _, mig := range result.Source {
-		// Perhaps a phanom migration.
+		// Perhaps a phantom migration.
 		if len(mig.Path) > 0 {
 			err = m.s.DeleteFile(ctx, mig.Path)
 			if err != nil {
@@ -979,7 +1005,7 @@ func MTMaybeSkipTruncateLog(cond bool) migrateToOpt {
 
 // migrateTo migrates to a migration.
 // If encountered some error during executing some operation, the operation will be put
-// to the new BASE, which can be retryed then.
+// to the new BASE, which can be retried then.
 func (m MigrationExt) migrateTo(ctx context.Context, mig *pb.Migration, opts ...migrateToOpt) MigratedTo {
 	opt := migToOpt{}
 	for _, o := range opts {
@@ -1670,12 +1696,4 @@ func hashMetaEdit(metaEdit *pb.MetaEdit) uint64 {
 
 func nameOf(mig *pb.Migration, sn int) string {
 	return fmt.Sprintf("%08d_%016X.mgrt", sn, hashMigration(mig))
-}
-
-func isEmptyMigration(mig *pb.Migration) bool {
-	return len(mig.Compactions) == 0 &&
-		len(mig.EditMeta) == 0 &&
-		len(mig.IngestedSstPaths) == 0 &&
-		len(mig.DestructPrefix) == 0 &&
-		mig.TruncatedTo == 0
 }

--- a/br/pkg/stream/stream_metas.go
+++ b/br/pkg/stream/stream_metas.go
@@ -766,11 +766,13 @@ func (m MigrationExt) DryRun(f func(MigrationExt)) []storage.Effect {
 // lockForAppend implements two-phase locking for append migration operations:
 // 1. Acquire read lock on main path (allows coexistence with restore)
 // 2. Acquire write lock on append path (prevents concurrent appends)
-func (m MigrationExt) lockForAppend(ctx context.Context, hint string) (readLock, appendLock storage.RemoteLock, err error) {
+func (m MigrationExt) lockForAppend(ctx context.Context, hint string) (
+	readLock, appendLock storage.RemoteLock, err error) {
 	// Phase 1: Acquire read lock on main path to coexist with restore but conflict with truncate
 	readLock, err = storage.LockWithRetry(ctx, storage.TryLockRemoteRead, m.s, lockPrefix, hint+" (read)")
 	if err != nil {
-		return storage.RemoteLock{}, storage.RemoteLock{}, errors.Annotate(err, "failed to acquire read lock for append operation")
+		return storage.RemoteLock{}, storage.RemoteLock{}, errors.Annotate(err,
+			"failed to acquire read lock for append operation")
 	}
 
 	// Phase 2: Acquire write lock on append path to prevent concurrent appends

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1520,12 +1520,24 @@ func restoreStream(
 	}
 
 	client := cfg.logClient
-	migs, err := client.GetMigrations(ctx)
+	migs, err := client.GetLockedMigrations(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	client.BuildMigrations(migs.Migs)
-	defer cleanUpWithRetErr(&err, migs.ReadLock.Unlock)
+
+	skipCleanup := false
+	failpoint.Inject("skip-migration-read-lock-cleanup", func(_ failpoint.Value) {
+		// Skip the cleanup - this keeps the read lock held
+		// and will cause lock conflicts for other restore operations
+		log.Info("Skipping migration read lock cleanup due to failpoint")
+		skipCleanup = true
+	})
+
+	if !skipCleanup {
+		defer cleanUpWithRetErr(&err, migs.ReadLock.Unlock)
+	}
+
 	defer client.RestoreSSTStatisticFields(&extraFields)
 
 	ddlFiles := cfg.ddlFiles

--- a/br/tests/br_parallel_restore/run.sh
+++ b/br/tests/br_parallel_restore/run.sh
@@ -696,6 +696,81 @@ test_restore_abort() {
     cleanup
 }
 
+test_cross_cluster_lock_conflict() {
+    echo "Test Case 7: Cross-cluster lock conflict"
+    echo "This test reproduces the lock conflict when two clusters restore from the same log backup storage"
+    
+    # Use separate backup directories for this test
+    LOCK_BACKUP_DIR="local://$TEST_DIR/lock_backup"
+    LOCK_LOG_BACKUP_DIR="local://$TEST_DIR/lock_log_backup"
+    
+    echo "Setting up backup data for lock conflict testing..."
+    
+    # Create both DB1 and DB2 data
+    run_sql "create database if not exists ${DB}1;"
+    run_sql "create database if not exists ${DB}2;"
+    
+    create_tables_with_values "cluster_a" $TABLE_COUNT ${DB}1
+    create_tables_with_values "cluster_b" $TABLE_COUNT ${DB}2
+    
+    # Start log backup
+    run_br log start --task-name ${TASK_NAME}_lock -s "$LOCK_LOG_BACKUP_DIR"
+    
+    # Take snapshot backup (contains both DB1 and DB2 data)
+    run_br backup full -s "$LOCK_BACKUP_DIR"
+    
+    # Wait for log checkpoint to advance
+    log_backup_ts=$(python3 -c "import time; print(int(time.time() * 1000) << 18)")
+    echo "Using log backup timestamp: $log_backup_ts"
+    . "$CUR/../br_test_utils.sh" && wait_log_checkpoint_advance ${TASK_NAME}_lock
+    
+    # Stop log backup
+    run_br log stop --task-name ${TASK_NAME}_lock
+    
+    # Drop all databases to simulate fresh cluster state
+    run_sql "drop database ${DB}1;"
+    run_sql "drop database ${DB}2;"
+    
+    echo "=== Step 1: First restore (DB1) acquires lock and holds it ==="
+    run_br log start --task-name ${TASK_NAME}_lock -s "$LOCK_LOG_BACKUP_DIR"
+
+    # Use failpoint to skip migration read lock cleanup
+    # This simulates the first restore holding the migration read lock indefinitely
+    export GO_FAILPOINTS="github.com/pingcap/tidb/br/pkg/task/skip-migration-read-lock-cleanup=return(true)"
+    
+    echo "Starting first restore: ${DB}1 (will hold migration read lock)..."
+    echo "This restore will acquire the migration read lock and not release it due to failpoint"
+    
+    # Start the first restore in background since it will complete but not release the lock
+    run_br restore point --filter "${DB}1.*" --restored-ts $log_backup_ts --full-backup-storage "$LOCK_BACKUP_DIR" -s "$LOCK_LOG_BACKUP_DIR"
+    export GO_FAILPOINTS=""
+    
+    echo "=== Step 2: Second restore (DB2) attempts do get read lock and append lock ==="
+    
+    restore_fail=0
+    run_br restore point --filter "${DB}2.*" --restored-ts $log_backup_ts --full-backup-storage "$LOCK_BACKUP_DIR" -s "$LOCK_LOG_BACKUP_DIR" > ${res_file}_second 2>&1 || restore_fail=1
+    
+    if [ $restore_fail -ne 0 ]; then
+        echo 'ERROR: Second restore failed but should have succeeded'
+        echo "Second restore error output:"
+        cat ${res_file}_second
+        exit 1
+    fi
+    
+    echo "Verifying second restore data (DB2)..."
+    for i in $(seq 1 $TABLE_COUNT); do
+        verify_table_data ${DB}2 "cluster_b" $i "Second restore of DB2"
+    done
+    
+    verify_no_temporary_databases "Concurrent restore operations test"
+    
+    echo "lock conflict tests succeeded"
+    
+    # Clean up the test databases
+    run_sql "drop database if exists ${DB}1;"
+    run_sql "drop database if exists ${DB}2;"
+}
+
 setup_test_environment
 
 test_mixed_parallel_restores
@@ -703,5 +778,6 @@ test_concurrent_restore_table_conflicts
 test_restore_with_different_systable_settings
 test_auto_restored_ts_conflict
 test_restore_abort
+test_cross_cluster_lock_conflict
 
 echo "Parallel restore tests completed successfully"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62546

Problem Summary:

### What changed and how does it work?
change append migration op to acquire read lock instead of write lock so it can works with restore at the same time.
create a new append_lock that append will acquire after acquiring read lock (two phase locking), to prevent multiple append threads to race.

Append migration should work fine with restore as new ssts added will have larger TS that any restore should filter out, effectively invisible to the ongoing restore.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
