### PR TITLE
planner: constant propagation can deal with anti semi join

### DIFF
--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -468,7 +468,7 @@ type propSpecialJoinConstSolver struct {
 	innerSchema *Schema
 	// nullSensitive indicates if this outer join is null sensitive, if true, we cannot generate
 	// additional `col is not null` condition from column equal conditions. Specifically, this value
-	// is true for LeftOuterSemiJoin, AntiLeftOuterSemiJoin and anti semi join.
+	// is true for LeftOuterSemiJoin, AntiLeftOuterSemiJoin and AntiSemiJoin.
 	nullSensitive bool
 }
 

--- a/pkg/planner/cascades/old/transformation_rules.go
+++ b/pkg/planner/cascades/old/transformation_rules.go
@@ -901,9 +901,9 @@ func (*pushDownJoin) predicatePushDown(
 		copy(remainCond, predicates)
 		nullSensitive := join.JoinType == logicalop.AntiLeftOuterSemiJoin || join.JoinType == logicalop.LeftOuterSemiJoin
 		if join.JoinType == logicalop.RightOuterJoin {
-			joinConds, remainCond = expression.PropConstOverOuterJoin(join.SCtx().GetExprCtx(), joinConds, remainCond, rightSchema, leftSchema, nullSensitive)
+			joinConds, remainCond = expression.PropConstOverSpecialJoin(join.SCtx().GetExprCtx(), joinConds, remainCond, rightSchema, leftSchema, nullSensitive)
 		} else {
-			joinConds, remainCond = expression.PropConstOverOuterJoin(join.SCtx().GetExprCtx(), joinConds, remainCond, leftSchema, rightSchema, nullSensitive)
+			joinConds, remainCond = expression.PropConstOverSpecialJoin(join.SCtx().GetExprCtx(), joinConds, remainCond, leftSchema, rightSchema, nullSensitive)
 		}
 		eq, left, right, other := join.ExtractOnCondition(joinConds, leftSchema, rightSchema, false, false)
 		join.AppendJoinConds(eq, left, right, other)

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1701,7 +1701,7 @@ func (p *LogicalJoin) outerJoinPropConst(predicates []expression.Expression) []e
 	p.LeftConditions = nil
 	p.RightConditions = nil
 	p.OtherConditions = nil
-	nullSensitive := p.JoinType == AntiLeftOuterSemiJoin || p.JoinType == LeftOuterSemiJoin
+	nullSensitive := p.JoinType == AntiLeftOuterSemiJoin || p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiSemiJoin
 	exprCtx := p.SCtx().GetExprCtx()
 	outerTableSchema := outerTable.Schema()
 	innerTableSchema := innerTable.Schema()

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -289,6 +289,7 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression, opt 
 		leftCond = leftPushCond
 		rightCond = append(p.RightConditions, rightPushCond...)
 		p.RightConditions = nil
+		p.EqualConditions = equalCond
 	}
 	leftCond = expression.RemoveDupExprs(leftCond)
 	rightCond = expression.RemoveDupExprs(rightCond)

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -271,7 +271,7 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression, opt 
 		leftCond = leftPushCond
 		rightCond = rightPushCond
 	case AntiSemiJoin:
-		predicates = utilfuncp.ApplyPredicateSimplification(p.SCtx(), predicates, false)
+		predicates = utilfuncp.ApplyPredicateSimplification(p.SCtx(), predicates, true)
 		predicates = p.outerJoinPropConst(predicates)
 		// Return table dual when filter is constant false or null.
 		dual := Conds2TableDual(p, predicates)
