### PR TITLE
[WIP] lightning: skip reading parquet row count for clustered table

### DIFF
--- a/lightning/pkg/importer/table_import.go
+++ b/lightning/pkg/importer/table_import.go
@@ -289,6 +289,7 @@ func (tr *TableImporter) Close() {
 func (tr *TableImporter) populateChunks(ctx context.Context, rc *Controller, cp *checkpoints.TableCheckpoint) error {
 	task := tr.logger.Begin(zap.InfoLevel, "load engines and files")
 	divideConfig := mydump.NewDataDivideConfig(rc.cfg, len(tr.tableInfo.Core.Columns), rc.ioWorkers, rc.store, tr.tableMeta)
+	divideConfig.TableInfo = tr.tableInfo.Desired
 	tableRegions, err := mydump.MakeTableRegions(ctx, divideConfig)
 	if err == nil {
 		timestamp := time.Now().Unix()

--- a/pkg/executor/importer/table_import.go
+++ b/pkg/executor/importer/table_import.go
@@ -426,6 +426,7 @@ func (e *LoadDataController) PopulateChunks(ctx context.Context) (chunksMap map[
 		DataInvalidCharReplace: string(utf8.RuneError),
 		ReadBlockSize:          LoadDataReadBlockSize,
 		CSV:                    *e.GenerateCSVConfig(),
+		TableInfo:              e.Table.Meta(),
 	}
 	makeEngineCtx := logutil.WithLogger(ctx, e.logger)
 	tableRegions, err2 := mydump.MakeTableRegions(makeEngineCtx, dataDivideCfg)

--- a/pkg/lightning/mydump/BUILD.bazel
+++ b/pkg/lightning/mydump/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/lightning/log",
         "//pkg/lightning/metric",
         "//pkg/lightning/worker",
+        "//pkg/meta/model",
         "//pkg/parser",
         "//pkg/parser/ast",
         "//pkg/parser/charset",

--- a/pkg/lightning/mydump/loader.go
+++ b/pkg/lightning/mydump/loader.go
@@ -268,8 +268,8 @@ type mdLoaderSetup struct {
 	tableIndexMap map[filter.Table]int
 	setupCfg      *MDLoaderSetupConfig
 
-	// store all file infos from parallel reading
-	sampledParquetRowSizes sync.Map
+	// store file info of parquet from parallel reading
+	sampledParquetInfo sync.Map
 }
 
 // NewLoader constructs a MyDumper loader that scanns the data source and constructs a set of metadatas.
@@ -464,11 +464,16 @@ func (s *mdLoaderSetup) setup(ctx context.Context) error {
 			continue
 		}
 
-		// process row size for parquet files
+		// process file size for parquet files
 		if info.FileMeta.Type == SourceTypeParquet {
-			v, _ := s.sampledParquetRowSizes.Load(info.TableName.String())
-			avgRowSize, _ := v.(float64)
-			info.FileMeta.RealSize = int64(float64(info.FileMeta.Rows) * avgRowSize)
+			v, _ := s.sampledParquetInfo.Load(info.TableName.String())
+			pinfo, _ := v.([]float64)
+			rowSize, ratio := pinfo[0], pinfo[1]
+			info.FileMeta.RealSize = int64(float64(info.FileMeta.FileSize) * ratio)
+			rows := float64(info.FileMeta.RealSize) / rowSize
+			if m, ok := metric.FromContext(ctx); ok {
+				m.RowsCounter.WithLabelValues(metric.StateTotalRestore, info.TableName.String()).Add(float64(rows))
+			}
 		}
 
 		switch info.FileMeta.Type {
@@ -602,37 +607,24 @@ func (s *mdLoaderSetup) constructFileInfo(ctx context.Context, f RawFile) (*File
 	case SourceTypeSQL, SourceTypeCSV:
 		info.FileMeta.RealSize = EstimateRealSizeForFile(ctx, info.FileMeta, s.loader.GetStore())
 	case SourceTypeParquet:
-		var (
-			totalRowCount int64
-			rowSize       float64
-			tableName     = info.TableName.String()
-		)
+		tableName := info.TableName.String()
 
 		// Only sample once for each table
-		_, loaded := s.sampledParquetRowSizes.LoadOrStore(tableName, 0)
+		_, loaded := s.sampledParquetInfo.LoadOrStore(tableName, 0)
 		if !loaded {
-			rowSize, err = SampleParquetRowSize(ctx, info.FileMeta, s.loader.GetStore())
+			rows, rowSize, err := SampleParquetRowSize(ctx, info.FileMeta, s.loader.GetStore())
 			if err != nil {
 				logger.Error("fail to sample parquet row size", zap.String("category", "loader"),
 					zap.String("schema", res.Schema), zap.String("table", res.Name),
 					zap.Stringer("type", res.Type), zap.Error(err))
 				return nil, errors.Trace(err)
 			}
-			s.sampledParquetRowSizes.Store(tableName, rowSize)
+			compressionRatio := float64(info.FileMeta.FileSize) / (rowSize * float64(rows))
+			s.sampledParquetInfo.Store(tableName, []float64{rowSize, compressionRatio})
 		}
 
-		totalRowCount, err = ReadParquetFileRowCountByFile(ctx, s.loader.GetStore(), info.FileMeta)
-		if err != nil {
-			logger.Error("fail to get file total row count", zap.String("category", "loader"),
-				zap.String("schema", res.Schema), zap.String("table", res.Name),
-				zap.Stringer("type", res.Type), zap.Error(err))
-			return nil, errors.Trace(err)
-		}
-
-		info.FileMeta.Rows = totalRowCount
-		if m, ok := metric.FromContext(ctx); ok {
-			m.RowsCounter.WithLabelValues(metric.StateTotalRestore, tableName).Add(float64(totalRowCount))
-		}
+		// Postpone the row count calculation
+		info.FileMeta.Rows = 0
 	}
 
 	logger.Debug("file route result", zap.String("schema", res.Schema),
@@ -936,21 +928,21 @@ func SampleFileCompressRatio(ctx context.Context, fileMeta SourceFileMeta, store
 }
 
 // SampleParquetRowSize samples row size of the parquet file.
-func SampleParquetRowSize(ctx context.Context, fileMeta SourceFileMeta, store storage.ExternalStorage) (float64, error) {
+func SampleParquetRowSize(ctx context.Context, fileMeta SourceFileMeta, store storage.ExternalStorage) (int64, float64, error) {
 	totalRowCount, err := ReadParquetFileRowCountByFile(ctx, store, fileMeta)
 	if totalRowCount == 0 || err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	reader, err := store.Open(ctx, fileMeta.Path, nil)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	parser, err := NewParquetParser(ctx, store, reader, fileMeta.Path)
 	if err != nil {
 		//nolint: errcheck
 		reader.Close()
-		return 0, err
+		return 0, 0, err
 	}
 	//nolint: errcheck
 	defer parser.Close()
@@ -965,7 +957,7 @@ func SampleParquetRowSize(ctx context.Context, fileMeta SourceFileMeta, store st
 			if errors.Cause(err) == io.EOF {
 				break
 			}
-			return 0, err
+			return 0, 0, err
 		}
 		lastRow := parser.LastRow()
 		rowCount++
@@ -975,5 +967,5 @@ func SampleParquetRowSize(ctx context.Context, fileMeta SourceFileMeta, store st
 			break
 		}
 	}
-	return float64(rowSize) / float64(rowCount), nil
+	return parser.Reader.Footer.NumRows, float64(rowSize) / float64(rowCount), nil
 }

--- a/pkg/lightning/mydump/loader_test.go
+++ b/pkg/lightning/mydump/loader_test.go
@@ -1179,13 +1179,9 @@ func testSampleParquetDataSize(t *testing.T, count int) {
 	err = store.WriteFile(ctx, fileName, bf.Bytes())
 	require.NoError(t, err)
 
-	rowSize, err := md.SampleParquetRowSize(ctx, md.SourceFileMeta{
+	rowCount, rowSize, err := md.SampleParquetRowSize(ctx, md.SourceFileMeta{
 		Path: fileName,
 	}, store)
-	require.NoError(t, err)
-	rowCount, err := md.ReadParquetFileRowCountByFile(ctx, store, md.SourceFileMeta{
-		Path: fileName,
-	})
 	require.NoError(t, err)
 	// expected error within 10%, so delta = totalRowSize / 10
 	require.InDelta(t, totalRowSize, int64(rowSize*float64(rowCount)), float64(totalRowSize)/10)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
