### PR TITLE
sem: add `tidb_service_scope` to SEM hidden variable list

### DIFF
--- a/pkg/util/sem/sem.go
+++ b/pkg/util/sem/sem.go
@@ -157,6 +157,7 @@ func IsInvisibleSysVar(varNameInLower string) bool {
 		vardef.TiDBRestrictedReadOnly,
 		vardef.TiDBTopSQLMaxTimeSeriesCount,
 		vardef.TiDBTopSQLMaxMetaCount,
+		vardef.TiDBServiceScope,
 		tidbAuditRetractLog:
 		return true
 	}

--- a/pkg/util/sem/sem_test.go
+++ b/pkg/util/sem/sem_test.go
@@ -103,6 +103,6 @@ func TestIsInvisibleSysVar(t *testing.T) {
 	assert.True(IsInvisibleSysVar(vardef.TiDBRowFormatVersion))
 	assert.True(IsInvisibleSysVar(vardef.TiDBRedactLog))
 	assert.True(IsInvisibleSysVar(vardef.TiDBTopSQLMaxTimeSeriesCount))
-	assert.True(IsInvisibleSysVar(vardef.TiDBTopSQLMaxTimeSeriesCount))
+	assert.True(IsInvisibleSysVar(vardef.TiDBServiceScope))
 	assert.True(IsInvisibleSysVar(tidbAuditRetractLog))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62583

Problem Summary:

The variable `tidb_service_scope` is not controlled by SEM.

### What changed and how does it work?

Add `tidb_service_scope` to the list of SEM.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```
mysql> set global tidb_service_scope = 'background';
ERROR 1227 (42000): Access denied; you need (at least one of) the RESTRICTED_VARIABLES_ADMIN privilege(s) for this operation
mysql> select @@tidb_service_scope;
ERROR 1227 (42000): Access denied; you need (at least one of) the RESTRICTED_VARIABLES_ADMIN privilege(s) for this operation
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
