### PR TITLE
executor: show consistent table and schema name for `RENAME TABLE`

### DIFF
--- a/pkg/ddl/db_rename_test.go
+++ b/pkg/ddl/db_rename_test.go
@@ -506,6 +506,11 @@ func TestShowRunningRenameTable(t *testing.T) {
 			require.Len(t, rs, 1)
 			require.Equal(t, "test2", rs[0][1])
 			require.Equal(t, "t2", rs[0][2])
+
+			rs = tk2.MustQuery("select db_name, table_name from information_schema.ddl_jobs where job_type = 'rename table'").Rows()
+			require.Len(t, rs, 1)
+			require.Equal(t, "test2", rs[0][0])
+			require.Equal(t, "t2", rs[0][1])
 		}
 	})
 

--- a/pkg/ddl/db_rename_test.go
+++ b/pkg/ddl/db_rename_test.go
@@ -499,9 +499,9 @@ func TestShowRunningRenameTable(t *testing.T) {
 	tk1.MustExec("create database test2")
 	tk1.MustExec("create table t1 (a int, b int)")
 
+	tk2 := testkit.NewTestKit(t, store)
 	failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/beforeWaitSchemaSynced", func(job *model.Job, _ int64) {
-		if job.State != model.JobStateSynced {
-			tk2 := testkit.NewTestKit(t, store)
+		if job.State != model.JobStateSynced && job.Type == model.ActionRenameTable {
 			rs := tk2.MustQuery("admin show ddl jobs where state != 'synced'").Rows()
 			require.Len(t, rs, 1)
 			require.Equal(t, "test2", rs[0][1])

--- a/pkg/ddl/db_rename_test.go
+++ b/pkg/ddl/db_rename_test.go
@@ -347,7 +347,7 @@ func TestRenameConcurrentAutoID(t *testing.T) {
 	}
 
 	// Switch to new client (tidb3)
-	waitFor("t1", "public", 4)
+	waitFor("t2", "public", 4)
 	tk3.MustExec(`begin`)
 	tk3.MustExec(`insert into test2.t2 values (null, "t2 first null")`)
 	tk3.MustQuery(`select _tidb_rowid, a, b from test2.t2`).Sort().Check(testkit.Rows("4 3 t2 first null"))

--- a/pkg/ddl/db_rename_test.go
+++ b/pkg/ddl/db_rename_test.go
@@ -500,7 +500,7 @@ func TestShowRunningRenameTable(t *testing.T) {
 	tk1.MustExec("create table t1 (a int, b int)")
 
 	failpoint.EnableCall("github.com/pingcap/tidb/pkg/ddl/beforeWaitSchemaSynced", func(job *model.Job, _ int64) {
-		if job.State == model.JobStateRunning {
+		if job.State != model.JobStateSynced {
 			tk2 := testkit.NewTestKit(t, store)
 			rs := tk2.MustQuery("admin show ddl jobs where state != 'synced'").Rows()
 			require.Len(t, rs, 1)

--- a/pkg/executor/show_ddl_jobs.go
+++ b/pkg/executor/show_ddl_jobs.go
@@ -220,6 +220,14 @@ func (e *DDLJobRetriever) appendJobToChunk(req *chunk.Chunk, job *model.Job, che
 		tableName = getTableName(e.is, job.TableID)
 	}
 
+	if job.Type == model.ActionRenameTable {
+		// The schema/table name stored in job is new schema/old table respectively.
+		// So here we show both new for running rename table job to keep consistency.
+		if arg, err := model.GetRenameTableArgs(job); err == nil && len(arg.NewTableName.L) > 0 {
+			tableName = arg.NewTableName.L
+		}
+	}
+
 	createTime := ts2Time(job.StartTS, e.TZLoc)
 	startTime := ts2Time(job.RealStartTS, e.TZLoc)
 	finishTime := ts2Time(finishTS, e.TZLoc)

--- a/pkg/executor/show_ddl_jobs.go
+++ b/pkg/executor/show_ddl_jobs.go
@@ -195,13 +195,13 @@ func (e *DDLJobRetriever) appendJobToChunk(req *chunk.Chunk, job *model.Job, che
 		if job.BinlogInfo.TableInfo != nil {
 			tableName = job.BinlogInfo.TableInfo.Name.L
 		} else if job.Type == model.ActionRenameTable {
-			// The schema/table name stored in job is new schema/old table respectively.
-			// So here we show both new for running rename table job to keep consistency.
+			// For running rename table jobs, we use old table name stored in job
+			// since TableInfo is not set yet. So we extract the new table name from
+			// job args for consistent output.
 			if arg, err := model.GetRenameTableArgs(job); err == nil && len(arg.NewTableName.L) > 0 {
 				tableName = arg.NewTableName.L
 			}
 		}
-
 		if job.BinlogInfo.MultipleTableInfos != nil {
 			tablenames := new(strings.Builder)
 			for i, affect := range job.BinlogInfo.MultipleTableInfos {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #46897

Problem Summary:

For `RENAME TABLE`, we store new schema name and old table name in the job, and old schema and new table name are stored in job args. 

And for running jobs, the table/schema name displayed in `ADMIN SHOW DDL JOBS` is get from job. So we will get inconsistent names for running `RENAME TABLE`

### What changed and how does it work?

I don't want to change the way we store job arguments, since it may arise compatibility issues, so just apply a patch for the outputs.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
