### PR TITLE
br/stream: initialize `newBase` for `doTruncateLog`.

### DIFF
--- a/br/pkg/glue/progressing.go
+++ b/br/pkg/glue/progressing.go
@@ -21,7 +21,15 @@ import (
 
 const OnlyOneTask int = -1
 
-var spinnerText []string = []string{".", "..", "..."}
+func coloredSpinner(s []string) []string {
+	c := color.New(color.Bold, color.FgGreen)
+	for i := range s {
+		s[i] = c.Sprint(s[i])
+	}
+	return s
+}
+
+var spinnerText []string = coloredSpinner([]string{"/", "-", "\\", "|"})
 
 type pbProgress struct {
 	bar      *mpb.Bar
@@ -47,6 +55,13 @@ func (p pbProgress) GetCurrent() int64 {
 // Close marks the progress as 100% complete and that Inc() can no longer be
 // called.
 func (p pbProgress) Close() {
+	// This wait shouldn't block.
+	// We are just waiting the progress bar refresh to the finished state.
+	defer func() {
+		p.bar.Wait()
+		p.progress.Wait()
+	}()
+
 	if p.bar.Completed() || p.bar.Aborted() {
 		return
 	}
@@ -165,7 +180,7 @@ func buildProgressBar(pb *mpb.Progress, title string, total int, extraFields ...
 }
 
 var (
-	spinnerDoneText = fmt.Sprintf("... %s", color.GreenString("DONE"))
+	spinnerDoneText = fmt.Sprintf(":: %s", color.GreenString("DONE"))
 )
 
 func buildOneTaskBar(pb *mpb.Progress, title string, total int) *mpb.Bar {

--- a/br/pkg/storage/local.go
+++ b/br/pkg/storage/local.go
@@ -52,7 +52,7 @@ func (l *LocalStorage) DeleteFile(_ context.Context, name string) error {
 		os.IsNotExist(err) {
 		return nil
 	}
-	return err
+	return errors.Annotatef(err, "failed to delete file %v", name)
 }
 
 // DeleteFiles deletes the files.

--- a/br/pkg/stream/BUILD.bazel
+++ b/br/pkg/stream/BUILD.bazel
@@ -64,7 +64,7 @@ go_test(
     ],
     embed = [":stream"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 47,
     deps = [
         "//br/pkg/storage",
         "//br/pkg/streamhelper",
@@ -87,6 +87,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@com_github_tikv_client_go_v2//oracle",
         "@org_golang_x_exp//maps",
+        "@org_uber_go_multierr//:multierr",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/br/pkg/stream/stream_metas.go
+++ b/br/pkg/stream/stream_metas.go
@@ -753,8 +753,8 @@ func (m MigrationExt) MergeAndMigrateTo(
 	err = m.writeBase(ctx, newBase)
 	if err != nil {
 		result.Warnings = append(
-			result.MigratedTo.Warnings,
-			errors.Annotatef(err, "failed to save the merged new base, nothing will happen"),
+			result.Warnings,
+			errors.Annotate(err, "failed to save the merged new base"),
 		)
 		// Put the new BASE here anyway. The caller may want this.
 		result.NewBase = newBase
@@ -776,9 +776,9 @@ func (m MigrationExt) MergeAndMigrateTo(
 	result.MigratedTo = m.MigrateTo(ctx, newBase, MTMaybeSkipTruncateLog(!config.alwaysRunTruncate && canSkipTruncate))
 
 	// Put the final BASE.
-	err = m.writeBase(ctx, result.MigratedTo.NewBase)
+	err = m.writeBase(ctx, result.NewBase)
 	if err != nil {
-		result.Warnings = append(result.MigratedTo.Warnings, errors.Annotatef(err, "failed to save the new base"))
+		result.Warnings = append(result.Warnings, errors.Annotatef(err, "failed to save the new base"))
 	}
 	return
 }
@@ -812,8 +812,6 @@ func (m MigrationExt) MigrateTo(ctx context.Context, mig *pb.Migration, opts ...
 	result := MigratedTo{
 		NewBase: new(pb.Migration),
 	}
-	// Fills: EditMeta for new Base.
-	m.doMetaEdits(ctx, mig, &result)
 	// Fills: TruncatedTo, Compactions, DesctructPrefix.
 	if !opt.skipTruncateLog {
 		m.doTruncating(ctx, mig, &result)
@@ -822,6 +820,10 @@ func (m MigrationExt) MigrateTo(ctx context.Context, mig *pb.Migration, opts ...
 		result.NewBase.Compactions = mig.Compactions
 		result.NewBase.TruncatedTo = mig.TruncatedTo
 	}
+
+	// We do skip truncate log first, so metas removed by truncating can be removed in this execution.
+	// Fills: EditMeta for new Base.
+	m.doMetaEdits(ctx, mig, &result)
 
 	return result
 }
@@ -839,6 +841,7 @@ func (m MigrationExt) writeBase(ctx context.Context, mig *pb.Migration) error {
 }
 
 // doMetaEdits applies the modification to the meta files in the storage.
+// This will delete data files firstly. Make sure the new BASE was persisted before calling this.
 func (m MigrationExt) doMetaEdits(ctx context.Context, mig *pb.Migration, out *MigratedTo) {
 	m.Hooks.StartHandlingMetaEdits(mig.EditMeta)
 
@@ -846,14 +849,26 @@ func (m MigrationExt) doMetaEdits(ctx context.Context, mig *pb.Migration, out *M
 		if isEmptyEdition(medit) {
 			return
 		}
+
+		// Sometimes, the meta file will be deleted by truncating.
+		// We clean up those meta edits.
+		// NOTE: can we unify the deletion of truncating and meta editing?
+		// Say, add a "normalize" phase that load all files to be deleted to the migration.
+		// The problem here is a huge migration may be created in memory then leading to OOM.
+		exists, errChkExist := m.s.FileExists(ctx, medit.Path)
+		if errChkExist == nil && !exists {
+			log.Warn("The meta file doesn't exist, skipping the edit", zap.String("path", medit.Path))
+			return
+		}
+
+		// Firstly delete data so they won't leak when BR crashes.
+		m.cleanUpFor(ctx, medit, out)
 		err := m.applyMetaEdit(ctx, medit)
 		if err != nil {
 			out.NewBase.EditMeta = append(out.NewBase.EditMeta, medit)
 			out.Warnings = append(out.Warnings, errors.Annotatef(err, "failed to apply meta edit %s to meta file", medit.Path))
 			return
 		}
-
-		m.cleanUpFor(ctx, medit, out)
 	}
 
 	defer m.Hooks.HandingMetaEditDone()
@@ -895,6 +910,13 @@ func (m MigrationExt) cleanUpFor(ctx context.Context, medit *pb.MetaEdit, out *M
 		}
 	}
 
+	if len(out.Warnings) > 0 {
+		log.Warn(
+			"Failed to clean up for meta edit.",
+			zap.String("meta-edit", medit.Path),
+			zap.Errors("warnings", out.Warnings),
+		)
+	}
 	if !isEmptyEdition(newMetaEdit) {
 		out.NewBase.EditMeta = append(out.NewBase.EditMeta, newMetaEdit)
 	}
@@ -933,7 +955,6 @@ func (m MigrationExt) applyMetaEditTo(ctx context.Context, medit *pb.MetaEdit, m
 	})
 	metadata.FileGroups = slices.DeleteFunc(metadata.FileGroups, func(dfg *pb.DataFileGroup) bool {
 		del := slices.Contains(medit.DeletePhysicalFiles, dfg.Path)
-		fmt.Println(medit.Path, medit.DeletePhysicalFiles, dfg.Path, del)
 		return del
 	})
 	for _, group := range metadata.FileGroups {
@@ -1102,6 +1123,7 @@ func (m MigrationExt) doTruncateLogs(
 			// We have already written `truncated-to` to the storage hence
 			// we don't need to worry that the user access files already deleted.
 			aOut := new(MigratedTo)
+			aOut.NewBase = new(pb.Migration)
 			m.cleanUpFor(ctx, me, aOut)
 			updateResult(func(r *MigratedTo) {
 				r.Warnings = append(r.Warnings, aOut.Warnings...)

--- a/br/pkg/stream/stream_metas_test.go
+++ b/br/pkg/stream/stream_metas_test.go
@@ -3,6 +3,7 @@
 package stream
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -23,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 )
@@ -347,8 +349,6 @@ func TestTruncateSafepoint(t *testing.T) {
 }
 
 func TestTruncateSafepointForGCS(t *testing.T) {
-	t.SkipNow()
-
 	require.True(t, intest.InTest)
 	ctx := context.Background()
 	opts := fakestorage.Options{
@@ -387,144 +387,6 @@ func TestTruncateSafepointForGCS(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ts, n, "failed at %d round: truncate safepoint mismatch", i)
 	}
-}
-
-func fakeMetaDatas(t *testing.T, helper *MetadataHelper, cf string) []*backuppb.Metadata {
-	ms := []*backuppb.Metadata{
-		{
-			StoreId: 1,
-			MinTs:   1500,
-			MaxTs:   2000,
-			Files: []*backuppb.DataFileInfo{
-				{
-					MinTs:                 1500,
-					MaxTs:                 2000,
-					Cf:                    cf,
-					MinBeginTsInDefaultCf: 800,
-				},
-			},
-		},
-		{
-			StoreId: 2,
-			MinTs:   3000,
-			MaxTs:   4000,
-			Files: []*backuppb.DataFileInfo{
-				{
-					MinTs:                 3000,
-					MaxTs:                 4000,
-					Cf:                    cf,
-					MinBeginTsInDefaultCf: 2000,
-				},
-			},
-		},
-		{
-			StoreId: 3,
-			MinTs:   5100,
-			MaxTs:   6100,
-			Files: []*backuppb.DataFileInfo{
-				{
-					MinTs:                 5100,
-					MaxTs:                 6100,
-					Cf:                    cf,
-					MinBeginTsInDefaultCf: 1800,
-				},
-			},
-		},
-	}
-
-	m2s := make([]*backuppb.Metadata, 0, len(ms))
-	for _, m := range ms {
-		raw, err := m.Marshal()
-		require.NoError(t, err)
-		m2, err := helper.ParseToMetadata(raw)
-		require.NoError(t, err)
-		m2s = append(m2s, m2)
-	}
-	return m2s
-}
-
-func fakeMetaDataV2s(t *testing.T, helper *MetadataHelper, cf string) []*backuppb.Metadata {
-	ms := []*backuppb.Metadata{
-		{
-			StoreId: 1,
-			MinTs:   1500,
-			MaxTs:   6100,
-			FileGroups: []*backuppb.DataFileGroup{
-				{
-					MinTs: 1500,
-					MaxTs: 6100,
-					DataFilesInfo: []*backuppb.DataFileInfo{
-						{
-							MinTs:                 1500,
-							MaxTs:                 2000,
-							Cf:                    cf,
-							MinBeginTsInDefaultCf: 800,
-						},
-						{
-							MinTs:                 3000,
-							MaxTs:                 4000,
-							Cf:                    cf,
-							MinBeginTsInDefaultCf: 2000,
-						},
-						{
-							MinTs:                 5200,
-							MaxTs:                 6100,
-							Cf:                    cf,
-							MinBeginTsInDefaultCf: 1700,
-						},
-					},
-				},
-				{
-					MinTs: 1000,
-					MaxTs: 5100,
-					DataFilesInfo: []*backuppb.DataFileInfo{
-						{
-							MinTs:                 9000,
-							MaxTs:                 10000,
-							Cf:                    cf,
-							MinBeginTsInDefaultCf: 0,
-						},
-						{
-							MinTs:                 3000,
-							MaxTs:                 4000,
-							Cf:                    cf,
-							MinBeginTsInDefaultCf: 2000,
-						},
-					},
-				},
-			},
-			MetaVersion: backuppb.MetaVersion_V2,
-		},
-		{
-			StoreId: 2,
-			MinTs:   4100,
-			MaxTs:   5100,
-			FileGroups: []*backuppb.DataFileGroup{
-				{
-					MinTs: 4100,
-					MaxTs: 5100,
-					DataFilesInfo: []*backuppb.DataFileInfo{
-						{
-							MinTs:                 4100,
-							MaxTs:                 5100,
-							Cf:                    cf,
-							MinBeginTsInDefaultCf: 1800,
-						},
-					},
-				},
-			},
-			MetaVersion: backuppb.MetaVersion_V2,
-		},
-	}
-	m2s := make([]*backuppb.Metadata, 0, len(ms))
-	for _, m := range ms {
-		raw, err := m.Marshal()
-		require.NoError(t, err)
-		m2, err := helper.ParseToMetadata(raw)
-		require.NoError(t, err)
-		m2s = append(m2s, m2)
-	}
-	return m2s
 }
 
 func ff(minTS, maxTS uint64) *backuppb.DataFileGroup {
@@ -707,12 +569,26 @@ func pmt(s storage.ExternalStorage, path string, mt *backuppb.Metadata) {
 	}
 }
 
+func pmlt(s storage.ExternalStorage, path string, mt *backuppb.Metadata, logPath func(i int) string) {
+	for i, g := range mt.FileGroups {
+		g.Path = logPath(i)
+		maxLen := uint64(0)
+		for _, sg := range g.DataFilesInfo {
+			if sg.RangeOffset+sg.Length > maxLen {
+				maxLen = sg.RangeOffset + sg.Length
+			}
+		}
+		os.WriteFile(g.Path, bytes.Repeat([]byte("0"), int(maxLen)), 0o644)
+	}
+	pmt(s, path, mt)
+}
+
 func pmig(s storage.ExternalStorage, num uint64, mt *backuppb.Migration) string {
 	numS := fmt.Sprintf("%08d", num)
-	if num == baseMigrationSN {
-		numS = baseMigrationName
-	}
 	name := fmt.Sprintf("%s_%08X.mgrt", numS, hashMigration(mt))
+	if num == baseMigrationSN {
+		name = baseMigrationName
+	}
 	p := path.Join(migrationPrefix, name)
 
 	data, err := mt.Marshal()
@@ -2829,4 +2705,84 @@ func TestWithSimpleTruncate(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestAppendingMigs(t *testing.T) {
+	s := tmp(t)
+	ctx := context.Background()
+	mN := func(n uint64) string { return fmt.Sprintf("v1/backupmeta/%05d.meta", n) }
+	lN := func(mn int) func(n int) string {
+		return func(n int) string { return fmt.Sprintf("v1/%05d_%05d.log", mn, n) }
+	}
+	placeholder := func(pfx string) string {
+		path := path.Join(pfx, "monolith")
+		require.NoError(t, s.WriteFile(ctx, path, []byte("🪨")))
+		return path
+	}
+	// asp appends a span to the data file info.
+	asp := func(b *backuppb.DataFileInfo, span *backuppb.Span) *backuppb.DataFileInfo {
+		b.RangeOffset = span.Offset
+		b.RangeLength = span.Length
+		return b
+	}
+
+	pmlt(s, mN(1), mf(1, [][]*backuppb.DataFileInfo{
+		{
+			asp(fi(10, 20, DefaultCF, 0), sp(0, 10)),
+			asp(fi(15, 30, WriteCF, 8), sp(10, 15)),
+			asp(fi(25, 35, WriteCF, 11), sp(25, 10)),
+			asp(fi(42, 65, WriteCF, 20), sp(35, 10)),
+		},
+	}), lN(1))
+	pmlt(s, mN(2), mf(2, [][]*backuppb.DataFileInfo{
+		{
+			asp(fi(45, 64, WriteCF, 32), sp(0, 19)),
+			asp(fi(65, 70, WriteCF, 55), sp(19, 5)),
+			asp(fi(50, 60, DefaultCF, 0), sp(24, 10)),
+			asp(fi(80, 85, WriteCF, 72), sp(34, 5)),
+		},
+	}), lN(2))
+	est := MigerationExtension(s)
+
+	cDir := func(n uint64) string { return fmt.Sprintf("%05d/output", n) }
+	aDir := func(n uint64) string { return fmt.Sprintf("%05d/metas", n) }
+	compaction := mCompaction(placeholder(cDir(1)), placeholder(aDir(1)), 15, 66)
+	del11 := mLogDel(mN(1), spans(lN(1)(0), 45, sp(0, 10), sp(10, 15)))
+	del12 := mLogDel(mN(1), spans(lN(1)(0), 45, sp(35, 10), sp(25, 10)))
+	del2 := mLogDel(mN(2), spans(lN(2)(0), 39, sp(24, 10)))
+	m := mig(compaction, del11, del2)
+	pmig(s, 1, m)
+	pmig(s, 2, mig(del12))
+
+	res := est.MergeAndMigrateTo(ctx, math.MaxInt, MMOptAlwaysRunTruncate(), MMOptAppendPhantomMigration(*mig(mTruncatedTo(65))))
+	require.NoError(t, multierr.Combine(res.Warnings...))
+	requireMigrationsEqual(t, res.NewBase, mig(mTruncatedTo(65), compaction, del2))
+	require.FileExists(t, filepath.Join(s.Base(), cDir(1), "monolith"))
+
+	res = est.MergeAndMigrateTo(ctx, math.MaxInt, MMOptInteractiveCheck(func(ctx context.Context, m *backuppb.Migration) bool {
+		return true
+	}), MMOptAlwaysRunTruncate(), MMOptAppendPhantomMigration(*mig(mTruncatedTo(100))))
+	require.NoError(t, multierr.Combine(res.Warnings...))
+	requireMigrationsEqual(t, res.NewBase, mig(mTruncatedTo(100)))
+	require.NoFileExists(t, filepath.Join(s.Base(), cDir(1), "monolith"))
+	require.NoFileExists(t, filepath.Join(s.Base(), mN(1)))
+	require.NoFileExists(t, filepath.Join(s.Base(), lN(1)(0)))
+}
+
+func TestUserAbort(t *testing.T) {
+	s := tmp(t)
+	ctx := context.Background()
+
+	pmig(s, 0, mig(mTruncatedTo(42)))
+	pmig(s, 1, mig(mTruncatedTo(96)))
+	est := MigerationExtension(s)
+	var res MergeAndMigratedTo
+	effs := est.DryRun(func(me MigrationExt) {
+		res = me.MergeAndMigrateTo(ctx, 1, MMOptInteractiveCheck(func(ctx context.Context, m *backuppb.Migration) bool {
+			return false
+		}))
+	})
+	require.Len(t, res.Warnings, 1)
+	require.ErrorContains(t, res.Warnings[0], "aborted")
+	require.Empty(t, effs)
 }


### PR DESCRIPTION


Signed-off-by: Juncen Yu <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63358

Problem Summary:
The `MigratedTo` field wasn't initialized, hence a failure on saving new metadata or deleting file causes a panic.

### What changed and how does it work?
This PR picked the optimization (without flags change) from #56761

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug that may cause `log truncate` panic when failed to delete file.
```
