### PR TITLE
br: fix alloc test for next gen

### DIFF
--- a/br/pkg/restore/snap_client/client_test.go
+++ b/br/pkg/restore/snap_client/client_test.go
@@ -491,8 +491,8 @@ func TestAllocTableIDs(t *testing.T) {
 	}
 	userTableIDNotReusedWhenNeedCheck, err = client.AllocTableIDs(ctx, tables, false, true, &checkpoint.PreallocIDs{
 		Start:          1,
-		ReusableBorder: 10000,
-		End:            20000,
+		ReusableBorder: max(10000, userDownstreamTableID),
+		End:            max(20000, userDownstreamTableID+1),
 		Hash:           computeIDsHash([]int64{userDownstreamTableID, 100, 200, 300}),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62803

Problem Summary:
The table ID of `mysql.user` in next gen is very large.
### What changed and how does it work?
Fix the unit test
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