@@ -1684,8 +1684,9 @@ func (p *LogicalJoin) getProj(idx int) *LogicalProjection {
 
 // outerJoinPropConst propagates constant equal and column equal conditions over outer join.
 func (p *LogicalJoin) outerJoinPropConst(predicates []expression.Expression) []expression.Expression {
-	outerTable := p.Children()[0]
-	innerTable := p.Children()[1]
+	children := p.Children()
+	innerTable := children[1]
+	outerTable := children[0]
 	if p.JoinType == RightOuterJoin {
 		innerTable, outerTable = outerTable, innerTable
 	}

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -289,7 +289,6 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression, opt 
 		leftCond = leftPushCond
 		rightCond = append(p.RightConditions, rightPushCond...)
 		p.RightConditions = nil
-		p.EqualConditions = equalCond
 	}
 	leftCond = expression.RemoveDupExprs(leftCond)
 	rightCond = expression.RemoveDupExprs(rightCond)

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -209,6 +209,7 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression, opt 
 	predicates = utilfuncp.ApplyPredicateSimplification(p.SCtx(), predicates, true)
 	var equalCond []*expression.ScalarFunction
 	var leftPushCond, rightPushCond, otherCond, leftCond, rightCond []expression.Expression
+	children := p.Children()
 	switch p.JoinType {
 	case LeftOuterJoin, LeftOuterSemiJoin, AntiLeftOuterSemiJoin:
 		predicates = p.outerJoinPropConst(predicates)
@@ -271,7 +272,38 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression, opt 
 		leftCond = leftPushCond
 		rightCond = rightPushCond
 	case AntiSemiJoin:
-		predicates = utilfuncp.ApplyPredicateSimplification(p.SCtx(), predicates, true)
+		leftSchema := children[0].Schema()
+		tempCond := make([]expression.Expression, 0, len(p.EqualConditions)+len(predicates)+1)
+		canPropagateConstantPredicates := make([]expression.Expression, 0, len(predicates))
+		cannotPropagateConstantPredicates := make([]expression.Expression, 0, len(predicates))
+		for _, predicate := range predicates {
+			// If it is a anti semi join, we need to check the predicate can be propagated to the left child.
+			// If the predicate contains columns from the right child, we cannot propagate it.
+			// reference: https://github.com/pingcap/tidb/issues/62536
+			columns := expression.ExtractColumns(predicate)
+			canPropagateConstant := true
+			for _, column := range columns {
+				if leftSchema.Contains(column) {
+					continue
+				}
+				canPropagateConstant = false
+			}
+			if canPropagateConstant {
+				canPropagateConstantPredicates = append(canPropagateConstantPredicates, predicate)
+			} else {
+				cannotPropagateConstantPredicates = append(cannotPropagateConstantPredicates, predicate)
+			}
+		}
+		if len(canPropagateConstantPredicates) != 0 {
+			tempCond = append(tempCond, canPropagateConstantPredicates...)
+			tempCond = append(tempCond, expression.ScalarFuncs2Exprs(p.EqualConditions)...)
+			tempCond = utilfuncp.ApplyPredicateSimplification(p.SCtx(), tempCond, true)
+		}
+		if len(cannotPropagateConstantPredicates) != 0 {
+			tempCond = append(tempCond, cannotPropagateConstantPredicates...)
+			tempCond = utilfuncp.ApplyPredicateSimplification(p.SCtx(), tempCond, false)
+		}
+		predicates = tempCond
 		// Return table dual when filter is constant false or null.
 		dual := Conds2TableDual(p, predicates)
 		if dual != nil {
@@ -292,7 +324,7 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression, opt 
 	leftCond = expression.RemoveDupExprs(leftCond)
 	rightCond = expression.RemoveDupExprs(rightCond)
 	evalCtx := p.SCtx().GetExprCtx().GetEvalCtx()
-	children := p.Children()
+
 	rightChild := children[1]
 	leftChild := children[0]
 	rightCond = constraint.DeleteTrueExprsBySchema(evalCtx, rightChild.Schema(), rightCond)

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -1420,52 +1420,52 @@ set @@tidb_skip_missing_partition_stats = off;
 set @@tidb_opt_fix_control = "";
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2), set_var(tidb_hash_join_version=legacy) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-HashJoin	2658.67	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
-├─PartitionUnion(Build)	13293.33	root		
-│ ├─TableReader	3323.33	root		data:Projection
-│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+HashJoin	2656.01	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
+├─PartitionUnion(Build)	13280.04	root		
+│ ├─TableReader	3320.01	root		data:Projection
+│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p0	keep order:false, stats:pseudo
-│ ├─TableReader	3323.33	root		data:Projection
-│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ ├─TableReader	3320.01	root		data:Projection
+│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p1	keep order:false, stats:pseudo
-│ ├─TableReader	3323.33	root		data:Projection
-│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ ├─TableReader	3320.01	root		data:Projection
+│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p2	keep order:false, stats:pseudo
-│ └─TableReader	3323.33	root		data:Projection
-│   └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│     └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ └─TableReader	3320.01	root		data:Projection
+│   └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│     └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │       └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p3	keep order:false, stats:pseudo
-└─TableReader(Probe)	3323.33	root		data:Selection
-  └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
+└─TableReader(Probe)	3320.01	root		data:Selection
+  └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1105	disable dynamic pruning due to t2_part has no global stats
 Warning	1815	Optimizer Hint /*+ INL_JOIN(t2_part) */ or /*+ TIDB_INLJ(t2_part) */ is inapplicable
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2), set_var(tidb_hash_join_version=optimized) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-HashJoin	2658.67	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
-├─PartitionUnion(Build)	13293.33	root		
-│ ├─TableReader	3323.33	root		data:Projection
-│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+HashJoin	2656.01	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
+├─PartitionUnion(Build)	13280.04	root		
+│ ├─TableReader	3320.01	root		data:Projection
+│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p0	keep order:false, stats:pseudo
-│ ├─TableReader	3323.33	root		data:Projection
-│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ ├─TableReader	3320.01	root		data:Projection
+│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p1	keep order:false, stats:pseudo
-│ ├─TableReader	3323.33	root		data:Projection
-│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ ├─TableReader	3320.01	root		data:Projection
+│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p2	keep order:false, stats:pseudo
-│ └─TableReader	3323.33	root		data:Projection
-│   └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│     └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+│ └─TableReader	3320.01	root		data:Projection
+│   └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│     └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
 │       └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p3	keep order:false, stats:pseudo
-└─TableReader(Probe)	3323.33	root		data:Selection
-  └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
+└─TableReader(Probe)	3320.01	root		data:Selection
+  └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1105	disable dynamic pruning due to t2_part has no global stats
@@ -1473,26 +1473,28 @@ Warning	1815	Optimizer Hint /*+ INL_JOIN(t2_part) */ or /*+ TIDB_INLJ(t2_part) *
 set @@tidb_opt_fix_control = "44262:ON";
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-IndexJoin	2658.67	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
-├─TableReader(Build)	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
+IndexJoin	2656.01	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
+├─TableReader(Build)	3320.01	root		data:Selection
+│ └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
 │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	4154.17	root	partition:all	
-  ├─IndexRangeScan(Build)	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
-  └─Selection(Probe)	4154.17	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-    └─TableRowIDScan	12500.00	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
+└─IndexLookUp(Probe)	4150.01	root	partition:all	
+  ├─Selection(Build)	12487.50	cop[tikv]		not(isnull(planner__core__casetest__integration.t2_part.a))
+  │ └─IndexRangeScan	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
+  └─Selection(Probe)	4150.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+    └─TableRowIDScan	12487.50	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
 set @@tidb_opt_fix_control = "";
 set @@tidb_skip_missing_partition_stats = on;
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-IndexJoin	2658.67	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
-├─TableReader(Build)	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
+IndexJoin	2656.01	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
+├─TableReader(Build)	3320.01	root		data:Selection
+│ └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
 │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	4154.17	root	partition:all	
-  ├─IndexRangeScan(Build)	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
-  └─Selection(Probe)	4154.17	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-    └─TableRowIDScan	12500.00	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
+└─IndexLookUp(Probe)	4150.01	root	partition:all	
+  ├─Selection(Build)	12487.50	cop[tikv]		not(isnull(planner__core__casetest__integration.t2_part.a))
+  │ └─IndexRangeScan	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
+  └─Selection(Probe)	4150.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+    └─TableRowIDScan	12487.50	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
 set @@tidb_skip_missing_partition_stats = default;
 drop table if exists t;
 create table t(a int(11) not null, b int) partition by range (a) (partition p0 values less than (4), partition p1 values less than(10), partition p2 values less than maxvalue);

--- a/tests/integrationtest/r/planner/core/casetest/integration.result
+++ b/tests/integrationtest/r/planner/core/casetest/integration.result
@@ -1420,52 +1420,52 @@ set @@tidb_skip_missing_partition_stats = off;
 set @@tidb_opt_fix_control = "";
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2), set_var(tidb_hash_join_version=legacy) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-HashJoin	2656.01	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
-├─PartitionUnion(Build)	13280.04	root		
-│ ├─TableReader	3320.01	root		data:Projection
-│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+HashJoin	2658.67	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
+├─PartitionUnion(Build)	13293.33	root		
+│ ├─TableReader	3323.33	root		data:Projection
+│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p0	keep order:false, stats:pseudo
-│ ├─TableReader	3320.01	root		data:Projection
-│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+│ ├─TableReader	3323.33	root		data:Projection
+│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p1	keep order:false, stats:pseudo
-│ ├─TableReader	3320.01	root		data:Projection
-│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+│ ├─TableReader	3323.33	root		data:Projection
+│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p2	keep order:false, stats:pseudo
-│ └─TableReader	3320.01	root		data:Projection
-│   └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│     └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+│ └─TableReader	3323.33	root		data:Projection
+│   └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│     └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │       └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p3	keep order:false, stats:pseudo
-└─TableReader(Probe)	3320.01	root		data:Selection
-  └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
+└─TableReader(Probe)	3323.33	root		data:Selection
+  └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1105	disable dynamic pruning due to t2_part has no global stats
 Warning	1815	Optimizer Hint /*+ INL_JOIN(t2_part) */ or /*+ TIDB_INLJ(t2_part) */ is inapplicable
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2), set_var(tidb_hash_join_version=optimized) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-HashJoin	2656.01	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
-├─PartitionUnion(Build)	13280.04	root		
-│ ├─TableReader	3320.01	root		data:Projection
-│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+HashJoin	2658.67	root		anti semi join, left side:TableReader, equal:[eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)]
+├─PartitionUnion(Build)	13293.33	root		
+│ ├─TableReader	3323.33	root		data:Projection
+│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p0	keep order:false, stats:pseudo
-│ ├─TableReader	3320.01	root		data:Projection
-│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+│ ├─TableReader	3323.33	root		data:Projection
+│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p1	keep order:false, stats:pseudo
-│ ├─TableReader	3320.01	root		data:Projection
-│ │ └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│ │   └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+│ ├─TableReader	3323.33	root		data:Projection
+│ │ └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│ │   └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │ │     └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p2	keep order:false, stats:pseudo
-│ └─TableReader	3320.01	root		data:Projection
-│   └─Projection	3320.01	cop[tikv]		planner__core__casetest__integration.t2_part.a
-│     └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20), not(isnull(planner__core__casetest__integration.t2_part.a))
+│ └─TableReader	3323.33	root		data:Projection
+│   └─Projection	3323.33	cop[tikv]		planner__core__casetest__integration.t2_part.a
+│     └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
 │       └─TableFullScan	10000.00	cop[tikv]	table:t2_part, partition:p3	keep order:false, stats:pseudo
