### PR TITLE
fix: close issue #62461 return empty array instead of null for json

### DIFF
--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -664,8 +664,15 @@ func newFakeSctx() *stmtctx.StatementContext {
 
 func (b *castJSONAsArrayFunctionSig) evalJSON(ctx EvalContext, row chunk.Row) (res types.BinaryJSON, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(ctx, row)
-	if isNull || err != nil {
-		return res, isNull, err
+	if err != nil {
+		return res, false, err
+	}
+
+	// When JSON path does not exist, return empty array instead of null
+	// More to check issue: #62461
+	if isNull {
+		// Return empty array when input is null (e.g., JSON path not found)
+		return types.CreateBinaryJSON([]any{}), false, nil
 	}
 
 	if val.TypeCode == types.JSONTypeCodeObject {

--- a/pkg/expression/builtin_cast_test.go
+++ b/pkg/expression/builtin_cast_test.go
@@ -1762,6 +1762,80 @@ func TestCastArrayFunc(t *testing.T) {
 	}
 }
 
+func TestCastJSONAsArrayWithNullInput(t *testing.T) {
+	ctx := createContext(t)
+
+	// Test case for issue #62461: When JSON path does not exist (returns null),
+	// CAST should return empty array instead of null
+	tp := types.NewFieldTypeBuilder().SetType(mysql.TypeLonglong).SetCharset(charset.CharsetBin).SetCollate(charset.CollationBin).SetArray(true).BuildP()
+
+	// Test 1: null input should return empty array
+	nullConstant := &Constant{
+		Value:   types.NewDatum(nil),
+		RetType: types.NewFieldType(mysql.TypeJSON),
+	}
+
+	baseFunc, err := newBaseBuiltinFunc(ctx, "", []Expression{nullConstant}, tp)
+	require.NoError(t, err)
+
+	castFunc := &castJSONAsArrayFunctionSig{
+		baseBuiltinFunc: baseFunc,
+	}
+	castFunc.tp = tp
+
+	result, isNull, err := castFunc.evalJSON(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.False(t, isNull, "Result should not be null")
+	require.Equal(t, types.JSONTypeCodeArray, result.TypeCode)
+	require.Equal(t, 0, result.GetElemCount(), "Should return empty array")
+
+	expectedEmptyArray := types.CreateBinaryJSON([]any{})
+	cmp := types.CompareBinaryJSON(expectedEmptyArray, result)
+	require.Equal(t, 0, cmp, "Result should be an empty array")
+
+	// Test 2: non-null JSON input should work normally
+	jsonInput := types.CreateBinaryJSON([]any{int64(1), int64(2), int64(3)})
+	nonNullConstant := &Constant{
+		Value:   types.NewDatum(jsonInput),
+		RetType: types.NewFieldType(mysql.TypeJSON),
+	}
+
+	baseFunc2, err := newBaseBuiltinFunc(ctx, "", []Expression{nonNullConstant}, tp)
+	require.NoError(t, err)
+
+	castFunc2 := &castJSONAsArrayFunctionSig{
+		baseBuiltinFunc: baseFunc2,
+	}
+	castFunc2.tp = tp
+
+	result2, isNull2, err := castFunc2.evalJSON(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.False(t, isNull2, "Result should not be null for valid input")
+	require.Equal(t, types.JSONTypeCodeArray, result2.TypeCode)
+	require.Equal(t, 3, result2.GetElemCount(), "Should return array with 3 elements")
+
+	// Test 3: single non-array JSON value should be wrapped in array
+	jsonSingle := types.CreateBinaryJSON(int64(42))
+	singleConstant := &Constant{
+		Value:   types.NewDatum(jsonSingle),
+		RetType: types.NewFieldType(mysql.TypeJSON),
+	}
+
+	baseFunc3, err := newBaseBuiltinFunc(ctx, "", []Expression{singleConstant}, tp)
+	require.NoError(t, err)
+
+	castFunc3 := &castJSONAsArrayFunctionSig{
+		baseBuiltinFunc: baseFunc3,
+	}
+	castFunc3.tp = tp
+
+	result3, isNull3, err := castFunc3.evalJSON(ctx, chunk.Row{})
+	require.NoError(t, err)
+	require.False(t, isNull3, "Result should not be null for valid input")
+	require.Equal(t, types.JSONTypeCodeArray, result3.TypeCode)
+	require.Equal(t, 1, result3.GetElemCount(), "Should return array with 1 element")
+}
+
 func TestCastAsCharFieldType(t *testing.T) {
 	type testCase struct {
 		input      *Constant


### PR DESCRIPTION
This patch close issue #62461 

the root cause is not from  runtime error: index out of range [3] with length 3

it is because json array here should not be null 
in

```go
func (c *Codec) decodeColumn(buffer []byte, col *Column, ordinal int) (remained []byte) {
	// Todo(Shenghui Wu): Optimize all data is null.
	// decode length.
	col.length = int(binary.LittleEndian.Uint32(buffer))
	buffer = buffer[4:]

	// decode nullCount.
	nullCount := int(binary.LittleEndian.Uint32(buffer))
	buffer = buffer[4:]
```

binary.LittleEndian.Uint32(buffer)  change to the wrong type buffer only 3 bytes not 4 bytes

so this patch correct the no json patch as empty array here correct it.

and maybe need to add guard for 	`buffer = buffer[4:]` but seems need to disscuss
so this patch do not contain it.



```go
func (c *Codec) decodeColumn(buffer []byte, col *Column, ordinal int) (remained []byte) {
	// Todo(Shenghui Wu): Optimize all data is null.
	// decode length.
	col.length = int(binary.LittleEndian.Uint32(buffer))
	buffer = buffer[4:]

	// decode nullCount.
	nullCount := int(binary.LittleEndian.Uint32(buffer))
	buffer = buffer[4:]

	// decode nullBitmap.
	if nullCount > 0 {
		numNullBitmapBytes := (col.length + 7) / 8
		col.nullBitmap = buffer[:numNullBitmapBytes:numNullBitmapBytes]
		buffer = buffer[numNullBitmapBytes:]
	} else {
		c.setAllNotNull(col)
	}

	// decode offsets.
	numFixedBytes := getFixedLen(c.colTypes[ordinal])
	numDataBytes := int64(numFixedBytes * col.length)
	if numFixedBytes == -1 {
		numOffsetBytes := (col.length + 1) * 8
		col.offsets = bytesToI64Slice(buffer[:numOffsetBytes:numOffsetBytes])
		buffer = buffer[numOffsetBytes:]
		numDataBytes = col.offsets[col.length]
	} else if cap(col.elemBuf) < numFixedBytes {
		col.elemBuf = make([]byte, numFixedBytes)
	}

	// decode data.
	col.data = buffer[:numDataBytes:numDataBytes]
	// The column reference the data of the grpc response, the memory of the grpc message cannot be GCed if we reuse
	// this column. Thus, we set `avoidReusing` to true.
	col.avoidReusing = true
	return buffer[numDataBytes:]
}
```

cc @lance6716 @hawkingrei


### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62461

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
