### PR TITLE
br/streamhelper: added a guard for dropping subscriber

### DIFF
--- a/br/pkg/streamhelper/advancer.go
+++ b/br/pkg/streamhelper/advancer.go
@@ -515,8 +515,10 @@ func (c *CheckpointAdvancer) advanceCheckpointBy(ctx context.Context,
 func (c *CheckpointAdvancer) stopSubscriber() {
 	c.subscriberMu.Lock()
 	defer c.subscriberMu.Unlock()
-	c.subscriber.Drop()
-	c.subscriber = nil
+	if c.subscriber != nil {
+		c.subscriber.Drop()
+		c.subscriber = nil
+	}
 }
 
 func (c *CheckpointAdvancer) SpawnSubscriptionHandler(ctx context.Context) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62939

Problem Summary:
When dropping the advancer, the subscription manager may not get initialized. Then dropping it causes a panic.

### What changed and how does it work?
Added a guard to prevent dropping a `nil` subscription manager.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > The modification is trivial.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
