### PR TITLE
Fix goroutine wait group handling in LoadJWKS4AuthToken

### DIFF
--- a/pkg/privilege/privileges/tidb_auth_token.go
+++ b/pkg/privilege/privileges/tidb_auth_token.go
@@ -60,9 +60,9 @@ func (jwks *JWKSImpl) verify(tokenBytes []byte) (payload []byte, err error) {
 func (jwks *JWKSImpl) LoadJWKS4AuthToken(ctx context.Context, wg *sync.WaitGroup, jwksPath string, interval time.Duration) error {
 	jwks.filepath = jwksPath
 	if ctx != nil && wg != nil {
+		wg.Add(1)
 		go func() {
 			ticker := time.Tick(interval)
-			wg.Add(1)
 			for {
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
Move incrementing the wait group prior to starting the go routine (as opposed to in the go routine) to prevent a potential race condition.
