### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/dumpling/export/config.go
+++ b/dumpling/export/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -634,7 +635,7 @@ func ParseTableFilter(tablesList, filters []string) (filter.Filter, error) {
 	}
 
 	// only parse -T when -f is default value. otherwise bail out.
-	if !sameStringArray(filters, []string{"*.*", DefaultTableFilter}) {
+	if !slices.Equal(filters, []string{"*.*", DefaultTableFilter}) {
 		return nil, errors.New("cannot pass --tables-list and --filter together")
 	}
 

--- a/dumpling/export/util.go
+++ b/dumpling/export/util.go
@@ -56,7 +56,6 @@ func checkSameCluster(tctx *tcontext.Context, db *sql.DB, pdAddrs []string) (boo
 	return slices.Equal(tidbDDLIDs, pdDDLIDs), nil
 }
 
-
 func string2Map(a, b []string) map[string]string {
 	a2b := make(map[string]string, len(a))
 	for i, str := range a {

--- a/dumpling/export/util.go
+++ b/dumpling/export/util.go
@@ -53,20 +53,9 @@ func checkSameCluster(tctx *tcontext.Context, db *sql.DB, pdAddrs []string) (boo
 	slices.Sort(tidbDDLIDs)
 	slices.Sort(pdDDLIDs)
 
-	return sameStringArray(tidbDDLIDs, pdDDLIDs), nil
+	return slices.Equal(tidbDDLIDs, pdDDLIDs), nil
 }
 
-func sameStringArray(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
 
 func string2Map(a, b []string) map[string]string {
 	a2b := make(map[string]string, len(a))

--- a/pkg/planner/core/partition_pruning_test.go
+++ b/pkg/planner/core/partition_pruning_test.go
@@ -270,7 +270,6 @@ func TestPartitionRangeForExpr(t *testing.T) {
 	}
 }
 
-
 func TestPartitionRangeOperation(t *testing.T) {
 	testIntersectionRange := []struct {
 		input1 partitionRangeOR

--- a/pkg/store/mockstore/unistore/cophandler/cop_handler_test.go
+++ b/pkg/store/mockstore/unistore/cophandler/cop_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/pingcap/badger"
@@ -166,15 +167,7 @@ func convertToPrefixNext(key []byte) []byte {
 // return whether these two keys are equal.
 func isPrefixNext(key []byte, expected []byte) bool {
 	key = convertToPrefixNext(key)
-	if len(key) != len(expected) {
-		return false
-	}
-	for i := range key {
-		if key[i] != expected[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(key, expected)
 }
 
 // return a dag context according to dagReq and key ranges.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).



Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
