### PR TITLE
statistics: support specify table IDs

### DIFF
--- a/pkg/statistics/handle/BUILD.bazel
+++ b/pkg/statistics/handle/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/util/intest",
         "//pkg/util/logutil",
         "//pkg/util/memory",
+        "//pkg/util/slice",
         "//pkg/util/sqlexec",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
@@ -49,13 +50,17 @@ go_library(
 go_test(
     name = "handle_test",
     timeout = "short",
-    srcs = ["main_test.go"],
+    srcs = [
+        "bootstrap_test.go",
+        "main_test.go",
+    ],
     embed = [":handle"],
     flaky = True,
     race = "on",
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/testkit/testsetup",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/pkg/statistics/handle/bootstrap.go
+++ b/pkg/statistics/handle/bootstrap.go
@@ -799,6 +799,8 @@ func (h *Handle) InitStatsLite(ctx context.Context, tableIDs ...int64) (err erro
 		return errors.Trace(err)
 	}
 	statslogutil.StatsLogger().Info("Complete loading the histogram in the lite mode", zap.Duration("duration", time.Since(start)))
+	// If tableIDs is empty, it means we load all the tables' stats meta and histograms.
+	// So we can replace the global cache with the new cache.
 	if len(tableIDs) == 0 {
 		h.Replace(cache)
 	} else {

--- a/pkg/statistics/handle/bootstrap_test.go
+++ b/pkg/statistics/handle/bootstrap_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test cases for genInitStatsHistogramsSQL. Mirrors patterns used elsewhere
-// in this package for concise, require-based assertions.
 func TestGenInitStatsHistogramsSQLAllRecords(t *testing.T) {
 	// Non-paging with no specific table IDs should load all records.
 	opts := newGenHistSQLOptionsForTableIDs(nil)

--- a/pkg/statistics/handle/bootstrap_test.go
+++ b/pkg/statistics/handle/bootstrap_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package handle
 
 import (

--- a/pkg/statistics/handle/bootstrap_test.go
+++ b/pkg/statistics/handle/bootstrap_test.go
@@ -1,0 +1,63 @@
+package handle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test cases for genInitStatsHistogramsSQL. Mirrors patterns used elsewhere
+// in this package for concise, require-based assertions.
+func TestGenInitStatsHistogramsSQLAllRecords(t *testing.T) {
+	// Non-paging with no specific table IDs should load all records.
+	opts := newGenHistSQLOptionsForTableIDs(nil)
+	got := genInitStatsHistogramsSQL(opts)
+
+	expected := "select /*+ ORDER_INDEX(mysql.stats_histograms,tbl) */ HIGH_PRIORITY " +
+		"table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, " +
+		"tot_col_size, stats_ver, correlation from mysql.stats_histograms order by table_id"
+
+	require.Equal(t, expected, got)
+}
+
+func TestGenInitStatsHistogramsSQLPaging(t *testing.T) {
+	// Paging mode adds a closed-open [start, end) range filter.
+	opts := newGenHistSQLOptionsForPaging([2]int64{100, 200})
+	got := genInitStatsHistogramsSQL(opts)
+
+	expected := "select /*+ ORDER_INDEX(mysql.stats_histograms,tbl) */ HIGH_PRIORITY " +
+		"table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, " +
+		"tot_col_size, stats_ver, correlation from mysql.stats_histograms" +
+		" where table_id >= 100 and table_id < 200 order by table_id"
+
+	require.Equal(t, expected, got)
+}
+
+func TestGenInitStatsHistogramsSQLTableIDs(t *testing.T) {
+	// Non-paging with specific table IDs should produce an IN (...) clause
+	// using the provided order.
+	ids := []int64{5, 2, 7}
+	opts := newGenHistSQLOptionsForTableIDs(ids)
+	got := genInitStatsHistogramsSQL(opts)
+
+	expected := "select /*+ ORDER_INDEX(mysql.stats_histograms,tbl) */ HIGH_PRIORITY " +
+		"table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, " +
+		"tot_col_size, stats_ver, correlation from mysql.stats_histograms" +
+		" where table_id in (5,2,7) order by table_id"
+
+	require.Equal(t, expected, got)
+}
+
+func TestGenInitStatsMetaSQLAllRecords(t *testing.T) {
+	got := genInitStatsMetaSQL()
+	expected := "select HIGH_PRIORITY version, table_id, modify_count, count, snapshot, last_stats_histograms_version from mysql.stats_meta"
+	require.Equal(t, expected, got)
+}
+
+func TestGenInitStatsMetaSQLTableIDs(t *testing.T) {
+	got := genInitStatsMetaSQL(5, 2, 7)
+	// Note the spaces around parentheses are intentional per implementation.
+	expected := "select HIGH_PRIORITY version, table_id, modify_count, count, snapshot, last_stats_histograms_version from mysql.stats_meta" +
+		" where table_id in (5,2,7)"
+	require.Equal(t, expected, got)
+}

--- a/pkg/statistics/handle/bootstrap_test.go
+++ b/pkg/statistics/handle/bootstrap_test.go
@@ -56,7 +56,6 @@ func TestGenInitStatsMetaSQLAllRecords(t *testing.T) {
 
 func TestGenInitStatsMetaSQLTableIDs(t *testing.T) {
 	got := genInitStatsMetaSQL(5, 2, 7)
-	// Note the spaces around parentheses are intentional per implementation.
 	expected := "select HIGH_PRIORITY version, table_id, modify_count, count, snapshot, last_stats_histograms_version from mysql.stats_meta" +
 		" where table_id in (5,2,7)"
 	require.Equal(t, expected, got)

--- a/pkg/statistics/handle/handletest/initstats/BUILD.bazel
+++ b/pkg/statistics/handle/handletest/initstats/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -14,7 +14,10 @@
 
 package slice
 
-import "slices"
+import (
+	"slices"
+	"strconv"
+)
 
 // AllOf returns true if all elements in the slice match the predict func.
 func AllOf[T any](s []T, p func(T) bool) bool {
@@ -23,4 +26,13 @@ func AllOf[T any](s []T, p func(T) bool) bool {
 	return !slices.ContainsFunc(s, func(x T) bool {
 		return !p(x)
 	})
+}
+
+// Int64sToStrings converts a slice of int64 to a slice of string.
+func Int64sToStrings(ints []int64) []string {
+	strs := make([]string, len(ints))
+	for i, v := range ints {
+		strs[i] = strconv.FormatInt(v, 10)
+	}
+	return strs
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61273

Problem Summary:

### What changed and how does it work?

In this PR, I added support for lite init stats to allow specifying table IDs. This enables us to implement the refresh stats command when specific tables are provided.

I introduced a general option to allow passing the table ID to the init stats functions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
