### PR TITLE
planner: reuse slices with buildKeyInfo

### DIFF
--- a/pkg/planner/core/rule/BUILD.bazel
+++ b/pkg/planner/core/rule/BUILD.bazel
@@ -15,5 +15,6 @@ go_library(
         "//pkg/planner/core/base",
         "//pkg/planner/core/rule/util",
         "//pkg/planner/util/optimizetrace",
+        "//pkg/util/zeropool",
     ],
 )

--- a/pkg/planner/core/rule/rule_build_key_info.go
+++ b/pkg/planner/core/rule/rule_build_key_info.go
@@ -60,8 +60,8 @@ func buildKeyInfo(lp base.LogicalPlan) {
 		childSchema = childSchema[:0]
 		childSchemaSlicePool.Put(childSchema)
 	}()
-	for i, child := range lp.Children() {
-		childSchema[i] = child.Schema()
+	for _, child := range lp.Children() {
+		childSchema = append(childSchema, child.Schema())
 	}
 	lp.BuildKeyInfo(lp.Schema(), childSchema)
 }

--- a/pkg/planner/core/rule/rule_build_key_info.go
+++ b/pkg/planner/core/rule/rule_build_key_info.go
@@ -42,8 +42,9 @@ func (*BuildKeySolver) Optimize(_ context.Context, p base.LogicalPlan, _ *optimi
 }
 
 // **************************** end implementation of LogicalOptRule interface ****************************
-
-var childSchemaSlicePool = zeropool.Pool[[]*expression.Schema]{}
+var childSchemaSlicePool = zeropool.New[[]*expression.Schema](func() []*expression.Schema {
+	return make([]*expression.Schema, 0, 4)
+})
 
 // buildKeyInfo recursively calls base.LogicalPlan's BuildKeyInfo method.
 func buildKeyInfo(lp base.LogicalPlan) {

--- a/pkg/planner/core/rule/rule_build_key_info.go
+++ b/pkg/planner/core/rule/rule_build_key_info.go
@@ -55,10 +55,10 @@ func buildKeyInfo(lp base.LogicalPlan) {
 		buildKeyInfo(child)
 	}
 	childSchema := childSchemaSlicePool.Get().([]*expression.Schema)
-	slices.Grow(childSchema, len(lp.Children()))
+	childSchema = slices.Grow(childSchema, len(lp.Children()))
 	defer func() {
 		childSchema = childSchema[:0]
-		childSchemaSlicePool.Put(childSchema)
+		childSchemaSlicePool.Put(&childSchema)
 	}()
 	for _, child := range lp.Children() {
 		childSchema = append(childSchema, child.Schema())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62526

Problem Summary:

### What changed and how does it work?

1、reuse slices and refrain from allocating the memory frequantly
2、this slices will not use in the logical ops's buildKeyInfo

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
