### PR TITLE
domain: skip loading privilege if the notification is from current tidb  | tidb-test=release-8.5-20250606-v8.5.2

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -1868,7 +1868,7 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 			resp         clientv3.WatchResponse
 		)
 		for {
-			ok := true
+			var ok bool
 			select {
 			case <-do.exit:
 				return


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #61706

Problem Summary:

If a DCL like `GRANT` or `REVOKE` is called on tidb-0, tidb-0 will load the whole privilege cache twice:
* one by `Update()` in `NotifyUpdatePrivilege()`
* another by `Update()` in `LoadPrivilegeLoop()`

If the size of the privilege cache is quite large, the cost of `Update()` can not be ignored

### What changed and how does it work?

* When `NotifyUpdatePrivilege`, write the current tidb server id into the value of `privilegeKey`
* When watching an event in `LoadPrivilegeLoop`, skip `Update()` if the event is from the tidb itself

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

#### test 1

1. Add a log in the entry at `func (h *Handle) Update()`
2. Bootstrap 2 tidb clusters with multiple tidb separately
3. Do DCL like `create user`, `grant` or `revoke`, see the number of log for `func (h *Handle) Update()`
Result:
* With the PR, the number of invocations of `func (h *Handle) Update()` among all tidb-server are the same
* Without this PR, the tidb-server receiving DCL invokes `func (h *Handle) Update()` twice as many times as other tidb

#### test 2 

1. bootstrap a cluster with one tidb, initialize 130k column privilege records
5. execute `GRANT` per second, observe the CPU framegraph and metric
**Before**
<img width="1280" height="586" alt="image" src="https://github.com/user-attachments/assets/f4bb267a-f505-4a8c-a681-ccd171c1f860" />
<img width="1812" height="532" alt="image" src="https://github.com/user-attachments/assets/69725ef6-badb-41d8-ac92-73534e76782f" />

**After**
<img width="3840" height="1888" alt="image" src="https://github.com/user-attachments/assets/d716e885-c977-41e1-aa67-49de81ace572" />
<img width="680" height="191" alt="image" src="https://github.com/user-attachments/assets/11753eec-a5d0-4b71-8c0e-807b805d13dc" />

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
