### PR TITLE
importinto: fix zero update time during validation phase and refine logs

### DIFF
--- a/pkg/disttask/framework/scheduler/scheduler.go
+++ b/pkg/disttask/framework/scheduler/scheduler.go
@@ -690,6 +690,11 @@ func (*BaseScheduler) isStepSucceed(cntByStates map[proto.SubtaskState]int64) bo
 	return len(cntByStates) == 0 || (len(cntByStates) == 1 && ok)
 }
 
+// GetLogger returns the logger.
+func (s *BaseScheduler) GetLogger() *zap.Logger {
+	return s.logger
+}
+
 // IsCancelledErr checks if the error is a cancelled error.
 func IsCancelledErr(err error) bool {
 	return strings.Contains(err.Error(), taskCancelMsg)

--- a/pkg/disttask/importinto/planner.go
+++ b/pkg/disttask/importinto/planner.go
@@ -55,6 +55,7 @@ type LogicalPlan struct {
 	Stmt              string
 	EligibleInstances []*serverinfo.ServerInfo
 	ChunkMap          map[int32][]importer.Chunk
+	Logger            *zap.Logger
 
 	// summary for next step
 	summary importer.StepSummary
@@ -294,7 +295,7 @@ func buildControllerForPlan(p *LogicalPlan) (*importer.LoadDataController, error
 	if err != nil {
 		return nil, err
 	}
-	controller, err := importer.NewLoadDataController(plan, tbl, astArgs)
+	controller, err := importer.NewLoadDataController(plan, tbl, astArgs, importer.WithLogger(p.Logger))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/disttask/importinto/proto.go
+++ b/pkg/disttask/importinto/proto.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/lightning/backend/external"
 	"github.com/pingcap/tidb/pkg/lightning/verification"
 	"github.com/pingcap/tidb/pkg/meta/autoid"
+	"go.uber.org/zap"
 )
 
 // TaskMeta is the task of IMPORT INTO.
@@ -162,6 +163,7 @@ type importStepMinimalTask struct {
 	Chunk      importer.Chunk
 	SharedVars *SharedVars
 	panicked   *atomic.Bool
+	logger     *zap.Logger
 }
 
 // RecoverArgs implements workerpool.TaskMayPanic interface.

--- a/pkg/disttask/importinto/scheduler.go
+++ b/pkg/disttask/importinto/scheduler.go
@@ -287,18 +287,19 @@ func (sch *importScheduler) OnNextSubtasksBatch(
 		// available.
 		nodeCnt = task.MaxNodeCount
 	}
+	taskMeta := &TaskMeta{}
+	err = json.Unmarshal(task.Meta, taskMeta)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	logger := logutil.BgLogger().With(
 		zap.Stringer("type", task.Type),
 		zap.Int64("task-id", task.ID),
 		zap.String("curr-step", proto.Step2Str(task.Type, task.Step)),
 		zap.String("next-step", proto.Step2Str(task.Type, nextStep)),
 		zap.Int("node-count", nodeCnt),
+		zap.Int64("table-id", taskMeta.Plan.TableInfo.ID),
 	)
-	taskMeta := &TaskMeta{}
-	err = json.Unmarshal(task.Meta, taskMeta)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	logger.Info("on next subtasks batch")
 
 	previousSubtaskMetas := make(map[proto.Step][][]byte, 1)

--- a/pkg/disttask/importinto/subtask_executor.go
+++ b/pkg/disttask/importinto/subtask_executor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl"
-	"github.com/pingcap/tidb/pkg/disttask/framework/proto"
 	"github.com/pingcap/tidb/pkg/disttask/framework/taskexecutor/execute"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor/importer"
@@ -63,8 +62,7 @@ func (e *importMinimalTaskExecutor) Run(
 	dataWriter, indexWriter backend.EngineWriter,
 	collector execute.Collector,
 ) error {
-	logger := logutil.BgLogger().With(zap.Stringer("type", proto.ImportInto), zap.Int64("table-id", e.mTtask.Plan.TableInfo.ID))
-	logger.Info("execute chunk")
+	logger := e.mTtask.logger
 	failpoint.Inject("beforeSortChunk", func() {})
 	failpoint.Inject("errorWhenSortChunk", func() {
 		failpoint.Return(errors.New("occur an error when sort chunk"))

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -241,6 +241,7 @@ outer:
 			Chunk:      chunk,
 			SharedVars: sharedVars,
 			panicked:   &panicked,
+			logger:     logger,
 		}:
 		case <-op.Done():
 			break outer

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -84,6 +84,7 @@ func getTableImporter(
 	taskID int64,
 	taskMeta *TaskMeta,
 	store tidbkv.Storage,
+	logger *zap.Logger,
 ) (*importer.TableImporter, error) {
 	idAlloc := kv.NewPanickingAllocators(taskMeta.Plan.TableInfo.SepAutoInc())
 	tbl, err := tables.TableFromMeta(idAlloc, taskMeta.Plan.TableInfo)
@@ -94,7 +95,7 @@ func getTableImporter(
 	if err != nil {
 		return nil, err
 	}
-	controller, err := importer.NewLoadDataController(&taskMeta.Plan, tbl, astArgs)
+	controller, err := importer.NewLoadDataController(&taskMeta.Plan, tbl, astArgs, importer.WithLogger(logger))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (s *importStepExecutor) Init(ctx context.Context) (err error) {
 	s.logger.Info("init subtask env")
 	var tableImporter *importer.TableImporter
 	var taskManager *dxfstorage.TaskManager
-	tableImporter, err = getTableImporter(ctx, s.taskID, s.taskMeta, s.store)
+	tableImporter, err = getTableImporter(ctx, s.taskID, s.taskMeta, s.store, s.logger)
 	if err != nil {
 		return err
 	}
@@ -498,7 +499,7 @@ type writeAndIngestStepExecutor struct {
 var _ execute.StepExecutor = &writeAndIngestStepExecutor{}
 
 func (e *writeAndIngestStepExecutor) Init(ctx context.Context) error {
-	tableImporter, err := getTableImporter(ctx, e.taskID, e.taskMeta, e.store)
+	tableImporter, err := getTableImporter(ctx, e.taskID, e.taskMeta, e.store, e.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -551,8 +551,18 @@ func ASTArgsFromStmt(stmt string) (*ASTArgs, error) {
 	}, nil
 }
 
+// Option is used to set optional parameters for LoadDataController.
+type Option func(c *LoadDataController)
+
+// WithLogger sets the logger for LoadDataController.
+func WithLogger(logger *zap.Logger) Option {
+	return func(c *LoadDataController) {
+		c.logger = logger
+	}
+}
+
 // NewLoadDataController create new controller.
-func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs) (*LoadDataController, error) {
+func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs, options ...Option) (*LoadDataController, error) {
 	fullTableName := tbl.Meta().Name.String()
 	logger := log.L().With(zap.String("table", fullTableName))
 	c := &LoadDataController{
@@ -562,6 +572,10 @@ func NewLoadDataController(plan *Plan, tbl table.Table, astArgs *ASTArgs) (*Load
 		logger:          logger,
 		ExecuteNodesCnt: 1,
 	}
+	for _, opt := range options {
+		opt(c)
+	}
+
 	if err := c.checkFieldParams(); err != nil {
 		return nil, err
 	}

--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -2456,7 +2456,13 @@ func FillOneImportJobInfo(result *chunk.Chunk, info *importer.JobInfo, runInfo *
 		return
 	}
 
-	result.AppendTime(14, runInfo.UpdateTime)
+	// update time of run info comes from subtask summary, but checksum step don't
+	// have period updated summary.
+	updateTime := runInfo.UpdateTime
+	if updateTime.IsZero() {
+		updateTime = info.UpdateTime
+	}
+	result.AppendTime(14, updateTime)
 	result.AppendString(15, proto.Step2Str(proto.ImportInto, runInfo.Step))
 	result.AppendString(16, runInfo.ProcessedSize())
 	result.AppendString(17, runInfo.TotalSize())

--- a/pkg/executor/show_test.go
+++ b/pkg/executor/show_test.go
@@ -44,8 +44,11 @@ func TestFillOneImportJobInfo(t *testing.T) {
 		fieldTypes = append(fieldTypes, fieldType)
 	}
 	c := chunk.New(fieldTypes, 10, 10)
+	t2024 := types.NewTime(types.FromGoTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)), mysql.TypeTimestamp, 0)
+	t2025 := types.NewTime(types.FromGoTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)), mysql.TypeTimestamp, 0)
 	jobInfo := &importer.JobInfo{
 		Parameters: importer.ImportParameters{},
+		UpdateTime: t2024,
 	}
 
 	fmap := plannercore.ImportIntoFieldMap
@@ -63,6 +66,8 @@ func TestFillOneImportJobInfo(t *testing.T) {
 	require.Equal(t, uint64(0), c.GetRow(1).GetUint64(rowCntIdx))
 	require.True(t, c.GetRow(1).IsNull(startIdx))
 	require.True(t, c.GetRow(1).IsNull(endIdx))
+	// runtime info doesn't have update time, so use job info's update time
+	require.EqualValues(t, t2024, c.GetRow(1).GetTime(14))
 
 	jobInfo.Status = importer.JobStatusFinished
 	jobInfo.Summary = &importer.Summary{ImportedRows: 123}
@@ -85,6 +90,10 @@ func TestFillOneImportJobInfo(t *testing.T) {
 	require.Equal(t, "97.66KiB", c.GetRow(3).GetString(fmap["CurStepTotalSize"]))
 	require.Equal(t, "0", c.GetRow(3).GetString(fmap["CurStepProgressPct"]))
 	require.Equal(t, "13:53:15", c.GetRow(3).GetString(fmap["CurStepETA"]))
+
+	// runtime info have update time, so use it
+	executor.FillOneImportJobInfo(c, jobInfo, &importinto.RuntimeInfo{ImportRows: 0, UpdateTime: t2025})
+	require.EqualValues(t, t2025, c.GetRow(4).GetTime(14))
 }
 
 func TestShow(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
we add update time in #62283, the value is from update time of subtask summary, but during validation phase, we don't have subtask level summary. this pr change to use the update time of the job itself in this case

refine logs to print related task/subtask id and other info
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before, at validating step, `Last_Update_Time` is zero
```
+--------+-----------+-------------+--------------+----------+------------+---------+------------------+---------------+----------------+----------------------------+----------------------------+----------+------------+---------------------+--------------+-------------------------+---------------------+-----------------------+----------------+--------------+
| Job_ID | Group_Key | Data_Source | Target_Table | Table_ID | Phase      | Status  | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time | Created_By | Last_Update_Time    | Cur_Step     | Cur_Step_Processed_Size | Cur_Step_Total_Size | Cur_Step_Progress_Pct | Cur_Step_Speed | Cur_Step_ETA |
+--------+-----------+-------------+--------------+----------+------------+---------+------------------+---------------+----------------+----------------------------+----------------------------+----------+------------+---------------------+--------------+-------------------------+---------------------+-----------------------+----------------+--------------+
|     24 | NULL      | s3://...... | `test`.`t1`  |       62 | validating | running | 906.2GiB         |    1813500000 |                | 2025-09-09 03:23:54.821017 | 2025-09-09 03:23:56.997573 | NULL     | root@%     | 0000-00-00 00:00:00 | post-process | 0B                      | 0B                  | N/A                   | 0B/s           | N/A          |
```
after this PR, we can see the `Last_Update_Time` is shown correctly
```
+--------+-----------+-------------+--------------+----------+------------+---------+------------------+---------------+----------------+----------------------------+----------------------------+----------+------------+----------------------------+--------------+-------------------------+---------------------+-----------------------+----------------+--------------+
| Job_ID | Group_Key | Data_Source | Target_Table | Table_ID | Phase      | Status  | Source_File_Size | Imported_Rows | Result_Message | Create_Time                | Start_Time                 | End_Time | Created_By | Last_Update_Time           | Cur_Step     | Cur_Step_Processed_Size | Cur_Step_Total_Size | Cur_Step_Progress_Pct | Cur_Step_Speed | Cur_Step_ETA |
+--------+-----------+-------------+--------------+----------+------------+---------+------------------+---------------+----------------+----------------------------+----------------------------+----------+------------+----------------------------+--------------+-------------------------+---------------------+-----------------------+----------------+--------------+
|      1 | NULL      | s3://...... | `test`.`ks1` |        7 | validating | running | 12B              |             6 |                | 2025-09-09 15:34:17.942410 | 2025-09-09 15:34:18.489710 | NULL     | root@%     | 2025-09-09 15:34:21.488645 | post-process | 0B                      | 0B                  | N/A                   | 0B/s           | N/A          |
+--------+-----------+-------------+--------------+----------+------------+---------+------------------+---------------+----------------+----------------------------+----------------------------+----------+------------+----------------------------+--------------+-------------------------+---------------------+-----------------------+----------------+--------------+
```


process chunk can print the task/subtask id
```
[2025/09/09 15:34:19.248 +08:00] [INFO] [chunk_process.go:377] ["process chunk start"] [keyspaceName=SYSTEM] [task-id=1] [task-key=SYSTEM/ImportInto/1] [step=import] [subtask-id=1] [key=a.csv:0]
```
print table id during scheduler, and print task info during other split subtasks of encode step
```
[2025/09/09 16:27:42.541 +08:00] [INFO] [scheduler.go:302] ["on next subtasks batch"] [keyspaceName=SYSTEM] [task-id=90001] [task-key=keyspace1/ImportInto/1] [curr-step=init] [next-step=import] [node-count=1] [table-id=7]
[2025/09/09 16:27:42.574 +08:00] [INFO] [s3.go:493] ["succeed to get bucket region from s3"] [keyspaceName=SYSTEM] ["bucket region"=us-east-1]
[2025/09/09 16:27:42.581 +08:00] [INFO] [import.go:1335] ["auto calculate resource related params"] [keyspaceName=SYSTEM] [task-id=90001] [task-key=keyspace1/ImportInto/1] [curr-step=init] [next-step=import] [node-count=1] [table-id=7] ["thread count"=1] ["max node count"=1] ["dist sql scan concurrency"=15] ["target node cpu count"=10] ["total file size"=12B]
[2025/09/09 16:27:42.581 +08:00] [INFO] [table_import.go:404] ["populate chunks start"] [keyspaceName=SYSTEM] [task-id=90001] [task-key=keyspace1/ImportInto/1] [curr-step=init] [next-step=import] [node-count=1] [table-id=7]
[2025/09/09 16:27:42.581 +08:00] [INFO] [table_import.go:415] ["adjust max engine size"] [keyspaceName=SYSTEM] [task-id=90001] [task-key=keyspace1/ImportInto/1] [curr-step=init] [next-step=import] [node-count=1] [table-id=7] [before=107374182400] [after=12]
[2025/09/09 16:27:42.581 +08:00] [INFO] [region.go:293] [makeTableRegions] [keyspaceName=SYSTEM] [task-id=90001] [task-key=keyspace1/ImportInto/1] [curr-step=init] [next-step=import] [node-count=1] [table-id=7] [filesCount=1] [MaxChunkSize=268435456] [RegionsCount=1] [BatchSize=12] [cost=21µs]
[2025/09/09 16:27:42.581 +08:00] [INFO] [table_import.go:406] ["populate chunks completed"] [keyspaceName=SYSTEM] [task-id=90001] [task-key=keyspace1/ImportInto/1] [curr-step=init] [next-step=import] [node-count=1] [table-id=7] [takeTime=420.291µs] []

```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
