### PR TITLE
planner: remove "SHOW PLAN FOR <SQL>" syntax

### DIFF
--- a/pkg/bindinfo/binding_auto.go
+++ b/pkg/bindinfo/binding_auto.go
@@ -47,7 +47,7 @@ var RecordRelevantOptVarsAndFixes func(sctx sessionctx.Context, stmt ast.StmtNod
 var GenBriefPlanWithSCtx func(sctx sessionctx.Context, stmt ast.StmtNode) (planDigest, planHintStr string, planText [][]string, err error)
 
 // BindingPlanInfo contains the binding info and its corresponding plan execution info, which is used by
-// "SHOW PLAN FOR <SQL>" to help users understand the historical plans for a specific SQL.
+// "EXPLAIN EXPLORE <SQL>" to help users understand the historical plans for a specific SQL.
 type BindingPlanInfo struct {
 	*Binding
 

--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -901,7 +901,6 @@ func (b *executorBuilder) buildShow(v *plannercore.PhysicalShow) exec.Executor {
 		Extractor:             v.Extractor,
 		ImportJobID:           v.ImportJobID,
 		DistributionJobID:     v.DistributionJobID,
-		SQLOrDigest:           v.SQLOrDigest,
 	}
 	if e.Tp == ast.ShowMasterStatus || e.Tp == ast.ShowBinlogStatus {
 		// show master status need start ts.

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3052,7 +3052,6 @@ const (
 	ShowBinlogStatus
 	ShowReplicaStatus
 	ShowDistributions
-	ShowPlanForSQL
 	ShowDistributionJobs
 )
 
@@ -3103,7 +3102,6 @@ type ShowStmt struct {
 	ShowProfileLimit *Limit // Used for `SHOW PROFILE` syntax
 
 	ImportJobID *int64 // Used for `SHOW IMPORT JOB <ID>` syntax
-	SQLOrDigest string // Used for `SHOW PLAN FOR ...` syntax
 
 	DistributionJobID *int64 // Used for `SHOW DISTRIBUTION JOB <ID>` syntax
 }
@@ -3454,9 +3452,6 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WriteKeyWord("SESSION_STATES")
 		case ShowReplicaStatus:
 			ctx.WriteKeyWord("REPLICA STATUS")
-		case ShowPlanForSQL:
-			ctx.WriteKeyWord("PLAN FOR ")
-			ctx.WriteString(n.SQLOrDigest)
 		default:
 			return errors.New("Unknown ShowStmt type")
 		}

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -12276,10 +12276,6 @@ ShowTargetFilterable:
 	{
 		$$ = &ast.ShowStmt{Tp: ast.ShowImportJobs}
 	}
-|	"PLAN" "FOR" stringLit
-	{
-		$$ = &ast.ShowStmt{Tp: ast.ShowPlanForSQL, SQLOrDigest: $3}
-	}
 |	"DISTRIBUTION" "JOBS"
 	{
 		$$ = &ast.ShowStmt{Tp: ast.ShowDistributionJobs}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5843,9 +5843,9 @@ func TestBinding(t *testing.T) {
 		{"CREATE GLOBAL BINDING FROM HISTORY USING PLAN DIGEST 'sss'", true, "CREATE GLOBAL BINDING FROM HISTORY USING PLAN DIGEST 'sss'"},
 		{"set binding enabled for sql digest '1'", true, "SET BINDING ENABLED FOR SQL DIGEST '1'"},
 		{"set binding disabled for sql digest '1'", true, "SET BINDING DISABLED FOR SQL DIGEST '1'"},
-		// Show plan for a specified SQL.
-		{"show plan for 'select a from t'", true, "SHOW PLAN FOR 'select a from t'"},
-		{"show plan for '23adc8e6f62'", true, "SHOW PLAN FOR '23adc8e6f62'"},
+		// Explain explore for a specified SQL.
+		{"explain explore 'select a from t'", true, "EXPLAIN EXPLORE 'select a from t'"},
+		{"explain explore '23adc8e6f62'", true, "EXPLAIN EXPLORE '23adc8e6f62'"},
 	}
 	RunTest(t, table, false)
 

--- a/pkg/planner/core/operator/logicalop/logical_show.go
+++ b/pkg/planner/core/operator/logicalop/logical_show.go
@@ -59,7 +59,6 @@ type ShowContents struct {
 	Limit       *ast.Limit // Used for limit Result Set row number.
 
 	ImportJobID       *int64 // Used for SHOW LOAD DATA JOB <jobID>
-	SQLOrDigest       string // Used for SHOW PLAN FOR <SQL or Digest>
 	DistributionJobID *int64 // Used for SHOW DISTRIBUTION JOB <JobID>
 }
 

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3493,7 +3493,6 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			Limit:                 show.Limit,
 			ImportJobID:           show.ImportJobID,
 			DistributionJobID:     show.DistributionJobID,
-			SQLOrDigest:           show.SQLOrDigest,
 		},
 	}.Init(b.ctx)
 	isView := false
@@ -5931,11 +5930,6 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 	case ast.ShowBindingCacheStatus:
 		names = []string{"bindings_in_cache", "bindings_in_table", "memory_usage", "memory_quota"}
 		ftypes = []byte{mysql.TypeLonglong, mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeVarchar}
-	case ast.ShowPlanForSQL:
-		names = []string{"statement", "binding_hint", "plan", "plan_digest", "avg_latency", "exec_times", "avg_scan_rows",
-			"avg_returned_rows", "latency_per_returned_row", "scan_rows_per_returned_row", "recommend", "reason"}
-		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeDouble, mysql.TypeDouble, mysql.TypeDouble,
-			mysql.TypeDouble, mysql.TypeDouble, mysql.TypeDouble, mysql.TypeVarchar, mysql.TypeVarchar}
 	case ast.ShowAnalyzeStatus:
 		names = []string{"Table_schema", "Table_name", "Partition_name", "Job_info", "Processed_rows", "Start_time",
 			"End_time", "State", "Fail_reason", "Instance", "Process_ID", "Remaining_seconds", "Progress", "Estimated_total_rows"}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #60148 

Problem Summary: `SHOW PLAN FOR <SQL>` was an early iteration of the SQL syntax for SPM, but has now been supplanted by the `EXPLAIN EXPLORE <SQL>` syntax. 

### What changed and how does it work?

Delete `ShowPlanForSQL` and related `SQLOrDigest` fields from the parser and the implementation of the `SHOW` SQL statement, and update tests accordingly.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
