### PR TITLE
ddl: move auto id handling from submitter to executor

### DIFF
--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -145,9 +145,9 @@ func createTable(jobCtx *jobContext, job *model.Job, r autoid.Requirement, args 
 			return tbInfo, errors.Wrapf(err, "failed to notify PD the placement rules")
 		}
 
-		// Updating auto id metakv is done in a separate txn.
-		// It's ok as these data are binded with table ID, and we won't use see these table IDs
-		// until info schema version is updated.
+		// Updating auto id meta kv is done in a separate txn.
+		// It's ok as these data are bind with table ID, and we won't use these
+		// table IDs until info schema version is updated.
 		if err := handleAutoIncID(r, job, tbInfo); err != nil {
 			return tbInfo, errors.Trace(err)
 		}
@@ -291,7 +291,6 @@ func (w *worker) createTableWithForeignKeys(jobCtx *jobContext, job *model.Job, 
 }
 
 func (w *worker) onCreateTables(jobCtx *jobContext, job *model.Job) (int64, error) {
-	failpoint.InjectCall("beforeCreateTables")
 	var ver int64
 
 	args, err := model.GetBatchCreateTableArgs(job)

--- a/pkg/ddl/db_table_test.go
+++ b/pkg/ddl/db_table_test.go
@@ -378,32 +378,11 @@ func TestBatchCreateTable(t *testing.T) {
 	// FIXME: we must change column type to give multiple id
 	// c.Assert(job[6], Matches, "[^,]+,[^,]+,[^,]+")
 
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/BatchCreateTableWithInfo", func() {
-		tk2 := testkit.NewTestKit(t, store)
-		tk2.MustExec("use test")
-		tk2.MustExec("create table tables_5(id int)")
-	})
-
-	infos = []*model.TableInfo{}
-	infos = append(infos, &model.TableInfo{
-		Name: ast.NewCIStr("tables_4"),
-	})
-	infos = append(infos, &model.TableInfo{
-		Name: ast.NewCIStr("tables_5"),
-	})
-	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = d.BatchCreateTableWithInfo(tk.Session(), ast.NewCIStr("test"), infos, ddl.WithOnExist(ddl.OnExistError))
-	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
-
-	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/BatchCreateTableWithInfo")
-
 	// duplicated name
 	infos[1].Name = ast.NewCIStr("tables_1")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
 	err = d.BatchCreateTableWithInfo(tk.Session(), ast.NewCIStr("test"), infos, ddl.WithOnExist(ddl.OnExistError))
 	require.True(t, terror.ErrorEqual(err, infoschema.ErrTableExists))
-
-	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
 
 	newinfo := &model.TableInfo{
 		Name: ast.NewCIStr("tables_4"),

--- a/pkg/ddl/db_table_test.go
+++ b/pkg/ddl/db_table_test.go
@@ -378,11 +378,32 @@ func TestBatchCreateTable(t *testing.T) {
 	// FIXME: we must change column type to give multiple id
 	// c.Assert(job[6], Matches, "[^,]+,[^,]+,[^,]+")
 
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/BatchCreateTableWithInfo", func() {
+		tk2 := testkit.NewTestKit(t, store)
+		tk2.MustExec("use test")
+		tk2.MustExec("create table tables_5(id int)")
+	})
+
+	infos = []*model.TableInfo{}
+	infos = append(infos, &model.TableInfo{
+		Name: ast.NewCIStr("tables_4"),
+	})
+	infos = append(infos, &model.TableInfo{
+		Name: ast.NewCIStr("tables_5"),
+	})
+	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	err = d.BatchCreateTableWithInfo(tk.Session(), ast.NewCIStr("test"), infos, ddl.WithOnExist(ddl.OnExistError))
+	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
+
+	testfailpoint.Disable(t, "github.com/pingcap/tidb/pkg/ddl/BatchCreateTableWithInfo")
+
 	// duplicated name
 	infos[1].Name = ast.NewCIStr("tables_1")
 	tk.Session().SetValue(sessionctx.QueryString, "skip")
 	err = d.BatchCreateTableWithInfo(tk.Session(), ast.NewCIStr("test"), infos, ddl.WithOnExist(ddl.OnExistError))
 	require.True(t, terror.ErrorEqual(err, infoschema.ErrTableExists))
