### PR TITLE
stats: optimize stats table copy to save memory

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4186,7 +4186,7 @@ func getStatsTable(ctx base.PlanContext, tblInfo *model.TableInfo, pid int64) *s
 				allowPseudoTblTriggerLoading = true
 			}
 			// Copy it so we can modify the ModifyCount and the RealtimeCount safely.
-			statsTbl = statsTbl.ShallowCopy()
+			statsTbl = statsTbl.ShallowCopy(statistics.CopyMetaOnly)
 			statsTbl.RealtimeCount = analyzeCount
 			statsTbl.ModifyCount = 0
 		}

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4186,7 +4186,7 @@ func getStatsTable(ctx base.PlanContext, tblInfo *model.TableInfo, pid int64) *s
 				allowPseudoTblTriggerLoading = true
 			}
 			// Copy it so we can modify the ModifyCount and the RealtimeCount safely.
-			statsTbl = statsTbl.ShallowCopy(statistics.CopyMetaOnly)
+			statsTbl = statsTbl.CopyAs(statistics.MetaOnly)
 			statsTbl.RealtimeCount = analyzeCount
 			statsTbl.ModifyCount = 0
 		}

--- a/pkg/statistics/BUILD.bazel
+++ b/pkg/statistics/BUILD.bazel
@@ -83,7 +83,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":statistics"],
     flaky = True,
