### PR TITLE
executor: Fix infoschema_reader_test for reading tiflash system table

### DIFF
--- a/pkg/executor/infoschema_reader.go
+++ b/pkg/executor/infoschema_reader.go
@@ -3523,6 +3523,7 @@ func (e *TiFlashSystemTableRetriever) dataForTiFlashSystemTables(ctx context.Con
 	targetTable := tiflashTargetTableName[e.table.Name.L]
 
 	var filters []string
+	// Add filter for keyspace_id if tidb is running in the keyspace mode.
 	if keyspace.GetKeyspaceNameBySettings() != "" {
 		keyspaceID := uint32(sctx.GetStore().GetCodec().GetKeyspaceID())
 		filters = append(filters, fmt.Sprintf("keyspace_id=%d", keyspaceID))

--- a/pkg/executor/infoschema_reader_test.go
+++ b/pkg/executor/infoschema_reader_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/tidb/pkg/keyspace"
 	"github.com/pingcap/tidb/pkg/store/mockstore"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,8 @@ func (client *getTiFlashSystemTableRequestMocker) AsOpt() mockstore.MockTiKVStor
 	})
 }
 
+var systemKeyspaceID = uint32(16777214)
+
 func TestTiFlashSystemTableWithTiFlashV620(t *testing.T) {
 	instances := []string{
 		"tiflash,127.0.0.1:3933,127.0.0.1:7777,,",
@@ -82,17 +85,30 @@ func TestTiFlashSystemTableWithTiFlashV620(t *testing.T) {
 	require.NoError(t, failpoint.Enable(fpName, fpExpr))
 	defer func() { require.NoError(t, failpoint.Disable(fpName)) }()
 
+	// Generate the tiflash system table request mocker
 	mocker := newGetTiFlashSystemTableRequestMocker(t)
-	mocker.MockQuery(`SELECT * FROM system.dt_segments LIMIT 0, 1024`, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
-		require.EqualValues(t, req.Sql, "SELECT * FROM system.dt_segments LIMIT 0, 1024")
+	var sqlTiFlashSegment string
+	if keyspace.GetKeyspaceNameBySettings() == "" {
+		sqlTiFlashSegment = `SELECT * FROM system.dt_segments LIMIT 0, 1024`
+	} else {
+		sqlTiFlashSegment = fmt.Sprintf(`SELECT * FROM system.dt_segments WHERE keyspace_id=%d LIMIT 0, 1024`, systemKeyspaceID)
+	}
+	mocker.MockQuery(sqlTiFlashSegment, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
+		require.EqualValues(t, req.Sql, sqlTiFlashSegment)
 		data, err := os.ReadFile("testdata/tiflash_v620_dt_segments.json")
 		require.NoError(t, err)
 		return &kvrpcpb.TiFlashSystemTableResponse{
 			Data: data,
 		}, nil
 	})
-	mocker.MockQuery(`SELECT * FROM system.dt_tables LIMIT 0, 1024`, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
-		require.EqualValues(t, req.Sql, "SELECT * FROM system.dt_tables LIMIT 0, 1024")
+	var sqlTiFlashTable string
+	if keyspace.GetKeyspaceNameBySettings() == "" {
+		sqlTiFlashTable = `SELECT * FROM system.dt_tables LIMIT 0, 1024`
+	} else {
+		sqlTiFlashTable = fmt.Sprintf(`SELECT * FROM system.dt_tables WHERE keyspace_id=%d LIMIT 0, 1024`, systemKeyspaceID)
+	}
+	mocker.MockQuery(sqlTiFlashTable, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
+		require.EqualValues(t, req.Sql, sqlTiFlashTable)
 		data, err := os.ReadFile("testdata/tiflash_v620_dt_tables.json")
 		require.NoError(t, err)
 		return &kvrpcpb.TiFlashSystemTableResponse{
@@ -129,9 +145,16 @@ func TestTiFlashSystemTableWithTiFlashV630(t *testing.T) {
 	require.NoError(t, failpoint.Enable(fpName, fpExpr))
 	defer func() { require.NoError(t, failpoint.Disable(fpName)) }()
 
+	// Generate the tiflash system table request mocker
 	mocker := newGetTiFlashSystemTableRequestMocker(t)
-	mocker.MockQuery(`SELECT * FROM system.dt_segments LIMIT 0, 1024`, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
-		require.EqualValues(t, req.Sql, "SELECT * FROM system.dt_segments LIMIT 0, 1024")
+	var sqlTiFlashSegment string
+	if keyspace.GetKeyspaceNameBySettings() == "" {
+		sqlTiFlashSegment = `SELECT * FROM system.dt_segments LIMIT 0, 1024`
+	} else {
+		sqlTiFlashSegment = fmt.Sprintf(`SELECT * FROM system.dt_segments WHERE keyspace_id=%d LIMIT 0, 1024`, systemKeyspaceID)
+	}
+	mocker.MockQuery(sqlTiFlashSegment, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
+		require.EqualValues(t, req.Sql, sqlTiFlashSegment)
 		data, err := os.ReadFile("testdata/tiflash_v630_dt_segments.json")
 		require.NoError(t, err)
 		return &kvrpcpb.TiFlashSystemTableResponse{
@@ -167,9 +190,16 @@ func TestTiFlashSystemTableWithTiFlashV640(t *testing.T) {
 	require.NoError(t, failpoint.Enable(fpName, fpExpr))
 	defer func() { require.NoError(t, failpoint.Disable(fpName)) }()
 
+	// Generate the tiflash system table request mocker
 	mocker := newGetTiFlashSystemTableRequestMocker(t)
-	mocker.MockQuery(`SELECT * FROM system.dt_tables LIMIT 0, 1024`, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
-		require.EqualValues(t, req.Sql, "SELECT * FROM system.dt_tables LIMIT 0, 1024")
+	var sqlTiFlashTable string
+	if keyspace.GetKeyspaceNameBySettings() == "" {
+		sqlTiFlashTable = `SELECT * FROM system.dt_tables LIMIT 0, 1024`
+	} else {
+		sqlTiFlashTable = fmt.Sprintf(`SELECT * FROM system.dt_tables WHERE keyspace_id=%d LIMIT 0, 1024`, systemKeyspaceID)
+	}
+	mocker.MockQuery(sqlTiFlashTable, func(req *kvrpcpb.TiFlashSystemTableRequest) (*kvrpcpb.TiFlashSystemTableResponse, error) {
+		require.EqualValues(t, req.Sql, sqlTiFlashTable)
 		data, err := os.ReadFile("testdata/tiflash_v640_dt_tables.json")
 		require.NoError(t, err)
 		return &kvrpcpb.TiFlashSystemTableResponse{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/62803

Problem Summary:

### What changed and how does it work?

When generating sql to fetch tiflash system table, tidb will append a filter with keyspace_id = xxx. The ut should adapt with the logic

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
make failpoint-enable
go test -timeout 30s -tags deadlock,intest,nextgen -run ^TestTiFlashSystemTableWithTiFlash github.com/pingcap/tidb/pkg/executor -v | grep 'TestTiFlashSystemTable'
=== RUN   TestTiFlashSystemTableWithTiFlashV620
--- PASS: TestTiFlashSystemTableWithTiFlashV620 (0.15s)
=== RUN   TestTiFlashSystemTableWithTiFlashV630
--- PASS: TestTiFlashSystemTableWithTiFlashV630 (0.14s)
=== RUN   TestTiFlashSystemTableWithTiFlashV640
--- PASS: TestTiFlashSystemTableWithTiFlashV640 (0.14s)
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
