### PR TITLE
executor: Optimize hash join/agg for `__bin` collator

### DIFF
--- a/pkg/executor/aggfuncs/func_count_distinct.go
+++ b/pkg/executor/aggfuncs/func_count_distinct.go
@@ -414,7 +414,7 @@ func evalAndEncode(
 		if err != nil || isNull {
 			break
 		}
-		encodedBytes = codec.EncodeCompactBytes(encodedBytes, collator.Key(val))
+		encodedBytes = codec.EncodeCompactBytes(encodedBytes, collator.ImmutableKey(val))
 	default:
 		return nil, false, errors.Errorf("unsupported column type for encode %d", tp)
 	}

--- a/pkg/executor/aggfuncs/func_group_concat.go
+++ b/pkg/executor/aggfuncs/func_group_concat.go
@@ -259,7 +259,7 @@ func (e *groupConcatDistinct) UpdatePartialResult(sctx AggFuncUpdateContext, row
 			if isNull {
 				break
 			}
-			p.encodeBytesBuffer = codec.EncodeBytes(p.encodeBytesBuffer, collators[i].Key(v))
+			p.encodeBytesBuffer = codec.EncodeBytes(p.encodeBytesBuffer, collators[i].ImmutableKey(v))
 			p.valsBuf.WriteString(v)
 		}
 		if isNull {
@@ -592,7 +592,7 @@ func (e *groupConcatDistinctOrder) UpdatePartialResult(sctx AggFuncUpdateContext
 			if isNull {
 				break
 			}
-			p.encodeBytesBuffer = codec.EncodeBytes(p.encodeBytesBuffer, collators[i].Key(v))
+			p.encodeBytesBuffer = codec.EncodeBytes(p.encodeBytesBuffer, collators[i].ImmutableKey(v))
 			buffer.WriteString(v)
 		}
 		if isNull {

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -547,8 +547,8 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)...)
 			}
 		} else {
+			collator := collate.GetCollator(tp.GetCollate())
 			for logicalRowIndex, physicalRowindex := range usedRows {
-				collator := collate.GetCollator(tp.GetCollate())
 				if canSkip(physicalRowindex) {
 					continue
 				}

--- a/pkg/util/codec/codec.go
+++ b/pkg/util/codec/codec.go
@@ -214,7 +214,7 @@ func EncodeMySQLTime(loc *time.Location, t types.Time, tp byte, b []byte) (_ []b
 
 func encodeString(b []byte, val types.Datum, comparable1 bool) []byte {
 	if collate.NewCollationEnabled() && comparable1 {
-		return encodeBytes(b, collate.GetCollator(val.Collation()).Key(val.GetString()), true)
+		return encodeBytes(b, collate.GetCollator(val.Collation()).ImmutableKey(val.GetString()), true)
 	}
 	return encodeBytes(b, val.GetBytes(), comparable1)
 }
@@ -481,11 +481,12 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&f)), sizeFloat64)...)
 		}
 	case mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		collator := collate.GetCollator(tp.GetCollate())
 		for logicalRowIndex, physicalRowIndex := range usedRows {
 			if canSkip(physicalRowIndex) {
 				continue
 			}
-			data := ConvertByCollation(column.GetBytes(physicalRowIndex), tp)
+			data := collator.ImmutableKey(string(hack.String(column.GetBytes(physicalRowIndex))))
 			size := uint32(len(data))
 			if serializeMode == KeepVarColumnLength {
 				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&size)), sizeUint32)...)
@@ -533,23 +534,30 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], b...)
 		}
 	case mysql.TypeEnum:
