### PR TITLE
tests: kill minio after tests to avoid process leak

### DIFF
--- a/tests/realtikvtest/scripts/classic/bootstrap-test-with-cluster.sh
+++ b/tests/realtikvtest/scripts/classic/bootstrap-test-with-cluster.sh
@@ -50,6 +50,8 @@ function cleanup() {
         killall -9 -r -q tikv-server || true
         killall -9 -r -q pd-server || true
     fi
+
+    make failpoint-disable
 }
 
 exit_code=0

--- a/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
+++ b/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
@@ -95,12 +95,16 @@ function cleanup() {
         killall -9 -q tikv-worker || true
         killall -9 -q tikv-server || true
         killall -9 -q pd-server || true
+        killall -9 -q minio || true
     else
         # Linux: supports -r for regex
         killall -9 -r -q tikv-worker || true
         killall -9 -r -q tikv-server || true
         killall -9 -r -q pd-server || true
+        killall -9 -r -q minio || true
     fi
+
+    make failpoint-disable
 }
 
 exit_code=0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62803

Problem Summary:

### What changed and how does it work?

- kill `minio` process after tests to avoid process leaking.
- recover for fail-point after testing.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
