### PR TITLE
txn: follower read only affect read-only statements

### DIFF
--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -333,11 +333,11 @@ func TestReplicaRead(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 
 	tk := testkit.NewTestKit(t, store)
-	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaRead())
+	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaReadUnadjusted())
 	tk.MustExec("set @@tidb_replica_read = 'follower';")
-	require.Equal(t, kv.ReplicaReadFollower, tk.Session().GetSessionVars().GetReplicaRead())
+	require.Equal(t, kv.ReplicaReadFollower, tk.Session().GetSessionVars().GetReplicaReadUnadjusted())
 	tk.MustExec("set @@tidb_replica_read = 'leader';")
-	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaRead())
+	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaReadUnadjusted())
 }
 
 func TestIsolationRead(t *testing.T) {

--- a/pkg/session/test/variable/variable_test.go
+++ b/pkg/session/test/variable/variable_test.go
@@ -333,11 +333,13 @@ func TestReplicaRead(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 
 	tk := testkit.NewTestKit(t, store)
-	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaReadUnadjusted())
+	require.Nil(t, failpoint.Enable("github.com/pingcap/tidb/pkg/sessionctx/variable/GetReplicaReadUnadjusted", "return(true)"))
+	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaRead())
 	tk.MustExec("set @@tidb_replica_read = 'follower';")
-	require.Equal(t, kv.ReplicaReadFollower, tk.Session().GetSessionVars().GetReplicaReadUnadjusted())
+	require.Equal(t, kv.ReplicaReadFollower, tk.Session().GetSessionVars().GetReplicaRead())
 	tk.MustExec("set @@tidb_replica_read = 'leader';")
