### PR TITLE
importinto: store summary struct directly instad of byte slice 

### DIFF
--- a/pkg/disttask/importinto/job.go
+++ b/pkg/disttask/importinto/job.go
@@ -265,8 +265,7 @@ func GetRuntimeInfoForJob(
 	}
 
 	var (
-		taskMeta    TaskMeta
-		taskSummary importer.Summary
+		taskMeta TaskMeta
 
 		latestTime time.Time
 		ri         = &RuntimeInfo{
@@ -282,12 +281,6 @@ func GetRuntimeInfoForJob(
 	if task.Error != nil {
 		ri.ErrorMsg = task.Error.Error()
 		return ri, nil
-	}
-
-	if len(taskMeta.TaskResult) != 0 {
-		if err = json.Unmarshal(taskMeta.TaskResult, &taskSummary); err != nil {
-			return nil, errors.Trace(err)
-		}
 	}
 
 	summaries, err := dxfTaskMgr.GetAllSubtaskSummaryByStep(ctx, task.ID, task.Step)
@@ -316,18 +309,18 @@ func GetRuntimeInfoForJob(
 	}
 
 	if task.Step == proto.ImportStepPostProcess {
-		ri.ImportRows = taskSummary.ImportedRows
+		ri.ImportRows = taskMeta.Summary.ImportedRows
 	} else if task.Step != proto.ImportStepWriteAndIngest && task.Step != proto.ImportStepImport {
 		ri.ImportRows = 0
 	}
 
 	switch task.Step {
 	case proto.ImportStepImport, proto.ImportStepWriteAndIngest:
-		ri.Total = taskSummary.IngestSummary.Bytes
+		ri.Total = taskMeta.Summary.IngestSummary.Bytes
 	case proto.ImportStepEncodeAndSort:
-		ri.Total = taskSummary.EncodeSummary.Bytes
+		ri.Total = taskMeta.Summary.EncodeSummary.Bytes
 	case proto.ImportStepMergeSort:
-		ri.Total = taskSummary.MergeSummary.Bytes
+		ri.Total = taskMeta.Summary.MergeSummary.Bytes
 	}
 
 	if !latestTime.IsZero() {

--- a/pkg/disttask/importinto/job_testkit_test.go
+++ b/pkg/disttask/importinto/job_testkit_test.go
@@ -187,20 +187,17 @@ func TestGetTaskImportedRows(t *testing.T) {
 	// local sort
 	taskMeta := importinto.TaskMeta{
 		Plan: importer.Plan{},
-	}
-	taskSummary := &importer.Summary{
-		EncodeSummary: importer.StepSummary{
-			Bytes:  10000,
-			RowCnt: 1000,
+		Summary: &importer.Summary{
+			EncodeSummary: importer.StepSummary{
+				Bytes:  10000,
+				RowCnt: 1000,
+			},
+			IngestSummary: importer.StepSummary{
+				Bytes:  10000,
+				RowCnt: 1000,
+			},
 		},
-		IngestSummary: importer.StepSummary{
-			Bytes:  10000,
-			RowCnt: 1000,
-		},
 	}
-	var err error
-	taskMeta.TaskResult, err = json.Marshal(taskSummary)
-	require.NoError(t, err)
 
 	bytes, err := json.Marshal(taskMeta)
 	require.NoError(t, err)
@@ -235,16 +232,13 @@ func TestGetTaskImportedRows(t *testing.T) {
 		Plan: importer.Plan{
 			CloudStorageURI: "s3://test-bucket/test-path",
 		},
-	}
-
-	taskSummary = &importer.Summary{
-		IngestSummary: importer.StepSummary{
-			Bytes:  10000,
-			RowCnt: 1000,
+		Summary: &importer.Summary{
+			IngestSummary: importer.StepSummary{
+				Bytes:  10000,
+				RowCnt: 1000,
+			},
 		},
 	}
-	taskMeta.TaskResult, err = json.Marshal(taskSummary)
-	require.NoError(t, err)
 
 	bytes, err = json.Marshal(taskMeta)
 	require.NoError(t, err)
@@ -295,18 +289,14 @@ func TestShowImportProgress(t *testing.T) {
 		Plan: importer.Plan{
 			CloudStorageURI: "s3://test-bucket/test-path",
 		},
+		Summary: &importer.Summary{
+			EncodeSummary: importer.StepSummary{Bytes: 1000, RowCnt: 100},
+			MergeSummary:  importer.StepSummary{Bytes: 0, RowCnt: 0},
+			IngestSummary: importer.StepSummary{Bytes: 1000, RowCnt: 100},
+			ImportedRows:  100,
+		},
 	}
 
-	taskSummary := &importer.Summary{
-		EncodeSummary: importer.StepSummary{Bytes: 1000, RowCnt: 100},
-		MergeSummary:  importer.StepSummary{Bytes: 0, RowCnt: 0},
-		IngestSummary: importer.StepSummary{Bytes: 1000, RowCnt: 100},
-		ImportedRows:  100,
-	}
-
-	var err error
-	taskMeta.TaskResult, err = json.Marshal(taskSummary)
-	require.NoError(t, err)
 	bytes, err := json.Marshal(taskMeta)
 	require.NoError(t, err)
 

--- a/pkg/disttask/importinto/proto.go
+++ b/pkg/disttask/importinto/proto.go
@@ -35,8 +35,8 @@ type TaskMeta struct {
 	Plan  importer.Plan
 	Stmt  string
 
-	// TaskResult stores the marshalled results
-	TaskResult []byte
+	// Summary is the summary of the whole import task.
+	Summary *importer.Summary
 
 	// eligible instances to run this task, we run on all instances if it's empty.
 	// we only need this when run IMPORT INTO without distributed option now, i.e.

--- a/pkg/disttask/importinto/scheduler.go
+++ b/pkg/disttask/importinto/scheduler.go
@@ -354,11 +354,7 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 			return nil, err
 		}
 		previousSubtaskMetas[step] = metas
-		var importResult importer.Summary
-		if err := json.Unmarshal(taskMeta.TaskResult, &importResult); err != nil {
-			return nil, errors.Trace(err)
-		}
-		logger.Info("move to post-process step ", zap.Any("result", importResult))
+		logger.Info("move to post-process step ", zap.Any("result", taskMeta.Summary))
 	case proto.StepDone:
 		return nil, nil
 	default:
@@ -530,25 +526,14 @@ func updateTaskSummary(
 	nextStep proto.Step,
 	p *LogicalPlan,
 ) error {
-	var (
-		importSummary importer.Summary
-		err           error
-	)
-
-	if len(taskMeta.TaskResult) > 0 {
-		if err = json.Unmarshal(taskMeta.TaskResult, &importSummary); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	// Process row count and data size
 	switch nextStep {
 	case proto.ImportStepEncodeAndSort, proto.ImportStepImport:
-		importSummary.EncodeSummary = p.summary
+		taskMeta.Summary.EncodeSummary = p.summary
 	case proto.ImportStepMergeSort:
-		importSummary.MergeSummary = p.summary
+		taskMeta.Summary.MergeSummary = p.summary
 	case proto.ImportStepWriteAndIngest:
-		importSummary.IngestSummary = p.summary
+		taskMeta.Summary.IngestSummary = p.summary
 	case proto.ImportStepPostProcess:
 		subtaskSummaries, err := handle.GetPreviousSubtaskSummary(task.ID, getStepOfEncode(taskMeta.Plan.IsGlobalSort()))
 		if err != nil {
@@ -556,12 +541,8 @@ func updateTaskSummary(
 		}
 
 		for _, subtaskSummary := range subtaskSummaries {
-			importSummary.ImportedRows += subtaskSummary.RowCnt.Load()
+			taskMeta.Summary.ImportedRows += subtaskSummary.RowCnt.Load()
 		}
-	}
-
-	if taskMeta.TaskResult, err = json.Marshal(importSummary); err != nil {
-		return errors.Trace(err)
 	}
 
 	return updateMeta(task, taskMeta)
@@ -618,23 +599,16 @@ func (sch *importScheduler) finishJob(ctx context.Context, logger *zap.Logger,
 		return err
 	}
 
-	summary := &importer.Summary{}
-	if len(taskMeta.TaskResult) > 0 {
-		if err := json.Unmarshal(taskMeta.TaskResult, summary); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	// retry for 3+6+12+24+(30-4)*30 ~= 825s ~= 14 minutes
 	backoffer := backoff.NewExponential(scheduler.RetrySQLInterval, 2, scheduler.RetrySQLMaxInterval)
 	return handle.RunWithRetry(ctx, scheduler.RetrySQLTimes, backoffer, logger,
 		func(ctx context.Context) (bool, error) {
 			return true, taskManager.WithNewSession(func(se sessionctx.Context) error {
-				if err := importer.FlushTableStats(ctx, se, taskMeta.Plan.TableInfo.ID, summary.ImportedRows); err != nil {
+				if err := importer.FlushTableStats(ctx, se, taskMeta.Plan.TableInfo.ID, taskMeta.Summary.ImportedRows); err != nil {
 					logger.Warn("flush table stats failed", zap.Error(err))
 				}
 				exec := se.GetSQLExecutor()
-				return importer.FinishJob(ctx, exec, taskMeta.JobID, summary)
+				return importer.FinishJob(ctx, exec, taskMeta.JobID, taskMeta.Summary)
 			})
 		},
 	)
@@ -642,13 +616,6 @@ func (sch *importScheduler) finishJob(ctx context.Context, logger *zap.Logger,
 
 func (sch *importScheduler) failJob(ctx context.Context, task *proto.Task,
 	taskMeta *TaskMeta, logger *zap.Logger, errorMsg string) error {
-	summary := &importer.Summary{}
-	if len(taskMeta.TaskResult) > 0 {
-		if err := json.Unmarshal(taskMeta.TaskResult, summary); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	sch.switchTiKV2NormalMode(ctx, task, logger)
 	sch.unregisterTask(ctx, task)
 	taskManager, err := sch.getTaskMgrForAccessingImportJob()
@@ -661,7 +628,7 @@ func (sch *importScheduler) failJob(ctx context.Context, task *proto.Task,
 		func(ctx context.Context) (bool, error) {
 			return true, taskManager.WithNewSession(func(se sessionctx.Context) error {
 				exec := se.GetSQLExecutor()
-				return importer.FailJob(ctx, exec, taskMeta.JobID, errorMsg, summary)
+				return importer.FailJob(ctx, exec, taskMeta.JobID, errorMsg, taskMeta.Summary)
 			})
 		},
 	)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61088

Problem Summary:

### What changed and how does it work?

Store `Summary` in task meta directly to make reading it easier via SQL

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

No logic changes, existing tests should be enough.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