-└─TableReader(Probe)	3320.01	root		data:Selection
-  └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
+└─TableReader(Probe)	3323.33	root		data:Selection
+  └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
     └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1105	disable dynamic pruning due to t2_part has no global stats
@@ -1473,28 +1473,26 @@ Warning	1815	Optimizer Hint /*+ INL_JOIN(t2_part) */ or /*+ TIDB_INLJ(t2_part) *
 set @@tidb_opt_fix_control = "44262:ON";
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-IndexJoin	2656.01	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
-├─TableReader(Build)	3320.01	root		data:Selection
-│ └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
+IndexJoin	2658.67	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
+├─TableReader(Build)	3323.33	root		data:Selection
+│ └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
 │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	4150.01	root	partition:all	
-  ├─Selection(Build)	12487.50	cop[tikv]		not(isnull(planner__core__casetest__integration.t2_part.a))
-  │ └─IndexRangeScan	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
-  └─Selection(Probe)	4150.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-    └─TableRowIDScan	12487.50	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
+└─IndexLookUp(Probe)	4154.17	root	partition:all	
+  ├─IndexRangeScan(Build)	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
+  └─Selection(Probe)	4154.17	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+    └─TableRowIDScan	12500.00	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
 set @@tidb_opt_fix_control = "";
 set @@tidb_skip_missing_partition_stats = on;
 explain format='brief' select /*+ TIDB_INLJ(t2_part@sel_2) */ * from t1 where t1.b<10 and not exists (select 1 from t2_part where t1.a=t2_part.a and t2_part.b<20);
 id	estRows	task	access object	operator info
