### PR TITLE
fix: make cgroup run happy on mac

### DIFF
--- a/pkg/util/cgroup/cgroup_memory_unsupport.go
+++ b/pkg/util/cgroup/cgroup_memory_unsupport.go
@@ -16,6 +16,18 @@
 
 package cgroup
 
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+)
+
 // GetMemoryLimit returns the memory limit for the current process.
 // This is Linux-specific and not supported on the current OS.
 func GetMemoryLimit() (limit uint64, err error) {
@@ -38,4 +50,176 @@ func GetMemoryUsage() (usage uint64, err error) {
 // This is Linux-specific and not supported on the current OS.
 func GetMemoryInactiveFileUsage() (usage uint64, err error) {
 	return 0, nil
+}
+
+// getCgroupMemUsage is used by tests but not supported on non-Linux platforms.
+func getCgroupMemUsage(root string) (usage uint64, err error) {
+	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "memory")
+	if err != nil {
+		return 0, err
+	}
+
+	if path == "" {
+		log.Warn("no cgroup memory controller detected")
+		return 0, nil
+	}
+
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "memory")
+	if err != nil {
+		return 0, err
+	}
+
+	if len(ver) == 2 {
+		usage, err = detectMemUsageInV1(filepath.Join(root, mount[0]))
+		if err != nil {
+			usage, err = detectMemUsageInV2(filepath.Join(root, mount[0], path))
+		}
+	} else {
+		switch ver[0] {
+		case 1:
+			// cgroupv1
+			usage, err = detectMemUsageInV1(filepath.Join(root, mount[0]))
+		case 2:
+			// cgroupv2
+			usage, err = detectMemUsageInV2(filepath.Join(root, mount[0], path))
+		default:
+			usage, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+		}
+	}
+
+	return usage, err
+}
+
+// getCgroupMemInactiveFileUsage is used by tests but not supported on non-Linux platforms.
+func getCgroupMemInactiveFileUsage(root string) (usage uint64, err error) {
+	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "memory")
+	if err != nil {
+		return 0, err
+	}
+
+	if path == "" {
+		log.Warn("no cgroup memory controller detected")
+		return 0, nil
+	}
+
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "memory")
+	if err != nil {
+		return 0, err
+	}
+
+	if len(ver) == 2 {
+		usage, err = detectMemInactiveFileInV1(filepath.Join(root, mount[0]))
+		if err != nil {
+			usage, err = detectMemInactiveFileInV2(filepath.Join(root, mount[0], path))
+		}
+	} else {
+		switch ver[0] {
+		case 1:
+			// cgroupv1
+			usage, err = detectMemInactiveFileInV1(filepath.Join(root, mount[0]))
+		case 2:
+			// cgroupv2
+			usage, err = detectMemInactiveFileInV2(filepath.Join(root, mount[0], path))
+		default:
+			usage, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+		}
+	}
+
+	return usage, err
+}
+
+// getCgroupMemLimit is used by tests but not supported on non-Linux platforms.
+func getCgroupMemLimit(root string) (limit uint64, version Version, err error) {
+	version = Unknown
+	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "memory")
+	if err != nil {
+		return 0, version, err
+	}
+
+	if path == "" {
+		log.Warn("no cgroup memory controller detected")
+		return 0, version, nil
+	}
+
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "memory")
+	if err != nil {
+		return 0, version, err
+	}
+
+	if len(ver) == 2 {
+		limit, version, err = detectMemLimitInV1(filepath.Join(root, mount[0]))
+		if err != nil {
+			limit, version, err = detectMemLimitInV2(filepath.Join(root, mount[0], path))
+		}
+	} else {
+		switch ver[0] {
+		case 1:
+			// cgroupv1
+			limit, version, err = detectMemLimitInV1(filepath.Join(root, mount[0]))
+		case 2:
+			// cgroupv2
+			limit, version, err = detectMemLimitInV2(filepath.Join(root, mount[0], path))
+		default:
+			limit, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+		}
+	}
+
+	return limit, version, err
+}
+
+// Mock implementations for testing - these functions are only available on Linux
+func detectMemUsageInV1(cRoot string) (usage uint64, err error) {
+	return readInt64Value(cRoot, cgroupV1MemUsage, 1)
+}
+
+func detectMemUsageInV2(cRoot string) (usage uint64, err error) {
+	return readInt64Value(cRoot, cgroupV2MemUsage, 2)
+}
+
+func detectMemLimitInV1(cRoot string) (limit uint64, version Version, err error) {
+	limit, err = detectMemStatValue(cRoot, cgroupV1MemStat, cgroupV1MemLimitStatKey, 1)
+	return limit, V1, err
+}
+
+func detectMemLimitInV2(cRoot string) (limit uint64, version Version, err error) {
+	limit, err = readInt64Value(cRoot, cgroupV2MemLimit, 2)
+	return limit, V2, err
+}
+
+func detectMemInactiveFileInV1(root string) (uint64, error) {
+	return detectMemStatValue(root, cgroupV1MemStat, cgroupV1MemInactiveFileUsageStatKey, 1)
+}
+
+func detectMemInactiveFileInV2(root string) (uint64, error) {
+	return detectMemStatValue(root, cgroupV2MemStat, cgroupV2MemInactiveFileUsageStatKey, 2)
+}
+
+func detectMemStatValue(cRoot, filename, key string, cgVersion int) (value uint64, err error) {
+	statFilePath := filepath.Join(cRoot, filename)
+	//nolint:gosec
+	stat, err := os.Open(statFilePath)
+	if err != nil {
+		return 0, errors.Wrapf(err, "can't read file %s from cgroup v%d", filename, cgVersion)
+	}
+	defer func() {
+		_ = stat.Close()
+	}()
+
+	scanner := bufio.NewScanner(stat)
+	for scanner.Scan() {
+		fields := bytes.Fields(scanner.Bytes())
+		if len(fields) != 2 || string(fields[0]) != key {
+			continue
+		}
+
+		trimmed := string(bytes.TrimSpace(fields[1]))
+		value, err = strconv.ParseUint(trimmed, 10, 64)
+		if err != nil {
+			return 0, errors.Wrapf(err, "can't read %q memory stat from cgroup v%d in %s", key, cgVersion, filename)
+		}
+
+		return value, nil
+	}
+
+	return 0, fmt.Errorf("failed to find expected memory stat %q for cgroup v%d in %s", key, cgVersion, filename)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

There no such function like `getCgroupMemLimit` on cgroup_memory_unsupport for now
so go test on mac will always fail

This patch mock this function and fix it.



Issue Number: ref #62782

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
