### PR TITLE
planner: filter generated columns that depend on skipped columns (#62968)

### DIFF
--- a/pkg/executor/test/analyzetest/analyze_test.go
+++ b/pkg/executor/test/analyzetest/analyze_test.go
@@ -3155,3 +3155,159 @@ func TestIssue55438(t *testing.T) {
 	tk.MustExec("CREATE INDEX i0 ON t0(c1);")
 	tk.MustExec("analyze table t0")
 }
+
+func TestIssue61609(t *testing.T) {
+	// Analyze table with only 1 sample (of 10 rows) - TopN result should multiply the 1 value by 10.
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (0),(0),(0),(0),(0),(0),(0),(0),(0),(0);")
+
+	tk.MustExec("explain select * from t where a = 0")
+	analyzehelper.TriggerPredicateColumnsCollection(t, tk, store, "t", "a")
+	tk.MustExec("analyze table t with 1 topn, 1 samples")
+	tk.MustExec("explain select * from t where a = 0")
+
+	h := dom.StatsHandle()
+	require.NoError(t, h.LoadNeededHistograms(dom.InfoSchema()))
+	tk.MustQuery("show stats_topn where db_name = 'test' and table_name = 't'").Sort().Check(testkit.Rows(
+		"test t  a 0 0 10",
+	))
+}
+
+// TestGeneratedColumns verifies that statistics collection works correctly for generated columns and their indexes.
+//
+// | Type                                             | Stats Collected | Reason                                              |
+// |--------------------------------------------------|-----------------|-----------------------------------------------------|
+// | Base JSON column (data)                          | ✅ Yes          | Regular column (used by the generated columns)     |
+// | Virtual generated column                         | ❌ No           | Cannot evaluate expression on TiKV side            |
+// | Stored generated column                          | ✅ Yes          | Value is stored in TiKV                            |
+// | JSON column (not used by the generated columns)  | ❌ No           | Excluded by tidb_analyze_skip_column_types setting |
+// | Index on virtual column                          | ✅ Yes          | Index entries are stored in TiKV                   |
+// | Index on stored column                           | ✅ Yes          | Index entries are stored in TiKV                   |
+func TestGeneratedColumns(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// Create table with JSON column and generated columns
+	tk.MustExec(`CREATE TABLE test_gen_cols (
+		id INT PRIMARY KEY,
+		data JSON,
+		virtual_col VARCHAR(50) AS (JSON_UNQUOTE(JSON_EXTRACT(data, '$.name'))) VIRTUAL,
+		stored_col VARCHAR(50) AS (JSON_UNQUOTE(JSON_EXTRACT(data, '$.status'))) STORED,
+		json_but_not_used_by_generated_column JSON,
+		INDEX idx_virtual (virtual_col),
+		INDEX idx_stored (stored_col)
+	)`)
+
+	// Insert test data with simple JSON
+	tk.MustExec(`INSERT INTO test_gen_cols (id, data, json_but_not_used_by_generated_column) VALUES
+		(1, '{"name": "user1", "status": "active"}', '{"category": "admin", "level": 1}'),
+		(2, '{"name": "user2", "status": "inactive"}', '{"category": "user", "level": 2}'),
+		(3, '{"name": "user3", "status": "active"}', '{"category": "user", "level": 1}')`)
+
+	// Analyze the table
+	tk.MustExec("ANALYZE TABLE test_gen_cols")
+
+	h := dom.StatsHandle()
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("test_gen_cols"))
+	require.NoError(t, err)
+
+	// Get the table statistics
+	tblStats := h.GetPhysicalTableStats(tbl.Meta().ID, tbl.Meta())
+	require.NotNil(t, tblStats)
+	require.True(t, tblStats.IsAnalyzed())
+
+	// For the base column used by generated columns, we should collect statistics even it is not used by any indexes.
+	require.True(t, tblStats.GetCol(tbl.Meta().Columns[1].ID).IsAnalyzed())
+
+	// For virtual generated columns, we don't collect statistics because we cannot evaluate the expression on the TiKV side
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[2].ID).IsAnalyzed())
+
+	// For stored generated columns, we collect statistics because the values are stored in TiKV
+	require.True(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
+
+	// For JSON columns that are not used by generated columns, we don't collect statistics because we exclude it by tidb_analyze_skip_column_types.
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[4].ID).IsAnalyzed())
+
+	// For indexes on generated columns, we collect statistics because index entries are stored in TiKV regardless of whether the column is virtual or stored
+	require.True(t, tblStats.GetIdx(tbl.Meta().Indices[0].ID).IsAnalyzed())
+	require.True(t, tblStats.GetIdx(tbl.Meta().Indices[1].ID).IsAnalyzed())
+}
+
+// TestSkipStatsForGeneratedColumnsOnSkippedColumns verifies that when we skip JSON columns, the generated columns that depend on them are also skipped.
+// See: https://github.com/pingcap/tidb/issues/62465
+func TestSkipStatsForGeneratedColumnsOnSkippedColumns(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	// Create table with JSON column and generated columns
+	tk.MustExec(`CREATE TABLE test_gen_cols (
+		id INT PRIMARY KEY,
+		data JSON,
+		virtual_col VARCHAR(50) AS (JSON_UNQUOTE(JSON_EXTRACT(data, '$.name'))) VIRTUAL,
+		stored_col VARCHAR(50) AS (JSON_UNQUOTE(JSON_EXTRACT(data, '$.status'))) STORED
+	)`)
+	// Insert test data with simple JSON
+	tk.MustExec(`INSERT INTO test_gen_cols (id, data) VALUES
+		(1, '{"name": "user1", "status": "active"}'),
+		(2, '{"name": "user2", "status": "inactive"}'),
+		(3, '{"name": "user3", "status": "active"}')`)
+
+	// Explicitly set tidb_analyze_skip_column_types to skip JSON columns
+	tk.MustExec("set @@tidb_analyze_skip_column_types = 'json, text, blob'")
+	// Check tidb_analyze_skip_column_types setting
+	tk.MustQuery("select @@tidb_analyze_skip_column_types").Check(testkit.Rows("json,text,blob"))
+	// Analyze the table with all columns
+	tk.MustExec("ANALYZE TABLE test_gen_cols all columns")
+	h := dom.StatsHandle()
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("test_gen_cols"))
+	require.NoError(t, err)
+	// Get the table statistics
+	tblStats := h.GetPhysicalTableStats(tbl.Meta().ID, tbl.Meta())
+	require.NotNil(t, tblStats)
+	require.True(t, tblStats.IsAnalyzed())
+	// For JSON column, it should not collect statistics because we skip it
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[1].ID).IsAnalyzed())
+	// For virtual generated columns, because it depends on the skipped JSON column, we also skip it
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[2].ID).IsAnalyzed())
+	// For stored columns, because it depends on the skipped JSON column, we also skip it
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
+
+	// Test the predicate columns.
+	tk.MustExec("select * from test_gen_cols where virtual_col = 'a' and stored_col = 'b'")
+	require.NoError(t, h.DumpColStatsUsageToKV())
+	// Check the predicate columns collection.
+	rows := tk.MustQuery("show column_stats_usage where table_name = 'test_gen_cols'").Rows()
+	require.Len(t, rows, 3)
+	require.Equal(t, "id", rows[0][3])
+	require.Equal(t, "virtual_col", rows[1][3])
+	require.Equal(t, "stored_col", rows[2][3])
+
+	tk.MustExec("ANALYZE TABLE test_gen_cols")
+	tblStats = h.GetPhysicalTableStats(tbl.Meta().ID, tbl.Meta())
+	require.NotNil(t, tblStats)
+	require.True(t, tblStats.IsAnalyzed())
+	// For JSON column, it should not collect statistics because we skip it
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[1].ID).IsAnalyzed())
+	// For virtual generated columns, because it depends on the skipped JSON column, we also skip it
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[2].ID).IsAnalyzed())
+	// For stored columns, because it depends on the skipped JSON column, we also skip it
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
+
+	// Remove the skip setting and re-analyze
+	tk.MustExec("set @@tidb_analyze_skip_column_types = 'text, blob'")
+	tk.MustQuery("select @@tidb_analyze_skip_column_types").Check(testkit.Rows("text,blob"))
+	tk.MustExec("ANALYZE TABLE test_gen_cols")
+	tblStats = h.GetPhysicalTableStats(tbl.Meta().ID, tbl.Meta())
+	require.NotNil(t, tblStats)
+	require.True(t, tblStats.IsAnalyzed())
+	// For JSON column, it should be analyzed now
+	require.True(t, tblStats.GetCol(tbl.Meta().Columns[1].ID).IsAnalyzed())
+	// For virtual generated columns, we still could not collect statistics because we couldn't evaluate the expression on the TiKV side
+	require.False(t, tblStats.GetCol(tbl.Meta().Columns[2].ID).IsAnalyzed())
+	// For stored columns, we can collect statistics because the values are stored in TiKV
+	require.True(t, tblStats.GetCol(tbl.Meta().Columns[3].ID).IsAnalyzed())
+}

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -2032,6 +2032,32 @@ type calcOnceMap struct {
 	calculated bool
 }
 
