### PR TITLE
statistics: use GetNonPseudoPhysicalTableStats to get stats in the show commands

### DIFF
--- a/pkg/executor/show_stats.go
+++ b/pkg/executor/show_stats.go
@@ -124,10 +124,10 @@ func (e *ShowExec) fetchShowStatsMeta(ctx context.Context) error {
 		fieldPatternsLike = e.Extractor.FieldPatternLike()
 	}
 	tableInfoResult := do.InfoSchema().ListTablesWithSpecialAttribute(infoschemacontext.PartitionAttribute)
-	paritionedTables := make(map[int64]*model.TableInfo)
+	partitionedTables := make(map[int64]*model.TableInfo)
 	for _, result := range tableInfoResult {
 		for _, tbl := range result.TableInfos {
-			paritionedTables[tbl.ID] = tbl
+			partitionedTables[tbl.ID] = tbl
 		}
 	}
 	for _, db := range dbs {
@@ -140,19 +140,19 @@ func (e *ShowExec) fetchShowStatsMeta(ctx context.Context) error {
 		terror.Log(err)
 		for _, nameInfo := range tableNames {
 			tblID := nameInfo.ID
-			paritionedTable, ok := paritionedTables[tblID]
+			partitionedTable, ok := partitionedTables[tblID]
 			// Partitioned table:
 			if ok {
 				// For dynamic partitioned table, we need to display the global table as well.
 				if e.Ctx().GetSessionVars().IsDynamicPartitionPruneEnabled() {
-					if stats, found := h.GetNonPseudoPhysicalTableStats(paritionedTable.ID); found {
-						e.appendTableForStatsMeta(db.O, paritionedTable.Name.O, "global", stats)
+					if stats, found := h.GetNonPseudoPhysicalTableStats(partitionedTable.ID); found {
+						e.appendTableForStatsMeta(db.O, partitionedTable.Name.O, "global", stats)
 					}
 				}
-				pi := paritionedTable.GetPartitionInfo()
+				pi := partitionedTable.GetPartitionInfo()
 				for _, def := range pi.Definitions {
 					if stats, found := h.GetNonPseudoPhysicalTableStats(def.ID); found {
-						e.appendTableForStatsMeta(db.O, paritionedTable.Name.O, def.Name.O, stats)
+						e.appendTableForStatsMeta(db.O, partitionedTable.Name.O, def.Name.O, stats)
 					}
 				}
 			} else {
@@ -539,10 +539,10 @@ func (e *ShowExec) fetchShowStatsHealthy(ctx context.Context) {
 		fieldPatternsLike = e.Extractor.FieldPatternLike()
 	}
 	tableInfoResult := do.InfoSchema().ListTablesWithSpecialAttribute(infoschemacontext.PartitionAttribute)
-	paritionedTables := make(map[int64]*model.TableInfo)
+	partitionedTables := make(map[int64]*model.TableInfo)
 	for _, result := range tableInfoResult {
 		for _, tbl := range result.TableInfos {
-			paritionedTables[tbl.ID] = tbl
+			partitionedTables[tbl.ID] = tbl
 		}
 	}
 	for _, db := range dbs {
@@ -555,19 +555,19 @@ func (e *ShowExec) fetchShowStatsHealthy(ctx context.Context) {
 		terror.Log(err)
 		for _, nameInfo := range tableNames {
 			tblID := nameInfo.ID
-			paritionedTable, ok := paritionedTables[tblID]
+			partitionedTable, ok := partitionedTables[tblID]
 			// Partitioned table:
 			if ok {
 				// For dynamic partitioned table, we need to display the global table as well.
 				if e.Ctx().GetSessionVars().IsDynamicPartitionPruneEnabled() {
-					if stats, found := h.GetNonPseudoPhysicalTableStats(paritionedTable.ID); found {
-						e.appendTableForStatsHealthy(db.O, paritionedTable.Name.O, "global", stats)
+					if stats, found := h.GetNonPseudoPhysicalTableStats(partitionedTable.ID); found {
+						e.appendTableForStatsHealthy(db.O, partitionedTable.Name.O, "global", stats)
 					}
 				}
-				pi := paritionedTable.GetPartitionInfo()
+				pi := partitionedTable.GetPartitionInfo()
 				for _, def := range pi.Definitions {
 					if stats, found := h.GetNonPseudoPhysicalTableStats(def.ID); found {
-						e.appendTableForStatsHealthy(db.O, paritionedTable.Name.O, def.Name.O, stats)
+						e.appendTableForStatsHealthy(db.O, partitionedTable.Name.O, def.Name.O, stats)
 					}
 				}
 			} else {

--- a/pkg/executor/show_stats.go
+++ b/pkg/executor/show_stats.go
@@ -145,15 +145,21 @@ func (e *ShowExec) fetchShowStatsMeta(ctx context.Context) error {
 			if ok {
 				// For dynamic partitioned table, we need to display the global table as well.
 				if e.Ctx().GetSessionVars().IsDynamicPartitionPruneEnabled() {
-					e.appendTableForStatsMeta(db.O, paritionedTable.Name.O, "global", h.GetNonPseudoPhysicalTableStats(paritionedTable.ID))
+					if stats, found := h.GetNonPseudoPhysicalTableStats(paritionedTable.ID); found {
+						e.appendTableForStatsMeta(db.O, paritionedTable.Name.O, "global", stats)
+					}
 				}
 				pi := paritionedTable.GetPartitionInfo()
 				for _, def := range pi.Definitions {
-					e.appendTableForStatsMeta(db.O, paritionedTable.Name.O, def.Name.O, h.GetNonPseudoPhysicalTableStats(def.ID))
+					if stats, found := h.GetNonPseudoPhysicalTableStats(def.ID); found {
+						e.appendTableForStatsMeta(db.O, paritionedTable.Name.O, def.Name.O, stats)
+					}
 				}
 			} else {
 				// Non-partitioned table:
-				e.appendTableForStatsMeta(db.O, nameInfo.Name.O, "", h.GetNonPseudoPhysicalTableStats(nameInfo.ID))
+				if stats, found := h.GetNonPseudoPhysicalTableStats(nameInfo.ID); found {
+					e.appendTableForStatsMeta(db.O, nameInfo.Name.O, "", stats)
+				}
 			}
 		}
 	}
@@ -554,15 +560,21 @@ func (e *ShowExec) fetchShowStatsHealthy(ctx context.Context) {
 			if ok {
 				// For dynamic partitioned table, we need to display the global table as well.
 				if e.Ctx().GetSessionVars().IsDynamicPartitionPruneEnabled() {
-					e.appendTableForStatsHealthy(db.O, paritionedTable.Name.O, "global", h.GetNonPseudoPhysicalTableStats(paritionedTable.ID))
+					if stats, found := h.GetNonPseudoPhysicalTableStats(paritionedTable.ID); found {
+						e.appendTableForStatsHealthy(db.O, paritionedTable.Name.O, "global", stats)
+					}
 				}
 				pi := paritionedTable.GetPartitionInfo()
 				for _, def := range pi.Definitions {
-					e.appendTableForStatsHealthy(db.O, paritionedTable.Name.O, def.Name.O, h.GetNonPseudoPhysicalTableStats(def.ID))
+					if stats, found := h.GetNonPseudoPhysicalTableStats(def.ID); found {
+						e.appendTableForStatsHealthy(db.O, paritionedTable.Name.O, def.Name.O, stats)
+					}
 				}
 			} else {
 				// Non-partitioned table:
-				e.appendTableForStatsHealthy(db.O, nameInfo.Name.O, "", h.GetNonPseudoPhysicalTableStats(nameInfo.ID))
+				if stats, found := h.GetNonPseudoPhysicalTableStats(nameInfo.ID); found {
+					e.appendTableForStatsHealthy(db.O, nameInfo.Name.O, "", stats)
+				}
 			}
 		}
 	}

--- a/pkg/executor/show_stats_test.go
+++ b/pkg/executor/show_stats_test.go
@@ -63,6 +63,10 @@ func TestShowStatsMeta(t *testing.T) {
 	require.Len(t, result.Rows(), 1)
 	require.Equal(t, "test2", result.Rows()[0][0])
 	require.Equal(t, "t", result.Rows()[0][1])
+	result = tk.MustQuery("show stats_meta like 'test2'")
+	require.Len(t, result.Rows(), 1)
+	require.Equal(t, "test2", result.Rows()[0][0])
+	require.Equal(t, "t", result.Rows()[0][1])
 }
 
 func TestShowStatsLocked(t *testing.T) {

--- a/pkg/executor/show_stats_test.go
+++ b/pkg/executor/show_stats_test.go
@@ -49,6 +49,20 @@ func TestShowStatsMeta(t *testing.T) {
 	result = tk.MustQuery("show stats_meta where table_name = 't'")
 	require.Len(t, result.Rows(), 1)
 	require.Equal(t, "t", result.Rows()[0][1])
+
+	// Create different database to test the like pattern.
+	tk.MustExec("create database test2")
+	tk.MustExec("use test2")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("analyze table t all columns")
+	// Test it works under different database.
+	tk.MustExec("use test")
+	// Test it is not case sensitive.
+	result = tk.MustQuery("show stats_meta like 'Test2%'")
+	require.Len(t, result.Rows(), 1)
+	require.Equal(t, "test2", result.Rows()[0][0])
+	require.Equal(t, "t", result.Rows()[0][1])
 }
 
 func TestShowStatsLocked(t *testing.T) {

--- a/pkg/executor/show_stats_test.go
+++ b/pkg/executor/show_stats_test.go
@@ -67,6 +67,33 @@ func TestShowStatsMeta(t *testing.T) {
 	require.Len(t, result.Rows(), 1)
 	require.Equal(t, "test2", result.Rows()[0][0])
 	require.Equal(t, "t", result.Rows()[0][1])
+
+	// For dynamic partitioned table, we need to display the global table as well.
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int) partition by range(a) (partition p0 values less than (6))")
+	tk.MustExec(`insert into t values (1, 1)`)
+	tk.MustExec("analyze table t all columns")
+	result = tk.MustQuery("show stats_meta where db_name = 'test' and table_name = 't'").Sort()
+	require.Len(t, result.Rows(), 2)
+	require.Equal(t, "test", result.Rows()[0][0])
+	require.Equal(t, "t", result.Rows()[0][1])
+	require.Equal(t, "global", result.Rows()[0][2])
+	require.Equal(t, "test", result.Rows()[1][0])
+	require.Equal(t, "t", result.Rows()[1][1])
+	require.Equal(t, "p0", result.Rows()[1][2])
+
+	// For static partitioned table, there is no global table.
+	tk.MustExec("set @@global.tidb_partition_prune_mode='static'")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int) partition by range(a) (partition p0 values less than (6))")
+	tk.MustExec(`insert into t values (1, 1)`)
+	tk.MustExec("analyze table t")
+	result = tk.MustQuery("show stats_meta where db_name = 'test' and table_name = 't'").Sort()
+	require.Len(t, result.Rows(), 1)
+	require.Equal(t, "test", result.Rows()[0][0])
+	require.Equal(t, "t", result.Rows()[0][1])
+	require.Equal(t, "p0", result.Rows()[0][2])
 }
 
 func TestShowStatsLocked(t *testing.T) {

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3573,6 +3573,12 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (base.P
 			err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SHOW", user.AuthUsername, user.AuthHostname, show.Table.Name.L)
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", err)
+		if show.Tp == ast.ShowStatsMeta {
+			if extractor := newShowBaseExtractor(*show); extractor.Extract() {
+				p.Extractor = extractor
+				buildPattern = false
+			}
+		}
 	case ast.ShowRegions:
 		tableInfo, err := b.is.TableByName(ctx, show.Table.Schema, show.Table.Name)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/62685

Problem Summary:

### What changed and how does it work?


based on https://github.com/pingcap/tidb/pull/62790

In this PR, we utilize SchemaSimpleTableInfos for the commands `show stats_meta` and `show stats_healthy`, which helps to accelerate the process of retrieving table information.

Additionally, I utilized `ListTablesWithSpecialAttribute` to retrieve information about the partitioned tables, as we still need the relationship between the global table and its partitions. 

After this change, the duration reduced from `5 min 44.55 sec` to `2.3 sec`.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] [Manual test](https://github.com/pingcap/tidb/pull/62811#issuecomment-3154778715)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复 `show stats_meta` 和 `show stats_helathy` 在表非常多的情况下过慢的问题
Fix the issue where `show stats_meta` and `show stats_healthy` are too slow when there are very many tables
```