+
+	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
 
 	newinfo := &model.TableInfo{
 		Name: ast.NewCIStr("tables_4"),

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1271,8 +1271,6 @@ func (e *executor) BatchCreateTableWithInfo(ctx sessionctx.Context,
 		return nil
 	}
 
-	failpoint.InjectCall("BatchCreateTableWithInfo")
-
 	jobW := NewJobWrapperWithArgs(job, args, c.IDAllocated)
 	err = e.DoDDLJobWrapper(ctx, jobW)
 	if err != nil {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1159,47 +1159,6 @@ func getSharedInvolvingSchemaInfo(info *model.TableInfo) []model.InvolvingSchema
 	return ret
 }
 
-func (e *executor) createTableWithInfoPost(
-	ctx sessionctx.Context,
-	tbInfo *model.TableInfo,
-	schemaID int64,
-	scatterScope string,
-) error {
-	var err error
-	var partitions []model.PartitionDefinition
-	if pi := tbInfo.GetPartitionInfo(); pi != nil {
-		partitions = pi.Definitions
-	}
-	preSplitAndScatter(ctx, e.store, tbInfo, partitions, scatterScope)
-	if tbInfo.AutoIncID > 1 {
-		// Default tableAutoIncID base is 0.
-		// If the first ID is expected to greater than 1, we need to do rebase.
-		newEnd := tbInfo.AutoIncID - 1
-		var allocType autoid.AllocatorType
-		if tbInfo.SepAutoInc() {
-			allocType = autoid.AutoIncrementType
-		} else {
-			allocType = autoid.RowIDAllocType
-		}
-		if err = e.handleAutoIncID(tbInfo, schemaID, newEnd, allocType); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	// For issue https://github.com/pingcap/tidb/issues/46093
-	if tbInfo.AutoIncIDExtra != 0 {
-		if err = e.handleAutoIncID(tbInfo, schemaID, tbInfo.AutoIncIDExtra-1, autoid.RowIDAllocType); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	if tbInfo.AutoRandID > 1 {
-		// Default tableAutoRandID base is 0.
-		// If the first ID is expected to greater than 1, we need to do rebase.
-		newEnd := tbInfo.AutoRandID - 1
-		err = e.handleAutoIncID(tbInfo, schemaID, newEnd, autoid.AutoRandomType)
-	}
-	return err
-}
-
 func (e *executor) CreateTableWithInfo(
 	ctx sessionctx.Context,
 	dbName ast.CIStr,
@@ -1223,13 +1182,14 @@ func (e *executor) CreateTableWithInfo(
 		if c.OnExist == OnExistIgnore && infoschema.ErrTableExists.Equal(err) {
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
 			err = nil
+		} else {
+			var scatterScope string
+			if val, ok := jobW.GetSessionVars(vardef.TiDBScatterRegion); ok {
+				scatterScope = val
+			}
+
+			preSplitAndScatterTable(ctx, e.store, tbInfo, scatterScope)
 		}
-	} else {
-		var scatterScope string
-		if val, ok := jobW.GetSessionVars(vardef.TiDBScatterRegion); ok {
-			scatterScope = val
-		}
-		err = e.createTableWithInfoPost(ctx, tbInfo, jobW.SchemaID, scatterScope)
 	}
 
 	return errors.Trace(err)
@@ -1311,6 +1271,8 @@ func (e *executor) BatchCreateTableWithInfo(ctx sessionctx.Context,
 		return nil
 	}
 
+	failpoint.InjectCall("BatchCreateTableWithInfo")
+
 	jobW := NewJobWrapperWithArgs(job, args, c.IDAllocated)
 	err = e.DoDDLJobWrapper(ctx, jobW)
 	if err != nil {
@@ -1326,9 +1288,7 @@ func (e *executor) BatchCreateTableWithInfo(ctx sessionctx.Context,
 		scatterScope = val
 	}
 	for _, tblArgs := range args.Tables {
-		if err = e.createTableWithInfoPost(ctx, tblArgs.TableInfo, jobW.SchemaID, scatterScope); err != nil {
-			return errors.Trace(err)
-		}
+		preSplitAndScatterTable(ctx, e.store, tblArgs.TableInfo, scatterScope)
 	}
 
 	return nil
@@ -1409,6 +1369,14 @@ func preSplitAndScatter(ctx sessionctx.Context, store kv.Storage, tbInfo *model.
 	} else {
 		go preSplit()
 	}
+}
+
+func preSplitAndScatterTable(ctx sessionctx.Context, store kv.Storage, tbInfo *model.TableInfo, scatterScope string) {
+	var partitions []model.PartitionDefinition
+	if pi := tbInfo.GetPartitionInfo(); pi != nil {
+		partitions = pi.Definitions
+	}
+	preSplitAndScatter(ctx, store, tbInfo, partitions, scatterScope)
 }
 
 func (e *executor) FlashbackCluster(ctx sessionctx.Context, flashbackTS uint64) error {

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1510,19 +1510,6 @@ func checkCharsetAndCollation(cs string, co string) error {
 	return nil
 }
 
-// handleAutoIncID handles auto_increment option in DDL. It creates a ID counter for the table and initiates the counter to a proper value.
-// For example if the option sets auto_increment to 10. The counter will be set to 9. So the next allocated ID will be 10.
-func (e *executor) handleAutoIncID(tbInfo *model.TableInfo, schemaID int64, newEnd int64, tp autoid.AllocatorType) error {
-	allocs := autoid.NewAllocatorsFromTblInfo(e.getAutoIDRequirement(), schemaID, tbInfo)
-	if alloc := allocs.Get(tp); alloc != nil {
-		err := alloc.Rebase(context.Background(), newEnd, false)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
 func (e *executor) getAutoIDRequirement() autoid.Requirement {
 	return &asAutoIDRequirement{
 		store:     e.store,

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -1182,16 +1182,15 @@ func (e *executor) CreateTableWithInfo(
 		if c.OnExist == OnExistIgnore && infoschema.ErrTableExists.Equal(err) {
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
 			err = nil
-		} else {
-			var scatterScope string
-			if val, ok := jobW.GetSessionVars(vardef.TiDBScatterRegion); ok {
-				scatterScope = val
-			}
-
-			preSplitAndScatterTable(ctx, e.store, tbInfo, scatterScope)
 		}
-	}
+	} else {
+		var scatterScope string
+		if val, ok := jobW.GetSessionVars(vardef.TiDBScatterRegion); ok {
+			scatterScope = val
+		}
 
+		preSplitAndScatterTable(ctx, e.store, tbInfo, scatterScope)
+	}
 	return errors.Trace(err)
 }
 

--- a/pkg/ddl/table.go
+++ b/pkg/ddl/table.go
@@ -577,15 +577,11 @@ func (w *worker) onTruncateTable(jobCtx *jobContext, job *model.Job) (ver int64,
 		}
 	})
 
-	var partitions []model.PartitionDefinition
-	if pi := tblInfo.GetPartitionInfo(); pi != nil {
-		partitions = tblInfo.GetPartitionInfo().Definitions
-	}
 	var scatterScope string
 	if val, ok := job.GetSessionVars(vardef.TiDBScatterRegion); ok {
 		scatterScope = val
 	}
-	preSplitAndScatter(w.sess.Context, jobCtx.store, tblInfo, partitions, scatterScope)
+	preSplitAndScatterTable(w.sess.Context, jobCtx.store, tblInfo, scatterScope)
 
 	ver, err = updateSchemaVersion(jobCtx, job)
 	if err != nil {

--- a/pkg/ddl/tests/fastcreatetable/fastcreatetable_test.go
+++ b/pkg/ddl/tests/fastcreatetable/fastcreatetable_test.go
@@ -130,7 +130,7 @@ func TestMergedJob(t *testing.T) {
 	wg.Run(func() {
 		tk1 := testkit.NewTestKit(t, store)
 		tk1.MustExec("use test")
-		tk1.MustExecToErr("create table t1(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 100")
+		tk1.MustExecToErr("create table t1(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 1000")
 	})
 	wg.Run(func() {
 		tk1 := testkit.NewTestKit(t, store)
@@ -147,7 +147,7 @@ func TestMergedJob(t *testing.T) {
 	wg.Run(func() {
 		tk1 := testkit.NewTestKit(t, store)
 		tk1.MustExec("use test")
-		tk1.MustExec("create table t1(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 1000")
+		tk1.MustExec("create table t1(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 100")
 	})
 	wg.Run(func() {
 		tk1 := testkit.NewTestKit(t, store)
@@ -164,6 +164,7 @@ func TestMergedJob(t *testing.T) {
 	close(startSchedule)
 	wg.Wait()
 
+	// Test the correctness of auto id after failed merge job 2
 	tk.MustExec("insert into test.t1(c) values(1)")
-	tk.MustQuery("select * from test.t1").Check(testkit.Rows("1001 1"))
+	tk.MustQuery("select * from test.t1").Check(testkit.Rows("100 1"))
 }

--- a/pkg/ddl/tests/fastcreatetable/fastcreatetable_test.go
+++ b/pkg/ddl/tests/fastcreatetable/fastcreatetable_test.go
@@ -130,12 +130,12 @@ func TestMergedJob(t *testing.T) {
 	wg.Run(func() {
 		tk1 := testkit.NewTestKit(t, store)
 		tk1.MustExec("use test")
-		tk1.MustExecToErr("create table t(a int)")
+		tk1.MustExecToErr("create table t1(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 100")
 	})
 	wg.Run(func() {
 		tk1 := testkit.NewTestKit(t, store)
 		tk1.MustExec("use test")
-		tk1.MustExecToErr("create table t1(a int)")
+		tk1.MustExecToErr("create table t(a int)")
 	})
 	require.Eventually(t, func() bool {
 		gotJobs, err := ddl.GetAllDDLJobs(ctx, tk.Session())
@@ -143,7 +143,27 @@ func TestMergedJob(t *testing.T) {
 		return len(gotJobs) == 2 && gotJobs[1].Type == model.ActionCreateTables
 	}, 10*time.Second, 100*time.Millisecond)
 
+	// below 2 jobs are merged into the third group, they will succeed together.
+	wg.Run(func() {
+		tk1 := testkit.NewTestKit(t, store)
+		tk1.MustExec("use test")
+		tk1.MustExec("create table t1(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 1000")
+	})
+	wg.Run(func() {
+		tk1 := testkit.NewTestKit(t, store)
+		tk1.MustExec("use test")
+		tk1.MustExec("create table t2(id int AUTO_INCREMENT, c int) AUTO_INCREMENT 100")
+	})
+	require.Eventually(t, func() bool {
+		gotJobs, err := ddl.GetAllDDLJobs(ctx, tk.Session())
+		require.NoError(t, err)
+		return len(gotJobs) == 3 && gotJobs[2].Type == model.ActionCreateTables
+	}, 10*time.Second, 100*time.Millisecond)
+
 	// start to run the jobs
 	close(startSchedule)
 	wg.Wait()
+
+	tk.MustExec("insert into test.t1(c) values(1)")
+	tk.MustQuery("select * from test.t1").Check(testkit.Rows("1001 1"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60804

Problem Summary:

Previously, the procedure of (batch) creating table is as follow:
- submitter submit the job and wait it finished
- ddl owner execute the job and mark table as public
- submitter pre-scatter the table and update the auto id.

But if the submitter quit before waiting job finished, the post process will be skipped. So the creation itself is **not atomic**.

### What changed and how does it work?

Now ddl owner takes the responsibility to update auto id and submitter only needs to pre-scatter the table.

https://github.com/pingcap/tidb/blob/1f24032d4e641c38fbd0e72b036bf5f679b809b0/pkg/ddl/job_submitter.go#L224-L227

Because merged ddl job only holds the session variables from the first job for now, which means all jobs share the same variables, we don't apply pre-scatter in ddl owner.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