+// addColumnsWithVirtualExprs adds columns to cols.data and processes their virtual expressions recursively.
+// columnSelector is a function that determines which columns to include and their virtual expressions.
+func (b *PlanBuilder) addColumnsWithVirtualExprs(tbl *resolve.TableNameW, cols *calcOnceMap, columnSelector func([]*expression.Column) []expression.Expression) error {
+	intest.Assert(cols.data != nil, "cols.data should not be nil before adding columns")
+	tblInfo := tbl.TableInfo
+	columns, _, err := expression.ColumnInfos2ColumnsAndNames(b.ctx.GetExprCtx(), tbl.Schema, tbl.Name, tblInfo.Columns, tblInfo)
+	if err != nil {
+		return err
+	}
+
+	virtualExprs := columnSelector(columns)
+	relatedCols := make(map[int64]*expression.Column, len(tblInfo.Columns))
+	for len(virtualExprs) > 0 {
+		expression.ExtractColumnsMapFromExpressionsWithReusedMap(relatedCols, nil, virtualExprs...)
+		virtualExprs = virtualExprs[:0]
+		for _, col := range relatedCols {
+			cols.data[col.ID] = struct{}{}
+			if col.VirtualExpr != nil {
+				virtualExprs = append(virtualExprs, col.VirtualExpr)
+			}
+		}
+		clear(relatedCols)
+	}
+	return nil
+}
+
 // getMustAnalyzedColumns puts the columns whose statistics must be collected into `cols` if `cols` has not been calculated.
 func (b *PlanBuilder) getMustAnalyzedColumns(tbl *resolve.TableNameW, cols *calcOnceMap) (map[int64]struct{}, error) {
 	if cols.calculated {
@@ -2042,34 +2068,24 @@ func (b *PlanBuilder) getMustAnalyzedColumns(tbl *resolve.TableNameW, cols *calc
 	if len(tblInfo.Indices) > 0 {
 		// Add indexed columns.
 		// Some indexed columns are generated columns so we also need to add the columns that make up those generated columns.
-		columns, _, err := expression.ColumnInfos2ColumnsAndNames(b.ctx.GetExprCtx(), tbl.Schema, tbl.Name, tblInfo.Columns, tblInfo)
+		err := b.addColumnsWithVirtualExprs(tbl, cols, func(columns []*expression.Column) []expression.Expression {
+			virtualExprs := make([]expression.Expression, 0, len(tblInfo.Columns))
+			for _, idx := range tblInfo.Indices {
+				if idx.State != model.StatePublic || idx.MVIndex || idx.IsColumnarIndex() {
+					continue
+				}
+				for _, idxCol := range idx.Columns {
+					colInfo := tblInfo.Columns[idxCol.Offset]
+					cols.data[colInfo.ID] = struct{}{}
+					if expr := columns[idxCol.Offset].VirtualExpr; expr != nil {
+						virtualExprs = append(virtualExprs, expr)
+					}
+				}
+			}
+			return virtualExprs
+		})
 		if err != nil {
 			return nil, err
-		}
-		virtualExprs := make([]expression.Expression, 0, len(tblInfo.Columns))
-		for _, idx := range tblInfo.Indices {
-			if idx.State != model.StatePublic || idx.MVIndex || idx.VectorInfo != nil {
-				continue
-			}
-			for _, idxCol := range idx.Columns {
-				colInfo := tblInfo.Columns[idxCol.Offset]
-				cols.data[colInfo.ID] = struct{}{}
-				if expr := columns[idxCol.Offset].VirtualExpr; expr != nil {
-					virtualExprs = append(virtualExprs, expr)
-				}
-			}
-		}
-		relatedCols := make([]*expression.Column, 0, len(tblInfo.Columns))
-		for len(virtualExprs) > 0 {
-			relatedCols = expression.ExtractColumnsFromExpressions(relatedCols, virtualExprs, nil)
-			virtualExprs = virtualExprs[:0]
-			for _, col := range relatedCols {
-				cols.data[col.ID] = struct{}{}
-				if col.VirtualExpr != nil {
-					virtualExprs = append(virtualExprs, col.VirtualExpr)
-				}
-			}
-			relatedCols = relatedCols[:0]
 		}
 	}
 	if tblInfo.PKIsHandle {
@@ -2116,8 +2132,30 @@ func (b *PlanBuilder) getPredicateColumns(tbl *resolve.TableNameW, cols *calcOnc
 			),
 		)
 	} else {
-		for _, id := range colList {
-			cols.data[id] = struct{}{}
+		// Some predicate columns are generated columns so we also need to add the columns that make up those generated columns.
+		err := b.addColumnsWithVirtualExprs(tbl, cols, func(columns []*expression.Column) []expression.Expression {
+			virtualExprs := make([]expression.Expression, 0, len(tblInfo.Columns))
+			for _, id := range colList {
+				columnInfo := tblInfo.GetColumnByID(id)
+				intest.Assert(columnInfo != nil, "column %d not found in table %s.%s", id, tbl.Schema.L, tbl.Name.L)
+				if columnInfo == nil {
+					statslogutil.StatsLogger().Warn("Column not found in table while getting predicate columns",
+						zap.Int64("columnID", id),
+						zap.String("tableSchema", tbl.Schema.L),
+						zap.String("table", tblInfo.Name.O),
+					)
+					// This should not happen, but we handle it gracefully.
+					continue
+				}
+				cols.data[columnInfo.ID] = struct{}{}
+				if expr := columns[columnInfo.Offset].VirtualExpr; expr != nil {
+					virtualExprs = append(virtualExprs, expr)
+				}
+			}
+			return virtualExprs
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 	cols.calculated = true
@@ -2379,6 +2417,30 @@ func (b *PlanBuilder) filterSkipColumnTypes(origin []*model.ColumnInfo, tbl *res
 		}
 		result = append(result, colInfo)
 	}
+	skipColNameMap := make(map[string]struct{}, len(skipCol))
+	for _, colInfo := range skipCol {
+		skipColNameMap[colInfo.Name.L] = struct{}{}
+	}
+
+	// Filter out generated columns that depend on skipped columns
+	filteredResult := make([]*model.ColumnInfo, 0, len(result))
+	for _, colInfo := range result {
+		shouldSkip := false
+		if colInfo.IsGenerated() {
+			// Check if any dependency is in the skip list
+			for depName := range colInfo.Dependences {
+				if _, exists := skipColNameMap[depName]; exists {
+					skipCol = append(skipCol, colInfo)
+					shouldSkip = true
+					break
+				}
+			}
+		}
+		if !shouldSkip {
+			filteredResult = append(filteredResult, colInfo)
+		}
+	}
+	result = filteredResult
 	return
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/62465

Problem Summary:

### What changed and how does it work?

When filtering columns, also skip generated columns that have dependencies on any of the skipped columns to maintain consistency and avoid reference errors in query planning.

Another issue is that the predicate should also consider the dependency columns. Otherwise, we will miss some column information when building the analyze executor.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
修复如果生成列依赖于被 tidb_analyze_skip_column_types 标记为忽略的列的时候收集统计信息可能 panic 的问题
Fix the issue where collecting statistics may panic when generated columns depend on columns marked to be ignored by tidb_analyze_skip_column_types
```
