### PR TITLE
ddl: add system table INFORMATION_SCHEMA.SCHEMATA_EXTENSIONS to check read only status | tidb-test=release-8.5.2

### DIFF
--- a/pkg/executor/builder.go
+++ b/pkg/executor/builder.go
@@ -2279,7 +2279,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) exec.Ex
 			strings.ToLower(infoschema.TableTiDBCheckConstraints),
 			strings.ToLower(infoschema.TableKeywords),
 			strings.ToLower(infoschema.TableTiDBIndexUsage),
-			strings.ToLower(infoschema.ClusterTableTiDBIndexUsage):
+			strings.ToLower(infoschema.ClusterTableTiDBIndexUsage),
+			strings.ToLower(infoschema.TableSchemataExtensions):
 			memTracker := memory.NewTracker(v.ID(), -1)
 			memTracker.AttachTo(b.ctx.GetSessionVars().StmtCtx.MemTracker)
 			return &MemTableReaderExec{

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -231,6 +231,8 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			err = e.setDataFromIndexUsage(ctx, sctx)
 		case infoschema.ClusterTableTiDBIndexUsage:
 			err = e.setDataFromClusterIndexUsage(ctx, sctx)
+		case infoschema.TableSchemataExtensions:
+			err = e.setDataFromSchemataExtensions(sctx)
 		}
 		if err != nil {
 			return nil, err
@@ -3951,6 +3953,38 @@ func (e *memtableRetriever) setDataFromClusterIndexUsage(ctx context.Context, sc
 	}
 	e.rows = rows
 	return nil
+}
+
+func (e *memtableRetriever) setDataFromSchemataExtensions(ctx sessionctx.Context) (err error) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	ex, ok := e.extractor.(*plannercore.InfoSchemaSchemataExtractor)
+	if !ok {
+		return errors.Errorf("wrong extractor type: %T, expected InfoSchemaSchemataExtractor", e.extractor)
+	}
+	if ex.SkipRequest {
+		return nil
+	}
+	schemas := ex.ListSchemas(e.is)
+	rows := make([][]types.Datum, 0, len(schemas))
+
+	for _, schemaName := range schemas {
+		schema, _ := e.is.SchemaByName(schemaName)
+		if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, "", "", mysql.AllPrivMask) {
+			continue
+		}
+		record := types.MakeDatums(
+			infoschema.CatalogVal, // CATALOG_NAME
+			schema.Name.O,         // SCHEMA_NAME
+		)
+		// todo:
+		//if schema.ReadOnly {
+		//	record = append(record, types.NewStringDatum("READ ONLY=1"))
+		//}
+		rows = append(rows, record)
+		e.recordMemoryConsume(record)
+	}
+	e.rows = rows
+	return
 }
 
 func checkRule(rule *label.Rule) (dbName, tableName string, partitionName string, err error) {

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3956,6 +3956,7 @@ func (e *memtableRetriever) setDataFromClusterIndexUsage(ctx context.Context, sc
 }
 
 func (e *memtableRetriever) setDataFromSchemataExtensions(ctx sessionctx.Context) (err error) {
+	const readOnly = "READ ONLY=1"
 	checker := privilege.GetPrivilegeManager(ctx)
 	ex, ok := e.extractor.(*plannercore.InfoSchemaSchemataExtractor)
 	if !ok {
@@ -3976,12 +3977,10 @@ func (e *memtableRetriever) setDataFromSchemataExtensions(ctx sessionctx.Context
 			infoschema.CatalogVal, // CATALOG_NAME
 			schema.Name.O,         // SCHEMA_NAME
 		)
-		// todo:
-		//if schema.ReadOnly {
-		//	record = append(record, types.NewStringDatum("READ ONLY=1"))
-		//}
+		if schema.ReadOnly {
+			record = append(record, types.NewStringDatum(readOnly))
+		}
 		rows = append(rows, record)
-		e.recordMemoryConsume(record)
 	}
 	e.rows = rows
 	return

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -655,7 +655,7 @@ func TestColumnTable(t *testing.T) {
 		testkit.RowsWithSep("|",
 			"test|tbl1|col_2"))
 	tk.MustQuery(`select count(*) from information_schema.columns;`).Check(
-		testkit.RowsWithSep("|", "4983"))
+		testkit.RowsWithSep("|", "4986"))
 }
 
 func TestIndexUsageTable(t *testing.T) {

--- a/pkg/infoschema/tables.go
+++ b/pkg/infoschema/tables.go
@@ -219,6 +219,8 @@ const (
 	TableKeywords = "KEYWORDS"
 	// TableTiDBIndexUsage is a table to show the usage stats of indexes in the current instance.
 	TableTiDBIndexUsage = "TIDB_INDEX_USAGE"
+	// TableSchemataExtensions is the table to show read only state of database.
+	TableSchemataExtensions = "SCHEMATA_EXTENSIONS"
 )
 
 const (
@@ -341,6 +343,7 @@ var tableIDMap = map[string]int64{
 	TableTiDBIndexUsage:                  autoid.InformationSchemaDBID + 93,
 	ClusterTableTiDBIndexUsage:           autoid.InformationSchemaDBID + 94,
 	TableTiFlashIndexes:                  autoid.InformationSchemaDBID + 95,
+	TableSchemataExtensions:              autoid.InformationSchemaDBID + 101,
 }
 
 // columnInfo represents the basic column information of all kinds of INFORMATION_SCHEMA tables
@@ -1736,6 +1739,12 @@ var tableTiDBIndexUsage = []columnInfo{
 	{name: "LAST_ACCESS_TIME", tp: mysql.TypeDatetime, size: 21},
 }
 
+var tableSchemataExtensions = []columnInfo{
+	{name: "CATALOG_NAME", tp: mysql.TypeVarchar, size: 64},
+	{name: "SCHEMA_NAME", tp: mysql.TypeVarchar, size: 64},
+	{name: "OPTIONS", tp: mysql.TypeVarchar, size: 256},
+}
+
 // GetShardingInfo returns a nil or description string for the sharding information of given TableInfo.
 // The returned description string may be:
 //   - "NOT_SHARDED": for tables that SHARD_ROW_ID_BITS is not specified.
@@ -2383,6 +2392,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableTiDBCheckConstraints:               tableTiDBCheckConstraintsCols,
 	TableKeywords:                           tableKeywords,
 	TableTiDBIndexUsage:                     tableTiDBIndexUsage,
+	TableSchemataExtensions:                 tableSchemataExtensions,
 }
 
 func createInfoSchemaTable(_ autoid.Allocators, _ func() (pools.Resource, error), meta *model.TableInfo) (table.Table, error) {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4854,7 +4854,7 @@ func (b *PlanBuilder) buildMemTable(_ context.Context, dbName pmodel.CIStr, tabl
 			p.Extractor = NewInfoSchemaPartitionsExtractor()
 		case infoschema.TableStatistics:
 			p.Extractor = NewInfoSchemaStatisticsExtractor()
-		case infoschema.TableSchemata:
+		case infoschema.TableSchemata, infoschema.TableSchemataExtensions:
 			p.Extractor = NewInfoSchemaSchemataExtractor()
 		case infoschema.TableSequences:
 			p.Extractor = NewInfoSchemaSequenceExtractor()

--- a/tests/integrationtest/r/ddl/db_read_only.result
+++ b/tests/integrationtest/r/ddl/db_read_only.result
@@ -1,0 +1,35 @@
+create database if not exists test;
+desc information_schema.schemata_extensions;
+Field	Type	Null	Key	Default	Extra
+CATALOG_NAME	varchar(64)	YES		NULL	
+SCHEMA_NAME	varchar(64)	YES		NULL	
+OPTIONS	varchar(256)	YES		NULL	
+select * from information_schema.schemata_extensions;
+CATALOG_NAME	SCHEMA_NAME	OPTIONS
+def	ddl__db_read_only	
+def	INFORMATION_SCHEMA	
+def	METRICS_SCHEMA	
+def	mysql	
+def	PERFORMANCE_SCHEMA	
+def	sys	
+def	test	
+alter schema test read only 1;
+select * from information_schema.schemata_extensions;
+CATALOG_NAME	SCHEMA_NAME	OPTIONS
+def	ddl__db_read_only	
+def	INFORMATION_SCHEMA	
+def	METRICS_SCHEMA	
+def	mysql	
+def	PERFORMANCE_SCHEMA	
+def	sys	
+def	test	READ ONLY=1
+alter schema test read only 0;
+select * from information_schema.schemata_extensions;
+CATALOG_NAME	SCHEMA_NAME	OPTIONS
+def	ddl__db_read_only	
+def	INFORMATION_SCHEMA	
+def	METRICS_SCHEMA	
+def	mysql	
+def	PERFORMANCE_SCHEMA	
+def	sys	
+def	test	

--- a/tests/integrationtest/t/ddl/db_read_only.test
+++ b/tests/integrationtest/t/ddl/db_read_only.test
@@ -1,0 +1,9 @@
+create database if not exists test;
+
+# test information_schema.schemata_extensions
+desc information_schema.schemata_extensions;
+select * from information_schema.schemata_extensions;
+alter schema test read only 1;
+select * from information_schema.schemata_extensions;
+alter schema test read only 0;
+select * from information_schema.schemata_extensions;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62122

Problem Summary:

### What changed and how does it work?
Add `INFORMATION_SCHEMA.SCHEMATA_EXTENSIONS` system table to check read only state. If the database is at read-only status, query this table will see the `OPTIONS` column has ` READ ONLY=1 ` content, read-write database shows nothing. The structure and content of this system table are consistent with MySQL.
```
mysql> select * from information_schema.schemata_extensions;
+--------------+--------------------+-------------+
| CATALOG_NAME | SCHEMA_NAME        | OPTIONS     |
+--------------+--------------------+-------------+
| def          | db_read_only       |             |
| def          | INFORMATION_SCHEMA |             |
| def          | METRICS_SCHEMA     |             |
| def          | mysql              |             |
| def          | PERFORMANCE_SCHEMA |             |
| def          | sys                |             |
| def          | test               | READ ONLY=1 |
+--------------+--------------------+-------------+

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
