### PR TITLE
owner: refine the log when getting owner

### DIFF
--- a/pkg/owner/manager.go
+++ b/pkg/owner/manager.go
@@ -496,7 +496,9 @@ func GetOwnerKeyInfo(
 	if err != nil {
 		return "", 0, errors.Trace(err)
 	}
-	logutil.BgLogger().Info("get owner", zap.String("key", etcdKey), zap.String("owner key", ownerKey),
+	logutil.BgLogger().Info("get owner",
+		zap.String("key", etcdKey),
+		zap.String("owner key", ownerKey),
 		zap.ByteString("ownerID", ownerID))
 	if string(ownerID) != id {
 		logutil.BgLogger().Warn("is not the owner", zap.String("key", etcdKey),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61702

Problem Summary:

"get owner" log is too noisy because it prints every time we `getOwnerInfo`. Especially in next-gen, we call the HTTP API `dxf/schedule/status` every few seconds.

```
[2025/09/10 08:53:48.026 +00:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/25a2992d24840984] [ownerID=1af5a186-1ddd-432d-9df9-7f4c96ec0ce1] [op=none]
[2025/09/10 08:53:35.622 +00:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/25a2992d24840984] [ownerID=1af5a186-1ddd-432d-9df9-7f4c96ec0ce1] [op=none]
[2025/09/10 08:53:32.962 +00:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/25a2992d24840984] [ownerID=1af5a186-1ddd-432d-9df9-7f4c96ec0ce1] [op=none]
[2025/09/10 08:53:20.562 +00:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/25a2992d24840984] [ownerID=1af5a186-1ddd-432d-9df9-7f4c96ec0ce1] [op=none]
[2025/09/10 08:53:17.908 +00:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/25a2992d24840984] [ownerID=1af5a186-1ddd-432d-9df9-7f4c96ec0ce1] [op=none]
[2025/09/10 08:53:05.499 +00:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/25a2992d24840984] [ownerID=1af5a186-1ddd-432d-9df9-7f4c96ec0ce1] [op=none]
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Before this PR:
```
curl http://127.0.0.1:10082/dxf/schedule/status
```
```
[2025/09/10 22:46:01.554 +08:00] [INFO] [manager.go:486] ["get owner"] [keyspaceName=SYSTEM] [key=/tidb/ddl/fg/owner] ["owner key"=/tidb/ddl/fg/owner/2231992eff82df70] [ownerID=236ce692-b643-4526-8c92-a14347a60020] [op=none]
[2025/09/10 22:46:01.557 +08:00] [INFO] [dxf.go:69] ["current DXF schedule status"] [keyspaceName=SYSTEM] [status="{\"version\":1,\"task_queue\":{},\"tidb_worker\":{\"cpu_count\":32,\"required_count\":1,\"current_count\":1,\"busy_nodes\":[{\"id\":\"127.0.0.1:4002\",\"is_owner\":true}]},\"tikv_worker\":{\"required_count\":1}}"]
```
After this PR:
```
[2025/09/10 22:49:07.703 +08:00] [INFO] [dxf.go:69] ["current DXF schedule status"] [keyspaceName=SYSTEM] [status="{\"version\":1,\"task_queue\":{},\"tidb_worker\":{\"cpu_count\":32,\"required_count\":1,\"current_count\":1,\"busy_nodes\":[{\"id\":\"127.0.0.1:4002\",\"is_owner\":true}]},\"tikv_worker\":{\"required_count\":1}}"]
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
