### PR TITLE
expression: constant skip the push-down check when to propagate constant

### DIFF
--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -359,14 +359,16 @@ func (s *propConstSolver) propagateColumnEQ() {
 				cond := s.conditions[k]
 				replaced, _, newExpr := tryToReplaceCond(s.ctx, coli, colj, cond, false)
 				if replaced {
-					if s.vaildExprFunc != nil && !s.vaildExprFunc(newExpr) {
+					// TODO(hawkingrei): if it is the true expression, we can remvoe it.
+					if !isConstant(newExpr) && s.vaildExprFunc != nil && !s.vaildExprFunc(newExpr) {
 						continue
 					}
 					s.conditions = append(s.conditions, newExpr)
 				}
 				replaced, _, newExpr = tryToReplaceCond(s.ctx, colj, coli, cond, false)
 				if replaced {
-					if s.vaildExprFunc != nil && !s.vaildExprFunc(newExpr) {
+					// TODO(hawkingrei): if it is the true expression, we can remvoe it.
+					if !isConstant(newExpr) && s.vaildExprFunc != nil && !s.vaildExprFunc(newExpr) {
 						continue
 					}
 					s.conditions = append(s.conditions, newExpr)
@@ -374,6 +376,12 @@ func (s *propConstSolver) propagateColumnEQ() {
 			}
 		}
 	}
+}
+
+// isConstant is to determine whether the expression is a constant.
+func isConstant(cond Expression) bool {
+	_, ok := cond.(*Constant)
+	return ok
 }
 
 func (s *propConstSolver) setConds2ConstFalse() {
@@ -721,7 +729,8 @@ func (s *propSpecialJoinConstSolver) deriveConds(outerCol, innerCol *Column, sch
 		}
 		replaced, _, newExpr := tryToReplaceCond(s.ctx, outerCol, innerCol, cond, true)
 		if replaced {
-			if s.vaildExprFunc != nil && !s.vaildExprFunc(newExpr) {
+			// TODO(hawkingrei): if it is the true expression, we can remvoe it.
+			if !isConstant(newExpr) && s.vaildExprFunc != nil && !s.vaildExprFunc(newExpr) {
 				continue
 			}
 			s.joinConds = append(s.joinConds, newExpr)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63374 

Problem Summary:

### What changed and how does it work?

At present, when performing constant folding, it may be possible to derive true/false. Currently, we can skip the push-down check, but in the future, this could directly handle expressions of true/false.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
