### PR TITLE
mdl: move the set variable check of nextgen from variable pkg to planner

### DIFF
--- a/pkg/sessionctx/vardef/BUILD.bazel
+++ b/pkg/sessionctx/vardef/BUILD.bazel
@@ -25,7 +25,10 @@ go_library(
 go_test(
     name = "vardef_test",
     timeout = "short",
-    srcs = ["tidb_vars_test.go"],
+    srcs = [
+        "runtime_test.go",
+        "tidb_vars_test.go",
+    ],
     embed = [":vardef"],
     flaky = True,
     deps = [

--- a/pkg/sessionctx/vardef/runtime.go
+++ b/pkg/sessionctx/vardef/runtime.go
@@ -15,6 +15,7 @@
 package vardef
 
 import (
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -62,4 +63,14 @@ func SetPlanReplayerGCLease(lease time.Duration) {
 // GetPlanReplayerGCLease returns the plan replayer gc lease time.
 func GetPlanReplayerGCLease() time.Duration {
 	return time.Duration(atomic.LoadInt64(&planReplayerGCLease))
+}
+
+// IsReadOnlyVarInNextGen checks if the variable is read-only in the nextgen.
+func IsReadOnlyVarInNextGen(name string) bool {
+	name = strings.ToLower(name)
+	switch name {
+	case TiDBEnableMDL:
+		return true
+	}
+	return false
 }

--- a/pkg/sessionctx/vardef/runtime_test.go
+++ b/pkg/sessionctx/vardef/runtime_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vardef
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReadOnlyVarInNextGen(t *testing.T) {
+	if kerneltype.IsClassic() {
+		t.Skip("This test is only for next-gen TiDB")
+	}
+	require.False(t, IsReadOnlyVarInNextGen("abc"))
+	require.True(t, IsReadOnlyVarInNextGen(TiDBEnableMDL))
+	require.True(t, IsReadOnlyVarInNextGen("TIDB_ENABLE_METADATA_LOCK"))
+}

--- a/pkg/sessionctx/variable/error.go
+++ b/pkg/sessionctx/variable/error.go
@@ -38,7 +38,7 @@ var (
 	errGlobalVariable              = dbterror.ClassVariable.NewStd(mysql.ErrGlobalVariable)
 	errLocalVariable               = dbterror.ClassVariable.NewStd(mysql.ErrLocalVariable)
 	errValueNotSupportedWhen       = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("%s = OFF is not supported when %s = ON", nil))
-	errNotSupportedInNextGen       = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("%s is not supported in the next generation of TiDB", nil))
+	ErrNotSupportedInNextGen       = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("%s is not supported in the next generation of TiDB", nil))
 	ErrNotValidPassword            = dbterror.ClassExecutor.NewStd(mysql.ErrNotValidPassword)
 	// ErrFunctionsNoopImpl is an error to say the behavior is protected by the tidb_enable_noop_functions sysvar.
 	// This is copied from expression.ErrFunctionsNoopImpl to prevent circular dependencies.

--- a/pkg/sessionctx/variable/nextgen_test.go
+++ b/pkg/sessionctx/variable/nextgen_test.go
@@ -35,7 +35,7 @@ func TestTiDBPessimisticTransactionFairLocking(t *testing.T) {
 
 	val, err = sv.Validate(vars, "on", vardef.ScopeSession)
 	require.Error(t, err)
-	require.True(t, errNotSupportedInNextGen.Equal(err))
+	require.True(t, ErrNotSupportedInNextGen.Equal(err))
 	require.Equal(t, vardef.Off, val)
 	require.Nil(t, sv.SetSessionFromHook(vars, val))
 	require.False(t, vars.PessimisticTransactionFairLocking)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1492,9 +1492,6 @@ var defaultSysVars = []*SysVar{
 		},
 	},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBEnableMDL, Value: BoolToOnOff(vardef.DefTiDBEnableMDL), Type: vardef.TypeBool, SetGlobal: func(_ context.Context, vars *SessionVars, val string) error {
-		if kerneltype.IsNextGen() {
-			return errNotSupportedInNextGen.FastGenByArgs(fmt.Sprintf("setting %s", vardef.TiDBEnableMDL))
-		}
 		if vardef.IsMDLEnabled() != TiDBOptOn(val) {
 			err := SwitchMDL(TiDBOptOn(val))
 			if err != nil {
@@ -3080,7 +3077,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBPessimisticTransactionFairLocking, Value: BoolToOnOff(vardef.DefTiDBPessimisticTransactionFairLocking), Type: vardef.TypeBool,
 		Validation: func(_ *SessionVars, val string, _ string, _ vardef.ScopeFlag) (string, error) {
 			if kerneltype.IsNextGen() && TiDBOptOn(val) {
-				return vardef.Off, errNotSupportedInNextGen.FastGenByArgs(vardef.TiDBPessimisticTransactionFairLocking)
+				return vardef.Off, ErrNotSupportedInNextGen.FastGenByArgs(vardef.TiDBPessimisticTransactionFairLocking)
 			}
 			return val, nil
 		},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
in https://github.com/pingcap/tidb/pull/62865, we forbid setting enableMDL var, but I didn't notice that `Domain.rebuildSysVarCache` will call `SetGlobal` directly, which will cause logging of the error `setting tidb_enable_metadata_lock is not supported in the next generation of TiDB`, although there is no harm, it's not expected, so we move the check to planner of `set statement`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test, **existing test `TestSetMDLInNextGen` also work**
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

run nextgen TiDB, there is no log like `setting tidb_enable_metadata_lock is not supported in the next generation of TiDB`
```
mysql> set global tidb_enable_metadata_lock=1;
ERROR 1235 (42000): setting tidb_enable_metadata_lock is not supported in the next generation of TiDB
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
