### PR TITLE
memory: fix tidb fail to start on macos

### DIFF
--- a/pkg/util/memory/meminfo.go
+++ b/pkg/util/memory/meminfo.go
@@ -181,7 +181,7 @@ func InitMemoryHook() error {
 	}
 	cgroupValue, err := cgroup.GetMemoryLimit()
 	if err != nil {
-		return err
+		return nil
 	}
 	physicalValue, err := memTotalNormal()
 	if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #62782

Problem Summary:


### What changed and how does it work?

ignore the error when read cgroup info

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
