### PR TITLE
planner: allow cartesian joins in greedy join order algo to explore better join orders

### DIFF
--- a/pkg/planner/core/casetest/rule/BUILD.bazel
+++ b/pkg/planner/core/casetest/rule/BUILD.bazel
@@ -16,7 +16,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         "//pkg/domain",
         "//pkg/expression",

--- a/pkg/planner/core/casetest/rule/testdata/join_reorder_suite_in.json
+++ b/pkg/planner/core/casetest/rule/testdata/join_reorder_suite_in.json
@@ -50,6 +50,12 @@
     ]
   },
   {
+    "name": "TestCartesianJoinOrder",
+    "cases": [
+      "select 1 from t1, t2, t3 where t1.a = t2.a and t2.b = t3.b"
+    ]
+  },
+  {
     "name": "TestJoinOrderHint4TiFlash",
     "cases": [
       "select /*+ straight_join() */ * from t1 join t2 on t1.a=t2.a join t3 on t2.b=t3.b",

--- a/pkg/planner/core/casetest/rule/testdata/join_reorder_suite_out.json
+++ b/pkg/planner/core/casetest/rule/testdata/join_reorder_suite_out.json
@@ -786,6 +786,27 @@
     ]
   },
   {
+    "Name": "TestCartesianJoinOrder",
+    "Cases": [
+      {
+        "SQL": "select 1 from t1, t2, t3 where t1.a = t2.a and t2.b = t3.b",
+        "Plan": [
+          "Projection 50000.00 root  1->Column#13",
+          "└─HashJoin 50000.00 root  inner join, equal:[eq(test.t1.a, test.t2.a) eq(test.t3.b, test.t2.b)]",
+          "  ├─HashJoin(Build) 50.00 root  CARTESIAN inner join",
+          "  │ ├─IndexReader(Build) 5.00 root  index:IndexFullScan",
+          "  │ │ └─IndexFullScan 5.00 cop[tikv] table:t3, index:b(b) keep order:false",
+          "  │ └─IndexReader(Probe) 10.00 root  index:IndexFullScan",
+          "  │   └─IndexFullScan 10.00 cop[tikv] table:t1, index:a(a) keep order:false",
+          "  └─TableReader(Probe) 10000.00 root  data:Selection",
+          "    └─Selection 10000.00 cop[tikv]  not(isnull(test.t2.a)), not(isnull(test.t2.b))",
+          "      └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false"
+        ],
+        "Warning": null
+      }
+    ]
+  },
+  {
     "Name": "TestJoinOrderHint4TiFlash",
     "Cases": [
       {

--- a/pkg/planner/core/casetest/rule/testdata/join_reorder_suite_xut.json
+++ b/pkg/planner/core/casetest/rule/testdata/join_reorder_suite_xut.json
@@ -786,6 +786,27 @@
     ]
   },
   {
+    "Name": "TestCartesianJoinOrder",
+    "Cases": [
+      {
+        "SQL": "select 1 from t1, t2, t3 where t1.a = t2.a and t2.b = t3.b",
+        "Plan": [
+          "Projection 50000.00 root  1->Column#13",
+          "└─HashJoin 50000.00 root  inner join, equal:[eq(test.t1.a, test.t2.a) eq(test.t3.b, test.t2.b)]",
+          "  ├─HashJoin(Build) 50.00 root  CARTESIAN inner join",
+          "  │ ├─IndexReader(Build) 5.00 root  index:IndexFullScan",
+          "  │ │ └─IndexFullScan 5.00 cop[tikv] table:t3, index:b(b) keep order:false",
+          "  │ └─IndexReader(Probe) 10.00 root  index:IndexFullScan",
+          "  │   └─IndexFullScan 10.00 cop[tikv] table:t1, index:a(a) keep order:false",
+          "  └─TableReader(Probe) 10000.00 root  data:Selection",
+          "    └─Selection 10000.00 cop[tikv]  not(isnull(test.t2.a)), not(isnull(test.t2.b))",
+          "      └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false"
+        ],
+        "Warning": null
+      }
+    ]
+  },
+  {
     "Name": "TestJoinOrderHint4TiFlash",
     "Cases": [
       {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63290

Problem Summary: planner: allow cartesian joins in greedy join order algo to explore better join orders

### What changed and how does it work?

In the current greedy join order algo implementation, we skip cartesian joins, which means we join tables with join keys with each others first. But this strategy might miss some optimal join orders (see #63290 as an example).

This PR allows cartesian joins in the greedy join order algo, and use a `ratio` to trade off the risk.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
