### PR TITLE
test: skip some upgrade tests for next-gen

### DIFF
--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -1334,7 +1334,7 @@ func TestSetLabelsConcurrentWithGetLabel(t *testing.T) {
 
 func TestUpgrade(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ts := createBasicHTTPHandlerTestSuite()

--- a/pkg/server/handler/tests/http_handler_test.go
+++ b/pkg/server/handler/tests/http_handler_test.go
@@ -1333,6 +1333,10 @@ func TestSetLabelsConcurrentWithGetLabel(t *testing.T) {
 }
 
 func TestUpgrade(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -336,6 +336,10 @@ func revertVersionAndVariables(t *testing.T, se sessionapi.Session, ver int) {
 
 // TestUpgrade tests upgrading
 func TestUpgrade(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 
 	store, dom := CreateStoreAndBootstrap(t)
@@ -431,6 +435,10 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestIssue17979_1(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 
 	store, dom := CreateStoreAndBootstrap(t)
@@ -466,6 +474,10 @@ func TestIssue17979_1(t *testing.T) {
 }
 
 func TestIssue17979_2(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 
 	store, dom := CreateStoreAndBootstrap(t)
@@ -508,6 +520,10 @@ func TestIssue17979_2(t *testing.T) {
 // but from 4.0 -> 5.0, the new default is picked up.
 
 func TestIssue20900_2(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 
 	store, dom := CreateStoreAndBootstrap(t)
@@ -611,6 +627,10 @@ func TestStmtSummary(t *testing.T) {
 }
 
 func TestUpgradeClusteredIndexDefaultValue(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 
@@ -702,6 +722,10 @@ func TestReferencesPrivilegeOnColumn(t *testing.T) {
 }
 
 func TestAnalyzeVersionUpgradeFrom300To500(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -777,6 +801,10 @@ func TestIndexMergeInNewCluster(t *testing.T) {
 }
 
 func TestIndexMergeUpgradeFrom300To540(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -828,10 +856,17 @@ func TestIndexMergeUpgradeFrom300To540(t *testing.T) {
 // We set tidb_enable_index_merge as on.
 // And after upgrade to 5.x, tidb_enable_index_merge should remains to be on.
 func TestIndexMergeUpgradeFrom400To540Enable(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	testIndexMergeUpgradeFrom400To540(t, true)
 }
 
 func TestIndexMergeUpgradeFrom400To540Disable(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
 	testIndexMergeUpgradeFrom400To540(t, false)
 }
 
@@ -928,6 +963,10 @@ func TestTiDBEnablePagingVariable(t *testing.T) {
 }
 
 func TestTiDBOptRangeMaxSizeWhenUpgrading(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -986,6 +1025,10 @@ func TestTiDBOptRangeMaxSizeWhenUpgrading(t *testing.T) {
 }
 
 func TestTiDBOptAdvancedJoinHintWhenUpgrading(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1096,6 +1139,10 @@ func TestTiDBCostModelInNewCluster(t *testing.T) {
 }
 
 func TestTiDBCostModelUpgradeFrom300To650(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1146,6 +1193,10 @@ func TestTiDBCostModelUpgradeFrom300To650(t *testing.T) {
 }
 
 func TestTiDBCostModelUpgradeFrom610To650(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	for i := range 2 {
 		func() {
 			ctx := context.Background()
@@ -1216,6 +1267,10 @@ func TestTiDBCostModelUpgradeFrom610To650(t *testing.T) {
 }
 
 func TestTiDBGCAwareUpgradeFrom630To650(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1270,6 +1325,10 @@ func TestTiDBGCAwareUpgradeFrom630To650(t *testing.T) {
 }
 
 func TestTiDBServerMemoryLimitUpgradeTo651_1(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1324,6 +1383,10 @@ func TestTiDBServerMemoryLimitUpgradeTo651_1(t *testing.T) {
 }
 
 func TestTiDBServerMemoryLimitUpgradeTo651_2(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1378,6 +1441,10 @@ func TestTiDBServerMemoryLimitUpgradeTo651_2(t *testing.T) {
 }
 
 func TestTiDBGlobalVariablesDefaultValueUpgradeFrom630To660(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1442,6 +1509,10 @@ func TestTiDBGlobalVariablesDefaultValueUpgradeFrom630To660(t *testing.T) {
 }
 
 func TestTiDBStoreBatchSizeUpgradeFrom650To660(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	for i := range 2 {
 		func() {
 			ctx := context.Background()
@@ -1512,6 +1583,10 @@ func TestTiDBStoreBatchSizeUpgradeFrom650To660(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer136(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -1551,6 +1626,10 @@ func TestTiDBUpgradeToVer136(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer140(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -1597,6 +1676,10 @@ func TestTiDBUpgradeToVer140(t *testing.T) {
 }
 
 func TestTiDBNonPrepPlanCacheUpgradeFrom540To700(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1657,6 +1740,10 @@ func TestTiDBNonPrepPlanCacheUpgradeFrom540To700(t *testing.T) {
 }
 
 func TestTiDBStatsLoadPseudoTimeoutUpgradeFrom610To650(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1711,6 +1798,10 @@ func TestTiDBStatsLoadPseudoTimeoutUpgradeFrom610To650(t *testing.T) {
 }
 
 func TestTiDBTiDBOptTiDBOptimizerEnableNAAJWhenUpgradingToVer138(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1762,6 +1853,10 @@ func TestTiDBTiDBOptTiDBOptimizerEnableNAAJWhenUpgradingToVer138(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer143(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -1793,6 +1888,10 @@ func TestTiDBUpgradeToVer143(t *testing.T) {
 }
 
 func TestTiDBLoadBasedReplicaReadThresholdUpgradingToVer141(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1847,6 +1946,10 @@ func TestTiDBLoadBasedReplicaReadThresholdUpgradingToVer141(t *testing.T) {
 }
 
 func TestTiDBPlanCacheInvalidationOnFreshStatsWhenUpgradingToVer144(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -1895,6 +1998,10 @@ func TestTiDBPlanCacheInvalidationOnFreshStatsWhenUpgradingToVer144(t *testing.T
 }
 
 func TestTiDBUpgradeToVer145(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -1926,6 +2033,10 @@ func TestTiDBUpgradeToVer145(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer170(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -1956,6 +2067,10 @@ func TestTiDBUpgradeToVer170(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer176(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -1987,6 +2102,10 @@ func TestTiDBUpgradeToVer176(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer177(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -2041,6 +2160,10 @@ func TestWriteDDLTableVersionToMySQLTiDB(t *testing.T) {
 }
 
 func TestWriteDDLTableVersionToMySQLTiDBWhenUpgradingTo178(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -2087,6 +2210,10 @@ func TestWriteDDLTableVersionToMySQLTiDBWhenUpgradingTo178(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer179(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
@@ -2175,6 +2302,10 @@ func testTiDBUpgradeWithDistTask(t *testing.T, injectQuery string, fatal bool) {
 }
 
 func TestTiDBUpgradeToVer209(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -2255,6 +2386,10 @@ func TestTiDBUpgradeWithDistTaskRunning(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer211(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, do := CreateStoreAndBootstrap(t)
 	defer func() {
@@ -2328,6 +2463,10 @@ func TestTiDBHistoryTableConsistent(t *testing.T) {
 }
 
 func TestTiDBUpgradeToVer212(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 
@@ -2558,6 +2697,10 @@ func TestTiDBUpgradeToVer240(t *testing.T) {
 }
 
 func TestWriteClusterIDToMySQLTiDBWhenUpgradingTo242(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -2614,6 +2757,10 @@ func TestWriteClusterIDToMySQLTiDBWhenUpgradingTo242(t *testing.T) {
 }
 
 func TestBindInfoUniqueIndex(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -337,7 +337,7 @@ func revertVersionAndVariables(t *testing.T, se sessionapi.Session, ver int) {
 // TestUpgrade tests upgrading
 func TestUpgrade(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -436,7 +436,7 @@ func TestUpgrade(t *testing.T) {
 
 func TestIssue17979_1(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -475,7 +475,7 @@ func TestIssue17979_1(t *testing.T) {
 
 func TestIssue17979_2(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -521,7 +521,7 @@ func TestIssue17979_2(t *testing.T) {
 
 func TestIssue20900_2(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -628,7 +628,7 @@ func TestStmtSummary(t *testing.T) {
 
 func TestUpgradeClusteredIndexDefaultValue(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, dom := CreateStoreAndBootstrap(t)
@@ -723,7 +723,7 @@ func TestReferencesPrivilegeOnColumn(t *testing.T) {
 
 func TestAnalyzeVersionUpgradeFrom300To500(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -802,7 +802,7 @@ func TestIndexMergeInNewCluster(t *testing.T) {
 
 func TestIndexMergeUpgradeFrom300To540(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -857,7 +857,7 @@ func TestIndexMergeUpgradeFrom300To540(t *testing.T) {
 // And after upgrade to 5.x, tidb_enable_index_merge should remains to be on.
 func TestIndexMergeUpgradeFrom400To540Enable(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	testIndexMergeUpgradeFrom400To540(t, true)
@@ -865,7 +865,7 @@ func TestIndexMergeUpgradeFrom400To540Enable(t *testing.T) {
 
 func TestIndexMergeUpgradeFrom400To540Disable(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 	testIndexMergeUpgradeFrom400To540(t, false)
 }
@@ -964,7 +964,7 @@ func TestTiDBEnablePagingVariable(t *testing.T) {
 
 func TestTiDBOptRangeMaxSizeWhenUpgrading(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1026,7 +1026,7 @@ func TestTiDBOptRangeMaxSizeWhenUpgrading(t *testing.T) {
 
 func TestTiDBOptAdvancedJoinHintWhenUpgrading(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1140,7 +1140,7 @@ func TestTiDBCostModelInNewCluster(t *testing.T) {
 
 func TestTiDBCostModelUpgradeFrom300To650(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1194,7 +1194,7 @@ func TestTiDBCostModelUpgradeFrom300To650(t *testing.T) {
 
 func TestTiDBCostModelUpgradeFrom610To650(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	for i := range 2 {
@@ -1268,7 +1268,7 @@ func TestTiDBCostModelUpgradeFrom610To650(t *testing.T) {
 
 func TestTiDBGCAwareUpgradeFrom630To650(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1326,7 +1326,7 @@ func TestTiDBGCAwareUpgradeFrom630To650(t *testing.T) {
 
 func TestTiDBServerMemoryLimitUpgradeTo651_1(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1384,7 +1384,7 @@ func TestTiDBServerMemoryLimitUpgradeTo651_1(t *testing.T) {
 
 func TestTiDBServerMemoryLimitUpgradeTo651_2(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1442,7 +1442,7 @@ func TestTiDBServerMemoryLimitUpgradeTo651_2(t *testing.T) {
 
 func TestTiDBGlobalVariablesDefaultValueUpgradeFrom630To660(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1510,7 +1510,7 @@ func TestTiDBGlobalVariablesDefaultValueUpgradeFrom630To660(t *testing.T) {
 
 func TestTiDBStoreBatchSizeUpgradeFrom650To660(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	for i := range 2 {
@@ -1584,7 +1584,7 @@ func TestTiDBStoreBatchSizeUpgradeFrom650To660(t *testing.T) {
 
 func TestTiDBUpgradeToVer136(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -1627,7 +1627,7 @@ func TestTiDBUpgradeToVer136(t *testing.T) {
 
 func TestTiDBUpgradeToVer140(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -1677,7 +1677,7 @@ func TestTiDBUpgradeToVer140(t *testing.T) {
 
 func TestTiDBNonPrepPlanCacheUpgradeFrom540To700(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1741,7 +1741,7 @@ func TestTiDBNonPrepPlanCacheUpgradeFrom540To700(t *testing.T) {
 
 func TestTiDBStatsLoadPseudoTimeoutUpgradeFrom610To650(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1799,7 +1799,7 @@ func TestTiDBStatsLoadPseudoTimeoutUpgradeFrom610To650(t *testing.T) {
 
 func TestTiDBTiDBOptTiDBOptimizerEnableNAAJWhenUpgradingToVer138(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1854,7 +1854,7 @@ func TestTiDBTiDBOptTiDBOptimizerEnableNAAJWhenUpgradingToVer138(t *testing.T) {
 
 func TestTiDBUpgradeToVer143(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -1889,7 +1889,7 @@ func TestTiDBUpgradeToVer143(t *testing.T) {
 
 func TestTiDBLoadBasedReplicaReadThresholdUpgradingToVer141(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1947,7 +1947,7 @@ func TestTiDBLoadBasedReplicaReadThresholdUpgradingToVer141(t *testing.T) {
 
 func TestTiDBPlanCacheInvalidationOnFreshStatsWhenUpgradingToVer144(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -1999,7 +1999,7 @@ func TestTiDBPlanCacheInvalidationOnFreshStatsWhenUpgradingToVer144(t *testing.T
 
 func TestTiDBUpgradeToVer145(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -2034,7 +2034,7 @@ func TestTiDBUpgradeToVer145(t *testing.T) {
 
 func TestTiDBUpgradeToVer170(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -2068,7 +2068,7 @@ func TestTiDBUpgradeToVer170(t *testing.T) {
 
 func TestTiDBUpgradeToVer176(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -2103,7 +2103,7 @@ func TestTiDBUpgradeToVer176(t *testing.T) {
 
 func TestTiDBUpgradeToVer177(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, do := CreateStoreAndBootstrap(t)
@@ -2161,7 +2161,7 @@ func TestWriteDDLTableVersionToMySQLTiDB(t *testing.T) {
 
 func TestWriteDDLTableVersionToMySQLTiDBWhenUpgradingTo178(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -2211,7 +2211,7 @@ func TestWriteDDLTableVersionToMySQLTiDBWhenUpgradingTo178(t *testing.T) {
 
 func TestTiDBUpgradeToVer179(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -2303,7 +2303,7 @@ func testTiDBUpgradeWithDistTask(t *testing.T, injectQuery string, fatal bool) {
 
 func TestTiDBUpgradeToVer209(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -2387,7 +2387,7 @@ func TestTiDBUpgradeWithDistTaskRunning(t *testing.T) {
 
 func TestTiDBUpgradeToVer211(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -2464,7 +2464,7 @@ func TestTiDBHistoryTableConsistent(t *testing.T) {
 
 func TestTiDBUpgradeToVer212(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	store, dom := CreateStoreAndBootstrap(t)
@@ -2652,6 +2652,9 @@ func (mebd *mockEtcdBackend) TLSConfig() *tls.Config { return nil }
 func (mebd *mockEtcdBackend) StartGCWorker() error { return nil }
 
 func TestTiDBUpgradeToVer240(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
 	ctx := context.Background()
 	store, dom := CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -2698,7 +2701,7 @@ func TestTiDBUpgradeToVer240(t *testing.T) {
 
 func TestWriteClusterIDToMySQLTiDBWhenUpgradingTo242(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -2758,7 +2761,7 @@ func TestWriteClusterIDToMySQLTiDBWhenUpgradingTo242(t *testing.T) {
 
 func TestBindInfoUniqueIndex(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     shard_count = 12,
     deps = [
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/kv",
         "//pkg/meta",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -114,7 +114,7 @@ func revertVersionAndVariables(t *testing.T, se sessionapi.Session, ver int) {
 
 func TestUpgradeVersion66(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -155,7 +155,7 @@ func TestUpgradeVersion66(t *testing.T) {
 
 func TestUpgradeVersion74(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	ctx := context.Background()
@@ -208,6 +208,9 @@ func TestUpgradeVersion74(t *testing.T) {
 }
 
 func TestUpgradeVersion75(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
 	ctx := context.Background()
 
 	store, dom := session.CreateStoreAndBootstrap(t)
@@ -318,7 +321,7 @@ func TestUpgradeVersionMockLatest(t *testing.T) {
 // TestUpgradeVersionWithUpgradeHTTPOp tests SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++ with HTTP op.
 func TestUpgradeVersionWithUpgradeHTTPOp(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	mock := true
@@ -372,7 +375,7 @@ func TestUpgradeVersionWithUpgradeHTTPOp(t *testing.T) {
 // TestUpgradeVersionWithoutUpgradeHTTPOp tests SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++ without HTTP op.
 func TestUpgradeVersionWithoutUpgradeHTTPOp(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because all primary key are clustered in next-gen")
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}
 
 	mock := true

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
@@ -112,6 +113,10 @@ func revertVersionAndVariables(t *testing.T, se sessionapi.Session, ver int) {
 }
 
 func TestUpgradeVersion66(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
@@ -149,6 +154,10 @@ func TestUpgradeVersion66(t *testing.T) {
 }
 
 func TestUpgradeVersion74(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	ctx := context.Background()
 
 	cases := []struct {
@@ -308,6 +317,10 @@ func TestUpgradeVersionMockLatest(t *testing.T) {
 
 // TestUpgradeVersionWithUpgradeHTTPOp tests SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++ with HTTP op.
 func TestUpgradeVersionWithUpgradeHTTPOp(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	mock := true
 	session.WithMockUpgrade = &mock
 	session.MockUpgradeToVerLatestKind = session.MockSimpleUpgradeToVerLatest
@@ -358,6 +371,10 @@ func TestUpgradeVersionWithUpgradeHTTPOp(t *testing.T) {
 
 // TestUpgradeVersionWithoutUpgradeHTTPOp tests SupportUpgradeHTTPOpVer upgrade SupportUpgradeHTTPOpVer++ without HTTP op.
 func TestUpgradeVersionWithoutUpgradeHTTPOp(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because all primary key are clustered in next-gen")
+	}
+
 	mock := true
 	session.WithMockUpgrade = &mock
 	session.MockUpgradeToVerLatestKind = session.MockSimpleUpgradeToVerLatest


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #61702

Problem Summary:

Since in next-gen cluster all tables that are created by bootstrap can not have non-clustered primary key, we can skip the test cases containing `upgradeToVer248`

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
