### PR TITLE
parser: format ADD COLUMN IF NOT EXISTS and similar DDLs in special comments

### DIFF
--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -572,10 +572,7 @@ func (n *ColumnOption) Restore(ctx *format.RestoreCtx) error {
 		pkTp := n.PrimaryKeyTp.String()
 		if len(pkTp) != 0 {
 			ctx.WritePlain(" ")
-			_ = ctx.WriteWithSpecialComments(tidb.FeatureIDClusteredIndex, func() error {
-				ctx.WriteKeyWord(pkTp)
-				return nil
-			})
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDClusteredIndex, pkTp)
 		}
 		if n.StrValue == "Global" {
 			ctx.WriteKeyWord(" GLOBAL")
@@ -781,10 +778,7 @@ func (n *IndexOption) Restore(ctx *format.RestoreCtx) error {
 		if hasPrevOption {
 			ctx.WritePlain(" ")
 		}
-		_ = ctx.WriteWithSpecialComments(tidb.FeatureIDClusteredIndex, func() error {
-			ctx.WriteKeyWord(n.PrimaryKeyTp.String())
-			return nil
-		})
+		ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDClusteredIndex, n.PrimaryKeyTp.String())
 		hasPrevOption = true
 	}
 	if n.KeyBlockSize > 0 {
@@ -2022,10 +2016,7 @@ type DropIndexStmt struct {
 func (n *DropIndexStmt) Restore(ctx *format.RestoreCtx) error {
 	ctx.WriteKeyWord("DROP INDEX ")
 	if n.IfExists {
-		_ = ctx.WriteWithSpecialComments("", func() error {
-			ctx.WriteKeyWord("IF EXISTS ")
-			return nil
-		})
+		ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 	}
 	ctx.WriteName(n.IndexName)
 	ctx.WriteKeyWord(" ON ")
@@ -2703,11 +2694,7 @@ func (n *TableOption) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteKeyWord(n.StrValue)
 	case TableOptionAutoIncrement:
 		if n.BoolValue {
-			_ = ctx.WriteWithSpecialComments(tidb.FeatureIDForceAutoInc, func() error {
-				ctx.WriteKeyWord("FORCE")
-				return nil
-			})
-			ctx.WritePlain(" ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDForceAutoInc, "FORCE ")
 		}
 		ctx.WriteKeyWord("AUTO_INCREMENT ")
 		ctx.WritePlain("= ")
@@ -2721,11 +2708,7 @@ func (n *TableOption) Restore(ctx *format.RestoreCtx) error {
 		})
 	case TableOptionAutoRandomBase:
 		if n.BoolValue {
-			_ = ctx.WriteWithSpecialComments(tidb.FeatureIDForceAutoInc, func() error {
-				ctx.WriteKeyWord("FORCE")
-				return nil
-			})
-			ctx.WritePlain(" ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDForceAutoInc, "FORCE ")
 		}
 		_ = ctx.WriteWithSpecialComments(tidb.FeatureIDAutoRandomBase, func() error {
 			ctx.WriteKeyWord("AUTO_RANDOM_BASE ")
@@ -3885,10 +3868,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 			return errors.Annotatef(err, "An error occurred while restore AlterTableSpec.StatsOptionsSpec")
 		}
 	case AlterTableRemoveTTL:
-		_ = ctx.WriteWithSpecialComments(tidb.FeatureIDTTL, func() error {
-			ctx.WriteKeyWord("REMOVE TTL")
-			return nil
-		})
+		ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTTL, "REMOVE TTL")
 	default:
 		// TODO: not support
 		ctx.WritePlainf(" /* AlterTableType(%d) is not supported */ ", n.Tp)

--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -956,12 +956,12 @@ func (n *Constraint) Restore(ctx *format.RestoreCtx) error {
 	case ConstraintKey:
 		ctx.WriteKeyWord("KEY")
 		if n.IfNotExists {
-			ctx.WriteKeyWord(" IF NOT EXISTS")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, " IF NOT EXISTS")
 		}
 	case ConstraintIndex:
 		ctx.WriteKeyWord("INDEX")
 		if n.IfNotExists {
-			ctx.WriteKeyWord(" IF NOT EXISTS")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, " IF NOT EXISTS")
 		}
 	case ConstraintUniq:
 		ctx.WriteKeyWord("UNIQUE")
@@ -992,12 +992,12 @@ func (n *Constraint) Restore(ctx *format.RestoreCtx) error {
 	case ConstraintVector:
 		ctx.WriteKeyWord("VECTOR INDEX")
 		if n.IfNotExists {
-			ctx.WriteKeyWord(" IF NOT EXISTS")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, " IF NOT EXISTS")
 		}
 	case ConstraintColumnar:
 		ctx.WriteKeyWord("COLUMNAR INDEX")
 		if n.IfNotExists {
-			ctx.WriteKeyWord(" IF NOT EXISTS")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, " IF NOT EXISTS")
 		}
 	}
 
@@ -1009,7 +1009,7 @@ func (n *Constraint) Restore(ctx *format.RestoreCtx) error {
 		}
 		ctx.WriteKeyWord("FOREIGN KEY ")
 		if n.IfNotExists {
-			ctx.WriteKeyWord("IF NOT EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF NOT EXISTS ")
 		}
 	} else if n.Name != "" || n.IsEmptyIndex {
 		ctx.WritePlain(" ")
@@ -1928,7 +1928,7 @@ func (n *CreateIndexStmt) Restore(ctx *format.RestoreCtx) error {
 	}
 	ctx.WriteKeyWord("INDEX ")
 	if n.IfNotExists {
-		ctx.WriteKeyWord("IF NOT EXISTS ")
+		ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF NOT EXISTS ")
 	}
 	ctx.WriteName(n.IndexName)
 	ctx.WriteKeyWord(" ON ")
@@ -3405,7 +3405,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 	case AlterTableAddColumns:
 		ctx.WriteKeyWord("ADD COLUMN ")
 		if n.IfNotExists {
-			ctx.WriteKeyWord("IF NOT EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF NOT EXISTS ")
 		}
 		if n.Position != nil && len(n.NewColumns) == 1 {
 			if err := n.NewColumns[0].Restore(ctx); err != nil {
@@ -3446,7 +3446,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 	case AlterTableDropColumn:
 		ctx.WriteKeyWord("DROP COLUMN ")
 		if n.IfExists {
-			ctx.WriteKeyWord("IF EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 		}
 		if err := n.OldColumnName.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore AlterTableSpec.OldColumnName")
@@ -3457,19 +3457,19 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 	case AlterTableDropIndex:
 		ctx.WriteKeyWord("DROP INDEX ")
 		if n.IfExists {
-			ctx.WriteKeyWord("IF EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 		}
 		ctx.WriteName(n.Name)
 	case AlterTableDropForeignKey:
 		ctx.WriteKeyWord("DROP FOREIGN KEY ")
 		if n.IfExists {
-			ctx.WriteKeyWord("IF EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 		}
 		ctx.WriteName(n.Name)
 	case AlterTableModifyColumn:
 		ctx.WriteKeyWord("MODIFY COLUMN ")
 		if n.IfExists {
-			ctx.WriteKeyWord("IF EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 		}
 		if err := n.NewColumns[0].Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore AlterTableSpec.NewColumns[0]")
@@ -3483,7 +3483,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 	case AlterTableChangeColumn:
 		ctx.WriteKeyWord("CHANGE COLUMN ")
 		if n.IfExists {
-			ctx.WriteKeyWord("IF EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 		}
 		if err := n.OldColumnName.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore AlterTableSpec.OldColumnName")
@@ -3571,7 +3571,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 	case AlterTableAddPartitions:
 		ctx.WriteKeyWord("ADD PARTITION")
 		if n.IfNotExists {
-			ctx.WriteKeyWord(" IF NOT EXISTS")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, " IF NOT EXISTS")
 		}
 		if n.NoWriteToBinlog {
 			ctx.WriteKeyWord(" NO_WRITE_TO_BINLOG")
@@ -3660,7 +3660,7 @@ func (n *AlterTableSpec) Restore(ctx *format.RestoreCtx) error {
 	case AlterTableDropPartition:
 		ctx.WriteKeyWord("DROP PARTITION ")
 		if n.IfExists {
-			ctx.WriteKeyWord("IF EXISTS ")
+			ctx.WriteKeyWordWithSpecialComments(tidb.FeatureIDTiDB, "IF EXISTS ")
 		}
 		for i, name := range n.PartitionNames {
 			if i != 0 {

--- a/pkg/parser/format/format.go
+++ b/pkg/parser/format/format.go
@@ -406,6 +406,14 @@ func (ctx *RestoreCtx) WriteWithSpecialComments(featureID string, fn func() erro
 	return nil
 }
 
+// WriteKeyWordWithSpecialComments writes a keyword with a special comment wrapped.
+func (ctx *RestoreCtx) WriteKeyWordWithSpecialComments(featureID string, keyWord string) {
+	_ = ctx.WriteWithSpecialComments(featureID, func() error {
+		ctx.WriteKeyWord(keyWord)
+		return nil
+	})
+}
+
 // WriteString writes the string into writer
 // `str` may be wrapped in quotes and escaped according to RestoreFlags.
 func (ctx *RestoreCtx) WriteString(str string) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63252

Problem Summary:

### What changed and how does it work?

In TiDB-specific DDLs like `ADD COLUMN IF NOT EXISTS`, put the `IF NOT EXISTS` inside `/*T! … */` when calling `Restore()` of the AST node.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
TiCDC: Replication of some TiDB-specific statements such as ADD COLUMN IF NOT EXISTS to MySQL no longer causes the changefeed to stop with error.
```
