### PR TITLE
planner: fix the error for `ADMIN CHECK INDEX` with multi-valued index

### DIFF
--- a/pkg/executor/test/admintest/BUILD.bazel
+++ b/pkg/executor/test/admintest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 25,
+    shard_count = 26,
     deps = [
         "//pkg/config",
         "//pkg/ddl",

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1892,8 +1892,12 @@ func (b *PlanBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string)
 		}
 		for _, idxCol := range idxInfo.Columns {
 			col := cols[idxCol.Offset]
+			colName := idxCol.Name
+			if col.Hidden && !col.IsGenerated() {
+				colName = col.Name
+			}
 			names = append(names, &types.FieldName{
-				ColName: idxCol.Name,
+				ColName: colName,
 				TblName: tn.Name,
 				DBName:  tn.Schema,
 			})
@@ -1903,7 +1907,7 @@ func (b *PlanBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string)
 				ID:       col.ID})
 		}
 		names = append(names, &types.FieldName{
-			ColName: ast.NewCIStr("handle"),
+			ColName: ast.NewCIStr("extra_handle"),
 			TblName: tn.Name,
 			DBName:  tn.Schema,
 		})

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1897,10 +1897,8 @@ func (b *PlanBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string)
 				TblName: tn.Name,
 				DBName:  tn.Schema,
 			})
-			tp := col.FieldType.Clone()
-			tp.SetArray(false)
 			schema.Append(&expression.Column{
-				RetType:  tp,
+				RetType:  col.FieldType.ArrayType(),
 				UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
 				ID:       col.ID})
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/62461

Problem Summary:

### What changed and how does it work?

1. restrict the usage of `ADMIN CHECK INDEX` only to pk index
2. fix the wrong column type used in building coprocessor request

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
