### PR TITLE
dxf: remove memory adjust for cgoups v2

### DIFF
--- a/pkg/domain/BUILD.bazel
+++ b/pkg/domain/BUILD.bazel
@@ -82,7 +82,6 @@ go_library(
         "//pkg/ttl/ttlworker",
         "//pkg/types",
         "//pkg/util",
-        "//pkg/util/cgroup",
         "//pkg/util/chunk",
         "//pkg/util/context",
         "//pkg/util/cpu",

--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -91,7 +91,6 @@ import (
 	"github.com/pingcap/tidb/pkg/ttl/ttlworker"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
-	"github.com/pingcap/tidb/pkg/util/cgroup"
 	"github.com/pingcap/tidb/pkg/util/cpu"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	disttaskutil "github.com/pingcap/tidb/pkg/util/disttask"
@@ -1142,22 +1141,6 @@ func calculateNodeResource() (*proto.NodeResource, error) {
 	totalCPU := cpu.GetCPUCount()
 	if totalCPU <= 0 || totalMem <= 0 {
 		return nil, errors.Errorf("invalid cpu or memory, cpu: %d, memory: %d", totalCPU, totalMem)
-	}
-	cgroupLimit, version, err := cgroup.GetCgroupMemLimit()
-	// ignore the error of cgroup.GetCgroupMemLimit, as it's not a must-success step.
-	if err == nil && version == cgroup.V2 {
-		// see cgroup.detectMemLimitInV2 for more details.
-		// below are some real memory limits tested on GCP:
-		// node-spec  real-limit  percent
-		// 16c32g        27.83Gi    87%
-		// 32c64g        57.36Gi    89.6%
-		// we use 'limit', not totalMem for adjust, as totalMem = min(physical-mem, 'limit')
-		// content of 'memory.max' might be 'max', so we use the min of them.
-		adjustedMem := min(totalMem, uint64(float64(cgroupLimit)*0.88))
-		logger.Info("adjust memory limit for cgroup v2",
-			zap.String("before", units.BytesSize(float64(totalMem))),
-			zap.String("after", units.BytesSize(float64(adjustedMem))))
-		totalMem = adjustedMem
 	}
 	var totalDisk uint64
 	cfg := config.GetGlobalConfig()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
in https://github.com/pingcap/tidb/pull/51575, we add the memory adjust for cgroups v2, as we think the memory got from `MemTotal` is not accurate on it, but now i found the memory we got from `MemTotal` is controlled by the `resource limit` of the pod.

so we can remove the adjustment, and use pod spec control it. the max limit memory can be set for a pod need also consider the reserved space by k8s, see https://learnk8s.io/allocatable-resources
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

below is the result tested on a 8c16g node, before this PR, we can see we set the pod limit to `13208 MiB/1024 = 12.9 GiB`
```
    resources:
      limits:
        cpu: "7"
        memory: 13208Mi
      requests:
        cpu: "7"
        memory: 13208Mi
```

and from the log of tidb, we can see, the memory we got is also `12.9GiB`, and we adjusted it to be `11.35GiB`. **`12.9GiB` is safe to use, no need to be adjusted again, so in this PR we remove the adjust**
```
[2025/07/18 17:58:50.592 +00:00] [INFO] [domain.go:1157] ["adjust memory limit for cgroup v2"] [keyspaceName=SYSTEM] [before=12.9GiB] [after=11.35GiB]
[2025/07/18 17:58:50.592 +00:00] [INFO] [domain.go:1171] ["initialize node resource"] [keyspaceName=SYSTEM] [total-cpu=7] [total-mem=11.35GiB] [total-disk=97.87GiB]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
