### PR TITLE
globalsort: use partitioned prefix to store intermediate files

### DIFF
--- a/br/pkg/storage/memstore.go
+++ b/br/pkg/storage/memstore.go
@@ -69,9 +69,6 @@ func (s *MemStorage) DeleteFile(ctx context.Context, name string) error {
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
 	if _, ok := s.dataStore[name]; !ok {
@@ -102,9 +99,6 @@ func (s *MemStorage) WriteFile(ctx context.Context, name string, data []byte) er
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	fileData := slices.Clone(data)
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
@@ -128,9 +122,6 @@ func (s *MemStorage) ReadFile(ctx context.Context, name string) ([]byte, error) 
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return nil, errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	theFile, ok := s.loadMap(name)
 	if !ok {
 		return nil, errors.Errorf("cannot find the file: %s", name)
@@ -148,9 +139,6 @@ func (s *MemStorage) FileExists(ctx context.Context, name string) (bool, error) 
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return false, errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	_, ok := s.loadMap(name)
 	return ok, nil
 }
@@ -160,9 +148,6 @@ func (s *MemStorage) FileExists(ctx context.Context, name string) (bool, error) 
 func (s *MemStorage) Open(ctx context.Context, filePath string, o *ReaderOption) (ExternalFileReader, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, errors.Trace(err)
-	}
-	if !path.IsAbs(filePath) {
-		return nil, errors.Errorf("file name is not an absolute path: %s", filePath)
 	}
 	theFile, ok := s.loadMap(filePath)
 	if !ok {
@@ -248,9 +233,6 @@ func (s *MemStorage) Create(ctx context.Context, name string, _ *WriterOption) (
 	default:
 		// continue on
 	}
-	if !path.IsAbs(name) {
-		return nil, errors.Errorf("file name is not an absolute path: %s", name)
-	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()
 	theFile := new(memFile)
@@ -268,9 +250,6 @@ func (s *MemStorage) Rename(ctx context.Context, oldFileName, newFileName string
 		return ctx.Err()
 	default:
 		// continue on
-	}
-	if !path.IsAbs(newFileName) {
-		return errors.Errorf("new file name is not an absolute path: %s", newFileName)
 	}
 	s.rwm.Lock()
 	defer s.rwm.Unlock()

--- a/pkg/disttask/importinto/planner_test.go
+++ b/pkg/disttask/importinto/planner_test.go
@@ -319,11 +319,6 @@ func TestGetSortedKVMetas(t *testing.T) {
 	require.Equal(t, []byte("i1_2_c"), allKVMetas["1"].EndKey)
 }
 
-func writeAndGetFiles(t *testing.T, writer *external.Writer, keys [][]byte, values [][]byte) (
-	dataFiles []string, statsFiles []string) {
-	return
-}
-
 func TestSplitForOneSubtask(t *testing.T) {
 	ctx := context.Background()
 	workDir := t.TempDir()

--- a/pkg/disttask/importinto/planner_test.go
+++ b/pkg/disttask/importinto/planner_test.go
@@ -319,6 +319,11 @@ func TestGetSortedKVMetas(t *testing.T) {
 	require.Equal(t, []byte("i1_2_c"), allKVMetas["1"].EndKey)
 }
 
+func writeAndGetFiles(t *testing.T, writer *external.Writer, keys [][]byte, values [][]byte) (
+	dataFiles []string, statsFiles []string) {
+	return
+}
+
 func TestSplitForOneSubtask(t *testing.T) {
 	ctx := context.Background()
 	workDir := t.TempDir()
@@ -344,9 +349,11 @@ func TestSplitForOneSubtask(t *testing.T) {
 			multiFileStat = s.MultipleFilesStats
 		}).
 		Build(store, "/mock-test", "0")
-	_, _, err = external.MockExternalEngineWithWriter(
-		store, writer, "/mock-test", keys, values,
-	)
+	for i := range keys {
+		err := writer.WriteRow(ctx, keys[i], values[i], nil)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close(ctx))
 	require.NoError(t, err)
 	kvMeta := &external.SortedKVMeta{
 		StartKey:           keys[0],

--- a/pkg/executor/test/indexmergereadtest/BUILD.bazel
+++ b/pkg/executor/test/indexmergereadtest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "indexmergereadtest_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "index_merge_reader_test.go",
         "main_test.go",

--- a/pkg/lightning/backend/external/bench_test.go
+++ b/pkg/lightning/backend/external/bench_test.go
@@ -15,12 +15,14 @@
 package external
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	goerrors "errors"
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,11 +90,9 @@ func writePlainFile(s *writeTestSuite) {
 }
 
 func cleanOldFiles(ctx context.Context, store storage.ExternalStorage, subDir string) {
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, subDir)
+	filenames, err := GetAllFileNames(ctx, store, subDir)
 	intest.AssertNoError(err)
-	err = store.DeleteFiles(ctx, dataFiles)
-	intest.AssertNoError(err)
-	err = store.DeleteFiles(ctx, statFiles)
+	err = store.DeleteFiles(ctx, filenames)
 	intest.AssertNoError(err)
 }
 
@@ -249,7 +249,7 @@ type readTestSuite struct {
 
 func readFileSequential(t *testing.T, s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
+	files, _, err := getKVAndStatFilesByScan(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
 
 	buf := make([]byte, s.memoryLimit)
@@ -285,9 +285,32 @@ func readFileSequential(t *testing.T, s *readTestSuite) {
 	)
 }
 
+func getKVAndStatFilesByScan(ctx context.Context,
+	store storage.ExternalStorage,
+	nonPartitionedDir string,
+) ([]string, []string, error) {
+	names, err := GetAllFileNames(ctx, store, nonPartitionedDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	var data, stats []string
+	for _, path := range names {
+		bs := []byte(path)
+		lastIdx := bytes.LastIndexByte(bs, '/')
+		secondLastIdx := bytes.LastIndexByte(bs[:lastIdx], '/')
+		parentDir := path[secondLastIdx+1 : lastIdx]
+		if strings.HasSuffix(parentDir, statSuffix) {
+			stats = append(stats, path)
+		} else {
+			data = append(data, path)
+		}
+	}
+	return data, stats, nil
+}
+
 func readFileConcurrently(t *testing.T, s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
+	files, _, err := getKVAndStatFilesByScan(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
 
 	conc := min(s.concurrency, len(files))
@@ -336,7 +359,7 @@ func readFileConcurrently(t *testing.T, s *readTestSuite) {
 
 func readMergeIter(t *testing.T, s *readTestSuite) {
 	ctx := context.Background()
-	files, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
+	files, _, err := getKVAndStatFilesByScan(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
 
 	if s.beforeCreateReader != nil {
@@ -484,7 +507,7 @@ type mergeTestSuite struct {
 
 func mergeStep(t *testing.T, s *mergeTestSuite) {
 	ctx := context.Background()
-	datas, _, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
+	datas, _, err := getKVAndStatFilesByScan(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
 
 	mergeOutput := "merge_output"
@@ -527,7 +550,7 @@ func mergeStep(t *testing.T, s *mergeTestSuite) {
 
 func newMergeStep(t *testing.T, s *mergeTestSuite) {
 	ctx := context.Background()
-	datas, stats, err := GetAllFileNames(ctx, s.store, "/"+s.subDir)
+	datas, stats, err := getKVAndStatFilesByScan(ctx, s.store, "/"+s.subDir)
 	intest.AssertNoError(err)
 
 	mergeOutput := "merge_output"
@@ -647,7 +670,7 @@ func TestReadAllDataLargeFiles(t *testing.T) {
 	writeExternalOneFile(suite2)
 	t.Logf("minKey: %s, maxKey: %s", minKey, maxKey)
 
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, "")
+	dataFiles, statFiles, err := getKVAndStatFilesByScan(ctx, store, "")
 	intest.AssertNoError(err)
 	intest.Assert(len(dataFiles) == 2)
 
@@ -800,7 +823,7 @@ func TestReadAllData(t *testing.T) {
 
 finishCreateFiles:
 
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, "/")
+	dataFiles, statFiles, err := getKVAndStatFilesByScan(ctx, store, "/")
 	require.NoError(t, err)
 	require.Equal(t, 2091, len(dataFiles))
 

--- a/pkg/lightning/backend/external/byte_reader_test.go
+++ b/pkg/lightning/backend/external/byte_reader_test.go
@@ -214,10 +214,12 @@ func TestSwitchMode(t *testing.T) {
 	t.Logf("seed: %d", seed)
 	st := storage.NewMemStorage()
 	// Prepare
+	var kvAndStat [2]string
 	ctx := context.Background()
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(st, "/test", "0")
 
 	writer.InitPartSizeAndLogger(ctx, 5*1024*1024)
@@ -244,9 +246,9 @@ func TestSwitchMode(t *testing.T) {
 	require.NoError(t, err)
 	pool := membuf.NewPool()
 	ConcurrentReaderBufferSizePerConc = rand.Intn(100) + 1
-	kvReader, err := NewKVReader(context.Background(), "/test/0/one-file", st, 0, 64*1024)
+	kvReader, err := NewKVReader(context.Background(), kvAndStat[0], st, 0, 64*1024)
 	require.NoError(t, err)
-	kvReader.byteReader.enableConcurrentRead(st, "/test/0/one-file", 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())
+	kvReader.byteReader.enableConcurrentRead(st, kvAndStat[0], 100, ConcurrentReaderBufferSizePerConc, pool.NewBuffer())
 	modeUseCon := false
 	i := 0
 	for {

--- a/pkg/lightning/backend/external/iter_test.go
+++ b/pkg/lightning/backend/external/iter_test.go
@@ -305,7 +305,7 @@ func testMergeIterSwitchMode(t *testing.T, f func([]byte, int) []byte) {
 	err := writer.Close(context.Background())
 	require.NoError(t, err)
 
-	dataNames, _, err := GetAllFileNames(context.Background(), st, "")
+	dataNames, _, err := getKVAndStatFilesByScan(context.Background(), st, "testprefix")
 	require.NoError(t, err)
 
 	offsets := make([]uint64, len(dataNames))

--- a/pkg/lightning/backend/external/onefile_writer.go
+++ b/pkg/lightning/backend/external/onefile_writer.go
@@ -17,6 +17,7 @@ package external
 import (
 	"context"
 	"encoding/binary"
+	"math/rand"
 	"path/filepath"
 	"slices"
 	"time"
@@ -62,6 +63,7 @@ type OneFileWriter struct {
 	// file information.
 	writerID       string
 	filenamePrefix string
+	rnd            *rand.Rand
 	dataFile       string
 	statFile       string
 	dataWriter     storage.ExternalFileWriter
@@ -97,14 +99,14 @@ func (w *OneFileWriter) lazyInitWriter(ctx context.Context) (err error) {
 		return nil
 	}
 
-	dataFile := filepath.Join(w.filenamePrefix, "one-file")
+	dataFile := filepath.Join(w.getPartitionedPrefix(), "one-file")
 	dataWriter, err := w.store.Create(ctx, dataFile, &storage.WriterOption{
 		Concurrency: maxUploadWorkersPerThread,
 		PartSize:    w.partSize})
 	if err != nil {
 		return err
 	}
-	statFile := filepath.Join(w.filenamePrefix+statSuffix, "one-file")
+	statFile := filepath.Join(w.getPartitionedPrefix()+statSuffix, "one-file")
 	statWriter, err := w.store.Create(ctx, statFile, &storage.WriterOption{
 		Concurrency: maxUploadWorkersPerThread,
 		PartSize:    MinUploadPartSize})
@@ -127,7 +129,7 @@ func (w *OneFileWriter) lazyInitDupFile(ctx context.Context) error {
 		return nil
 	}
 
-	dupFile := filepath.Join(w.filenamePrefix+dupSuffix, "one-file")
+	dupFile := filepath.Join(w.getPartitionedPrefix()+dupSuffix, "one-file")
 	dupWriter, err := w.store.Create(ctx, dupFile, &storage.WriterOption{
 		// too many duplicates will cause duplicate resolution part very slow,
 		// we temporarily use 1 as we don't expect too many duplicates, if there
@@ -345,6 +347,10 @@ func (w *OneFileWriter) closeImpl(ctx context.Context) (err error) {
 		}
 	}
 	return nil
+}
+
+func (w *OneFileWriter) getPartitionedPrefix() string {
+	return randPartitionedPrefix(w.filenamePrefix, w.rnd)
 }
 
 // caller should make sure the buf is large enough to hold the encoded data.

--- a/pkg/lightning/backend/external/onefile_writer_test.go
+++ b/pkg/lightning/backend/external/onefile_writer_test.go
@@ -46,9 +46,11 @@ func TestOnefileWriterBasic(t *testing.T) {
 	// 1. write into one file.
 	// 2. read kv file and check result.
 	// 3. read stat file and check result.
+	var kvAndStat [2]string
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/test", "0")
 
 	writer.InitPartSizeAndLogger(ctx, 5*1024*1024)
@@ -73,7 +75,7 @@ func TestOnefileWriterBasic(t *testing.T) {
 	require.NoError(t, writer.Close(ctx))
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/test/0/one-file", memStore, 0, bufSize)
+	kvReader, err := NewKVReader(ctx, kvAndStat[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := range kvCnt {
 		key, value, err := kvReader.nextKV()
@@ -85,7 +87,7 @@ func TestOnefileWriterBasic(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 	require.NoError(t, kvReader.Close())
 
-	statReader, err := newStatsReader(ctx, memStore, "/test/0_stat/one-file", bufSize)
+	statReader, err := newStatsReader(ctx, memStore, kvAndStat[1], bufSize)
 	require.NoError(t, err)
 
 	var keyCnt uint64 = 0
@@ -109,17 +111,21 @@ func TestOnefileWriterStat(t *testing.T) {
 	// 3. read stat file and check result.
 	for _, kvCnt := range kvCntArr {
 		for _, distance := range distanceCntArr {
-			checkOneFileWriterStatWithDistance(t, kvCnt, distance, DefaultMemSizeLimit, "test"+strconv.Itoa(int(distance)))
+			t.Run(fmt.Sprintf("kvCnt=%d, distance=%d", kvCnt, distance), func(t *testing.T) {
+				checkOneFileWriterStatWithDistance(t, kvCnt, distance, DefaultMemSizeLimit, "test"+strconv.Itoa(int(distance)))
+			})
 		}
 	}
 }
 
 func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance uint64, memSizeLimit uint64, prefix string) {
+	var kvAndStat [2]string
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(keysDistance).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/"+prefix, "0")
 
 	writer.InitPartSizeAndLogger(ctx, 5*1024*1024)
@@ -136,7 +142,7 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 	require.NoError(t, writer.Close(ctx))
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/"+prefix+"/0/one-file", memStore, 0, bufSize)
+	kvReader, err := NewKVReader(ctx, kvAndStat[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := range kvCnt {
 		key, value, err := kvReader.nextKV()
@@ -148,7 +154,7 @@ func checkOneFileWriterStatWithDistance(t *testing.T, kvCnt int, keysDistance ui
 	require.ErrorIs(t, err, io.EOF)
 	require.NoError(t, kvReader.Close())
 
-	statReader, err := newStatsReader(ctx, memStore, "/"+prefix+"/0_stat/one-file", bufSize)
+	statReader, err := newStatsReader(ctx, memStore, kvAndStat[1], bufSize)
 	require.NoError(t, err)
 
 	var keyCnt uint64 = 0
@@ -178,10 +184,12 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 	// 2. merge 3 files into one file.
 	// 3. read one file and check result.
 	// 4. check duplicate key.
+	var kvAndStats [][2]string
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(1000).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStats = summary.MultipleFilesStats[0].Filenames }).
 		Build(memStore, "/test", "0")
 
 	kvCount := 2000000
@@ -207,15 +215,20 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 
 	collector := &execute.TestCollector{}
 
+	dataFiles := make([]string, 0, len(kvAndStats))
+	for _, f := range kvAndStats {
+		dataFiles = append(dataFiles, f[0])
+	}
+	var onefile [2]string
 	require.NoError(t, mergeOverlappingFilesInternal(
 		ctx,
-		[]string{"/test/0/0", "/test/0/1", "/test/0/2"},
+		dataFiles,
 		memStore,
 		int64(5*size.MB),
 		"/test2",
 		"mergeID",
 		1000,
-		nil,
+		func(summary *WriterSummary) { onefile = summary.MultipleFilesStats[0].Filenames[0] },
 		collector,
 		true,
 		engineapi.OnDuplicateKeyIgnore,
@@ -226,7 +239,7 @@ func TestMergeOverlappingFilesInternal(t *testing.T) {
 
 	kvs := make([]kvPair, 0, kvCount)
 
-	kvReader, err := NewKVReader(ctx, "/test2/mergeID/one-file", memStore, 0, 100)
+	kvReader, err := NewKVReader(ctx, onefile[0], memStore, 0, 100)
 	require.NoError(t, err)
 	for range kvCount {
 		key, value, err := kvReader.nextKV()
@@ -261,10 +274,12 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	// 2. merge one file.
 	// 3. read kv file and check the result.
 	// 4. check the writeSummary.
+	var kvAndStat [2]string
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(1000).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/test", "0")
 
 	writer.InitPartSizeAndLogger(ctx, 5*1024*1024)
@@ -309,7 +324,7 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	defaultOneWriterMemSizeLimit = 1000
 	require.NoError(t, mergeOverlappingFilesInternal(
 		ctx,
-		[]string{"/test/0/one-file"},
+		[]string{kvAndStat[0]},
 		memStore,
 		int64(5*size.MB),
 		"/test2",
@@ -322,7 +337,8 @@ func TestOnefileWriterManyRows(t *testing.T) {
 	))
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/test2/mergeID/one-file", memStore, 0, bufSize)
+	kvAndStat2 := resSummary.MultipleFilesStats[0].Filenames[0]
+	kvReader, err := NewKVReader(ctx, kvAndStat2[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := range kvCnt {
 		key, value, err := kvReader.nextKV()
@@ -336,11 +352,9 @@ func TestOnefileWriterManyRows(t *testing.T) {
 
 	// check writerSummary.
 	expected := MultipleFilesStat{
-		MinKey: kvs[0].Key,
-		MaxKey: kvs[len(kvs)-1].Key,
-		Filenames: [][2]string{
-			{"/test2/mergeID/one-file", "/test2/mergeID_stat/one-file"},
-		},
+		MinKey:            kvs[0].Key,
+		MaxKey:            kvs[len(kvs)-1].Key,
+		Filenames:         [][2]string{kvAndStat2},
 		MaxOverlappingNum: 1,
 	}
 	require.EqualValues(t, expected.MinKey, resSummary.Min)
@@ -361,11 +375,13 @@ func TestOnefilePropOffset(t *testing.T) {
 
 	// 1. write into one file.
 	// 2. read stat file and check offset ascending.
+	var kvAndStat [2]string
 	writer := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
 		SetBlockSize(memSizeLimit).
 		SetMemorySizeLimit(uint64(memSizeLimit)).
+		SetOnCloseFunc(func(summary *WriterSummary) { kvAndStat = summary.MultipleFilesStats[0].Filenames[0] }).
 		BuildOneFile(memStore, "/test", "0")
 
 	writer.InitPartSizeAndLogger(ctx, 5*1024*1024)
@@ -389,7 +405,7 @@ func TestOnefilePropOffset(t *testing.T) {
 
 	require.NoError(t, writer.Close(ctx))
 
-	rd, err := newStatsReader(ctx, memStore, "/test/0_stat/one-file", 4096)
+	rd, err := newStatsReader(ctx, memStore, kvAndStat[1], 4096)
 	require.NoError(t, err)
 	lastOffset := uint64(0)
 	for {

--- a/pkg/lightning/backend/external/reader_test.go
+++ b/pkg/lightning/backend/external/reader_test.go
@@ -40,11 +40,13 @@ func TestReadAllDataBasic(t *testing.T) {
 	memStore := storage.NewMemStorage()
 	memSizeLimit := (rand.Intn(10) + 1) * 400
 
+	var summary *WriterSummary
 	w := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
 		SetMemorySizeLimit(uint64(memSizeLimit)).
 		SetBlockSize(memSizeLimit).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, "/test", "0")
 
 	writer := NewEngineWriter(w)
@@ -65,8 +67,7 @@ func TestReadAllDataBasic(t *testing.T) {
 		return bytes.Compare(i.Key, j.Key)
 	})
 
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
-	require.NoError(t, err)
+	datas, stats := getKVAndStatFiles(summary)
 
 	testReadAndCompare(ctx, t, kvs, memStore, datas, stats, kvs[0].Key, memSizeLimit)
 }
@@ -79,10 +80,12 @@ func TestReadAllOneFile(t *testing.T) {
 	memStore := storage.NewMemStorage()
 	memSizeLimit := (rand.Intn(10) + 1) * 400
 
+	var summary *WriterSummary
 	w := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
 		SetMemorySizeLimit(uint64(memSizeLimit)).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		BuildOneFile(memStore, "/test", "0")
 
 	w.InitPartSizeAndLogger(ctx, int64(5*size.MB))
@@ -103,8 +106,7 @@ func TestReadAllOneFile(t *testing.T) {
 		return bytes.Compare(i.Key, j.Key)
 	})
 
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
-	require.NoError(t, err)
+	datas, stats := getKVAndStatFiles(summary)
 
 	testReadAndCompare(ctx, t, kvs, memStore, datas, stats, kvs[0].Key, memSizeLimit)
 }
@@ -118,9 +120,11 @@ func TestReadLargeFile(t *testing.T) {
 	})
 	ConcurrentReaderBufferSizePerConc = 512 * 1024
 
+	var summary *WriterSummary
 	w := NewWriterBuilder().
 		SetPropSizeDistance(128*1024).
 		SetPropKeysDistance(1000).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		BuildOneFile(memStore, "/test", "0")
 
 	w.InitPartSizeAndLogger(ctx, int64(5*size.MB))
@@ -132,8 +136,7 @@ func TestReadLargeFile(t *testing.T) {
 	}
 	require.NoError(t, w.Close(ctx))
 
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
-	require.NoError(t, err)
+	datas, stats := getKVAndStatFiles(summary)
 	require.Len(t, datas, 1)
 
 	failpoint.Enable("github.com/pingcap/tidb/pkg/lightning/backend/external/assertReloadAtMostOnce", "return()")
@@ -151,7 +154,7 @@ func TestReadLargeFile(t *testing.T) {
 	startKey := []byte("key000000")
 	maxKey := []byte("key004998")
 	endKey := []byte("key004999")
-	err = readAllData(ctx, memStore, datas, stats, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
+	err := readAllData(ctx, memStore, datas, stats, startKey, endKey, smallBlockBufPool, largeBlockBufPool, output)
 	require.NoError(t, err)
 	output.build(ctx)
 	require.Equal(t, startKey, output.kvs[0].key)

--- a/pkg/lightning/backend/external/sort_test.go
+++ b/pkg/lightning/backend/external/sort_test.go
@@ -140,7 +140,7 @@ func TestGlobalSortLocalWithMerge(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. merge step
-	datas, stats, err := GetAllFileNames(ctx, memStore, "")
+	datas, stats, err := getKVAndStatFilesByScan(ctx, memStore, "test")
 	require.NoError(t, err)
 
 	dataGroup, _ := splitDataAndStatFiles(datas, stats)

--- a/pkg/lightning/backend/external/split_test.go
+++ b/pkg/lightning/backend/external/split_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -112,19 +113,54 @@ notExhausted:
 	require.NoError(t, splitter.Close())
 }
 
+func writeKVs(t *testing.T, writer *Writer, keys [][]byte, values [][]byte) {
+	ctx := context.Background()
+	for i := range keys {
+		err := writer.WriteRow(ctx, keys[i], values[i], nil)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close(ctx))
+}
+
+func getKVAndStatFiles(sum *WriterSummary) (dataFiles []string, statsFiles []string) {
+	for _, ms := range sum.MultipleFilesStats {
+		for _, f := range ms.Filenames {
+			dataFiles = append(dataFiles, f[0])
+			statsFiles = append(statsFiles, f[1])
+		}
+	}
+	return
+}
+
+func removePartitionPrefix(t *testing.T, in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		bs := []byte(s)
+		idx := bytes.IndexByte(bs, '/')
+		require.GreaterOrEqual(t, idx, 0)
+		require.True(t, isValidPartition(bs[:idx]))
+		// we include / after partition prefix in the out, as all tests have it.
+		out = append(out, s[idx:])
+	}
+	sort.Strings(out)
+	return out
+}
+
 func TestOnlyOneGroup(t *testing.T) {
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 	subDir := "/mock-test"
 
+	var summary *WriterSummary
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(20).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "5")
 
-	dataFiles, statFiles, err := MockExternalEngineWithWriter(memStore, writer, subDir, [][]byte{{1}, {2}}, [][]byte{{1}, {2}})
-	require.NoError(t, err)
+	writeKVs(t, writer, [][]byte{{1}, {2}}, [][]byte{{1}, {2}})
+	dataFiles, statFiles := getKVAndStatFiles(summary)
 	require.Len(t, dataFiles, 1)
 	require.Len(t, statFiles, 1)
 
@@ -199,11 +235,13 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	memStore := storage.NewMemStorage()
 	subDir := "/mock-test"
 
+	var summary *WriterSummary
 	writer1 := NewWriterBuilder().
 		SetMemorySizeLimit(2*(lengthBytes*2+10)).
 		SetBlockSize(2*(lengthBytes*2+10)).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "1")
 	keys1 := [][]byte{
 		[]byte("key01"), []byte("key11"), []byte("key21"),
@@ -211,8 +249,9 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	values1 := [][]byte{
 		[]byte("val01"), []byte("val11"), []byte("val21"),
 	}
-	dataFiles1, statFiles1, err := MockExternalEngineWithWriter(memStore, writer1, subDir, keys1, values1)
-	require.NoError(t, err)
+
+	writeKVs(t, writer1, keys1, values1)
+	dataFiles1, statFiles1 := getKVAndStatFiles(summary)
 	require.Len(t, dataFiles1, 2)
 	require.Len(t, statFiles1, 2)
 
@@ -221,6 +260,7 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 		SetBlockSize(2*(lengthBytes*2+10)).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "2")
 	keys2 := [][]byte{
 		[]byte("key02"), []byte("key12"), []byte("key22"),
@@ -228,16 +268,17 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	values2 := [][]byte{
 		[]byte("val02"), []byte("val12"), []byte("val22"),
 	}
-	dataFiles12, statFiles12, err := MockExternalEngineWithWriter(memStore, writer2, subDir, keys2, values2)
-	require.NoError(t, err)
-	require.Len(t, dataFiles12, 4)
-	require.Len(t, statFiles12, 4)
+	writeKVs(t, writer2, keys2, values2)
+	dataFiles2, statFiles2 := getKVAndStatFiles(summary)
+	require.Len(t, dataFiles2, 2)
+	require.Len(t, statFiles2, 2)
 
 	writer3 := NewWriterBuilder().
 		SetMemorySizeLimit(2*(lengthBytes*2+10)).
 		SetBlockSize(2*(lengthBytes*2+10)).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "3")
 	keys3 := [][]byte{
 		[]byte("key03"), []byte("key13"), []byte("key23"),
@@ -245,23 +286,23 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	values3 := [][]byte{
 		[]byte("val03"), []byte("val13"), []byte("val23"),
 	}
-	dataFiles123, statFiles123, err := MockExternalEngineWithWriter(memStore, writer3, subDir, keys3, values3)
-	require.NoError(t, err)
-	require.Len(t, dataFiles123, 6)
-	require.Len(t, statFiles123, 6)
+	writeKVs(t, writer3, keys3, values3)
+	dataFiles3, statFiles3 := getKVAndStatFiles(summary)
+	require.Len(t, dataFiles3, 2)
+	require.Len(t, statFiles3, 2)
 
 	// "/mock-test/X/0" contains "key0X" and "key1X"
 	// "/mock-test/X/1" contains "key2X"
 	require.Equal(t, []string{
-		"/mock-test/1/0", "/mock-test/1/1",
-		"/mock-test/2/0", "/mock-test/2/1",
 		"/mock-test/3/0", "/mock-test/3/1",
-	}, dataFiles123)
+	}, removePartitionPrefix(t, dataFiles3))
 
-	multi := mockOneMultiFileStat(dataFiles123[:4], statFiles123[:4])
+	dataFiles12 := append(append([]string{}, dataFiles1...), dataFiles2...)
+	statFiles12 := append(append([]string{}, statFiles1...), statFiles2...)
+	multi := mockOneMultiFileStat(dataFiles12, statFiles12)
 	multi[0].MinKey = []byte("key01")
 	multi[0].MaxKey = []byte("key21")
-	multi2 := mockOneMultiFileStat(dataFiles123[4:], statFiles123[4:])
+	multi2 := mockOneMultiFileStat(dataFiles3, statFiles3)
 	multi2[0].MinKey = []byte("key02")
 	multi2[0].MaxKey = []byte("key22")
 	multiFileStat := []MultipleFilesStat{multi2[0], multi[0]}
@@ -279,8 +320,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err := splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key03"), endKey)
-	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0"}, statFiles)
+	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key02")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key02")}, regionSplitKeys)
 
@@ -288,8 +329,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key12"), endKey)
-	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0", "/mock-test/3/0"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0", "/mock-test/3_stat/0"}, statFiles)
+	require.Equal(t, []string{"/mock-test/1/0", "/mock-test/2/0", "/mock-test/3/0"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/1_stat/0", "/mock-test/2_stat/0", "/mock-test/3_stat/0"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key11")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key11")}, regionSplitKeys)
 
@@ -298,8 +339,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key21"), endKey)
-	require.Equal(t, []string{"/mock-test/2/0", "/mock-test/3/0"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/2_stat/0", "/mock-test/3_stat/0"}, statFiles)
+	require.Equal(t, []string{"/mock-test/2/0", "/mock-test/3/0"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/2_stat/0", "/mock-test/3_stat/0"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key13")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key13")}, regionSplitKeys)
 
@@ -309,8 +350,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.EqualValues(t, kv.Key("key23"), endKey)
-	require.Equal(t, []string{"/mock-test/1/1", "/mock-test/2/1"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/1_stat/1", "/mock-test/2_stat/1"}, statFiles)
+	require.Equal(t, []string{"/mock-test/1/1", "/mock-test/2/1"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/1_stat/1", "/mock-test/2_stat/1"}, removePartitionPrefix(t, statFiles))
 	require.Equal(t, [][]byte{[]byte("key22")}, rangeJobKeys)
 	require.Equal(t, [][]byte{[]byte("key22")}, regionSplitKeys)
 
@@ -318,8 +359,8 @@ func TestRangeSplitterStrictCase(t *testing.T) {
 	endKey, dataFiles, statFiles, rangeJobKeys, regionSplitKeys, err = splitter.SplitOneRangesGroup()
 	require.NoError(t, err)
 	require.Nil(t, endKey)
-	require.Equal(t, []string{"/mock-test/3/1"}, dataFiles)
-	require.Equal(t, []string{"/mock-test/3_stat/1"}, statFiles)
+	require.Equal(t, []string{"/mock-test/3/1"}, removePartitionPrefix(t, dataFiles))
+	require.Equal(t, []string{"/mock-test/3_stat/1"}, removePartitionPrefix(t, statFiles))
 	require.Len(t, rangeJobKeys, 0)
 	require.Len(t, regionSplitKeys, 0)
 
@@ -348,14 +389,16 @@ func TestExactlyKeyNum(t *testing.T) {
 
 	subDir := "/mock-test"
 
+	var summary *WriterSummary
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(15).
 		SetPropSizeDistance(1).
 		SetPropKeysDistance(1).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(memStore, subDir, "5")
 
-	dataFiles, statFiles, err := MockExternalEngineWithWriter(memStore, writer, subDir, keys, values)
-	require.NoError(t, err)
+	writeKVs(t, writer, keys, values)
+	dataFiles, statFiles := getKVAndStatFiles(summary)
 	multiFileStat := mockOneMultiFileStat(dataFiles, statFiles)
 
 	// maxRangeKeys = 3

--- a/pkg/lightning/backend/external/util.go
+++ b/pkg/lightning/backend/external/util.go
@@ -138,8 +138,8 @@ func seekPropsOffsets(
 //   - 30001/7/meta.json
 //   - 30001/plan/ingest/1/meta.json
 //   - 30001/plan/merge-sort/1/meta.json
-//   - e6/30001/7/617527bf-e25d-4312-8784-4a4576eb0195_stat/one-file
-//   - fa/30001/7/617527bf-e25d-4312-8784-4a4576eb0195/one-file
+//   - p00110000/30001/7/617527bf-e25d-4312-8784-4a4576eb0195_stat/one-file
+//   - p00000000/30001/7/617527bf-e25d-4312-8784-4a4576eb0195/one-file
 func GetAllFileNames(
 	ctx context.Context,
 	store storage.ExternalStorage,

--- a/pkg/lightning/backend/external/util.go
+++ b/pkg/lightning/backend/external/util.go
@@ -19,16 +19,17 @@ import (
 	"context"
 	"encoding/json"
 	goerrors "errors"
+	"hash/fnv"
 	"io"
 	"path"
 	"reflect"
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/lightning/log"
@@ -127,53 +128,74 @@ func seekPropsOffsets(
 	return offsetsPerKey, nil
 }
 
-// GetAllFileNames returns data file paths and stat file paths. Both paths are
-// sorted.
+// GetAllFileNames returns files with the same non-partitioned dir.
+//   - for intermediate KV/stat files we store them with a partitioned way to mitigate
+//     limitation on Cloud, see randPartitionedPrefix for how we partition the files.
+//   - for meta files, we store them directly under the non-partitioned dir.
+//
+// for example, if nonPartitionedDir is '30001', the files returned might be
+//   - 30001/6/meta.json
+//   - 30001/7/meta.json
+//   - 30001/plan/ingest/1/meta.json
+//   - 30001/plan/merge-sort/1/meta.json
+//   - e6/30001/7/617527bf-e25d-4312-8784-4a4576eb0195_stat/one-file
+//   - fa/30001/7/617527bf-e25d-4312-8784-4a4576eb0195/one-file
 func GetAllFileNames(
 	ctx context.Context,
 	store storage.ExternalStorage,
-	subDir string,
-) ([]string, []string, error) {
+	nonPartitionedDir string,
+) ([]string, error) {
 	var data []string
-	var stats []string
 
 	err := store.WalkDir(ctx,
-		&storage.WalkOption{SubDir: subDir},
+		&storage.WalkOption{},
 		func(path string, size int64) error {
-			// path example: /subtask/0_stat/0
-
-			// extract the parent dir
+			// extract the first dir
 			bs := hack.Slice(path)
-			lastIdx := bytes.LastIndexByte(bs, '/')
-			secondLastIdx := bytes.LastIndexByte(bs[:lastIdx], '/')
-			parentDir := path[secondLastIdx+1 : lastIdx]
+			firstIdx := bytes.IndexByte(bs, '/')
+			if firstIdx == -1 {
+				return nil
+			}
 
-			if strings.HasSuffix(parentDir, statSuffix) {
-				stats = append(stats, path)
-			} else {
+			firstDir := bs[:firstIdx]
+			if string(firstDir) == nonPartitionedDir {
+				data = append(data, path)
+				return nil
+			}
+
+			if !isValidPartition(firstDir) {
+				return nil
+			}
+			secondIdx := bytes.IndexByte(bs[firstIdx+1:], '/')
+			if secondIdx == -1 {
+				return nil
+			}
+			secondDir := path[firstIdx+1 : firstIdx+1+secondIdx]
+
+			if secondDir == nonPartitionedDir {
 				data = append(data, path)
 			}
 			return nil
 		})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	// in case the external storage does not guarantee the order of walk
 	sort.Strings(data)
-	sort.Strings(stats)
-	return data, stats, nil
+	return data, nil
 }
 
-// CleanUpFiles delete all data and stat files under one subDir.
-func CleanUpFiles(ctx context.Context, store storage.ExternalStorage, subDir string) error {
-	dataNames, statNames, err := GetAllFileNames(ctx, store, subDir)
+// CleanUpFiles delete all data and stat files under the same non-partitioned dir.
+// see randPartitionedPrefix for how we partition the files.
+func CleanUpFiles(ctx context.Context, store storage.ExternalStorage, nonPartitionedDir string) error {
+	failpoint.Inject("skipCleanUpFiles", func() {
+		failpoint.Return(nil)
+	})
+	names, err := GetAllFileNames(ctx, store, nonPartitionedDir)
 	if err != nil {
 		return err
 	}
-	allFiles := make([]string, 0, len(dataNames)+len(statNames))
-	allFiles = append(allFiles, dataNames...)
-	allFiles = append(allFiles, statNames...)
-	return store.DeleteFiles(ctx, allFiles)
+	return store.DeleteFiles(ctx, names)
 }
 
 // MockExternalEngine generates an external engine with the given keys and values.
@@ -182,25 +204,14 @@ func MockExternalEngine(
 	keys [][]byte,
 	values [][]byte,
 ) (dataFiles []string, statsFiles []string, err error) {
-	subDir := "/mock-test"
+	var summary *WriterSummary
 	writer := NewWriterBuilder().
 		SetMemorySizeLimit(10*(lengthBytes*2+10)).
 		SetBlockSize(10*(lengthBytes*2+10)).
 		SetPropSizeDistance(32).
 		SetPropKeysDistance(4).
+		SetOnCloseFunc(func(s *WriterSummary) { summary = s }).
 		Build(storage, "/mock-test", "0")
-	return MockExternalEngineWithWriter(storage, writer, subDir, keys, values)
-}
-
-// MockExternalEngineWithWriter generates an external engine with the given
-// writer, keys and values.
-func MockExternalEngineWithWriter(
-	storage storage.ExternalStorage,
-	writer *Writer,
-	subDir string,
-	keys [][]byte,
-	values [][]byte,
-) (dataFiles []string, statsFiles []string, err error) {
 	ctx := context.Background()
 	for i := range keys {
 		err := writer.WriteRow(ctx, keys[i], values[i], nil)
@@ -212,7 +223,13 @@ func MockExternalEngineWithWriter(
 	if err != nil {
 		return nil, nil, err
 	}
-	return GetAllFileNames(ctx, storage, subDir)
+	for _, ms := range summary.MultipleFilesStats {
+		for _, f := range ms.Filenames {
+			dataFiles = append(dataFiles, f[0])
+			statsFiles = append(statsFiles, f[1])
+		}
+	}
+	return
 }
 
 // EndpointTp is the type of Endpoint.Key.
@@ -570,4 +587,11 @@ func DivideMergeSortDataFiles(dataFiles []string, nodeCnt int, mergeConc int) ([
 		dataFiles = dataFiles[s:]
 	}
 	return result, nil
+}
+
+func getHash(s string) int64 {
+	h := fnv.New64a()
+	// this hash function never return error
+	_, _ = h.Write([]byte(s))
+	return int64(h.Sum64())
 }

--- a/pkg/lightning/backend/external/util_test.go
+++ b/pkg/lightning/backend/external/util_test.go
@@ -183,18 +183,17 @@ func TestGetAllFileNames(t *testing.T) {
 	err = w3.Close(ctx)
 	require.NoError(t, err)
 
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, "/subtask")
+	filenames, err := GetAllFileNames(ctx, store, "subtask")
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
-		"/subtask/12_stat/0", "/subtask/12_stat/1", "/subtask/12_stat/2",
-		"/subtask/3_stat/0", "/subtask/3_stat/1", "/subtask/3_stat/2",
-	}, statFiles)
+	filenames = removePartitionPrefix(t, filenames)
 	require.Equal(t, []string{
 		"/subtask/0/0", "/subtask/0/1", "/subtask/0/2",
+		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
 		"/subtask/12/0", "/subtask/12/1", "/subtask/12/2",
+		"/subtask/12_stat/0", "/subtask/12_stat/1", "/subtask/12_stat/2",
 		"/subtask/3/0", "/subtask/3/1", "/subtask/3/2",
-	}, dataFiles)
+		"/subtask/3_stat/0", "/subtask/3_stat/1", "/subtask/3_stat/2",
+	}, filenames)
 }
 
 func TestCleanUpFiles(t *testing.T) {
@@ -219,21 +218,19 @@ func TestCleanUpFiles(t *testing.T) {
 	err := w.Close(ctx)
 	require.NoError(t, err)
 
-	dataFiles, statFiles, err := GetAllFileNames(ctx, store, "/subtask")
+	filenames, err := GetAllFileNames(ctx, store, "subtask")
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
-	}, statFiles)
+	filenames = removePartitionPrefix(t, filenames)
 	require.Equal(t, []string{
 		"/subtask/0/0", "/subtask/0/1", "/subtask/0/2",
-	}, dataFiles)
+		"/subtask/0_stat/0", "/subtask/0_stat/1", "/subtask/0_stat/2",
+	}, filenames)
 
-	require.NoError(t, CleanUpFiles(ctx, store, "/subtask"))
+	require.NoError(t, CleanUpFiles(ctx, store, "subtask"))
 
-	dataFiles, statFiles, err = GetAllFileNames(ctx, store, "/subtask")
+	filenames, err = GetAllFileNames(ctx, store, "subtask")
 	require.NoError(t, err)
-	require.Equal(t, []string(nil), statFiles)
-	require.Equal(t, []string(nil), dataFiles)
+	require.Equal(t, []string(nil), filenames)
 }
 
 func TestGetMaxOverlapping(t *testing.T) {

--- a/pkg/lightning/backend/external/writer.go
+++ b/pkg/lightning/backend/external/writer.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"math"
+	"math/rand"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -52,6 +54,10 @@ var (
 	// this value might not be optimal.
 	// TODO need data on AWS and other machine types
 	maxUploadWorkersPerThread = 8
+	// we use hex of 0-256 as partition prefix, it might duplicate with task ID,
+	// so we add a header to it.
+	partitionHeader     = "p"
+	partitionHeaderChar = partitionHeader[0]
 
 	// maxMergeSortOverlapThreshold is the maximum threshold of overlap between sorted kv files.
 	// if the overlap ratio is greater than this threshold, we will merge the files. Note: Use GetAdjustedMergeSortOverlapThreshold() instead.
@@ -283,6 +289,7 @@ func (b *WriterBuilder) Build(
 		membuf.WithBlockNum(0),
 		membuf.WithBlockSize(b.blockSize),
 	)
+	rnd := rand.New(rand.NewSource(getHash(filenamePrefix)))
 	ret := &Writer{
 		rc: &rangePropertiesCollector{
 			props:        make([]*rangeProperty, 0, 1024),
@@ -295,6 +302,7 @@ func (b *WriterBuilder) Build(
 		kvBuffer:       p.NewBuffer(membuf.WithBufferMemoryLimit(b.memSizeLimit)),
 		currentSeq:     0,
 		filenamePrefix: filenamePrefix,
+		rnd:            rnd,
 		writerID:       writerID,
 		groupOffset:    b.groupOffset,
 		onClose:        b.onClose,
@@ -319,6 +327,8 @@ func (b *WriterBuilder) BuildOneFile(
 	filenamePrefix := filepath.Join(prefix, writerID)
 	p := membuf.NewPool(membuf.WithBlockNum(0), membuf.WithBlockSize(b.blockSize))
 
+	rnd := rand.New(rand.NewSource(getHash(filenamePrefix)))
+
 	ret := &OneFileWriter{
 		rc: &rangePropertiesCollector{
 			props:        make([]*rangeProperty, 0, 1024),
@@ -330,6 +340,7 @@ func (b *WriterBuilder) BuildOneFile(
 		store:          store,
 		filenamePrefix: filenamePrefix,
 		writerID:       writerID,
+		rnd:            rnd,
 		kvStore:        nil,
 		onClose:        b.onClose,
 		closed:         false,
@@ -417,6 +428,7 @@ type Writer struct {
 	groupOffset    int
 	currentSeq     int
 	filenamePrefix string
+	rnd            *rand.Rand
 
 	rc *rangePropertiesCollector
 
@@ -789,7 +801,7 @@ func (w *Writer) createStorageWriter(ctx context.Context) (
 	data, stats storage.ExternalFileWriter,
 	err error,
 ) {
-	dataPath := filepath.Join(w.filenamePrefix, strconv.Itoa(w.currentSeq))
+	dataPath := filepath.Join(w.getPartitionedPrefix(), strconv.Itoa(w.currentSeq))
 	dataWriter, err := w.store.Create(ctx, dataPath, &storage.WriterOption{
 		Concurrency: 20,
 		PartSize:    MinUploadPartSize,
@@ -797,7 +809,7 @@ func (w *Writer) createStorageWriter(ctx context.Context) (
 	if err != nil {
 		return "", "", nil, nil, err
 	}
-	statPath := filepath.Join(w.filenamePrefix+statSuffix, strconv.Itoa(w.currentSeq))
+	statPath := filepath.Join(w.getPartitionedPrefix()+statSuffix, strconv.Itoa(w.currentSeq))
 	statsWriter, err := w.store.Create(ctx, statPath, &storage.WriterOption{
 		Concurrency: 20,
 		PartSize:    MinUploadPartSize,
@@ -810,12 +822,44 @@ func (w *Writer) createStorageWriter(ctx context.Context) (
 }
 
 func (w *Writer) createDupWriter(ctx context.Context) (string, storage.ExternalFileWriter, error) {
-	path := filepath.Join(w.filenamePrefix+dupSuffix, strconv.Itoa(w.currentSeq))
+	path := filepath.Join(w.getPartitionedPrefix()+dupSuffix, strconv.Itoa(w.currentSeq))
 	writer, err := w.store.Create(ctx, path, &storage.WriterOption{
 		Concurrency: 20,
 		PartSize:    MinUploadPartSize,
 	})
 	return path, writer, err
+}
+
+func (w *Writer) getPartitionedPrefix() string {
+	return randPartitionedPrefix(w.filenamePrefix, w.rnd)
+}
+
+// when importing large mount of data, during merge-sort and ingest, it's possible
+// we need to read many files in parallel, but for Object Storage like S3, it will
+// partition all object keys by prefix and each partition have its own request
+// quota. Initially, each bucket only have one partition, and the auto-partition
+// of object storage is mostly slow, so we might be throttled for some time to wait
+// S3 server do auto-partition.
+// to mitigate this issue, we design the file prefix in a way which is easy to
+// be partitioned, and let the user file a ticket to let cloud provider partition
+// by prefix manually before import large dataset.
+//
+// the rule is: generate a random byte in range [0, 256) and encode to hex string,
+// and use it as the partitioned prefix.
+func randPartitionedPrefix(prefix string, rnd *rand.Rand) string {
+	partitionID := byte(rnd.Intn(math.MaxUint8 + 1))
+	return filepath.Join(partitionHeader+hex.EncodeToString([]byte{partitionID}), prefix)
+}
+
+func isLowerHexChar(b byte) bool {
+	return ('0' <= b && b <= '9') || ('a' <= b && b <= 'f')
+}
+
+func isValidPartition(in []byte) bool {
+	if len(in) != 3 || in[0] != partitionHeaderChar {
+		return false
+	}
+	return isLowerHexChar(in[1]) && isLowerHexChar(in[2])
 }
 
 // EngineWriter implements backend.EngineWriter interface.

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -20,6 +20,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"slices"
 	"sort"
 	"strconv"
@@ -40,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/size"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"golang.org/x/exp/rand"
 )
 
 // only used in testing for now.
@@ -103,14 +103,16 @@ func mergeOverlappingFilesImpl(ctx context.Context,
 
 func TestWriter(t *testing.T) {
 	seed := time.Now().Unix()
-	rand.Seed(uint64(seed))
+	rand.Seed(seed)
 	t.Logf("seed: %d", seed)
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
 
+	var kvAndStat [2]string
 	w := NewWriterBuilder().
 		SetPropSizeDistance(100).
 		SetPropKeysDistance(2).
+		SetOnCloseFunc(func(s *WriterSummary) { kvAndStat = s.MultipleFilesStats[0].Filenames[0] }).
 		Build(memStore, "/test", "0")
 
 	writer := NewEngineWriter(w)
@@ -137,7 +139,7 @@ func TestWriter(t *testing.T) {
 	})
 
 	bufSize := rand.Intn(100) + 1
-	kvReader, err := NewKVReader(ctx, "/test/0/0", memStore, 0, bufSize)
+	kvReader, err := NewKVReader(ctx, kvAndStat[0], memStore, 0, bufSize)
 	require.NoError(t, err)
 	for i := range kvCnt {
 		key, value, err := kvReader.nextKV()
@@ -149,7 +151,7 @@ func TestWriter(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 	require.NoError(t, kvReader.Close())
 
-	statReader, err := newStatsReader(ctx, memStore, "/test/0_stat/0", bufSize)
+	statReader, err := newStatsReader(ctx, memStore, kvAndStat[1], bufSize)
 	require.NoError(t, err)
 
 	var keyCnt uint64 = 0
@@ -167,7 +169,7 @@ func TestWriter(t *testing.T) {
 
 func TestWriterFlushMultiFileNames(t *testing.T) {
 	seed := time.Now().Unix()
-	rand.Seed(uint64(seed))
+	rand.Seed(seed)
 	t.Logf("seed: %d", seed)
 	ctx := context.Background()
 	memStore := storage.NewMemStorage()
@@ -197,18 +199,13 @@ func TestWriterFlushMultiFileNames(t *testing.T) {
 	err := writer.Close(ctx)
 	require.NoError(t, err)
 
-	var dataFiles, statFiles []string
-	err = memStore.WalkDir(ctx, &storage.WalkOption{SubDir: "/test"}, func(path string, size int64) error {
-		if strings.Contains(path, "_stat") {
-			statFiles = append(statFiles, path)
-		} else {
-			dataFiles = append(dataFiles, path)
-		}
-		return nil
-	})
+	dataFiles, statFiles, err := getKVAndStatFilesByScan(ctx, memStore, "test")
+	require.NoError(t, err)
 	require.NoError(t, err)
 	require.Len(t, dataFiles, 4)
 	require.Len(t, statFiles, 4)
+	dataFiles = removePartitionPrefix(t, dataFiles)
+	statFiles = removePartitionPrefix(t, statFiles)
 	for i := range 4 {
 		require.Equal(t, dataFiles[i], fmt.Sprintf("/test/0/%d", i))
 		require.Equal(t, statFiles[i], fmt.Sprintf("/test/0_stat/%d", i))
@@ -265,6 +262,15 @@ func TestMultiFileStatOverlap(t *testing.T) {
 
 	s3.MinKey = dbkv.Key{0}
 	require.EqualValues(t, 260, GetMaxOverlappingTotal([]MultipleFilesStat{s1, s2, s3}))
+}
+
+func removePartitionFromMultipleFilesStat(t *testing.T, in MultipleFilesStat) MultipleFilesStat {
+	out := in
+	for i := range out.Filenames {
+		namesWithoutPartition := removePartitionPrefix(t, []string{out.Filenames[i][0], out.Filenames[i][1]})
+		out.Filenames[i] = [2]string{namesWithoutPartition[0], namesWithoutPartition[1]}
+	}
+	return out
 }
 
 func TestWriterMultiFileStat(t *testing.T) {
@@ -352,7 +358,7 @@ func TestWriterMultiFileStat(t *testing.T) {
 		},
 		MaxOverlappingNum: 1,
 	}
-	require.Equal(t, expected, summary.MultipleFilesStats[0])
+	require.Equal(t, expected, removePartitionFromMultipleFilesStat(t, summary.MultipleFilesStats[0]))
 	expected = MultipleFilesStat{
 		MinKey: []byte("key11"),
 		MaxKey: []byte("key16"),
@@ -363,7 +369,7 @@ func TestWriterMultiFileStat(t *testing.T) {
 		},
 		MaxOverlappingNum: 2,
 	}
-	require.Equal(t, expected, summary.MultipleFilesStats[1])
+	require.Equal(t, expected, removePartitionFromMultipleFilesStat(t, summary.MultipleFilesStats[1]))
 	expected = MultipleFilesStat{
 		MinKey: []byte("key20"),
 		MaxKey: []byte("key24"),
@@ -374,14 +380,12 @@ func TestWriterMultiFileStat(t *testing.T) {
 		},
 		MaxOverlappingNum: 3,
 	}
-	require.Equal(t, expected, summary.MultipleFilesStats[2])
+	require.Equal(t, expected, removePartitionFromMultipleFilesStat(t, summary.MultipleFilesStats[2]))
 	require.EqualValues(t, "key01", summary.Min)
 	require.EqualValues(t, "key24", summary.Max)
 
-	allDataFiles := make([]string, 9)
-	for i := range allDataFiles {
-		allDataFiles[i] = fmt.Sprintf("/test/0/%d", i)
-	}
+	allDataFiles, _, err := getKVAndStatFilesByScan(ctx, memStore, "test")
+	require.NoError(t, err)
 
 	err = mergeOverlappingFilesImpl(
 		ctx,
@@ -410,7 +414,7 @@ func TestWriterMultiFileStat(t *testing.T) {
 		},
 		MaxOverlappingNum: 1,
 	}
-	require.Equal(t, expected, summary.MultipleFilesStats[0])
+	require.Equal(t, expected, removePartitionFromMultipleFilesStat(t, summary.MultipleFilesStats[0]))
 	expected = MultipleFilesStat{
 		MinKey: []byte("key11"),
 		MaxKey: []byte("key16"),
@@ -421,7 +425,7 @@ func TestWriterMultiFileStat(t *testing.T) {
 		},
 		MaxOverlappingNum: 1,
 	}
-	require.Equal(t, expected, summary.MultipleFilesStats[1])
+	require.Equal(t, expected, removePartitionFromMultipleFilesStat(t, summary.MultipleFilesStats[1]))
 	expected = MultipleFilesStat{
 		MinKey: []byte("key20"),
 		MaxKey: []byte("key24"),
@@ -432,7 +436,7 @@ func TestWriterMultiFileStat(t *testing.T) {
 		},
 		MaxOverlappingNum: 1,
 	}
-	require.Equal(t, expected, summary.MultipleFilesStats[2])
+	require.Equal(t, expected, removePartitionFromMultipleFilesStat(t, summary.MultipleFilesStats[2]))
 	require.EqualValues(t, "key01", summary.Min)
 	require.EqualValues(t, "key24", summary.Max)
 }
@@ -511,10 +515,12 @@ func TestFlushKVsRetry(t *testing.T) {
 	ctx := context.Background()
 	store := &writerFirstCloseFailStorage{ExternalStorage: storage.NewMemStorage(), shouldFail: true}
 
+	var kvAndStat [2]string
 	writer := NewWriterBuilder().
 		SetPropKeysDistance(4).
 		SetMemorySizeLimit(100).
 		SetBlockSize(100). // 2 KV pair will trigger flush
+		SetOnCloseFunc(func(s *WriterSummary) { kvAndStat = s.MultipleFilesStats[0].Filenames[0] }).
 		Build(store, "/test", "0")
 	err := writer.WriteRow(ctx, []byte("key1"), []byte("val1"), nil)
 	require.NoError(t, err)
@@ -522,13 +528,11 @@ func TestFlushKVsRetry(t *testing.T) {
 	require.NoError(t, err)
 	err = writer.WriteRow(ctx, []byte("key2"), []byte("val2"), nil)
 	require.NoError(t, err)
-	// manually test flushKVs
-	err = writer.flushKVs(ctx, false)
-	require.NoError(t, err)
+	require.NoError(t, writer.Close(ctx))
 
 	require.False(t, store.shouldFail)
 
-	r, err := newStatsReader(ctx, store, "/test/0_stat/0", 100)
+	r, err := newStatsReader(ctx, store, kvAndStat[1], 100)
 	require.NoError(t, err)
 	p, err := r.nextProp()
 	lastKey := []byte{}
@@ -858,4 +862,18 @@ func TestGetAdjustedMergeSortOverlapThresholdAndMergeSortFileCountStep(t *testin
 			t.Errorf("GetAdjustedMergeSortFileCountStep() = %v, want %v", got, tt.want)
 		}
 	}
+}
+
+func TestRandPartitionedPrefix(t *testing.T) {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	prefix := "write-prefix"
+	partitioned := randPartitionedPrefix(prefix, rnd)
+	require.Equal(t, partitionHeaderChar, partitioned[0])
+	require.Equal(t, partitioned[4:], prefix)
+	require.True(t, isValidPartition([]byte(partitioned[:3])))
+
+	require.False(t, isValidPartition([]byte("aa")))
+	require.False(t, isValidPartition([]byte("aaa")))
+	require.False(t, isValidPartition([]byte("paz")))
+	require.False(t, isValidPartition([]byte("pza")))
 }

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -869,11 +869,13 @@ func TestRandPartitionedPrefix(t *testing.T) {
 	prefix := "write-prefix"
 	partitioned := randPartitionedPrefix(prefix, rnd)
 	require.Equal(t, partitionHeaderChar, partitioned[0])
-	require.Equal(t, partitioned[4:], prefix)
-	require.True(t, isValidPartition([]byte(partitioned[:3])))
+	require.Equal(t, partitioned[10:], prefix)
+	require.True(t, isValidPartition([]byte(partitioned[:9])))
 
 	require.False(t, isValidPartition([]byte("aa")))
-	require.False(t, isValidPartition([]byte("aaa")))
-	require.False(t, isValidPartition([]byte("paz")))
-	require.False(t, isValidPartition([]byte("pza")))
+	require.False(t, isValidPartition([]byte("pa")))
+	require.False(t, isValidPartition([]byte("p1111000a")))
+	require.False(t, isValidPartition([]byte("pa111000")))
+	require.True(t, isValidPartition([]byte("p00000000")))
+	require.True(t, isValidPartition([]byte("p11110000")))
 }

--- a/pkg/lightning/backend/external/writer_test.go
+++ b/pkg/lightning/backend/external/writer_test.go
@@ -867,10 +867,12 @@ func TestGetAdjustedMergeSortOverlapThresholdAndMergeSortFileCountStep(t *testin
 func TestRandPartitionedPrefix(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	prefix := "write-prefix"
-	partitioned := randPartitionedPrefix(prefix, rnd)
-	require.Equal(t, partitionHeaderChar, partitioned[0])
-	require.Equal(t, partitioned[10:], prefix)
-	require.True(t, isValidPartition([]byte(partitioned[:9])))
+	for range 2560 {
+		partitioned := randPartitionedPrefix(prefix, rnd)
+		require.Equal(t, partitionHeaderChar, partitioned[0])
+		require.Equal(t, partitioned[10:], prefix)
+		require.True(t, isValidPartition([]byte(partitioned[:9])))
+	}
 
 	require.False(t, isValidPartition([]byte("aa")))
 	require.False(t, isValidPartition([]byte("pa")))

--- a/pkg/statistics/handle/handletest/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "handletest_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "handle_test.go",
         "main_test.go",

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -94,22 +94,28 @@ func checkFileCleaned(t *testing.T, jobID, taskID int64, sortStorageURI string) 
 	require.NoError(t, err)
 	for _, id := range []int64{jobID, taskID} {
 		prefix := strconv.Itoa(int(id))
-		dataFiles, statFiles, err := external.GetAllFileNames(context.Background(), extStore, prefix)
+		files, err := external.GetAllFileNames(context.Background(), extStore, prefix)
 		require.NoError(t, err)
 		require.Greater(t, jobID, int64(0))
-		require.Equal(t, 0, len(dataFiles))
-		require.Equal(t, 0, len(statFiles))
+		require.Equal(t, 0, len(files))
 	}
 }
 
-func checkFileExist(t *testing.T, sortStorageURI string, prefix string) {
+// check the file under dir or partitioned dir have files with keyword
+func checkFileExist(t *testing.T, sortStorageURI string, dir, keyword string) {
 	storeBackend, err := storage.ParseBackend(sortStorageURI, nil)
 	require.NoError(t, err)
 	extStore, err := storage.NewWithDefaultOpt(context.Background(), storeBackend)
 	require.NoError(t, err)
-	dataFiles, _, err := external.GetAllFileNames(context.Background(), extStore, prefix)
+	dataFiles, err := external.GetAllFileNames(context.Background(), extStore, dir)
 	require.NoError(t, err)
-	require.Greater(t, len(dataFiles), 0)
+	filteredFiles := make([]string, 0)
+	for _, f := range dataFiles {
+		if strings.Contains(f, keyword) {
+			filteredFiles = append(filteredFiles, f)
+		}
+	}
+	require.Greater(t, len(filteredFiles), 0)
 }
 
 func checkDataAndShowJobs(t *testing.T, tk *testkit.TestKit, count int) {
@@ -197,8 +203,8 @@ func TestGlobalSortBasic(t *testing.T) {
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
 	taskID = getTaskID(t, jobID)
-	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID))+"/plan/ingest")
-	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID))+"/plan/merge-sort")
+	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID)), "/plan/ingest")
+	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID)), "/plan/merge-sort")
 	<-ch
 	<-ch
 	checkFileCleaned(t, jobID, taskID, cloudStorageURI)
@@ -207,8 +213,8 @@ func TestGlobalSortBasic(t *testing.T) {
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
 	taskID = getTaskID(t, jobID)
-	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID))+"/plan/ingest")
-	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID))+"/plan/merge-sort")
+	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID)), "/plan/ingest")
+	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID)), "/plan/merge-sort")
 	<-ch
 	<-ch
 	checkFileCleaned(t, jobID, taskID, cloudStorageURI)

--- a/tests/realtikvtest/addindextest2/global_sort_test.go
+++ b/tests/realtikvtest/addindextest2/global_sort_test.go
@@ -193,7 +193,7 @@ func TestGlobalSortBasic(t *testing.T) {
 	checkDataAndShowJobs(t, tk, size)
 	checkExternalFields(t, tk)
 	taskID := getTaskID(t, jobID)
-	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID))+"/plan/ingest")
+	checkFileExist(t, cloudStorageURI, strconv.Itoa(int(taskID)), "/plan/ingest")
 	<-ch
 	<-ch
 	checkFileCleaned(t, jobID, taskID, cloudStorageURI)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62904

Problem Summary:

### What changed and how does it work?
- this is a manually pick of https://github.com/pingcap/tidb/pull/60816
- we also change the partition prefix schema from hex to binary string, so the partition can response faster as it's binary.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

intermediate files of importing using global sort, and they are successfully cleanup after it.
```
➜  minio bin/mc ls -r minio/mybucket/gsort
[2025-08-11 12:34:35 CST]   467B STANDARD 2/4/meta.json
[2025-08-11 12:34:34 CST]   194B STANDARD 2/plan/encode/1/meta.json
[2025-08-11 12:34:36 CST]   521B STANDARD 2/plan/ingest/1/meta.json
[2025-08-11 12:34:35 CST]    82B STANDARD p01001100/2/4/data/f3af2ec6-b252-4221-af32-42c5bf12c8cb_stat/0
[2025-08-11 12:34:35 CST]   294B STANDARD p11010101/2/4/data/f3af2ec6-b252-4221-af32-42c5bf12c8cb/0
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
