### PR TITLE
br: concurrently set tiflash replicas

### DIFF
--- a/br/pkg/restore/log_client/client.go
+++ b/br/pkg/restore/log_client/client.go
@@ -1516,11 +1516,10 @@ func (rc *LogClient) ResetTiflashReplicas(ctx context.Context, sqls []string, g 
 	workerpool := tidbutil.NewWorkerPool(16, "repair ingest index")
 	eg, ectx := errgroup.WithContext(ctx)
 	for _, sql := range sqls {
-		resetSQL := sql
 		workerpool.ApplyWithIDInErrorGroup(eg, func(id uint64) error {
 			resetSession := resetSessions[id%uint64(len(resetSessions))]
 			log.Info("reset tiflash replica", zap.String("sql", sql))
-			return resetSession.ExecuteInternal(ectx, resetSQL)
+			return resetSession.ExecuteInternal(ectx, sql)
 		})
 	}
 	return eg.Wait()

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1783,7 +1783,7 @@ func restoreStream(
 		sqls := cfg.tiflashRecorder.GenerateAlterTableDDLs(mgr.GetDomain().InfoSchema())
 		log.Info("Generating SQLs for restoring TiFlash Replica",
 			zap.Strings("sqls", sqls))
-		if client.ResetTiflashReplicas(ctx, sqls, g); err != nil {
+		if err := client.ResetTiflashReplicas(ctx, sqls, g); err != nil {
 			return errors.Annotate(err, "failed to reset tiflash replicas")
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63177

Problem Summary:
Currently, BR set tiflash replica one by one without any concurrency.
### What changed and how does it work?
optimize the speed of setting tiflash replica after log restore
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