-IndexJoin	2656.01	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
-├─TableReader(Build)	3320.01	root		data:Selection
-│ └─Selection	3320.01	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10), not(isnull(planner__core__casetest__integration.t1.a))
+IndexJoin	2658.67	root		anti semi join, inner:IndexLookUp, left side:TableReader, outer key:planner__core__casetest__integration.t1.a, inner key:planner__core__casetest__integration.t2_part.a, equal cond:eq(planner__core__casetest__integration.t1.a, planner__core__casetest__integration.t2_part.a)
+├─TableReader(Build)	3323.33	root		data:Selection
+│ └─Selection	3323.33	cop[tikv]		lt(planner__core__casetest__integration.t1.b, 10)
 │   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
-└─IndexLookUp(Probe)	4150.01	root	partition:all	
-  ├─Selection(Build)	12487.50	cop[tikv]		not(isnull(planner__core__casetest__integration.t2_part.a))
-  │ └─IndexRangeScan	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
-  └─Selection(Probe)	4150.01	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
-    └─TableRowIDScan	12487.50	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
+└─IndexLookUp(Probe)	4154.17	root	partition:all	
+  ├─IndexRangeScan(Build)	12500.00	cop[tikv]	table:t2_part, index:a(a)	range: decided by [eq(planner__core__casetest__integration.t2_part.a, planner__core__casetest__integration.t1.a)], keep order:false, stats:pseudo
+  └─Selection(Probe)	4154.17	cop[tikv]		lt(planner__core__casetest__integration.t2_part.b, 20)
+    └─TableRowIDScan	12500.00	cop[tikv]	table:t2_part	keep order:false, stats:pseudo
 set @@tidb_skip_missing_partition_stats = default;
 drop table if exists t;
 create table t(a int(11) not null, b int) partition by range (a) (partition p0 values less than (4), partition p1 values less than(10), partition p2 values less than maxvalue);