-    shard_count = 40,
+    shard_count = 41,
     deps = [
         "//pkg/config",
         "//pkg/meta/model",

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -139,7 +139,6 @@ func (*Handle) initStatsHistograms4ChunkLite(cache statstypes.StatsCache, iter *
 			if !ok {
 				continue
 			}
-			table = table.Copy()
 		}
 		isIndex := row.GetInt64(1)
 		id := row.GetInt64(2)

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -188,7 +188,6 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 			if !ok {
 				continue
 			}
-			table = table.Copy()
 		}
 		// All the objects in the table share the same stats version.
 		if statsVer != statistics.Version0 {
@@ -395,7 +394,6 @@ func (*Handle) initStatsTopN4Chunk(cache statstypes.StatsCache, iter *chunk.Iter
 			if !ok {
 				continue
 			}
-			table = table.Copy()
 		}
 		idx := table.GetIdx(row.GetInt64(1))
 		if idx == nil || (idx.CMSketch == nil && idx.StatsVer <= statistics.Version1) {
@@ -568,7 +566,6 @@ func (*Handle) initStatsBuckets4Chunk(cache statstypes.StatsCache, iter *chunk.I
 			if !ok {
 				continue
 			}
-			table = table.Copy()
 		}
 		var lower, upper types.Datum
 		var hist *statistics.Histogram

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -139,6 +139,7 @@ func (*Handle) initStatsHistograms4ChunkLite(cache statstypes.StatsCache, iter *
 			if !ok {
 				continue
 			}
+			table = table.ShallowCopy(statistics.CopyWithBothMaps)
 		}
 		isIndex := row.GetInt64(1)
 		id := row.GetInt64(2)
@@ -188,6 +189,7 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 			if !ok {
 				continue
 			}
+			table = table.ShallowCopy(statistics.CopyWithBothMaps)
 		}
 		// All the objects in the table share the same stats version.
 		if statsVer != statistics.Version0 {
@@ -394,6 +396,9 @@ func (*Handle) initStatsTopN4Chunk(cache statstypes.StatsCache, iter *chunk.Iter
 			if !ok {
 				continue
 			}
+			// existing idx is modified so if using shallow copy the modified idx is shared and will mess up the cache
+			// cost calculation
+			table = table.Copy()
 		}
 		idx := table.GetIdx(row.GetInt64(1))
 		if idx == nil || (idx.CMSketch == nil && idx.StatsVer <= statistics.Version1) {
@@ -566,6 +571,9 @@ func (*Handle) initStatsBuckets4Chunk(cache statstypes.StatsCache, iter *chunk.I
 			if !ok {
 				continue
 			}
+			// existing idx is modified so if using shallow copy the modified idx is shared and will mess up the cache
+			// cost calculation
+			table = table.Copy()
 		}
 		var lower, upper types.Datum
 		var hist *statistics.Histogram

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -139,7 +139,7 @@ func (*Handle) initStatsHistograms4ChunkLite(cache statstypes.StatsCache, iter *
 			if !ok {
 				continue
 			}
-			table = table.ShallowCopy(statistics.CopyWithBothMaps)
+			table = table.CopyAs(statistics.MetaOnly)
 		}
 		isIndex := row.GetInt64(1)
 		id := row.GetInt64(2)
@@ -189,7 +189,7 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache stats
 			if !ok {
 				continue
 			}
-			table = table.ShallowCopy(statistics.CopyWithBothMaps)
+			table = table.CopyAs(statistics.BothMapsWritable)
 		}
 		// All the objects in the table share the same stats version.
 		if statsVer != statistics.Version0 {
@@ -398,7 +398,7 @@ func (*Handle) initStatsTopN4Chunk(cache statstypes.StatsCache, iter *chunk.Iter
 			}
 			// existing idx is modified so if using shallow copy the modified idx is shared and will mess up the cache
 			// cost calculation
-			table = table.Copy()
+			table = table.CopyAs(statistics.AllDataWritable)
 		}
 		idx := table.GetIdx(row.GetInt64(1))
 		if idx == nil || (idx.CMSketch == nil && idx.StatsVer <= statistics.Version1) {
@@ -573,7 +573,7 @@ func (*Handle) initStatsBuckets4Chunk(cache statstypes.StatsCache, iter *chunk.I
 			}
 			// existing idx is modified so if using shallow copy the modified idx is shared and will mess up the cache
 			// cost calculation
-			table = table.Copy()
+			table = table.CopyAs(statistics.AllDataWritable)
 		}
 		var lower, upper types.Datum
 		var hist *statistics.Histogram

--- a/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
+++ b/pkg/statistics/handle/cache/internal/lfu/lfu_cache.go
@@ -159,7 +159,7 @@ func (s *LFU) dropMemory(item *ristretto.Item) {
 	// We do not need to calculate the cost during onEvict,
 	// because the onexit function is also called when the evict event occurs.
 	// TODO(hawkingrei): not copy the useless part.
-	table := item.Value.(*statistics.Table).Copy()
+	table := item.Value.(*statistics.Table).CopyAs(statistics.AllDataWritable)
 	table.DropEvicted()
 	s.resultKeySet.AddKeyValue(int64(item.Key), table)
 	after := table.MemoryUsage().TotalTrackingMemUsage()

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -206,7 +206,7 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema, t
 		// If the column/index stats has not been updated, we can reuse the old table stats.
 		// Only need to update the count and modify count.
 		if ok && latestHistUpdateVersion > 0 && oldTbl.LastStatsHistVersion >= latestHistUpdateVersion {
-			tbl = oldTbl.ShallowCopy()
+			tbl = oldTbl.ShallowCopy(statistics.CopyMetaOnly)
 			// count and modify count is updated in finalProcess
 			needLoadColAndIdxStats = false
 		}

--- a/pkg/statistics/handle/cache/statscache.go
+++ b/pkg/statistics/handle/cache/statscache.go
@@ -206,7 +206,7 @@ func (s *StatsCacheImpl) Update(ctx context.Context, is infoschema.InfoSchema, t
 		// If the column/index stats has not been updated, we can reuse the old table stats.
 		// Only need to update the count and modify count.
 		if ok && latestHistUpdateVersion > 0 && oldTbl.LastStatsHistVersion >= latestHistUpdateVersion {
-			tbl = oldTbl.ShallowCopy(statistics.CopyMetaOnly)
+			tbl = oldTbl.CopyAs(statistics.MetaOnly)
 			// count and modify count is updated in finalProcess
 			needLoadColAndIdxStats = false
 		}

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -532,8 +532,8 @@ func TableStatsFromStorage(sctx sessionctx.Context, snapshot uint64, tableInfo *
 
 	if needsCopy {
 		if len(rows) == 0 {
-			// Only metadata update needed - use cheap shallow copy
-			table = table.ShallowCopy()
+			// Only metadata update needed - use cheap metadata-only copy
+			table = table.ShallowCopy(statistics.CopyMetaOnly)
 		} else {
 			// Histogram modifications needed - use full copy
 			table = table.Copy()
@@ -778,7 +778,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		)
 		return nil
 	}
-	statsTbl = statsTbl.CopyForColumnMapUpdate()
+	statsTbl = statsTbl.ShallowCopy(statistics.CopyWithColumns)
 	if colHist.StatsAvailable() {
 		if fullLoad {
 			colHist.StatsLoadedStatus = statistics.NewStatsFullLoadStatus()
@@ -891,7 +891,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 		)
 		return nil
 	}
-	tbl = tbl.CopyForIndexMapUpdate()
+	tbl = tbl.ShallowCopy(statistics.CopyWithIndices)
 	if idxHist.StatsVer != statistics.Version0 {
 		tbl.StatsVer = int(idxHist.StatsVer)
 		tbl.LastAnalyzeVersion = max(tbl.LastAnalyzeVersion, idxHist.LastUpdateVersion)

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -532,11 +532,11 @@ func TableStatsFromStorage(sctx sessionctx.Context, snapshot uint64, tableInfo *
 
 	if needsCopy {
 		if len(rows) == 0 {
-			// Only metadata update needed - use cheap metadata-only copy
-			table = table.ShallowCopy(statistics.CopyMetaOnly)
+			// Only metadata update needed - use metadata-only copy
+			table = table.CopyAs(statistics.MetaOnly)
 		} else {
-			// Histogram modifications needed - use full copy
-			table = table.Copy()
+			// Indexes and Columns map potentially get updated
+			table = table.CopyAs(statistics.BothMapsWritable)
 		}
 	}
 
@@ -584,7 +584,7 @@ func TableStatsFromStorage(sctx sessionctx.Context, snapshot uint64, tableInfo *
 		}
 	}
 	table.ColAndIdxExistenceMap.SetChecked()
-	return ExtendedStatsFromStorage(sctx, table, tableID, loadAll)
+	return ExtendedStatsFromStorage(sctx, table.CopyAs(statistics.ExtendedStatsWritable), tableID, loadAll)
 }
 
 // LoadHistogram will load histogram from storage.
@@ -714,7 +714,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		// Otherwise, it will trigger the sync/async load again, even if the column has not been analyzed.
 		if loadNeeded && !analyzed {
 			fakeCol := statistics.EmptyColumn(tblInfo.ID, tblInfo.PKIsHandle, colInfo)
-			statsTbl = statsTbl.Copy()
+			statsTbl = statsTbl.CopyAs(statistics.ColumnMapWritable)
 			statsTbl.SetCol(col.ID, fakeCol)
 			statsHandle.UpdateStatsCache(statstypes.CacheUpdate{
 				Updated: []*statistics.Table{statsTbl},
@@ -778,7 +778,7 @@ func loadNeededColumnHistograms(sctx sessionctx.Context, statsHandle statstypes.
 		)
 		return nil
 	}
-	statsTbl = statsTbl.ShallowCopy(statistics.CopyWithColumns)
+	statsTbl = statsTbl.CopyAs(statistics.ColumnMapWritable)
 	if colHist.StatsAvailable() {
 		if fullLoad {
 			colHist.StatsLoadedStatus = statistics.NewStatsFullLoadStatus()
@@ -891,7 +891,7 @@ func loadNeededIndexHistograms(sctx sessionctx.Context, is infoschema.InfoSchema
 		)
 		return nil
 	}
-	tbl = tbl.ShallowCopy(statistics.CopyWithIndices)
+	tbl = tbl.CopyAs(statistics.IndexMapWritable)
 	if idxHist.StatsVer != statistics.Version0 {
 		tbl.StatsVer = int(idxHist.StatsVer)
 		tbl.LastAnalyzeVersion = max(tbl.LastAnalyzeVersion, idxHist.LastUpdateVersion)

--- a/pkg/statistics/handle/storage/read.go
+++ b/pkg/statistics/handle/storage/read.go
@@ -532,10 +532,10 @@ func TableStatsFromStorage(sctx sessionctx.Context, snapshot uint64, tableInfo *
 
 	if needsCopy {
 		if len(rows) == 0 {
-			// Only metadata update needed - use metadata-only copy
+			// Only metadata update needed
 			table = table.CopyAs(statistics.MetaOnly)
 		} else {
-			// Indexes and Columns map potentially get updated
+			// Indexes and Columns maps potentially get updated
 			table = table.CopyAs(statistics.BothMapsWritable)
 		}
 	}

--- a/pkg/statistics/handle/storage/stats_read_writer.go
+++ b/pkg/statistics/handle/storage/stats_read_writer.go
@@ -321,7 +321,7 @@ func (s *statsReadWriter) ReloadExtendedStatistics() error {
 	return util.CallWithSCtx(s.statsHandler.SPool(), func(sctx sessionctx.Context) error {
 		tables := make([]*statistics.Table, 0, s.statsHandler.Len())
 		for _, tbl := range s.statsHandler.Values() {
-			t, err := ExtendedStatsFromStorage(sctx, tbl.Copy(), tbl.PhysicalID, true)
+			t, err := ExtendedStatsFromStorage(sctx, tbl.CopyAs(statistics.ExtendedStatsWritable), tbl.PhysicalID, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/statistics/handle/storage/update.go
+++ b/pkg/statistics/handle/storage/update.go
@@ -261,7 +261,7 @@ func removeExtendedStatsItem(statsCache types.StatsCache,
 	if !ok || tbl.ExtendedStats == nil || len(tbl.ExtendedStats.Stats) == 0 {
 		return
 	}
-	newTbl := tbl.Copy()
+	newTbl := tbl.CopyAs(statistics.ExtendedStatsWritable)
 	delete(newTbl.ExtendedStats.Stats, statsName)
 	statsCache.UpdateStatsCache(types.CacheUpdate{
 		Updated: []*statistics.Table{newTbl},

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -586,8 +586,10 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 	if !ok {
 		return false
 	}
+	var tableCopied bool
 	if !tbl.ColAndIdxExistenceMap.Checked() {
-		tbl = tbl.CopyForMapUpdate()
+		tbl = tbl.CopyForMapsUpdate()
+		tableCopied = true
 		for _, col := range tbl.HistColl.GetColSlice() {
 			if tblInfo.FindColumnByID(col.ID) == nil {
 				tbl.DelCol(col.ID)
@@ -607,7 +609,9 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		if c != nil && (c.IsFullLoad() || !fullLoaded) {
 			return false
 		}
-		tbl = tbl.CopyForColumnUpdate()
+		if !tableCopied {
+			tbl = tbl.CopyForColumnMapUpdate()
+		}
 		tbl.SetCol(item.ID, colHist)
 
 		// If the column is analyzed we refresh the map for the possible change.
@@ -627,7 +631,9 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		if index != nil && (index.IsFullLoad() || !fullLoaded) {
 			return true
 		}
-		tbl = tbl.CopyForIndexUpdate()
+		if !tableCopied {
+			tbl = tbl.CopyForIndexMapUpdate()
+		}
 		tbl.SetIdx(item.ID, idxHist)
 		// If the index is analyzed we refresh the map for the possible change.
 		if idxHist.IsAnalyzed() {

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -588,7 +588,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 	}
 	var tableCopied bool
 	if !tbl.ColAndIdxExistenceMap.Checked() {
-		tbl = tbl.CopyForMapsUpdate()
+		tbl = tbl.ShallowCopy(statistics.CopyWithBothMaps)
 		tableCopied = true
 		for _, col := range tbl.HistColl.GetColSlice() {
 			if tblInfo.FindColumnByID(col.ID) == nil {
@@ -610,7 +610,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 			return false
 		}
 		if !tableCopied {
-			tbl = tbl.CopyForColumnMapUpdate()
+			tbl = tbl.ShallowCopy(statistics.CopyWithColumns)
 		}
 		tbl.SetCol(item.ID, colHist)
 
@@ -632,7 +632,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 			return true
 		}
 		if !tableCopied {
-			tbl = tbl.CopyForIndexMapUpdate()
+			tbl = tbl.ShallowCopy(statistics.CopyWithIndices)
 		}
 		tbl.SetIdx(item.ID, idxHist)
 		// If the index is analyzed we refresh the map for the possible change.

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -588,7 +588,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 	}
 	var tableCopied bool
 	if !tbl.ColAndIdxExistenceMap.Checked() {
-		tbl = tbl.ShallowCopy(statistics.CopyWithBothMaps)
+		tbl = tbl.CopyAs(statistics.BothMapsWritable)
 		tableCopied = true
 		for _, col := range tbl.HistColl.GetColSlice() {
 			if tblInfo.FindColumnByID(col.ID) == nil {
@@ -610,7 +610,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 			return false
 		}
 		if !tableCopied {
-			tbl = tbl.ShallowCopy(statistics.CopyWithColumns)
+			tbl = tbl.CopyAs(statistics.ColumnMapWritable)
 		}
 		tbl.SetCol(item.ID, colHist)
 
@@ -632,7 +632,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 			return true
 		}
 		if !tableCopied {
-			tbl = tbl.ShallowCopy(statistics.CopyWithIndices)
+			tbl = tbl.CopyAs(statistics.IndexMapWritable)
 		}
 		tbl.SetIdx(item.ID, idxHist)
 		// If the index is analyzed we refresh the map for the possible change.

--- a/pkg/statistics/handle/syncload/stats_syncload.go
+++ b/pkg/statistics/handle/syncload/stats_syncload.go
@@ -587,7 +587,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		return false
 	}
 	if !tbl.ColAndIdxExistenceMap.Checked() {
-		tbl = tbl.Copy()
+		tbl = tbl.CopyForMapUpdate()
 		for _, col := range tbl.HistColl.GetColSlice() {
 			if tblInfo.FindColumnByID(col.ID) == nil {
 				tbl.DelCol(col.ID)
@@ -607,7 +607,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		if c != nil && (c.IsFullLoad() || !fullLoaded) {
 			return false
 		}
-		tbl = tbl.Copy()
+		tbl = tbl.CopyForColumnUpdate()
 		tbl.SetCol(item.ID, colHist)
 
 		// If the column is analyzed we refresh the map for the possible change.
@@ -627,7 +627,7 @@ func (s *statsSyncLoad) updateCachedItem(tblInfo *model.TableInfo, item model.Ta
 		if index != nil && (index.IsFullLoad() || !fullLoaded) {
 			return true
 		}
-		tbl = tbl.Copy()
+		tbl = tbl.CopyForIndexUpdate()
 		tbl.SetIdx(item.ID, idxHist)
 		// If the index is analyzed we refresh the map for the possible change.
 		if idxHist.IsAnalyzed() {

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -663,17 +663,13 @@ func (t *Table) ShallowCopy() *Table {
 	return nt
 }
 
-// CopyForColumnUpdate creates a copy optimized for column updates.
-func (t *Table) CopyForColumnUpdate() *Table {
-	newColumns := make(map[int64]*Column, len(t.columns))
-	for id, col := range t.columns {
-		newColumns[id] = col
-	}
+// CopyForColumnMapUpdate creates a copy optimized for column updates.
+func (t *Table) CopyForColumnMapUpdate() *Table {
 
 	newHistColl := HistColl{
 		PhysicalID:    t.PhysicalID,
 		RealtimeCount: t.RealtimeCount,
-		columns:       newColumns,
+		columns:       maps.Clone(t.columns),
 		indices:       t.indices,
 		Pseudo:        t.Pseudo,
 		ModifyCount:   t.ModifyCount,
@@ -691,18 +687,13 @@ func (t *Table) CopyForColumnUpdate() *Table {
 	return nt
 }
 
-// CopyForIndexUpdate creates a copy optimized for index updates.
-func (t *Table) CopyForIndexUpdate() *Table {
-	newIndices := make(map[int64]*Index, len(t.indices))
-	for id, idx := range t.indices {
-		newIndices[id] = idx
-	}
-
+// CopyForIndexMapUpdate creates a copy optimized for index updates.
+func (t *Table) CopyForIndexMapUpdate() *Table {
 	newHistColl := HistColl{
 		PhysicalID:    t.PhysicalID,
 		RealtimeCount: t.RealtimeCount,
 		columns:       t.columns,
-		indices:       newIndices,
+		indices:       maps.Clone(t.indices),
 		Pseudo:        t.Pseudo,
 		ModifyCount:   t.ModifyCount,
 		StatsVer:      t.StatsVer,
@@ -719,13 +710,13 @@ func (t *Table) CopyForIndexUpdate() *Table {
 	return nt
 }
 
-// CopyForMapUpdate creates a copy optimized for map-only updates like DelCol/DelIdx.
-func (t *Table) CopyForMapUpdate() *Table {
+// CopyForMapsUpdate creates a copy for both col and index map updates.
+func (t *Table) CopyForMapsUpdate() *Table {
 	newHistColl := HistColl{
 		PhysicalID:    t.PhysicalID,
 		RealtimeCount: t.RealtimeCount,
-		columns:       t.columns,
-		indices:       t.indices,
+		columns:       maps.Clone(t.columns),
+		indices:       maps.Clone(t.indices),
 		Pseudo:        t.Pseudo,
 		ModifyCount:   t.ModifyCount,
 		StatsVer:      t.StatsVer,

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -665,7 +665,6 @@ func (t *Table) ShallowCopy() *Table {
 
 // CopyForColumnMapUpdate creates a copy optimized for column updates.
 func (t *Table) CopyForColumnMapUpdate() *Table {
-
 	newHistColl := HistColl{
 		PhysicalID:    t.PhysicalID,
 		RealtimeCount: t.RealtimeCount,

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -638,8 +638,9 @@ func (t *Table) Copy() *Table {
 	return nt
 }
 
-// ShallowCopy creates a shallow copy of the current table.
-// Only the struct Table (and embedded HistColl) is copied - all maps and statistics objects are shared.
+// ShallowCopy copies the current table.
+// It's different from Copy(). Only the struct Table (and also the embedded HistColl) is copied here.
+// The internal containers, like t.Columns and t.Indices, and the stats, like TopN and Histogram are not copied.
 func (t *Table) ShallowCopy() *Table {
 	newHistColl := HistColl{
 		PhysicalID:    t.PhysicalID,

--- a/pkg/statistics/table_test.go
+++ b/pkg/statistics/table_test.go
@@ -30,47 +30,90 @@ func TestCloneColAndIdxExistenceMap(t *testing.T) {
 	require.Equal(t, m, m2)
 }
 
-func TestShallowCopy(t *testing.T) {
+type ShareMode uint8
+
+const (
+	Shared ShareMode = iota
+	Cloned
+)
+
+func TestCopyAs(t *testing.T) {
 	tests := []struct {
-		name              string
-		mode              CopyMode
-		expectColsShared  bool
-		expectIdxsShared  bool
-		expectExistShared bool
+		name           string
+		intent         CopyIntent
+		expectCols     ShareMode
+		expectIdxs     ShareMode
+		expectExist    ShareMode
+		expectExtended ShareMode
 	}{
-		{"CopyMetaOnly", CopyMetaOnly, true, true, true},
-		{"CopyWithColumns", CopyWithColumns, false, true, false},
-		{"CopyWithIndices", CopyWithIndices, true, false, false},
-		{"CopyWithBothMaps", CopyWithBothMaps, false, false, false},
+		{"MetaOnly", MetaOnly, Shared, Shared, Shared, Shared},
+		{"ColumnMapWritable", ColumnMapWritable, Cloned, Shared, Cloned, Shared},
+		{"IndexMapWritable", IndexMapWritable, Shared, Cloned, Cloned, Shared},
+		{"BothMapsWritable", BothMapsWritable, Cloned, Cloned, Cloned, Shared},
+		{"ExtendedStatsWritable", ExtendedStatsWritable, Shared, Shared, Shared, Cloned},
+		{"AllDataWritable", AllDataWritable, Cloned, Cloned, Cloned, Cloned},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Create original table with ExtendedStats for testing
+			originalStats := &ExtendedStatsColl{
+				Stats:             make(map[string]*ExtendedStatsItem),
+				LastUpdateVersion: 1,
+			}
+			originalStats.Stats["test"] = &ExtendedStatsItem{StringVals: "original"}
+
 			table := &Table{
 				HistColl:              *NewHistColl(1, 1, 1, 1, 1),
 				ColAndIdxExistenceMap: NewColAndIndexExistenceMap(1, 1),
+				ExtendedStats:         originalStats,
 			}
 
-			copied := table.ShallowCopy(tt.mode)
+			copied := table.CopyAs(tt.intent)
 
+			// Test columns map sharing/cloning
 			copied.SetCol(1, &Column{PhysicalID: 123})
-			if tt.expectColsShared {
+			if tt.expectCols == Shared {
 				require.NotNil(t, table.GetCol(1), "shared columns: addition to copy should appear in original")
 			} else {
 				require.Nil(t, table.GetCol(1), "cloned columns: addition to copy should not appear in original")
 			}
 
+			// Test indices map sharing/cloning
 			copied.SetIdx(1, &Index{PhysicalID: 123})
-			if tt.expectIdxsShared {
+			if tt.expectIdxs == Shared {
 				require.NotNil(t, table.GetIdx(1), "shared indices: addition to copy should appear in original")
 			} else {
 				require.Nil(t, table.GetIdx(1), "cloned indices: addition to copy should not appear in original")
 			}
 
-			if tt.expectExistShared {
+			// Test existence map sharing/cloning
+			if tt.expectExist == Shared {
 				require.Same(t, table.ColAndIdxExistenceMap, copied.ColAndIdxExistenceMap)
 			} else {
 				require.NotSame(t, table.ColAndIdxExistenceMap, copied.ColAndIdxExistenceMap)
+			}
+
+			// Test ExtendedStats handling
+			if tt.expectExtended == Cloned {
+				// Should be able to modify ExtendedStats without affecting original
+				newStats := &ExtendedStatsColl{
+					Stats:             make(map[string]*ExtendedStatsItem),
+					LastUpdateVersion: 2,
+				}
+				newStats.Stats["test"] = &ExtendedStatsItem{StringVals: "modified"}
+				copied.ExtendedStats = newStats
+
+				// Verify original is unchanged
+				require.Equal(t, uint64(1), table.ExtendedStats.LastUpdateVersion)
+				require.Equal(t, "original", table.ExtendedStats.Stats["test"].StringVals)
+
+				// Verify copy was modified
+				require.Equal(t, uint64(2), copied.ExtendedStats.LastUpdateVersion)
+				require.Equal(t, "modified", copied.ExtendedStats.Stats["test"].StringVals)
+			} else {
+				// For shared ExtendedStats
+				require.Same(t, table.ExtendedStats, copied.ExtendedStats)
 			}
 		})
 	}

--- a/pkg/statistics/table_test.go
+++ b/pkg/statistics/table_test.go
@@ -29,3 +29,49 @@ func TestCloneColAndIdxExistenceMap(t *testing.T) {
 	m2 := m.Clone()
 	require.Equal(t, m, m2)
 }
+
+func TestShallowCopy(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              CopyMode
+		expectColsShared  bool
+		expectIdxsShared  bool
+		expectExistShared bool
+	}{
+		{"CopyMetaOnly", CopyMetaOnly, true, true, true},
+		{"CopyWithColumns", CopyWithColumns, false, true, false},
+		{"CopyWithIndices", CopyWithIndices, true, false, false},
+		{"CopyWithBothMaps", CopyWithBothMaps, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := &Table{
+				HistColl:              *NewHistColl(1, 1, 1, 1, 1),
+				ColAndIdxExistenceMap: NewColAndIndexExistenceMap(1, 1),
+			}
+
+			copied := table.ShallowCopy(tt.mode)
+
+			copied.SetCol(1, &Column{PhysicalID: 123})
+			if tt.expectColsShared {
+				require.NotNil(t, table.GetCol(1), "shared columns: addition to copy should appear in original")
+			} else {
+				require.Nil(t, table.GetCol(1), "cloned columns: addition to copy should not appear in original")
+			}
+
+			copied.SetIdx(1, &Index{PhysicalID: 123})
+			if tt.expectIdxsShared {
+				require.NotNil(t, table.GetIdx(1), "shared indices: addition to copy should appear in original")
+			} else {
+				require.Nil(t, table.GetIdx(1), "cloned indices: addition to copy should not appear in original")
+			}
+
+			if tt.expectExistShared {
+				require.Same(t, table.ColAndIdxExistenceMap, copied.ColAndIdxExistenceMap)
+			} else {
+				require.NotSame(t, table.ColAndIdxExistenceMap, copied.ColAndIdxExistenceMap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63076

Problem Summary:

1. remove copy in InitStatsLite as it's single thread update, so can update in place
2. postpone deep copy in TableStatsFromStorage and use shallow copy if applicable
3. add copyForCol and copyForIndex method to only copy relevant components instead of everything and apply to updateCachedItem and TableStatsFromStorage
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
