### PR TITLE
executor, conn: wait for the goroutine in preprocessLoadDataLocal to finish before step to next query

### DIFF
--- a/pkg/executor/test/loaddatatest/load_data_test.go
+++ b/pkg/executor/test/loaddatatest/load_data_test.go
@@ -17,6 +17,7 @@ package loaddatatest
 import (
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/executor"
@@ -43,10 +44,13 @@ func checkCases(
 ) {
 	for _, tt := range tests {
 		var reader io.ReadCloser = mydump.NewStringReader(string(tt.data))
-		var readerBuilder executor.LoadDataReaderBuilder = func(_ string) (
-			r io.ReadCloser, err error,
-		) {
-			return reader, nil
+		var readerBuilder executor.LoadDataReaderBuilder = executor.LoadDataReaderBuilder{
+			Build: func(_ string) (
+				r io.ReadCloser, err error,
+			) {
+				return reader, nil
+			},
+			Wg: &sync.WaitGroup{},
 		}
 
 		ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)

--- a/pkg/executor/test/writetest/write_test.go
+++ b/pkg/executor/test/writetest/write_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/errctx"
@@ -174,10 +175,13 @@ func checkCases(
 ) {
 	for _, tt := range tests {
 		var reader io.ReadCloser = mydump.NewStringReader(string(tt.data))
-		var readerBuilder executor.LoadDataReaderBuilder = func(_ string) (
-			r io.ReadCloser, err error,
-		) {
-			return reader, nil
+		var readerBuilder executor.LoadDataReaderBuilder = executor.LoadDataReaderBuilder{
+			Build: func(_ string) (
+				r io.ReadCloser, err error,
+			) {
+				return reader, nil
+			},
+			Wg: &sync.WaitGroup{},
 		}
 
 		ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)

--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2150,7 +2150,8 @@ func (cc *clientConn) preprocessLoadDataLocal(ctx context.Context) error {
 		return servererr.ErrNotAllowedCommand
 	}
 
-	var readerBuilder executor.LoadDataReaderBuilder = func(filepath string) (
+	wg := &sync.WaitGroup{}
+	builderFunc := func(filepath string) (
 		io.ReadCloser, error,
 	) {
 		err := cc.writeReq(ctx, filepath)
@@ -2161,7 +2162,10 @@ func (cc *clientConn) preprocessLoadDataLocal(ctx context.Context) error {
 		drained := false
 		r, w := io.Pipe()
 
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
+
 			var errOccurred error
 
 			defer func() {
@@ -2217,13 +2221,27 @@ func (cc *clientConn) preprocessLoadDataLocal(ctx context.Context) error {
 		return r, nil
 	}
 
+	var readerBuilder executor.LoadDataReaderBuilder = executor.LoadDataReaderBuilder{
+		Build: builderFunc,
+		Wg:    wg,
+	}
+
 	cc.ctx.SetValue(executor.LoadDataReaderBuilderKey, readerBuilder)
 
 	return nil
 }
 
 func (cc *clientConn) postprocessLoadDataLocal() {
-	cc.ctx.ClearValue(executor.LoadDataReaderBuilderKey)
+	builder := cc.ctx.Value(executor.LoadDataReaderBuilderKey)
+	if builder != nil {
+		builder, ok := builder.(executor.LoadDataReaderBuilder)
+		if !ok {
+			intest.Assert(false, "LoadDataReaderBuilder should be of type executor.LoadDataReaderBuilder")
+			return
+		}
+		builder.Wg.Wait()
+		cc.ctx.ClearValue(executor.LoadDataReaderBuilderKey)
+	}
 }
 
 func (cc *clientConn) handleFileTransInConn(ctx context.Context, status uint16) (bool, error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62673 

Problem Summary:

The current implementation of `LOAD DATA ... INFILE ...` doesn't wait for the background goroutine (which is used to continuously read file data from client) to stop. Therefore, if the `LOAD DATA` statement meets any error, it's possible that the connection has two reading goroutines:

1. Expect to read the file data.
2. Expect to read the next command.

Then there will be a data race in the internal buffer, and cause deadlock or panic. The user reported a panic but in my testcase it'd be easier to reproduce deadlock (but theoritically all possible, maybe related to the error position).

### What changed and how does it work?

Also create a `WaitGroup` to wait for this goroutine to finish before stepping to the next statement.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that if the `LOAD DATA ... INFILE ...` meets error, it may cause panic or deadlock.
```