--- a/tests/integrationtest/r/planner/core/rule_constant_propagation.result
+++ b/tests/integrationtest/r/planner/core/rule_constant_propagation.result
@@ -227,12 +227,12 @@ INSERT INTO t3 (k, b) VALUES
 (6, 600);
 explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
 id	estRows	task	access object	operator info
-HashJoin_16	8000.00	root		CARTESIAN anti semi join, left side:TableReader_18, left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
-├─TableReader_21(Build)	10.00	root		data:Selection_20
-│ └─Selection_20	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
-│   └─TableFullScan_19	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-└─TableReader_18(Probe)	10000.00	root		data:TableFullScan_17
-  └─TableFullScan_17	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+HashJoin_16	8000.00	root		anti semi join, left side:TableReader_19, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)], left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
+├─TableReader_22(Build)	10.00	root		data:Selection_21
+│ └─Selection_21	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
+│   └─TableFullScan_20	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
+  └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain select * from t2 where exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
 id	estRows	task	access object	operator info
 HashJoin_17	7.99	root		semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
@@ -249,13 +249,13 @@ WHERE t3.k = t2.k AND t3.b = t2.b
 )
 AND t2.k = 1;
 id	estRows	task	access object	operator info
-HashJoin_17	8.00	root		CARTESIAN anti semi join, left side:TableReader_20
-├─TableReader_23(Build)	10.00	root		data:Selection_22
-│ └─Selection_22	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
-│   └─TableFullScan_21	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-└─TableReader_20(Probe)	10.00	root		data:Selection_19
-  └─Selection_19	10.00	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1)
-    └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+HashJoin_17	8.00	root		anti semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
+├─TableReader_24(Build)	10.00	root		data:Selection_23
+│ └─Selection_23	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
+│   └─TableFullScan_22	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_21(Probe)	10.00	root		data:Selection_20
+  └─Selection_20	10.00	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1)
+    └─TableFullScan_19	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 SELECT * FROM t2
 WHERE NOT EXISTS (
 SELECT 1 FROM t3

--- a/tests/integrationtest/r/planner/core/rule_constant_propagation.result
+++ b/tests/integrationtest/r/planner/core/rule_constant_propagation.result
@@ -227,12 +227,21 @@ INSERT INTO t3 (k, b) VALUES
 (6, 600);
 explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
 id	estRows	task	access object	operator info
-HashJoin_16	8000.00	root		anti semi join, left side:TableReader_19, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)], left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
-├─TableReader_22(Build)	10.00	root		data:Selection_21
-│ └─Selection_21	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
-│   └─TableFullScan_20	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-└─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
-  └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+HashJoin_16	8000.00	root		CARTESIAN anti semi join, left side:TableReader_18, left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
+├─TableReader_21(Build)	10.00	root		data:Selection_20
+│ └─Selection_20	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
+│   └─TableFullScan_19	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_18(Probe)	10000.00	root		data:TableFullScan_17
+  └─TableFullScan_17	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+explain select * from t2 where exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
+id	estRows	task	access object	operator info
+HashJoin_17	7.99	root		semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
+├─TableReader_24(Build)	9.99	root		data:Selection_23
+│ └─Selection_23	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
+│   └─TableFullScan_22	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_21(Probe)	9.99	root		data:Selection_20
+  └─Selection_20	9.99	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1), not(isnull(planner__core__rule_constant_propagation.t2.b))
+    └─TableFullScan_19	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 EXPLAIN SELECT * FROM t2
 WHERE NOT EXISTS (
 SELECT 1 FROM t3
@@ -240,12 +249,33 @@ WHERE t3.k = t2.k AND t3.b = t2.b
 )
 AND t2.k = 1;
 id	estRows	task	access object	operator info
