### PR TITLE
stats: reduce updating col predicate usage table

### DIFF
--- a/pkg/domain/domain.go
+++ b/pkg/domain/domain.go
@@ -2208,8 +2208,10 @@ func (do *Domain) gcStatsWorker() {
 
 func (do *Domain) dumpColStatsUsageWorker() {
 	logutil.BgLogger().Info("dumpColStatsUsageWorker started.")
-	lease := do.statsLease
-	dumpColStatsUsageTicker := time.NewTicker(100 * lease)
+	// We need to have different nodes trigger tasks at different times to avoid the herd effect.
+	randDuration := time.Duration(rand.Int63n(int64(time.Minute)))
+	dumpDuration := 100*do.statsLease + randDuration
+	dumpColStatsUsageTicker := time.NewTicker(dumpDuration)
 	statsHandle := do.StatsHandle()
 	defer func() {
 		dumpColStatsUsageTicker.Stop()

--- a/pkg/statistics/handle/usage/BUILD.bazel
+++ b/pkg/statistics/handle/usage/BUILD.bazel
@@ -40,10 +40,10 @@ go_test(
         "predicate_column_test.go",
         "session_stats_collect_test.go",
     ],
-    embed = [":usage"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 13,
     deps = [
+        ":usage",
         "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/statistics/handle/usage/indexusage",

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -46,9 +46,17 @@ var (
 	// dumpStatsMaxDuration is the max duration since last update.
 	dumpStatsMaxDuration = 5 * time.Minute
 
+	// colStatsUsageUpdateInterval is the minimum interval to update last_used_at when it already exists.
+	colStatsUsageUpdateInterval = 12 * time.Hour
+
 	// batchInsertSize is the batch size used by internal SQL to insert values to stats usage table.
-	batchInsertSize = 8192
+	batchInsertSize = 2048
 )
+
+// TimeCostRecorder can collect per-batch timings when provided (e.g., in tests).
+type TimeCostRecorder interface {
+	Record(duration time.Duration)
+}
 
 // needDumpStatsDelta checks whether to dump stats delta.
 // 1. If the table doesn't exist or is a mem table or system table, then return false.
@@ -324,46 +332,70 @@ func (s *statsUsageImpl) DumpColStatsUsageToKV() error {
 	defer func() {
 		s.SessionStatsUsage().Merge(colMap)
 	}()
-	type pair struct {
-		lastUsedAt string
-		tblColID   model.TableItemID
-	}
-	pairs := make([]pair, 0, len(colMap))
+	pairs := make([]ColStatsUsageEntry, 0, len(colMap))
 	for id, t := range colMap {
-		pairs = append(pairs, pair{tblColID: id, lastUsedAt: t.UTC().Format(types.TimeFormat)})
+		pairs = append(pairs, ColStatsUsageEntry{TableID: id.TableID, ColumnID: id.ID, LastUsedAt: t.UTC().Format(types.TimeFormat)})
 	}
-	slices.SortFunc(pairs, func(i, j pair) int {
-		if i.tblColID.TableID == j.tblColID.TableID {
-			return cmp.Compare(i.tblColID.ID, j.tblColID.ID)
-		}
-		return cmp.Compare(i.tblColID.TableID, j.tblColID.TableID)
-	})
-	// Use batch insert to reduce cost.
-	for i := 0; i < len(pairs); i += batchInsertSize {
-		end := min(i+batchInsertSize, len(pairs))
-		sql := new(strings.Builder)
-		sqlescape.MustFormatSQL(sql, "INSERT INTO mysql.column_stats_usage (table_id, column_id, last_used_at) VALUES ")
-		for j := i; j < end; j++ {
-			// Since we will use some session from session pool to execute the insert statement, we pass in UTC time here and covert it
-			// to the session's time zone when executing the insert statement. In this way we can make the stored time right.
-			sqlescape.MustFormatSQL(sql, "(%?, %?, CONVERT_TZ(%?, '+00:00', @@TIME_ZONE))", pairs[j].tblColID.TableID, pairs[j].tblColID.ID, pairs[j].lastUsedAt)
-			if j < end-1 {
-				sqlescape.MustFormatSQL(sql, ",")
-			}
-		}
-		sqlescape.MustFormatSQL(sql, " ON DUPLICATE KEY UPDATE last_used_at = CASE WHEN last_used_at IS NULL THEN VALUES(last_used_at) ELSE GREATEST(last_used_at, VALUES(last_used_at)) END")
-		if err := utilstats.CallWithSCtx(s.statsHandle.SPool(), func(sctx sessionctx.Context) error {
-			_, _, err := utilstats.ExecRows(sctx, sql.String())
-			return err
-		}); err != nil {
-			return errors.Trace(err)
-		}
+	if err := DumpColStatsUsageEntries(s.statsHandle.SPool(), pairs, nil); err != nil {
+		return errors.Trace(err)
+	}
+	for id := range colMap {
+		delete(colMap, id)
+	}
+	return nil
+}
 
-		for j := i; j < end; j++ {
-			delete(colMap, pairs[j].tblColID)
+// DumpColStatsUsageEntries batches and executes the insert/update for column_stats_usage.
+func DumpColStatsUsageEntries(pool util.DestroyableSessionPool, entries []ColStatsUsageEntry, rec TimeCostRecorder) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	// sort entries to ensure consistent order and reduce deadlock chance
+	slices.SortFunc(entries, func(a, b ColStatsUsageEntry) int {
+		if a.TableID == b.TableID {
+			return cmp.Compare(a.ColumnID, b.ColumnID)
+		}
+		return cmp.Compare(a.TableID, b.TableID)
+	})
+	for i := 0; i < len(entries); i += batchInsertSize {
+		end := min(i+batchInsertSize, len(entries))
+		batch := entries[i:end]
+		if err := utilstats.CallWithSCtx(pool, func(sctx sessionctx.Context) error {
+			// build simple INSERT ... VALUES with threshold gating in ON DUPLICATE KEY UPDATE
+			thresholdMinutes := int(colStatsUsageUpdateInterval / time.Minute)
+			sql := new(strings.Builder)
+			sqlescape.MustFormatSQL(sql, "INSERT INTO mysql.column_stats_usage (table_id, column_id, last_used_at) VALUES ")
+			for j := 0; j < len(batch); j++ {
+				sqlescape.MustFormatSQL(sql, "(%?, %?, CONVERT_TZ(%?, '+00:00', @@TIME_ZONE))", batch[j].TableID, batch[j].ColumnID, batch[j].LastUsedAt)
+				if j < len(batch)-1 {
+					sqlescape.MustFormatSQL(sql, ",")
+				}
+			}
+			sqlescape.MustFormatSQL(sql, " ON DUPLICATE KEY UPDATE last_used_at = CASE WHEN last_used_at IS NULL OR TIMESTAMPDIFF(MINUTE, last_used_at, VALUES(last_used_at)) >= %? THEN VALUES(last_used_at) ELSE last_used_at END", thresholdMinutes)
+			start := time.Now()
+			if _, _, err := utilstats.ExecRows(sctx, sql.String()); err != nil {
+				return err
+			}
+			dur := time.Since(start)
+			statslogutil.StatsSampleLogger().Info("column_stats_usage: upsert-only(threshold) batch done",
+				zap.Int("batchSize", len(batch)),
+				zap.Duration("duration", dur))
+			if rec != nil {
+				rec.Record(dur)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// ColStatsUsageEntry represents one (table_id, column_id, last_used_at) item to persist.
+type ColStatsUsageEntry struct {
+	TableID    int64
+	ColumnID   int64
+	LastUsedAt string
 }
 
 // NewSessionStatsItem allocates a stats collector for a session.

--- a/pkg/statistics/handle/usage/session_stats_collect.go
+++ b/pkg/statistics/handle/usage/session_stats_collect.go
@@ -365,7 +365,7 @@ func DumpColStatsUsageEntries(pool util.DestroyableSessionPool, entries []ColSta
 			thresholdMinutes := int(colStatsUsageUpdateInterval / time.Minute)
 			sql := new(strings.Builder)
 			sqlescape.MustFormatSQL(sql, "INSERT INTO mysql.column_stats_usage (table_id, column_id, last_used_at) VALUES ")
-			for j := range len(batch) {
+			for j := range batch {
 				// Since we will use some session from session pool to execute the insert statement, we pass in UTC time here and covert it
 				// to the session's time zone when executing the insert statement. In this way we can make the stored time right.
 				sqlescape.MustFormatSQL(sql, "(%?, %?, CONVERT_TZ(%?, '+00:00', @@TIME_ZONE))", batch[j].TableID, batch[j].ColumnID, batch[j].LastUsedAt)

--- a/pkg/statistics/handle/usage/session_stats_collect_test.go
+++ b/pkg/statistics/handle/usage/session_stats_collect_test.go
@@ -12,32 +12,251 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package usage
+package usage_test
 
 import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/statistics/handle/usage"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
 
-func TestInsertAndDelete(t *testing.T) {
-	sl := NewSessionStatsList()
-	items := make([]*SessionStatsItem, 0, 5)
-	for range 5 {
-		items = append(items, sl.NewSessionStatsItem())
+// Test that first-time predicate usage creates a row with last_used_at set (NULL -> value).
+func TestPredicateUsage_FirstTouchCreatesRow(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int)")
+
+	// trigger predicate usage on column a
+	tk.MustQuery("select * from t where a > 0").Check(testkit.Rows())
+	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
+
+	// resolve table and column IDs
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+	colAID := tbl.Meta().Columns[0].ID
+
+	// verify last_used_at is NOT NULL for (tableID, colAID)
+	rows := tk.MustQuery(
+		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+	).Rows()
+	require.Len(t, rows, 1)
+	require.NotEqual(t, "<nil>", rows[0][0])
+}
+
+// Test that repeated usage within throttle interval does not bump last_used_at.
+func TestPredicateUsage_NoBumpWithinThrottle(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int)")
+
+	// first touch
+	tk.MustQuery("select * from t where a > 0").Check(testkit.Rows())
+	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
+
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+	colAID := tbl.Meta().Columns[0].ID
+
+	ts1 := tk.MustQuery(
+		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+	).Rows()[0][0].(string)
+
+	// touch again shortly and dump; throttled path should skip bump
+	tk.MustQuery("select * from t where a > 0").Check(testkit.Rows())
+	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
+
+	ts2 := tk.MustQuery(
+		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+	).Rows()[0][0].(string)
+	require.Equal(t, ts1, ts2)
+}
+
+// Test that when stored last_used_at is very old, a new usage bumps it (exceeds 12h threshold).
+func TestPredicateUsage_BumpAfterOldStoredValue(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int)")
+
+	// first touch to create the row
+	tk.MustQuery("select * from t where a > 0").Check(testkit.Rows())
+	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
+
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	tableID := tbl.Meta().ID
+	colAID := tbl.Meta().Columns[0].ID
+
+	// set an ancient last_used_at so the next usage exceeds throttle interval
+	tk.MustExec(fmt.Sprintf(
+		"update mysql.column_stats_usage set last_used_at = timestamp '2000-01-01 00:00:00' where table_id=%d and column_id=%d",
+		tableID, colAID,
+	))
+
+	// touch again and dump; should bump to a recent timestamp
+	tk.MustQuery("select * from t where a > 0").Check(testkit.Rows())
+	require.NoError(t, dom.StatsHandle().DumpColStatsUsageToKV())
+
+	// verify last_used_at changed from the ancient value
+	got := tk.MustQuery(
+		fmt.Sprintf("select last_used_at from mysql.column_stats_usage where table_id=%d and column_id=%d", tableID, colAID),
+	).Rows()[0][0].(string)
+	require.NotEqual(t, "2000-01-01 00:00:00", got)
+}
+
+type testTimeCollector struct {
+	mu   sync.Mutex
+	data []time.Duration
+}
+
+func (c *testTimeCollector) Record(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = append(c.data, d)
+}
+
+func calculateStats(durations []time.Duration) (avg, min, max time.Duration) {
+	if len(durations) == 0 {
+		return 0, 0, 0
 	}
-	items[0].Delete() // delete tail
-	items[2].Delete() // delete middle
-	items[4].Delete() // delete head
-	sl.SweepSessionStatsList()
+	var sum time.Duration
+	min = durations[0]
+	max = durations[0]
+	for _, d := range durations {
+		sum += d
+		if d < min {
+			min = d
+		}
+		if d > max {
+			max = d
+		}
+	}
+	avg = time.Duration(int64(sum) / int64(len(durations)))
+	return avg, min, max
+}
 
-	require.Equal(t, items[3], sl.listHead.next)
-	require.Equal(t, items[1], items[3].next)
-	require.Nil(t, items[1].next)
+func TestDumpColStatsUsageWriter_ConcurrentMultiTables(t *testing.T) {
+	t.Skip("Skipping concurrent stats test - run manually if needed")
+	// create 100 domains to mimic 100 TiDB nodes; share the same underlying store
+	dec := testkit.NewDistExecutionContextWithLease(t, 10, 200*time.Millisecond)
+	defer dec.Close()
+	tk := testkit.NewTestKit(t, dec.GetDomain(0).Store())
+	tk.MustExec("use test")
 
-	// delete rest
-	items[1].Delete()
-	items[3].Delete()
-	sl.SweepSessionStatsList()
-	require.Nil(t, sl.listHead.next)
+	// attach collector to capture per-query timings inside usage code
+	tc := &testTimeCollector{}
+
+	const tableCount = 100
+	const numCols = 1000
+	for i := 1; i <= tableCount; i++ {
+		tk.MustExec(fmt.Sprintf("drop table if exists t%d", i))
+		cols := make([]string, 0, numCols)
+		for c := 0; c < numCols; c++ {
+			cols = append(cols, fmt.Sprintf("c%d int", c))
+		}
+		tk.MustExec(fmt.Sprintf("create table t%d (%s)", i, strings.Join(cols, ", ")))
+	}
+
+	// collect ids
+	is := dec.GetDomain(0).InfoSchema()
+	tableIDs := make([]int64, 0, tableCount)
+	allCols := make([][]int64, 0, tableCount)
+	for i := 1; i <= tableCount; i++ {
+		tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr(fmt.Sprintf("t%d", i)))
+		require.NoError(t, err)
+		tid := tbl.Meta().ID
+		tableIDs = append(tableIDs, tid)
+		cids := make([]int64, 0, numCols)
+		for c := 0; c < numCols; c++ {
+			cids = append(cids, tbl.Meta().Columns[c].ID)
+		}
+		allCols = append(allCols, cids)
+	}
+
+	seedTSUTC := time.Now().UTC().Format("2006-01-02 15:04:05")
+	seed := make([]usage.ColStatsUsageEntry, 0, tableCount*numCols)
+	for i, tid := range tableIDs {
+		for _, cid := range allCols[i] {
+			seed = append(seed, usage.ColStatsUsageEntry{TableID: tid, ColumnID: cid, LastUsedAt: seedTSUTC})
+		}
+	}
+	require.NoError(t, usage.DumpColStatsUsageEntries(dec.GetDomain(0).StatsHandle().SPool(), seed, nil))
+
+	noBumpTSUTC := time.Now().UTC().Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	bumpTSUTC := time.Now().UTC().Add(13 * time.Hour).Format("2006-01-02 15:04:05")
+	entries := make([]usage.ColStatsUsageEntry, 0, tableCount*numCols)
+	updatedExpect := 0
+	idx := 0
+	for i, tid := range tableIDs {
+		for _, cid := range allCols[i] {
+			if idx%1000 == 0 {
+				entries = append(entries, usage.ColStatsUsageEntry{TableID: tid, ColumnID: cid, LastUsedAt: bumpTSUTC})
+				updatedExpect++
+			} else {
+				entries = append(entries, usage.ColStatsUsageEntry{TableID: tid, ColumnID: cid, LastUsedAt: noBumpTSUTC})
+			}
+			idx++
+		}
+	}
+
+	const goroutines = 10
+	elapsedCh := make(chan time.Duration, goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			gStart := time.Now()
+			dom := dec.GetDomain(id)
+			err := usage.DumpColStatsUsageEntries(dom.StatsHandle().SPool(), entries, tc)
+			gElapsed := time.Since(gStart)
+			if err != nil {
+				t.Logf("writer goroutine %d error: %v (elapsed=%s)", id, err, gElapsed)
+			}
+			require.NoError(t, err)
+			t.Logf("writer goroutine %d finished in %s", id, gElapsed)
+			elapsedCh <- gElapsed
+		}(g)
+	}
+	goroutineTimes := make([]time.Duration, goroutines)
+	for g := 0; g < goroutines; g++ {
+		goroutineTimes[g] = <-elapsedCh
+	}
+	avg, min, max := calculateStats(goroutineTimes)
+
+	// verify only the intended subset updated: match exact UTC bumpTS via CONVERT_TZ
+	totalUpdated := 0
+	for _, tid := range tableIDs {
+		row := tk.MustQuery(
+			fmt.Sprintf(
+				"select count(*) from mysql.column_stats_usage where table_id=%d and CONVERT_TZ(last_used_at, @@TIME_ZONE, '+00:00') = timestamp '%s'",
+				tid, bumpTSUTC,
+			),
+		).Rows()[0][0].(string)
+		var c int
+		_, _ = fmt.Sscanf(row, "%d", &c)
+		totalUpdated += c
+	}
+	require.Equal(t, updatedExpect, totalUpdated)
+	// one consolidated summary line combining per-goroutine and collector stats
+	tc.mu.Lock()
+	batches := len(tc.data)
+	colAvg, colMin, colMax := calculateStats(tc.data)
+	tc.mu.Unlock()
+	t.Logf("DumpColStatsUsage concurrent: goroutines=%d tables=%d cols/table=%d per-g: avg=%s min=%s max=%s; updated=%d/%d; batches=%d per-batch: avg=%s min=%s max=%s", goroutines, tableCount, numCols, avg, min, max, totalUpdated, tableCount*numCols, batches, colAvg, colMin, colMax)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63426 

Problem Summary:

### What changed and how does it work?

We noticed updating to cols usage query has been taking 10s seconds when scale TIDB nodes to 100. It was mainly due to lock contention that every node trying to update the same set of cols. 

By doing some experiments locally, it is noticed that the batch size might contribute a lot to the lock contention. By tuning down the batch size, it should mitigate the problem.

This PR also tries to not update the cols if it's only timestamp change, we decide to update the col timestamp every 12 hours, that should also reduce the update time and lock contention.

Perf with different batch size:
```
// batch size 1024
DumpColStatsUsage concurrent: goroutines=10 tables=100 cols/table=1000 per-g: avg=7.486120933s min=7.300108708s max=7.718235625s; updated=100/100000; batches=980 per-batch: avg=75.721586ms min=11.163959ms max=927.45675ms

// batch size 2048
DumpColStatsUsage concurrent: goroutines=10 tables=100 cols/table=1000 per-g: avg=6.412777945s min=6.262234292s max=6.551383291s; updated=100/100000; batches=490 per-batch: avg=128.168868ms min=29.5895ms max=538.059583ms

// batch size 4096
DumpColStatsUsage concurrent: goroutines=10 tables=100 cols/table=1000 per-g: avg=6.889603845s min=6.633772208s max=7.037077708s; updated=100/100000; batches=250 per-batch: avg=273.157262ms min=37.115208ms max=1.215064s

// batch size 8192
DumpColStatsUsage concurrent: goroutines=10 tables=100 cols/table=1000 per-g: avg=8.217947175s min=7.566108792s max=8.744043541s; updated=100/100000; batches=130 per-batch: avg=626.931753ms min=28.640833ms max=3.102622292s
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
