### PR TITLE
planner: handle histogram last bucket end value underrepresented

### DIFF
--- a/pkg/planner/cardinality/BUILD.bazel
+++ b/pkg/planner/cardinality/BUILD.bazel
@@ -60,7 +60,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":cardinality"],
     flaky = True,
-    shard_count = 35,
+    shard_count = 36,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/cardinality/row_count_column.go
+++ b/pkg/planner/cardinality/row_count_column.go
@@ -168,7 +168,14 @@ func equalRowCountOnColumn(sctx planctx.PlanContext, c *statistics.Column, val t
 	// 2. try to find this value in bucket.Repeat(the last value in every bucket)
 	histCnt, matched := c.Histogram.EqualRowCount(sctx, val, true)
 	if matched {
-		return histCnt, nil
+		// Check if this last bucket end value should fall through to uniform distribution
+		if IsLastBucketEndValueUnderrepresented(&c.Histogram, val, histCnt, realtimeRowCount, modifyCount, sctx) {
+			matched = false
+		}
+
+		if matched {
+			return histCnt, nil
+		}
 	}
 	// 3. use uniform distribution assumption for the rest (even when this value is not covered by the range of stats)
 	// branch1: histDNV <= 0 means that all NDV's are in TopN, and no histograms.

--- a/pkg/planner/cardinality/row_count_column.go
+++ b/pkg/planner/cardinality/row_count_column.go
@@ -167,9 +167,11 @@ func equalRowCountOnColumn(sctx planctx.PlanContext, c *statistics.Column, val t
 	}
 	// 2. try to find this value in bucket.Repeat(the last value in every bucket)
 	histCnt, matched := c.Histogram.EqualRowCount(sctx, val, true)
+	// Calculate histNDV here as it's needed for both the underrepresented check and later calculations
+	histNDV := float64(c.Histogram.NDV - int64(c.TopN.Num()))
 	// also check if this last bucket end value is underrepresented
-	if matched && !IsLastBucketEndValueUnderrepresented(
-		&c.Histogram, val, histCnt, realtimeRowCount, modifyCount, sctx) {
+	if matched && !IsLastBucketEndValueUnderrepresented(sctx,
+		&c.Histogram, val, histCnt, histNDV, realtimeRowCount, modifyCount) {
 		return histCnt, nil
 	}
 	// 3. use uniform distribution assumption for the rest (even when this value is not covered by the range of stats)
@@ -177,7 +179,6 @@ func equalRowCountOnColumn(sctx planctx.PlanContext, c *statistics.Column, val t
 	// branch2: histDNA > 0 basically means while there is still a case, c.Histogram.NDV >
 	// c.TopN.Num() a little bit, but the histogram is still empty. In this case, we should use the branch1 and for the diff
 	// in NDV, it's mainly comes from the NDV is conducted and calculated ahead of sampling.
-	histNDV := float64(c.Histogram.NDV - int64(c.TopN.Num()))
 	if histNDV <= 0 || (c.IsFullLoad() && c.Histogram.NotNullCount() == 0) {
 		// branch 1: all NDV's are in TopN, and no histograms
 		// If histNDV is zero - we have all NDV's in TopN - and no histograms. This function uses

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -421,15 +421,10 @@ func equalRowCountOnIndex(sctx planctx.PlanContext, idx *statistics.Index, b []b
 	}
 	// 2. try to find this value in bucket.Repeat(the last value in every bucket)
 	histCnt, matched := idx.Histogram.EqualRowCount(sctx, val, true)
-	if matched {
-		// Check if this last bucket end value should fall through to uniform distribution
-		if IsLastBucketEndValueUnderrepresented(&idx.Histogram, val, histCnt, realtimeRowCount, modifyCount, sctx) {
-			matched = false
-		}
-
-		if matched {
-			return histCnt
-		}
+	// also check if this last bucket end value is underrepresented
+	if matched && !IsLastBucketEndValueUnderrepresented(
+		&idx.Histogram, val, histCnt, realtimeRowCount, modifyCount, sctx) {
+		return histCnt
 	}
 	// 3. use uniform distribution assumption for the rest (even when this value is not covered by the range of stats)
 	histNDV := float64(idx.Histogram.NDV - int64(idx.TopN.Num()))

--- a/pkg/planner/cardinality/row_count_index.go
+++ b/pkg/planner/cardinality/row_count_index.go
@@ -421,13 +421,14 @@ func equalRowCountOnIndex(sctx planctx.PlanContext, idx *statistics.Index, b []b
 	}
 	// 2. try to find this value in bucket.Repeat(the last value in every bucket)
 	histCnt, matched := idx.Histogram.EqualRowCount(sctx, val, true)
+	// Calculate histNDV here as it's needed for both the underrepresented check and later calculations
+	histNDV := float64(idx.Histogram.NDV - int64(idx.TopN.Num()))
 	// also check if this last bucket end value is underrepresented
-	if matched && !IsLastBucketEndValueUnderrepresented(
-		&idx.Histogram, val, histCnt, realtimeRowCount, modifyCount, sctx) {
+	if matched && !IsLastBucketEndValueUnderrepresented(sctx,
+		&idx.Histogram, val, histCnt, histNDV, realtimeRowCount, modifyCount) {
 		return histCnt
 	}
 	// 3. use uniform distribution assumption for the rest (even when this value is not covered by the range of stats)
-	histNDV := float64(idx.Histogram.NDV - int64(idx.TopN.Num()))
 	// branch1: histDNV <= 0 means that all NDV's are in TopN, and no histograms.
 	// branch2: histDNA > 0 basically means while there is still a case, c.Histogram.NDV >
 	// c.TopN.Num() a little bit, but the histogram is still empty. In this case, we should use the branch1 and for the diff

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -592,47 +592,33 @@ func compareType(l, r int) int {
 
 const unknownColumnID = math.MinInt64
 
-// StaleLastBucketThreshold is the threshold for detecting stale last bucket estimates.
+// staleLastBucketThreshold is the threshold for detecting stale last bucket estimates.
 // If the last bucket's count is less than 30% of the average bucket count, we consider
 // it potentially stale.
-const StaleLastBucketThreshold = 0.3
+const staleLastBucketThreshold = 0.3
 
-// bucketAwareRowAddedThreshold is the minimum ratio of newly added rows relative to
-// the average bucket size required to trigger the stale bucket heuristic.
-// If new rows >= (avgBucketSize * threshold), we consider applying the heuristic.
-const bucketAwareRowAddedThreshold = 0.5
-
-// MinRowCountForStaleHeuristic is the minimum original row count required to apply
-// the stale bucket heuristic. This prevents the heuristic from triggering on very
-// small tables where a few new rows would create misleadingly high growth ratios.
-const MinRowCountForStaleHeuristic = 100
+// valueAwareRowAddedThreshold is the minimum ratio of newly added rows relative to
+// the average value count required to trigger the stale bucket heuristic.
+// If new rows >= (avgValueCount * threshold), we consider applying the heuristic.
+const valueAwareRowAddedThreshold = 0.5
 
 // IsLastBucketEndValueUnderrepresented detects when the last value (upper bound) of the last bucket
 // has a suspiciously low count that may be stale due to concentrated writes after ANALYZE.
-func IsLastBucketEndValueUnderrepresented(hg *statistics.Histogram, val types.Datum,
-	histCnt float64, realtimeRowCount, modifyCount int64, sctx planctx.PlanContext) bool {
-	if modifyCount <= 0 || len(hg.Buckets) == 0 {
+func IsLastBucketEndValueUnderrepresented(sctx planctx.PlanContext, hg *statistics.Histogram, val types.Datum,
+	histCnt float64, histNDV float64, realtimeRowCount, modifyCount int64) bool {
+	if modifyCount <= 0 || len(hg.Buckets) == 0 || histNDV <= 0 {
 		return false
 	}
 
-	originalNonNullCount := hg.NotNullCount()
+	// This represents data changes since ANALYZE - we use absolute difference as a proxy for
+	// activity level since we cannot distinguish between inserts, deletes, and updates
+	newRowsAdded := hg.AbsRowCountDifference(realtimeRowCount)
 
-	// Only apply heuristic to tables with sufficient size to avoid false positives
-	// on very small tables where a few new rows create misleadingly high growth ratios
-	if originalNonNullCount < MinRowCountForStaleHeuristic {
-		return false
-	}
+	// Calculate average count per distinct value
+	avgValueCount := hg.NotNullCount() / histNDV
 
-	// This represents new rows added since ANALYZE
-	newRowsAdded := realtimeRowCount - int64(hg.TotalRowCount())
-	if newRowsAdded <= 0 {
-		return false
-	}
-
-	// Only apply heuristic when new rows are significant relative to average bucket size
-	// Use non-null count for bucket size since buckets contain non-null distributions
-	avgBucketSize := originalNonNullCount / float64(len(hg.Buckets))
-	if float64(newRowsAdded) < avgBucketSize*bucketAwareRowAddedThreshold {
+	// Only apply heuristic when new rows are significant relative to average value count
+	if newRowsAdded < avgValueCount*valueAwareRowAddedThreshold {
 		return false
 	}
 
@@ -645,8 +631,8 @@ func IsLastBucketEndValueUnderrepresented(hg *statistics.Histogram, val types.Da
 		return false
 	}
 
-	// If count is much less than average, it's likely underrepresented
-	return histCnt < avgBucketSize*StaleLastBucketThreshold
+	// If count is much less than average value count, it's likely underrepresented
+	return histCnt < avgValueCount*staleLastBucketThreshold
 }
 
 // getConstantColumnID receives two expressions and if one of them is column and another is constant, it returns the

--- a/pkg/planner/cardinality/selectivity.go
+++ b/pkg/planner/cardinality/selectivity.go
@@ -645,12 +645,8 @@ func IsLastBucketEndValueUnderrepresented(hg *statistics.Histogram, val types.Da
 		return false
 	}
 
-	// Check if the count is suspiciously low compared to other buckets
-	// Use same non-null count basis as bucket size calculation for consistency
-	avgBucketCount := originalNonNullCount / float64(len(hg.Buckets))
-
 	// If count is much less than average, it's likely underrepresented
-	return histCnt < avgBucketCount*StaleLastBucketThreshold
+	return histCnt < avgBucketSize*StaleLastBucketThreshold
 }
 
 // getConstantColumnID receives two expressions and if one of them is column and another is constant, it returns the

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1756,8 +1756,8 @@ func TestLastBucketEndValueHeuristic(t *testing.T) {
 	// Should be much higher due to heuristic
 	require.InDelta(t, 100.09, enhancedCount, 0.1, "Enhanced count should be approximately 100.09")
 
-	// Verify other values don't trigger heuristic
-	otherCount, err := cardinality.GetColumnRowCount(sctx.GetPlanCtx(), col, getRange(1, 1), statsTbl.RealtimeCount, statsTbl.ModifyCount, false)
+	// Verify other end values don't trigger heuristic
+	otherCount, err := cardinality.GetColumnRowCount(sctx.GetPlanCtx(), col, getRange(3, 3), statsTbl.RealtimeCount, statsTbl.ModifyCount, false)
 	require.NoError(t, err)
 	require.InDelta(t, 109.99, otherCount, 0.1, "Other value count should be approximately 109.99")
 
@@ -1768,7 +1768,7 @@ func TestLastBucketEndValueHeuristic(t *testing.T) {
 		require.NoError(t, err)
 		require.InDelta(t, 100.09, idxEnhancedCount, 0.1, "Index enhanced count should be approximately 100.09")
 
-		idxOtherCount, _, err := cardinality.GetRowCountByIndexRanges(sctx.GetPlanCtx(), &statsTbl.HistColl, table.Meta().Indices[0].ID, getRange(1, 1))
+		idxOtherCount, _, err := cardinality.GetRowCountByIndexRanges(sctx.GetPlanCtx(), &statsTbl.HistColl, table.Meta().Indices[0].ID, getRange(3, 3))
 		require.NoError(t, err)
 		require.InDelta(t, 109.99, idxOtherCount, 0.1, "Index other count should be approximately 109.99")
 	}

--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -1705,7 +1705,7 @@ func TestLastBucketEndValueHeuristic(t *testing.T) {
 	require.NoError(t, h.DumpStatsDeltaToKV(true))
 	require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
 
-	testKit.MustExec("analyze table t with 0 topn")
+	testKit.MustExec("analyze table t with 5 buckets, 0 topn")
 
 	table, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
 	require.NoError(t, err)

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -610,6 +610,12 @@ func (hg *Histogram) TotalRowCount() float64 {
 	return hg.NotNullCount() + float64(hg.NullCount)
 }
 
+// AbsRowCountDifference returns the absolute difference between the realtime row count
+// and the histogram's total row count, representing data changes since the last ANALYZE.
+func (hg *Histogram) AbsRowCountDifference(realtimeRowCount int64) float64 {
+	return math.Abs(float64(realtimeRowCount) - hg.TotalRowCount())
+}
+
 // NotNullCount indicates the count of non-null values in column histogram and single-column index histogram,
 // for multi-column index histogram, since we cannot define null for the row, we treat all rows as non-null, that means,
 // notNullCount would return same value as TotalRowCount for multi-column index histograms.
@@ -1094,7 +1100,7 @@ func (hg *Histogram) OutOfRangeRowCount(
 	// Use absolute value to account for the case where rows may have been added on one side,
 	// but deleted from the other, resulting in qualifying out of range rows even though
 	// realtimeRowCount is less than histogram count
-	addedRows := math.Abs(float64(realtimeRowCount) - hg.TotalRowCount())
+	addedRows := hg.AbsRowCountDifference(realtimeRowCount)
 	totalPercent := min(leftPercent*0.5+rightPercent*0.5, 1.0)
 	// Assume on average, half of newly added rows are within the histogram range, and the other
 	// half are distributed out of range according to the diagram in the function description.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62665

Problem Summary:

Like what the linked issue describes, the end value in the last histogram bucket could be underrepresented due to stale stats. This PR tries to detect such case precisely by looking at two conditions:
1.  The value should be in last histogram bucket and it should be the upper bound
2. The last bucket end count is much less than the average count of other NDV, indicating this might be a tail write traffic

After detecting the underrepresented value, instead of passing it back using stale stats from histogram, we reuse the current logic of handling other value by taking the average histogram value count.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
better handle histogram last bucket end value underrepresented issue, tail writes on equal predicate on the latest value  should have better performance even with stale stats 
```
