### PR TITLE
stmtsummary: Fix statement summary persist evicted entry failure issue

### DIFF
--- a/pkg/util/stmtsummary/v2/stmtsummary.go
+++ b/pkg/util/stmtsummary/v2/stmtsummary.go
@@ -412,7 +412,8 @@ func newStmtEvicted() *stmtEvicted {
 			AuthUsers:    make(map[string]struct{}),
 			MinLatency:   time.Duration(math.MaxInt64),
 			BackoffTypes: make(map[string]int),
-			FirstSeen:    time.Unix(math.MaxInt64, 0),
+			FirstSeen:    time.Now(),
+			LastSeen:     time.Now(),
 		},
 	}
 }

--- a/pkg/util/stmtsummary/v2/stmtsummary_test.go
+++ b/pkg/util/stmtsummary/v2/stmtsummary_test.go
@@ -15,6 +15,7 @@
 package stmtsummary
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,8 @@ func TestStmtWindow(t *testing.T) {
 	require.Equal(t, 5, ss.window.lru.Size())
 	require.Equal(t, 2, ss.window.evicted.count())
 	require.Equal(t, int64(4), ss.window.evicted.other.ExecCount) // digest1 digest1 digest2 digest2
+	_, err := json.Marshal(ss.window.evicted.other)
+	require.NoError(t, err)
 	ss.Clear()
 	require.Equal(t, 0, ss.window.lru.Size())
 	require.Equal(t, 0, ss.window.evicted.count())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63197 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
Manually check the dumped tidb_statements.log to see the evicted entry, and tidb.log to check no Marshall warning message.
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that the persist of evicted statements will fail when tidb_stmt_summary_enable_persistent is turned on.
```
