### PR TITLE
session: record RUStats for internal sessions

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1881,6 +1881,7 @@ func (s *session) executeInternalImpl(ctx context.Context, sql string, args ...a
 	defer r.End()
 	logutil.Eventf(ctx, "execute: %s", sql)
 
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	stmtNode, err := s.ParseWithParams(ctx, sql, args...)
 	if err != nil {
 		return nil, err

--- a/pkg/sessionctx/sessionstates/BUILD.bazel
+++ b/pkg/sessionctx/sessionstates/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/sessionctx/vardef",
         "//pkg/testkit",
         "//pkg/util",
+        "//pkg/util/execdetails",
         "//pkg/util/sem/compat",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/pkg/testkit/BUILD.bazel
+++ b/pkg/testkit/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/breakpoint",
         "//pkg/util/chunk",
+        "//pkg/util/execdetails",
         "//pkg/util/gctuner",
         "//pkg/util/intest",
         "//pkg/util/logutil",

--- a/pkg/testkit/testkit.go
+++ b/pkg/testkit/testkit.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
+	"github.com/pingcap/tidb/pkg/util/execdetails"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/metricsutil"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -153,6 +154,7 @@ func (tk *TestKit) MustExec(sql string, args ...any) {
 		}
 	}()
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	tk.MustExecWithContext(ctx, sql, args...)
 }
 
@@ -248,6 +250,7 @@ func (tk *TestKit) MustQueryToErr(sql string, args ...any) {
 func (tk *TestKit) MustQueryWithContext(ctx context.Context, sql string, args ...any) *Result {
 	comment := fmt.Sprintf("sql:%s, args:%v", sql, args)
 	cmts := append([]any{comment}, tk.comments...)
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	rs, err := tk.ExecWithContext(ctx, sql, args...)
 	tk.require.NoError(err, cmts)
 	tk.require.NotNil(rs, cmts)
@@ -381,6 +384,7 @@ func (tk *TestKit) NotHasKeywordInOperatorInfo(sql string, keyword string, args 
 // Exec executes a sql statement using the prepared stmt API
 func (tk *TestKit) Exec(sql string, args ...any) (sqlexec.RecordSet, error) {
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
+	ctx = execdetails.ContextWithInitializedExecDetails(ctx)
 	return tk.ExecWithContext(ctx, sql, args...)
 }
 

--- a/pkg/util/execdetails/BUILD.bazel
+++ b/pkg/util/execdetails/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv",
+        "//pkg/util/intest",
         "@com_github_influxdata_tdigest//:tdigest",
         "@com_github_pingcap_kvproto//pkg/resource_manager",
         "@com_github_pingcap_tipb//go-tipb",

--- a/pkg/util/execdetails/util.go
+++ b/pkg/util/execdetails/util.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/influxdata/tdigest"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/tikv/client-go/v2/util"
 )
 
@@ -47,6 +48,7 @@ func GetExecDetailsFromContext(ctx context.Context) (stmtDetail StmtExecDetails,
 		ruDetails = ruDetailsVal.(*util.RUDetails)
 	} else {
 		ruDetails = util.NewRUDetails()
+		intest.Assert(false, "ruDetails should not be nil in execdetails")
 	}
 
 	return

--- a/tests/realtikvtest/sessiontest/BUILD.bazel
+++ b/tests/realtikvtest/sessiontest/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "infoschema_test.go",
         "infoschema_v2_test.go",
+        "internal_session_test.go",
         "main_test.go",
         "paging_test.go",
         "session_fail_test.go",
@@ -16,12 +17,14 @@ go_test(
     deps = [
         "//pkg/config",
         "//pkg/infoschema",
+        "//pkg/kv",
         "//pkg/meta",
         "//pkg/parser/ast",
         "//pkg/session",
         "//pkg/sessionctx/vardef",
         "//pkg/store/helper",
         "//pkg/testkit",
+        "//pkg/util/sqlexec",
         "//pkg/util/sqlkiller",
         "//tests/realtikvtest",
         "@com_github_pingcap_failpoint//:failpoint",

--- a/tests/realtikvtest/sessiontest/internal_session_test.go
+++ b/tests/realtikvtest/sessiontest/internal_session_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessiontest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/util/sqlexec"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteInternalShouldHaveRUStats(t *testing.T) {
+	if !*realtikvtest.WithRealTiKV {
+		t.Skip("This test only runs with real TiKV")
+	}
+
+	store := realtikvtest.CreateMockStoreAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test;")
+	tk.MustExec("create table t(id int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+
+	// The `intest.Assert` in `GetExecDetailsFromContext` will panic if the context does not have ru details.
+	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
+	rs, err := tk.Session().ExecuteInternal(ctx, "select * from t")
+	require.NoError(t, err)
+	_, err = sqlexec.DrainRecordSet(ctx, rs, 8)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62964

Problem Summary:

Without calling `execdetails.ContextWithInitializedExecDetails`, `ExecuteInternal` method will not record RU usage. The most obvious issue is that all TTL statements will not show RU stats in the slow log.

### What changed and how does it work?

1. Call `execdetails.ContextWithInitializedExecDetails` in the `ExecuteInternal`
2. Add a `intest.Assert` to assert that the ru stats is always not nil.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
  
Mock a big latency and trigger the TTL, the slow log item contains RU usage:

![825c3a89-5400-4c6e-8534-c4da72dec732](https://github.com/user-attachments/assets/058e5d96-1d3e-4c73-9eca-968db30adb3f)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the ru usage is not recorded in slow log for some internal queries.
```
