### PR TITLE
filter: no need to always convert dbname to lowercase in IsSystemSchema

### DIFF
--- a/pkg/planner/core/plan_cacheable_checker.go
+++ b/pkg/planner/core/plan_cacheable_checker.go
@@ -495,7 +495,7 @@ func (checker *nonPreparedPlanCacheableChecker) Enter(in ast.Node) (out ast.Node
 		}
 		return in, !checker.cacheable
 	case *ast.TableName:
-		if filter.IsSystemSchema(node.Schema.O) {
+		if filter.IsSystemSchema(node.Schema.L) {
 			checker.cacheable = false
 			checker.reason = "access tables in system schema"
 			return in, !checker.cacheable

--- a/pkg/util/filter/BUILD.bazel
+++ b/pkg/util/filter/BUILD.bazel
@@ -26,5 +26,8 @@ go_test(
     ],
     embed = [":filter"],
     flaky = True,
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//pkg/parser/ast",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/util/filter/BUILD.bazel
+++ b/pkg/util/filter/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/meta/metadef",
+        "//pkg/util/intest",
         "//pkg/util/table-filter",
         "//pkg/util/table-rule-selector",
         "@com_github_pingcap_errors//:errors",

--- a/pkg/util/filter/schema.go
+++ b/pkg/util/filter/schema.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb/pkg/meta/metadef"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 var (
@@ -30,7 +31,9 @@ var (
 // IsSystemSchema checks whether schema is system schema or not.
 // case insensitive
 func IsSystemSchema(schema string) bool {
-	schema = strings.ToLower(schema)
+	intest.AssertFunc(func() bool {
+		return schema == strings.ToLower(schema)
+	})
 	return schema == DMHeartbeatSchema || schema == InspectionSchemaName ||
 		metadef.IsMemOrSysDB(schema)
 }

--- a/pkg/util/filter/schema_test.go
+++ b/pkg/util/filter/schema_test.go
@@ -17,6 +17,7 @@ package filter
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,7 @@ func TestIsSystemSchema(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		require.Equalf(t, tt.expected, IsSystemSchema(tt.name), "schema name = %s", tt.name)
+		name := ast.NewCIStr(tt.name)
+		require.Equalf(t, tt.expected, IsSystemSchema(name.L), "schema name = %s", tt.name)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62658

Problem Summary:

### What changed and how does it work?

no need to always convert dbname to lowercase in IsSystemSchema. Each input is lowercase

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
