### PR TITLE
planner: TTL scan can trigger sync/async load/generateRuntimeFilter

### DIFF
--- a/pkg/planner/core/collect_column_stats_usage.go
+++ b/pkg/planner/core/collect_column_stats_usage.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/util/filter"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/intset"
 )
 
@@ -128,6 +129,7 @@ func (c *columnStatsUsageCollector) updateColMapFromExpressions(col *expression.
 func (c *columnStatsUsageCollector) collectPredicateColumnsForDataSource(askedColGroups [][]*expression.Column, ds *logicalop.DataSource) {
 	// Skip all system tables.
 	if filter.IsSystemSchema(ds.DBName.L) {
+		intest.Assert(!ds.SCtx().GetSessionVars().InRestrictedSQL, "system table should have been skipped in restricted SQL mode")
 		return
 	}
 	// For partition tables, no matter whether it is static or dynamic pruning mode, we use table ID rather than partition ID to

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -481,8 +481,7 @@ func postOptimize(ctx context.Context, sctx base.PlanContext, plan base.Physical
 }
 
 func generateRuntimeFilter(sctx base.PlanContext, plan base.PhysicalPlan) {
-	if !sctx.GetSessionVars().IsRuntimeFilterEnabled() ||
-		(sctx.GetSessionVars().InRestrictedSQL && !sctx.GetSessionVars().InternalSQLScanUserTable) {
+	if !sctx.GetSessionVars().IsRuntimeFilterEnabled() || sctx.GetSessionVars().InRestrictedSQL {
 		return
 	}
 	logutil.BgLogger().Debug("Start runtime filter generator")

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -375,7 +375,8 @@ func adjustOptimizationFlags(flag uint64, logic base.LogicalPlan) uint64 {
 		// When we use the straight Join Order hint, we should disable the join reorder optimization.
 		flag &= ^rule.FlagJoinReOrder
 	}
-	if !logic.SCtx().GetSessionVars().InRestrictedSQL {
+	// InternalSQLUseUserTable is for ttl scan.
+	if !logic.SCtx().GetSessionVars().InRestrictedSQL || logic.SCtx().GetSessionVars().InternalSQLUseUserTable {
 		flag |= rule.FlagCollectPredicateColumnsPoint
 		flag |= rule.FlagSyncWaitStatsLoadPoint
 	}
@@ -480,7 +481,8 @@ func postOptimize(ctx context.Context, sctx base.PlanContext, plan base.Physical
 }
 
 func generateRuntimeFilter(sctx base.PlanContext, plan base.PhysicalPlan) {
-	if !sctx.GetSessionVars().IsRuntimeFilterEnabled() || sctx.GetSessionVars().InRestrictedSQL {
+	if !sctx.GetSessionVars().IsRuntimeFilterEnabled() ||
+		(sctx.GetSessionVars().InRestrictedSQL && !sctx.GetSessionVars().InternalSQLUseUserTable) {
 		return
 	}
 	logutil.BgLogger().Debug("Start runtime filter generator")

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -375,8 +375,8 @@ func adjustOptimizationFlags(flag uint64, logic base.LogicalPlan) uint64 {
 		// When we use the straight Join Order hint, we should disable the join reorder optimization.
 		flag &= ^rule.FlagJoinReOrder
 	}
-	// InternalSQLUseUserTable is for ttl scan.
-	if !logic.SCtx().GetSessionVars().InRestrictedSQL || logic.SCtx().GetSessionVars().InternalSQLUseUserTable {
+	// InternalSQLScanUserTable is for ttl scan.
+	if !logic.SCtx().GetSessionVars().InRestrictedSQL || logic.SCtx().GetSessionVars().InternalSQLScanUserTable {
 		flag |= rule.FlagCollectPredicateColumnsPoint
 		flag |= rule.FlagSyncWaitStatsLoadPoint
 	}
@@ -482,7 +482,7 @@ func postOptimize(ctx context.Context, sctx base.PlanContext, plan base.Physical
 
 func generateRuntimeFilter(sctx base.PlanContext, plan base.PhysicalPlan) {
 	if !sctx.GetSessionVars().IsRuntimeFilterEnabled() ||
-		(sctx.GetSessionVars().InRestrictedSQL && !sctx.GetSessionVars().InternalSQLUseUserTable) {
+		(sctx.GetSessionVars().InRestrictedSQL && !sctx.GetSessionVars().InternalSQLScanUserTable) {
 		return
 	}
 	logutil.BgLogger().Debug("Start runtime filter generator")

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -41,7 +41,7 @@ type CollectPredicateColumnsPoint struct{}
 // Optimize implements LogicalOptRule.<0th> interface.
 func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.LogicalPlan, _ *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
 	planChanged := false
-	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL, "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
+	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL || plan.SCtx().GetSessionVars().InternalSQLUseUserTable, "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait.Load()
 	syncLoadEnabled := syncWait > 0
 	predicateColumns, visitedPhysTblIDs, tid2pids, opNum := CollectColumnStatsUsage(plan)
@@ -224,7 +224,7 @@ type SyncWaitStatsLoadPoint struct{}
 // Optimize implements the base.LogicalOptRule.<0th> interface.
 func (SyncWaitStatsLoadPoint) Optimize(_ context.Context, plan base.LogicalPlan, _ *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
 	planChanged := false
-	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL, "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
+	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL || plan.SCtx().GetSessionVars().InternalSQLUseUserTable, "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
 	if plan.SCtx().GetSessionVars().StmtCtx.IsSyncStatsFailed {
 		return plan, planChanged, nil
 	}

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -41,7 +41,8 @@ type CollectPredicateColumnsPoint struct{}
 // Optimize implements LogicalOptRule.<0th> interface.
 func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.LogicalPlan, _ *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
 	planChanged := false
-	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL || plan.SCtx().GetSessionVars().InternalSQLUseUserTable, "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
+	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL ||
+		(plan.SCtx().GetSessionVars().InternalSQLUseUserTable && plan.SCtx().GetSessionVars().InRestrictedSQL), "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait.Load()
 	syncLoadEnabled := syncWait > 0
 	predicateColumns, visitedPhysTblIDs, tid2pids, opNum := CollectColumnStatsUsage(plan)
@@ -224,7 +225,8 @@ type SyncWaitStatsLoadPoint struct{}
 // Optimize implements the base.LogicalOptRule.<0th> interface.
 func (SyncWaitStatsLoadPoint) Optimize(_ context.Context, plan base.LogicalPlan, _ *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
 	planChanged := false
-	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL || plan.SCtx().GetSessionVars().InternalSQLUseUserTable, "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
+	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL ||
+		(plan.SCtx().GetSessionVars().InRestrictedSQL && plan.SCtx().GetSessionVars().InternalSQLUseUserTable), "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
 	if plan.SCtx().GetSessionVars().StmtCtx.IsSyncStatsFailed {
 		return plan, planChanged, nil
 	}

--- a/pkg/planner/core/rule_collect_plan_stats.go
+++ b/pkg/planner/core/rule_collect_plan_stats.go
@@ -42,7 +42,7 @@ type CollectPredicateColumnsPoint struct{}
 func (c *CollectPredicateColumnsPoint) Optimize(_ context.Context, plan base.LogicalPlan, _ *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
 	planChanged := false
 	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL ||
-		(plan.SCtx().GetSessionVars().InternalSQLUseUserTable && plan.SCtx().GetSessionVars().InRestrictedSQL), "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
+		(plan.SCtx().GetSessionVars().InternalSQLScanUserTable && plan.SCtx().GetSessionVars().InRestrictedSQL), "CollectPredicateColumnsPoint should not be called in restricted SQL mode")
 	syncWait := plan.SCtx().GetSessionVars().StatsLoadSyncWait.Load()
 	syncLoadEnabled := syncWait > 0
 	predicateColumns, visitedPhysTblIDs, tid2pids, opNum := CollectColumnStatsUsage(plan)
@@ -226,7 +226,7 @@ type SyncWaitStatsLoadPoint struct{}
 func (SyncWaitStatsLoadPoint) Optimize(_ context.Context, plan base.LogicalPlan, _ *optimizetrace.LogicalOptimizeOp) (base.LogicalPlan, bool, error) {
 	planChanged := false
 	intest.Assert(!plan.SCtx().GetSessionVars().InRestrictedSQL ||
-		(plan.SCtx().GetSessionVars().InRestrictedSQL && plan.SCtx().GetSessionVars().InternalSQLUseUserTable), "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
+		(plan.SCtx().GetSessionVars().InRestrictedSQL && plan.SCtx().GetSessionVars().InternalSQLScanUserTable), "SyncWaitStatsLoadPoint should not be called in restricted SQL mode")
 	if plan.SCtx().GetSessionVars().StmtCtx.IsSyncStatsFailed {
 		return plan, planChanged, nil
 	}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1734,7 +1734,7 @@ type SessionVars struct {
 	BulkDMLEnabled bool
 
 	// InternalSQLUseUserTable indicates whether to use user table for internal SQL. it will be used by TTL scan
-	InternalSQLUseUserTable bool
+	InternalSQLScanUserTable bool
 }
 
 // ResetRelevantOptVarsAndFixes resets the relevant optimizer variables and fixes.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1732,6 +1732,9 @@ type SessionVars struct {
 
 	// BulkDMLEnabled indicates whether to enable bulk DML in pipelined mode.
 	BulkDMLEnabled bool
+
+	// InternalSQLUseUserTable indicates whether to use user table for internal SQL. it will be used by TTL scan
+	InternalSQLUseUserTable bool
 }
 
 // ResetRelevantOptVarsAndFixes resets the relevant optimizer variables and fixes.

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1733,7 +1733,7 @@ type SessionVars struct {
 	// BulkDMLEnabled indicates whether to enable bulk DML in pipelined mode.
 	BulkDMLEnabled bool
 
-	// InternalSQLUseUserTable indicates whether to use user table for internal SQL. it will be used by TTL scan
+	// InternalSQLScanUserTable indicates whether to use user table for internal SQL. it will be used by TTL scan
 	InternalSQLScanUserTable bool
 }
 

--- a/pkg/ttl/ttlworker/session.go
+++ b/pkg/ttl/ttlworker/session.go
@@ -205,8 +205,9 @@ func newTableSession(se session.Session, tbl *cache.PhysicalTable, expire time.T
 func NewScanSession(se session.Session, tbl *cache.PhysicalTable, expire time.Time) (*ttlTableSession, func() error, error) {
 	origConcurrency := se.GetSessionVars().DistSQLScanConcurrency()
 	origPaging := se.GetSessionVars().EnablePaging
-
+	se.GetSessionVars().InternalSQLUseUserTable = true
 	restore := func() error {
+		se.GetSessionVars().InternalSQLUseUserTable = false
 		_, err := se.ExecuteSQL(context.Background(), "set @@tidb_distsql_scan_concurrency=%?", origConcurrency)
 		terror.Log(err)
 		if err != nil {

--- a/pkg/ttl/ttlworker/session.go
+++ b/pkg/ttl/ttlworker/session.go
@@ -205,9 +205,9 @@ func newTableSession(se session.Session, tbl *cache.PhysicalTable, expire time.T
 func NewScanSession(se session.Session, tbl *cache.PhysicalTable, expire time.Time) (*ttlTableSession, func() error, error) {
 	origConcurrency := se.GetSessionVars().DistSQLScanConcurrency()
 	origPaging := se.GetSessionVars().EnablePaging
-	se.GetSessionVars().InternalSQLUseUserTable = true
+	se.GetSessionVars().InternalSQLScanUserTable = true
 	restore := func() error {
-		se.GetSessionVars().InternalSQLUseUserTable = false
+		se.GetSessionVars().InternalSQLScanUserTable = false
 		_, err := se.ExecuteSQL(context.Background(), "set @@tidb_distsql_scan_concurrency=%?", origConcurrency)
 		terror.Log(err)
 		if err != nil {

--- a/pkg/ttl/ttlworker/session_integration_test.go
+++ b/pkg/ttl/ttlworker/session_integration_test.go
@@ -391,6 +391,7 @@ func TestNewScanSession(t *testing.T) {
 					// NewScanSession should override @@dist_sql_scan_concurrency and @@tidb_enable_paging
 					require.Equal(t, 1, se.GetSessionVars().DistSQLScanConcurrency())
 					require.False(t, se.GetSessionVars().EnablePaging)
+					require.True(t, se.GetSessionVars().InternalSQLUseUserTable)
 					// restore should restore the session variables
 					restore()
 				} else {
@@ -402,6 +403,7 @@ func TestNewScanSession(t *testing.T) {
 				// Not matter returns an error or not, the session should be closed
 				require.Equal(t, 123, se.GetSessionVars().DistSQLScanConcurrency())
 				require.True(t, se.GetSessionVars().EnablePaging)
+				require.False(t, se.GetSessionVars().InternalSQLUseUserTable)
 				return nil
 			}))
 			require.True(t, called)

--- a/pkg/ttl/ttlworker/session_integration_test.go
+++ b/pkg/ttl/ttlworker/session_integration_test.go
@@ -391,7 +391,7 @@ func TestNewScanSession(t *testing.T) {
 					// NewScanSession should override @@dist_sql_scan_concurrency and @@tidb_enable_paging
 					require.Equal(t, 1, se.GetSessionVars().DistSQLScanConcurrency())
 					require.False(t, se.GetSessionVars().EnablePaging)
-					require.True(t, se.GetSessionVars().InternalSQLUseUserTable)
+					require.True(t, se.GetSessionVars().InternalSQLScanUserTable)
 					// restore should restore the session variables
 					restore()
 				} else {
@@ -403,7 +403,7 @@ func TestNewScanSession(t *testing.T) {
 				// Not matter returns an error or not, the session should be closed
 				require.Equal(t, 123, se.GetSessionVars().DistSQLScanConcurrency())
 				require.True(t, se.GetSessionVars().EnablePaging)
-				require.False(t, se.GetSessionVars().InternalSQLUseUserTable)
+				require.False(t, se.GetSessionVars().InternalSQLScanUserTable)
 				return nil
 			}))
 			require.True(t, called)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #61822

Problem Summary:

### What changed and how does it work?

The TTL scan is different from our other internal SQL, as it reads user tables. So, our previous approach of determining whether to perform sync load based on whether it is internal SQL has issues.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
