### PR TITLE
tici: fix tidb fail to get meta service leader address when tidb starts after meta service leader

### DIFF
--- a/pkg/store/copr/tici_shard_cache.go
+++ b/pkg/store/copr/tici_shard_cache.go
@@ -114,7 +114,7 @@ type TiCIShardCacheClient struct {
 
 // NewTiCIShardCacheClient creates a new TiCIShardCacheClient instance.
 func NewTiCIShardCacheClient(etcdClient *clientv3.Client) (*TiCIShardCacheClient, error) {
-	client, err := tici.NewNilManagerCtx(context.Background(), etcdClient)
+	client, err := tici.NewManagerCtx(context.Background(), etcdClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tici/tici_manager_client.go
+++ b/pkg/tici/tici_manager_client.go
@@ -140,7 +140,6 @@ func (t *ManagerCtx) updateClient(ch clientv3.WatchChan) {
 					if t.metaClient != nil {
 						t.metaClient.Close()
 					}
-					// TODO: Support retrying connection if it fails
 					metaClient, err := newMetaClient(t.ctx, string(event.Kv.Value))
 					if err != nil {
 						t.metaClient = nil

--- a/pkg/tici/tici_manager_client_test.go
+++ b/pkg/tici/tici_manager_client_test.go
@@ -59,9 +59,11 @@ func (m *MockMetaServiceClient) GetShardLocalCacheInfo(ctx context.Context, in *
 
 func newTestTiCIManagerCtx(mockClient MetaServiceClient) *ManagerCtx {
 	return &ManagerCtx{
-		conn:              nil,
-		metaServiceClient: mockClient,
-		ctx:               context.Background(),
+		metaClient: &metaClient{
+			conn:   nil, // Not used in tests
+			client: mockClient,
+		},
+		ctx: context.Background(),
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
