### PR TITLE
[wip]bootstrap: use reserved ID for system schema in nextgen

### DIFF
--- a/pkg/meta/BUILD.bazel
+++ b/pkg/meta/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/meta",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/errno",
         "//pkg/kv",
         "//pkg/meta/metadef",
@@ -41,11 +42,13 @@ go_test(
     ],
     embed = [":meta"],
     flaky = True,
-    shard_count = 18,
+    shard_count = 21,
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/infoschema/context",
         "//pkg/kv",
+        "//pkg/meta/metadef",
         "//pkg/meta/model",
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//pkg/bindinfo",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/ddl/placement",
         "//pkg/ddl/schematracker",
@@ -39,6 +40,7 @@ go_library(
         "//pkg/executor/staticrecordset",
         "//pkg/expression",
         "//pkg/expression/exprctx",
+        "//pkg/expression/exprstatic",
         "//pkg/expression/sessionexpr",
         "//pkg/extension",
         "//pkg/extension/extensionimpl",

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -113,12 +113,12 @@ const (
 		PRIMARY KEY (Host, User),
 		KEY i_user (User));`
 	// CreateGlobalPrivTable is the SQL statement creates Global scope privilege table in system db.
-	CreateGlobalPrivTable = "CREATE TABLE IF NOT EXISTS mysql.global_priv (" +
-		"Host CHAR(255) NOT NULL DEFAULT ''," +
-		"User CHAR(80) NOT NULL DEFAULT ''," +
-		"Priv LONGTEXT NOT NULL DEFAULT ''," +
-		"PRIMARY KEY (Host, User)," +
-		"KEY i_user (User))"
+	CreateGlobalPrivTable = `CREATE TABLE IF NOT EXISTS mysql.global_priv (
+		Host CHAR(255) NOT NULL DEFAULT '',
+		User CHAR(80) NOT NULL DEFAULT '',
+		Priv LONGTEXT NOT NULL DEFAULT '',
+		PRIMARY KEY (Host, User),
+		KEY i_user (User))`
 
 	// For `mysql.db`, `mysql.tables_priv` and `mysql.columns_priv` table, we have a slight different
 	// schema definition with MySQL: columns `DB`/`Table_name`/`Column_name` are defined with case-insensitive

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -49,6 +49,7 @@ import (
 )
 
 func TestMySQLDBTables(t *testing.T) {
+	require.Len(t, tablesInSystemDatabase, 52)
 	testTableBasicInfoSlice(t, tablesInSystemDatabase)
 	reservedIDs := make([]int64, 0, len(ddlTableVersionTables)*2)
 	for _, v := range ddlTableVersionTables {
@@ -269,7 +270,7 @@ func TestDDLTableCreateBackfillTable(t *testing.T) {
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	ver, err := m.CheckDDLTableVersion()
+	ver, err := m.GetDDLTableVersion()
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, ver, meta.BackfillTableVersion)
 
@@ -301,7 +302,7 @@ func TestDDLTableCreateDDLNotifierTable(t *testing.T) {
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	ver, err := m.CheckDDLTableVersion()
+	ver, err := m.GetDDLTableVersion()
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, ver, meta.DDLNotifierTableVersion)
 
@@ -2018,7 +2019,7 @@ func TestWriteDDLTableVersionToMySQLTiDB(t *testing.T) {
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	ddlTableVer, err := m.CheckDDLTableVersion()
+	ddlTableVer, err := m.GetDDLTableVersion()
 	require.NoError(t, err)
 
 	// Verify that 'ddl_table_version' has been set to the correct value
@@ -2041,7 +2042,7 @@ func TestWriteDDLTableVersionToMySQLTiDBWhenUpgradingTo178(t *testing.T) {
 	txn, err := store.Begin()
 	require.NoError(t, err)
 	m := meta.NewMutator(txn)
-	ddlTableVer, err := m.CheckDDLTableVersion()
+	ddlTableVer, err := m.GetDDLTableVersion()
 	require.NoError(t, err)
 
 	// bootstrap as version177

--- a/pkg/session/test/meta/BUILD.bazel
+++ b/pkg/session/test/meta/BUILD.bazel
@@ -8,9 +8,10 @@ go_test(
         "session_test.go",
     ],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/kv",
         "//pkg/meta",

--- a/pkg/session/test/meta/session_test.go
+++ b/pkg/session/test/meta/session_test.go
@@ -88,7 +88,7 @@ func TestInitDDLTables(t *testing.T) {
 			require.True(t, slices.EqualFunc(c.tables, gotTables, func(a, b session.TableBasicInfo) bool {
 				return a.ID == b.ID && a.Name == b.Name
 			}))
-			postVer, err2 := m.CheckDDLTableVersion()
+			postVer, err2 := m.GetDDLTableVersion()
 			require.NoError(t, err2)
 			require.Equal(t, meta.DDLNotifierTableVersion, postVer)
 

--- a/pkg/session/upgrade.go
+++ b/pkg/session/upgrade.go
@@ -1711,7 +1711,7 @@ func writeDDLTableVersion(s sessionapi.Session) {
 	var ddlTableVersion meta.DDLTableVersion
 	err = kv.RunInNewTxn(kv.WithInternalSourceType(context.Background(), kv.InternalTxnBootstrap), s.GetStore(), true, func(_ context.Context, txn kv.Transaction) error {
 		t := meta.NewMutator(txn)
-		ddlTableVersion, err = t.CheckDDLTableVersion()
+		ddlTableVersion, err = t.GetDDLTableVersion()
 		return err
 	})
 	terror.MustNil(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
for nextgen, we initialize system dbs/tables in the same way we init DDL related tables, without going through DDL, so we can use reserved ID to create them.

with reserved ID, we can load related Database or schema without scanning all of them, this also can make cross keyspace loading faster
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
