### PR TITLE
br: fix stats meta count is zero if no checksum 8.5

### DIFF
--- a/br/pkg/metautil/metafile.go
+++ b/br/pkg/metautil/metafile.go
@@ -161,6 +161,7 @@ type Table struct {
 	TotalKvs         uint64
 	TotalBytes       uint64
 	Files            []*backuppb.File
+	TotalKvsMap      map[int64]uint64
 	TiFlashReplicas  int
 	Stats            *util.JSONTable
 	StatsFileIndexes []*backuppb.StatsFileIndex
@@ -249,6 +250,14 @@ func (stats ChecksumStats) ChecksumExists() bool {
 		return false
 	}
 	return true
+}
+
+func CalculateTotalKvsOnFiles(files []*backuppb.File) uint64 {
+	totalKvs := uint64(0)
+	for _, file := range files {
+		totalKvs += file.TotalKvs
+	}
+	return totalKvs
 }
 
 // CalculateChecksumStatsOnFiles returns the ChecksumStats for the given files
@@ -436,12 +445,14 @@ func (reader *MetaReader) ReadSchemasFiles(ctx context.Context, output chan<- *T
 			if table.Info != nil {
 				if fileMap != nil {
 					if files, ok := fileMap[table.Info.ID]; ok {
+						table.TotalKvsMap[table.Info.ID] = CalculateTotalKvsOnFiles(files)
 						table.Files = append(table.Files, files...)
 					}
 					if table.Info.Partition != nil {
 						// Partition table can have many table IDs (partition IDs).
 						for _, p := range table.Info.Partition.Definitions {
 							if files, ok := fileMap[p.ID]; ok {
+								table.TotalKvsMap[p.ID] = CalculateTotalKvsOnFiles(files)
 								table.Files = append(table.Files, files...)
 							}
 						}
@@ -498,6 +509,7 @@ func parseSchemaFile(s *backuppb.Schema) (*Table, error) {
 		Crc64Xor:         s.Crc64Xor,
 		TotalKvs:         s.TotalKvs,
 		TotalBytes:       s.TotalBytes,
+		TotalKvsMap:      make(map[int64]uint64),
 		TiFlashReplicas:  int(s.TiflashReplicas),
 		Stats:            stats,
 		StatsFileIndexes: statsFileIndexes,

--- a/br/pkg/restore/snap_client/pipeline_items.go
+++ b/br/pkg/restore/snap_client/pipeline_items.go
@@ -225,12 +225,19 @@ func (rc *SnapClient) GoUpdateMetaAndLoadStats(
 		}
 
 		if statsErr != nil || !loadStats || (oldTable.Stats == nil && len(oldTable.StatsFileIndexes) == 0) {
-			// Not need to return err when failed because of update analysis-meta
-			log.Info("start update metas", zap.Stringer("table", oldTable.Info.Name), zap.Stringer("db", oldTable.DB.Name))
-			// the total kvs contains the index kvs, but the stats meta needs the count of rows
-			count := int64(oldTable.TotalKvs / uint64(len(oldTable.Info.Indices)+1))
-			if statsErr = statsHandler.SaveMetaToStorage(tbl.Table.ID, count, 0, "br restore", false); statsErr != nil {
-				log.Error("update stats meta failed", zap.Any("table", tbl.Table), zap.Error(statsErr))
+			for physicalID, totalKvs := range oldTable.TotalKvsMap {
+				// the total kvs contains the index kvs, but the stats meta needs the count of rows
+				count := int64(totalKvs / uint64(len(oldTable.Info.Indices)+1))
+				// Not need to return err when failed because of update analysis-meta
+				log.Info("start update metas",
+					zap.Stringer("table", oldTable.Info.Name),
+					zap.Stringer("db", oldTable.DB.Name),
+					zap.Int64("physical id", physicalID),
+					zap.Int64("count", count),
+				)
+				if statsErr = statsHandler.SaveMetaToStorage(physicalID, count, 0, "br restore", false); statsErr != nil {
+					log.Error("update stats meta failed", zap.Any("table", tbl.Table), zap.Error(statsErr))
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60978

Problem Summary:
the count of stats_meta is zero if backup has no checksum
### What changed and how does it work?
get the count of stats_meta by collecting the files instead of total kvs of table.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