-		for logicalRowIndex, physicalRowindex := range usedRows {
-			if canSkip(physicalRowindex) {
-				continue
-			}
-			v := column.GetEnum(physicalRowindex).Value
-			if mysql.HasEnumSetAsIntFlag(tp.GetFlag()) {
+		if mysql.HasEnumSetAsIntFlag(tp.GetFlag()) {
+			for logicalRowIndex, physicalRowindex := range usedRows {
+				if canSkip(physicalRowindex) {
+					continue
+				}
+				v := column.GetEnum(physicalRowindex).Value
 				// check serializeMode here because enum maybe compare to integer type directly
 				if serializeMode == NeedSignFlag {
 					serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], uintFlag)
 				}
 				serializedKeysVector[logicalRowIndex] = append(serializedKeysVector[logicalRowIndex], unsafe.Slice((*byte)(unsafe.Pointer(&v)), sizeUint64)...)
-			} else {
+			}
+		} else {
+			for logicalRowIndex, physicalRowindex := range usedRows {
+				collator := collate.GetCollator(tp.GetCollate())
+				if canSkip(physicalRowindex) {
+					continue
+				}
+				v := column.GetEnum(physicalRowindex).Value
 				str := ""
 				if enum, err := types.ParseEnumValue(tp.GetElems(), v); err == nil {
 					str = enum.Name
 				}
-				b := ConvertByCollation(hack.Slice(str), tp)
+				b := collator.ImmutableKey(str)
 				if serializeMode == KeepVarColumnLength {
 					// for enum, the size must be less than uint32.MAX, so use uint32 here
 					size := uint32(len(b))
@@ -559,6 +567,7 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			}
 		}
 	case mysql.TypeSet:
+		collator := collate.GetCollator(tp.GetCollate())
 		for logicalRowIndex, physicalRowindex := range usedRows {
 			if canSkip(physicalRowindex) {
 				continue
@@ -567,7 +576,7 @@ func SerializeKeys(typeCtx types.Context, chk *chunk.Chunk, tp *types.FieldType,
 			if err != nil {
 				return err
 			}
-			b := ConvertByCollation(hack.Slice(s.Name), tp)
+			b := collator.ImmutableKey(s.Name)
 			if serializeMode == KeepVarColumnLength {
 				// for enum, the size must be less than uint32.MAX, so use uint32 here
 				size := uint32(len(b))
@@ -699,6 +708,7 @@ func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk,
 			_, _ = h[i].Write(b)
 		}
 	case mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		collator := collate.GetCollator(tp.GetCollate())
 		for i := range rows {
 			if sel != nil && !sel[i] {
 				continue
@@ -709,7 +719,7 @@ func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk,
 			} else {
 				buf[0] = compactBytesFlag
 				b = column.GetBytes(i)
-				b = ConvertByCollation(b, tp)
+				b = collator.ImmutableKey(string(hack.String(b)))
 			}
 
 			// As the golang doc described, `Hash.Write` never returns an error.
@@ -785,6 +795,10 @@ func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk,
 			_, _ = h[i].Write(b)
 		}
 	case mysql.TypeEnum:
+		var collator collate.Collator
+		if !mysql.HasEnumSetAsIntFlag(tp.GetFlag()) {
+			collator = collate.GetCollator(tp.GetCollate())
+		}
 		for i := range rows {
 			if sel != nil && !sel[i] {
 				continue
@@ -804,7 +818,7 @@ func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk,
 					// str will be empty string if v out of definition of enum.
 					str = enum.Name
 				}
-				b = ConvertByCollation(hack.Slice(str), tp)
+				b = collator.ImmutableKey(str)
 			}
 
 			// As the golang doc described, `Hash.Write` never returns an error.
@@ -813,6 +827,7 @@ func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk,
 			_, _ = h[i].Write(b)
 		}
 	case mysql.TypeSet:
+		collator := collate.GetCollator(tp.GetCollate())
 		for i := range rows {
 			if sel != nil && !sel[i] {
 				continue
@@ -826,7 +841,7 @@ func HashChunkSelected(typeCtx types.Context, h []hash.Hash64, chk *chunk.Chunk,
 				if err != nil {
 					return err
 				}
-				b = ConvertByCollation(hack.Slice(s.Name), tp)
+				b = collator.ImmutableKey(s.Name)
 			}
 
 			// As the golang doc described, `Hash.Write` never returns an error.
@@ -1554,11 +1569,12 @@ func HashGroupKey(loc *time.Location, n int, col *chunk.Column, buf [][]byte, ft
 			}
 		}
 	case types.ETString:
+		collator := collate.GetCollator(ft.GetCollate())
 		for i := range n {
 			if col.IsNull(i) {
 				buf[i] = append(buf[i], NilFlag)
 			} else {
-				buf[i] = encodeBytes(buf[i], ConvertByCollation(col.GetBytes(i), ft), false)
+				buf[i] = encodeBytes(buf[i], collator.ImmutableKey(string(hack.String(col.GetBytes(i)))), false)
 			}
 		}
 	case types.ETVectorFloat32:

--- a/pkg/util/collate/bin.go
+++ b/pkg/util/collate/bin.go
@@ -17,6 +17,7 @@ package collate
 import (
 	"strings"
 
+	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 )
 
@@ -32,6 +33,11 @@ func (*binCollator) Compare(a, b string) int {
 // Key implement Collator interface.
 func (*binCollator) Key(str string) []byte {
 	return []byte(str)
+}
+
+// ImmutableKey implement Collator interface.
+func (*binCollator) ImmutableKey(str string) []byte {
+	return hack.Slice(str)
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.
@@ -67,6 +73,11 @@ func (*binPaddingCollator) Compare(a, b string) int {
 
 func (*binPaddingCollator) Key(str string) []byte {
 	return []byte(truncateTailingSpace(str))
+}
+
+// ImmutableKey implement Collator interface.
+func (*binPaddingCollator) ImmutableKey(str string) []byte {
+	return hack.Slice(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/collate.go
+++ b/pkg/util/collate/collate.go
@@ -60,6 +60,9 @@ type Collator interface {
 	Compare(a, b string) int
 	// Key returns the collate key for str. If the collation is padding, make sure the PadLen >= len(rune[]str) in opt.
 	Key(str string) []byte
+	// ImmutableKey is the same as Key except that the returned key should not be changed by future calls.
+	// It can avoid memory allocation and copy in some collations. The caller should not modify the returned value.
+	ImmutableKey(str string) []byte
 	// KeyWithoutTrimRightSpace returns the collate key for str. The difference with Key is str will not be trimed.
 	KeyWithoutTrimRightSpace(str string) []byte
 	// Pattern get a collation-aware WildcardPattern.

--- a/pkg/util/collate/collate_bench_test.go
+++ b/pkg/util/collate/collate_bench_test.go
@@ -53,6 +53,15 @@ func key(b *testing.B, collator Collator, length int) {
 	}
 }
 
+func immutableKey(b *testing.B, collator Collator, length int) {
+	s := generateData(length)
+
+	b.ResetTimer()
+	for range b.N {
+		collator.ImmutableKey(s)
+	}
+}
+
 func BenchmarkUtf8mb4Bin_CompareShort(b *testing.B) {
 	compare(b, &binPaddingCollator{}, short)
 }
@@ -117,58 +126,118 @@ func BenchmarkUtf8mb4Bin_KeyShort(b *testing.B) {
 	key(b, &binPaddingCollator{}, short)
 }
 
+func BenchmarkUtf8mb4Bin_ImmutableKeyShort(b *testing.B) {
+	immutableKey(b, &binPaddingCollator{}, short)
+}
+
 func BenchmarkUtf8mb4GeneralCI_KeyShort(b *testing.B) {
 	key(b, &generalCICollator{}, short)
+}
+
+func BenchmarkUtf8mb4GeneralCI_ImmutableKeyShort(b *testing.B) {
+	immutableKey(b, &generalCICollator{}, short)
 }
 
 func BenchmarkUtf8mb4UnicodeCI_KeyShort(b *testing.B) {
 	key(b, &unicodeCICollator{}, short)
 }
 
+func BenchmarkUtf8mb4UnicodeCI_ImmutableKeyShort(b *testing.B) {
+	immutableKey(b, &unicodeCICollator{}, short)
+}
+
 func BenchmarkUtf8mb40900AICI_KeyShort(b *testing.B) {
 	key(b, &unicode0900AICICollator{}, short)
+}
+
+func BenchmarkUtf8mb40900AICI_ImmutableKeyShort(b *testing.B) {
+	immutableKey(b, &unicode0900AICICollator{}, short)
 }
 
 func BenchmarkUtf8mb40900Bin_KeyShort(b *testing.B) {
 	key(b, &derivedBinCollator{}, short)
 }
 
+func BenchmarkUtf8mb40900Bin_ImmutableKeyShort(b *testing.B) {
+	immutableKey(b, &derivedBinCollator{}, short)
+}
+
 func BenchmarkUtf8mb4Bin_KeyMid(b *testing.B) {
 	key(b, &binPaddingCollator{}, middle)
+}
+
+func BenchmarkUtf8mb4Bin_ImmutableKeyMid(b *testing.B) {
+	immutableKey(b, &binPaddingCollator{}, middle)
 }
 
 func BenchmarkUtf8mb4GeneralCI_KeyMid(b *testing.B) {
 	key(b, &generalCICollator{}, middle)
 }
 
+func BenchmarkUtf8mb4GeneralCI_ImmutableKeyMid(b *testing.B) {
+	immutableKey(b, &generalCICollator{}, middle)
+}
+
 func BenchmarkUtf8mb4UnicodeCI_KeyMid(b *testing.B) {
 	key(b, &unicodeCICollator{}, middle)
+}
+
+func BenchmarkUtf8mb4UnicodeCI_ImmutableKeyMid(b *testing.B) {
+	immutableKey(b, &unicodeCICollator{}, middle)
 }
 
 func BenchmarkUtf8mb40900AICI_KeyMid(b *testing.B) {
 	key(b, &unicode0900AICICollator{}, middle)
 }
 
+func BenchmarkUtf8mb40900AICI_ImmutableKeyMid(b *testing.B) {
+	immutableKey(b, &unicode0900AICICollator{}, middle)
+}
+
 func BenchmarkUtf8mb40900Bin_KeyMid(b *testing.B) {
 	key(b, &derivedBinCollator{}, middle)
+}
+
+func BenchmarkUtf8mb40900Bin_ImmutableKeyMid(b *testing.B) {
+	immutableKey(b, &derivedBinCollator{}, middle)
 }
 
 func BenchmarkUtf8mb4Bin_KeyLong(b *testing.B) {
 	key(b, &binPaddingCollator{}, long)
 }
 
+func BenchmarkUtf8mb4Bin_ImmutableKeyLong(b *testing.B) {
+	immutableKey(b, &binPaddingCollator{}, long)
+}
+
 func BenchmarkUtf8mb4GeneralCI_KeyLong(b *testing.B) {
 	key(b, &generalCICollator{}, long)
+}
+
+func BenchmarkUtf8mb4GeneralCI_ImmutableKeyLong(b *testing.B) {
+	immutableKey(b, &generalCICollator{}, long)
 }
 
 func BenchmarkUtf8mb4UnicodeCI_KeyLong(b *testing.B) {
 	key(b, &unicodeCICollator{}, long)
 }
 
+func BenchmarkUtf8mb4UnicodeCI_ImmutableKeyLong(b *testing.B) {
+	immutableKey(b, &unicodeCICollator{}, long)
+}
+
 func BenchmarkUtf8mb40900AICI_KeyLong(b *testing.B) {
 	key(b, &unicode0900AICICollator{}, long)
 }
 
+func BenchmarkUtf8mb40900AICI_ImmutableKeyLong(b *testing.B) {
+	immutableKey(b, &unicode0900AICICollator{}, long)
+}
+
 func BenchmarkUtf8mb40900Bin_KeyLong(b *testing.B) {
 	key(b, &derivedBinCollator{}, long)
+}
+
+func BenchmarkUtf8mb40900Bin_ImmutableKeyLong(b *testing.B) {
+	immutableKey(b, &derivedBinCollator{}, long)
 }

--- a/pkg/util/collate/collate_test.go
+++ b/pkg/util/collate/collate_test.go
@@ -49,6 +49,7 @@ func testKeyTable(t *testing.T, collations []string, tests []keyTable) {
 		for _, test := range tests {
 			comment := fmt.Sprintf("key %v, using %v", test.Str, c)
 			require.Equal(t, test.Expect[i], collator.Key(test.Str), comment)
+			require.Equal(t, test.Expect[i], collator.ImmutableKey(test.Str), comment)
 		}
 	}
 }

--- a/pkg/util/collate/gb18030_bin.go
+++ b/pkg/util/collate/gb18030_bin.go
@@ -77,6 +77,11 @@ func (g *gb18030BinCollator) Key(str string) []byte {
 	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
+// ImmutableKey implement Collator interface.
+func (g *gb18030BinCollator) ImmutableKey(str string) []byte {
+	return g.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implement Collator interface.
 func (g *gb18030BinCollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str))

--- a/pkg/util/collate/gb18030_bin.go
+++ b/pkg/util/collate/gb18030_bin.go
@@ -79,7 +79,7 @@ func (g *gb18030BinCollator) Key(str string) []byte {
 
 // ImmutableKey implement Collator interface.
 func (g *gb18030BinCollator) ImmutableKey(str string) []byte {
-	return g.Key(str)
+	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/gb18030_chinese_ci.go
+++ b/pkg/util/collate/gb18030_chinese_ci.go
@@ -71,6 +71,11 @@ func (g *gb18030ChineseCICollator) Key(str string) []byte {
 	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
+// ImmutableKey implement Collator interface.
+func (g *gb18030ChineseCICollator) ImmutableKey(str string) []byte {
+	return g.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implement Collator interface.
 func (*gb18030ChineseCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str)*2)

--- a/pkg/util/collate/gb18030_chinese_ci.go
+++ b/pkg/util/collate/gb18030_chinese_ci.go
@@ -73,7 +73,7 @@ func (g *gb18030ChineseCICollator) Key(str string) []byte {
 
 // ImmutableKey implement Collator interface.
 func (g *gb18030ChineseCICollator) ImmutableKey(str string) []byte {
-	return g.Key(str)
+	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/gbk_bin.go
+++ b/pkg/util/collate/gbk_bin.go
@@ -69,7 +69,7 @@ func (g *gbkBinCollator) Key(str string) []byte {
 
 // ImmutableKey implement Collator interface.
 func (g *gbkBinCollator) ImmutableKey(str string) []byte {
-	return g.Key(str)
+	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/gbk_bin.go
+++ b/pkg/util/collate/gbk_bin.go
@@ -67,6 +67,11 @@ func (g *gbkBinCollator) Key(str string) []byte {
 	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
+// ImmutableKey implement Collator interface.
+func (g *gbkBinCollator) ImmutableKey(str string) []byte {
+	return g.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implement Collator interface.
 func (g *gbkBinCollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str))

--- a/pkg/util/collate/gbk_chinese_ci.go
+++ b/pkg/util/collate/gbk_chinese_ci.go
@@ -56,6 +56,11 @@ func (g *gbkChineseCICollator) Key(str string) []byte {
 	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
+// ImmutableKey implement Collator interface.
+func (g *gbkChineseCICollator) ImmutableKey(str string) []byte {
+	return g.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implement Collator interface.
 func (*gbkChineseCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str)*2)

--- a/pkg/util/collate/gbk_chinese_ci.go
+++ b/pkg/util/collate/gbk_chinese_ci.go
@@ -58,7 +58,7 @@ func (g *gbkChineseCICollator) Key(str string) []byte {
 
 // ImmutableKey implement Collator interface.
 func (g *gbkChineseCICollator) ImmutableKey(str string) []byte {
-	return g.Key(str)
+	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implement Collator interface.

--- a/pkg/util/collate/general_ci.go
+++ b/pkg/util/collate/general_ci.go
@@ -56,8 +56,8 @@ func (gc *generalCICollator) Key(str string) []byte {
 }
 
 // ImmutableKey implement Collator interface.
-func (g *generalCICollator) ImmutableKey(str string) []byte {
-	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
+func (gc *generalCICollator) ImmutableKey(str string) []byte {
+	return gc.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implements Collator interface.

--- a/pkg/util/collate/general_ci.go
+++ b/pkg/util/collate/general_ci.go
@@ -55,6 +55,11 @@ func (gc *generalCICollator) Key(str string) []byte {
 	return gc.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
+// ImmutableKey implement Collator interface.
+func (g *generalCICollator) ImmutableKey(str string) []byte {
+	return g.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implements Collator interface.
 func (*generalCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str))

--- a/pkg/util/collate/general_ci.go
+++ b/pkg/util/collate/general_ci.go
@@ -57,7 +57,7 @@ func (gc *generalCICollator) Key(str string) []byte {
 
 // ImmutableKey implement Collator interface.
 func (g *generalCICollator) ImmutableKey(str string) []byte {
-	return g.Key(str)
+	return g.KeyWithoutTrimRightSpace(truncateTailingSpace(str))
 }
 
 // KeyWithoutTrimRightSpace implements Collator interface.

--- a/pkg/util/collate/pinyin_tidb_as_cs.go
+++ b/pkg/util/collate/pinyin_tidb_as_cs.go
@@ -28,6 +28,11 @@ func (*zhPinyinTiDBASCSCollator) Key(_ string) []byte {
 	panic("implement me")
 }
 
+// ImmutableKey implement Collator interface.
+func (*zhPinyinTiDBASCSCollator) ImmutableKey(str string) []byte {
+	panic("implement me")
+}
+
 // KeyWithoutTrimRightSpace is not implemented.
 func (*zhPinyinTiDBASCSCollator) KeyWithoutTrimRightSpace(_ string) []byte {
 	panic("implement me")

--- a/pkg/util/collate/pinyin_tidb_as_cs.go
+++ b/pkg/util/collate/pinyin_tidb_as_cs.go
@@ -29,7 +29,7 @@ func (*zhPinyinTiDBASCSCollator) Key(_ string) []byte {
 }
 
 // ImmutableKey implement Collator interface.
-func (*zhPinyinTiDBASCSCollator) ImmutableKey(str string) []byte {
+func (*zhPinyinTiDBASCSCollator) ImmutableKey(_ string) []byte {
 	panic("implement me")
 }
 

--- a/pkg/util/collate/ucaimpl/unicode_ci.go.tpl
+++ b/pkg/util/collate/ucaimpl/unicode_ci.go.tpl
@@ -31,7 +31,7 @@ type {{.Name}} struct {
 
 // Clone implements Collator interface.
 func (uc *{{.Name}}) Clone() Collator {
-    return &{{.Name}}{impl: uc.impl.Clone()}
+	return &{{.Name}}{impl: uc.impl.Clone()}
 }
 
 // Compare implements Collator interface.
@@ -106,7 +106,7 @@ func (uc *{{.Name}}) Key(str string) []byte {
 
 // ImmutableKey implements Collator interface.
 func (uc *{{.Name}}) ImmutableKey(str string) []byte {
-	return uc.Key(str)
+	return uc.KeyWithoutTrimRightSpace(uc.impl.Preprocess(str))
 }
 
 // KeyWithoutTrimRightSpace implements Collator interface.

--- a/pkg/util/collate/ucaimpl/unicode_ci.go.tpl
+++ b/pkg/util/collate/ucaimpl/unicode_ci.go.tpl
@@ -104,6 +104,11 @@ func (uc *{{.Name}}) Key(str string) []byte {
 	return uc.KeyWithoutTrimRightSpace(uc.impl.Preprocess(str))
 }
 
+// ImmutableKey implements Collator interface.
+func (uc *{{.Name}}) ImmutableKey(str string) []byte {
+	return uc.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implements Collator interface.
 func (uc *{{.Name}}) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str)*2)

--- a/pkg/util/collate/unicode_0400_ci_generated.go
+++ b/pkg/util/collate/unicode_0400_ci_generated.go
@@ -106,7 +106,7 @@ func (uc *unicodeCICollator) Key(str string) []byte {
 
 // ImmutableKey implements Collator interface.
 func (uc *unicodeCICollator) ImmutableKey(str string) []byte {
-	return uc.Key(str)
+	return uc.KeyWithoutTrimRightSpace(uc.impl.Preprocess(str))
 }
 
 // KeyWithoutTrimRightSpace implements Collator interface.

--- a/pkg/util/collate/unicode_0400_ci_generated.go
+++ b/pkg/util/collate/unicode_0400_ci_generated.go
@@ -104,6 +104,11 @@ func (uc *unicodeCICollator) Key(str string) []byte {
 	return uc.KeyWithoutTrimRightSpace(uc.impl.Preprocess(str))
 }
 
+// ImmutableKey implements Collator interface.
+func (uc *unicodeCICollator) ImmutableKey(str string) []byte {
+	return uc.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implements Collator interface.
 func (uc *unicodeCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str)*2)

--- a/pkg/util/collate/unicode_0900_ai_ci_generated.go
+++ b/pkg/util/collate/unicode_0900_ai_ci_generated.go
@@ -106,7 +106,7 @@ func (uc *unicode0900AICICollator) Key(str string) []byte {
 
 // ImmutableKey implements Collator interface.
 func (uc *unicode0900AICICollator) ImmutableKey(str string) []byte {
-	return uc.Key(str)
+	return uc.KeyWithoutTrimRightSpace(uc.impl.Preprocess(str))
 }
 
 // KeyWithoutTrimRightSpace implements Collator interface.

--- a/pkg/util/collate/unicode_0900_ai_ci_generated.go
+++ b/pkg/util/collate/unicode_0900_ai_ci_generated.go
@@ -104,6 +104,11 @@ func (uc *unicode0900AICICollator) Key(str string) []byte {
 	return uc.KeyWithoutTrimRightSpace(uc.impl.Preprocess(str))
 }
 
+// ImmutableKey implements Collator interface.
+func (uc *unicode0900AICICollator) ImmutableKey(str string) []byte {
+	return uc.Key(str)
+}
+
 // KeyWithoutTrimRightSpace implements Collator interface.
 func (uc *unicode0900AICICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	buf := make([]byte, 0, len(str)*2)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63507

Problem Summary:

### What changed and how does it work?
1. add `ImmutableKey` to `Collator`, so the caller can use this instead of `Key` if the return value will not be modified.
2. optimize `SerializeKeys` and `HashChunkSelected` for string type by getting collator each chunk instead of each row.
### Check List

Benchmark
```
BenchmarkUtf8mb4Bin_KeyShort-16                   	34731619	        35.26 ns/op	      48 B/op	       1 allocs/op
BenchmarkUtf8mb4Bin_ImmutableKeyShort-16          	476855181	         2.538 ns/op	       0 B/op	       0 allocs/op
BenchmarkUtf8mb4GeneralCI_KeyShort-16             	 4594576	       258.4 ns/op	     128 B/op	       2 allocs/op
BenchmarkUtf8mb4GeneralCI_ImmutableKeyShort-16    	 4685094	       261.7 ns/op	     144 B/op	       2 allocs/op
BenchmarkUtf8mb4UnicodeCI_KeyShort-16             	 5209453	       240.1 ns/op	      96 B/op	       1 allocs/op
BenchmarkUtf8mb4UnicodeCI_ImmutableKeyShort-16    	 4694634	       235.2 ns/op	      96 B/op	       1 allocs/op
BenchmarkUtf8mb40900AICI_KeyShort-16              	 5230291	       251.4 ns/op	      96 B/op	       1 allocs/op
BenchmarkUtf8mb40900AICI_ImmutableKeyShort-16     	 5196056	       229.3 ns/op	      80 B/op	       1 allocs/op
BenchmarkUtf8mb40900Bin_KeyShort-16               	32984313	        34.63 ns/op	      48 B/op	       1 allocs/op
BenchmarkUtf8mb40900Bin_ImmutableKeyShort-16      	612621256	         2.005 ns/op	       0 B/op	       0 allocs/op
BenchmarkUtf8mb4Bin_KeyMid-16                     	 3097436	       397.5 ns/op	    3072 B/op	       1 allocs/op
BenchmarkUtf8mb4Bin_ImmutableKeyMid-16            	501212491	         2.388 ns/op	       0 B/op	       0 allocs/op
BenchmarkUtf8mb4GeneralCI_KeyMid-16               	   63870	     17622 ns/op	    7168 B/op	       2 allocs/op
BenchmarkUtf8mb4GeneralCI_ImmutableKeyMid-16      	   67890	     18827 ns/op	    7168 B/op	       2 allocs/op
BenchmarkUtf8mb4UnicodeCI_KeyMid-16               	   61974	     19660 ns/op	    6144 B/op	       1 allocs/op
BenchmarkUtf8mb4UnicodeCI_ImmutableKeyMid-16      	   63304	     19058 ns/op	    6144 B/op	       1 allocs/op
BenchmarkUtf8mb40900AICI_KeyMid-16                	   59450	     18310 ns/op	    6144 B/op	       1 allocs/op
BenchmarkUtf8mb40900AICI_ImmutableKeyMid-16       	   64184	     18812 ns/op	    6144 B/op	       1 allocs/op
BenchmarkUtf8mb40900Bin_KeyMid-16                 	 3216708	       392.4 ns/op	    3072 B/op	       1 allocs/op
BenchmarkUtf8mb40900Bin_ImmutableKeyMid-16        	649398882	         1.863 ns/op	       0 B/op	       0 allocs/op
BenchmarkUtf8mb4Bin_KeyLong-16                    	    4040	    264139 ns/op	 2801671 B/op	       1 allocs/op
BenchmarkUtf8mb4Bin_ImmutableKeyLong-16           	492805200	         2.422 ns/op	       0 B/op	       0 allocs/op
BenchmarkUtf8mb4GeneralCI_KeyLong-16              	      61	  19841427 ns/op	10674194 B/op	       3 allocs/op
BenchmarkUtf8mb4GeneralCI_ImmutableKeyLong-16     	      62	  19808817 ns/op	10674197 B/op	       3 allocs/op
BenchmarkUtf8mb4UnicodeCI_KeyLong-16              	      55	  19803463 ns/op	 5595142 B/op	       1 allocs/op
BenchmarkUtf8mb4UnicodeCI_ImmutableKeyLong-16     	      57	  20020112 ns/op	 5595141 B/op	       1 allocs/op
BenchmarkUtf8mb40900AICI_KeyLong-16               	      68	  19316250 ns/op	 5595140 B/op	       1 allocs/op
BenchmarkUtf8mb40900AICI_ImmutableKeyLong-16      	      58	  19642420 ns/op	 5595139 B/op	       1 allocs/op
BenchmarkUtf8mb40900Bin_KeyLong-16                	    4111	    261792 ns/op	 2801672 B/op	       1 allocs/op
BenchmarkUtf8mb40900Bin_ImmutableKeyLong-16       	650685670	         1.862 ns/op	       0 B/op	       0 allocs/op
```

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Optimize the performance of hash agg/join when string with `xx_bin` collator as the agg/join key
```
