### PR TITLE
importinto: set request resource during checksum for nextgen

### DIFF
--- a/br/pkg/checksum/BUILD.bazel
+++ b/br/pkg/checksum/BUILD.bazel
@@ -28,12 +28,13 @@ go_test(
     name = "checksum_test",
     timeout = "short",
     srcs = [
+        "executor_nokit_test.go",
         "executor_test.go",
         "main_test.go",
     ],
     embed = [":checksum"],
     flaky = True,
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//br/pkg/metautil",
         "//br/pkg/mock",
@@ -46,6 +47,7 @@ go_test(
         "//pkg/testkit/testsetup",
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_stretchr_testify//require",
+        "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/br/pkg/checksum/BUILD.bazel
+++ b/br/pkg/checksum/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_log//:log",
         "@com_github_pingcap_tipb//go-tipb",
+        "@com_github_tikv_client_go_v2//util",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/br/pkg/checksum/executor_nokit_test.go
+++ b/br/pkg/checksum/executor_nokit_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checksum
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/util"
+)
+
+func TestBuilderRequestSource(t *testing.T) {
+	b := NewExecutorBuilder(nil, 0)
+	require.Equal(t, util.RequestSource{}, b.requestSource)
+
+	b.SetExplicitRequestSourceType("aaa")
+	require.EqualValues(t, util.RequestSource{ExplicitRequestSourceType: "aaa"}, b.requestSource)
+
+	reqSource := util.RequestSource{RequestSourceInternal: true, RequestSourceType: "type", ExplicitRequestSourceType: "bbb"}
+	b.SetRequestSource(reqSource)
+	require.EqualValues(t, reqSource, b.requestSource)
+}

--- a/br/pkg/checksum/main_test.go
+++ b/br/pkg/checksum/main_test.go
@@ -28,6 +28,7 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("github.com/lestrrat-go/httprc.runFetchWorker"),
 		goleak.IgnoreTopFunction("github.com/klauspost/compress/zstd.(*blockDec).startDecoder"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 	}
 	testsetup.SetupForCommonTest()
 	goleak.VerifyTestMain(m, opts...)

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
+	"github.com/tikv/client-go/v2/util"
 )
 
 // RequestBuilder is used to build a "kv.Request".
@@ -397,9 +398,9 @@ func (builder *RequestBuilder) SetResourceGroupName(name string) *RequestBuilder
 	return builder
 }
 
-// SetRequestSourceType sets the request source type.
-func (builder *RequestBuilder) SetRequestSourceType(sourceType string) *RequestBuilder {
-	builder.RequestSource.RequestSourceType = sourceType
+// SetRequestSource sets the request source.
+func (builder *RequestBuilder) SetRequestSource(reqSource util.RequestSource) *RequestBuilder {
+	builder.RequestSource = reqSource
 	return builder
 }
 

--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -397,6 +397,12 @@ func (builder *RequestBuilder) SetResourceGroupName(name string) *RequestBuilder
 	return builder
 }
 
