### PR TITLE
*: fix `TestConfig`,`TestResourceGroupTagEncoding` UT for nextgen

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/config/kerneltype",
         "//pkg/parser/terror",
+        "//pkg/util/intest",
         "//pkg/util/logutil",
         "//pkg/util/naming",
         "//pkg/util/tikvutil",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ import (
 	zaplog "github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/naming"
 	"github.com/pingcap/tidb/pkg/util/tikvutil"
@@ -1494,6 +1495,14 @@ func init() {
 
 func initByLDFlags(edition, checkBeforeDropLDFlag string) {
 	conf := defaultConf
+	if intest.InTest && kerneltype.IsNextGen() {
+		// In test mode, without reading a config file, we still assume the `GetGlobalConfig()` returns
+		// a valid config file. However, the "valid" nextgen config file should always have a keyspace name.
+		// So we set the keyspace name to "SYSTEM" here for test.
+		//
+		// Didn't use `keyspace.SYSTEM` to avoid cyclic dependency.
+		conf.KeyspaceName = "SYSTEM"
+	}
 	StoreGlobalConfig(&conf)
 	if checkBeforeDropLDFlag == "1" {
 		CheckTableBeforeDrop = true

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -18,6 +18,9 @@ path = "/tmp/tidb"
 # The socket file to use for connection.
 socket = "/tmp/tidb-{Port}.sock"
 
+# The Keyspace Name of the tidb
+keyspace-name = "SYSTEM"
+
 # Schema lease duration, very dangerous to change only if you know what you do.
 lease = "45s"
 

--- a/pkg/config/config.toml.nextgen.example
+++ b/pkg/config/config.toml.nextgen.example
@@ -1,0 +1,477 @@
+# TiDB Configuration.
+
+# TiDB server host.
+host = "0.0.0.0"
+
+# tidb server advertise IP.
+advertise-address = ""
+
+# TiDB server port.
+port = 4000
+
+# Registered store name, [tikv, mocktikv, unistore]
+store = "unistore"
+
+# TiDB storage path.
+path = "/tmp/tidb"
+
+# The socket file to use for connection.
+socket = "/tmp/tidb-{Port}.sock"
+
+# Schema lease duration, very dangerous to change only if you know what you do.
+lease = "45s"
+
+# When create table, split a separated region for it. It is recommended to
+# turn off this option if there will be a large number of tables created.
+split-table = true
+
+# The limit of concurrent executed sessions.
+token-limit = 1000
+
+# The temporary directory to store the intermediate compute results.
+temp-dir = "/tmp/tidb"
+
+# Specifies the temporary storage path for some operators when a single SQL statement exceeds the memory quota specified by the memory quota.
+# It defaults to a generated directory in `<TMPDIR>/<os/user.Current().Uid>_tidb/` if it is unset.
+# It only takes effect when `tidb_enable_tmp_storage_on_oom` is `true`.
+# tmp-storage-path = "/tmp/<os/user.Current().Uid>_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage"
+
+# Specifies the maximum use of temporary storage (bytes) for all active queries when `tidb_enable_tmp_storage_on_oom` is enabled.
+# If the `tmp-storage-quota` exceeds the capacity of the temporary storage directory, tidb-server would return an error and exit.
+# The default value of tmp-storage-quota is under 0 which means tidb-server wouldn't check the capacity.
+tmp-storage-quota = -1
+
+# Make "kill query" behavior compatible with MySQL. It's not recommend to
+# turn on this option when TiDB server is behind a proxy.
+compatible-kill-query = false
+
+# Make SIGTERM wait N seconds before starting the shutdown procedure. This is designed for when TiDB is behind a proxy/load balancer.
+# The health check will fail immediately but the server will not start shutting down until the time has elapsed.
+graceful-wait-before-shutdown = 0
+
+# treat-old-version-utf8-as-utf8mb4 use for upgrade compatibility. Set to true will treat old version table/column UTF8 charset as UTF8MB4.
+treat-old-version-utf8-as-utf8mb4 = true
+
+# max-index-length is used to deal with compatibility issues from v3.0.7 and previous version upgrades. It can only be in [3072, 3072*4].
+max-index-length = 3072
+
+# index-limit is used to deal with compatibility issues. It can only be in [64, 64*8].
+index-limit = 64
+
+# enable-table-lock is used to control table lock feature. Default is false, indicate the table lock feature is disabled.
+enable-table-lock = false
+
+# delay-clean-table-lock is used to control the time (Milliseconds) of delay before unlock the table in the abnormal situation.
+delay-clean-table-lock = 0
+
+# Maximum number of the splitting region, which is used by the split region statement.
+split-region-max-num = 1000
+
+# alter-primary-key is used to control whether the primary keys are clustered. 
+# Note that this config is deprecated. Only valid when @@global.tidb_enable_clustered_index = 'int_only'.
+# Default is false, only the integer primary keys are clustered.
+# If it is true, all types of primary keys are nonclustered.
+alter-primary-key = false
+
+# server-version is used to change the version string of TiDB in the following scenarios:
+# 1. the server version returned by builtin-function `VERSION()`.
+# 2. the server version filled in handshake packets of MySQL Connection Protocol, see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html for more details.
+# if server-version = "", the default value(original TiDB version string) is used.
+server-version = ""
+
+# repair mode is used to repair the broken table meta in TiKV in extreme cases.
+repair-mode = false
+
+# Repair table list is used to list the tables in repair mode with the format like ["db.table",].
+# In repair mode, repairing table which is not in repair list will get wrong database or wrong table error.
+repair-table-list = []
+
+# Whether new collations are enabled, as indicated by its name, this configuration entry take effect ONLY when a TiDB cluster bootstraps for the first time.
+new_collations_enabled_on_first_bootstrap = true
+
+# Don't register information of this TiDB to etcd, so this instance of TiDB won't appear in the services like dashboard.
+# This option is useful when you want to embed TiDB into your service(i.e. use TiDB as a library).
+# *If you want to start a TiDB service, NEVER enable this.*
+skip-register-to-dashboard = false
+
+# When enabled, usage data (for example, instance versions) will be reported to log periodically for user experience analytics.
+# If this config is set to `false`, telemetry will be always disabled regardless of the value of the global variable `tidb_enable_telemetry`.
+enable-telemetry = false
+
+# deprecate-integer-display-length is used to be compatible with MySQL 8.0 in which the integer declared with display length will be returned with
+# a warning like `Integer display width is deprecated and will be removed in a future release`.
+deprecate-integer-display-length = true
+
+# enable-enum-length-limit is used to deal with compatibility issues. When true, the enum/set element length is limited.
+# According to MySQL 8.0 Refman:
+# The maximum supported length of an individual SET element is M <= 255 and (M x w) <= 1020,
+# where M is the element literal length and w is the number of bytes required for the maximum-length character in the character set.
+# See https://dev.mysql.com/doc/refman/8.0/en/string-type-syntax.html for more details.
+enable-enum-length-limit = true
+
+# enable-global-kill is used to control global kill feature. When it is enabled, connection ID is globally unique and KILL
+# command can be forwarded to the right TiDB instance to execute.
+enable-global-kill = true
+
+# disaggregated-tiflash indicates whether TiDB is in disaggregated tiflash mode, if true, MPP will runs on tiflash_compute nodes.
+disaggregated-tiflash = false
+
+# autoscaler-type indicates which type of AutoScaler will be used. Possible values are: mock, aws, gcp.
+# Only meaningful when disaggregated-tiflash is true.
+autoscaler-type = "aws"
+
+# autoscaler-addr is the host of AutoScaler, Only meaningful when disaggregated-tiflash is true.
+# Only meaningful when disaggregated-tiflash is true.
+autoscaler-addr = "tiflash-autoscale-lb.tiflash-autoscale.svc.cluster.local:8081"
+
+# autoscaler-cluster-id is the unique id for each TiDB cluster, which will used by AutoScaler.
+# Only meaningful when disaggregated-tiflash is true.
+autoscaler-cluster-id = ""
+
+# use-autoscaler indicates whether use AutoScaler or PD for tiflash_compute nodes, only meaningful when disaggregated-tiflash is true.
+use-autoscaler = false
+
+# in-mem-slow-query-topn-num indicates the number of TopN slow queries stored in memory.
+in-mem-slow-query-topn-num = 30
+
+# in-mem-slow-query-recent-num indicates the number of recent slow queries stored in memory.
+in-mem-slow-query-recent-num = 500
+
+[log]
+# Log level: debug, info, warn, error, fatal.
+level = "info"
+
+# Log format, one of json or text.
+format = "text"
+
+# Enable automatic timestamps in log output, if not set, it will be defaulted to true.
+# enable-timestamp = true
+
+# Enable annotating logs with the full stack error message, if not set, it will be defaulted to false.
+# enable-error-stack = false
+
+# Stores slow query log into separated files.
+slow-query-file = "tidb-slow.log"
+
+# Stores general log into separated files.
+# If it equals to empty, the general log will be written to the server log.
+general-log-file = ""
+
+# Make tidb panic if the write log operation hang for 15s
+# timeout = 15
+
+# File logging.
+[log.file]
+# Log file name.
+filename = ""
+
+# Max log file size in MB (upper limit to 4096MB).
+max-size = 300
+
+# Max log file keep days. No clean up by default.
+max-days = 0
+
+# Maximum number of old log files to retain. No clean up by default.
+max-backups = 0
+
+# Compression function for rotated files.
+# It can be empty or "gzip", empty means compression disabled.
+compression = ""
+
+[security]
+# Path of file that contains list of trusted SSL CAs for connection with mysql client.
+ssl-ca = ""
+
+# Path of file that contains X509 certificate in PEM format for connection with mysql client.
+ssl-cert = ""
+
+# Path of file that contains X509 key in PEM format for connection with mysql client.
+ssl-key = ""
+
+# Path of file that contains list of trusted SSL CAs for connection with cluster components.
+cluster-ssl-ca = ""
+
+# Path of file that contains X509 certificate in PEM format for connection with cluster components.
+cluster-ssl-cert = ""
+
+# Path of file that contains X509 key in PEM format for connection with cluster components.
+cluster-ssl-key = ""
+
+# Configurations of the encryption method to use for encrypting the spilled data files.
+# Possible values are "plaintext", "aes128-ctr", if not set, it will be "plaintext" by default.
+# "plaintext" means encryption is disabled.
+spilled-file-encryption-method = "plaintext"
+
+# Security Enhanced Mode (SEM) restricts the "SUPER" privilege and requires fine-grained privileges instead.
+enable-sem = false
+
+# Automatic creation of TLS certificates.
+# Setting it to 'true' is recommended because it is safer and tie with the default configuration of MySQL.
+# If this config is commented/missed, the value would be 'false' for the compatibility with TiDB versions that does not support it.
+auto-tls = true
+
+# Minium TLS version to use, e.g. "TLSv1.2"
+tls-version = ""
+
+# The RSA Key size for automatic generated RSA keys
+rsa-key-size = 4096
+
+[status]
+# If enable status report HTTP service.
+report-status = true
+
+# TiDB status host.
+status-host = "0.0.0.0"
+
+## status-host is the HTTP address for reporting the internal status of a TiDB server, for example:
+## API for prometheus: http://${status-host}:${status_port}/metrics
+## API for pprof:      http://${status-host}:${status_port}/debug/pprof
+# TiDB status port.
+status-port = 10080
+
+# Prometheus pushgateway address, leaves it empty will disable push to pushgateway.
+metrics-addr = ""
+
+# Prometheus client push interval in second, set \"0\" to disable push to pushgateway.
+metrics-interval = 15
+
+# Record statements qps by database name if it is enabled.
+record-db-qps = false
+
+# Record database name label if it is enabled.
+record-db-label = false
+
+[performance]
+# Max CPUs to use, 0 use number of CPUs in the machine.
+max-procs = 0
+
+# Memory size quota for tidb server, 0 means unlimited
+server-memory-quota = 0
+
+# StmtCountLimit limits the max count of statement inside a transaction.
+stmt-count-limit = 5000
+
+# Set keep alive option for tcp connection.
+tcp-keep-alive = true
+
+# Set nodelay option for tcp connection.
+tcp-no-delay = true
+
+# Whether support cartesian product.
+cross-join = true
+
+# Stats lease duration, which influences the time of analyze and stats load.
+stats-lease = "3s"
+
+# Pseudo stats will be used if the ratio between the modify count and
+# row count in statistics of a table is greater than it.
+pseudo-estimate-ratio = 0.8
+
+# Bind info lease duration, which influences the duration of loading bind info and handling invalid bind.
+bind-info-lease = "3s"
+
+# Whether support pushing down aggregation with distinct to cop task
+distinct-agg-push-down = false
+
+# The limitation of the size in byte for the entries in one transaction.
+# If using TiKV as the storage, the entry represents a key/value pair.
+# NOTE: If binlog is enabled with Kafka (e.g. arbiter cluster),
+# this value should be less than 1073741824(1G) because this is the maximum size that can be handled by Kafka.
+# If binlog is disabled or binlog is enabled without Kafka, this value should be less than 1099511627776(1T).
+txn-total-size-limit = 104857600
+
+# The limitation of the size in byte for each entry in one transaction.
+# NOTE: Increasing this limit may cause performance problems.
+txn-entry-size-limit = 6291456
+
+# max lifetime of transaction ttl manager.
+max-txn-ttl = 3600000
+
+# The Go GC trigger factor, you can get more information about it at https://golang.org/pkg/runtime.
+# If you encounter OOM when executing large query, you can decrease this value to trigger GC earlier.
+# If you find the CPU used by GC is too high or GC is too frequent and impact your business you can increase this value.
+gogc = 100
+
+# Whether to use the lite mode of init stats.
+lite-init-stats = true
+
+# Whether to wait for init stats to finish before providing service during startup
+force-init-stats = true
+
+[proxy-protocol]
+# PROXY protocol acceptable client networks.
+# Empty string means disable PROXY protocol, * means all networks.
+networks = ""
+
+# PROXY protocol header read timeout, unit is second
+header-timeout = 5
+
+[opentracing]
+# Enable opentracing.
+enable = false
+
+# Whether to enable the rpc metrics.
+rpc-metrics = false
+
+[opentracing.sampler]
+# Type specifies the type of the sampler: const, probabilistic, rateLimiting, or remote
+type = "const"
+
+# Param is a value passed to the sampler.
+# Valid values for Param field are:
+# - for "const" sampler, 0 or 1 for always false/true respectively
+# - for "probabilistic" sampler, a probability between 0 and 1
+# - for "rateLimiting" sampler, the number of spans per second
+# - for "remote" sampler, param is the same as for "probabilistic"
+# and indicates the initial sampling rate before the actual one
+# is received from the mothership
+param = 1.0
+
+# SamplingServerURL is the address of jaeger-agent's HTTP sampling server
+sampling-server-url = ""
+
+# MaxOperations is the maximum number of operations that the sampler
+# will keep track of. If an operation is not tracked, a default probabilistic
+# sampler will be used rather than the per operation specific sampler.
+max-operations = 0
+
+# SamplingRefreshInterval controls how often the remotely controlled sampler will poll
+# jaeger-agent for the appropriate sampling strategy.
+sampling-refresh-interval = 0
+
+[opentracing.reporter]
+# QueueSize controls how many spans the reporter can keep in memory before it starts dropping
+# new spans. The queue is continuously drained by a background go-routine, as fast as spans
+# can be sent out of process.
+queue-size = 0
+
+# BufferFlushInterval controls how often the buffer is force-flushed, even if it's not full.
+# It is generally not useful, as it only matters for very low traffic services.
+buffer-flush-interval = 0
+
+# LogSpans, when true, enables LoggingReporter that runs in parallel with the main reporter
+# and logs all submitted spans. Main Configuration.Logger must be initialized in the code
+# for this option to have any effect.
+log-spans = false
+
+#  LocalAgentHostPort instructs reporter to send spans to jaeger-agent at this address
+local-agent-host-port = ""
+
+[pd-client]
+# Max time which PD client will wait for the PD server in seconds.
+pd-server-timeout = 3
+
+[tikv-client]
+# Max gRPC connections that will be established with each tikv-server.
+grpc-connection-count = 4
+
+# After a duration of this time in seconds if the client doesn't see any activity it pings
+# the server to see if the transport is still alive.
+grpc-keepalive-time = 10
+
+# After having pinged for keepalive check, the client waits for a duration of Timeout in seconds
+# and if no activity is seen even after that the connection is closed.
+grpc-keepalive-timeout = 3
+
+# The compression type for gRPC channel: none or gzip.
+grpc-compression-type = "none"
+
+# Max time for commit command, must be twice bigger than raft election timeout.
+commit-timeout = "41s"
+
+# Max batch size in gRPC.
+max-batch-size = 128
+# Overload threshold of TiKV.
+overload-threshold = 200
+# Max batch wait time in nanosecond to avoid waiting too long. 0 means disable this feature.
+max-batch-wait-time = 0
+# Batch wait size, to avoid waiting too long.
+batch-wait-size = 8
+
+# If a Region has not been accessed for more than the given duration (in seconds), it
+# will be reloaded from the PD.
+region-cache-ttl = 600
+
+# store-limit is used to restrain TiDB from sending request to some stores which is up to the limit.
+# If a store has been up to the limit, it will return error for the successive request in same store.
+# default 0 means shutting off store limit.
+store-limit = 0
+
+# store-liveness-timeout is used to control timeout for store liveness after sending request failed.
+store-liveness-timeout = "1s"
+
+# ttl-refreshed-txn-size decides whether a transaction should update its lock TTL.
+# If the size(in byte) of a transaction is large than `ttl-refreshed-txn-size`, it update the lock TTL during the 2PC.
+ttl-refreshed-txn-size = 33554432
+
+# If the number of keys that one prewrite request of one region involves exceed this threshold, it will use `ResolveLock` instead of `ResolveLockLite`.
+resolve-lock-lite-threshold = 16
+
+[tikv-client.copr-cache]
+# The capacity in MB of the cache. Zero means disable coprocessor cache.
+capacity-mb = 1000.0
+
+[pessimistic-txn]
+# max retry count for a statement in a pessimistic transaction.
+max-retry-count = 256
+
+# The max count of deadlock events that will be recorded in the information_schema.deadlocks table.
+deadlock-history-capacity = 10
+
+# Whether retryable deadlocks (in-statement deadlocks) are collected to the information_schema.deadlocks table.
+deadlock-history-collect-retryable = false
+
+# If true it means the auto-commit transactions will be in pessimistic mode.
+pessimistic-auto-commit = true
+
+# experimental section controls the features that are still experimental: their semantics,
+# interfaces are subject to change, using these features in the production environment is not recommended.
+[experimental]
+# enable creating expression index.
+allow-expression-index = false
+
+# server level isolation read by engines and labels
+[isolation-read]
+# engines means allow the tidb server read data from which types of engines. options: "tikv", "tiflash", "tidb".
+engines = ["tikv", "tiflash", "tidb"]
+
+# instance scope variables
+# These options are also available as a system variable for online configuration
+# changes to the system variable do not persist to the cluster. You must make changes
+# in this configuration file on each tidb-server.
+[instance]
+
+# tidb_general_log is used to log every query in the server in info level.
+tidb_general_log = false
+
+# tidb_pprof_sql_cpu is used to add label sql label to pprof result.
+tidb_pprof_sql_cpu = false
+
+# ddl_slow_threshold sets log DDL operations whose execution time exceeds the threshold value.
+ddl_slow_threshold = 300
+
+# tidb_expensive_query_time_threshold indicates the time threshold of expensive query.
+tidb_expensive_query_time_threshold = 60
+
+# Force the priority of all statements in a specified priority.
+# The value could be "NO_PRIORITY", "LOW_PRIORITY", "HIGH_PRIORITY" or "DELAYED".
+tidb_force_priority = "NO_PRIORITY"
+
+# check mb4 value in utf8 is used to control whether to check the mb4 characters when the charset is utf8.
+tidb_check_mb4_value_in_utf8 = true
+
+# Whether to enable slow query log.
+tidb_enable_slow_log = true
+
+# Queries with execution time greater than this value will be logged. (Milliseconds)
+tidb_slow_log_threshold = 300
+
+# tidb_record_plan_in_slow_log is used to enable record query plan in slow log.
+# 0 is disable. 1 is enable.
+tidb_record_plan_in_slow_log = 1
+
+# The maximum permitted number of simultaneous client connections. When the value is 0, the number of connections is unlimited.
+max_connections = 0
+
+# Run ddl worker on this tidb-server.
+tidb_enable_ddl = true

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -916,6 +916,9 @@ grpc-keepalive-timeout = 0.01
 	require.Equal(t, "grpc-keepalive-timeout should be at least 0.05, but got 0.010000", conf.Valid().Error())
 
 	configFile = "config.toml.example"
+	if kerneltype.IsNextGen() {
+		configFile = "config.toml.nextgen.example"
+	}
 	require.NoError(t, conf.Load(configFile))
 
 	// Make sure the example config is the same as default config except `auto_tls`.

--- a/pkg/kv/kv_test.go
+++ b/pkg/kv/kv_test.go
@@ -49,7 +49,7 @@ func TestResourceGroupTagEncoding(t *testing.T) {
 	require.Nil(t, resTag.KeyspaceName)
 
 	sqlDigest = parser.NewDigest([]byte{'a', 'a'})
-	tag = NewResourceGroupTagBuilder(keyspace.GetKeyspaceNameBytesBySettings()).SetSQLDigest(sqlDigest).EncodeTagWithKey([]byte(""))
+	tag = NewResourceGroupTagBuilder(nil).SetSQLDigest(sqlDigest).EncodeTagWithKey([]byte(""))
 	// version(1) + prefix(1) + length(1) + content(2hex -> 1byte)
 	if kerneltype.IsNextGen() {
 		require.Len(t, tag, 8)
@@ -81,5 +81,10 @@ func TestResourceGroupTagEncoding(t *testing.T) {
 	resTag = &tipb.ResourceGroupTag{}
 	err = resTag.Unmarshal(tag)
 	require.NoError(t, err)
-	require.Len(t, resTag.KeyspaceName, 0)
+	if kerneltype.IsNextGen() {
+		require.NotNil(t, resTag.KeyspaceName)
+		require.Equal(t, resTag.KeyspaceName, keyspace.GetKeyspaceNameBytesBySettings())
+	} else {
+		require.Nil(t, resTag.KeyspaceName)
+	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62702

Problem Summary:

The default config with/without nextgen is different. The nextgen sets `pessimistic-auto-commit = true` by default. I think we should also provide an example for the default config of nextgen, so I added a `config.toml.nextgen.example` in the same folder. Ref:

<img width="1911" height="209" alt="image" src="https://github.com/user-attachments/assets/964e20b6-6bb6-40e2-9eca-4147b3507954" />


### What changed and how does it work?

Add a `config.toml.nextgen.example`, and use this file if the test is running with nextgen.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
