### PR TITLE
ddl,executor: fix usages of getting regions from pd client

### DIFF
--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -73,7 +73,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/backoff"
 	"github.com/pingcap/tidb/pkg/util/chunk"
-	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/generatedexpr"
 	"github.com/pingcap/tidb/pkg/util/intest"
@@ -2978,25 +2977,10 @@ func estimateRowSizeFromRegion(ctx context.Context, store kv.Storage, tbl table.
 	}
 	pid := tbl.Meta().ID
 	sk, ek := tablecodec.GetTableHandleKeyRange(pid)
-	sRegion, err := pdCli.GetRegionByKey(ctx, codec.EncodeBytes(nil, sk))
-	if err != nil {
-		return 0, err
-	}
-	eRegion, err := pdCli.GetRegionByKey(ctx, codec.EncodeBytes(nil, ek))
-	if err != nil {
-		return 0, err
-	}
-	sk, err = hex.DecodeString(sRegion.StartKey)
-	if err != nil {
-		return 0, err
-	}
-	ek, err = hex.DecodeString(eRegion.EndKey)
-	if err != nil {
-		return 0, err
-	}
+	start, end := hStore.GetCodec().EncodeRegionRange(sk, ek)
 	// We use the second region to prevent the influence of the front and back tables.
 	regionLimit := 3
