### PR TITLE
importinto: redact option cloud_storage_uri in show process list and log

### DIFF
--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -115,7 +115,7 @@ const (
 	//
 	// default false for local sort, true for global sort.
 	disableTiKVImportModeOption = "disable_tikv_import_mode"
-	cloudStorageURIOption       = "cloud_storage_uri"
+	cloudStorageURIOption       = ast.CloudStorageURI
 	disablePrecheckOption       = "disable_precheck"
 	// used for test
 	maxEngineSizeOption  = "__max_engine_size"

--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -2242,6 +2242,19 @@ func (n *ImportIntoStmt) Accept(v Visitor) (Node, bool) {
 func (n *ImportIntoStmt) SecureText() string {
 	redactedStmt := *n
 	redactedStmt.Path = RedactURL(n.Path)
+	redactedStmt.Options = make([]*LoadDataOpt, 0, len(n.Options))
+	for _, opt := range n.Options {
+		outOpt := opt
+		ln := strings.ToLower(opt.Name)
+		if ln == CloudStorageURI {
+			redactedStr := RedactURL(opt.Value.(ValueExpr).GetString())
+			outOpt = &LoadDataOpt{
+				Name:  opt.Name,
+				Value: NewValueExpr(redactedStr, "", ""),
+			}
+		}
+		redactedStmt.Options = append(redactedStmt.Options, outOpt)
+	}
 	var sb strings.Builder
 	_ = redactedStmt.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))
 	return sb.String()

--- a/pkg/parser/ast/dml_test.go
+++ b/pkg/parser/ast/dml_test.go
@@ -628,6 +628,10 @@ func TestImportIntoSecureText(t *testing.T) {
 			input:   "import into t from 'gcs://bucket/prefix?access-key=aaaaa&secret-access-key=bbbbb'",
 			secured: "\\QIMPORT INTO `t` FROM 'gcs://bucket/prefix?access-key=aaaaa&secret-access-key=bbbbb'\\E",
 		},
+		{
+			input:   "import into t from 's3://bucket/prefix?access-key=aaaaa&secret-access-key=bbbbb' with CLOUD_STORAGE_uri='s3://bucket/prefix?access-key=cccccc&secret-access-key=dddddd'",
+			secured: `^IMPORT INTO .t. FROM \Q's3://bucket/prefix?\E((access-key=xxxxxx|secret-access-key=xxxxxx)(&|')){2} WITH cloud_storage_uri=\Q's3://bucket/prefix?\E((access-key=xxxxxx|secret-access-key=xxxxxx)(&|')){2}`,
+		},
 	}
 
 	p := parser.New()

--- a/pkg/parser/ast/misc.go
+++ b/pkg/parser/ast/misc.go
@@ -951,6 +951,9 @@ const (
 	SetCharset = "SetCharset"
 	// TiDBCloudStorageURI is the const for set tidb_cloud_storage_uri stmt.
 	TiDBCloudStorageURI = "tidb_cloud_storage_uri"
+	// CloudStorageURI is similar to above tidb var, but it's used in import into
+	// to set a separate param for a single import job.
+	CloudStorageURI = "cloud_storage_uri"
 )
 
 // VariableAssignment is a variable assignment struct.

--- a/tests/realtikvtest/importintotest4/BUILD.bazel
+++ b/tests/realtikvtest/importintotest4/BUILD.bazel
@@ -32,5 +32,6 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",
         "@com_github_tikv_client_go_v2//util",
+        "@org_uber_go_atomic//:atomic",
     ],
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62966

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

before this pr
```sql
mysql> show full processlist;
+------------+------+-----------------+------+---------+------+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Id         | User | Host            | db   | Command | Time | State      | Info                                                                                                                                                                                                                                                                           |
+------------+------+-----------------+------+---------+------+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 2816475140 | root | 127.0.0.1:64511 | test | Query   |   14 | autocommit | IMPORT INTO `test`.`t` FROM 's3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&secret-access-key=xxxxxx' WITH cloud_storage_uri=_UTF8MB4's3://mybucket/gsort?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000' |
| 2816475142 | root | 127.0.0.1:64548 | test | Query   |    0 | autocommit | show full processlist                                                                                                                                                                                                                                                          |
+------------+------+-----------------+------+---------+------+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
```log
[2025/08/13 14:28:04.679 +08:00] [WARN] [expensivequery.go:154] [expensive_query] [keyspaceName=SYSTEM] [cost_time=5.05266875s] [conn=2816475140] [user=root] [database=test] [txn_start_ts=0] [mem_max="0 Bytes (0 Bytes)"] [sql="IMPORT INTO `test`.`t` FROM 's3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&secret-access-key=xxxxxx' WITH cloud_storage_uri=_UTF8MB4's3://mybucket/gsort?access-key=minioadmin&secret-access-key=minioadmin&endpoint=http%3a%2f%2f0.0.0.0%3a9000'"] [session_alias=] ["affected rows"=0]
```

after this pr
```sql
mysql> show full processlist;
+------------+------+-----------------+------+---------+------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Id         | User | Host            | db   | Command | Time | State      | Info                                                                                                                                                                                                                                                           |
+------------+------+-----------------+------+---------+------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 1637875716 | root | 127.0.0.1:62912 | test | Query   |   22 | autocommit | IMPORT INTO `test`.`t` FROM 's3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&secret-access-key=xxxxxx' WITH cloud_storage_uri='s3://mybucket/gsort?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&secret-access-key=xxxxxx' |
| 1637875718 | root | 127.0.0.1:62925 | test | Query   |    0 | autocommit | show full processlist                                                                                                                                                                                                                                          |
+------------+------+-----------------+------+---------+------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
```log
[2025/08/13 14:19:56.599 +08:00] [WARN] [expensivequery.go:154] [expensive_query] [keyspaceName=SYSTEM] [cost_time=5.046032333s] [conn=1637875716] [user=root] [database=test] [txn_start_ts=0] [mem_max="0 Bytes (0 Bytes)"] [sql="IMPORT INTO `test`.`t` FROM 's3://mybucket/a.csv?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&secret-access-key=xxxxxx' WITH cloud_storage_uri='s3://mybucket/gsort?access-key=xxxxxx&endpoint=http%3A%2F%2F0.0.0.0%3A9000&secret-access-key=xxxxxx'"] [session_alias=] ["affected rows"=0]
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
