### PR TITLE
tests: skip NextGen incompatible tests across multiple packages

### DIFF
--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3657,7 +3657,9 @@ func GlobalSystemVariableInitialValue(varName, varVal string) string {
 	case vardef.TiDBRowFormatVersion:
 		varVal = strconv.Itoa(vardef.DefTiDBRowFormatV2)
 	case vardef.TiDBTxnAssertionLevel:
-		if !kerneltype.IsNextGen() {
+		if kerneltype.IsNextGen() {
+			varVal = vardef.GetDefaultTxnAssertionLevel()
+		} else {
 			varVal = vardef.AssertionFastStr
 		}
 	case vardef.TiDBEnableMutationChecker:

--- a/pkg/sessiontxn/BUILD.bazel
+++ b/pkg/sessiontxn/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     shard_count = 25,
     deps = [
         ":sessiontxn",
+        "//pkg/config",
         "//pkg/config/kerneltype",
         "//pkg/domain",
         "//pkg/errno",

--- a/pkg/sessiontxn/isolation/BUILD.bazel
+++ b/pkg/sessiontxn/isolation/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
     deps = [
         ":isolation",
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/executor",
         "//pkg/expression",
         "//pkg/infoschema",

--- a/pkg/sessiontxn/isolation/readcommitted_test.go
+++ b/pkg/sessiontxn/isolation/readcommitted_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/infoschema"
@@ -565,6 +566,12 @@ func initializePessimisticRCProvider(t testing.TB, tk *testkit.TestKit) *isolati
 }
 
 func TestFailedDMLConsistency1(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		// NextGen hangs when acquiring pessimistic locks after failed DML with fair locking disabled
+		// root cause: cleanup not triggered properly for non-fair mode
+		// this 35682 might be related.
+		t.Skip("skip for next-gen kernel, as this test requires fair-locking")
+	}
 	store := testkit.CreateMockStore(t)
 
 	tk1 := testkit.NewTestKit(t, store)
@@ -595,6 +602,12 @@ func TestFailedDMLConsistency1(t *testing.T) {
 }
 
 func TestFailedDMLConsistency2(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		// NextGen hangs when acquiring pessimistic locks after failed DML with fair locking disabled
+		// root cause: cleanup not triggered properly for non-fair mode.
+		// this 35682 might be related.
+		t.Skip("skip for next-gen kernel, as this test requires fair-locking")
+	}
 	store := testkit.CreateMockStore(t)
 	tk1 := testkit.NewTestKit(t, store)
 	tk1.MustExec("set @@tidb_txn_assertion_level=strict")

--- a/pkg/sessiontxn/txn_context_test.go
+++ b/pkg/sessiontxn/txn_context_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/errno"
@@ -813,6 +814,10 @@ func TestStillWriteConflictAfterRetry(t *testing.T) {
 }
 
 func TestOptimisticTxnRetryInPessimisticMode(t *testing.T) {
+	defer config.RestoreFunc()()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.PessimisticTxn.PessimisticAutoCommit.Store(false)
+	})
 	store, _ := setupTxnContextTest(t)
 
 	queries := []string{

--- a/pkg/store/copr/copr_test/BUILD.bazel
+++ b/pkg/store/copr/copr_test/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     shard_count = 5,
     deps = [
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/kv",
         "//pkg/resourcegroup/runaway",
         "//pkg/store/copr",

--- a/pkg/store/gcworker/BUILD.bazel
+++ b/pkg/store/gcworker/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     shard_count = 26,
     deps = [
         "//pkg/config",
+        "//pkg/config/kerneltype",
         "//pkg/ddl/placement",
         "//pkg/ddl/util",
         "//pkg/domain",

--- a/pkg/store/gcworker/gc_worker_test.go
+++ b/pkg/store/gcworker/gc_worker_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/pkg/config"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl/placement"
 	"github.com/pingcap/tidb/pkg/ddl/util"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -314,6 +315,9 @@ func TestGetOracleTime(t *testing.T) {
 }
 
 func TestPrepareGC(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("skip TestPrepareGC when kernel type is NextGen - test not yet adjusted to support next-gen")
+	}
 	// as we are adjusting the base TS, we need a larger schema lease to avoid
 	// the info schema outdated error. as we keep adding offset to time oracle,
 	// so we need set a very large lease.
@@ -968,6 +972,9 @@ Loop:
 }
 
 func TestLeaderTick(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("skip TestLeaderTick when kernel type is NextGen - test not yet adjusted to support next-gen")
+	}
 	// as we are adjusting the base TS, we need a larger schema lease to avoid
 	// the info schema outdated error.
 	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, time.Hour)
@@ -1256,6 +1263,9 @@ func TestResolveLockRangeMeetRegionEnlargeCausedByRegionMerge(t *testing.T) {
 }
 
 func TestRunGCJob(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("skip TestRunGCJob when kernel type is NextGen - test not yet adjusted to support next-gen")
+	}
 	s := createGCWorkerSuite(t)
 
 	txnSafePointSyncWaitTime = 0
@@ -1502,6 +1512,9 @@ func TestGCLabelRules(t *testing.T) {
 }
 
 func TestGCWithPendingTxn(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("skip TestGCWithPendingTxn when kernel type is NextGen - test not yet adjusted to support next-gen")
+	}
 	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, 30*time.Minute)
 
 	ctx := gcContext()
@@ -1628,6 +1641,9 @@ func TestGCWithPendingTxn2(t *testing.T) {
 }
 
 func TestSkipGCAndOnlyResolveLock(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("skip TestSkipGCAndOnlyResolveLock when kernel type is NextGen - test not yet adjusted to support next-gen")
+	}
 	// as we are adjusting the base TS, we need a larger schema lease to avoid
 	// the info schema outdated error.
 	s := createGCWorkerSuiteWithStoreType(t, mockstore.EmbedUnistore, 10*time.Minute)

--- a/pkg/store/helper/BUILD.bazel
+++ b/pkg/store/helper/BUILD.bazel
@@ -38,7 +38,9 @@ go_test(
     flaky = True,
     shard_count = 6,
     deps = [
+        "//pkg/config/kerneltype",
         "//pkg/infoschema/context",
+        "//pkg/kv",
         "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/store/mockstore",

--- a/pkg/store/helper/helper_test.go
+++ b/pkg/store/helper/helper_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	infoschema "github.com/pingcap/tidb/pkg/infoschema/context"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/store/helper"
@@ -42,6 +44,18 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
 )
+
+// getKeyspaceAwareKey uses the store codec to encode keys properly in NextGen mode
+// This ensures compatibility with keyspace encoding
+func getKeyspaceAwareKey(store kv.Storage, key []byte) []byte {
+	if !kerneltype.IsNextGen() || store == nil {
+		return key
+	}
+
+	// Use the store's codec to encode the key - single source of truth
+	codec := store.GetCodec()
+	return codec.EncodeKey(key)
+}
 
 func TestHotRegion(t *testing.T) {
 	store := createMockStore(t)
@@ -151,9 +165,16 @@ func createMockStore(t *testing.T) (store helper.Storage) {
 	server := mockPDHTTPServer()
 
 	pdAddrs := []string{"invalid_pd_address", server.URL[len("http://"):]}
+
+	// Get keyspace-aware region boundary by creating a temp store to access codec
+	tempStore, err := teststore.NewMockStoreWithoutBootstrap()
+	require.NoError(t, err)
+	xKey := getKeyspaceAwareKey(tempStore, []byte("x"))
+	tempStore.Close()
+
 	s, err := teststore.NewMockStoreWithoutBootstrap(
 		mockstore.WithClusterInspector(func(c testutils.Cluster) {
-			mockstore.BootstrapWithMultiRegions(c, []byte("x"))
+			mockstore.BootstrapWithMultiRegions(c, xKey)
 		}),
 		mockstore.WithTiKVOptions(tikv.WithPDHTTPClient("store-helper-test", pdAddrs)),
 		mockstore.WithPDAddr(pdAddrs),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63343

Problem Summary:

Several tests across multiple packages are not yet compatible with NextGen (CSE/Cloud Storage Engine) and need to be skipped when running in NextGen mode to prevent test failures.

### What changed and how does it work?

This PR adds NextGen kernel type checks to skip tests that are not yet adjusted to support next-gen across multiple packages:

**GC Worker tests** (`pkg/store/gcworker/`):
- TestGCWithPendingTxn
- TestLeaderTick  
- TestPrepareGC
- TestRunGCJob
- TestSkipGCAndOnlyResolveLock

**Coprocessor tests** (`pkg/store/copr/`):
- Fixed region boundary handling for keyspace-aware keys in NextGen mode
- Added proper keyspace encoding using store codec

**Session transaction tests** (`pkg/sessiontxn/`):
- TestFailedDMLConsistency1 and TestFailedDMLConsistency2 (require fair locking)
- Fixed TestOptimisticTxnRetryInPessimisticMode configuration

**Other test fixes**:
- Helper tests: proper keyspace encoding for region boundaries
- Telemetry tests: skip fair locking tests in NextGen mode  
- Global system variable initialization fix for TiDBTxnAssertionLevel

All tests use `kerneltype.IsNextGen()` check with clear skip messages explaining the incompatibility reason.

### Check List

Tests
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory  
- [ ] Breaking backward compatibility

Documentation
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```