-	regionInfos, err := pdCli.GetRegionsByKeyRange(ctx, pdHttp.NewKeyRange(sk, ek), regionLimit)
+	regionInfos, err := pdCli.GetRegionsByKeyRange(ctx, pdHttp.NewKeyRange(start, end), regionLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/ddl/reorg_util.go
+++ b/pkg/ddl/reorg_util.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/pkg/store/helper"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/tablecodec"
-	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	pdhttp "github.com/tikv/pd/client/http"
 	"go.uber.org/zap"
@@ -172,7 +171,7 @@ func getTableSizeByID(ctx context.Context, store kv.Storage, tbl table.Table) in
 	}
 	var totalSize int64
 	for _, pid := range pids {
-		size, err := estimateTableSizeByID(ctx, pdCli, pid)
+		size, err := estimateTableSizeByID(ctx, pdCli, helperStore, pid)
 		if err != nil {
 			logutil.DDLLogger().Warn("failed to estimate table size for calculating concurrency",
 				zap.Int64("physicalID", pid),
@@ -193,28 +192,12 @@ func getTableSizeByID(ctx context.Context, store kv.Storage, tbl table.Table) in
 	return totalSize
 }
 
-func estimateTableSizeByID(ctx context.Context, pdCli pdhttp.Client, pid int64) (int64, error) {
+func estimateTableSizeByID(ctx context.Context, pdCli pdhttp.Client, store helper.Storage, pid int64) (int64, error) {
 	sk, ek := tablecodec.GetTableHandleKeyRange(pid)
-	sRegion, err := pdCli.GetRegionByKey(ctx, codec.EncodeBytes(nil, sk))
-	if err != nil {
-		return 0, err
-	}
-	eRegion, err := pdCli.GetRegionByKey(ctx, codec.EncodeBytes(nil, ek))
-	if err != nil {
-		return 0, err
-	}
-	sk, err = hex.DecodeString(sRegion.StartKey)
-	if err != nil {
-		return 0, err
-	}
-	ek, err = hex.DecodeString(eRegion.EndKey)
-	if err != nil {
-		return 0, err
-	}
-
+	start, end := store.GetCodec().EncodeRegionRange(sk, ek)
 	var totalSize int64
 	for {
-		regionInfos, err := pdCli.GetRegionsByKeyRange(ctx, pdhttp.NewKeyRange(sk, ek), 128)
+		regionInfos, err := pdCli.GetRegionsByKeyRange(ctx, pdhttp.NewKeyRange(start, end), 128)
 		if err != nil {
 			return 0, err
 		}
@@ -225,11 +208,11 @@ func estimateTableSizeByID(ctx context.Context, pdCli pdhttp.Client, pid int64) 
 			totalSize += r.ApproximateSize * units.MiB
 		}
 		lastKey := regionInfos.Regions[len(regionInfos.Regions)-1].EndKey
-		sk, err = hex.DecodeString(lastKey)
+		start, err = hex.DecodeString(lastKey)
 		if err != nil {
 			return 0, err
 		}
-		if bytes.Compare(sk, ek) >= 0 {
+		if bytes.Compare(start, end) >= 0 {
 			break
 		}
 	}

--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -2140,23 +2140,8 @@ func (*memtableRetriever) getRegionsInfoForSingleTable(ctx context.Context, help
 		return nil, err
 	}
 	sk, ek := tablecodec.GetTableHandleKeyRange(tableID)
-	sRegion, err := pdCli.GetRegionByKey(ctx, codec.EncodeBytes(nil, sk))
-	if err != nil {
-		return nil, err
-	}
-	eRegion, err := pdCli.GetRegionByKey(ctx, codec.EncodeBytes(nil, ek))
-	if err != nil {
-		return nil, err
-	}
-	sk, err = hex.DecodeString(sRegion.StartKey)
-	if err != nil {
-		return nil, err
-	}
-	ek, err = hex.DecodeString(eRegion.EndKey)
-	if err != nil {
-		return nil, err
-	}
-	return pdCli.GetRegionsByKeyRange(ctx, pd.NewKeyRange(sk, ek), -1)
+	start, end := helper.Store.GetCodec().EncodeRegionRange(sk, ek)
+	return pdCli.GetRegionsByKeyRange(ctx, pd.NewKeyRange(start, end), -1)
 }
 
 func (e *memtableRetriever) setNewTiKVRegionStatusCol(region *pd.RegionInfo, table *helper.TableInfo) {

--- a/tests/realtikvtest/sessiontest/BUILD.bazel
+++ b/tests/realtikvtest/sessiontest/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "sessiontest_test",
     timeout = "moderate",
     srcs = [
+        "infoschema_test.go",
         "infoschema_v2_test.go",
         "main_test.go",
         "paging_test.go",
@@ -11,7 +12,7 @@ go_test(
     ],
     flaky = True,
     race = "on",
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/config",
         "//pkg/infoschema",

--- a/tests/realtikvtest/sessiontest/infoschema_test.go
+++ b/tests/realtikvtest/sessiontest/infoschema_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessiontest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/tests/realtikvtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextGenTiKVRegionStatus(t *testing.T) {
+	store, dom := realtikvtest.CreateMockStoreAndDomainAndSetup(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int);")
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+
+	showRegions := tk.MustQuery("show table t regions").Rows()
+	t.Log(showRegions)
+	require.Equal(t, 1, len(showRegions), showRegions)
+	tikvRegions := tk.MustQuery(fmt.Sprintf(
+		"select region_id from information_schema.tikv_region_status where table_id = %d", tbl.Meta().ID)).Rows()
+	require.Equal(t, 1, len(tikvRegions), tikvRegions)
+	t.Log(tikvRegions)
+	require.Equal(t, showRegions[0][0], tikvRegions[0][0])
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/61702

Problem Summary:

The old impl doesn't work in next-gen because the keys are not encoded by the keyspace.

### What changed and how does it work?

- Use `store.GetCodec()` to encode region ranges before sending get-region requests.
- Add a test for `information_schema.tikv_region_status`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Sysbench 20,000,000 rows (tableSizeInBytes=4.092GiB):
```
[2025/09/04 14:44:00.614 +08:00] [INFO] [reorg_util.go:134] ["initialize reorg meta"] [keyspaceName=keyspace1] [category=ddl] [jobSchema=test] [jobTable=sbtest1] [jobType="add index"] [enableDistTask=true] [enableFastReorg=true] [targetScope=dxf_service] [maxNodeCount=1] [tableSizeInBytes=4.092GiB] [concurrency=1] [batchSize=256]
```
Before this PR:
```
mysql> select * from information_schema.tikv_region_status where table_id = 7;
+-----------+--------------------+--------------------+----------+---------+------------+----------+----------+------------+--------------+--------------+----------------+----------------+---------------+---------------+------------+------------------+------------------+-------------------------+---------------------------+
| REGION_ID | START_KEY          | END_KEY            | TABLE_ID | DB_NAME | TABLE_NAME | IS_INDEX | INDEX_ID | INDEX_NAME | IS_PARTITION | PARTITION_ID | PARTITION_NAME | EPOCH_CONF_VER | EPOCH_VERSION | WRITTEN_BYTES | READ_BYTES | APPROXIMATE_SIZE | APPROXIMATE_KEYS | REPLICATIONSTATUS_STATE | REPLICATIONSTATUS_STATEID |
+-----------+--------------------+--------------------+----------+---------+------------+----------+----------+------------+--------------+--------------+----------------+----------------+---------------+---------------+------------+------------------+------------------+-------------------------+---------------------------+
|        14 | 72FFFFFF00000000FB | 7800000100000000FB |        7 | test    | sbtest1    |        1 |        1 | k_1        |            0 |         NULL | NULL           |              1 |            11 |             0 |          0 |                1 |                0 | NULL                    |                      NULL |
|        14 | 72FFFFFF00000000FB | 7800000100000000FB |        7 | test    | sbtest1    |        0 |     NULL | NULL       |            0 |         NULL | NULL           |              1 |            11 |             0 |          0 |                1 |                0 | NULL                    |                      NULL |
+-----------+--------------------+--------------------+----------+---------+------------+----------+----------+------------+--------------+--------------+----------------+----------------+---------------+---------------+------------+------------------+------------------+-------------------------+---------------------------+
2 rows in set (1 min 20.46 sec)

mysql> show table sbtest1 regions;
+-----------+------------------------------------------------+------------------------------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+------------------------+------------------+
| REGION_ID | START_KEY                                      | END_KEY                                        | LEADER_ID | LEADER_STORE_ID | PEERS | SCATTERING | WRITTEN_BYTES | READ_BYTES | APPROXIMATE_SIZE(MB) | APPROXIMATE_KEYS | SCHEDULING_CONSTRAINTS | SCHEDULING_STATE |
+-----------+------------------------------------------------+------------------------------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+------------------------+------------------+
|       270 | t_7_i_1_038000000001089dc20380000000000c530300 | t_7_r_4716102                                  |       271 |               1 | 271   |          0 |             0 |          0 |                 1031 |          4741227 |                        |                  |
|       272 | t_7_r_4716102                                  | t_7_r_9358899                                  |       273 |               1 | 273   |          0 |             0 |          0 |                 1029 |          4670598 |                        |                  |
|       274 | t_7_r_9358899                                  | t_7_r_14381182                                 |       275 |               1 | 275   |          0 |             0 |          0 |                 1040 |          5041457 |                        |                  |
|       146 | t_7_r_14381182                                 | t_281474976710596_                             |       147 |               1 | 147   |          0 |             0 |          0 |                 1177 |          5735440 |                        |                  |
|       276 | t_7_                                           | t_7_i_1_0380000000002426cb03800000000054a65e   |       277 |               1 | 277   |          0 |             0 |          0 |                    1 |                0 |                        |                  |
|       278 | t_7_i_1_0380000000002426cb03800000000054a65e   | t_7_i_1_03800000000098f7150380000000002ccea1   |       279 |               1 | 279   |          0 |             0 |          0 |                   72 |          9998595 |                        |                  |
|       280 | t_7_i_1_03800000000098f7150380000000002ccea1   | t_7_i_1_038000000001089dc20380000000000c530300 |       281 |               1 | 281   |          0 |             0 |          0 |                   72 |         10001405 |                        |                  |
+-----------+------------------------------------------------+------------------------------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+------------------------+------------------+
7 rows in set (0.01 sec)
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
