### PR TITLE
config: limit keyspace name to at most 20 chars

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1330,7 +1330,7 @@ func (c *Config) Load(confFile string) error {
 
 // Valid checks if this config is valid.
 func (c *Config) Valid() error {
-	if err := naming.Check(c.KeyspaceName); err != nil {
+	if err := naming.CheckKeyspaceName(c.KeyspaceName); err != nil {
 		return errors.Annotate(err, "invalid keyspace name")
 	}
 	if c.Log.EnableErrorStack == c.Log.DisableErrorStack && c.Log.EnableErrorStack != nbUnset {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1438,4 +1438,8 @@ func TestKeyspaceName(t *testing.T) {
 	require.ErrorContains(t, conf.Valid(), "is invalid")
 	conf.KeyspaceName = "abc"
 	require.NoError(t, conf.Valid())
+	conf.KeyspaceName = "18446744073709551615" // max uint64
+	require.NoError(t, conf.Valid())
+	conf.KeyspaceName = "a18446744073709551615"
+	require.ErrorContains(t, conf.Valid(), "invalid keyspace name")
 }

--- a/pkg/util/naming/OWNERS
+++ b/pkg/util/naming/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+  - sig-approvers-ddl

--- a/pkg/util/naming/naming.go
+++ b/pkg/util/naming/naming.go
@@ -19,12 +19,26 @@ import (
 	"regexp"
 )
 
+const (
+	// mostly we use an uint64 as the keyspace name, the max value is 20 characters.
+	// And there are at most 16,777,215 keyspace ID in a single physical cluster,
+	// as keyspace ID is encoded into KV, it's very hard to extend its length, so
+	// current keyspace name limit is more than enough for current usage and later
+	// extension.
+	maxKeyspaceNameLength = 20
+)
+
 // Check if the name is valid.
 // Valid name must be 64 characters or fewer and consist only of letters (a-z, A-Z),
 // numbers (0-9), hyphens (-), and underscores (_).
 // currently, we enforce this rule to tidb_service_scope and keyspace_name
 func Check(name string) error {
 	return CheckWithMaxLen(name, 64)
+}
+
+// CheckKeyspaceName checks if the keyspace name is valid.
+func CheckKeyspaceName(name string) error {
+	return CheckWithMaxLen(name, maxKeyspaceNameLength)
 }
 
 // CheckWithMaxLen checks if the name is valid with the specified maximum length.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
as keyspace name might be stored inside system table, we limit the length to help us design related column and avoid potential `truncated value`
```
	// mostly we use an uint64 as the keyspace name, the max value is 20 characters.
	// And there are at most 16,777,215 keyspace ID in a single physical cluster,
	// as keyspace ID is encoded into KV, it's very hard to extend its length, so
	// current keyspace name limit is more than enough for current usage and later
	// extension.
```
related PD pr https://github.com/tikv/pd/pull/9708
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
~/code/pingcap/tidb git:[limit-ks-mame] bin/tidb-server --keyspace-name 18446744073709551615a
load config file: /Users/jujiajia/code/pingcap/tidb
invalid config invalid keyspace name: the value '18446744073709551615a' is invalid. It must be 20 characters or fewer and consist only of letters (a-z, A-Z), numbers (0-9), hyphens (-), and underscores (_)


~/code/pingcap/tidb git:[limit-ks-mame] bin/tidb-server --keyspace-name 18446744073709551615
[2025/09/01 15:43:52.751 +08:00] [INFO] [meminfo.go:196] ["use physical memory hook"] [keyspaceName=18446744073709551615] [cgroupMemorySize=0] [physicalMemorySize=17179869184]
[2025/09/01 15:43:52.751 +08:00] [INFO] [cpuprofile.go:113] ["parallel cpu profiler started"] [keyspaceName=18446744073709551615]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