+// SetRequestSourceType sets the request source type.
+func (builder *RequestBuilder) SetRequestSourceType(sourceType string) *RequestBuilder {
+	builder.RequestSource.RequestSourceType = sourceType
+	return builder
+}
+
 // SetExplicitRequestSourceType sets the explicit request source type.
 func (builder *RequestBuilder) SetExplicitRequestSourceType(sourceType string) *RequestBuilder {
 	builder.RequestSource.ExplicitRequestSourceType = sourceType

--- a/pkg/lightning/backend/local/checksum.go
+++ b/pkg/lightning/backend/local/checksum.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tipb/go-tipb"
 	tikvstore "github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/oracle"
+	tikvutil "github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 	pderrs "github.com/tikv/pd/client/errs"
 	"go.uber.org/atomic"
@@ -279,13 +280,12 @@ func updateGCLifeTime(ctx context.Context, db *sql.DB, gcLifeTime string) error 
 
 // TiKVChecksumManager is a manager that can compute checksum of a table using TiKV.
 type TiKVChecksumManager struct {
-	client                    kv.Client
-	manager                   *gcTTLManager
-	distSQLScanConcurrency    uint
-	backoffWeight             int
-	resourceGroupName         string
-	requestSourceType         string
-	explicitRequestSourceType string
+	client                 kv.Client
+	manager                *gcTTLManager
+	distSQLScanConcurrency uint
+	backoffWeight          int
+	resourceGroupName      string
+	requestSource          tikvutil.RequestSource
 }
 
 var _ ChecksumManager = &TiKVChecksumManager{}
@@ -293,13 +293,14 @@ var _ ChecksumManager = &TiKVChecksumManager{}
 // NewTiKVChecksumManager return a new tikv checksum manager
 func NewTiKVChecksumManager(client kv.Client, pdClient pd.Client, distSQLScanConcurrency uint, backoffWeight int, resourceGroupName, explicitRequestSourceType string) *TiKVChecksumManager {
 	return &TiKVChecksumManager{
-		client:                    client,
-		manager:                   newGCTTLManager(pdClient, lightningServicePrefix),
-		distSQLScanConcurrency:    distSQLScanConcurrency,
-		backoffWeight:             backoffWeight,
-		resourceGroupName:         resourceGroupName,
-		requestSourceType:         kv.InternalTxnLightning,
-		explicitRequestSourceType: explicitRequestSourceType,
+		client:                 client,
+		manager:                newGCTTLManager(pdClient, lightningServicePrefix),
+		distSQLScanConcurrency: distSQLScanConcurrency,
+		backoffWeight:          backoffWeight,
+		resourceGroupName:      resourceGroupName,
+		requestSource: tikvutil.RequestSource{
+			ExplicitRequestSourceType: explicitRequestSourceType,
+		},
 	}
 }
 
@@ -307,13 +308,15 @@ func NewTiKVChecksumManager(client kv.Client, pdClient pd.Client, distSQLScanCon
 func NewTiKVChecksumManagerForImportInto(store kv.Storage, taskID int64, distSQLScanConcurrency uint, backoffWeight int, resourceGroupName string) *TiKVChecksumManager {
 	prefix := fmt.Sprintf("%s-%d", importIntoServicePrefix, taskID)
 	return &TiKVChecksumManager{
-		client:                    store.GetClient(),
-		manager:                   newGCTTLManager(store.(kv.StorageWithPD).GetPDClient(), prefix),
-		distSQLScanConcurrency:    distSQLScanConcurrency,
-		backoffWeight:             backoffWeight,
-		resourceGroupName:         resourceGroupName,
-		requestSourceType:         kv.InternalImportInto,
-		explicitRequestSourceType: importIntoServicePrefix,
+		client:                 store.GetClient(),
+		manager:                newGCTTLManager(store.(kv.StorageWithPD).GetPDClient(), prefix),
+		distSQLScanConcurrency: distSQLScanConcurrency,
+		backoffWeight:          backoffWeight,
+		resourceGroupName:      resourceGroupName,
+		requestSource: tikvutil.RequestSource{
+			RequestSourceInternal: true,
+			RequestSourceType:     kv.InternalImportInto,
+		},
 	}
 }
 
@@ -322,8 +325,7 @@ func (e *TiKVChecksumManager) checksumDB(ctx context.Context, tableInfo *checkpo
 		SetConcurrency(e.distSQLScanConcurrency).
 		SetBackoffWeight(e.backoffWeight).
 		SetResourceGroupName(e.resourceGroupName).
-		SetRequestSourceType(e.requestSourceType).
-		SetExplicitRequestSourceType(e.explicitRequestSourceType).
+		SetRequestSource(e.requestSource).
 		Build()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/pkg/lightning/backend/local/checksum.go
+++ b/pkg/lightning/backend/local/checksum.go
@@ -284,6 +284,7 @@ type TiKVChecksumManager struct {
 	distSQLScanConcurrency    uint
 	backoffWeight             int
 	resourceGroupName         string
+	requestSourceType         string
 	explicitRequestSourceType string
 }
 
@@ -297,6 +298,7 @@ func NewTiKVChecksumManager(client kv.Client, pdClient pd.Client, distSQLScanCon
 		distSQLScanConcurrency:    distSQLScanConcurrency,
 		backoffWeight:             backoffWeight,
 		resourceGroupName:         resourceGroupName,
+		requestSourceType:         kv.InternalTxnLightning,
 		explicitRequestSourceType: explicitRequestSourceType,
 	}
 }
@@ -310,6 +312,7 @@ func NewTiKVChecksumManagerForImportInto(store kv.Storage, taskID int64, distSQL
 		distSQLScanConcurrency:    distSQLScanConcurrency,
 		backoffWeight:             backoffWeight,
 		resourceGroupName:         resourceGroupName,
+		requestSourceType:         kv.InternalImportInto,
 		explicitRequestSourceType: importIntoServicePrefix,
 	}
 }
@@ -319,6 +322,7 @@ func (e *TiKVChecksumManager) checksumDB(ctx context.Context, tableInfo *checkpo
 		SetConcurrency(e.distSQLScanConcurrency).
 		SetBackoffWeight(e.backoffWeight).
 		SetResourceGroupName(e.resourceGroupName).
+		SetRequestSourceType(e.requestSourceType).
 		SetExplicitRequestSourceType(e.explicitRequestSourceType).
 		Build()
 	if err != nil {

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1421,6 +1421,10 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		req.ReplicaReadType = options.GetTiKVReplicaReadType(kv.ReplicaReadFollower)
 		ops = append(ops, tikv.WithMatchStores([]uint64{*task.redirect2Replica}))
 	}
+	if req.InputRequestSource != "internal_DistTask" && req.InputRequestSource != "internal_others" &&
+		req.InputRequestSource != "internal_ddl" && req.InputRequestSource != "internal_stats" && req.InputRequestSource != "internal_DDLNotifier" {
+		fmt.Printf("cop request source: %+v\n", req.InputRequestSource)
+	}
 	resp, rpcCtx, storeAddr, err := worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
 		timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
 	err = derr.ToTiDBErr(err)

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1421,10 +1421,6 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		req.ReplicaReadType = options.GetTiKVReplicaReadType(kv.ReplicaReadFollower)
 		ops = append(ops, tikv.WithMatchStores([]uint64{*task.redirect2Replica}))
 	}
-	if req.InputRequestSource != "internal_DistTask" && req.InputRequestSource != "internal_others" &&
-		req.InputRequestSource != "internal_ddl" && req.InputRequestSource != "internal_stats" && req.InputRequestSource != "internal_DDLNotifier" {
-		fmt.Printf("cop request source: %+v\n", req.InputRequestSource)
-	}
 	resp, rpcCtx, storeAddr, err := worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
 		timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
 	err = derr.ToTiDBErr(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

apply below diff
<details><summary>code diff</summary>

```diff
diff --git a/pkg/store/copr/coprocessor.go b/pkg/store/copr/coprocessor.go
index 28eaaeef54..2dcbe28f19 100644
--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1421,6 +1421,10 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 		req.ReplicaReadType = options.GetTiKVReplicaReadType(kv.ReplicaReadFollower)
 		ops = append(ops, tikv.WithMatchStores([]uint64{*task.redirect2Replica}))
 	}
+	if req.InputRequestSource != "internal_DistTask" && req.InputRequestSource != "internal_others" &&
+		req.InputRequestSource != "internal_ddl" && req.InputRequestSource != "internal_stats" && req.InputRequestSource != "internal_DDLNotifier" {
+		fmt.Printf("cop request source: %+v\n", req.InputRequestSource)
+	}
 	resp, rpcCtx, storeAddr, err := worker.kvclient.SendReqCtx(bo.TiKVBackoffer(), req, task.region,
 		timeout, getEndPointType(task.storeType), task.storeAddr, ops...)
 	err = derr.ToTiDBErr(err)
```

</details>

then start nextgen, and import with `import into t from '/minio/a.csv';`
```
cop request source: internal_ImportInto
```
then we do add index with multiple schema change `alter table t add index ia1(id), add index ia2(id), add index ia3(id);`
```
cop request source: internal_ddl_add_index
cop request source: internal_ddl_add_index_ddl
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
