### PR TITLE
tici: add index id into shard cache | tidb-test=3b2adda7436d5e712bffaa859f679c5ca370811b

### DIFF
--- a/pkg/store/copr/tici_shard_cache_test.go
+++ b/pkg/store/copr/tici_shard_cache_test.go
@@ -114,7 +114,7 @@ func TestShardCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, locs, 5)
 	// [a,c), [c,e), [e,g), [i,k), [k,m)
-	require.Equal(t, cache.mu.sorted.b.Len(), 5)
+	require.Equal(t, cache.mu.sorted[0].b.Len(), 5)
 
 	ranges = ranges[:0]
 	ranges = append(ranges, kv.KeyRange{
@@ -125,5 +125,23 @@ func TestShardCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, locs, 3)
 	// [e,g), [g,i), [i,k)
-	require.Equal(t, cache.mu.sorted.b.Len(), 6) // insert [g,i) into the cache
+	require.Equal(t, cache.mu.sorted[0].b.Len(), 6) // insert [g,i) into the cache
+
+	ranges = make([]kv.KeyRange, 0)
+	ranges = append(ranges, kv.KeyRange{
+		StartKey: []byte("b"),
+		EndKey:   []byte("f"),
+	})
+
+	ranges = append(ranges, kv.KeyRange{
+		StartKey: []byte("i"),
+		EndKey:   []byte("l"),
+	})
+
+	locs, err = cache.BatchLocateKeyRanges(ctx, 0, 1, ranges)
+	require.NoError(t, err)
+	require.Len(t, locs, 5)
+	// test another indexID
+	require.Equal(t, cache.mu.sorted[0].b.Len(), 6)
+	require.Equal(t, cache.mu.sorted[1].b.Len(), 5)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

Different indexes use the same range domain, this will cause queries on different indexes to return incorrect shard information
So we need each index to have its own independent range domain.

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
ALTER TABLE test.hdfs ADD FULLTEXT INDEX ft_index (body) WITH PARSER standard;
ALTER TABLE test.hdfs ADD FULLTEXT INDEX ft_index2 (severity_text) WITH PARSER standard;

select * from hdfs where fts_match_word("Receiving", body);
-- The second query returns the correct result
select * from hdfs where fts_match_word("info", severity_text);
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