-HashJoin_17	8.00	root		anti semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
-├─TableReader_24(Build)	10.00	root		data:Selection_23
-│ └─Selection_23	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
+HashJoin_17	8.00	root		CARTESIAN anti semi join, left side:TableReader_20
+├─TableReader_23(Build)	10.00	root		data:Selection_22
+│ └─Selection_22	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
+│   └─TableFullScan_21	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_20(Probe)	10.00	root		data:Selection_19
+  └─Selection_19	10.00	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1)
+    └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+SELECT * FROM t2
+WHERE NOT EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+k	b
+EXPLAIN SELECT * FROM t2
+WHERE EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+id	estRows	task	access object	operator info
+HashJoin_17	7.99	root		semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
+├─TableReader_24(Build)	9.99	root		data:Selection_23
+│ └─Selection_23	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
 │   └─TableFullScan_22	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-└─TableReader_21(Probe)	10.00	root		data:Selection_20
-  └─Selection_20	10.00	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1)
+└─TableReader_21(Probe)	9.99	root		data:Selection_20
+  └─Selection_20	9.99	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1), not(isnull(planner__core__rule_constant_propagation.t2.b))
     └─TableFullScan_19	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 SELECT * FROM t2
 WHERE NOT EXISTS (
@@ -266,6 +296,13 @@ NULL	400
 5	500
 DELETE FROM t3 WHERE k = 1 AND b = 100;
 SELECT * FROM t2
+WHERE EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+k	b
+SELECT * FROM t2
 WHERE NOT EXISTS (
 SELECT 1 FROM t3
 WHERE t3.k = t2.k AND t3.b = t2.b
@@ -273,6 +310,13 @@ WHERE t3.k = t2.k AND t3.b = t2.b
 AND t2.k = 1;
 k	b
 1	100
+SELECT * FROM t2
+WHERE EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+k	b
 SELECT * FROM t2
 WHERE NOT EXISTS (
 SELECT 1 FROM t3
@@ -284,3 +328,9 @@ k	b
 3	300
 NULL	400
 5	500
+SELECT * FROM t2
+WHERE EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
+);
+k	b

--- a/tests/integrationtest/r/planner/core/rule_constant_propagation.result
+++ b/tests/integrationtest/r/planner/core/rule_constant_propagation.result
@@ -227,9 +227,10 @@ INSERT INTO t3 (k, b) VALUES
 (6, 600);
 explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
 id	estRows	task	access object	operator info
-HashJoin_16	8000.00	root		anti semi join, left side:TableReader_19, equal:[eq(planner__core__rule_constant_propagation.t2.k, planner__core__rule_constant_propagation.t3.k) eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)], left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
-├─TableReader_21(Build)	10000.00	root		data:TableFullScan_20
-│ └─TableFullScan_20	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+HashJoin_16	8000.00	root		anti semi join, left side:TableReader_19, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)], left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
+├─TableReader_22(Build)	9.99	root		data:Selection_21
+│ └─Selection_21	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
+│   └─TableFullScan_20	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
 └─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
   └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 EXPLAIN SELECT * FROM t2
