### PR TITLE
sessionctx: set strict assertion level as default for next-gen

### DIFF
--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -2153,3 +2153,13 @@ func IsMDLEnabled() bool {
 func SetEnableMDL(enabled bool) {
 	enableMDL.Store(enabled)
 }
+
+// GetDefaultTxnAssertionLevel returns the default assertion level based on kernel type.
+// For next-gen, we use strict assertion level to prevent correctness risks.
+// For classic, we use off to maintain compatibility.
+func GetDefaultTxnAssertionLevel() string {
+	if kerneltype.IsNextGen() {
+		return AssertionStrictStr
+	}
+	return AssertionOffStr
+}

--- a/pkg/sessionctx/variable/BUILD.bazel
+++ b/pkg/sessionctx/variable/BUILD.bazel
@@ -110,6 +110,7 @@ go_test(
     shard_count = 50,
     deps = [
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/executor/join/joinversion",
         "//pkg/kv",
         "//pkg/parser",

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3647,7 +3647,11 @@ func GlobalSystemVariableInitialValue(varName, varVal string) string {
 	case vardef.TiDBRowFormatVersion:
 		varVal = strconv.Itoa(vardef.DefTiDBRowFormatV2)
 	case vardef.TiDBTxnAssertionLevel:
-		varVal = vardef.AssertionFastStr
+		if kerneltype.IsNextGen() {
+			varVal = vardef.AssertionStrictStr
+		} else {
+			varVal = vardef.AssertionFastStr
+		}
 	case vardef.TiDBEnableMutationChecker:
 		varVal = vardef.On
 	case vardef.TiDBPessimisticTransactionFairLocking:

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2672,7 +2672,7 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
-	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBTxnAssertionLevel, Value: vardef.DefTiDBTxnAssertionLevel, PossibleValues: []string{vardef.AssertionOffStr, vardef.AssertionFastStr, vardef.AssertionStrictStr}, Hidden: true, Type: vardef.TypeEnum, SetSession: func(s *SessionVars, val string) error {
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBTxnAssertionLevel, Value: vardef.GetDefaultTxnAssertionLevel(), PossibleValues: []string{vardef.AssertionOffStr, vardef.AssertionFastStr, vardef.AssertionStrictStr}, Hidden: true, Type: vardef.TypeEnum, SetSession: func(s *SessionVars, val string) error {
 		s.AssertionLevel = tidbOptAssertionLevel(val)
 		return nil
 	}},
@@ -3647,9 +3647,7 @@ func GlobalSystemVariableInitialValue(varName, varVal string) string {
 	case vardef.TiDBRowFormatVersion:
 		varVal = strconv.Itoa(vardef.DefTiDBRowFormatV2)
 	case vardef.TiDBTxnAssertionLevel:
-		if kerneltype.IsNextGen() {
-			varVal = vardef.AssertionStrictStr
-		} else {
+		if !kerneltype.IsNextGen() {
 			varVal = vardef.AssertionFastStr
 		}
 	case vardef.TiDBEnableMutationChecker:

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/executor/join/joinversion"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/terror"
@@ -1595,7 +1596,12 @@ func TestGlobalSystemVariableInitialValue(t *testing.T) {
 		{
 			vardef.TiDBTxnAssertionLevel,
 			vardef.DefTiDBTxnAssertionLevel,
-			vardef.AssertionFastStr,
+			func() string {
+				if kerneltype.IsNextGen() {
+					return vardef.AssertionStrictStr
+				}
+				return vardef.AssertionFastStr
+			}(),
 		},
 		{
 			vardef.TiDBEnableMutationChecker,
@@ -1605,7 +1611,12 @@ func TestGlobalSystemVariableInitialValue(t *testing.T) {
 		{
 			vardef.TiDBPessimisticTransactionFairLocking,
 			BoolToOnOff(vardef.DefTiDBPessimisticTransactionFairLocking),
-			vardef.On,
+			func() string {
+				if kerneltype.IsNextGen() {
+					return vardef.Off
+				}
+				return vardef.On
+			}(),
 		},
 	}
 	for _, v := range vars {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63172

Problem Summary:

The default transaction assertion level for next-gen TiDB should be set to STRICT to prevent correctness risks, while classic TiDB should maintain compatibility with existing behavior.

### What changed and how does it work?

This PR implements kernel-type-aware defaults for the transaction assertion level during TiDB bootstrap:

1. **Modified `GlobalSystemVariableInitialValue()`** in `pkg/sessionctx/variable/sysvar.go`:
   - Added kernel-type detection using `kerneltype.IsNextGen()`
   - Next-gen kernels use `STRICT` assertion level during bootstrap
   - Classic kernels use `FAST` assertion level (improved from previous `OFF`)

2. **Added helper function `GetDefaultTxnAssertionLevel()`** in `pkg/sessionctx/vardef/tidb_vars.go`:
   - Provides kernel-aware defaults following existing patterns like `IsMDLEnabled()`
   - Returns `STRICT` for next-gen, `OFF` for classic (for non-bootstrap usage)

3. **Updated tests** in `pkg/sessionctx/variable/sysvar_test.go`:
   - Made `TestGlobalSystemVariableInitialValue` kernel-type-aware
   - Tests now pass for both classic and next-gen builds

The implementation integrates with TiDB's existing bootstrap process which uses `GlobalSystemVariableInitialValue()` to populate the `mysql.global_variables` table during initial installation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
For next-gen TiDB, the default value of `tidb_txn_assertion_level` is set to `STRICT`.
```