### PR TITLE
bindinfo: add last_used_date to track bindinfo usage frequency

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -121,7 +121,7 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 //
 // The above variables are in the file br/pkg/restore/systable_restore.go
 func TestMonitorTheSystemTableIncremental(t *testing.T) {
-	require.Equal(t, int64(252), session.CurrentBootstrapVersion)
+	require.Equal(t, int64(253), session.CurrentBootstrapVersion)
 }
 
 func TestIsStatsTemporaryTable(t *testing.T) {

--- a/pkg/bindinfo/binding.go
+++ b/pkg/bindinfo/binding.go
@@ -100,6 +100,7 @@ func (b *Binding) UpdateUsageInfo() {
 	b.UsageInfo.Update()
 }
 
+// ResetUsageInfo is to reset the bindinfo useage info after writing into storage.
 func (b *Binding) ResetUsageInfo() {
 	b.UsageInfo.CreateAt.Store(nil)
 	b.UsageInfo.LastUsedAt.Store(nil)

--- a/pkg/bindinfo/binding.go
+++ b/pkg/bindinfo/binding.go
@@ -100,7 +100,7 @@ func (b *Binding) UpdateUsageInfo() {
 	b.UsageInfo.Update()
 }
 
-// ResetUsageInfo is to reset the bindinfo useage info after writing into storage.
+// ResetUsageInfo is to reset the bindinfo usage info after writing into storage.
 func (b *Binding) ResetUsageInfo() {
 	b.UsageInfo.CreateAt.Store(nil)
 	b.UsageInfo.LastUsedAt.Store(nil)

--- a/pkg/bindinfo/binding.go
+++ b/pkg/bindinfo/binding.go
@@ -98,11 +98,12 @@ func (b *Binding) size() float64 {
 
 // UpdateLastUsedAt is to update binding usage info when this binding is used.
 func (b *Binding) UpdateLastUsedAt() {
-	b.UsageInfo.UpdateLastUsedAt()
+	now := time.Now()
+	b.UsageInfo.LastUsedAt.Store(&now)
 }
 
-// UpdateSavedAt is to update the last saved time
-func (b *Binding) UpdateSavedAt(ts *time.Time) {
+// UpdateLastSavedAt is to update the last saved time
+func (b *Binding) UpdateLastSavedAt(ts *time.Time) {
 	b.UsageInfo.LastSavedAt.Store(ts)
 }
 
@@ -114,11 +115,6 @@ type bindingInfoUsageInfo struct {
 	LastUsedAt atomic.Pointer[time.Time]
 	// LastSavedAt records the last time when this binding is saved into storage.
 	LastSavedAt atomic.Pointer[time.Time]
-}
-
-func (b *bindingInfoUsageInfo) UpdateLastUsedAt() {
-	now := time.Now()
-	b.LastUsedAt.Store(&now)
 }
 
 var (

--- a/pkg/bindinfo/binding.go
+++ b/pkg/bindinfo/binding.go
@@ -109,7 +109,7 @@ func (b *Binding) UpdateLastSavedAt(ts *time.Time) {
 
 type bindingInfoUsageInfo struct {
 	// LastUsedAt records the last time when this binding is used.
-	// It is nil if this binding has never been used or has been reset after writing into storage.
+	// It is nil if this binding has never been used.
 	// It is updated when this binding is used.
 	// It is used to update the `last_used_time` field in mysql.bind_info table.
 	LastUsedAt atomic.Pointer[time.Time]

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -38,6 +38,9 @@ type BindingCacheUpdater interface {
 	// LoadFromStorageToCache loads global bindings from storage to the memory cache.
 	LoadFromStorageToCache(fullLoad bool) (err error)
 
+	// UpdateBindingUsageInfoToStorage is to update the binding usage info into storage
+	UpdateBindingUsageInfoToStorage()
+
 	// LastUpdateTime returns the last update time.
 	LastUpdateTime() types.Time
 }
@@ -94,6 +97,15 @@ func (u *bindingCacheUpdater) LoadFromStorageToCache(fullLoad bool) (err error) 
 	metrics.BindingCacheMemLimit.Set(float64(u.GetMemCapacity()))
 	metrics.BindingCacheNumBindings.Set(float64(len(u.GetAllBindings())))
 	return nil
+}
+
+// UpdateBindingUsageInfoToStorage is to update the binding usage info into storage
+func (u *bindingCacheUpdater) UpdateBindingUsageInfoToStorage() {
+	bindings := u.GetAllBindings()
+	err := UpdateBindingUsageInfoToStorage(u.sPool, bindings)
+	if err != nil {
+		bindingLogger().Warn("BindingHandle.UpdateBindingUsageInfoToStorage", zap.Error(err))
+	}
 }
 
 // LastUpdateTime returns the last update time.

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -38,7 +38,7 @@ type BindingCacheUpdater interface {
 	// LoadFromStorageToCache loads global bindings from storage to the memory cache.
 	LoadFromStorageToCache(fullLoad bool) (err error)
 
-	// UpdateBindingUsageInfoToStorage is to update the binding usage info into storage
+	// updateBindingUsageInfoToStorage is to update the binding usage info into storage
 	UpdateBindingUsageInfoToStorage()
 
 	// LastUpdateTime returns the last update time.
@@ -99,10 +99,10 @@ func (u *bindingCacheUpdater) LoadFromStorageToCache(fullLoad bool) (err error) 
 	return nil
 }
 
-// UpdateBindingUsageInfoToStorage is to update the binding usage info into storage
+// updateBindingUsageInfoToStorage is to update the binding usage info into storage
 func (u *bindingCacheUpdater) UpdateBindingUsageInfoToStorage() {
 	bindings := u.GetAllBindings()
-	err := UpdateBindingUsageInfoToStorage(u.sPool, bindings)
+	err := updateBindingUsageInfoToStorage(u.sPool, bindings)
 	if err != nil {
 		bindingLogger().Warn("BindingHandle.UpdateBindingUsageInfoToStorage", zap.Error(err))
 	}

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -38,8 +38,8 @@ type BindingCacheUpdater interface {
 	// LoadFromStorageToCache loads global bindings from storage to the memory cache.
 	LoadFromStorageToCache(fullLoad bool) (err error)
 
-	// updateBindingUsageInfoToStorage is to update the binding usage info into storage
-	UpdateBindingUsageInfoToStorage()
+	// UpdateBindingUsageInfoToStorage is to update the binding usage info into storage
+	UpdateBindingUsageInfoToStorage() error
 
 	// LastUpdateTime returns the last update time.
 	LastUpdateTime() types.Time
@@ -99,13 +99,15 @@ func (u *bindingCacheUpdater) LoadFromStorageToCache(fullLoad bool) (err error) 
 	return nil
 }
 
-// updateBindingUsageInfoToStorage is to update the binding usage info into storage
-func (u *bindingCacheUpdater) UpdateBindingUsageInfoToStorage() {
+// UpdateBindingUsageInfoToStorage is to update the binding usage info into storage
+func (u *bindingCacheUpdater) UpdateBindingUsageInfoToStorage() error {
+	defer func() {
+		if r := recover(); r != nil {
+			bindingLogger().Warn("panic when update usage info for binding", zap.Any("recover", r))
+		}
+	}()
 	bindings := u.GetAllBindings()
-	err := updateBindingUsageInfoToStorage(u.sPool, bindings)
-	if err != nil {
-		bindingLogger().Warn("BindingHandle.UpdateBindingUsageInfoToStorage", zap.Error(err))
-	}
+	return updateBindingUsageInfoToStorage(u.sPool, bindings)
 }
 
 // LastUpdateTime returns the last update time.

--- a/pkg/bindinfo/binding_operator.go
+++ b/pkg/bindinfo/binding_operator.go
@@ -106,7 +106,9 @@ func (op *bindingOperator) CreateBinding(sctx sessionctx.Context, bindings []*Bi
 			}
 			_, err = exec(
 				sctx,
-				`INSERT INTO mysql.bind_info VALUES (%?,%?, %?, %?, %?, %?, %?, %?, %?, %?, %?)`,
+				`INSERT INTO mysql.bind_info(
+ original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest
+) VALUES (%?,%?, %?, %?, %?, %?, %?, %?, %?, %?, %?)`,
 				binding.OriginalSQL,
 				binding.BindSQL,
 				strings.ToLower(binding.Db),

--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -96,7 +96,7 @@ func TestBindingLastUpdateTimeWithInvalidBind(t *testing.T) {
 	updateTime0 := rows0[0][1]
 	require.Equal(t, updateTime0, "0000-00-00 00:00:00")
 
-	tk.MustExec("insert into mysql.bind_info values('select * from `test` . `t`', 'invalid_binding', 'test', 'enabled', '2000-01-01 09:00:00', '2000-01-01 09:00:00', '', '','" +
+	tk.MustExec("insert into mysql.bind_info (original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest) values('select * from `test` . `t`', 'invalid_binding', 'test', 'enabled', '2000-01-01 09:00:00', '2000-01-01 09:00:00', '', '','" +
 		bindinfo.SourceManual + "', '', '')")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -260,7 +260,7 @@ func TestSetBindingStatusWithoutBindingInCache(t *testing.T) {
 
 	// Simulate creating bindings on other machines
 	_, sqlDigest := parser.NormalizeDigestForBinding("select * from `test` . `t` where `a` > ?")
-	tk.MustExec("insert into mysql.bind_info values('select * from `test` . `t` where `a` > ?', 'SELECT /*+ USE_INDEX(`t` `idx_a`)*/ * FROM `test`.`t` WHERE `a` > 10', 'test', 'enabled', '2000-01-02 09:00:00', '2000-01-02 09:00:00', '', '','" +
+	tk.MustExec("insert into mysql.bind_info (original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest) values('select * from `test` . `t` where `a` > ?', 'SELECT /*+ USE_INDEX(`t` `idx_a`)*/ * FROM `test`.`t` WHERE `a` > 10', 'test', 'enabled', '2000-01-02 09:00:00', '2000-01-02 09:00:00', '', '','" +
 		bindinfo.SourceManual + "', '" + sqlDigest.String() + "', '')")
 	tk.MustExec("set binding disabled for select * from t where a > 10")
 	tk.MustExec("admin reload bindings")
@@ -272,7 +272,7 @@ func TestSetBindingStatusWithoutBindingInCache(t *testing.T) {
 	utilCleanBindingEnv(tk)
 
 	// Simulate creating bindings on other machines
-	tk.MustExec("insert into mysql.bind_info values('select * from `test` . `t` where `a` > ?', 'SELECT * FROM `test`.`t` WHERE `a` > 10', 'test', 'disabled', '2000-01-02 09:00:00', '2000-01-02 09:00:00', '', '','" +
+	tk.MustExec("insert into mysql.bind_info (original_sql, bind_sql, default_db, status, create_time, update_time, charset, collation, source, sql_digest, plan_digest) values('select * from `test` . `t` where `a` > ?', 'SELECT * FROM `test`.`t` WHERE `a` > 10', 'test', 'disabled', '2000-01-02 09:00:00', '2000-01-02 09:00:00', '', '','" +
 		bindinfo.SourceManual + "', '" + sqlDigest.String() + "', '')")
 	tk.MustExec("set binding enabled for select * from t where a > 10")
 	tk.MustExec("admin reload bindings")

--- a/pkg/bindinfo/tests/BUILD.bazel
+++ b/pkg/bindinfo/tests/BUILD.bazel
@@ -5,12 +5,13 @@ go_test(
     timeout = "moderate",
     srcs = [
         "bind_test.go",
+        "bind_usage_info_test.go",
         "cross_db_binding_test.go",
         "main_test.go",
     ],
     flaky = True,
     race = "on",
-    shard_count = 22,
+    shard_count = 23,
     deps = [
         "//pkg/bindinfo",
         "//pkg/domain",

--- a/pkg/bindinfo/tests/bind_test.go
+++ b/pkg/bindinfo/tests/bind_test.go
@@ -44,7 +44,6 @@ func utilCleanBindingEnv(tk *testkit.TestKit) {
 func TestPrepareCacheWithBinding(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
-	tk.MustExec(`set tidb_enable_prepared_plan_cache=1`)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1(a int, b int, c int, key idx_b(b), key idx_c(c))")

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -56,7 +56,7 @@ func TestBindUsageInfo(t *testing.T) {
 	tk.MustExec(`create global binding using select /*+ leading(t1, t2, t3, t4, t5) */ * from *.t1, *.t2, *.t3, *.t4, *.t5`)
 	tk.MustExec("select * from t1, t2, t3, t4, t5")
 	tk.MustExec("execute stmt1;")
-	origin := tk.MustQuery(`select sql_digest,last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' order by sql_digest`)
+	origin := tk.MustQuery(fmt.Sprintf(`select sql_digest,last_used_date from mysql.bind_info where original_sql != '%s' order by sql_digest`, bindinfo.BuiltinPseudoSQL4BindLock))
 	origin.Check(testkit.Rows(
 		"5ce1df6eadf8b24222668b1bd2e995b72d4c88e6fe9340d8b13e834703e28c32 <nil>",
 		"5d3975ef2160c1e0517353798dac90a9914095d82c025e7cd97bd55aeb804798 <nil>",

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -68,7 +68,7 @@ func TestBindUsageInfo(t *testing.T) {
 	t.Log("result:", result.Rows())
 	// The last_used_date should be updated.
 	require.True(t, !origin.Equal(result.Rows()))
-	var last *testkit.Result
+	var first *testkit.Result
 	for range 5 {
 		tk.MustExec("execute stmt1;")
 		tk.MustExec("execute stmt2;")
@@ -82,10 +82,11 @@ func TestBindUsageInfo(t *testing.T) {
 		tk.MustQuery(fmt.Sprintf(`select last_used_date from mysql.bind_info where original_sql != '%s' and last_used_date is null`, bindinfo.BuiltinPseudoSQL4BindLock)).Check(testkit.Rows())
 		result := tk.MustQuery(fmt.Sprintf(`select sql_digest,last_used_date from mysql.bind_info where original_sql != '%s' order by sql_digest`, bindinfo.BuiltinPseudoSQL4BindLock))
 		t.Log("result:", result.Rows())
-		if last == nil {
-			last = result
+		if first == nil {
+			first = result
 		} else {
-			require.True(t, last.Equal(result.Rows()))
+			// in fact, The result of each for-loop should be the same.
+			require.True(t, first.Equal(result.Rows()))
 		}
 	}
 	// Set all last_used_date to null to simulate that the bindinfo in storage is not updated.

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -16,11 +16,16 @@ package tests
 
 import (
 	"testing"
+	"time"
 
+	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/testkit"
 )
 
 func TestBindUsageInfo(t *testing.T) {
+	bindinfo.WriteIntervalAfterNoReadBinding = 10 * time.Microsecond
+	bindinfo.MinCheckIntervalForUpdateBindingUsageInfo = 1
+	bindinfo.MaxCheckIntervalForUpdateBindingUsageInfo = 2
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 
@@ -34,4 +39,5 @@ func TestBindUsageInfo(t *testing.T) {
 	tk.MustExec(`create table t (a int, b int, c int, d int, e int, key(a), key(b), key(c), key(d), key(e))`)
 
 	tk.MustExec(`admin reload bindings`)
+
 }

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -100,13 +100,6 @@ func TestBindUsageInfo(t *testing.T) {
 	tk.MustExec("execute stmt1;")
 	tk.MustExec("execute stmt2;")
 	tk.MustExec("execute stmt3;")
-	tk.MustExec(`delete from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock'`)
-	// Althought we execute the stmts, we set a very long interval, so last_used_date should not be updated.
-	require.NoError(t, bindingHandle.UpdateBindingUsageInfoToStorage())
-	tk.MustQuery(`select * from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock'`).Check(testkit.Rows())
-	tk.MustExec("execute stmt1;")
-	tk.MustExec("execute stmt2;")
-	tk.MustExec("execute stmt3;")
 	tk.MustExec("select * from t1, t2, t3, t4, t5")
 	time.Sleep(1 * time.Second)
 	require.NoError(t, bindingHandle.UpdateBindingUsageInfoToStorage())

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -1,0 +1,37 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/testkit"
+)
+
+func TestBindUsageInfo(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t (a int, b int, c int, d int, e int, key(a), key(b), key(c), key(d), key(e))`)
+	tk.MustExec(`create database test1`)
+	tk.MustExec(`use test1`)
+	tk.MustExec(`create table t (a int, b int, c int, d int, e int, key(a), key(b), key(c), key(d), key(e))`)
+	tk.MustExec(`create database test2`)
+	tk.MustExec(`use test2`)
+	tk.MustExec(`create table t (a int, b int, c int, d int, e int, key(a), key(b), key(c), key(d), key(e))`)
+
+	tk.MustExec(`admin reload bindings`)
+}

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -101,7 +101,7 @@ func TestBindUsageInfo(t *testing.T) {
 	tk.MustExec("execute stmt2;")
 	tk.MustExec("execute stmt3;")
 	tk.MustExec(`delete from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock'`)
-	// Alought we execute the stmts, but we set a very long interval, so last_used_date should not be updated.
+	// Althought we execute the stmts, we set a very long interval, so last_used_date should not be updated.
 	require.NoError(t, bindingHandle.UpdateBindingUsageInfoToStorage())
 	tk.MustQuery(`select * from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock'`).Check(testkit.Rows())
 	tk.MustExec("execute stmt1;")

--- a/pkg/bindinfo/tests/bind_usage_info_test.go
+++ b/pkg/bindinfo/tests/bind_usage_info_test.go
@@ -64,7 +64,7 @@ func TestBindUsageInfo(t *testing.T) {
 		"aa3c510b94b9d680f729252ca88415794c8a4f52172c5f9e06c27bee57d08329 <nil>"))
 	time.Sleep(50 * time.Microsecond)
 	require.NoError(t, bindingHandle.UpdateBindingUsageInfoToStorage())
-	result := tk.MustQuery(`select sql_digest,last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' order by sql_digest`)
+	result := tk.MustQuery(fmt.Sprintf(`select sql_digest,last_used_date from mysql.bind_info where original_sql != '%s' order by sql_digest`, bindinfo.BuiltinPseudoSQL4BindLock))
 	t.Log("result:", result.Rows())
 	// The last_used_date should be updated.
 	require.True(t, !origin.Equal(result.Rows()))
@@ -79,8 +79,8 @@ func TestBindUsageInfo(t *testing.T) {
 		resetAllLastUsedData(tk)
 		require.NoError(t, bindingHandle.UpdateBindingUsageInfoToStorage())
 		checkBindinfoInMemory(t, bindingHandle, checklist)
-		tk.MustQuery(`select last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' and last_used_date is null`).Check(testkit.Rows())
-		result := tk.MustQuery(`select sql_digest,last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' order by sql_digest`)
+		tk.MustQuery(fmt.Sprintf(`select last_used_date from mysql.bind_info where original_sql != '%s' and last_used_date is null`, bindinfo.BuiltinPseudoSQL4BindLock)).Check(testkit.Rows())
+		result := tk.MustQuery(fmt.Sprintf(`select sql_digest,last_used_date from mysql.bind_info where original_sql != '%s' order by sql_digest`, bindinfo.BuiltinPseudoSQL4BindLock))
 		t.Log("result:", result.Rows())
 		if last == nil {
 			last = result

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -187,18 +187,13 @@ func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings
 		}
 	}()
 	for _, binding := range bindings {
-		lastSaved := binding.UsageInfo.LastSavedAt.Load()
-		if lastSaved == nil {
+		lastUsedAt := binding.UsageInfo.LastUsedAt.Load()
+		if lastUsedAt == nil {
 			continue
 		}
-		intest.AssertFunc(func() bool {
-			lastUsed := binding.UsageInfo.LastUsedAt.Load()
-			if lastUsed == nil {
-				return false
-			}
-			return lastUsed.Compare(*lastSaved) >= 0
-		}, " lastUsed should be later than or equal to lastSaved and lastSaved is not nil")
-		if time.Since(*lastSaved) > MaxWriteInterval {
+		lastSaved := binding.UsageInfo.LastSavedAt.Load()
+		if (lastSaved != nil && time.Since(*lastSaved) > MaxWriteInterval) ||
+			time.Since(*lastUsedAt) > MaxWriteInterval {
 			toWrite = append(toWrite, binding)
 			cnt++
 		}

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -192,8 +192,11 @@ func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings
 			continue
 		}
 		lastSaved := binding.UsageInfo.LastSavedAt.Load()
-		if (lastSaved != nil && time.Since(*lastSaved) > MaxWriteInterval) ||
-			time.Since(*lastUsedAt) > MaxWriteInterval {
+		// If a certain amount of time specified by MaxWriteInterval has passed since the last record was written,
+		// and it has been used in between, it will be written.
+		// If it has never been written before, it will be written if lastUsedAt exceeds MaxWriteInterval.
+		if (lastSaved != nil && time.Since(*lastSaved) >= MaxWriteInterval && lastUsedAt.After(*lastSaved)) ||
+			(lastSaved == nil && time.Since(*lastUsedAt) > MaxWriteInterval) {
 			toWrite = append(toWrite, binding)
 			cnt++
 		}

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -231,7 +231,7 @@ func updateBindingUsageInfoToStorageInternal(sPool util.DestroyableSessionPool, 
 		for _, binding := range bindings {
 			lastUsed := binding.UsageInfo.LastUsedAt.Load()
 			intest.Assert(lastUsed != nil)
-			err = saveBindUsage(sctx, binding.SQLDigest, binding.PlanDigest, *lastUsed)
+			err = saveBindingUsage(sctx, binding.SQLDigest, binding.PlanDigest, *lastUsed)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -269,7 +269,7 @@ func addLockForBinds(sctx sessionctx.Context, bindings []*Binding) error {
 	return nil
 }
 
-func saveBindUsage(sctx sessionctx.Context, sqldigest, planDigest string, ts time.Time) error {
+func saveBindingUsage(sctx sessionctx.Context, sqldigest, planDigest string, ts time.Time) error {
 	lastUsedTime := ts.UTC().Format(types.TimeFormat)
 	var sql = "UPDATE mysql.bind_info USE INDEX(digest_index) SET last_used_date = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE) WHERE sql_digest = %?"
 	if planDigest == "" {

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tidb/pkg/util/hint"
+	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	utilparser "github.com/pingcap/tidb/pkg/util/parser"
 	"github.com/pingcap/tidb/pkg/util/sqlexec"
@@ -169,50 +170,118 @@ func readBindingsFromStorage(sPool util.DestroyableSessionPool, condition string
 	return
 }
 
-const updateBindingUsageInfoBatchSize = 10
-
 var (
-	// WriteIntervalAfterNoReadBinding indicates the interval at which a write operation needs to be performed after a binding has not been read.
-	WriteIntervalAfterNoReadBinding = 1 * time.Hour
-	// MinCheckIntervalForUpdateBindingUsageInfo indicates the minimum interval to check whether to update binding usage info.
-	MinCheckIntervalForUpdateBindingUsageInfo = 5
-	// MaxCheckIntervalForUpdateBindingUsageInfo indicates the maximum interval to check whether to update binding usage info.
-	MaxCheckIntervalForUpdateBindingUsageInfo = 60
+	// UpdateBindingUsageInfoBatchSize indicates the batch size when updating binding usage info to storage.
+	UpdateBindingUsageInfoBatchSize = 100
+	// MaxWriteInterval indicates the interval at which a write operation needs to be performed after a binding has not been read.
+	MaxWriteInterval = 6 * time.Hour
 )
 
 func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings []*Binding) error {
-	err := callWithSCtx(sPool, true, func(sctx sessionctx.Context) error {
-		cnt := 0
+	toWrite := make([]*Binding, 0, UpdateBindingUsageInfoBatchSize)
+	now := time.Now()
+	cnt := 0
+	defer func() {
+		if cnt > 0 {
+			bindingLogger().Info("update binding usage info to storage", zap.Int("count", cnt), zap.Duration("duration", time.Since(now)))
+		}
+	}()
+	for _, binding := range bindings {
+		lastSaved := binding.UsageInfo.LastSavedAt.Load()
+		if lastSaved == nil {
+			continue
+		}
+		intest.AssertFunc(func() bool {
+			lastUsed := binding.UsageInfo.LastUsedAt.Load()
+			if lastUsed == nil {
+				return false
+			}
+			return lastUsed.Compare(*lastSaved) >= 0
+		}, " lastUsed should be later than or equal to lastSaved and lastSaved is not nil")
+		if time.Since(*lastSaved) > MaxWriteInterval {
+			toWrite = append(toWrite, binding)
+			cnt++
+		}
+		if len(toWrite) == UpdateBindingUsageInfoBatchSize {
+			err := updateBindingUsageInfoToStorageInternal(sPool, toWrite)
+			if err != nil {
+				return err
+			}
+			toWrite = toWrite[:0]
+		}
+	}
+	if len(toWrite) > 0 {
+		err := updateBindingUsageInfoToStorageInternal(sPool, toWrite)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateBindingUsageInfoToStorageInternal(sPool util.DestroyableSessionPool, bindings []*Binding) error {
+	err := callWithSCtx(sPool, true, func(sctx sessionctx.Context) (err error) {
+		if err = lockBindInfoTable(sctx); err != nil {
+			return errors.Trace(err)
+		}
+		// lockBindInfoTable is to prefetch the rows and lock them, it is good for performance when
+		// there are many bindings to update with multi tidb nodes.
+		// in the performance test, it takes 26.24s to update 44679 bindings.
+		if err = addLockForBinds(sctx, bindings); err != nil {
+			return errors.Trace(err)
+		}
 		for _, binding := range bindings {
-			createAt := binding.UsageInfo.CreateAt.Load()
-			if createAt == nil {
-				continue
-			}
-			lastUsedAt := binding.UsageInfo.LastUsedAt.Load()
-			if lastUsedAt == nil {
-				continue
-			}
-			if time.Since(*lastUsedAt) > WriteIntervalAfterNoReadBinding || lastUsedAt.Sub(*createAt) > 12*time.Hour {
-				err := saveBindUsage(sctx, binding.SQLDigest, *lastUsedAt)
-				if err != nil {
-					return err
-				}
-				binding.ResetUsageInfo()
-			}
-			if cnt > updateBindingUsageInfoBatchSize {
-				break
+			lastUsed := binding.UsageInfo.LastUsedAt.Load()
+			intest.Assert(lastUsed != nil)
+			err = saveBindUsage(sctx, binding.SQLDigest, binding.PlanDigest, *lastUsed)
+			if err != nil {
+				return errors.Trace(err)
 			}
 		}
 		return nil
 	})
+	if err == nil {
+		ts := time.Now()
+		for _, binding := range bindings {
+			binding.UpdateSavedAt(&ts)
+		}
+	}
 	return err
 }
 
-func saveBindUsage(sctx sessionctx.Context, sqldigest string, ts time.Time) error {
+func addLockForBinds(sctx sessionctx.Context, bindings []*Binding) error {
+	condition := make([]string, 0, len(bindings))
+	for _, binding := range bindings {
+		sqlDigest := binding.SQLDigest
+		planDigest := binding.PlanDigest
+		sql := fmt.Sprintf("('%s'", sqlDigest)
+		if planDigest == "" {
+			sql += ",NULL)"
+		} else {
+			sql += fmt.Sprintf(",'%s')", planDigest)
+		}
+		condition = append(condition, sql)
+	}
+	locksql := "select 1 from mysql.bind_info use index(digest_index) where (plan_digest, sql_digest) in (" +
+		strings.Join(condition, " , ") + ") for update"
+	_, err := exec(sctx, locksql)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func saveBindUsage(sctx sessionctx.Context, sqldigest, planDigest string, ts time.Time) error {
 	lastUsedTime := ts.UTC().Format(types.TimeFormat)
-	_, _, err := execRows(
+	var sql = "UPDATE mysql.bind_info USE INDEX(digest_index) SET last_used_date = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE) WHERE sql_digest = %?"
+	if planDigest == "" {
+		sql += " AND plan_digest IS NULL"
+	} else {
+		sql += fmt.Sprintf(" AND plan_digest = '%s'", planDigest)
+	}
+	_, err := exec(
 		sctx,
-		"UPDATE mysql.bind_info SET last_used_time = CONVERT_TZ(%?, '+00:00', @@TIME_ZONE) WHERE sql_digest = %?",
+		sql,
 		lastUsedTime, sqldigest,
 	)
 	return err

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -241,7 +241,7 @@ func updateBindingUsageInfoToStorageInternal(sPool util.DestroyableSessionPool, 
 	if err == nil {
 		ts := time.Now()
 		for _, binding := range bindings {
-			binding.UpdateSavedAt(&ts)
+			binding.UpdateLastSavedAt(&ts)
 		}
 	}
 	return err

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -214,7 +214,7 @@ func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings
 }
 
 func shouldUpdateBinding(lastSaved, lastUsed *time.Time) bool {
-	if lastUsed == nil {
+	if lastSaved == nil {
 		// If it has never been written before, it will be written.
 		return true
 	}

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -196,7 +196,7 @@ func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings
 		// and it has been used in between, it will be written.
 		// If it has never been written before, it will be written if lastUsedAt exceeds MaxWriteInterval.
 		if (lastSaved != nil && time.Since(*lastSaved) >= MaxWriteInterval && lastUsedAt.After(*lastSaved)) ||
-			(lastSaved == nil && time.Since(*lastUsedAt) > MaxWriteInterval) {
+			(lastSaved == nil) {
 			toWrite = append(toWrite, binding)
 			cnt++
 		}

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -174,7 +174,7 @@ const updateBindingUsageInfoBatchSize = 10
 // WriteIntervalAfterNoReadBinding indicates the interval at which a write operation needs to be performed after a binding has not been read.
 var WriteIntervalAfterNoReadBinding = 2 * time.Hour
 
-func UpdateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings []*Binding) error {
+func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings []*Binding) error {
 	err := callWithSCtx(sPool, true, func(sctx sessionctx.Context) error {
 		cnt := 0
 		for _, binding := range bindings {
@@ -191,6 +191,7 @@ func UpdateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings
 				if err != nil {
 					return err
 				}
+				binding.ResetUsageInfo()
 			}
 			if cnt > updateBindingUsageInfoBatchSize {
 				break

--- a/pkg/bindinfo/utils.go
+++ b/pkg/bindinfo/utils.go
@@ -171,8 +171,14 @@ func readBindingsFromStorage(sPool util.DestroyableSessionPool, condition string
 
 const updateBindingUsageInfoBatchSize = 10
 
-// WriteIntervalAfterNoReadBinding indicates the interval at which a write operation needs to be performed after a binding has not been read.
-var WriteIntervalAfterNoReadBinding = 2 * time.Hour
+var (
+	// WriteIntervalAfterNoReadBinding indicates the interval at which a write operation needs to be performed after a binding has not been read.
+	WriteIntervalAfterNoReadBinding = 1 * time.Hour
+	// MinCheckIntervalForUpdateBindingUsageInfo indicates the minimum interval to check whether to update binding usage info.
+	MinCheckIntervalForUpdateBindingUsageInfo = 5
+	// MaxCheckIntervalForUpdateBindingUsageInfo indicates the maximum interval to check whether to update binding usage info.
+	MaxCheckIntervalForUpdateBindingUsageInfo = 60
+)
 
 func updateBindingUsageInfoToStorage(sPool util.DestroyableSessionPool, bindings []*Binding) error {
 	err := callWithSCtx(sPool, true, func(sctx sessionctx.Context) error {

--- a/pkg/infoschema/test/clustertablestest/BUILD.bazel
+++ b/pkg/infoschema/test/clustertablestest/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     flaky = True,
     shard_count = 50,
     deps = [
+        "//pkg/bindinfo",
         "//pkg/config",
         "//pkg/config/kerneltype",
         "//pkg/domain",

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -1532,6 +1532,7 @@ func TestSetBindingStatusBySQLDigest(t *testing.T) {
 	tk.MustExec(sql)
 	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
 	bindinfo.MaxWriteInterval = 1 * time.Microsecond
+	time.Sleep(1 * time.Second)
 	require.NoError(t, s.dom.BindingHandle().UpdateBindingUsageInfoToStorage())
 	tk.MustQuery(`select last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' and last_used_date is null`).Check(testkit.Rows())
 	sqlDigest := tk.MustQuery("show global bindings").Rows()

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/fn"
 	"github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -1530,7 +1531,9 @@ func TestSetBindingStatusBySQLDigest(t *testing.T) {
 	sql = "select * from t where t.a = 1"
 	tk.MustExec(sql)
 	tk.MustQuery("select @@last_plan_from_binding").Check(testkit.Rows("1"))
-
+	bindinfo.MaxWriteInterval = 1 * time.Microsecond
+	require.NoError(t, s.dom.BindingHandle().UpdateBindingUsageInfoToStorage())
+	tk.MustQuery(`select last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' and last_used_date is null`).Check(testkit.Rows())
 	sqlDigest := tk.MustQuery("show global bindings").Rows()
 	tk.MustExec(fmt.Sprintf("set binding disabled for sql digest '%s'", sqlDigest[0][9]))
 	tk.MustExec(sql)

--- a/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
+++ b/pkg/infoschema/test/clustertablestest/cluster_tables_test.go
@@ -1534,7 +1534,8 @@ func TestSetBindingStatusBySQLDigest(t *testing.T) {
 	bindinfo.MaxWriteInterval = 1 * time.Microsecond
 	time.Sleep(1 * time.Second)
 	require.NoError(t, s.dom.BindingHandle().UpdateBindingUsageInfoToStorage())
-	tk.MustQuery(`select last_used_date from mysql.bind_info where original_sql != 'builtin_pseudo_sql_for_bind_lock' and last_used_date is null`).Check(testkit.Rows())
+	tk.MustQuery(fmt.Sprintf(`select last_used_date from mysql.bind_info where original_sql != '%s' and last_used_date is null`,
+		bindinfo.BuiltinPseudoSQL4BindLock)).Check(testkit.Rows())
 	sqlDigest := tk.MustQuery("show global bindings").Rows()
 	tk.MustExec(fmt.Sprintf("set binding disabled for sql digest '%s'", sqlDigest[0][9]))
 	tk.MustExec(sql)

--- a/pkg/session/BUILD.bazel
+++ b/pkg/session/BUILD.bazel
@@ -164,6 +164,7 @@ go_test(
     shard_count = 50,
     deps = [
         "//pkg/autoid_service",
+        "//pkg/bindinfo",
         "//pkg/config",
         "//pkg/config/kerneltype",
         "//pkg/ddl",

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -296,6 +296,7 @@ const (
 		source VARCHAR(10) NOT NULL DEFAULT 'unknown',
 		sql_digest varchar(64) DEFAULT NULL,
 		plan_digest varchar(64) DEFAULT NULL,
+		last_used_time TIMESTAMP DEFAULT NULL,
 		INDEX sql_index(original_sql(700),default_db(68)) COMMENT "accelerate the speed when add global binding query",
 		INDEX time_index(update_time) COMMENT "accelerate the speed when querying with last update time",
 		UNIQUE INDEX digest_index(plan_digest, sql_digest) COMMENT "avoid duplicated records"

--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -296,7 +296,7 @@ const (
 		source VARCHAR(10) NOT NULL DEFAULT 'unknown',
 		sql_digest varchar(64) DEFAULT NULL,
 		plan_digest varchar(64) DEFAULT NULL,
-		last_used_time TIMESTAMP DEFAULT NULL,
+		last_used_date date DEFAULT NULL,
 		INDEX sql_index(original_sql(700),default_db(68)) COMMENT "accelerate the speed when add global binding query",
 		INDEX time_index(update_time) COMMENT "accelerate the speed when querying with last update time",
 		UNIQUE INDEX digest_index(plan_digest, sql_digest) COMMENT "avoid duplicated records"

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2862,7 +2862,7 @@ func TestBindInfoUniqueIndex(t *testing.T) {
 	for _, sqlDigest := range []string{"null", "'x'", "'y'"} {
 		for _, planDigest := range []string{"null", "'x'", "'y'"} {
 			insertStmt := fmt.Sprintf(`insert into mysql.bind_info values (
-             "sql", "bind_sql", "db", "disabled", NOW(), NOW(), "", "", "", %s, %s)`,
+             "sql", "bind_sql", "db", "disabled", NOW(), NOW(), "", "", "", %s, %s, null)`,
 				sqlDigest, planDigest)
 			MustExec(t, seV245, insertStmt)
 			MustExec(t, seV245, insertStmt)

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -157,7 +158,7 @@ func TestBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, req.NumRows())
 	se.Close()
-	r = MustExecToRecodeSet(t, se, "select * from mysql.bind_info where original_sql = 'builtin_pseudo_sql_for_bind_lock'")
+	r = MustExecToRecodeSet(t, se, fmt.Sprintf("select * from mysql.bind_info where original_sql = ''%s''"), bindinfo.BuiltinPseudoSQL4BindLock)
 	req = r.NewChunk(nil)
 	err = r.Next(ctx, req)
 	require.NoError(t, err)

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -157,6 +157,12 @@ func TestBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, req.NumRows())
 	se.Close()
+	r = MustExecToRecodeSet(t, se, "select * from mysql.bind_info where original_sql = 'builtin_pseudo_sql_for_bind_lock'")
+	req = r.NewChunk(nil)
+	err = r.Next(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, req.NumRows())
+	se.Close()
 }
 
 func globalVarsCount() int64 {

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -158,7 +158,7 @@ func TestBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, req.NumRows())
 	se.Close()
-	r = MustExecToRecodeSet(t, se, fmt.Sprintf("select * from mysql.bind_info where original_sql = ''%s''"), bindinfo.BuiltinPseudoSQL4BindLock)
+	r = MustExecToRecodeSet(t, se, fmt.Sprintf("select * from mysql.bind_info where original_sql = '%s'", bindinfo.BuiltinPseudoSQL4BindLock))
 	req = r.NewChunk(nil)
 	err = r.Next(ctx, req)
 	require.NoError(t, err)

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 14,
+    shard_count = 15,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -962,3 +962,31 @@ func TestUpgradeBDRSecondary(t *testing.T) {
 	require.Equal(t, session.CurrentBootstrapVersion, ver)
 	newVer.Close()
 }
+
+func TestUpgradeBindInfo(t *testing.T) {
+	fromVersion := 251
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+	seV251 := session.CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(fromVersion))
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	revertVersionAndVariables(t, seV251, fromVersion)
+	require.NoError(t, err)
+	session.MustExec(t, seV251, "ADMIN RELOAD BINDINGS;")
+	store.SetOption(session.StoreBootstrappedKey, nil)
+	ver, err := session.GetBootstrapVersion(seV251)
+	require.NoError(t, err)
+	require.Equal(t, int64(fromVersion), ver)
+	dom.Close()
+	newVer, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	ver, err = session.GetBootstrapVersion(seV251)
+	require.NoError(t, err)
+	require.Equal(t, session.CurrentBootstrapVersion, ver)
+	session.MustExec(t, seV251, "ADMIN RELOAD BINDINGS;")
+	newVer.Close()
+}

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -984,9 +984,11 @@ func TestUpgradeBindInfo(t *testing.T) {
 	dom.Close()
 	newVer, err := session.BootstrapSession(store)
 	require.NoError(t, err)
-	ver, err = session.GetBootstrapVersion(seV251)
+	seLatestV := session.CreateSessionAndSetID(t, store)
+	ver, err = session.GetBootstrapVersion(seLatestV)
 	require.NoError(t, err)
 	require.Equal(t, session.CurrentBootstrapVersion, ver)
-	session.MustExec(t, seV251, "ADMIN RELOAD BINDINGS;")
+	session.MustExec(t, seLatestV, "ADMIN RELOAD BINDINGS;")
 	newVer.Close()
+	seLatestV.Close()
 }

--- a/pkg/session/upgrade.go
+++ b/pkg/session/upgrade.go
@@ -466,9 +466,12 @@ const (
 	version251 = 251
 
 	// version 252
-	// Update FSP of mysql.bind_info timestamp columns to microsecond precision and
-	// add last_used_time to mysql.bind_info
+	// Update FSP of mysql.bind_info timestamp columns to microsecond precision.
 	version252 = 252
+
+	// version253
+	// Add last_used_date to mysql.bind_info
+	version253 = 253
 )
 
 // versionedUpgradeFunction is a struct that holds the upgrade function related
@@ -482,7 +485,7 @@ type versionedUpgradeFunction struct {
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version252
+var currentBootstrapVersion int64 = version253
 
 var (
 	// this list must be ordered by version in ascending order, and the function
@@ -659,6 +662,7 @@ var (
 		{version: version250, fn: upgradeToVer250},
 		{version: version251, fn: upgradeToVer251},
 		{version: version252, fn: upgradeToVer252},
+		{version: version253, fn: upgradeToVer253},
 	}
 )
 
@@ -2028,5 +2032,8 @@ func upgradeToVer251(s sessionapi.Session, _ int64) {
 func upgradeToVer252(s sessionapi.Session, _ int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.bind_info CHANGE create_time create_time TIMESTAMP(6)")
 	doReentrantDDL(s, "ALTER TABLE mysql.bind_info CHANGE update_time update_time TIMESTAMP(6)")
-	doReentrantDDL(s, "ALTER TABLE mysql.bind_info ADD COLUMN last_used_time TIMESTAMP DEFAULT NULL AFTER `plan_digest`", infoschema.ErrColumnExists)
+}
+
+func upgradeToVer253(s sessionapi.Session, _ int64) {
+	doReentrantDDL(s, "ALTER TABLE mysql.bind_info ADD COLUMN last_used_date DATE DEFAULT NULL AFTER `plan_digest`", infoschema.ErrColumnExists)
 }

--- a/pkg/session/upgrade.go
+++ b/pkg/session/upgrade.go
@@ -466,7 +466,8 @@ const (
 	version251 = 251
 
 	// version 252
-	// Update FSP of mysql.bind_info timestamp columns to microsecond precision.
+	// Update FSP of mysql.bind_info timestamp columns to microsecond precision and
+	// add last_used_time to mysql.bind_info
 	version252 = 252
 )
 
@@ -2027,4 +2028,5 @@ func upgradeToVer251(s sessionapi.Session, _ int64) {
 func upgradeToVer252(s sessionapi.Session, _ int64) {
 	doReentrantDDL(s, "ALTER TABLE mysql.bind_info CHANGE create_time create_time TIMESTAMP(6)")
 	doReentrantDDL(s, "ALTER TABLE mysql.bind_info CHANGE update_time update_time TIMESTAMP(6)")
+	doReentrantDDL(s, "ALTER TABLE mysql.bind_info ADD COLUMN last_used_time TIMESTAMP DEFAULT NULL AFTER `plan_digest`", infoschema.ErrColumnExists)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63407 

Problem Summary:

### What changed and how does it work?

Currently, some customers have created a large number of bindings. However, it is difficult to determine whether these bindings are still in use. The sheer volume of bindings also puts pressure on TiDB. Therefore, we need a way to identify and mark the bindings that are not in use.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

start a tidb with master which is started by script. ```Tikv``` and ```PD``` is started by ```tiup playground nightly --mode tikv-slim```.

```
+----------------------------------+----------------------------------+------------+---------+-------------------------+-------------------------+---------+-----------+---------+------------+-------------+
| original_sql                     | bind_sql                         | default_db | status  | create_time             | update_time             | charset | collation | source  | sql_digest | plan_digest |
+----------------------------------+----------------------------------+------------+---------+-------------------------+-------------------------+---------+-----------+---------+------------+-------------+
| builtin_pseudo_sql_for_bind_lock | builtin_pseudo_sql_for_bind_lock | mysql      | builtin | 0000-00-00 00:00:00.000 | 0000-00-00 00:00:00.000 |         |           | builtin | <null>     | <null>      |
+----------------------------------+----------------------------------+------------+---------+-------------------------+-------------------------+---------+-----------+---------+------------+-------------+
```

kill this TiDB and start changed tidb verson.

```
+----------------------------------+----------------------------------+------------+---------+-------------------------+-------------------------+---------+-----------+---------+------------+-------------+----------------+
| original_sql                     | bind_sql                         | default_db | status  | create_time             | update_time             | charset | collation | source  | sql_digest | plan_digest | last_used_time |
+----------------------------------+----------------------------------+------------+---------+-------------------------+-------------------------+---------+-----------+---------+------------+-------------+----------------+
| builtin_pseudo_sql_for_bind_lock | builtin_pseudo_sql_for_bind_lock | mysql      | builtin | 0000-00-00 00:00:00.000 | 0000-00-00 00:00:00.000 |         |           | builtin | <null>     | <null>      | <null>         |
+----------------------------------+----------------------------------+------------+---------+-------------------------+-------------------------+---------+-----------+---------+------------+-------------+----------------+
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