@@ -239,12 +240,12 @@ WHERE t3.k = t2.k AND t3.b = t2.b
 )
 AND t2.k = 1;
 id	estRows	task	access object	operator info
-HashJoin_17	7.99	root		anti semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.k, planner__core__rule_constant_propagation.t3.k) eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
+HashJoin_17	8.00	root		anti semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
 ├─TableReader_24(Build)	9.99	root		data:Selection_23
 │ └─Selection_23	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
 │   └─TableFullScan_22	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
-└─TableReader_21(Probe)	9.99	root		data:Selection_20
-  └─Selection_20	9.99	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1), not(isnull(planner__core__rule_constant_propagation.t2.b))
+└─TableReader_21(Probe)	10.00	root		data:Selection_20
+  └─Selection_20	10.00	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1)
     └─TableFullScan_19	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 SELECT * FROM t2
 WHERE NOT EXISTS (

--- a/tests/integrationtest/r/planner/core/rule_constant_propagation.result
+++ b/tests/integrationtest/r/planner/core/rule_constant_propagation.result
@@ -205,3 +205,81 @@ id	value
 20	400
 30	500
 drop table if exists t1, t2;
+CREATE TABLE t2 (
+k INT,
+b INT
+);
+CREATE TABLE t3 (
+k INT,
+b INT
+);
+INSERT INTO t2 (k, b) VALUES
+(1, 100),
+(2, NULL),
+(3, 300),
+(NULL, 400),
+(5, 500);
+INSERT INTO t3 (k, b) VALUES
+(1, 100),
+(2, NULL),
+(3, 300),
+(NULL, 400),
+(6, 600);
+explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
+id	estRows	task	access object	operator info
+HashJoin_16	8000.00	root		anti semi join, left side:TableReader_19, equal:[eq(planner__core__rule_constant_propagation.t2.k, planner__core__rule_constant_propagation.t3.k) eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)], left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
+├─TableReader_21(Build)	10000.00	root		data:TableFullScan_20
+│ └─TableFullScan_20	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
+  └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+EXPLAIN SELECT * FROM t2
+WHERE NOT EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+id	estRows	task	access object	operator info
+HashJoin_17	7.99	root		anti semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.k, planner__core__rule_constant_propagation.t3.k) eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
+├─TableReader_24(Build)	9.99	root		data:Selection_23
+│ └─Selection_23	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
+│   └─TableFullScan_22	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+└─TableReader_21(Probe)	9.99	root		data:Selection_20
+  └─Selection_20	9.99	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1), not(isnull(planner__core__rule_constant_propagation.t2.b))
+    └─TableFullScan_19	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
+SELECT * FROM t2
+WHERE NOT EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+k	b
+SELECT * FROM t2
+WHERE NOT EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
+);
+k	b
+2	NULL
+3	300
+NULL	400
+5	500
+DELETE FROM t3 WHERE k = 1 AND b = 100;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+k	b
+1	100
+SELECT * FROM t2
+WHERE NOT EXISTS (
+SELECT 1 FROM t3
+WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
+);
+k	b
+1	100
+2	NULL
+3	300
+NULL	400
+5	500

--- a/tests/integrationtest/r/planner/core/rule_constant_propagation.result
+++ b/tests/integrationtest/r/planner/core/rule_constant_propagation.result
@@ -228,8 +228,8 @@ INSERT INTO t3 (k, b) VALUES
 explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
 id	estRows	task	access object	operator info
 HashJoin_16	8000.00	root		anti semi join, left side:TableReader_19, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)], left cond:[eq(planner__core__rule_constant_propagation.t2.k, 1)]
