### PR TITLE
planner: rewrite semi join when to predicate push down

### DIFF
--- a/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
+++ b/pkg/planner/core/casetest/physicalplantest/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 39,
+    shard_count = 40,
     deps = [
         "//pkg/config",
         "//pkg/domain",

--- a/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
+++ b/pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
@@ -275,18 +275,15 @@ func TestIssue37520(t *testing.T) {
 }
 
 func TestMPPHints(t *testing.T) {
-	store := testkit.CreateMockStore(t, mockstore.WithMockTiFlash(2))
+	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
 	tk.MustExec("create table t (a int, b int, c int, index idx_a(a), index idx_b(b))")
-	tk.MustExec("alter table t set tiflash replica 1")
 	tk.MustExec("set @@session.tidb_allow_mpp=ON")
 	tk.MustExec("create definer='root'@'localhost' view v as select a, sum(b) from t group by a, c;")
 	tk.MustExec("create definer='root'@'localhost' view v1 as select t1.a from t t1, t t2 where t1.a=t2.a;")
-	tb := external.GetTableByName(t, tk, "test", "t")
-	err := domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
-	require.NoError(t, err)
+	testkit.SetTiFlashReplica(t, dom, "test", "t")
 
 	var input []string
 	var output []struct {
@@ -1648,4 +1645,23 @@ func TestAllocMPPID(t *testing.T) {
 	require.Equal(t, int64(1), physicalop.AllocMPPTaskID(ctx))
 	require.Equal(t, int64(2), physicalop.AllocMPPTaskID(ctx))
 	require.Equal(t, int64(3), physicalop.AllocMPPTaskID(ctx))
+}
+
+func TestSemiJoinRewriter(t *testing.T) {
+	testkit.RunTestUnderCascades(t, func(t *testing.T, tk *testkit.TestKit, cascades, caller string) {
+		tk.MustExec("use test")
+		tk.MustExec(`set @@tidb_opt_enable_semi_join_rewrite=on;`)
+		tk.MustExec(`create table t1(a int);`)
+		tk.MustExec(`create table t2(a varchar(10));`)
+		tk.MustExec(`create table t3(a int);`)
+		tk.MustQuery(`explain format = 'plan_tree' select * from t1 where exists(select 1 from t2 where t1.a=t2.a);`).Check(testkit.Rows(
+			`HashJoin root  inner join, equal:[eq(Column#6, Column#7)]`,
+			`├─HashAgg(Build) root  group by:Column#7, funcs:firstrow(Column#7)->Column#7`,
+			`│ └─Projection root  cast(test.t2.a, double BINARY)->Column#7`,
+			`│   └─TableReader root  data:TableFullScan`,
+			`│     └─TableFullScan cop[tikv] table:t2 keep order:false, stats:pseudo`,
+			`└─Projection(Probe) root  test.t1.a, cast(test.t1.a, double BINARY)->Column#6`,
+			`  └─TableReader root  data:TableFullScan`,
+			`    └─TableFullScan cop[tikv] table:t1 keep order:false, stats:pseudo`))
+	})
 }

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/aggregation"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/cardinality"
@@ -1772,6 +1773,79 @@ func mergeOnClausePredicates(p *LogicalJoin, predicates []expression.Expression)
 	combinedCond = append(combinedCond, p.OtherConditions...)
 	combinedCond = append(combinedCond, predicates...)
 	return combinedCond
+}
+
+func (p *LogicalJoin) SemiJoinRewrite() (base.LogicalPlan, error) {
+	// If it's not a p, or not a (outer) semi p. We just return it since no optimization is needed.
+	// Actually the check of the preferRewriteSemiJoin is a superset of checking the p type. We remain them for a better understanding.
+	if !(p.JoinType == base.SemiJoin || p.JoinType == base.LeftOuterSemiJoin) {
+		return p, nil
+	}
+
+	if p.JoinType == base.LeftOuterSemiJoin {
+		p.SCtx().GetSessionVars().StmtCtx.SetHintWarning("SEMI_JOIN_REWRITE() is inapplicable for LeftOuterSemiJoin.")
+		return p, nil
+	}
+
+	// If we have jumped the above if condition. We can make sure that the current p is a non-correlated one.
+
+	// If there's left condition or other condition, we cannot rewrite
+	if len(p.LeftConditions) > 0 || len(p.OtherConditions) > 0 {
+		p.SCtx().GetSessionVars().StmtCtx.SetHintWarning("SEMI_JOIN_REWRITE() is inapplicable for SemiJoin with left conditions or other conditions.")
+		return p, nil
+	}
+
+	innerChild := p.Children()[1]
+
+	// If there's right conditions:
+	//   - If it's semi p, then right condition should be pushed.
+	//   - If it's outer semi p, then it still should be pushed since the outer p should not remain any cond of the inner side.
+	// But the aggregation we added may block the predicate push down since we've not maintained the functional dependency to pass the equiv class to guide the push down.
+	// So we create a selection before we build the aggregation.
+	if len(p.RightConditions) > 0 {
+		sel := LogicalSelection{Conditions: make([]expression.Expression, len(p.RightConditions))}.Init(p.SCtx(), innerChild.QueryBlockOffset())
+		copy(sel.Conditions, p.RightConditions)
+		sel.SetChildren(innerChild)
+		innerChild = sel
+	}
+
+	subAgg := LogicalAggregation{
+		AggFuncs:     make([]*aggregation.AggFuncDesc, 0, len(p.EqualConditions)),
+		GroupByItems: make([]expression.Expression, 0, len(p.EqualConditions)),
+	}.Init(p.SCtx(), p.Children()[1].QueryBlockOffset())
+
+	aggOutputCols := make([]*expression.Column, 0, len(p.EqualConditions))
+	for i := range p.EqualConditions {
+		innerCol := p.EqualConditions[i].GetArgs()[1].(*expression.Column)
+		firstRow, err := aggregation.NewAggFuncDesc(p.SCtx().GetExprCtx(), ast.AggFuncFirstRow, []expression.Expression{innerCol}, false)
+		if err != nil {
+			return nil, err
+		}
+		subAgg.AggFuncs = append(subAgg.AggFuncs, firstRow)
+		subAgg.GroupByItems = append(subAgg.GroupByItems, innerCol)
+		aggOutputCols = append(aggOutputCols, innerCol)
+	}
+	subAgg.SetChildren(innerChild)
+	subAgg.SetSchema(expression.NewSchema(aggOutputCols...))
+	subAgg.BuildSelfKeyInfo(subAgg.Schema())
+
+	innerJoin := LogicalJoin{
+		JoinType:        base.InnerJoin,
+		HintInfo:        p.HintInfo,
+		PreferJoinType:  p.PreferJoinType,
+		PreferJoinOrder: p.PreferJoinOrder,
+		EqualConditions: make([]*expression.ScalarFunction, 0, len(p.EqualConditions)),
+	}.Init(p.SCtx(), p.QueryBlockOffset())
+	innerJoin.SetChildren(p.Children()[0], subAgg)
+	innerJoin.SetSchema(expression.MergeSchema(p.Children()[0].Schema(), subAgg.Schema()))
+	innerJoin.AttachOnConds(expression.ScalarFuncs2Exprs(p.EqualConditions))
+
+	proj := LogicalProjection{
+		Exprs: expression.Column2Exprs(p.Children()[0].Schema().Columns),
+	}.Init(p.SCtx(), p.QueryBlockOffset())
+	proj.SetChildren(innerJoin)
+	proj.SetSchema(p.Children()[0].Schema())
+	return proj, nil
 }
 
 func appendTopNPushDownJoinTraceStep(p *LogicalJoin, topN *LogicalTopN, idx int, opt *optimizetrace.LogicalOptimizeOp) {

--- a/pkg/planner/core/operator/logicalop/logical_join.go
+++ b/pkg/planner/core/operator/logicalop/logical_join.go
@@ -1796,7 +1796,7 @@ func (p *LogicalJoin) SemiJoinRewrite() (base.LogicalPlan, error) {
 	if _, ok := p.Self().(*LogicalApply); ok {
 		return p.Self(), nil
 	}
-	// Gate by hint or session variable.
+	// Get by hint or session variable.
 	if (p.PreferJoinType&utilhint.PreferRewriteSemiJoin) == 0 && !p.SCtx().GetSessionVars().EnableSemiJoinRewrite {
 		return p.Self(), nil
 	}

--- a/pkg/planner/core/rule_semi_join_rewrite.go
+++ b/pkg/planner/core/rule_semi_join_rewrite.go
@@ -66,81 +66,8 @@ func (smj *SemiJoinRewriter) recursivePlan(p base.LogicalPlan) (base.LogicalPlan
 	}
 	p.SetChildren(newChildren...)
 	join, ok := p.(*logicalop.LogicalJoin)
-	// If it's not a join, or not a (outer) semi join. We just return it since no optimization is needed.
-	// Actually the check of the preferRewriteSemiJoin is a superset of checking the join type. We remain them for a better understanding.
-	if !ok || !(join.JoinType == base.SemiJoin || join.JoinType == base.LeftOuterSemiJoin) {
+	if !ok {
 		return p, nil
 	}
-	// Gate by hint or session variable.
-	if (join.PreferJoinType&h.PreferRewriteSemiJoin) == 0 && !p.SCtx().GetSessionVars().EnableSemiJoinRewrite {
-		return p, nil
-	}
-	// The preferRewriteSemiJoin flag only be used here. We should reset it in order to not affect other parts.
-	join.PreferJoinType &= ^h.PreferRewriteSemiJoin
-
-	if join.JoinType == base.LeftOuterSemiJoin {
-		p.SCtx().GetSessionVars().StmtCtx.SetHintWarning("SEMI_JOIN_REWRITE() is inapplicable for LeftOuterSemiJoin.")
-		return p, nil
-	}
-
-	// If we have jumped the above if condition. We can make sure that the current join is a non-correlated one.
-
-	// If there's left condition or other condition, we cannot rewrite
-	if len(join.LeftConditions) > 0 || len(join.OtherConditions) > 0 {
-		p.SCtx().GetSessionVars().StmtCtx.SetHintWarning("SEMI_JOIN_REWRITE() is inapplicable for SemiJoin with left conditions or other conditions.")
-		return p, nil
-	}
-
-	innerChild := join.Children()[1]
-
-	// If there's right conditions:
-	//   - If it's semi join, then right condition should be pushed.
-	//   - If it's outer semi join, then it still should be pushed since the outer join should not remain any cond of the inner side.
-	// But the aggregation we added may block the predicate push down since we've not maintained the functional dependency to pass the equiv class to guide the push down.
-	// So we create a selection before we build the aggregation.
-	if len(join.RightConditions) > 0 {
-		sel := logicalop.LogicalSelection{Conditions: make([]expression.Expression, len(join.RightConditions))}.Init(p.SCtx(), innerChild.QueryBlockOffset())
-		copy(sel.Conditions, join.RightConditions)
-		sel.SetChildren(innerChild)
-		innerChild = sel
-	}
-
-	subAgg := logicalop.LogicalAggregation{
-		AggFuncs:     make([]*aggregation.AggFuncDesc, 0, len(join.EqualConditions)),
-		GroupByItems: make([]expression.Expression, 0, len(join.EqualConditions)),
-	}.Init(p.SCtx(), p.Children()[1].QueryBlockOffset())
-
-	aggOutputCols := make([]*expression.Column, 0, len(join.EqualConditions))
-	for i := range join.EqualConditions {
-		innerCol := join.EqualConditions[i].GetArgs()[1].(*expression.Column)
-		firstRow, err := aggregation.NewAggFuncDesc(join.SCtx().GetExprCtx(), ast.AggFuncFirstRow, []expression.Expression{innerCol}, false)
-		if err != nil {
-			return nil, err
-		}
-		subAgg.AggFuncs = append(subAgg.AggFuncs, firstRow)
-		subAgg.GroupByItems = append(subAgg.GroupByItems, innerCol)
-		aggOutputCols = append(aggOutputCols, innerCol)
-	}
-	subAgg.SetChildren(innerChild)
-	subAgg.SetSchema(expression.NewSchema(aggOutputCols...))
-	subAgg.BuildSelfKeyInfo(subAgg.Schema())
-
-	innerJoin := logicalop.LogicalJoin{
-		JoinType:        base.InnerJoin,
-		HintInfo:        join.HintInfo,
-		PreferJoinType:  join.PreferJoinType,
-		PreferJoinOrder: join.PreferJoinOrder,
-		EqualConditions: make([]*expression.ScalarFunction, 0, len(join.EqualConditions)),
-	}.Init(p.SCtx(), p.QueryBlockOffset())
-	innerJoin.SetChildren(join.Children()[0], subAgg)
-	innerJoin.SetSchema(expression.MergeSchema(join.Children()[0].Schema(), subAgg.Schema()))
-	innerJoin.AttachOnConds(expression.ScalarFuncs2Exprs(join.EqualConditions))
-
-	proj := logicalop.LogicalProjection{
-		Exprs: expression.Column2Exprs(join.Children()[0].Schema().Columns),
-	}.Init(p.SCtx(), p.QueryBlockOffset())
-	proj.SetChildren(innerJoin)
-	proj.SetSchema(join.Children()[0].Schema())
-
-	return proj, nil
+	return join.SemiJoinRewrite()
 }

--- a/pkg/planner/core/rule_semi_join_rewrite.go
+++ b/pkg/planner/core/rule_semi_join_rewrite.go
@@ -17,13 +17,9 @@ package core
 import (
 	"context"
 
-	"github.com/pingcap/tidb/pkg/expression"
-	"github.com/pingcap/tidb/pkg/expression/aggregation"
-	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/logicalop"
 	"github.com/pingcap/tidb/pkg/planner/util/optimizetrace"
-	h "github.com/pingcap/tidb/pkg/util/hint"
 )
 
 // SemiJoinRewriter rewrites semi join to inner join with aggregation.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58958

Problem Summary:

### What changed and how does it work?

When we perform predicate pushdown, we simplify the predicates. After simplification, the join may have the opportunity to undergo semi join rewrite. Therefore, we attempt semi join rewrite on the join that has undergone predicate pushdown.

Additionally, there is another issue here. When we process LogicalApply and call predicate pushdown, the object being operated on is actually a LogicalJoin. If we return the LogicalJoin at this point, it will cause problems. Therefore, the correct approach here is to return p.Self().



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
