### PR TITLE
ddl/placement: fix meta range to exclude RawKV keys from placement rules

### DIFF
--- a/pkg/ddl/placement/BUILD.bazel
+++ b/pkg/ddl/placement/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/pingcap/tidb/pkg/ddl/placement",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/meta/model",
         "//pkg/tablecodec",
         "//pkg/util/codec",

--- a/pkg/ddl/placement/bundle.go
+++ b/pkg/ddl/placement/bundle.go
@@ -463,7 +463,10 @@ func GetRangeStartAndEndKeyHex(rangeBundleID string) (startKey string, endKey st
 	if rangeBundleID == TiDBBundleRangePrefixForMeta {
 		// Use codec.EncodeBytes to properly encode the meta prefix in table mode
 		startKey = hex.EncodeToString(codec.EncodeBytes(nil, metaPrefix))
-		endKey = hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(0)))
+		// Use rawPrefix as endKey to ensure the meta range [metaPrefix, rawPrefix) only
+		// contains meta keys and excludes RawKV keys. This prevents unintended placement
+		// policy application to raw keys that fall between meta ('m', 0x6d) and table ('t', 0x74) prefixes.
+		endKey = hex.EncodeToString(codec.EncodeBytes(nil, rawPrefix))
 	}
 	return startKey, endKey
 }

--- a/pkg/ddl/placement/bundle_test.go
+++ b/pkg/ddl/placement/bundle_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/tablecodec"
 	"github.com/pingcap/tidb/pkg/util/codec"
@@ -1468,14 +1469,14 @@ func TestGetRangeStartAndEndKeyHex(t *testing.T) {
 	startKeyBytes, err := hex.DecodeString(startKey)
 	require.NoError(t, err)
 
-	// Both keys should be valid codec encoded bytes
+	// startKey should be valid codec encoded bytes
 	_, startKeyDecoded, err := codec.DecodeBytes(startKeyBytes, nil)
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(metaPrefix, startKeyDecoded), "metaPrefix and startKeyDecoded should have the same content")
 
+	// endKey should be the PrefixNext of startKey
 	endKeyBytes, err := hex.DecodeString(endKey)
 	require.NoError(t, err)
-	_, endKeyDecoded, err := codec.DecodeBytes(endKeyBytes, nil)
-	require.NoError(t, err)
-	require.True(t, bytes.Equal(rawPrefix, endKeyDecoded), "rawPrefix and endKeyDecoded should have the same content")
+	expectedEndKey := kv.Key(startKeyBytes).PrefixNext()
+	require.True(t, bytes.Equal(expectedEndKey, endKeyBytes), "endKey should equal PrefixNext(startKey)")
 }

--- a/pkg/ddl/placement/bundle_test.go
+++ b/pkg/ddl/placement/bundle_test.go
@@ -1477,5 +1477,5 @@ func TestGetRangeStartAndEndKeyHex(t *testing.T) {
 	require.NoError(t, err)
 	_, endKeyDecoded, err := codec.DecodeBytes(endKeyBytes, nil)
 	require.NoError(t, err)
-	require.True(t, bytes.Equal(tablecodec.GenTablePrefix(0), endKeyDecoded), "tablePrefix and endKeyDecoded should have the same content")
+	require.True(t, bytes.Equal(rawPrefix, endKeyDecoded), "rawPrefix and endKeyDecoded should have the same content")
 }

--- a/pkg/ddl/placement/common.go
+++ b/pkg/ddl/placement/common.go
@@ -39,6 +39,9 @@ const (
 )
 
 var metaPrefix = []byte("m")
+// rawPrefix defines the prefix for RawKV keys (0x72). 
+// Used as the end key for meta range to exclude RawKV keys from meta placement rules.
+var rawPrefix = []byte("r")
 
 // GroupID accepts a tableID or whatever integer, and encode the integer into a valid GroupID for PD.
 func GroupID(id int64) string {

--- a/pkg/ddl/placement/common.go
+++ b/pkg/ddl/placement/common.go
@@ -39,9 +39,6 @@ const (
 )
 
 var metaPrefix = []byte("m")
-// rawPrefix defines the prefix for RawKV keys (0x72). 
-// Used as the end key for meta range to exclude RawKV keys from meta placement rules.
-var rawPrefix = []byte("r")
 
 // GroupID accepts a tableID or whatever integer, and encode the integer into a valid GroupID for PD.
 func GroupID(id int64) string {


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close [#63133 ](https://github.com/pingcap/tidb/issues/63133)

Problem Summary:

### What changed and how does it work?
When using ALTER RANGE META to assign placement rules to the meta key range, the generated end key was previously set to the table prefix ('t', 0x74). This incorrectly included RawKV keys ('r', 0x72) in the meta range placement rules, as the range was [metaPrefix, tablePrefix) = ['m', 't').

This fix changes the end key to use the raw prefix ('r', 0x72), making the meta range [metaPrefix, rawPrefix) = ['m', 'r'). This ensures:

1. Meta placement rules only apply to actual meta keys
2. RawKV keys are excluded from meta placement policies
3. No unintended placement policy application for users who use RawKV

The key ordering is: meta ('m', 0x6d) < raw ('r', 0x72) < table ('t', 0x74)

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
