### PR TITLE
planner: remove tidb_enable_pseudo_for_outdated_stats and related logic

### DIFF
--- a/cmd/tidb-server/BUILD.bazel
+++ b/cmd/tidb-server/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//pkg/sessionctx/vardef",
         "//pkg/sessionctx/variable",
         "//pkg/standby",
-        "//pkg/statistics",
         "//pkg/store",
         "//pkg/store/copr",
         "//pkg/store/driver",

--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -56,7 +56,6 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/standby"
-	"github.com/pingcap/tidb/pkg/statistics"
 	kvstore "github.com/pingcap/tidb/pkg/store"
 	"github.com/pingcap/tidb/pkg/store/copr"
 	"github.com/pingcap/tidb/pkg/store/driver"
@@ -823,7 +822,6 @@ func setGlobalVars() {
 	planReplayerGCLease := parseDuration(cfg.Performance.PlanReplayerGCLease)
 	vardef.SetPlanReplayerGCLease(planReplayerGCLease)
 	bindinfo.Lease = parseDuration(cfg.Performance.BindInfoLease)
-	statistics.RatioOfPseudoEstimate.Store(cfg.Performance.PseudoEstimateRatio)
 	if cfg.SplitTable {
 		atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -700,16 +700,15 @@ type Performance struct {
 	ServerMemoryQuota uint64 `toml:"server-memory-quota" json:"server-memory-quota"`
 	StatsLease        string `toml:"stats-lease" json:"stats-lease"`
 	// Deprecated: transaction auto retry is deprecated.
-	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
-	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
-	BindInfoLease       string  `toml:"bind-info-lease" json:"bind-info-lease"`
-	TxnEntrySizeLimit   uint64  `toml:"txn-entry-size-limit" json:"txn-entry-size-limit"`
-	TxnTotalSizeLimit   uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
-	TCPKeepAlive        bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
-	TCPNoDelay          bool    `toml:"tcp-no-delay" json:"tcp-no-delay"`
-	CrossJoin           bool    `toml:"cross-join" json:"cross-join"`
-	DistinctAggPushDown bool    `toml:"distinct-agg-push-down" json:"distinct-agg-push-down"`
-	MaxTxnTTL           uint64  `toml:"max-txn-ttl" json:"max-txn-ttl"`
+	StmtCountLimit      uint   `toml:"stmt-count-limit" json:"stmt-count-limit"`
+	BindInfoLease       string `toml:"bind-info-lease" json:"bind-info-lease"`
+	TxnEntrySizeLimit   uint64 `toml:"txn-entry-size-limit" json:"txn-entry-size-limit"`
+	TxnTotalSizeLimit   uint64 `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
+	TCPKeepAlive        bool   `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
+	TCPNoDelay          bool   `toml:"tcp-no-delay" json:"tcp-no-delay"`
+	CrossJoin           bool   `toml:"cross-join" json:"cross-join"`
+	DistinctAggPushDown bool   `toml:"distinct-agg-push-down" json:"distinct-agg-push-down"`
+	MaxTxnTTL           uint64 `toml:"max-txn-ttl" json:"max-txn-ttl"`
 	// Deprecated
 	MemProfileInterval string `toml:"-" json:"-"`
 
@@ -1010,7 +1009,6 @@ var defaultConf = Config{
 		CrossJoin:                         true,
 		StatsLease:                        "3s",
 		StmtCountLimit:                    5000,
-		PseudoEstimateRatio:               0.8,
 		ForcePriority:                     "NO_PRIORITY",
 		BindInfoLease:                     "3s",
 		TxnEntrySizeLimit:                 DefTxnEntrySizeLimit,

--- a/pkg/config/config_util.go
+++ b/pkg/config/config_util.go
@@ -37,21 +37,20 @@ func CloneConf(conf *Config) (*Config, error) {
 var (
 	// dynamicConfigItems contains all config items that can be changed during runtime.
 	dynamicConfigItems = map[string]struct{}{
-		"Performance.MaxProcs":            {},
-		"Performance.MaxMemory":           {},
-		"Performance.CrossJoin":           {},
-		"Performance.PseudoEstimateRatio": {},
-		"Performance.StmtCountLimit":      {},
-		"Performance.TCPKeepAlive":        {},
-		"TiKVClient.StoreLimit":           {},
-		"Log.Level":                       {},
-		"Log.ExpensiveThreshold":          {},
-		"Instance.SlowThreshold":          {},
-		"Instance.CheckMb4ValueInUTF8":    {},
-		"TxnLocalLatches.Capacity":        {},
-		"CompatibleKillQuery":             {},
-		"TreatOldVersionUTF8AsUTF8MB4":    {},
-		"OpenTracing.Enable":              {},
+		"Performance.MaxProcs":         {},
+		"Performance.MaxMemory":        {},
+		"Performance.CrossJoin":        {},
+		"Performance.StmtCountLimit":   {},
+		"Performance.TCPKeepAlive":     {},
+		"TiKVClient.StoreLimit":        {},
+		"Log.Level":                    {},
+		"Log.ExpensiveThreshold":       {},
+		"Instance.SlowThreshold":       {},
+		"Instance.CheckMb4ValueInUTF8": {},
+		"TxnLocalLatches.Capacity":     {},
+		"CompatibleKillQuery":          {},
+		"TreatOldVersionUTF8AsUTF8MB4": {},
+		"OpenTracing.Enable":           {},
 	}
 )
 

--- a/pkg/config/config_util_test.go
+++ b/pkg/config/config_util_test.go
@@ -50,7 +50,6 @@ func TestMergeConfigItems(t *testing.T) {
 	newConf.Performance.MaxProcs = 123
 	newConf.Performance.MaxMemory = 123
 	newConf.Performance.CrossJoin = false
-	newConf.Performance.PseudoEstimateRatio = 123
 	newConf.TiKVClient.StoreLimit = 123
 
 	// rejected
@@ -74,7 +73,6 @@ func TestMergeConfigItems(t *testing.T) {
 	require.Equal(t, newConf.Performance.MaxProcs, oldConf.Performance.MaxProcs)
 	require.Equal(t, newConf.Performance.MaxMemory, oldConf.Performance.MaxMemory)
 	require.Equal(t, newConf.Performance.CrossJoin, oldConf.Performance.CrossJoin)
-	require.Equal(t, newConf.Performance.PseudoEstimateRatio, oldConf.Performance.PseudoEstimateRatio)
 	require.Equal(t, newConf.TiKVClient.StoreLimit, oldConf.TiKVClient.StoreLimit)
 	require.Equal(t, newConf.Instance.SlowThreshold, oldConf.Instance.SlowThreshold)
 

--- a/pkg/planner/core/casetest/cbotest/BUILD.bazel
+++ b/pkg/planner/core/casetest/cbotest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 21,
+    shard_count = 20,
     deps = [
         "//pkg/domain",
         "//pkg/executor",
@@ -20,7 +20,6 @@ go_test(
         "//pkg/planner/core/resolve",
         "//pkg/session",
         "//pkg/sessionctx/vardef",
-        "//pkg/statistics",
         "//pkg/statistics/handle/ddl/testutil",
         "//pkg/testkit",
         "//pkg/testkit/testdata",

--- a/pkg/planner/core/casetest/cbotest/cbo_test.go
+++ b/pkg/planner/core/casetest/cbotest/cbo_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/core/resolve"
 	"github.com/pingcap/tidb/pkg/session"
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
-	"github.com/pingcap/tidb/pkg/statistics"
 	statstestutil "github.com/pingcap/tidb/pkg/statistics/handle/ddl/testutil"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testdata"
@@ -144,8 +143,6 @@ func TestTableDual(t *testing.T) {
 
 func TestEstimation(t *testing.T) {
 	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
-		statistics.RatioOfPseudoEstimate.Store(10.0)
-		defer statistics.RatioOfPseudoEstimate.Store(0.7)
 		testKit.MustExec("use test")
 		testKit.MustExec("create table t (a int)")
 		testKit.MustExec("insert into t values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)")
@@ -431,51 +428,6 @@ func TestAnalyze(t *testing.T) {
 				output[i] = planString
 			})
 			require.Equalf(t, output[i], planString, "case: %v", tt)
-		}
-	})
-}
-
-func TestOutdatedAnalyze(t *testing.T) {
-	testkit.RunTestUnderCascadesWithDomain(t, func(t *testing.T, testKit *testkit.TestKit, dom *domain.Domain, cascades, caller string) {
-		testKit.MustExec("use test")
-		testKit.MustExec("create table t (a int, b int, index idx(a))")
-		for i := range 10 {
-			testKit.MustExec(fmt.Sprintf("insert into t values (%d,%d)", i, i))
-		}
-		h := dom.StatsHandle()
-		err := statstestutil.HandleNextDDLEventWithTxn(h)
-		require.NoError(t, err)
-		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		testKit.MustExec("analyze table t all columns")
-		testKit.MustExec("insert into t select * from t")
-		testKit.MustExec("insert into t select * from t")
-		testKit.MustExec("insert into t select * from t")
-		require.NoError(t, h.DumpStatsDeltaToKV(true))
-		require.NoError(t, h.Update(context.Background(), dom.InfoSchema()))
-		var input []struct {
-			SQL                          string
-			EnablePseudoForOutdatedStats bool
-			RatioOfPseudoEstimate        float64
-		}
-		var output []struct {
-			SQL                          string
-			EnablePseudoForOutdatedStats bool
-			RatioOfPseudoEstimate        float64
-			Plan                         []string
-		}
-		analyzeSuiteData := GetAnalyzeSuiteData()
-		analyzeSuiteData.LoadTestCases(t, &input, &output, cascades, caller)
-		for i, tt := range input {
-			testKit.Session().GetSessionVars().SetEnablePseudoForOutdatedStats(tt.EnablePseudoForOutdatedStats)
-			statistics.RatioOfPseudoEstimate.Store(tt.RatioOfPseudoEstimate)
-			plan := testKit.MustQuery(tt.SQL)
-			testdata.OnRecord(func() {
-				output[i].SQL = tt.SQL
-				output[i].EnablePseudoForOutdatedStats = tt.EnablePseudoForOutdatedStats
-				output[i].RatioOfPseudoEstimate = tt.RatioOfPseudoEstimate
-				output[i].Plan = testdata.ConvertRowsToStrings(plan.Rows())
-			})
-			plan.Check(testkit.Rows(output[i].Plan...))
 		}
 	})
 }

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
@@ -20,31 +20,6 @@
     ]
   },
   {
-    "name": "TestOutdatedAnalyze",
-    "cases": [
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": true,
-        "RatioOfPseudoEstimate": 10
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": true,
-        "RatioOfPseudoEstimate": 0.7
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": false,
-        "RatioOfPseudoEstimate": 10
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": false,
-        "RatioOfPseudoEstimate": 0.7
-      }
-    ]
-  },
-  {
     "name": "TestInconsistentEstimation",
     "cases": [
       // Using the histogram (a, b) to estimate `a = 5` will get 1.22, while using the CM Sketch to estimate

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "Name": "TestOutdatedAnalyze",
-    "Cases": [
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": true,
-        "RatioOfPseudoEstimate": 10,
-        "Plan": [
-          "TableReader 28.80 root  data:Selection",
-          "└─Selection 28.80 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false"
-        ]
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": true,
-        "RatioOfPseudoEstimate": 0.7,
-        "Plan": [
-          "TableReader 8.84 root  data:Selection",
-          "└─Selection 8.84 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": false,
-        "RatioOfPseudoEstimate": 10,
-        "Plan": [
-          "TableReader 28.80 root  data:Selection",
-          "└─Selection 28.80 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false"
-        ]
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": false,
-        "RatioOfPseudoEstimate": 0.7,
-        "Plan": [
-          "TableReader 28.80 root  data:Selection",
-          "└─Selection 28.80 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false"
-        ]
-      }
-    ]
-  },
-  {
     "Name": "TestInconsistentEstimation",
     "Cases": [
       {

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
@@ -54,51 +54,6 @@
     ]
   },
   {
-    "Name": "TestOutdatedAnalyze",
-    "Cases": [
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": true,
-        "RatioOfPseudoEstimate": 10,
-        "Plan": [
-          "TableReader 28.80 root  data:Selection",
-          "└─Selection 28.80 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false"
-        ]
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": true,
-        "RatioOfPseudoEstimate": 0.7,
-        "Plan": [
-          "TableReader 8.84 root  data:Selection",
-          "└─Selection 8.84 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false, stats:pseudo"
-        ]
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": false,
-        "RatioOfPseudoEstimate": 10,
-        "Plan": [
-          "TableReader 28.80 root  data:Selection",
-          "└─Selection 28.80 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false"
-        ]
-      },
-      {
-        "SQL": "explain format = 'brief' select * from t where a <= 5 and b <= 5",
-        "EnablePseudoForOutdatedStats": false,
-        "RatioOfPseudoEstimate": 0.7,
-        "Plan": [
-          "TableReader 28.80 root  data:Selection",
-          "└─Selection 28.80 cop[tikv]  le(test.t.a, 5), le(test.t.b, 5)",
-          "  └─TableFullScan 80.00 cop[tikv] table:t keep order:false"
-        ]
-      }
-    ]
-  },
-  {
     "Name": "TestInconsistentEstimation",
     "Cases": [
       {

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4201,8 +4201,7 @@ func getStatsTable(ctx base.PlanContext, tblInfo *model.TableInfo, pid int64) *s
 
 	// 3. statistics is uninitialized or outdated.
 	pseudoStatsForUninitialized = !statsTbl.IsInitialized()
-	pseudoStatsForOutdated = ctx.GetSessionVars().GetEnablePseudoForOutdatedStats() && statsTbl.IsOutdated()
-	if pseudoStatsForUninitialized || pseudoStatsForOutdated {
+	if pseudoStatsForUninitialized {
 		tbl := *statsTbl
 		tbl.Pseudo = true
 		statsTbl = &tbl

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -787,9 +787,6 @@ const (
 	// TiDBRemoveOrderbyInSubquery indicates whether to remove ORDER BY in subquery.
 	TiDBRemoveOrderbyInSubquery = "tidb_remove_orderby_in_subquery"
 
-	// TiDBEnablePseudoForOutdatedStats indicates whether use pseudo for outdated stats
-	TiDBEnablePseudoForOutdatedStats = "tidb_enable_pseudo_for_outdated_stats"
-
 	// TiDBRegardNULLAsPoint indicates whether regard NULL as point when optimizing
 	TiDBRegardNULLAsPoint = "tidb_regard_null_as_point"
 
@@ -1483,7 +1480,6 @@ const (
 	DefPDEnableFollowerHandleRegion                   = true
 	DefTiDBEnableBatchQueryRegion                     = false
 	DefTiDBEnableOrderedResultMode                    = false
-	DefTiDBEnablePseudoForOutdatedStats               = false
 	DefTiDBRegardNULLAsPoint                          = true
 	DefEnablePlacementCheck                           = true
 	DefTimestamp                                      = "0"

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1389,9 +1389,6 @@ type SessionVars struct {
 	// EnableStableResultMode if stabilize query results.
 	EnableStableResultMode bool
 
-	// EnablePseudoForOutdatedStats if using pseudo for outdated stats
-	EnablePseudoForOutdatedStats bool
-
 	// RegardNULLAsPoint if regard NULL as Point
 	RegardNULLAsPoint bool
 
@@ -2416,16 +2413,6 @@ func (s *SessionVars) GetEnableIndexMerge() bool {
 // SetEnableIndexMerge set SessionVars.enableIndexMerge.
 func (s *SessionVars) SetEnableIndexMerge(val bool) {
 	s.enableIndexMerge = val
-}
-
-// GetEnablePseudoForOutdatedStats get EnablePseudoForOutdatedStats from SessionVars.EnablePseudoForOutdatedStats.
-func (s *SessionVars) GetEnablePseudoForOutdatedStats() bool {
-	return s.EnablePseudoForOutdatedStats
-}
-
-// SetEnablePseudoForOutdatedStats set SessionVars.EnablePseudoForOutdatedStats.
-func (s *SessionVars) SetEnablePseudoForOutdatedStats(val bool) {
-	s.EnablePseudoForOutdatedStats = val
 }
 
 // GetReplicaRead get ReplicaRead from sql hints and SessionVars.replicaRead.

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2616,10 +2616,6 @@ var defaultSysVars = []*SysVar{
 		s.EnableStableResultMode = TiDBOptOn(val)
 		return nil
 	}},
-	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBEnablePseudoForOutdatedStats, Value: BoolToOnOff(vardef.DefTiDBEnablePseudoForOutdatedStats), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
-		s.EnablePseudoForOutdatedStats = TiDBOptOn(val)
-		return nil
-	}},
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBRegardNULLAsPoint, Value: BoolToOnOff(vardef.DefTiDBRegardNULLAsPoint), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.RegardNULLAsPoint = TiDBOptOn(val)
 		return nil

--- a/pkg/statistics/BUILD.bazel
+++ b/pkg/statistics/BUILD.bazel
@@ -58,7 +58,6 @@ go_library(
         "@com_github_pingcap_failpoint//:failpoint",
         "@com_github_pingcap_tipb//go-tipb",
         "@com_github_twmb_murmur3//:murmur3",
-        "@org_uber_go_atomic//:atomic",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/planctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/ranger"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -886,10 +885,6 @@ func (t *Table) IndexIsLoadNeeded(id int64) (*Index, bool) {
 	return idx, false
 }
 
-// RatioOfPseudoEstimate means if modifyCount / statsTblCount is greater than this ratio, we think the stats is invalid
-// and use pseudo estimation.
-var RatioOfPseudoEstimate = atomic.NewFloat64(0.7)
-
 // IsInitialized returns true if any column/index stats of the table is initialized.
 func (t *Table) IsInitialized() bool {
 	for _, col := range t.columns {
@@ -901,18 +896,6 @@ func (t *Table) IsInitialized() bool {
 		if idx != nil && idx.IsStatsInitialized() {
 			return true
 		}
-	}
-	return false
-}
-
-// IsOutdated returns true if the table stats is outdated.
-func (t *Table) IsOutdated() bool {
-	rowcount := t.GetAnalyzeRowCount()
-	if rowcount < 0 {
-		rowcount = float64(t.RealtimeCount)
-	}
-	if rowcount > 0 && float64(t.ModifyCount)/rowcount > RatioOfPseudoEstimate.Load() {
-		return true
 	}
 	return false
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63151 

Problem Summary:

### What changed and how does it work?

Remove the unused session variable / config / code logic of  "outdated stats using the pseudo stats"


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
