### PR TITLE
server/handler: register missing http handlers related to ingest param

### DIFF
--- a/pkg/lightning/backend/local/rate_limiter_param.go
+++ b/pkg/lightning/backend/local/rate_limiter_param.go
@@ -46,33 +46,29 @@ var (
 // InitializeRateLimiterParam initializes the rate limiter params.
 func InitializeRateLimiterParam(m *meta.Mutator, logger *zap.Logger) error {
 	err := initializeVariables(
-		m.GetIngestMaxBatchSplitRanges,
-		defaultMaxBatchSplitRanges,
-		&CurrentMaxBatchSplitRanges,
+		m.GetIngestMaxBatchSplitRanges, m.SetIngestMaxBatchSplitRanges,
+		defaultMaxBatchSplitRanges, &CurrentMaxBatchSplitRanges,
 		logger, "maxBatchSplitRanges")
 	if err != nil {
 		return err
 	}
 	err = initializeVariables(
-		m.GetIngestMaxSplitRangesPerSec,
-		defaultSplitRangesPerSec,
-		&CurrentMaxSplitRangesPerSec,
+		m.GetIngestMaxSplitRangesPerSec, m.SetIngestMaxSplitRangesPerSec,
+		defaultSplitRangesPerSec, &CurrentMaxSplitRangesPerSec,
 		logger, "maxSplitRangesPerSec")
 	if err != nil {
 		return err
 	}
 	err = initializeVariables(
-		m.GetIngestMaxInflight,
-		defaultMaxIngestInflight,
-		&CurrentMaxIngestInflight,
+		m.GetIngestMaxInflight, m.SetIngestMaxInflight,
+		defaultMaxIngestInflight, &CurrentMaxIngestInflight,
 		logger, "maxIngestInflight")
 	if err != nil {
 		return err
 	}
 	err = initializeVariables(
-		m.GetIngestMaxPerSec,
-		defaultMaxIngestPerSec,
-		&CurrentMaxIngestPerSec,
+		m.GetIngestMaxPerSec, m.SetIngestMaxPerSec,
+		defaultMaxIngestPerSec, &CurrentMaxIngestPerSec,
 		logger, "maxIngestPerSec")
 	if err != nil {
 		return err
@@ -82,6 +78,7 @@ func InitializeRateLimiterParam(m *meta.Mutator, logger *zap.Logger) error {
 
 func initializeVariables[T comparable](
 	metaGetter func() (v T, isNull bool, err error),
+	metaSetter func(v T) error,
 	defaultVal T,
 	globalVar *atomic.Pointer[T],
 	logger *zap.Logger,
@@ -92,11 +89,17 @@ func initializeVariables[T comparable](
 		return errors.Annotatef(err, "failed to read %s value from meta store", varName)
 	}
 	var zero T
-	if isNull || val == zero {
+	if isNull {
+		err = metaSetter(defaultVal)
+		if err != nil {
+			return errors.Annotatef(err, "failed to set %s value to meta store", varName)
+		}
 		val = defaultVal
 		logger.Info("meta kv not found in meta store, initialized to default and persisted",
 			zap.String("key", varName),
 			zap.Any("value", defaultVal))
+	} else if val == zero {
+		val = defaultVal
 	} else {
 		logger.Info("loaded value from meta store",
 			zap.String("key", varName),

--- a/pkg/server/handler/tests/BUILD.bazel
+++ b/pkg/server/handler/tests/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 40,
+    shard_count = 41,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -761,32 +761,34 @@ func TestIngestParam(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		resp, err := ts.FetchStatus(tc.url)
-		require.NoError(t, err)
-		defer func() { require.NoError(t, resp.Body.Close()) }()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		decoder := json.NewDecoder(resp.Body)
-		var payload struct {
-			Value  float64 `json:"value"`
-			IsNull bool    `json:"is_null"`
-		}
-		err = decoder.Decode(&payload)
-		require.NoError(t, err)
-		require.Equal(t, tc.defaultVal, payload.Value)
+		t.Run(tc.url, func(t *testing.T) {
+			resp, err := ts.FetchStatus(tc.url)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			decoder := json.NewDecoder(resp.Body)
+			var payload struct {
+				Value  float64 `json:"value"`
+				IsNull bool    `json:"is_null"`
+			}
+			err = decoder.Decode(&payload)
+			require.NoError(t, err)
+			require.Equal(t, tc.defaultVal, payload.Value)
 
-		resp, err = ts.PostStatus(tc.url, "", bytes.NewBuffer([]byte(fmt.Sprintf(`{"value": %v}`, tc.modVal))))
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		defer func() { require.NoError(t, resp.Body.Close()) }()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+			resp, err = ts.PostStatus(tc.url, "", bytes.NewBuffer([]byte(fmt.Sprintf(`{"value": %v}`, tc.modVal))))
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		resp, err = ts.FetchStatus(tc.url)
-		require.NoError(t, err)
-		defer func() { require.NoError(t, resp.Body.Close()) }()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		decoder = json.NewDecoder(resp.Body)
-		err = decoder.Decode(&payload)
-		require.NoError(t, err)
-		require.Equal(t, tc.expectedVal, payload.Value)
+			resp, err = ts.FetchStatus(tc.url)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			decoder = json.NewDecoder(resp.Body)
+			err = decoder.Decode(&payload)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedVal, payload.Value)
+		})
 	}
 }

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -742,3 +742,51 @@ func TestGC(t *testing.T) {
 	var empty gc.GCState
 	require.NotEqual(t, empty, state)
 }
+
+func TestIngestParam(t *testing.T) {
+	ts := createBasicHTTPHandlerTestSuite()
+	ts.startServer(t)
+	defer ts.stopServer(t)
+
+	testCases := []struct {
+		url         string
+		defaultVal  any
+		modVal      any
+		expectedVal any
+	}{
+		{"/ingest/max-batch-split-ranges", float64(0), 1000, float64(1000)},
+		{"/ingest/max-split-ranges-per-sec", float64(0), 2000, float64(2000)},
+		{"/ingest/max-ingest-inflight", float64(0), 1000, float64(1000)},
+		{"/ingest/max-ingest-per-sec", float64(0), 2000, float64(2000)},
+	}
+
+	for _, tc := range testCases {
+		resp, err := ts.FetchStatus(tc.url)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		decoder := json.NewDecoder(resp.Body)
+		var payload struct {
+			Value  float64 `json:"value"`
+			IsNull bool    `json:"is_null"`
+		}
+		err = decoder.Decode(&payload)
+		require.NoError(t, err)
+		require.Equal(t, tc.defaultVal, payload.Value)
+
+		resp, err = ts.PostStatus(tc.url, "", bytes.NewBuffer([]byte(fmt.Sprintf(`{"value": %v}`, tc.modVal))))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		resp, err = ts.FetchStatus(tc.url)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		decoder = json.NewDecoder(resp.Body)
+		err = decoder.Decode(&payload)
+		require.NoError(t, err)
+		require.Equal(t, tc.expectedVal, payload.Value)
+	}
+}

--- a/pkg/server/handler/tests/http_handler_serial_test.go
+++ b/pkg/server/handler/tests/http_handler_serial_test.go
@@ -754,7 +754,7 @@ func TestIngestParam(t *testing.T) {
 		modVal      any
 		expectedVal any
 	}{
-		{"/ingest/max-batch-split-ranges", float64(0), 1000, float64(1000)},
+		{"/ingest/max-batch-split-ranges", float64(2048), 1000, float64(1000)},
 		{"/ingest/max-split-ranges-per-sec", float64(0), 2000, float64(2000)},
 		{"/ingest/max-ingest-inflight", float64(0), 1000, float64(1000)},
 		{"/ingest/max-ingest-per-sec", float64(0), 2000, float64(2000)},

--- a/pkg/server/http_status.go
+++ b/pkg/server/http_status.go
@@ -266,6 +266,16 @@ func (s *Server) startHTTPServer() {
 	// HTTP path for upgrade operations.
 	router.Handle("/upgrade/{op}", handler.NewClusterUpgradeHandler(tikvHandlerTool.Store.(kv.Storage))).Name("upgrade operations")
 
+	// HTTP path for ingest configurations
+	router.Handle("/ingest/max-batch-split-ranges", tikvhandler.NewIngestConcurrencyHandler(
+		tikvHandlerTool, tikvhandler.IngestParamMaxBatchSplitRanges)).Name("IngestMaxBatchSplitRanges")
+	router.Handle("/ingest/max-split-ranges-per-sec", tikvhandler.NewIngestConcurrencyHandler(
+		tikvHandlerTool, tikvhandler.IngestParamMaxSplitRangesPerSec)).Name("IngestMaxSplitRangesPerSec")
+	router.Handle("/ingest/max-ingest-inflight", tikvhandler.NewIngestConcurrencyHandler(
+		tikvHandlerTool, tikvhandler.IngestParamMaxInflight)).Name("IngestMaxInflight")
+	router.Handle("/ingest/max-ingest-per-sec", tikvhandler.NewIngestConcurrencyHandler(
+		tikvHandlerTool, tikvhandler.IngestParamMaxPerSecond)).Name("IngestMaxPerSec")
+
 	if s.cfg.Store == config.StoreTypeTiKV {
 		// HTTP path for tikv.
 		router.Handle("/tables/{db}/{table}/regions", tikvhandler.NewTableHandler(tikvHandlerTool, tikvhandler.OpTableRegions))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61553

Problem Summary:

When I cherry-pick #61622 to master(https://github.com/pingcap/tidb/pull/61555), the http handler registering part is missed. We can't modify the ingest parameters through http API.

### What changed and how does it work?

Register missing http handlers related to ingest param.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
❯ curl http://127.0.0.1:10080/ingest/max-batch-split-ranges
{
 "is_null": false,
 "value": 2048
}% 
❯ curl http://127.0.0.1:10080/ingest/max-batch-split-ranges -X POST -d '{"value": 1}'
{
 "message": "success"
}%                                                                              
❯ curl http://127.0.0.1:10080/ingest/max-batch-split-ranges
{
 "is_null": false,
 "value": 1
}%                                                                         
❯ curl http://127.0.0.1:10080/ingest/max-split-ranges-per-sec -X POST -d '{"value": 123}'
{
 "message": "success"
}%                                                                              
❯ curl http://127.0.0.1:10080/ingest/max-ingest-inflight -X POST -d '{"value": 5}'
{
 "message": "success"
}%                                                                              
❯ curl http://127.0.0.1:10080/ingest/max-ingest-per-sec -X POST -d '{"value": 0.35}'
{
 "message": "success"
}% 
```
```
[2025/08/20 17:34:25.600 +08:00] [INFO] [local.go:1232] ["start import engine"] [task-id=3] [task-key=ddl/backfill/120] [subtaskID=3] [step=read-index] [uuid=59619405-c4b5-56d9-8335-6527f473cadd] ["region ranges"=1] [count=1] [size=38] [maxReqInFlight=5] [maxReqPerSec=0.35]
[2025/08/20 17:34:25.600 +08:00] [INFO] [local.go:918] ["import engine ranges"] [task-id=3] [task-key=ddl/backfill/120] [subtaskID=3] [step=read-index] [len(regionSplitKeys)=2] [splitRangesBatch=1] [splitRangePerSec=123]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
