### PR TITLE
Cascades Planner: correct plan generation logic for PartitionUnionAll for limit in cascades mode

### DIFF
--- a/pkg/planner/core/operator/logicalop/logical_partition_union_all.go
+++ b/pkg/planner/core/operator/logicalop/logical_partition_union_all.go
@@ -54,6 +54,21 @@ func (p *LogicalPartitionUnionAll) PruneColumns(parentUsedCols []*expression.Col
 	return p, nil
 }
 
+// PushDownTopN implements LogicalPlan interface.
+func (p *LogicalPartitionUnionAll) PushDownTopN(topNLogicalPlan base.LogicalPlan, opt *optimizetrace.LogicalOptimizeOp) base.LogicalPlan {
+	transformedUnionAll := p.LogicalUnionAll.PushDownTopN(topNLogicalPlan, opt)
+
+	unionAll, isUnionAll := transformedUnionAll.(*LogicalUnionAll)
+	if !isUnionAll {
+		// Return the transformed plan if it's no longer a LogicalUnionAll
+		return transformedUnionAll
+	}
+
+	// Update the wrapped LogicalUnionAll with the transformed result
+	p.LogicalUnionAll = *unionAll
+	return p
+}
+
 // ExhaustPhysicalPlans implements LogicalPlan interface.
 func (p *LogicalPartitionUnionAll) ExhaustPhysicalPlans(prop *property.PhysicalProperty) ([]base.PhysicalPlan, bool, error) {
 	return utilfuncp.ExhaustPhysicalPlans4LogicalPartitionUnionAll(p, prop)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62764 , ref #62328  #62472

Problem Summary:
When a partitioned table generates a parent plan using *logicalop.LogicalPartitionUnionAll, it inherits the methods of LogicalUnionAll. 
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
