### PR TITLE
*: support the variable of `default_collation_for_utf8`

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -3526,6 +3526,11 @@ error = '''
 Invalid default collation %s: utf8mb4_0900_ai_ci or utf8mb4_general_ci or utf8mb4_bin expected
 '''
 
+["variable:3722"]
+error = '''
+Invalid default collation %s: utf8_unicode_ci or utf8_general_ci or utf8_bin expected
+'''
+
 ["variable:8047"]
 error = '''
 variable '%s' does not yet support value: %s

--- a/pkg/ddl/create_table.go
+++ b/pkg/ddl/create_table.go
@@ -765,14 +765,14 @@ func BuildSessionTemporaryTableInfo(ctx *metabuild.Context, store kv.Storage, is
 // BuildTableInfoWithStmt builds model.TableInfo from a SQL statement without validity check
 func BuildTableInfoWithStmt(ctx *metabuild.Context, s *ast.CreateTableStmt, dbCharset, dbCollate string, placementPolicyRef *model.PolicyRefInfo) (*model.TableInfo, error) {
 	colDefs := s.Cols
-	tableCharset, tableCollate, err := GetCharsetAndCollateInTableOption(0, s.Options, ctx.GetDefaultCollationForUTF8MB4())
+	tableCharset, tableCollate, err := GetCharsetAndCollateInTableOption(0, s.Options, ctx.GetDefaultCollationForUTF8MB4(), ctx.GetDefaultCollationForUTF8())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	tableCharset, tableCollate, err = ResolveCharsetCollation([]ast.CharsetOpt{
 		{Chs: tableCharset, Col: tableCollate},
 		{Chs: dbCharset, Col: dbCollate},
-	}, ctx.GetDefaultCollationForUTF8MB4())
+	}, ctx.GetDefaultCollationForUTF8MB4(), ctx.GetDefaultCollationForUTF8())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/ddl/metabuild_test.go
+++ b/pkg/ddl/metabuild_test.go
@@ -47,6 +47,8 @@ func TestNewMetaBuildContextWithSctx(t *testing.T) {
 				require.Equal(t, sqlMode, ctx.GetSQLMode())
 				require.Equal(t, sctx.GetSessionVars().DefaultCollationForUTF8MB4, ctx.GetDefaultCollationForUTF8MB4())
 				require.Equal(t, "utf8mb4_bin", ctx.GetDefaultCollationForUTF8MB4())
+				require.Equal(t, sctx.GetSessionVars().DefaultCollationForUTF8, ctx.GetDefaultCollationForUTF8())
+				require.Equal(t, "utf8_bin", ctx.GetDefaultCollationForUTF8())
 				warn := errors.New("warn1")
 				note := errors.New("note1")
 				ctx.AppendWarning(warn)

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1117,7 +1117,7 @@ func ProcessColumnCharsetAndCollation(ctx *metabuild.Context, col *table.Column,
 		chs = col.FieldType.GetCharset()
 		coll = col.FieldType.GetCollate()
 	} else {
-		chs, coll, err = getCharsetAndCollateInColumnDef(specNewColumn, ctx.GetDefaultCollationForUTF8MB4())
+		chs, coll, err = getCharsetAndCollateInColumnDef(specNewColumn, ctx.GetDefaultCollationForUTF8MB4(), ctx.GetDefaultCollationForUTF8())
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1125,8 +1125,8 @@ func ProcessColumnCharsetAndCollation(ctx *metabuild.Context, col *table.Column,
 			{Chs: chs, Col: coll},
 			{Chs: meta.Charset, Col: meta.Collate},
 			{Chs: schema.Charset, Col: schema.Collate},
-		}, ctx.GetDefaultCollationForUTF8MB4())
-		chs, coll = OverwriteCollationWithBinaryFlag(specNewColumn, chs, coll, ctx.GetDefaultCollationForUTF8MB4())
+		}, ctx.GetDefaultCollationForUTF8MB4(), ctx.GetDefaultCollationForUTF8())
+		chs, coll = OverwriteCollationWithBinaryFlag(specNewColumn, chs, coll, ctx.GetDefaultCollationForUTF8MB4(), ctx.GetDefaultCollationForUTF8())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/ddl/schematracker/dm_tracker.go
+++ b/pkg/ddl/schematracker/dm_tracker.go
@@ -78,7 +78,11 @@ func (d *SchemaTracker) CreateSchema(ctx sessionctx.Context, stmt *ast.CreateDat
 	if ctx != nil {
 		utf8MB4DefaultColl = ctx.GetSessionVars().DefaultCollationForUTF8MB4
 	}
-	chs, coll, err := ddl.ResolveCharsetCollation([]ast.CharsetOpt{charsetOpt}, utf8MB4DefaultColl)
+	utf8DefaultColl := ""
+	if ctx != nil {
+		utf8DefaultColl = ctx.GetSessionVars().DefaultCollationForUTF8
+	}
+	chs, coll, err := ddl.ResolveCharsetCollation([]ast.CharsetOpt{charsetOpt}, utf8MB4DefaultColl, utf8DefaultColl)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -153,7 +157,7 @@ func (d *SchemaTracker) AlterSchema(ctx sessionctx.Context, stmt *ast.AlterDatab
 		}
 	}
 	if toCollate == "" {
-		if toCollate, err = ddl.GetDefaultCollation(toCharset, ctx.GetSessionVars().DefaultCollationForUTF8MB4); err != nil {
+		if toCollate, err = ddl.GetDefaultCollation(toCharset, ctx.GetSessionVars().DefaultCollationForUTF8MB4, ctx.GetSessionVars().DefaultCollationForUTF8); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -962,7 +966,7 @@ func (d *SchemaTracker) AlterTable(ctx context.Context, sctx sessionctx.Context,
 						continue
 					}
 					var toCharset, toCollate string
-					toCharset, toCollate, err = ddl.GetCharsetAndCollateInTableOption(i, spec.Options, sctx.GetSessionVars().DefaultCollationForUTF8MB4)
+					toCharset, toCollate, err = ddl.GetCharsetAndCollateInTableOption(i, spec.Options, sctx.GetSessionVars().DefaultCollationForUTF8MB4, sctx.GetSessionVars().DefaultCollationForUTF8)
 					if err != nil {
 						return err
 					}

--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -900,6 +900,7 @@ const (
 	ErrNotHintUpdatable                                      = 3637
 	ErrExistsInHistoryPassword                               = 3638
 	ErrInvalidDefaultUTF8MB4Collation                        = 3721
+	ErrInvalidDefaultUTF8Collation                           = 3722
 	ErrForeignKeyCannotDropParent                            = 3730
 	ErrForeignKeyCannotUseVirtualColumn                      = 3733
 	ErrForeignKeyNoColumnInParent                            = 3734

--- a/pkg/errno/errname.go
+++ b/pkg/errno/errname.go
@@ -896,6 +896,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrNotHintUpdatable:                                      mysql.Message("Variable '%s' might not be affected by SET_VAR hint.", nil),
 	ErrExistsInHistoryPassword:                               mysql.Message("Cannot use these credentials for '%s@%s' because they contradict the password history policy.", nil),
 	ErrInvalidDefaultUTF8MB4Collation:                        mysql.Message("Invalid default collation %s: utf8mb4_0900_ai_ci or utf8mb4_general_ci or utf8mb4_bin expected", nil),
+	ErrInvalidDefaultUTF8Collation:                           mysql.Message("Invalid default collation %s: utf8_unicode_ci or utf8_general_ci or utf8_bin expected", nil),
 	ErrForeignKeyCannotDropParent:                            mysql.Message("Cannot drop table '%s' referenced by a foreign key constraint '%s' on table '%s'.", nil),
 	ErrForeignKeyCannotUseVirtualColumn:                      mysql.Message("Foreign key '%s' uses virtual column '%s' which is not supported.", nil),
 	ErrForeignKeyNoColumnInParent:                            mysql.Message("Failed to add the foreign key constraint. Missing column '%s' for constraint '%s' in the referenced table '%s'", nil),

--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -274,6 +274,8 @@ func (e *SetExecutor) setCharset(cs, co string, isSetName bool) error {
 	if co == "" {
 		if cs == mysql.UTF8MB4Charset {
 			co = sessionVars.DefaultCollationForUTF8MB4
+		} else if cs == mysql.UTF8Charset {
+			co = sessionVars.DefaultCollationForUTF8
 		} else if co, err = charset.GetDefaultCollation(cs); err != nil {
 			return err
 		}

--- a/pkg/expression/exprctx/context.go
+++ b/pkg/expression/exprctx/context.go
@@ -102,6 +102,8 @@ type BuildContext interface {
 	GetCharsetInfo() (string, string)
 	// GetDefaultCollationForUTF8MB4 returns the default collation of UTF8MB4.
 	GetDefaultCollationForUTF8MB4() string
+	// GetDefaultCollationForUTF8 returns the default collation of UTF8.
+	GetDefaultCollationForUTF8() string
 	// GetBlockEncryptionMode returns the variable `block_encryption_mode`.
 	GetBlockEncryptionMode() string
 	// GetSysdateIsNow returns a bool to determine whether Sysdate is an alias of Now function.

--- a/pkg/expression/exprstatic/exprctx.go
+++ b/pkg/expression/exprstatic/exprctx.go
@@ -37,6 +37,7 @@ type exprCtxState struct {
 	charset                    string
 	collation                  string
 	defaultCollationForUTF8MB4 string
+	defaultCollationForUTF8    string
 	blockEncryptionMode        string
 	sysDateIsNow               bool
 	noopFuncsMode              int
@@ -71,6 +72,13 @@ func WithCharset(charset, collation string) ExprCtxOption {
 func WithDefaultCollationForUTF8MB4(collation string) ExprCtxOption {
 	return func(s *exprCtxState) {
 		s.defaultCollationForUTF8MB4 = collation
+	}
+}
+
+// WithDefaultCollationForUTF8 sets the default collation for utf8 for `ExprContext`.
+func WithDefaultCollationForUTF8(collation string) ExprCtxOption {
+	return func(s *exprCtxState) {
+		s.defaultCollationForUTF8 = collation
 	}
 }
 
@@ -158,6 +166,7 @@ func NewExprContext(opts ...ExprCtxOption) *ExprContext {
 			charset:                    cs.Name,
 			collation:                  cs.DefaultCollation,
 			defaultCollationForUTF8MB4: mysql.DefaultCollationName,
+			defaultCollationForUTF8:    mysql.UTF8DefaultCollation,
 			blockEncryptionMode:        vardef.DefBlockEncryptionMode,
 			sysDateIsNow:               vardef.DefSysdateIsNow,
 			noopFuncsMode:              variable.TiDBOptOnOffWarn(vardef.DefTiDBEnableNoopFuncs),
@@ -221,6 +230,11 @@ func (ctx *ExprContext) GetCharsetInfo() (string, string) {
 // GetDefaultCollationForUTF8MB4 implements the `ExprContext.GetDefaultCollationForUTF8MB4`.
 func (ctx *ExprContext) GetDefaultCollationForUTF8MB4() string {
 	return ctx.defaultCollationForUTF8MB4
+}
+
+// GetDefaultCollationForUTF8 implements the `ExprContext.GetDefaultCollationForUTF8`.
+func (ctx *ExprContext) GetDefaultCollationForUTF8() string {
+	return ctx.defaultCollationForUTF8
 }
 
 // GetBlockEncryptionMode implements the `ExprContext.GetBlockEncryptionMode`.
@@ -314,6 +328,7 @@ func MakeExprContextStatic(ctx exprctx.StaticConvertibleExprContext) *ExprContex
 		WithEvalCtx(staticEvalContext),
 		WithCharset(ctx.GetCharsetInfo()),
 		WithDefaultCollationForUTF8MB4(ctx.GetDefaultCollationForUTF8MB4()),
+		WithDefaultCollationForUTF8(ctx.GetDefaultCollationForUTF8()),
 		WithBlockEncryptionMode(ctx.GetBlockEncryptionMode()),
 		WithSysDateIsNow(ctx.GetSysdateIsNow()),
 		WithNoopFuncsMode(ctx.GetNoopFuncsMode()),
@@ -348,6 +363,8 @@ func (ctx *ExprContext) loadSessionVarsInternal(
 			opts = append(opts, WithCharset(sessionVars.GetCharsetInfo()))
 		case vardef.DefaultCollationForUTF8MB4:
 			opts = append(opts, WithDefaultCollationForUTF8MB4(sessionVars.DefaultCollationForUTF8MB4))
+		case vardef.DefaultCollationForUTF8:
+			opts = append(opts, WithDefaultCollationForUTF8(sessionVars.DefaultCollationForUTF8))
 		case vardef.BlockEncryptionMode:
 			blockMode, ok := sessionVars.GetSystemVar(vardef.BlockEncryptionMode)
 			intest.Assert(ok)

--- a/pkg/expression/exprstatic/exprctx_test.go
+++ b/pkg/expression/exprstatic/exprctx_test.go
@@ -169,6 +169,7 @@ func TestMakeExprContextStatic(t *testing.T) {
 		WithEvalCtx(evalCtx),
 		WithCharset("a", "b"),
 		WithDefaultCollationForUTF8MB4("c"),
+		WithDefaultCollationForUTF8("e"),
 		WithBlockEncryptionMode("d"),
 		WithSysDateIsNow(true),
 		WithNoopFuncsMode(1),
@@ -238,6 +239,15 @@ func TestExprCtxLoadSystemVars(t *testing.T) {
 			assert: func(ctx *ExprContext, vars *variable.SessionVars) {
 				require.Equal(t, "utf8mb4_general_ci", ctx.GetDefaultCollationForUTF8MB4())
 				require.Equal(t, vars.DefaultCollationForUTF8MB4, ctx.GetDefaultCollationForUTF8MB4())
+			},
+		},
+		{
+			name:  "default_collation_for_utf8",
+			val:   "utf8_general_ci",
+			field: "$.defaultCollationForUTF8",
+			assert: func(ctx *ExprContext, vars *variable.SessionVars) {
+				require.Equal(t, "utf8_general_ci", ctx.GetDefaultCollationForUTF8())
+				require.Equal(t, vars.DefaultCollationForUTF8, ctx.GetDefaultCollationForUTF8())
 			},
 		},
 		{

--- a/pkg/expression/sessionexpr/sessionctx.go
+++ b/pkg/expression/sessionexpr/sessionctx.go
@@ -73,6 +73,11 @@ func (ctx *ExprContext) GetDefaultCollationForUTF8MB4() string {
 	return ctx.sctx.GetSessionVars().DefaultCollationForUTF8MB4
 }
 
+// GetDefaultCollationForUTF8 returns the default collation of UTF8.
+func (ctx *ExprContext) GetDefaultCollationForUTF8() string {
+	return ctx.sctx.GetSessionVars().DefaultCollationForUTF8
+}
+
 // GetBlockEncryptionMode returns the variable block_encryption_mode
 func (ctx *ExprContext) GetBlockEncryptionMode() string {
 	blockMode, _ := ctx.sctx.GetSessionVars().GetSystemVar(vardef.BlockEncryptionMode)

--- a/pkg/expression/sessionexpr/sessionctx_test.go
+++ b/pkg/expression/sessionexpr/sessionctx_test.go
@@ -290,6 +290,7 @@ func TestSessionBuildContext(t *testing.T) {
 	err = vars.SetSystemVar("collation_connection", "gbk_chinese_ci")
 	require.NoError(t, err)
 	vars.DefaultCollationForUTF8MB4 = "utf8mb4_0900_ai_ci"
+	vars.DefaultCollationForUTF8 = "utf8_unicode_ci"
 
 	charset, collate := impl.GetCharsetInfo()
 	require.Equal(t, "gbk", charset)

--- a/pkg/meta/metabuild/context.go
+++ b/pkg/meta/metabuild/context.go
@@ -153,6 +153,11 @@ func (ctx *Context) GetDefaultCollationForUTF8MB4() string {
 	return ctx.exprCtx.GetDefaultCollationForUTF8MB4()
 }
 
+// GetDefaultCollationForUTF8 returns the default collation for utf8.
+func (ctx *Context) GetDefaultCollationForUTF8() string {
+	return ctx.exprCtx.GetDefaultCollationForUTF8()
+}
+
 // GetSQLMode returns the SQL mode.
 func (ctx *Context) GetSQLMode() mysql.SQLMode {
 	return ctx.exprCtx.GetEvalCtx().SQLMode()

--- a/pkg/meta/metabuild/context_test.go
+++ b/pkg/meta/metabuild/context_test.go
@@ -55,6 +55,7 @@ func TestMetaBuildContext(t *testing.T) {
 				require.Equal(t, defSQLMode, ctx.GetSQLMode())
 				require.Equal(t, ctx.GetExprCtx().GetEvalCtx().SQLMode(), ctx.GetSQLMode())
 				require.Equal(t, defVars.DefaultCollationForUTF8MB4, ctx.GetDefaultCollationForUTF8MB4())
+				require.Equal(t, defVars.DefaultCollationForUTF8, ctx.GetDefaultCollationForUTF8())
 				require.Equal(t, ctx.GetExprCtx().GetDefaultCollationForUTF8MB4(), ctx.GetDefaultCollationForUTF8MB4())
 			},
 			option: func(val any) metabuild.Option {

--- a/pkg/parser/mysql/charset.go
+++ b/pkg/parser/mysql/charset.go
@@ -546,6 +546,7 @@ const (
 	BinaryDefaultCollationID  = 63
 	GB18030DefaultCollationID = 248
 	UTF8MB4DefaultCollation   = "utf8mb4_bin"
+	UTF8DefaultCollation      = "utf8_bin"
 	DefaultCollationName      = UTF8MB4DefaultCollation
 	UTF8MB4GeneralCICollation = "utf8mb4_general_ci"
 

--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -1405,6 +1405,12 @@ func (er *expressionRewriter) adjustUTF8MB4Collation(tp *types.FieldType) {
 	}
 }
 
+func (er *expressionRewriter) adjustUTF8Collation(tp *types.FieldType) {
+	if tp.GetFlag()&mysql.UnderScoreCharsetFlag > 0 && charset.CharsetUTF8 == tp.GetCharset() {
+		tp.SetCollate(er.sctx.GetDefaultCollationForUTF8())
+	}
+}
+
 // Leave implements Visitor interface.
 func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok bool) {
 	if er.err != nil {
@@ -1440,6 +1446,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		value := &expression.Constant{Value: v.Datum, RetType: retType}
 		initConstantRepertoire(er.sctx.GetEvalCtx(), value)
 		er.adjustUTF8MB4Collation(retType)
+		er.adjustUTF8Collation(retType)
 		if er.err != nil {
 			return retNode, false
 		}
@@ -2442,6 +2449,7 @@ func (er *expressionRewriter) toParamMarker(v *driver.ParamMarkerExpr) {
 	}
 	initConstantRepertoire(er.sctx.GetEvalCtx(), value)
 	er.adjustUTF8MB4Collation(value.RetType)
+	er.adjustUTF8Collation(value.RetType)
 	if er.err != nil {
 		return
 	}

--- a/pkg/sessionctx/vardef/sysvar.go
+++ b/pkg/sessionctx/vardef/sysvar.go
@@ -274,6 +274,8 @@ const (
 	CollationServer = "collation_server"
 	// DefaultCollationForUTF8MB4 is the name of 'default_collation_for_utf8mb4' variable.
 	DefaultCollationForUTF8MB4 = "default_collation_for_utf8mb4"
+	// DefaultCollationForUTF8 is the name of 'default_collation_for_utf8' variable.
+	DefaultCollationForUTF8 = "default_collation_for_utf8"
 	// NetWriteTimeout is the name of 'net_write_timeout' variable.
 	NetWriteTimeout = "net_write_timeout"
 	// ThreadPoolSize is the name of 'thread_pool_size' variable.

--- a/pkg/sessionctx/variable/error.go
+++ b/pkg/sessionctx/variable/error.go
@@ -46,6 +46,7 @@ var (
 	ErrFunctionsNoopImpl                 = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("function %s has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions", nil))
 	ErrVariableNoLongerSupported         = dbterror.ClassVariable.NewStd(mysql.ErrVariableNoLongerSupported)
 	ErrInvalidDefaultUTF8MB4Collation    = dbterror.ClassVariable.NewStd(mysql.ErrInvalidDefaultUTF8MB4Collation)
+	ErrInvalidDefaultUTF8Collation       = dbterror.ClassVariable.NewStd(mysql.ErrInvalidDefaultUTF8Collation)
 	ErrWarnDeprecatedSyntaxNoReplacement = dbterror.ClassVariable.NewStdErr(mysql.ErrWarnDeprecatedSyntaxNoReplacement, pmysql.Message("Updating '%s' is deprecated. It will be made read-only in a future release.", nil))
 	ErrWarnDeprecatedSyntaxSimpleMsg     = dbterror.ClassVariable.NewStdErr(mysql.ErrWarnDeprecatedSyntaxNoReplacement, pmysql.Message("%s is deprecated and will be removed in a future release.", nil))
 )

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1107,6 +1107,9 @@ type SessionVars struct {
 	// DefaultCollationForUTF8MB4 indicates the default collation of UTF8MB4.
 	DefaultCollationForUTF8MB4 string
 
+	// DefaultCollationForUTF8 indicates the default collation of UTF8.
+	DefaultCollationForUTF8 string
+
 	// BatchInsert indicates if we should split insert data into multiple batches.
 	BatchInsert bool
 
@@ -2303,6 +2306,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		TiFlashComputeDispatchPolicy:  tiflashcompute.DispatchPolicyConsistentHash,
 		ResourceGroupName:             resourcegroup.DefaultResourceGroupName,
 		DefaultCollationForUTF8MB4:    mysql.DefaultCollationName,
+		DefaultCollationForUTF8:       mysql.UTF8DefaultCollation,
 		GroupConcatMaxLen:             vardef.DefGroupConcatMaxLen,
 		EnableRedactLog:               vardef.DefTiDBRedactLog,
 		EnableWindowFunction:          vardef.DefEnableWindowFunction,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1741,16 +1741,38 @@ var defaultSysVars = []*SysVar{
 		}
 		return nil
 	}},
-	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.DefaultCollationForUTF8MB4, Value: mysql.DefaultCollationName, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
-		coll, err := checkDefaultCollationForUTF8MB4(vars, normalizedValue, originalValue, scope)
-		if err == nil {
-			vars.StmtCtx.AppendWarning(ErrWarnDeprecatedSyntaxNoReplacement.FastGenByArgs(vardef.DefaultCollationForUTF8MB4))
-		}
-		return coll, err
-	}, SetSession: func(s *SessionVars, val string) error {
-		s.DefaultCollationForUTF8MB4 = val
-		return nil
-	}},
+	{
+		Scope: vardef.ScopeGlobal | vardef.ScopeSession,
+		Name:  vardef.DefaultCollationForUTF8MB4,
+		Value: mysql.DefaultCollationName,
+		Validation: func(
+			vars *SessionVars, normalizedValue string, originalValue string,
+			scope vardef.ScopeFlag,
+		) (string, error) {
+			coll, err := checkDefaultCollationForUTF8MB4(vars, normalizedValue, originalValue, scope)
+			if err == nil {
+				vars.StmtCtx.AppendWarning(ErrWarnDeprecatedSyntaxNoReplacement.FastGenByArgs(vardef.DefaultCollationForUTF8MB4))
+			}
+			return coll, err
+		}, SetSession: func(s *SessionVars, val string) error {
+			s.DefaultCollationForUTF8MB4 = val
+			return nil
+		}},
+	{
+		Scope: vardef.ScopeGlobal | vardef.ScopeSession,
+		Name:  vardef.DefaultCollationForUTF8,
+		Value: mysql.UTF8DefaultCollation,
+		Validation: func(
+			vars *SessionVars, normalizedValue string, originalValue string,
+			scope vardef.ScopeFlag,
+		) (string, error) {
+			coll, err := checkDefaultCollationForUTF8(vars, normalizedValue, originalValue, scope)
+			return coll, err
+		},
+		SetSession: func(s *SessionVars, val string) error {
+			s.DefaultCollationForUTF8 = val
+			return nil
+		}},
 	{
 		Scope:                   vardef.ScopeGlobal | vardef.ScopeSession,
 		Name:                    vardef.TimeZone,

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -240,6 +240,25 @@ func TestDefaultCollationForUTF8MB4(t *testing.T) {
 	require.EqualError(t, err, ErrInvalidDefaultUTF8MB4Collation.GenWithStackByArgs("latin1_bin").Error())
 }
 
+func TestDefaultCollationForUTF8(t *testing.T) {
+	sv := GetSysVar(vardef.DefaultCollationForUTF8)
+	vars := NewSessionVars(nil)
+
+	// test normalization
+	val, err := sv.Validate(vars, "utf8_BIN", vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, "utf8_bin", val)
+	val, err = sv.Validate(vars, "utf8_GENeral_CI", vardef.ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, "utf8_general_ci", val)
+	val, err = sv.Validate(vars, "utf8_UNIcode_CI", vardef.ScopeSession)
+	require.NoError(t, err)
+	require.Equal(t, "utf8_unicode_ci", val)
+	// test set variable failed
+	_, err = sv.Validate(vars, "LATIN1_bin", vardef.ScopeSession)
+	require.EqualError(t, err, ErrInvalidDefaultUTF8Collation.GenWithStackByArgs("latin1_bin").Error())
+}
+
 func TestTimeZone(t *testing.T) {
 	sv := GetSysVar(vardef.TimeZone)
 	vars := NewSessionVars(nil)

--- a/pkg/sessionctx/variable/varsutil.go
+++ b/pkg/sessionctx/variable/varsutil.go
@@ -73,6 +73,17 @@ func checkDefaultCollationForUTF8MB4(vars *SessionVars, normalizedValue string, 
 	return coll.Name, nil
 }
 
+func checkDefaultCollationForUTF8(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
+	coll, err := collate.GetCollationByName(normalizedValue)
+	if err != nil {
+		return normalizedValue, errors.Trace(err)
+	}
+	if !collate.IsDefaultCollationForUTF8(coll.Name) {
+		return "", ErrInvalidDefaultUTF8Collation.GenWithStackByArgs(coll.Name)
+	}
+	return coll.Name, nil
+}
+
 func checkCharacterSet(normalizedValue string, argName string) (string, error) {
 	if normalizedValue == "" {
 		return normalizedValue, errors.Trace(ErrWrongValueForVar.FastGenByArgs(argName, "NULL"))

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -295,6 +295,11 @@ func IsDefaultCollationForUTF8MB4(collate string) bool {
 	return collate == "utf8mb4_bin" || collate == "utf8mb4_general_ci" || collate == "utf8mb4_0900_ai_ci"
 }
 
+// IsDefaultCollationForUTF8 returns if the collation is DefaultCollationForUTF8.
+func IsDefaultCollationForUTF8(collate string) bool {
+	return collate == "utf8_bin" || collate == "utf8_general_ci" || collate == "utf8_unicode_ci"
+}
+
 // IsCICollation returns if the collation is case-insensitive
 func IsCICollation(collate string) bool {
 	return collate == "utf8_general_ci" || collate == "utf8mb4_general_ci" ||


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63328

Problem Summary:

### What changed and how does it work?
support the variable of `default_collation_for_utf8`


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->
```
MySQL [(none)]> set default_collation_for_utf8='utf8_bin';
Query OK, 0 rows affected (0.006 sec)

MySQL [(none)]> show variables like 'default_collation_for_utf8';
+----------------------------+----------+
| Variable_name              | Value    |
+----------------------------+----------+
| default_collation_for_utf8 | utf8_bin |
+----------------------------+----------+
1 row in set (0.004 sec)

MySQL [(none)]> SHOW CHARACTER set;SHOW CHARACTER set;
+---------+-------------------------------------+--------------------+--------+
| Charset | Description                         | Default collation  | Maxlen |
+---------+-------------------------------------+--------------------+--------+
| ascii   | US ASCII                            | ascii_bin          |      1 |
| binary  | binary                              | binary             |      1 |
| gb18030 | China National Standard GB18030     | gb18030_chinese_ci |      4 |
| gbk     | Chinese Internal Code Specification | gbk_chinese_ci     |      2 |
| latin1  | Latin1                              | latin1_bin         |      1 |
| utf8    | UTF-8 Unicode                       | utf8_bin           |      3 |
| utf8mb4 | UTF-8 Unicode                       | utf8mb4_general_ci |      4 |
+---------+-------------------------------------+--------------------+--------+
7 rows in set (0.001 sec)

MySQL [(none)]> create database t1 DEFAULT CHARACTER SET utf8;
show create database t1 ;Query OK, 0 rows affected (0.021 sec)

MySQL [(none)]> show create database t1 ;
+----------+-------------------------------------------------------------+
| Database | Create Database                                             |
+----------+-------------------------------------------------------------+
| t1       | CREATE DATABASE `t1` /*!40100 DEFAULT CHARACTER SET utf8 */ |
+----------+-------------------------------------------------------------+
1 row in set (0.002 sec)

MySQL [(none)]> create table t1.a(a int) DEFAULT CHARSET=utf8;
show create table t1.a ;
Query OK, 0 rows affected (0.015 sec)

MySQL [(none)]> show create table t1.a ;
+-------+-------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                    |
+-------+-------------------------------------------------------------------------------------------------+
| a     | CREATE TABLE `a` (
  `a` int DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------+
1 row in set (0.001 sec)

MySQL [(none)]> create table t1.b(a int);
show create table t1.b ;
Query OK, 0 rows affected (0.015 sec)

MySQL [(none)]> show create table t1.b ;
+-------+-------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                    |
+-------+-------------------------------------------------------------------------------------------------+
| b     | CREATE TABLE `b` (
  `a` int DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)

MySQL [(none)]> drop table t1.a;
drop table t1.b;
drop database t1;Query OK, 0 rows affected (0.028 sec)

MySQL [(none)]> drop table t1.b;
Query OK, 0 rows affected (0.017 sec)

MySQL [(none)]> drop database t1;
Query OK, 0 rows affected (0.029 sec)

# ------------------------------------------------------------------------

MySQL [(none)]> set default_collation_for_utf8='utf8_general_ci';
Query OK, 0 rows affected (0.001 sec)

MySQL [(none)]> show variables like 'default_collation_for_utf8';
+----------------------------+-----------------+
| Variable_name              | Value           |
+----------------------------+-----------------+
| default_collation_for_utf8 | utf8_general_ci |
+----------------------------+-----------------+
1 row in set (0.001 sec)

MySQL [(none)]> SHOW CHARACTER set;
+---------+-------------------------------------+--------------------+--------+
| Charset | Description                         | Default collation  | Maxlen |
+---------+-------------------------------------+--------------------+--------+
| ascii   | US ASCII                            | ascii_bin          |      1 |
| binary  | binary                              | binary             |      1 |
| gb18030 | China National Standard GB18030     | gb18030_chinese_ci |      4 |
| gbk     | Chinese Internal Code Specification | gbk_chinese_ci     |      2 |
| latin1  | Latin1                              | latin1_bin         |      1 |
| utf8    | UTF-8 Unicode                       | utf8_general_ci    |      3 |
| utf8mb4 | UTF-8 Unicode                       | utf8mb4_general_ci |      4 |
+---------+-------------------------------------+--------------------+--------+
7 rows in set (0.001 sec)

MySQL [(none)]> create database t1 DEFAULT CHARACTER SET utf8;
show create database t1 ;Query OK, 0 rows affected (0.016 sec)

MySQL [(none)]> show create database t1 ;
+----------+-------------------------------------------------------------------------------------+
| Database | Create Database                                                                     |
+----------+-------------------------------------------------------------------------------------+
| t1       | CREATE DATABASE `t1` /*!40100 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci */ |
+----------+-------------------------------------------------------------------------------------+
1 row in set (0.001 sec)

MySQL [(none)]> create table t1.a(a int) DEFAULT CHARSET=utf8;
show create table t1.a ;
Query OK, 0 rows affected (0.017 sec)

MySQL [(none)]> show create table t1.a ;
+-------+--------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                           |
+-------+--------------------------------------------------------------------------------------------------------+
| a     | CREATE TABLE `a` (
  `a` int DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci |
+-------+--------------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)

MySQL [(none)]> create table t1.b(a int);
show create table t1.b ;
Query OK, 0 rows affected (0.012 sec)

MySQL [(none)]> show create table t1.b ;
+-------+--------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                           |
+-------+--------------------------------------------------------------------------------------------------------+
| b     | CREATE TABLE `b` (
  `a` int DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci |
+-------+--------------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)
```





Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Added a new variable `default_collation_for_utf8` to set the default collation for the character set utf8.
```
