### PR TITLE
*: replace UpdateServiceGCSafePoint with the new SetGCBarrier API

### DIFF
--- a/br/pkg/restore/log_client/BUILD.bazel
+++ b/br/pkg/restore/log_client/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "@com_github_tikv_client_go_v2//kv",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//http",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//keepalive",

--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -70,6 +70,7 @@ import (
 	"github.com/tikv/client-go/v2/config"
 	kvutil "github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/constants"
 	pdhttp "github.com/tikv/pd/client/http"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -1814,9 +1815,11 @@ func (rc *LogClient) FailpointDoChecksumForLogRestore(
 		log.Info("start to remove gc-safepoint keeper")
 		// close the gc safe point keeper at first
 		gcSafePointKeeperCancel()
-		// set the ttl to 0 to remove the gc-safe-point
+
+		cli := pdClient.GetGCStatesClient(constants.NullKeyspaceID)
 		sp.TTL = 0
-		if err := utils.UpdateServiceSafePoint(ctx, pdClient, sp); err != nil {
+		_, err := cli.DeleteGCBarrier(ctx, sp.ID)
+		if err != nil {
 			log.Warn("failed to update service safe point, backup may fail if gc triggered",
 				zap.Error(err),
 			)

--- a/br/pkg/streamhelper/BUILD.bazel
+++ b/br/pkg/streamhelper/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "@com_github_tikv_client_go_v2//txnkv/rangetask",
         "@com_github_tikv_client_go_v2//txnkv/txnlock",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//opt",
         "@io_etcd_go_etcd_client_v3//:client",
         "@org_golang_google_grpc//:grpc",

--- a/br/pkg/streamhelper/advancer_env.go
+++ b/br/pkg/streamhelper/advancer_env.go
@@ -57,6 +57,9 @@ func (c PDRegionScanner) BlockGCUntil(ctx context.Context, at uint64) (uint64, e
 		return 0, errors.Trace(err)
 	}
 	state, err := cli.GetGCState(ctx)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	return state.TxnSafePoint, nil
 }
 

--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -94,6 +94,7 @@ go_library(
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//http",
         "@com_google_cloud_go_storage//:storage",
         "@io_etcd_go_etcd_client_pkg_v3//transport",

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -41,6 +41,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/tikv/client-go/v2/oracle"
 	kvutil "github.com/tikv/client-go/v2/util"
+	"github.com/tikv/pd/client/constants"
 	"go.uber.org/zap"
 )
 
@@ -519,7 +520,9 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 		gcSafePointKeeperCancel()
 		// set the ttl to 0 to remove the gc-safe-point
 		sp.TTL = 0
-		if err := utils.UpdateServiceSafePoint(ctx, mgr.GetPDClient(), sp); err != nil {
+		cli := mgr.GetPDClient().GetGCStatesClient(constants.NullKeyspaceID)
+		_, err := cli.DeleteGCBarrier(ctx, sp.ID)
+		if err != nil {
 			log.Warn("failed to update service safe point, backup may fail if gc triggered",
 				zap.Error(err),
 			)

--- a/br/pkg/task/operator/BUILD.bazel
+++ b/br/pkg/task/operator/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//opt",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//keepalive",

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -63,6 +63,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/tikv/client-go/v2/tikv"
 	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/constants"
 	"github.com/tikv/pd/client/http"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -1498,7 +1499,9 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		gcSafePointKeeperCancel()
 		// set the ttl to 0 to remove the gc-safe-point
 		sp.TTL = 0
-		if err := utils.UpdateServiceSafePoint(ctx, mgr.GetPDClient(), sp); err != nil {
+		cli := mgr.GetPDClient().GetGCStatesClient(constants.NullKeyspaceID)
+		_, err := cli.DeleteGCBarrier(ctx, sp.ID)
+		if err != nil {
 			log.Warn("failed to update service safe point, backup may fail if gc triggered",
 				zap.Error(err),
 			)

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -117,6 +117,7 @@ go_test(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/brpb",
         "@com_github_pingcap_kvproto//pkg/errorpb",
+        "@com_github_pingcap_log//:log",
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//tikv",
@@ -127,5 +128,6 @@ go_test(
         "@org_uber_go_atomic//:atomic",
         "@org_uber_go_goleak//:goleak",
         "@org_uber_go_multierr//:multierr",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/br/pkg/utils/BUILD.bazel
+++ b/br/pkg/utils/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "@com_github_tikv_client_go_v2//oracle",
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@io_etcd_go_etcd_client_v3//:client",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//backoff",

--- a/br/pkg/utils/safe_point.go
+++ b/br/pkg/utils/safe_point.go
@@ -13,7 +13,6 @@ import (
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
-	"github.com/tikv/pd/client/constants"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/br/pkg/utils/safe_point.go
+++ b/br/pkg/utils/safe_point.go
@@ -13,6 +13,7 @@ import (
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/constants"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/dumpling/export/BUILD.bazel
+++ b/dumpling/export/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "@com_github_soheilhy_cmux//:cmux",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//http",
         "@com_github_tikv_pd_client//pkg/caller",
         "@io_etcd_go_etcd_client_v3//:client",

--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/codec"
 	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/constants"
 	"github.com/tikv/pd/client/pkg/caller"
 	gatomic "go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -1534,7 +1535,8 @@ func updateServiceSafePoint(tctx *tcontext.Context, pdClient pd.Client, ttl int6
 			zap.Uint64("safePoint", snapshotTS),
 			zap.Int64("ttl", ttl))
 		for retryCnt := range 11 {
-			_, err := pdClient.UpdateServiceGCSafePoint(tctx, dumplingServiceSafePointID, ttl, snapshotTS)
+			cli := pdClient.GetGCStatesClient(constants.NullKeyspaceID)
+			_, err := cli.SetGCBarrier(tctx, dumplingServiceSafePointID, snapshotTS, time.Duration(ttl)*time.Second)
 			if err == nil {
 				break
 			}

--- a/lightning/pkg/importer/BUILD.bazel
+++ b/lightning/pkg/importer/BUILD.bazel
@@ -91,6 +91,7 @@ go_library(
         "@com_github_tikv_client_go_v2//config",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//http",
         "@com_github_tikv_pd_client//pkg/caller",
         "@com_github_tikv_pd_client//pkg/retry",

--- a/lightning/pkg/importer/import.go
+++ b/lightning/pkg/importer/import.go
@@ -1221,10 +1221,8 @@ func (rc *Controller) keepPauseGCForDupeRes(ctx context.Context) (<-chan struct{
 				zap.Uint64("minSafePoint", state.TxnSafePoint),
 				zap.Uint64("newMinSafePoint", state.TxnSafePoint+1),
 			)
+			continue
 		}
-
-		pdCli.Close()
-		return nil, errors.Trace(err)
 	}
 	if !paused {
 		pdCli.Close()

--- a/pkg/lightning/backend/local/BUILD.bazel
+++ b/pkg/lightning/backend/local/BUILD.bazel
@@ -95,6 +95,7 @@ go_library(
         "@com_github_tikv_client_go_v2//tikv",
         "@com_github_tikv_client_go_v2//util",
         "@com_github_tikv_pd_client//:client",
+        "@com_github_tikv_pd_client//constants",
         "@com_github_tikv_pd_client//errs",
         "@com_github_tikv_pd_client//http",
         "@com_github_tikv_pd_client//opt",

--- a/pkg/store/gcworker/BUILD.bazel
+++ b/pkg/store/gcworker/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/store/mockstore",
         "//pkg/testkit/testmain",
         "//pkg/testkit/testsetup",
+        "//pkg/util/logutil",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/errorpb",
@@ -83,5 +84,6 @@ go_test(
         "@com_github_tikv_pd_client//clients/gc",
         "@com_github_tikv_pd_client//constants",
         "@org_uber_go_goleak//:goleak",
+        "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/store/mockstore/unistore/tikv/mock_region.go
+++ b/pkg/store/mockstore/unistore/tikv/mock_region.go
@@ -1000,6 +1000,7 @@ func (m *gcStatesManagerSimulator) getGCState(keyspaceID uint32) *gcState {
 	return internalState
 }
 
+// UpdateServiceGCSafePoint is deprecated, used SetGCBarrier instead.
 func (m *gcStatesManagerSimulator) UpdateServiceGCSafePoint(ctx context.Context, serviceID string, ttlSecs int64, safePoint uint64) (uint64, error) {
 	// Compatibility code. See: https://github.com/tikv/pd/blob/b486e2181603e0140be9647f1f05b25f3177634a/pkg/gc/gc_state_manager.go#L705
 	if serviceID == "gc_worker" {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58720

Problem Summary:

### What changed and how does it work?

`UpdateServiceGCSafePoint` is deprecated, we should replace the code with the new `SetGCBarrier` API.

This commit replaces all `UpdateServiceGCSafePoint()` usage in tidb repository (test may still referencing UpdateServiceGCSafePoint but it doesn't matter).

Important note, the keyspace ID is all set to constants.NullKeyspaceID, this is what the old API doing.
I assume br&lightning&dumpling will not work under NEXT_GEN=1


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
  No logic change, the code should work the same way as before.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
