### PR TITLE
ddl: fix adding GBK columns to tables with TiFlash replicas

### DIFF
--- a/pkg/ddl/tiflash_replica_test.go
+++ b/pkg/ddl/tiflash_replica_test.go
@@ -250,6 +250,7 @@ func TestSetTiFlashReplicaForAddGBKColumn(t *testing.T) {
 	require.Equal(t, uint64(1), tbl.Meta().TiFlashReplica.Count)
 	tk.MustGetErrCode("alter table tgbk add column c1 varchar(10);", errno.ErrUnsupportedDDLOperation)
 	tk.MustGetErrCode("alter table tgbk add column c1 varchar(10), add column c2 varchar(10);", errno.ErrUnsupportedDDLOperation)
+	tk.MustExec("alter table tgbk add column c1 varchar(10) character set utf8;")
 
 	// GB18030
 	tk.MustExec("create table t1 (id int);")
@@ -267,6 +268,7 @@ func TestSetTiFlashReplicaForAddGBKColumn(t *testing.T) {
 	require.Equal(t, uint64(1), tbl.Meta().TiFlashReplica.Count)
 	tk.MustGetErrCode("alter table tgb18030 add column c1 varchar(10);", errno.ErrUnsupportedDDLOperation)
 	tk.MustGetErrCode("alter table tgb18030 add column c1 varchar(10), add column c2 varchar(10);", errno.ErrUnsupportedDDLOperation)
+	tk.MustExec("alter table tgb18030 add column c1 varchar(10) character set utf8;")
 }
 
 func TestSetTableFlashReplicaForSystemTable(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/46041

Problem Summary:
```
create table t (id int);
alter table t set tiflash replica 1;
alter table t add column c1 varchar(10) character set gbk;

create table tgbk (id int) charset = gbk;
alter table tgbk set tiflash replica 1;
alter table tgbk add column c1 varchar(10);
```
All of the preceding statements executed successfully. But TiFlash does not support GBK encoding.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
