### PR TITLE
dxf: fix flaky test TestResourceControl/scale-in

### DIFF
--- a/pkg/disttask/framework/integrationtests/resource_control_test.go
+++ b/pkg/disttask/framework/integrationtests/resource_control_test.go
@@ -247,9 +247,6 @@ func TestResourceControl(t *testing.T) {
 		}
 		allSubtasks := c.getAllSubtasks()
 		c.continueAllSubtasks()
-		// wait all subtasks done, else we don't know whether they are done or cancelled,
-		// so hard to do wait
-		c.waitTotalSubtaskCount(0)
 		// now there are 4 subtasks left, 1 node should be enough to run them
 		c.ScaleIn(2)
 		c.waitTotalSubtaskCount(4)

--- a/pkg/disttask/framework/integrationtests/resource_control_test.go
+++ b/pkg/disttask/framework/integrationtests/resource_control_test.go
@@ -247,6 +247,11 @@ func TestResourceControl(t *testing.T) {
 		}
 		allSubtasks := c.getAllSubtasks()
 		c.continueAllSubtasks()
+		// wait all subtasks done, else we don't know whether they are done or cancelled,
+		// so hard to do wait
+		for taskID := int64(1); taskID <= 4; taskID++ {
+			c.waitNewSubtasksNotIn(taskID, allSubtasks[taskID], 1)
+		}
 		// now there are 4 subtasks left, 1 node should be enough to run them
 		c.ScaleIn(2)
 		c.waitTotalSubtaskCount(4)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61354

Problem Summary:

### What changed and how does it work?
after we continue all running subtasks, they finish, and scheduler will try to schedule left subtasks immediately, so the active running subtask count might be in range `[0, 4]`, `c.waitTotalSubtaskCount(0)` night not hold, so change to another way to check
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test. **TEST CHANGE**
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
