### PR TITLE
ddl: support read only ddl | tidb-test=release-8.5.2

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -1191,6 +1191,11 @@ error = '''
 A primary key index cannot be invisible
 '''
 
+["ddl:3552"]
+error = '''
+Access to system schema '%s' is rejected.
+'''
+
 ["ddl:3593"]
 error = '''
 You cannot use the window function '%s' in this context.'

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -445,8 +445,8 @@ func (e *executor) ModifySchemaReadOnlyState(ctx sessionctx.Context, stmt *ast.A
 		SQLMode: ctx.GetSessionVars().SQLMode,
 	}
 	args := &model.ModifySchemaArgs{
-		ReadOnly:  readOnly,
-		DDLConnID: ctx.GetSessionVars().ConnectionID,
+		ReadOnly:   readOnly,
+		DDLStartTS: ctx.GetSessionVars().TxnCtx.StartTS,
 	}
 	err = e.doDDLJob2(ctx, job, args)
 	return errors.Trace(err)

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -90,6 +90,8 @@ const (
 	// Once tiflashCheckPendingTablesLimit is reached, we trigger a limiter detection.
 	tiflashCheckPendingTablesLimit = 100
 	tiflashCheckPendingTablesRetry = 7
+	// "1" means the database is read-only, "0" or "default" means read-write.
+	databaseReadOnly = "1"
 )
 
 var errCheckConstraintIsOff = errors.NewNoStackError(variable.TiDBEnableCheckConstraint + " is off")
@@ -413,6 +415,40 @@ func (e *executor) ModifySchemaDefaultPlacement(ctx sessionctx.Context, stmt *as
 	return errors.Trace(err)
 }
 
+func (e *executor) ModifySchemaReadOnlyState(ctx sessionctx.Context, stmt *ast.AlterDatabaseStmt, readOnly bool) (err error) {
+	dbName := stmt.Name
+	if metadef.IsMemOrSysDB(dbName.L) {
+		return dbterror.ErrAccessSystemDBRejected.GenWithStackByArgs(dbName.L)
+	}
+	is := e.infoCache.GetLatest()
+	dbInfo, ok := is.SchemaByName(dbName)
+	if !ok {
+		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbName.O)
+	}
+	if dbInfo.ReadOnly == readOnly {
+		return nil
+	}
+	// Do the DDL job.
+	job := &model.Job{
+		Version:        model.GetJobVerInUse(),
+		SchemaID:       dbInfo.ID,
+		SchemaName:     dbInfo.Name.L,
+		Type:           model.ActionModifySchemaReadOnly,
+		BinlogInfo:     &model.HistoryInfo{},
+		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
+		InvolvingSchemaInfo: []model.InvolvingSchemaInfo{{
+			Database: dbInfo.Name.L,
+			Table:    model.InvolvingAll,
+		}},
+		SQLMode: ctx.GetSessionVars().SQLMode,
+	}
+	args := &model.ModifySchemaArgs{
+		ReadOnly: readOnly,
+	}
+	err = e.doDDLJob2(ctx, job, args)
+	return errors.Trace(err)
+}
+
 // getPendingTiFlashTableCount counts unavailable TiFlash replica by iterating all tables in infoCache.
 func (e *executor) getPendingTiFlashTableCount(originVersion int64, pendingCount uint32) (int64, uint32) {
 	is := e.infoCache.GetLatest()
@@ -680,10 +716,11 @@ func checkMultiSchemaSpecs(_ sessionctx.Context, specs []*ast.DatabaseOption) er
 func (e *executor) AlterSchema(sctx sessionctx.Context, stmt *ast.AlterDatabaseStmt) (err error) {
 	// Resolve target charset and collation from options.
 	var (
-		toCharset, toCollate     string
-		isAlterCharsetAndCollate bool
-		placementPolicyRef       *model.PolicyRefInfo
-		tiflashReplica           *ast.TiFlashReplicaSpec
+		toCharset, toCollate           string
+		isAlterCharsetAndCollate       bool
+		placementPolicyRef             *model.PolicyRefInfo
+		tiflashReplica                 *ast.TiFlashReplicaSpec
+		modifyReadOnlyOption, readOnly bool
 	)
 
 	err = checkMultiSchemaSpecs(sctx, stmt.Options)
@@ -716,6 +753,11 @@ func (e *executor) AlterSchema(sctx sessionctx.Context, stmt *ast.AlterDatabaseS
 			placementPolicyRef = &model.PolicyRefInfo{Name: pmodel.NewCIStr(val.Value)}
 		case ast.DatabaseSetTiFlashReplica:
 			tiflashReplica = val.TiFlashReplica
+		case ast.DatabaseOptionReadOnly:
+			modifyReadOnlyOption = true
+			if val.Value == databaseReadOnly {
+				readOnly = true
+			}
 		}
 	}
 
@@ -731,6 +773,11 @@ func (e *executor) AlterSchema(sctx sessionctx.Context, stmt *ast.AlterDatabaseS
 	}
 	if tiflashReplica != nil {
 		if err = e.ModifySchemaSetTiFlashReplica(sctx, stmt, tiflashReplica); err != nil {
+			return err
+		}
+	}
+	if modifyReadOnlyOption {
+		if err = e.ModifySchemaReadOnlyState(sctx, stmt, readOnly); err != nil {
 			return err
 		}
 	}

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -417,7 +417,7 @@ func (e *executor) ModifySchemaDefaultPlacement(ctx sessionctx.Context, stmt *as
 
 func (e *executor) ModifySchemaReadOnlyState(ctx sessionctx.Context, stmt *ast.AlterDatabaseStmt, readOnly bool) (err error) {
 	dbName := stmt.Name
-	if metadef.IsMemOrSysDB(dbName.L) {
+	if util.IsSysDB(dbName.L) || util.IsSystemView(dbName.L) {
 		return dbterror.ErrAccessSystemDBRejected.GenWithStackByArgs(dbName.L)
 	}
 	is := e.infoCache.GetLatest()

--- a/pkg/ddl/job_worker.go
+++ b/pkg/ddl/job_worker.go
@@ -1053,6 +1053,8 @@ func (w *worker) runOneJobStep(
 		ver, err = onDropCheckConstraint(jobCtx, job)
 	case model.ActionAlterCheckConstraint:
 		ver, err = w.onAlterCheckConstraint(jobCtx, job)
+	case model.ActionModifySchemaReadOnly:
+		ver, err = w.onModifySchemaReadOnly(jobCtx, job)
 	default:
 		// Invalid job, cancel it.
 		job.State = model.JobStateCancelled

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -190,7 +190,7 @@ func (w *worker) onModifySchemaReadOnly(jobCtx *jobContext, job *model.Job) (ver
 	}
 	trxTableName := infoschema.ClusterTableTiDBTrx
 	failpoint.Inject("mockModifySchemaReadOnlyDDL", func() {
-		trxTableName = "TIDB_TRX"
+		trxTableName = infoschema.TableTiDBTrx
 	})
 
 	switch job.SchemaState {

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -17,15 +17,22 @@ package ddl
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl/label"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
+	sess "github.com/pingcap/tidb/pkg/ddl/session"
 	"github.com/pingcap/tidb/pkg/domain/infosync"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/util/logutil"
+	"go.uber.org/zap"
 )
 
 func onCreateSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
@@ -152,6 +159,144 @@ func onModifySchemaDefaultPlacement(jobCtx *jobContext, job *model.Job) (ver int
 	}
 	job.FinishDBJob(model.JobStateDone, model.StatePublic, ver, dbInfo)
 	return ver, nil
+}
+
+func (w *worker) onModifySchemaReadOnly(jobCtx *jobContext, job *model.Job) (ver int64, err error) {
+	args, err := model.GetModifySchemaArgs(job)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+	dbInfo, err := checkSchemaExistAndCancelNotExistJob(jobCtx.metaMut, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+
+	if job.SchemaState == model.StateNone && dbInfo.ReadOnly == args.ReadOnly {
+		job.FinishDBJob(model.JobStateDone, model.StatePublic, ver, dbInfo)
+		return ver, nil
+	}
+	// If the database is set to read-write from read-only, we don't need the middle state.
+	if dbInfo.ReadOnly && !args.ReadOnly {
+		dbInfo.ReadOnly = args.ReadOnly
+		if err = jobCtx.metaMut.UpdateDatabase(dbInfo); err != nil {
+			return ver, errors.Trace(err)
+		}
+		if ver, err = updateSchemaVersion(jobCtx, job); err != nil {
+			return ver, errors.Trace(err)
+		}
+		job.FinishDBJob(model.JobStateDone, model.StatePublic, ver, dbInfo)
+		return ver, nil
+	}
+	trxTableName := "CLUSTER_TIDB_TRX"
+	failpoint.Inject("mockModifySchemaReadOnlyDDL", func() {
+		trxTableName = "TIDB_TRX"
+	})
+
+	switch job.SchemaState {
+	case model.StateNone:
+		dbInfo.ReadOnly = args.ReadOnly
+		if err = jobCtx.metaMut.UpdateDatabase(dbInfo); err != nil {
+			return ver, errors.Trace(err)
+		}
+		if ver, err = updateSchemaVersion(jobCtx, job); err != nil {
+			return ver, errors.Trace(err)
+		}
+		job.SchemaState = model.StatePendingReadOnly
+	case model.StatePendingReadOnly:
+		uncommittedTxn, err := getUncommittedTxnIDs(jobCtx, w.sess, job.Query, dbInfo.ID, trxTableName)
+		failpoint.Inject("mockCheckUncommittedTxnError", func() {
+			if err == nil {
+				err = errors.New("mock error for check uncommitted txn")
+			}
+		})
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+
+		// check and wait all uncommitted txn
+		for len(uncommittedTxn) > 0 {
+			for txnID := range uncommittedTxn {
+				sql := fmt.Sprintf("SELECT ID FROM INFORMATION_SCHEMA.%s WHERE ID = %d", trxTableName, txnID)
+				r, err := w.sess.Execute(jobCtx.stepCtx, sql, "check if txn committed")
+				if err != nil {
+					return ver, errors.Trace(err)
+				}
+				if len(r) == 0 {
+					delete(uncommittedTxn, txnID)
+					continue
+				}
+				logutil.BgLogger().Info("uncommitted txn block read only ddl", zap.Int64("txn ID", txnID))
+				break
+			}
+			time.Sleep(300 * time.Millisecond)
+			failpoint.InjectCall("checkUncommittedTxns", uncommittedTxn)
+		}
+
+		if err = jobCtx.metaMut.UpdateDatabase(dbInfo); err != nil {
+			return ver, errors.Trace(err)
+		}
+		if ver, err = updateSchemaVersion(jobCtx, job); err != nil {
+			return ver, errors.Trace(err)
+		}
+		job.FinishDBJob(model.JobStateDone, model.StatePublic, ver, dbInfo)
+	}
+	return ver, nil
+}
+
+func getUncommittedTxnIDs(jobCtx *jobContext, sess *sess.Session, ddlQuery string, targetDBID int64, trxTableName string) (map[int64]struct{}, error) {
+	var currTS = uint64(0)
+	err := kv.RunInNewTxn(jobCtx.ctx, jobCtx.store, true, func(_ context.Context, txn kv.Transaction) error {
+		currTS = txn.StartTS()
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	is := jobCtx.infoCache.GetLatest()
+	sql := fmt.Sprintf(
+		"SELECT RELATED_TABLE_IDS, CURRENT_SQL_DIGEST, ID "+
+			"FROM INFORMATION_SCHEMA.%s "+
+			"WHERE (CURRENT_SQL_DIGEST IS NULL OR CURRENT_SQL_DIGEST != TIDB_ENCODE_SQL_DIGEST('%s')) "+ // exclude ddl
+			"AND ID < %d", // exclude new transactions
+		trxTableName,
+		ddlQuery,
+		currTS,
+	)
+	t := time.Now()
+	r, err := sess.Execute(jobCtx.stepCtx, sql, "get uncommitted txn id")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	queryDur := time.Since(t)
+	ids := make(map[int64]struct{})
+	for _, row := range r {
+		txnID := row.GetInt64(2)
+		relatedTableIDs := row.GetString(0)
+		if relatedTableIDs == "" {
+			continue
+		}
+		tblIDs := strings.Split(relatedTableIDs, ",")
+		for _, tblID := range tblIDs {
+			id, err := strconv.Atoi(tblID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			tblInfo, ok := is.TableByID(jobCtx.stepCtx, int64(id))
+			if !ok {
+				return nil, errors.Errorf("table %d not found in infoschema", id)
+			}
+			if tblInfo.Meta().DBID == targetDBID {
+				ids[txnID] = struct{}{}
+				break
+			}
+		}
+	}
+	jobCtx.logger.Info("get uncommitted txn id",
+		zap.Int("txn count", len(ids)),
+		zap.Duration("query time", queryDur),
+		zap.Duration("parse time", time.Since(t)-queryDur))
+	return ids, nil
 }
 
 func (w *worker) onDropSchema(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -188,7 +188,7 @@ func (w *worker) onModifySchemaReadOnly(jobCtx *jobContext, job *model.Job) (ver
 		job.FinishDBJob(model.JobStateDone, model.StatePublic, ver, dbInfo)
 		return ver, nil
 	}
-	trxTableName := "CLUSTER_TIDB_TRX"
+	trxTableName := infoschema.ClusterTableTiDBTrx
 	failpoint.Inject("mockModifySchemaReadOnlyDDL", func() {
 		trxTableName = "TIDB_TRX"
 	})

--- a/pkg/ddl/schema.go
+++ b/pkg/ddl/schema.go
@@ -197,6 +197,7 @@ func (w *worker) onModifySchemaReadOnly(jobCtx *jobContext, job *model.Job) (ver
 	case model.StateNone:
 		dbInfo.ReadOnly = args.ReadOnly
 		if err = jobCtx.metaMut.UpdateDatabase(dbInfo); err != nil {
+		    job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
 		if ver, err = updateSchemaVersion(jobCtx, job); err != nil {

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -661,7 +660,7 @@ func TestReadOnlyInMiddleState(t *testing.T) {
 		return len(txnIDs) == 1
 	}, 5*time.Second, 100*time.Millisecond)
 	is := sessiontxn.GetTxnManager(tk3.Session()).GetTxnInfoSchema()
-	dbInfo, ok := is.SchemaByName(ast.NewCIStr("test_db"))
+	dbInfo, ok := is.SchemaByName(pmodel.NewCIStr("test_db"))
 	require.True(t, ok)
 	require.True(t, dbInfo.ReadOnly)
 	tk3.MustExec("insert into test_db.t values (1)") // TODO(fzzf678): this should fail, fix this after adding the check read only logic

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/ngaut/pools"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -503,19 +502,13 @@ func TestRenameTableAutoIDs(t *testing.T) {
 }
 
 // enableReadOnlyDDLFp enables the failpoint to mock read-only DDLs.
-func enableReadOnlyDDLFp() {
-	failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockModifySchemaReadOnlyDDL", "return")
-	failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockModifySchemaReadOnlyDDL", "return")
-}
-
-func disableReadOnlyDDLFp() {
-	failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockModifySchemaReadOnlyDDL")
-	failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockModifySchemaReadOnlyDDL")
+func enableReadOnlyDDLFp(t *testing.T) {
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockModifySchemaReadOnlyDDL", "return")
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/executor/mockModifySchemaReadOnlyDDL", "return")
 }
 
 func TestAlterSchemaReadonlyBasic(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("create database if not exists test")
@@ -535,8 +528,7 @@ func TestAlterSchemaReadonlyBasic(t *testing.T) {
 }
 
 func TestAlterSchemaReadonlyPrivilege(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("create database if not exists test")
@@ -559,8 +551,7 @@ func TestAlterSchemaReadonlyPrivilege(t *testing.T) {
 }
 
 func TestAlterDBReadOnlyBlockByTxn(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
@@ -587,8 +578,7 @@ func TestAlterDBReadOnlyBlockByTxn(t *testing.T) {
 }
 
 func TestAlterDBReadOnlyNotBlockByIrrelevantTxn(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
@@ -604,8 +594,7 @@ func TestAlterDBReadOnlyNotBlockByIrrelevantTxn(t *testing.T) {
 }
 
 func TestAccessDBInTxnAfterDDLDone(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
@@ -619,8 +608,7 @@ func TestAccessDBInTxnAfterDDLDone(t *testing.T) {
 }
 
 func TestReadWriteDDLNotBlockByTxn(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
@@ -635,8 +623,7 @@ func TestReadWriteDDLNotBlockByTxn(t *testing.T) {
 }
 
 func TestReadOnlyInMiddleState(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 	tk2 := testkit.NewTestKit(t, store)
@@ -669,8 +656,7 @@ func TestReadOnlyInMiddleState(t *testing.T) {
 }
 
 func TestKillBlockReadOnlyDDLTxn(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
+	enableReadOnlyDDLFp(t)
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	sv := server.CreateMockServer(t, store)
 	sv.SetDomain(dom)
@@ -707,10 +693,8 @@ func TestKillBlockReadOnlyDDLTxn(t *testing.T) {
 }
 
 func TestErrInWaitingUncommittedTxn(t *testing.T) {
-	enableReadOnlyDDLFp()
-	defer disableReadOnlyDDLFp()
-	failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCheckUncommittedTxnError", "return")
-	defer failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockCheckUncommittedTxnError")
+	enableReadOnlyDDLFp(t)
+	testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/ddl/mockCheckUncommittedTxnError", "return")
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -17,22 +17,31 @@ package ddl_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/ngaut/pools"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
+	"github.com/pingcap/tidb/pkg/server"
+	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessiontxn"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -492,4 +501,222 @@ func TestRenameTableAutoIDs(t *testing.T) {
 		"62 61 9",
 		"64 63 10",
 	))
+}
+
+// enableReadOnlyDDLFp enables the failpoint to mock read-only DDLs.
+func enableReadOnlyDDLFp() {
+	failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockModifySchemaReadOnlyDDL", "return")
+	failpoint.Enable("github.com/pingcap/tidb/pkg/executor/mockModifySchemaReadOnlyDDL", "return")
+}
+
+func disableReadOnlyDDLFp() {
+	failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockModifySchemaReadOnlyDDL")
+	failpoint.Disable("github.com/pingcap/tidb/pkg/executor/mockModifySchemaReadOnlyDDL")
+}
+
+func TestAlterSchemaReadonlyBasic(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database if not exists test")
+	tk.MustExec("alter database test read only = 1")
+	tk.MustQuery("show create database test").Check(testkit.Rows("test CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /* READ ONLY = 1 */"))
+	is := sessiontxn.GetTxnManager(tk.Session()).GetTxnInfoSchema()
+	v := is.SchemaMetaVersion()
+	tk.MustExec("alter database test read only = 1")
+	tk.MustQuery("show create database test").Check(testkit.Rows("test CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /* READ ONLY = 1 */"))
+	require.Equal(t, v, is.SchemaMetaVersion())
+	tk.MustExec("alter database test read only = 0")
+	tk.MustQuery("show create database test").Check(testkit.Rows("test CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */"))
+	// Can't modify the read-only status when TiDB is in restricted read-only mode.
+	tk.MustExec("set global tidb_restricted_read_only = 1")
+	require.NoError(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
+	tk.MustGetErrMsg("alter database test read only = 1", "[planner:1836]Running in read-only mode")
+}
+
+func TestAlterSchemaReadonlyPrivilege(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database if not exists test")
+	tk.MustExec("create user 'u1'@'%'")
+	se, err := session.CreateSession4Test(store)
+	require.NoError(t, err)
+	defer se.Close()
+	require.NoError(t, se.Auth(&auth.UserIdentity{Username: "u1", Hostname: "%"}, nil, nil, nil))
+	ctx := context.Background()
+	_, err = se.Execute(ctx, "alter database test read only = 1")
+	require.Equal(t, "[planner:1044]Access denied for user 'u1'@'%' to database 'test'", err.Error())
+	_, err = se.Execute(ctx, "alter database test read only = 0")
+	require.Equal(t, "[planner:1044]Access denied for user 'u1'@'%' to database 'test'", err.Error())
+
+	tk.MustExec("grant alter on test.* to 'u1'@'%'")
+	_, err = se.Execute(ctx, "alter database test read only = 1")
+	require.NoError(t, err)
+	_, err = se.Execute(ctx, "alter database test read only = 0")
+	require.NoError(t, err)
+}
+
+func TestAlterDBReadOnlyBlockByTxn(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk1.MustExec("create database test_db")
+	tk1.MustExec("use test_db")
+	tk1.MustExec("create table t (a int)")
+	tk1.MustExec("begin")
+	tk1.MustExec("select * from t")
+	r := tk1.MustQuery("select @@tidb_current_ts").Rows()
+	txnID, err := strconv.ParseInt(r[0][0].(string), 10, 64)
+	require.NoError(t, err)
+	var txnIDs map[int64]struct{}
+	go func() {
+		require.Eventually(t, func() bool {
+			return len(txnIDs) == 1 && txnIDs[txnID] == struct{}{}
+		}, 5*time.Second, 100*time.Millisecond)
+		tk1.MustExec("commit")
+	}()
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkUncommittedTxns", func(ids map[int64]struct{}) {
+		txnIDs = ids
+	})
+	tk2.MustExec("alter database test_db read only = 1")
+	tk2.MustQuery("show create database test_db").Check(testkit.Rows("test_db CREATE DATABASE `test_db` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /* READ ONLY = 1 */"))
+}
+
+func TestAlterDBReadOnlyNotBlockByIrrelevantTxn(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+
+	tk1.MustExec("create database test_db")
+	tk1.MustExec("create database if not exists test")
+	tk1.MustExec("use test_db")
+	tk1.MustExec("create table t (a int)")
+	tk1.MustExec("begin")
+	tk1.MustExec("select * from t")
+	tk2.MustExec("alter database test read only = 1")
+	tk2.MustQuery("show create database test").Check(testkit.Rows("test CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /* READ ONLY = 1 */"))
+}
+
+func TestAccessDBInTxnAfterDDLDone(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+
+	tk1.MustExec("create database test_db")
+	tk1.MustExec("create table test_db.t(a int)")
+	tk1.MustExec("begin; use test_db;")
+	tk2.MustExec("alter database test read only = 1")
+	tk2.MustQuery("show create database test").Check(testkit.Rows("test CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /* READ ONLY = 1 */"))
+	tk1.MustGetErrMsg("select * from test_db", "[schema:1146]Table 'test_db.test_db' doesn't exist")
+}
+
+func TestReadWriteDDLNotBlockByTxn(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+
+	tk1.MustExec("create database test_db")
+	tk1.MustExec("create table test_db.t(a int)")
+	tk1.MustExec("alter schema test_db read only = 1")
+	tk1.MustExec("begin;use test_db;")
+	tk1.MustExec("select * from t")
+	tk2.MustExec("alter database test_db read only = 0") // won't be blocked
+	tk2.MustQuery("show create database test").Check(testkit.Rows("test CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8mb4 */"))
+}
+
+func TestReadOnlyInMiddleState(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+	tk2 := testkit.NewTestKit(t, store)
+	tk3 := testkit.NewTestKit(t, store)
+
+	tk1.MustExec("create database test_db")
+	tk1.MustExec("create table test_db.t(a int)")
+	tk1.MustExec("begin;use test_db;")
+	tk1.MustExec("select * from t")
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tk2.MustExec("alter database test_db read only = 1")
+	}()
+	var txnIDs map[int64]struct{}
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkUncommittedTxns", func(ids map[int64]struct{}) {
+		txnIDs = ids
+	})
+	require.Eventually(t, func() bool {
+		return len(txnIDs) == 1
+	}, 5*time.Second, 100*time.Millisecond)
+	is := sessiontxn.GetTxnManager(tk3.Session()).GetTxnInfoSchema()
+	dbInfo, ok := is.SchemaByName(ast.NewCIStr("test_db"))
+	require.True(t, ok)
+	require.True(t, dbInfo.ReadOnly)
+	tk3.MustExec("insert into test_db.t values (1)") // TODO(fzzf678): this should fail, fix this after adding the check read only logic
+	tk1.MustExec("commit")
+	wg.Wait()
+}
+
+func TestKillBlockReadOnlyDDLTxn(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	sv := server.CreateMockServer(t, store)
+	sv.SetDomain(dom)
+	dom.InfoSyncer().SetSessionManager(sv)
+	defer sv.Close()
+
+	conn1 := server.CreateMockConn(t, sv)
+	tk1 := testkit.NewTestKitWithSession(t, store, conn1.Context().Session)
+	conn2 := server.CreateMockConn(t, sv)
+	tk2 := testkit.NewTestKitWithSession(t, store, conn2.Context().Session)
+	tk1.MustExec("use test")
+	tk1.MustExec("set global tidb_enable_metadata_lock=1")
+	tk1.MustExec("create table t(a int);")
+	tk1.MustExec("insert into t values(1);")
+	tk1.MustExec("begin")
+	tk1.MustQuery("select * from t;")
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tk2.MustExec("alter schema test read only = 1")
+	}()
+	var txnIDs map[int64]struct{}
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/checkUncommittedTxns", func(ids map[int64]struct{}) {
+		txnIDs = ids
+	})
+	require.Eventually(t, func() bool {
+		return len(txnIDs) == 1
+	}, 5*time.Second, 100*time.Millisecond)
+
+	conn1.Close()
+	wg.Wait()
+}
+
+func TestErrInWaitingUncommittedTxn(t *testing.T) {
+	enableReadOnlyDDLFp()
+	defer disableReadOnlyDDLFp()
+	failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockCheckUncommittedTxnError", "return")
+	defer failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockCheckUncommittedTxnError")
+	store := testkit.CreateMockStore(t)
+	tk1 := testkit.NewTestKit(t, store)
+
+	tk1.MustExec("set global tidb_ddl_error_count_limit = 2")
+	tk1.MustExec("create database test_db")
+	tk1.MustExec("create table test_db.t(a int)")
+	tk1.MustGetErrMsg("alter schema test_db read only = 1", "[ddl:-1]DDL job rollback, error msg: mock error for check uncommitted txn")
 }

--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -866,6 +866,7 @@ const (
 	ErrPKIndexCantBeInvisible                                = 3522
 	ErrGrantRole                                             = 3523
 	ErrRoleNotGranted                                        = 3530
+	ErrAccessSysDBRejected                                   = 3552
 	ErrLockAcquireFailAndNoWaitSet                           = 3572
 	ErrCTERecursiveRequiresUnion                             = 3573
 	ErrCTERecursiveRequiresNonRecursiveFirst                 = 3574

--- a/pkg/errno/errname.go
+++ b/pkg/errno/errname.go
@@ -944,6 +944,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrConstraintNotFound:                                    mysql.Message("Constraint '%s' does not exist.", nil),
 	ErrDependentByCheckConstraint:                            mysql.Message("Check constraint '%s' uses column '%s', hence column cannot be dropped or renamed.", nil),
 	ErrJSONInBooleanContext:                                  mysql.Message("Evaluating a JSON value in SQL boolean context does an implicit comparison against JSON integer 0; if this is not what you want, consider converting JSON to a SQL numeric type with JSON_VALUE RETURNING", nil),
+	ErrAccessSysDBRejected:                                   mysql.Message("Access to system schema '%s' is rejected.", nil),
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed:         mysql.Message("Only one DEFAULT partition allowed", nil),
 	ErrWrongPartitionTypeExpectedSystemTime: mysql.Message("Wrong partitioning type, expected type: `SYSTEM_TIME`", nil),

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2920,6 +2920,11 @@ func (e *tidbTrxTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Co
 		e.initialized = true
 
 		sm := sctx.GetSessionManager()
+		failpoint.Inject("mockModifySchemaReadOnlyDDL", func() {
+			if sm == nil {
+				sm = sctx.GetDomain().(*domain.Domain).InfoSyncer().GetSessionManager()
+			}
+		})
 		if sm == nil {
 			e.retrieved = true
 			return nil, nil

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2922,7 +2922,7 @@ func (e *tidbTrxTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Co
 		sm := sctx.GetSessionManager()
 		failpoint.Inject("mockModifySchemaReadOnlyDDL", func() {
 			if sm == nil {
-				sm = sctx.GetDomain().(*domain.Domain).InfoSyncer().GetSessionManager()
+				sm = domain.GetDomain(sctx).InfoSyncer().GetSessionManager()
 			}
 		})
 		if sm == nil {

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1607,6 +1607,10 @@ func ConstructResultOfShowCreateDatabase(ctx sessionctx.Context, dbInfo *model.D
 		// add placement ref info here
 		fmt.Fprintf(buf, " /*T![placement] PLACEMENT POLICY=%s */", stringutil.Escape(dbInfo.PlacementPolicyRef.Name.O, sqlMode))
 	}
+
+	if dbInfo.ReadOnly {
+		fmt.Fprint(buf, " /* READ ONLY = 1 */")
+	}
 	return nil
 }
 

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -1499,7 +1499,7 @@ func (b *Builder) applyModifySchemaReadOnlyV2(m meta.Reader, diff *model.SchemaD
 	newDBInfo := oldDBInfo.Clone()
 	newDBInfo.ReadOnly = di.ReadOnly
 	b.infoschemaV2.deleteDB(di, diff.Version)
-	b.infoschemaV2.addDB(diff.Version, di)
+	b.infoschemaV2.addDB(diff.Version, newDBInfo)
 	return nil
 }
 

--- a/pkg/infoschema/infoschema_v2.go
+++ b/pkg/infoschema/infoschema_v2.go
@@ -1309,6 +1309,13 @@ func applyModifySchemaDefaultPlacement(b *Builder, m meta.Reader, diff *model.Sc
 	return b.applyModifySchemaDefaultPlacement(m, diff)
 }
 
+func applyModifySchemaReadOnly(b *Builder, m meta.Reader, diff *model.SchemaDiff) error {
+	if b.enableV2 {
+		return b.applyModifySchemaReadOnlyV2(m, diff)
+	}
+	return b.applyModifySchemaReadOnly(m, diff)
+}
+
 func applyDropTable(b *Builder, diff *model.SchemaDiff, dbInfo *model.DBInfo, tableID int64, affected []int64) []int64 {
 	if b.enableV2 {
 		return b.applyDropTableV2(diff, dbInfo, tableID, affected)
@@ -1474,6 +1481,25 @@ func (b *Builder) applyModifySchemaDefaultPlacementV2(m meta.Reader, diff *model
 	newDBInfo.PlacementPolicyRef = di.PlacementPolicyRef
 	b.infoschemaV2.deleteDB(di, diff.Version)
 	b.infoschemaV2.addDB(diff.Version, newDBInfo)
+	return nil
+}
+
+func (b *Builder) applyModifySchemaReadOnlyV2(m meta.Reader, diff *model.SchemaDiff) error {
+	di, err := m.GetDatabase(diff.SchemaID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if di == nil {
+		// This should never happen.
+		return ErrDatabaseNotExists.GenWithStackByArgs(
+			fmt.Sprintf("(Schema ID %d)", diff.SchemaID),
+		)
+	}
+	oldDBInfo, _ := b.infoschemaV2.SchemaByID(diff.SchemaID)
+	newDBInfo := oldDBInfo.Clone()
+	newDBInfo.ReadOnly = di.ReadOnly
+	b.infoschemaV2.deleteDB(di, diff.Version)
+	b.infoschemaV2.addDB(diff.Version, di)
 	return nil
 }
 

--- a/pkg/meta/model/bdr.go
+++ b/pkg/meta/model/bdr.go
@@ -102,6 +102,7 @@ var BDRActionMap = map[DDLBDRType][]ActionType{
 		ActionAlterTablePartitioning,
 		ActionRemovePartitioning,
 		ActionAddVectorIndex,
+		ActionModifySchemaReadOnly,
 	},
 	UnmanagementDDL: {
 		ActionCreatePlacementPolicy,

--- a/pkg/meta/model/db.go
+++ b/pkg/meta/model/db.go
@@ -32,6 +32,7 @@ type DBInfo struct {
 	State              SchemaState      `json:"state"`
 	PlacementPolicyRef *PolicyRefInfo   `json:"policy_ref_info"`
 	TableName2ID       map[string]int64 `json:"-"`
+	ReadOnly           bool             `json:"read_only"`
 }
 
 // Clone clones DBInfo.

--- a/pkg/meta/model/job.go
+++ b/pkg/meta/model/job.go
@@ -111,6 +111,7 @@ const (
 	ActionAlterTablePartitioning ActionType = 71
 	ActionRemovePartitioning     ActionType = 72
 	ActionAddVectorIndex         ActionType = 73
+	ActionModifySchemaReadOnly   ActionType = 77
 )
 
 // ActionMap is the map of DDL ActionType to string.
@@ -183,6 +184,7 @@ var ActionMap = map[ActionType]string{
 	ActionAlterTablePartitioning:        "alter table partition by",
 	ActionRemovePartitioning:            "alter table remove partitioning",
 	ActionAddVectorIndex:                "add vector index",
+	ActionModifySchemaReadOnly:          "modify schema read only",
 
 	// `ActionAlterTableAlterPartition` is removed and will never be used.
 	// Just left a tombstone here for compatibility.
@@ -218,6 +220,8 @@ const (
 	StateReplicaOnly
 	// StateGlobalTxnOnly means we can only use global txn for operator on this schema element
 	StateGlobalTxnOnly
+	// StatePendingReadOnly means this database is pending to be read-only.
+	StatePendingReadOnly
 	/*
 	 *  Please add the new state at the end to keep the values consistent across versions.
 	 */

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -185,11 +185,15 @@ type ModifySchemaArgs struct {
 	// used for modify schema placement policy.
 	// might be nil, means set it to default.
 	PolicyRef *PolicyRefInfo `json:"policy_ref,omitempty"`
+	// used for modify schema read only state.
+	ReadOnly bool `json:"read_only,omitempty"`
 }
 
 func (a *ModifySchemaArgs) getArgsV1(job *Job) []any {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
 		return []any{a.ToCharset, a.ToCollate}
+	} else if job.Type == ActionModifySchemaReadOnly {
+		return []any{a.ReadOnly}
 	}
 	return []any{a.PolicyRef}
 }
@@ -197,6 +201,8 @@ func (a *ModifySchemaArgs) getArgsV1(job *Job) []any {
 func (a *ModifySchemaArgs) decodeV1(job *Job) error {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
 		return errors.Trace(job.decodeArgs(&a.ToCharset, &a.ToCollate))
+	} else if job.Type == ActionModifySchemaReadOnly {
+		return errors.Trace(job.decodeArgs(&a.ReadOnly))
 	}
 	return errors.Trace(job.decodeArgs(&a.PolicyRef))
 }

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -186,15 +186,15 @@ type ModifySchemaArgs struct {
 	// might be nil, means set it to default.
 	PolicyRef *PolicyRefInfo `json:"policy_ref,omitempty"`
 	// used for modify schema read only state.
-	ReadOnly  bool   `json:"read_only,omitempty"`
-	DDLConnID uint64 `json:"ddl_conn_id,omitempty"`
+	ReadOnly   bool   `json:"read_only,omitempty"`
+	DDLStartTS uint64 `json:"ddl_start_ts,omitempty"`
 }
 
 func (a *ModifySchemaArgs) getArgsV1(job *Job) []any {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
 		return []any{a.ToCharset, a.ToCollate}
 	} else if job.Type == ActionModifySchemaReadOnly {
-		return []any{a.ReadOnly, a.DDLConnID}
+		return []any{a.ReadOnly, a.DDLStartTS}
 	}
 	return []any{a.PolicyRef}
 }
@@ -203,7 +203,7 @@ func (a *ModifySchemaArgs) decodeV1(job *Job) error {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
 		return errors.Trace(job.decodeArgs(&a.ToCharset, &a.ToCollate))
 	} else if job.Type == ActionModifySchemaReadOnly {
-		return errors.Trace(job.decodeArgs(&a.ReadOnly, &a.DDLConnID))
+		return errors.Trace(job.decodeArgs(&a.ReadOnly, &a.DDLStartTS))
 	}
 	return errors.Trace(job.decodeArgs(&a.PolicyRef))
 }

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -186,14 +186,15 @@ type ModifySchemaArgs struct {
 	// might be nil, means set it to default.
 	PolicyRef *PolicyRefInfo `json:"policy_ref,omitempty"`
 	// used for modify schema read only state.
-	ReadOnly bool `json:"read_only,omitempty"`
+	ReadOnly  bool   `json:"read_only,omitempty"`
+	DDLConnID uint64 `json:"ddl_conn_id,omitempty"`
 }
 
 func (a *ModifySchemaArgs) getArgsV1(job *Job) []any {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
 		return []any{a.ToCharset, a.ToCollate}
 	} else if job.Type == ActionModifySchemaReadOnly {
-		return []any{a.ReadOnly}
+		return []any{a.ReadOnly, a.DDLConnID}
 	}
 	return []any{a.PolicyRef}
 }
@@ -202,7 +203,7 @@ func (a *ModifySchemaArgs) decodeV1(job *Job) error {
 	if job.Type == ActionModifySchemaCharsetAndCollate {
 		return errors.Trace(job.decodeArgs(&a.ToCharset, &a.ToCollate))
 	} else if job.Type == ActionModifySchemaReadOnly {
-		return errors.Trace(job.decodeArgs(&a.ReadOnly))
+		return errors.Trace(job.decodeArgs(&a.ReadOnly, &a.DDLConnID))
 	}
 	return errors.Trace(job.decodeArgs(&a.PolicyRef))
 }

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -134,8 +134,8 @@ func TestModifySchemaArgs(t *testing.T) {
 		}
 	}
 	inArgs = &ModifySchemaArgs{
-		ReadOnly:  true,
-		DDLConnID: 12345,
+		ReadOnly:   true,
+		DDLStartTS: 123,
 	}
 	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
 		j2 := &Job{}
@@ -143,7 +143,7 @@ func TestModifySchemaArgs(t *testing.T) {
 		args, err := GetModifySchemaArgs(j2)
 		require.NoError(t, err)
 		require.True(t, args.ReadOnly)
-		require.Equal(t, uint64(12345), args.DDLConnID)
+		require.Equal(t, uint64(123), args.DDLStartTS)
 	}
 }
 

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -133,6 +133,16 @@ func TestModifySchemaArgs(t *testing.T) {
 			require.EqualValues(t, inArgs.PolicyRef, args.PolicyRef)
 		}
 	}
+	inArgs = &ModifySchemaArgs{
+		ReadOnly: true,
+	}
+	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
+		j2 := &Job{}
+		require.NoError(t, j2.Decode(getJobBytes(t, inArgs, v, ActionModifySchemaReadOnly)))
+		args, err := GetModifySchemaArgs(j2)
+		require.NoError(t, err)
+		require.True(t, args.ReadOnly)
+	}
 }
 
 func TestCreateTableArgs(t *testing.T) {

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -134,7 +134,8 @@ func TestModifySchemaArgs(t *testing.T) {
 		}
 	}
 	inArgs = &ModifySchemaArgs{
-		ReadOnly: true,
+		ReadOnly:  true,
+		DDLConnID: 12345,
 	}
 	for _, v := range []JobVersion{JobVersion1, JobVersion2} {
 		j2 := &Job{}
@@ -142,6 +143,7 @@ func TestModifySchemaArgs(t *testing.T) {
 		args, err := GetModifySchemaArgs(j2)
 		require.NoError(t, err)
 		require.True(t, args.ReadOnly)
+		require.Equal(t, uint64(12345), args.DDLConnID)
 	}
 }
 

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1935,7 +1935,7 @@ func tryLockMDLAndUpdateSchemaIfNecessary(ctx context.Context, sctx base.PlanCon
 		if err != nil {
 			return nil, err
 		}
-		dbInfoLatest, _ := latestIS.SchemaByName(dbName)
+		dbInfoLatest, _ := domainSchema.SchemaByName(dbName)
 		if dbInfo.ReadOnly != dbInfoLatest.ReadOnly {
 			return nil, domain.ErrInfoSchemaChanged.GenWithStack("public schema %s read only state has changed", dbInfo.Name.L)
 		}

--- a/pkg/planner/core/preprocess.go
+++ b/pkg/planner/core/preprocess.go
@@ -1910,6 +1910,7 @@ func tryLockMDLAndUpdateSchemaIfNecessary(ctx context.Context, sctx base.PlanCon
 		return tbl, nil
 	}
 	tableInfo := tbl.Meta()
+	dbInfo, _ := is.SchemaByName(dbName)
 	shouldLockMDL = true
 	if _, ok := sctx.GetSessionVars().GetRelatedTableForMDL().Load(tableInfo.ID); !ok {
 		if se, ok := is.(*infoschema.SessionExtendedInfoSchema); ok && skipLock && se.MdlTables != nil {
@@ -1933,6 +1934,10 @@ func tryLockMDLAndUpdateSchemaIfNecessary(ctx context.Context, sctx base.PlanCon
 		tbl, err = domainSchema.TableByName(ctx, dbName, tableInfo.Name)
 		if err != nil {
 			return nil, err
+		}
+		dbInfoLatest, _ := latestIS.SchemaByName(dbName)
+		if dbInfo.ReadOnly != dbInfoLatest.ReadOnly {
+			return nil, domain.ErrInfoSchemaChanged.GenWithStack("public schema %s read only state has changed", dbInfo.Name.L)
 		}
 		if !skipLock {
 			sctx.GetSessionVars().GetRelatedTableForMDL().Store(tbl.Meta().ID, domainSchemaVer)

--- a/pkg/util/dbterror/ddl_terror.go
+++ b/pkg/util/dbterror/ddl_terror.go
@@ -503,6 +503,8 @@ var (
 	// ErrWarnGlobalIndexNeedManuallyAnalyze is used for global indexes,
 	// which cannot trigger automatic analysis when it contains prefix columns or virtual generated columns.
 	ErrWarnGlobalIndexNeedManuallyAnalyze = ClassDDL.NewStd(mysql.ErrWarnGlobalIndexNeedManuallyAnalyze)
+	// ErrAccessSystemDBRejected is returned when access system database is rejected.
+	ErrAccessSystemDBRejected = ClassDDL.NewStd(mysql.ErrAccessSysDBRejected)
 )
 
 // ReorgRetryableErrCodes are the error codes that are retryable for reorganization.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62122

Problem Summary:

### What changed and how does it work?
Support setting databases to a read-only state by DDL. The main points:
* Block the read-only DDL by checking uncommitted transactions, this is achieved by checking the information_schema.cluster_tidb_trx sys table.
* In transactions, check the latest DBInfo if changed before access it.
* Make read-only DDL as Non-replicable DDLs in BDR mode.
* show create database displays the read only status.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