-├─TableReader_22(Build)	9.99	root		data:Selection_21
-│ └─Selection_21	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
+├─TableReader_22(Build)	10.00	root		data:Selection_21
+│ └─Selection_21	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
 │   └─TableFullScan_20	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
 └─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
   └─TableFullScan_18	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
@@ -241,8 +241,8 @@ WHERE t3.k = t2.k AND t3.b = t2.b
 AND t2.k = 1;
 id	estRows	task	access object	operator info
 HashJoin_17	8.00	root		anti semi join, left side:TableReader_21, equal:[eq(planner__core__rule_constant_propagation.t2.b, planner__core__rule_constant_propagation.t3.b)]
-├─TableReader_24(Build)	9.99	root		data:Selection_23
-│ └─Selection_23	9.99	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k), not(isnull(planner__core__rule_constant_propagation.t3.b))
+├─TableReader_24(Build)	10.00	root		data:Selection_23
+│ └─Selection_23	10.00	cop[tikv]		eq(1, planner__core__rule_constant_propagation.t3.k)
 │   └─TableFullScan_22	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
 └─TableReader_21(Probe)	10.00	root		data:Selection_20
   └─Selection_20	10.00	cop[tikv]		eq(planner__core__rule_constant_propagation.t2.k, 1)

--- a/tests/integrationtest/t/planner/core/rule_constant_propagation.test
+++ b/tests/integrationtest/t/planner/core/rule_constant_propagation.test
@@ -52,3 +52,55 @@ update t1 set value = (select count(*) from t2 where t1.id = t2.id) where t1.id 
 select * from t1;
 select * from t2;
 drop table if exists t1, t2;
+
+CREATE TABLE t2 (
+    k INT,
+    b INT
+);
+
+CREATE TABLE t3 (
+    k INT,
+    b INT
+);
+INSERT INTO t2 (k, b) VALUES
+(1, 100),
+(2, NULL),
+(3, 300),
+(NULL, 400),
+(5, 500);
+INSERT INTO t3 (k, b) VALUES
+(1, 100),
+(2, NULL),
+(3, 300),
+(NULL, 400),
+(6, 600);
+explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
+EXPLAIN SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
+);
+DELETE FROM t3 WHERE k = 1 AND b = 100;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
+);

--- a/tests/integrationtest/t/planner/core/rule_constant_propagation.test
+++ b/tests/integrationtest/t/planner/core/rule_constant_propagation.test
@@ -75,8 +75,21 @@ INSERT INTO t3 (k, b) VALUES
 (NULL, 400),
 (6, 600);
 explain select * from t2 where not exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
+explain select * from t2 where exists (select 1 from t3 where t3.k = t2.k and t3.b = t2.b and t2.k = 1);
 EXPLAIN SELECT * FROM t2
 WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+EXPLAIN SELECT * FROM t2
+WHERE EXISTS (
     SELECT 1 FROM t3
     WHERE t3.k = t2.k AND t3.b = t2.b
 )
@@ -94,13 +107,30 @@ WHERE NOT EXISTS (
 );
 DELETE FROM t3 WHERE k = 1 AND b = 100;
 SELECT * FROM t2
-WHERE NOT EXISTS (
+WHERE EXISTS (
     SELECT 1 FROM t3
     WHERE t3.k = t2.k AND t3.b = t2.b
 )
 AND t2.k = 1;
 SELECT * FROM t2
 WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+SELECT * FROM t2
+WHERE EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b
+)
+AND t2.k = 1;
+SELECT * FROM t2
+WHERE NOT EXISTS (
+    SELECT 1 FROM t3
+    WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
+);
+SELECT * FROM t2
+WHERE EXISTS (
     SELECT 1 FROM t3
     WHERE t3.k = t2.k AND t3.b = t2.b AND t2.k = 1
 );


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62536 

close #38662

Problem Summary:

### What changed and how does it work?

In an anti join, if the condition column is in the left schema, then this condition can be subject to constant propagation. PgSQL has this kind of optimization.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
