### PR TITLE
planner: fix handling of empty plan digests in `getBindingPlanInfo`

### DIFF
--- a/pkg/bindinfo/binding_auto.go
+++ b/pkg/bindinfo/binding_auto.go
@@ -245,7 +245,9 @@ func (ba *bindingAuto) getBindingPlanInfo(currentDB, sqlOrDigest, charset, colla
 			}); err != nil {
 				bindingLogger().Error("get plan digest failed",
 					zap.String("bind_sql", binding.BindSQL), zap.Error(err))
+				continue
 			}
+			binding.PlanDigest = planDigest
 		}
 
 		pInfo, err := ba.getPlanExecInfo(planDigest)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #60148

Problem Summary:

When SPM's `EXPLAIN EXPLORE` obtains plan and execution information for existing bindings, it uses the plan digest stored in the binding to obtain execution information. If the plan digest is empty, we run the optimizer to calculate the plan digest, which we then use to obtain execution info. However, we don't update the binding structure with this calculated plan digest, which means the plan displayed to the user has an empty plan digest, resulting in `EXPLAIN EXPLORE` producing the following incorrect output:

```
explain_analyze: EXPLAIN ANALYZE ''                                                                                                                                                  
binding: CREATE GLOBAL BINDING FROM HISTORY USING PLAN DIGEST ''
``` 

### What changed and how does it work?

* If the binding's stored plan digest is empty, update `binding.PlanDigest` with the newly calculated plan digest.
* If we fail to get the plan digest, we now skip that plan (instead of just logging an error and including the plan).
* Modify the `TestExplainExploreBasic` unit test to ensure that no plan digest is ever empty.
    * Also, change `require.True` to `require.Equal` when checking row counts, so test failures will show what the actual (unexpected) output was, instead of just saying the condition was false.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
