### PR TITLE
conn: add buffer for zlib & zstd compressor

### DIFF
--- a/pkg/server/internal/packetio.go
+++ b/pkg/server/internal/packetio.go
@@ -315,24 +315,24 @@ func (p *PacketIO) Flush() error {
 
 func newCompressedWriter(w io.Writer, ca int, seq *uint8) *compressedWriter {
 	return &compressedWriter{
+		compressorBuffer{nil, nil, nil},
 		w,
 		new(bytes.Buffer),
 		seq,
+		nil,
 		ca,
 		3,
-		nil,
-		compressorBuffer{nil, nil, nil},
 	}
 }
 
 type compressedWriter struct {
+	compressorBuffer     compressorBuffer
 	w                    io.Writer
 	buf                  *bytes.Buffer
 	compressedSequence   *uint8
+	compressedPacket     *bytes.Buffer
 	compressionAlgorithm int
 	zstdLevel            zstd.EncoderLevel
-	compressedPacket     *bytes.Buffer
-	compressorBuffer     compressorBuffer
 }
 
 func (cw *compressedWriter) Write(data []byte) (n int, err error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62795

Problem Summary:

### What changed and how does it work?

Buffer the zlib writer and zstd encoder because the small object allocations are unacceptable overhead.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->


Run sysbench read-only in fixed rate, the CPU usage of TiDB is optimized from 1300% to 1000%.

```bash
sysbench]$ sysbench --config-file="config" oltp_read_only --tables=1 --table-size=100000000 --rate=1000 --mysql-compression=on run
```

<img width="799" height="539" alt="image" src="https://github.com/user-attachments/assets/dc6ad6be-0d66-4c90-b64a-6abb1212cfec" />


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Optimize the performance of connection's traffic compressing.
```
