### PR TITLE
br/stream_helper: make dial timeout shorter

### DIFF
--- a/br/pkg/utils/store_manager.go
+++ b/br/pkg/utils/store_manager.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	dialTimeout     = 30 * time.Second
-	resetRetryTimes = 3
+	defaultDialTimeout = 30 * time.Second
+	resetRetryTimes    = 3
 )
 
 // Pool is a lazy pool of gRPC channels.
@@ -95,6 +95,8 @@ type StoreManager struct {
 	}
 	keepalive keepalive.ClientParameters
 	tlsConf   *tls.Config
+
+	DialTimeout time.Duration
 }
 
 func (mgr *StoreManager) GetKeepalive() keepalive.ClientParameters {
@@ -112,6 +114,13 @@ func NewStoreManager(pdCli pd.Client, kl keepalive.ClientParameters, tlsConf *tl
 		keepalive: kl,
 		tlsConf:   tlsConf,
 	}
+}
+
+func (mgr *StoreManager) getDialTimeout() time.Duration {
+	if mgr.DialTimeout > 0 {
+		return mgr.DialTimeout
+	}
+	return defaultDialTimeout
 }
 
 func (mgr *StoreManager) PDClient() pd.Client {
@@ -141,7 +150,7 @@ func (mgr *StoreManager) getGrpcConnLocked(ctx context.Context, storeID uint64) 
 	if mgr.tlsConf != nil {
 		opt = grpc.WithTransportCredentials(credentials.NewTLS(mgr.tlsConf))
 	}
-	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	ctx, cancel := context.WithTimeout(ctx, mgr.getDialTimeout())
 	bfConf := backoff.DefaultConfig
 	bfConf.MaxDelay = time.Second * 3
 	addr := store.GetPeerAddress()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number:  ref #62620

ref https://github.com/tikv/tikv/issues/18734

Problem Summary:
When establishing the connection to TiKV to subscribe flush events, in k8s context, dialing a disconnected store may be stuck, then the whole tick timed out, nothing in `optionalTick` can be finished then.

### What changed and how does it work?
This PR reduced the dial timeout from 30s to 8s. Which is somehow acceptable because `optionalTick` has a timeout of about `12s`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
