### PR TITLE
planner: don't consider an empty plan a simple point plan

### DIFF
--- a/pkg/bindinfo/binding_auto.go
+++ b/pkg/bindinfo/binding_auto.go
@@ -341,6 +341,7 @@ type planExecInfo struct {
 // IsSimplePointPlan checks whether the plan is a simple point plan.
 // Expose this function for testing.
 func IsSimplePointPlan(plan string) bool {
+	empty := true
 	// if the plan only contains Point_Get, Batch_Point_Get, Selection and Projection, it's a simple point plan.
 	lines := strings.Split(plan, "\n")
 	for _, line := range lines {
@@ -348,6 +349,7 @@ func IsSimplePointPlan(plan string) bool {
 		if line == "" {
 			continue
 		}
+		empty = false
 		operatorName := strings.Split(line, " ")[0]
 		// TODO: these hard-coding lines are a temporary implementation, refactor this part later.
 		if operatorName == "id" || // the first line with column names
@@ -359,5 +361,5 @@ func IsSimplePointPlan(plan string) bool {
 		}
 		return false
 	}
-	return true
+	return !empty
 }

--- a/pkg/bindinfo/binding_auto_test.go
+++ b/pkg/bindinfo/binding_auto_test.go
@@ -127,6 +127,8 @@ func TestIsSimplePointPlan(t *testing.T) {
 	require.False(t, bindinfo.IsSimplePointPlan(`       id  task    estRows operator info  actRows execution info  memory          disk
         HashJoin    root    1       plus(test.t.a, 1)->Column#3     0       time:173µs, open:24.9µs, close:8.92µs, loops:1, Concurrency:OFF                         380 Bytes       N/A
         └─Point_Get_5   root    1       table:t, handle:2               0       time:143.2µs, open:1.71µs, close:5.92µs, loops:1, Get:{num_rpc:1, total_time:40µs}      N/A             N/A`))
+	require.False(t, bindinfo.IsSimplePointPlan(``))
+	require.False(t, bindinfo.IsSimplePointPlan(`  \n   `))
 }
 
 func TestRelevantOptVarsAndFixes(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #60148 

Problem Summary: Empty plans are currently considered simple point plans, which is incorrect. (Passing empty plans to this function indicates other issues, but those are out of scope for this PR.)

### What changed and how does it work?

Modify `bindinfo.IsSimplePointPlan` to check for empty plans (or plans that only consist of whitespace), and modify `TestIsSimplePointPlan` to exercise this case.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
