### PR TITLE
ddl: Export `ProcessModifyColumnOptions` to allow its use across packages.

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -788,7 +788,7 @@ func GetModifiableColumnJob(
 		// TODO: If user explicitly set NULL, we should throw error ErrPrimaryCantHaveNull.
 	}
 
-	if err = processModifyColumnOptions(sctx, newCol, specNewColumn.Options); err != nil {
+	if err = ProcessModifyColumnOptions(sctx, newCol, specNewColumn.Options); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -1221,8 +1221,8 @@ func checkModifyTypes(from, to *model.ColumnInfo, needRewriteCollationData bool)
 	return errors.Trace(err)
 }
 
-// processModifyColumnOptions process column options.
-func processModifyColumnOptions(ctx sessionctx.Context, col *table.Column, options []*ast.ColumnOption) error {
+// ProcessModifyColumnOptions process column options.
+func ProcessModifyColumnOptions(ctx sessionctx.Context, col *table.Column, options []*ast.ColumnOption) error {
 	var sb strings.Builder
 	restoreFlags := format.RestoreStringSingleQuotes | format.RestoreKeyWordLowercase | format.RestoreNameBackQuotes |
 		format.RestoreSpacesAroundBinaryOperation | format.RestoreWithoutSchemaName | format.RestoreWithoutSchemaName


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63304

Problem Summary:
The `processModifyColumnOptions` function, which encapsulates the logic for processing column options, was previously an unexported (private) function within the `ddl` package. This limited its direct reusability by other internal components or DDL sub-systems that might need to apply or validate column options independently. By exporting this function, we enable its direct use across different parts of the codebase, improving modularity and reducing potential code duplication for column option handling.

### What changed and how does it work?

This PR refactors the DDL column modification logic by exporting the `processModifyColumnOptions` function.

The changes include:

* Renamed the unexported function `processModifyColumnOptions` to `ProcessModifyColumnOptions`. This makes the function accessible from other packages within TiDB.
* Updated the call site within `GetModifiableColumnJob` to use the new, exported function name `ProcessModifyColumnOptions`.
* Adjusted the accompanying comments to reflect the new function name and its exported status.

This change allows other parts of the DDL system or related modules to directly utilize the column option processing logic, promoting code reuse and maintainability without altering its core functionality.

### Check List

Tests

* [ ] Unit test
* [ ] Integration test
* [ ] Manual test (add detailed scripts or steps below)
* [x] No need to test

Side effects

* [ ] Performance regression: Consumes more CPU
* [ ] Performance regression: Consumes more Memory
* [ ] Breaking backward compatibility

Documentation

* [ ] Affects user behaviors
* [ ] Contains syntax changes
* [ ] Contains variable changes
* [ ] Contains experimental features
* [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
