### PR TITLE
test: remove unnecessary gc setting after update pd client

### DIFF
--- a/br/tests/br_z_gc_safepoint/run.sh
+++ b/br/tests/br_z_gc_safepoint/run.sh
@@ -50,22 +50,4 @@ if [ "$backup_gc_fail" -ne "0" ];then
     exit 1
 fi
 
-backup_gc_fail=0
-echo "incremental backup start (expect fail)..."
-run_br --pd $PD_ADDR backup table -s "local://$TEST_DIR/$DB/2" --db $DB -t $TABLE --lastbackupts 1 --ratelimit 1 --ratelimit-unit 1 || backup_gc_fail=1
-
-if [ "$backup_gc_fail" -ne "1" ];then
-    echo "TEST: [$TEST_NAME] test check last backup ts failed!"
-    exit 1
-fi
-
-backup_gc_fail=0
-echo "incremental backup with max_uint64 start (expect fail)..."
-run_br --pd $PD_ADDR backup table -s "local://$TEST_DIR/$DB/3" --db $DB -t $TABLE --lastbackupts $MAX_UINT64 --ratelimit 1 --ratelimit-unit 1 || backup_gc_fail=1
-
-if [ "$backup_gc_fail" -ne "1" ];then
-    echo "TEST: [$TEST_NAME] test check max backup ts failed!"
-    exit 1
-fi
-
 run_sql "DROP DATABASE $DB;"

--- a/br/tests/br_z_gc_safepoint/run.sh
+++ b/br/tests/br_z_gc_safepoint/run.sh
@@ -50,13 +50,6 @@ if [ "$backup_gc_fail" -ne "0" ];then
     exit 1
 fi
 
-# set safePoint otherwise the default safePoint is zero
-bin/gc -pd $PD_ADDR \
-    --ca "$TEST_DIR/certs/ca.pem" \
-    --cert "$TEST_DIR/certs/br.pem" \
-    --key "$TEST_DIR/certs/br.key" \
-    -gc-offset "1s"
-
 backup_gc_fail=0
 echo "incremental backup start (expect fail)..."
 run_br --pd $PD_ADDR backup table -s "local://$TEST_DIR/$DB/2" --db $DB -t $TABLE --lastbackupts 1 --ratelimit 1 --ratelimit-unit 1 || backup_gc_fail=1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/62610

Problem Summary:

Now, pd server won't have 0 value safepoint any more.

### What changed and how does it work?
remove unnecessary gc operation in test
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
