### PR TITLE
planner: Remove InPreparedPlanBuilding member from RangerContext

### DIFF
--- a/pkg/util/ranger/context/context.go
+++ b/pkg/util/ranger/context/context.go
@@ -32,7 +32,6 @@ type RangerContext struct {
 	*contextutil.PlanCacheTracker
 	OptimizerFixControl      map[uint64]string
 	UseCache                 bool
-	InPreparedPlanBuilding   bool
 	RegardNULLAsPoint        bool
 	OptPrefixIndexSingleScan bool
 }

--- a/pkg/util/ranger/context/context_test.go
+++ b/pkg/util/ranger/context/context_test.go
@@ -37,7 +37,6 @@ func TestContextDetach(t *testing.T) {
 		PlanCacheTracker:         &planCacheTracker,
 		OptimizerFixControl:      map[uint64]string{1: "a"},
 		UseCache:                 true,
-		InPreparedPlanBuilding:   true,
 		RegardNULLAsPoint:        true,
 		OptPrefixIndexSingleScan: true,
 	}

--- a/pkg/util/ranger/ranger.go
+++ b/pkg/util/ranger/ranger.go
@@ -163,10 +163,9 @@ func convertPoint(sctx *rangerctx.RangerContext, point *point, newTp *types.Fiel
 	}
 	casted, err := point.value.ConvertTo(sctx.TypeCtx, newTp)
 	if err != nil {
-		if sctx.InPreparedPlanBuilding {
-			// skip plan cache in this case for safety.
-			sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), point.value))
-		}
+		// skip plan cache in this case for safety.
+		sctx.SetSkipPlanCache(fmt.Sprintf("%s when converting %v", err.Error(), point.value))
+
 		//revive:disable:empty-block
 		if newTp.GetType() == mysql.TypeYear && terror.ErrorEqual(err, types.ErrWarnDataOutOfRange) {
 			// see issue #20101: overflow when converting integer to year


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61876

Problem Summary:
The InPreparedPlanBuilding member was removed from StatementContext in a previous patch, so the InPreparedPlanBuilding member in RangerContext will no longer be set correctly.  As a result, the code in ranger.convertPoint will not call SetSkipPlanCache as needed when there is an error, which could result in caching ineligible plans.  Since it is safe to call SetSkipPlanCache even if the code was not reached via the plan cache code, we can fix this by just removing the enclosing if statement.

### What changed and how does it work?
This pull request removes the InPreparedPlanBuilding member from RangerContext, and changes ranger.convertPoint to call sctx.SetSkipPlanCache without checking whether the plan could potentially be cached.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
