### PR TITLE
perf: using generics instead of reflect for better performance

### DIFF
--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -4903,8 +4903,8 @@ func checkPartitionExprArgs(_ expression.BuildContext, tblInfo *model.TableInfo,
 			return errors.Trace(dbterror.ErrWrongExprInPartitionFunc)
 		}
 	case ast.DateDiff:
-		return errors.Trace(checkResultOK(slice.AllOf(argsType, func(i int) bool {
-			return hasDateArgs(argsType[i])
+		return errors.Trace(checkResultOK(slice.AllOf(argsType, func(arg byte) bool {
+			return hasDateArgs(arg)
 		})))
 
 	case ast.Abs, ast.Ceiling, ast.Floor, ast.Mod:
@@ -4934,26 +4934,26 @@ func collectArgsType(tblInfo *model.TableInfo, exprs ...ast.ExprNode) ([]byte, e
 }
 
 func hasDateArgs(argsType ...byte) bool {
-	return slice.AnyOf(argsType, func(i int) bool {
-		return argsType[i] == mysql.TypeDate || argsType[i] == mysql.TypeDatetime
+	return slices.ContainsFunc(argsType, func(t byte) bool {
+		return t == mysql.TypeDate || t == mysql.TypeDatetime
 	})
 }
 
 func hasTimeArgs(argsType ...byte) bool {
-	return slice.AnyOf(argsType, func(i int) bool {
-		return argsType[i] == mysql.TypeDuration || argsType[i] == mysql.TypeDatetime
+	return slices.ContainsFunc(argsType, func(t byte) bool {
+		return t == mysql.TypeDuration || t == mysql.TypeDatetime
 	})
 }
 
 func hasTimestampArgs(argsType ...byte) bool {
-	return slice.AnyOf(argsType, func(i int) bool {
-		return argsType[i] == mysql.TypeTimestamp
+	return slices.ContainsFunc(argsType, func(t byte) bool {
+		return t == mysql.TypeTimestamp
 	})
 }
 
 func hasDatetimeArgs(argsType ...byte) bool {
-	return slice.AnyOf(argsType, func(i int) bool {
-		return argsType[i] == mysql.TypeDatetime
+	return slices.ContainsFunc(argsType, func(t byte) bool {
+		return t == mysql.TypeDatetime
 	})
 }
 

--- a/pkg/ddl/partition.go
+++ b/pkg/ddl/partition.go
@@ -4946,9 +4946,7 @@ func hasTimeArgs(argsType ...byte) bool {
 }
 
 func hasTimestampArgs(argsType ...byte) bool {
-	return slices.ContainsFunc(argsType, func(t byte) bool {
-		return t == mysql.TypeTimestamp
-	})
+	return slices.Contains(argsType, mysql.TypeTimestamp)
 }
 
 func hasDatetimeArgs(argsType ...byte) bool {

--- a/pkg/lightning/mydump/BUILD.bazel
+++ b/pkg/lightning/mydump/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/regexpr-router",
         "//pkg/util/set",
-        "//pkg/util/slice",
         "//pkg/util/sqlescape",
         "//pkg/util/table-filter",
         "//pkg/util/zeropool",

--- a/pkg/lightning/mydump/router.go
+++ b/pkg/lightning/mydump/router.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
 	"github.com/pingcap/tidb/pkg/util/filter"
-	"github.com/pingcap/tidb/pkg/util/slice"
 	"go.uber.org/zap"
 )
 
@@ -411,9 +411,9 @@ func (regexRouterParser) checkSubPatterns(pat *regexp.Regexp, t string) error {
 			if number > pat.NumSubexp() {
 				return errors.Errorf("sub pattern capture '%s' out of range", subVar)
 			}
-		} else if !slice.AnyOf(pat.SubexpNames(), func(i int) bool {
+		} else if !slices.ContainsFunc(pat.SubexpNames(), func(name string) bool {
 			// FIXME: we should use re.SubexpIndex here, but not supported in go1.13 yet
-			return pat.SubexpNames()[i] == tmplName
+			return name == tmplName
 		}) {
 			return errors.Errorf("invalid named capture '%s'", subVar)
 		}

--- a/pkg/lightning/mydump/router.go
+++ b/pkg/lightning/mydump/router.go
@@ -411,10 +411,7 @@ func (regexRouterParser) checkSubPatterns(pat *regexp.Regexp, t string) error {
 			if number > pat.NumSubexp() {
 				return errors.Errorf("sub pattern capture '%s' out of range", subVar)
 			}
-		} else if !slices.ContainsFunc(pat.SubexpNames(), func(name string) bool {
-			// FIXME: we should use re.SubexpIndex here, but not supported in go1.13 yet
-			return name == tmplName
-		}) {
+		} else if !slices.Contains(pat.SubexpNames(), tmplName) {
 			return errors.Errorf("invalid named capture '%s'", subVar)
 		}
 	}

--- a/pkg/planner/core/casetest/cbotest/BUILD.bazel
+++ b/pkg/planner/core/casetest/cbotest/BUILD.bazel
@@ -9,7 +9,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    race = "on",
     shard_count = 21,
     deps = [
         "//pkg/domain",

--- a/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
+++ b/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
@@ -9,7 +9,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    race = "on",
     shard_count = 37,
     deps = [
         "//pkg/config",

--- a/pkg/planner/core/issuetest/BUILD.bazel
+++ b/pkg/planner/core/issuetest/BUILD.bazel
@@ -9,7 +9,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    race = "on",
     shard_count = 12,
     deps = [
         "//pkg/parser",

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -15,7 +15,7 @@
 package slice
 
 // AnyOf returns true if any element in the slice matches the predict func.
-func AnyOf[E any](s []E, p func(int) bool) bool {
+func AnyOf[T any](s []T, p func(int) bool) bool {
 	for i := range s {
 		if p(i) {
 			return true
@@ -25,12 +25,12 @@ func AnyOf[E any](s []E, p func(int) bool) bool {
 }
 
 // NoneOf returns true if no element in the slice matches the predict func.
-func NoneOf[E any](s []E, p func(int) bool) bool {
+func NoneOf[T any](s []T, p func(int) bool) bool {
 	return !AnyOf(s, p)
 }
 
 // AllOf returns true if all elements in the slice match the predict func.
-func AllOf[E any](s []E, p func(int) bool) bool {
+func AllOf[T any](s []T, p func(int) bool) bool {
 	return !AnyOf(s, func(i int) bool {
 		return !p(i)
 	})

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -14,12 +14,9 @@
 
 package slice
 
-import "reflect"
-
 // AnyOf returns true if any element in the slice matches the predict func.
-func AnyOf(s any, p func(int) bool) bool {
-	l := reflect.ValueOf(s).Len()
-	for i := range l {
+func AnyOf[E any](s []E, p func(int) bool) bool {
+	for i := range s {
 		if p(i) {
 			return true
 		}
@@ -28,14 +25,13 @@ func AnyOf(s any, p func(int) bool) bool {
 }
 
 // NoneOf returns true if no element in the slice matches the predict func.
-func NoneOf(s any, p func(int) bool) bool {
+func NoneOf[E any](s []E, p func(int) bool) bool {
 	return !AnyOf(s, p)
 }
 
 // AllOf returns true if all elements in the slice match the predict func.
-func AllOf(s any, p func(int) bool) bool {
-	np := func(i int) bool {
+func AllOf[E any](s []E, p func(int) bool) bool {
+	return !AnyOf(s, func(i int) bool {
 		return !p(i)
-	}
-	return NoneOf(s, np)
+	})
 }

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -14,24 +14,13 @@
 
 package slice
 
-// AnyOf returns true if any element in the slice matches the predict func.
-func AnyOf[T any](s []T, p func(int) bool) bool {
-	for i := range s {
-		if p(i) {
-			return true
-		}
-	}
-	return false
-}
-
-// NoneOf returns true if no element in the slice matches the predict func.
-func NoneOf[T any](s []T, p func(int) bool) bool {
-	return !AnyOf(s, p)
-}
+import "slices"
 
 // AllOf returns true if all elements in the slice match the predict func.
-func AllOf[T any](s []T, p func(int) bool) bool {
-	return !AnyOf(s, func(i int) bool {
-		return !p(i)
+func AllOf[T any](s []T, p func(T) bool) bool {
+	// Use the inverse of ContainsFunc with negated predicate
+	// AllOf(s, p) is equivalent to !ContainsFunc(s, !p)
+	return !slices.ContainsFunc(s, func(x T) bool {
+		return !p(x)
 	})
 }

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -23,22 +23,18 @@ import (
 
 func TestSlice(t *testing.T) {
 	tests := []struct {
-		a      []int
-		anyOf  bool
-		noneOf bool
-		allOf  bool
+		a     []int
+		allOf bool
 	}{
-		{[]int{}, false, true, true},
-		{[]int{1, 2, 3}, true, false, false},
-		{[]int{1, 3}, false, true, false},
-		{[]int{2, 2, 4}, true, false, true},
+		{[]int{}, true},
+		{[]int{1, 2, 3}, false},
+		{[]int{1, 3}, false},
+		{[]int{2, 2, 4}, true},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.a), func(t *testing.T) {
-			even := func(i int) bool { return test.a[i]%2 == 0 }
-			require.Equal(t, test.anyOf, AnyOf(test.a, even))
-			require.Equal(t, test.noneOf, NoneOf(test.a, even))
+			even := func(val int) bool { return val%2 == 0 }
 			require.Equal(t, test.allOf, AllOf(test.a, even))
 		})
 	}

--- a/pkg/util/workloadrepo/table.go
+++ b/pkg/util/workloadrepo/table.go
@@ -156,8 +156,8 @@ func (w *worker) checkTablesExists(ctx context.Context, now time.Time) bool {
 	sess := _sessctx.(sessionctx.Context)
 	defer w.sesspool.Put(_sessctx)
 	is := sess.GetLatestInfoSchema().(infoschema.InfoSchema)
-	return slice.AllOf(w.workloadTables, func(i int) bool {
-		return checkTableExistsByIS(ctx, is, w.workloadTables[i].destTable, now)
+	return slice.AllOf(w.workloadTables, func(table repositoryTable) bool {
+		return checkTableExistsByIS(ctx, is, table.destTable, now)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

as diff I run some bench mark local seems it can have a better performance, 
and I am still learning it, not sure it is 100% right


benchmark:

```cli
BenchmarkAnyOf_New_Small-10             144057651                8.305 ns/op           0 B/op          0 allocs/op
BenchmarkAnyOf_Old_Small-10             121768545                9.815 ns/op           0 B/op          0 allocs/op
BenchmarkAnyOf_New_Medium-10            30066207                39.44 ns/op            0 B/op          0 allocs/op
BenchmarkAnyOf_Old_Medium-10            29319988                40.62 ns/op            0 B/op          0 allocs/op
BenchmarkAnyOf_New_Large-10             30374875                39.85 ns/op            0 B/op          0 allocs/op
BenchmarkAnyOf_Old_Large-10             29228607                40.93 ns/op            0 B/op          0 allocs/op
BenchmarkAnyOf_New_XLarge-10            29980574                39.67 ns/op            0 B/op          0 allocs/op
BenchmarkAnyOf_Old_XLarge-10            29309665                40.75 ns/op            0 B/op          0 allocs/op
BenchmarkAnyOf_New_WorstCase-10          1713400               701.5 ns/op             0 B/op          0 allocs/op
BenchmarkAnyOf_Old_WorstCase-10          1734120               690.2 ns/op             0 B/op          0 allocs/op
BenchmarkAnyOf_New_BestCase-10          1000000000               1.168 ns/op           0 B/op          0 allocs/op
BenchmarkAnyOf_Old_BestCase-10          554618565                2.169 ns/op           0 B/op          0 allocs/op
BenchmarkAnyOf_StringSlice_New-10        9882049               121.1 ns/op             0 B/op          0 allocs/op
BenchmarkAnyOf_StringSlice_Old-10        3419708               350.7 ns/op             0 B/op          0 allocs/op
BenchmarkAnyOf_Float64Slice_New-10       9883820               121.4 ns/op             0 B/op          0 allocs/op
BenchmarkAnyOf_Float64Slice_Old-10       3424080               352.5 ns/op             0 B/op          0 allocs/op

BenchmarkNoneOf_New_Medium-10           30326326                39.30 ns/op            0 B/op          0 allocs/op
BenchmarkNoneOf_Old_Medium-10           29606510                40.30 ns/op            0 B/op          0 allocs/op
BenchmarkNoneOf_New_Large-10            30235838                39.68 ns/op            0 B/op          0 allocs/op
BenchmarkNoneOf_Old_Large-10            29523350                40.33 ns/op            0 B/op          0 allocs/op


BenchmarkAllOf_New_Medium-10            593807331                1.847 ns/op           0 B/op          0 allocs/op
BenchmarkAllOf_Old_Medium-10            277587498                4.333 ns/op           0 B/op          0 allocs/op
BenchmarkAllOf_New_Large-10             651542288                1.846 ns/op           0 B/op          0 allocs/op
BenchmarkAllOf_Old_Large-10             275393266                4.340 ns/op           0 B/op          0 allocs/op
BenchmarkAllOf_New_WorstCase-10         1000000000               1.148 ns/op           0 B/op          0 allocs/op
BenchmarkAllOf_Old_WorstCase-10         344983638                3.495 ns/op           0 B/op          0 allocs/op
BenchmarkAllOf_New_BestCase-10           1715023               710.6 ns/op             0 B/op          0 allocs/op
BenchmarkAllOf_Old_BestCase-10           1000000              1186 ns/op      
```

code
```go
// Copyright 2021 PingCAP, Inc.
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

package slice

import (
	"reflect"
	"testing"
)

// oldAnyOf is the old reflection-based implementation for comparison
func oldAnyOf(s any, p func(int) bool) bool {
	l := reflect.ValueOf(s).Len()
	for i := range l {
		if p(i) {
			return true
		}
	}
	return false
}

// oldNoneOf is the old reflection-based implementation for comparison
func oldNoneOf(s any, p func(int) bool) bool {
	return !oldAnyOf(s, p)
}

// oldAllOf is the old reflection-based implementation for comparison
func oldAllOf(s any, p func(int) bool) bool {
	np := func(i int) bool {
		return !p(i)
	}
	return oldNoneOf(s, np)
}

// Benchmark data
var (
	intSlice10    = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
	intSlice100   = make([]int, 100)
	intSlice1000  = make([]int, 1000)
	intSlice10000 = make([]int, 10000)
)

func init() {
	for i := range intSlice100 {
		intSlice100[i] = i
	}
	for i := range intSlice1000 {
		intSlice1000[i] = i
	}
	for i := range intSlice10000 {
		intSlice10000[i] = i
	}
}

// Predicate functions for benchmarking
var (
	// Always false predicate - worst case for AnyOf, best case for AllOf
	alwaysFalse = func(int) bool { return false }
	// Always true predicate - best case for AnyOf, worst case for AllOf
	alwaysTrue = func(int) bool { return true }
	// Find middle element - average case
	findMiddle = func(i int) bool { return i == 50 }
	// Even numbers predicate
	isEven = func(i int) bool { return i%2 == 0 }
)

// AnyOf benchmarks
func BenchmarkAnyOf_New_Small(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AnyOf(intSlice10, findMiddle)
	}
}

func BenchmarkAnyOf_Old_Small(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAnyOf(intSlice10, findMiddle)
	}
}

func BenchmarkAnyOf_New_Medium(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AnyOf(intSlice100, findMiddle)
	}
}

func BenchmarkAnyOf_Old_Medium(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAnyOf(intSlice100, findMiddle)
	}
}

func BenchmarkAnyOf_New_Large(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AnyOf(intSlice1000, findMiddle)
	}
}

func BenchmarkAnyOf_Old_Large(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAnyOf(intSlice1000, findMiddle)
	}
}

func BenchmarkAnyOf_New_XLarge(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AnyOf(intSlice10000, findMiddle)
	}
}

func BenchmarkAnyOf_Old_XLarge(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAnyOf(intSlice10000, findMiddle)
	}
}

// AnyOf worst case (always false)
func BenchmarkAnyOf_New_WorstCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AnyOf(intSlice1000, alwaysFalse)
	}
}

func BenchmarkAnyOf_Old_WorstCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAnyOf(intSlice1000, alwaysFalse)
	}
}

// AnyOf best case (always true)
func BenchmarkAnyOf_New_BestCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AnyOf(intSlice1000, alwaysTrue)
	}
}

func BenchmarkAnyOf_Old_BestCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAnyOf(intSlice1000, alwaysTrue)
	}
}

// NoneOf benchmarks
func BenchmarkNoneOf_New_Medium(b *testing.B) {
	for i := 0; i < b.N; i++ {
		NoneOf(intSlice100, findMiddle)
	}
}

func BenchmarkNoneOf_Old_Medium(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldNoneOf(intSlice100, findMiddle)
	}
}

func BenchmarkNoneOf_New_Large(b *testing.B) {
	for i := 0; i < b.N; i++ {
		NoneOf(intSlice1000, findMiddle)
	}
}

func BenchmarkNoneOf_Old_Large(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldNoneOf(intSlice1000, findMiddle)
	}
}

// AllOf benchmarks
func BenchmarkAllOf_New_Medium(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AllOf(intSlice100, isEven)
	}
}

func BenchmarkAllOf_Old_Medium(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAllOf(intSlice100, isEven)
	}
}

func BenchmarkAllOf_New_Large(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AllOf(intSlice1000, isEven)
	}
}

func BenchmarkAllOf_Old_Large(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAllOf(intSlice1000, isEven)
	}
}

// AllOf worst case (always false predicate)
func BenchmarkAllOf_New_WorstCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AllOf(intSlice1000, alwaysFalse)
	}
}

func BenchmarkAllOf_Old_WorstCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAllOf(intSlice1000, alwaysFalse)
	}
}

// AllOf best case (always true predicate)
func BenchmarkAllOf_New_BestCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		AllOf(intSlice1000, alwaysTrue)
	}
}

func BenchmarkAllOf_Old_BestCase(b *testing.B) {
	for i := 0; i < b.N; i++ {
		oldAllOf(intSlice1000, alwaysTrue)
	}
}

// Different slice types to test generics vs reflection
func BenchmarkAnyOf_StringSlice_New(b *testing.B) {
	stringSlice := make([]string, 1000)
	for i := range stringSlice {
		stringSlice[i] = "test"
	}
	
	for i := 0; i < b.N; i++ {
		AnyOf(stringSlice, func(i int) bool { return i == 500 })
	}
}

func BenchmarkAnyOf_StringSlice_Old(b *testing.B) {
	stringSlice := make([]string, 1000)
	for i := range stringSlice {
		stringSlice[i] = "test"
	}
	
	for i := 0; i < b.N; i++ {
		oldAnyOf(stringSlice, func(i int) bool { return i == 500 })
	}
}

func BenchmarkAnyOf_Float64Slice_New(b *testing.B) {
	floatSlice := make([]float64, 1000)
	for i := range floatSlice {
		floatSlice[i] = float64(i)
	}
	
	for i := 0; i < b.N; i++ {
		AnyOf(floatSlice, func(i int) bool { return i == 500 })
	}
}

func BenchmarkAnyOf_Float64Slice_Old(b *testing.B) {
	floatSlice := make([]float64, 1000)
	for i := range floatSlice {
		floatSlice[i] = float64(i)
	}
	
	for i := 0; i < b.N; i++ {
		oldAnyOf(floatSlice, func(i int) bool { return i == 500 })
	}
}

```

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62972

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