-	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaReadUnadjusted())
+	require.Equal(t, kv.ReplicaReadLeader, tk.Session().GetSessionVars().GetReplicaRead())
+	require.Nil(t, failpoint.Disable("github.com/pingcap/tidb/pkg/sessionctx/variable/GetReplicaReadUnadjusted"))
 }
 
 func TestIsolationRead(t *testing.T) {

--- a/pkg/sessionctx/variable/BUILD.bazel
+++ b/pkg/sessionctx/variable/BUILD.bazel
@@ -77,6 +77,7 @@ go_library(
         "//pkg/util/versioninfo",
         "@com_github_docker_go_units//:go-units",
         "@com_github_pingcap_errors//:errors",
+        "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_kvproto//pkg/kvrpcpb",
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_tikv_client_go_v2//config",

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2430,7 +2430,7 @@ func (s *SessionVars) SetEnablePseudoForOutdatedStats(val bool) {
 
 // GetReplicaRead get ReplicaRead from sql hints and SessionVars.replicaRead.
 func (s *SessionVars) GetReplicaRead() kv.ReplicaReadType {
-	// Replica only works for read-only statements.
+	// Replica read only works for read-only statements.
 	if !s.StmtCtx.IsReadOnly {
 		if s.StmtCtx.HasReplicaReadHint {
 			s.StmtCtx.AppendWarning(errors.New("Ignore replica read hint for non-read-only statement"))

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2437,6 +2437,9 @@ func (s *SessionVars) GetReplicaRead() kv.ReplicaReadType {
 		}
 		return kv.ReplicaReadLeader
 	}
+	if s.StmtCtx.RCCheckTS || s.RcWriteCheckTS {
+		return kv.ReplicaReadLeader
+	}
 	if s.StmtCtx.HasReplicaReadHint {
 		return kv.ReplicaReadType(s.StmtCtx.ReplicaRead)
 	}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2428,7 +2428,7 @@ func (s *SessionVars) SetEnablePseudoForOutdatedStats(val bool) {
 	s.EnablePseudoForOutdatedStats = val
 }
 
-// GetReplicaRead get ReplicaRead from sql hints and SessionVars.replicaRead.
+// GetReplicaRead get ReplicaRead from sql hints and SessionVars.replicaRead with adjusted.
 func (s *SessionVars) GetReplicaRead() kv.ReplicaReadType {
 	// Replica read only works for read-only statements.
 	if !s.StmtCtx.IsReadOnly {
@@ -2447,6 +2447,12 @@ func (s *SessionVars) GetReplicaRead() kv.ReplicaReadType {
 	if s.replicaRead == kv.ReplicaReadClosestAdaptive && !IsAdaptiveReplicaReadEnabled() {
 		return kv.ReplicaReadLeader
 	}
+	return s.replicaRead
+}
+
+// GetReplicaReadUnadjusted returns the unadjusted replica read type.
+// In most cases, you should use GetReplicaRead instead of this method.
+func (s *SessionVars) GetReplicaReadUnadjusted() kv.ReplicaReadType {
 	return s.replicaRead
 }
 

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2430,6 +2430,13 @@ func (s *SessionVars) SetEnablePseudoForOutdatedStats(val bool) {
 
 // GetReplicaRead get ReplicaRead from sql hints and SessionVars.replicaRead.
 func (s *SessionVars) GetReplicaRead() kv.ReplicaReadType {
+	// Replica only works for read-only statements.
+	if !s.StmtCtx.IsReadOnly {
+		if s.StmtCtx.HasReplicaReadHint {
+			s.StmtCtx.AppendWarning(errors.New("Ignore replica read hint for non-read-only statement"))
+		}
+		return kv.ReplicaReadLeader
+	}
 	if s.StmtCtx.HasReplicaReadHint {
 		return kv.ReplicaReadType(s.StmtCtx.ReplicaRead)
 	}

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2438,7 +2438,18 @@ func (s *SessionVars) GetReplicaRead() kv.ReplicaReadType {
 	// Replica read only works for read-only statements.
 	if !s.StmtCtx.IsReadOnly {
 		if s.StmtCtx.HasReplicaReadHint {
-			s.StmtCtx.AppendWarning(errors.New("Ignore replica read hint for non-read-only statement"))
+			const warnMsg = "Ignore replica read hint for non-read-only statement"
+			existWarnings := s.StmtCtx.GetWarnings()
+			hasWarning := false
+			for _, warn := range existWarnings {
+				if warn.Err.Error() == warnMsg {
+					hasWarning = true
+					break
+				}
+			}
+			if !hasWarning {
+				s.StmtCtx.AppendWarning(errors.New(warnMsg))
+			}
 		}
 		return kv.ReplicaReadLeader
 	}

--- a/pkg/sessionctx/variable/varsutil_test.go
+++ b/pkg/sessionctx/variable/varsutil_test.go
@@ -373,19 +373,19 @@ func TestVarsutil(t *testing.T) {
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBReplicaRead)
 	require.NoError(t, err)
 	require.Equal(t, "follower", val)
-	require.Equal(t, kv.ReplicaReadFollower, v.GetReplicaReadUnadjusted())
+	require.Equal(t, kv.ReplicaReadFollower, v.replicaRead)
 	err = v.SetSystemVar(vardef.TiDBReplicaRead, "leader")
 	require.NoError(t, err)
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBReplicaRead)
 	require.NoError(t, err)
 	require.Equal(t, "leader", val)
-	require.Equal(t, kv.ReplicaReadLeader, v.GetReplicaReadUnadjusted())
+	require.Equal(t, kv.ReplicaReadLeader, v.replicaRead)
 	err = v.SetSystemVar(vardef.TiDBReplicaRead, "leader-and-follower")
 	require.NoError(t, err)
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBReplicaRead)
 	require.NoError(t, err)
 	require.Equal(t, "leader-and-follower", val)
-	require.Equal(t, kv.ReplicaReadMixed, v.GetReplicaReadUnadjusted())
+	require.Equal(t, kv.ReplicaReadMixed, v.replicaRead)
 
 	for _, c := range []struct {
 		a string

--- a/pkg/sessionctx/variable/varsutil_test.go
+++ b/pkg/sessionctx/variable/varsutil_test.go
@@ -373,19 +373,19 @@ func TestVarsutil(t *testing.T) {
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBReplicaRead)
 	require.NoError(t, err)
 	require.Equal(t, "follower", val)
-	require.Equal(t, kv.ReplicaReadFollower, v.GetReplicaRead())
+	require.Equal(t, kv.ReplicaReadFollower, v.GetReplicaReadUnadjusted())
 	err = v.SetSystemVar(vardef.TiDBReplicaRead, "leader")
 	require.NoError(t, err)
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBReplicaRead)
 	require.NoError(t, err)
 	require.Equal(t, "leader", val)
-	require.Equal(t, kv.ReplicaReadLeader, v.GetReplicaRead())
+	require.Equal(t, kv.ReplicaReadLeader, v.GetReplicaReadUnadjusted())
 	err = v.SetSystemVar(vardef.TiDBReplicaRead, "leader-and-follower")
 	require.NoError(t, err)
 	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBReplicaRead)
 	require.NoError(t, err)
 	require.Equal(t, "leader-and-follower", val)
-	require.Equal(t, kv.ReplicaReadMixed, v.GetReplicaRead())
+	require.Equal(t, kv.ReplicaReadMixed, v.GetReplicaReadUnadjusted())
 
 	for _, c := range []struct {
 		a string

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -175,7 +175,7 @@ func (p *baseTxnContextProvider) GetReadReplicaScope() string {
 		return txnScope
 	}
 
-	if p.sctx.GetSessionVars().GetReplicaRead().IsClosestRead() {
+	if p.sctx.GetSessionVars().GetReplicaReadUnadjusted().IsClosestRead() {
 		// If closest read is set, we should use the scope where instance located.
 		return config.GetTxnScopeFromConfig()
 	}

--- a/pkg/sessiontxn/isolation/base.go
+++ b/pkg/sessiontxn/isolation/base.go
@@ -175,7 +175,7 @@ func (p *baseTxnContextProvider) GetReadReplicaScope() string {
 		return txnScope
 	}
 
-	if p.sctx.GetSessionVars().GetReplicaReadUnadjusted().IsClosestRead() {
+	if p.sctx.GetSessionVars().GetReplicaRead().IsClosestRead() {
 		// If closest read is set, we should use the scope where instance located.
 		return config.GetTxnScopeFromConfig()
 	}

--- a/pkg/sessiontxn/isolation/main_test.go
+++ b/pkg/sessiontxn/isolation/main_test.go
@@ -89,7 +89,9 @@ func (a *txnAssert[T]) Check(t testing.TB) {
 	require.Equal(t, a.couldRetry, txnCtx.CouldRetry)
 	require.Equal(t, assertTxnScope, txnCtx.TxnScope)
 	require.Equal(t, assertTxnScope, provider.GetTxnScope())
+	require.Nil(t, failpoint.Enable("github.com/pingcap/tidb/pkg/sessionctx/variable/GetReplicaReadUnadjusted", "return(true)"))
 	require.Equal(t, assertReplicaReadScope, provider.GetReadReplicaScope())
+	require.Nil(t, failpoint.Disable("github.com/pingcap/tidb/pkg/sessionctx/variable/GetReplicaReadUnadjusted"))
 
 	txn, err := a.sctx.Txn(false)
 	require.NoError(t, err)

--- a/tests/realtikvtest/txntest/BUILD.bazel
+++ b/tests/realtikvtest/txntest/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "isolation_test.go",
         "main_test.go",
+        "replica_read_test.go",
         "stale_read_test.go",
         "txn_state_test.go",
         "txn_test.go",
@@ -32,6 +33,7 @@ go_test(
         "@com_github_docker_go_units//:go-units",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
+        "@com_github_pingcap_kvproto//pkg/coprocessor",
         "@com_github_pingcap_kvproto//pkg/errorpb",
         "@com_github_pingcap_kvproto//pkg/kvrpcpb",
         "@com_github_stretchr_testify//require",

--- a/tests/realtikvtest/txntest/replica_read_test.go
+++ b/tests/realtikvtest/txntest/replica_read_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txntest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/tikvrpc/interceptor"
+)
+
+func TestReplicaReadEffectScope(t *testing.T) {
+	defer config.RestoreFunc()()
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Performance.EnableAsyncBatchGet = false
+	})
+
+	testCases := []struct {
+		name        string
+		sql         string
+		replicaRead bool
+	}{
+		{
+			"select can use replica read",
+			"SELECT * FROM t WHERE %s",
+			true,
+		},
+		{
+			"select for update can't use replica read",
+			"SELECT * FROM t WHERE %s FOR UPDATE",
+			false,
+		},
+		{
+			"select for share can't use replica read",
+			"SELECT * FROM t WHERE %s FOR SHARE",
+			false,
+		},
+		{
+			"update can't use replica read",
+			"UPDATE t SET v = v + 1 WHERE %s",
+			false,
+		},
+		{
+			"delete can't use replica read",
+			"DELETE FROM t WHERE %s",
+			false,
+		},
+		{
+			"insert can't use replica read",
+			"INSERT INTO t SELECT id + 100, v + 100 FROM t WHERE %s",
+			false,
+		},
+		{
+			"replace can't use replica read",
+			"REPLACE INTO t SELECT id, v + 100 FROM t WHERE %s",
+			false,
+		},
+	}
+
+	conds := []string{
+		"id = 1",       // point get
+		"id IN (1, 2)", // batch get
+		"id > 1",       // coprocessor
+	}
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (id int primary key, v int)")
+	tk.MustExec("set session tidb_replica_read = 'follower'")
+	tk.MustExec("set session tidb_enable_noop_functions='on'")
+	for _, testCase := range testCases {
+		for _, cond := range conds {
+			t.Run(fmt.Sprintf("%s(%s)", testCase.name, cond), func(t *testing.T) {
+				interceptorCtx := interceptor.WithRPCInterceptor(context.Background(), interceptor.NewRPCInterceptor(testCase.name, func(next interceptor.RPCInterceptorFunc) interceptor.RPCInterceptorFunc {
+					return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+						tikvrpc.AttachContext(req, req.Context)
+						switch req.Req.(type) {
+						case *kvrpcpb.GetRequest, *kvrpcpb.BatchGetRequest, *coprocessor.Request:
+							replicaRead := req.Context.GetReplicaRead()
+							require.Equal(t, replicaRead, testCase.replicaRead)
+						default:
+						}
+						return next(target, req)
+					}
+				}))
+
+				tk.MustExec("delete from t")
+				tk.MustExec("insert into t values (1, 10), (2, 20), (3, 30)")
+
+				sql := fmt.Sprintf(testCase.sql, cond)
+				tk.MustExec("begin pessimistic")
+				if strings.HasPrefix(sql, "SELECT") {
+					tk.MustQueryWithContext(interceptorCtx, sql)
+				} else {
+					tk.MustExecWithContext(interceptorCtx, sql)
+				}
+				tk.MustExec("rollback")
+				if strings.HasPrefix(sql, "SELECT") {
+					tk.MustQueryWithContext(interceptorCtx, sql)
+				} else {
+					tk.MustExecWithContext(interceptorCtx, sql)
+				}
+			})
+		}
+	}
+}

--- a/tests/realtikvtest/txntest/replica_read_test.go
+++ b/tests/realtikvtest/txntest/replica_read_test.go
@@ -76,6 +76,11 @@ func TestReplicaReadEffectScope(t *testing.T) {
 			false,
 		},
 		{
+			"insert on duplicate key update can't use replica read",
+			"INSERT INTO t SELECT id + 100, v + 100 FROM t WHERE %s ON DUPLICATE KEY UPDATE v = VALUES(v)",
+			false,
+		},
+		{
 			"replace can't use replica read",
 			"REPLACE INTO t SELECT id, v + 100 FROM t WHERE %s",
 			false,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62856

Problem Summary:

### What changed and how does it work?

For the follower read function, DML is neither an optimization target nor a benefit one. Letting the reading phase of DML be affected by follower read only increases risk. This PR makes follower read no longer apply to DML, thereby reducing the risk of functionality overlap.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Run range update with `tidb_replica_read="closest-replicas"`.

<img width="1121" height="270" alt="image" src="https://github.com/user-attachments/assets/e89bfee4-862d-4c64-9ef1-637617ba3ec1" />


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Replica read only works for read-only statements.
```
