### PR TITLE
backend/local: add missing collector for next-gen ingest

### DIFF
--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1481,6 +1481,7 @@ func (local *Backend) newRegionJobWorker(
 			ingestCli:      ingestcli.NewClient(local.TiKVWorkerURL, clusterID, isHTTPS, local.nextgenHTTPCli, local.splitCli),
 			writeBatchSize: local.KVWriteBatchSize,
 			bufPool:        local.engineMgr.getBufferPool(),
+			collector:      local.collector,
 		}
 		base.writeFn = cloudW.write
 		base.ingestFn = cloudW.ingest

--- a/tests/realtikvtest/importintotest3/BUILD.bazel
+++ b/tests/realtikvtest/importintotest3/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//br/pkg/storage",
         "//pkg/config/kerneltype",
         "//pkg/disttask/framework/storage",
+        "//pkg/disttask/framework/taskexecutor/execute",
         "//pkg/disttask/framework/testutil",
         "//pkg/disttask/importinto",
         "//pkg/executor/importer",

--- a/tests/realtikvtest/importintotest3/BUILD.bazel
+++ b/tests/realtikvtest/importintotest3/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "//pkg/disttask/framework/storage",
         "//pkg/disttask/framework/testutil",
         "//pkg/disttask/importinto",
+        "//pkg/executor/importer",
         "//pkg/kv",
         "//pkg/lightning/mydump",
         "//pkg/store",

--- a/tests/realtikvtest/importintotest3/cross_ks_test.go
+++ b/tests/realtikvtest/importintotest3/cross_ks_test.go
@@ -78,7 +78,7 @@ func TestOnUserKeyspace(t *testing.T) {
 
 	// reverse check
 	sysKSTk.MustQuery(jobQuerySQL).Check(testkit.Rows("0"))
-	userTK.MustQuery(taskQuerySQL).Check(testkit.Rows("0"))
+	require.Len(t, userTK.MustQuery(taskQuerySQL).Rows(), 0)
 
 	// Check the job summary from user keyspace is correct, which is get from subtask summaries.
 	rs = userTK.MustQuery(fmt.Sprintf("select summary from mysql.tidb_import_jobs where id = %d", jobID)).Rows()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61088

Problem Summary:

Next-gen and classic kernel have different code path for ingest, but we only add metric collector for classic kernel.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

You can also start a next-gen cluster with tiup and run `TestOnUserKeyspace` locally. Note, you should disable the remote coprocessor for tikv (ref https://github.com/pingcap/tidb/pull/62701/files#diff-6f6451c097e1954613b68d673de4a921e43820e8e46d842c946cfad2ad84c0cdR14-R17) to make post-process succeed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
