### PR TITLE
stats: avoid creating pseudo stats table when dumping stats delta 

### DIFF
--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -697,7 +697,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		// If this column is not analyzed yet and we don't have it in memory.
 		// We create a fake one for the pseudo estimation.
 		// Otherwise, it will trigger the sync/async load again, even if the column has not been analyzed.
-		if loadNeeded {
+		if loadNeeded && !analyzed {
 			fakeCol := statistics.EmptyColumn(tblInfo.ID, tblInfo.PKIsHandle, colInfo)
 			statsTbl = statsTbl.Copy()
 			statsTbl.SetCol(col.ID, fakeCol)

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -697,7 +697,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		// If this column is not analyzed yet and we don't have it in memory.
 		// We create a fake one for the pseudo estimation.
 		// Otherwise, it will trigger the sync/async load again, even if the column has not been analyzed.
-		if loadNeeded && !analyzed {
+		if loadNeeded {
 			fakeCol := statistics.EmptyColumn(tblInfo.ID, tblInfo.PKIsHandle, colInfo)
 			statsTbl = statsTbl.Copy()
 			statsTbl.SetCol(col.ID, fakeCol)

--- a/pkg/statistics/handle/types/interfaces.go
+++ b/pkg/statistics/handle/types/interfaces.go
@@ -516,10 +516,6 @@ type StatsHandle interface {
 	// Note: this function may return nil if the table is not found in the cache.
 	GetNonPseudoPhysicalTableStats(physicalTableID int64) (*statistics.Table, bool)
 
-	// GetPartitionStatsByID retrieves the partition stats from cache by partition ID.
-	// TODO: remove this function and use GetPhysicalTableStats instead.
-	GetPartitionStatsByID(is infoschema.InfoSchema, pid int64) *statistics.Table
-
 	// StatsGC is used to do the GC job.
 	StatsGC
 

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -73,8 +73,10 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 		// Dump the stats to kv at least once 5 minutes.
 		return true
 	}
-	statsTbl := s.statsHandle.GetPartitionStatsByID(is, id)
-	if statsTbl == nil || statsTbl.Pseudo || statsTbl.RealtimeCount == 0 || float64(item.Count)/float64(statsTbl.RealtimeCount) > DumpStatsDeltaRatio {
+	// use GetNonPseudoPhysicalTableStats to avoid creating pseudo tables and dropping instantly
+	statsTable, ok := s.statsHandle.GetNonPseudoPhysicalTableStats(id)
+	if !ok || statsTable.RealtimeCount == 0 ||
+		float64(item.Count)/float64(statsTable.RealtimeCount) > DumpStatsDeltaRatio {
 		// Dump the stats when there are many modifications.
 		return true
 	}

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -74,8 +74,8 @@ func (s *statsUsageImpl) needDumpStatsDelta(is infoschema.InfoSchema, dumpAll bo
 		return true
 	}
 	// use GetNonPseudoPhysicalTableStats to avoid creating pseudo tables and dropping instantly
-	statsTable, ok := s.statsHandle.GetNonPseudoPhysicalTableStats(id)
-	if !ok || statsTable.RealtimeCount == 0 ||
+	statsTable, found := s.statsHandle.GetNonPseudoPhysicalTableStats(id)
+	if !found || statsTable == nil || statsTable.RealtimeCount == 0 ||
 		float64(item.Count)/float64(statsTable.RealtimeCount) > DumpStatsDeltaRatio {
 		// Dump the stats when there are many modifications.
 		return true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62590

Problem Summary:

based on issue reproduction and memory analysis , the majority of memory waste comes from creating pseudo stats table when doing needDumpStatsDelta check, we can simply use a lightweight approach to solve it without changing too much of the code.

This is happening during millions table workload while dumping stats happens frequently, in the issue mentioned smaller table size should also have same effect but I was unable to reproduce, maybe query creates only limited number of pseudo stats and quickly got GC, whereas dump stats happened for all tables in a burst, causing memory pressure.   
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
