### PR TITLE
planner: fix the USE_INDEX hint for tici index

### DIFF
--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_in.json
@@ -19,5 +19,12 @@
       "explain format='brief' select id from t1 where (fts_match_prefix('apple', title) and fts_match_word('boy', title)) or (fts_match_word('banana', title) and fts_match_word('girl', title))",
       "explain format='brief' select /*+ inl_join(t1) */ * from t1, t2 where t2.col=t1.title"
     ]
+  },
+  {
+    "name": "TestTiCIWithIndexHintCases",
+    "cases": [
+      "explain format='brief' select * from t1 use index(idx_title)",
+      "explain format='brief' select * from t1 use index(idx_field) where fts_match_word('hello', title)"
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
+++ b/pkg/planner/core/casetest/tici/testdata/tici_index_suite_out.json
@@ -173,5 +173,31 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestTiCIWithIndexHintCases",
+    "Cases": [
+      {
+        "SQL": "explain format='brief' select * from t1 use index(idx_title)",
+        "Plan": [
+          "TableReader 10000.00 root  data:TableFullScan",
+          "└─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "[planner:3126]Hint USE_INDEX is ignored as conflicting/duplicated."
+        ]
+      },
+      {
+        "SQL": "explain format='brief' select * from t1 use index(idx_field) where fts_match_word('hello', title)",
+        "Plan": [
+          "IndexLookUp 1000.00 root  ",
+          "├─IndexRangeScan(Build) 1000.00 batchCop[tiflash] table:t1, index:idx_title(title) range:[NULL,+inf], search func:fts_match_word(\"hello\", test.t1.title), keep order:false, stats:pseudo",
+          "└─TableRowIDScan(Probe) 1000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "Warn": [
+          "[planner:3126]Hint USE_INDEX is ignored as conflicting/duplicated."
+        ]
+      }
+    ]
   }
 ]

--- a/pkg/planner/core/casetest/tici/tici_test.go
+++ b/pkg/planner/core/casetest/tici/tici_test.go
@@ -49,12 +49,59 @@ func TestTiCISearchExplain(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec(`create table t1(
 		id INT PRIMARY KEY, title TEXT, body TEXT, field1 int,
-		FULLTEXT KEY (title),
+		FULLTEXT INDEX idx_title (title),
 		index idx_field1 (field1)
 	)`)
 	dom := domain.GetDomain(tk.Session())
 	testkit.SetTiFlashReplica(t, dom, "test", "t1")
 	tk.MustExec("create table t2(col text)")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+		Warn []string
+	}
+	integrationSuiteData := GetFTSIndexSuiteData()
+	integrationSuiteData.LoadTestCases(t, &input, &output)
+	for i, tt := range input {
+		testdata.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+			output[i].Warn = testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+		require.Equal(t, output[i].Warn, testdata.ConvertSQLWarnToStrings(tk.Session().GetSessionVars().StmtCtx.GetWarnings()))
+	}
+}
+
+func TestTiCIWithIndexHintCases(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/tici/MockCreateTiCIIndexSuccess", `return(true)`))
+	defer func() {
+		err := failpoint.Disable("github.com/pingcap/tidb/pkg/tici/MockCreateTiCIIndexSuccess")
+		require.NoError(t, err)
+	}()
+
+	store := testkit.CreateMockStoreWithSchemaLease(t, 1*time.Second, mockstore.WithMockTiFlash(2))
+
+	tk := testkit.NewTestKit(t, store)
+
+	tiflash := infosync.NewMockTiFlash()
+	infosync.SetMockTiFlash(tiflash)
+	defer func() {
+		tiflash.Lock()
+		tiflash.StatusServer.Close()
+		tiflash.Unlock()
+	}()
+
+	tk.MustExec("use test")
+	tk.MustExec(`create table t1(
+		id INT PRIMARY KEY, title TEXT, body TEXT, field1 int,
+		FULLTEXT INDEX idx_title (title),
+		index idx_field1 (field1)
+	)`)
+	dom := domain.GetDomain(tk.Session())
+	testkit.SetTiFlashReplica(t, dom, "test", "t1")
 
 	var input []string
 	var output []struct {

--- a/pkg/planner/core/stats.go
+++ b/pkg/planner/core/stats.go
@@ -133,6 +133,9 @@ func deriveStats4DataSource(lp base.LogicalPlan) (*property.StatsInfo, bool, err
 	for i, expr := range ds.PushedDownConds {
 		ds.PushedDownConds[i] = expression.EliminateNoPrecisionLossCast(exprCtx, expr)
 	}
+	// Cleanup the unused TiCI indexes.
+	// They are not suitable for normal read.
+	ds.CleanUnusedTiCIIndexes()
 	for _, path := range ds.AllPossibleAccessPaths {
 		if path.IsTablePath() {
 			continue

--- a/pkg/planner/util/path.go
+++ b/pkg/planner/util/path.go
@@ -130,10 +130,6 @@ type AccessPath struct {
 	// Maybe added in model.IndexInfo better, but the cache of model.IndexInfo may lead side effect
 	IsUkShardIndexPath bool
 
-	FullText     bool
-	QueryColumns []*expression.Column
-	QueryJSONStr string
-
 	FtsQueryInfo *tipb.FTSQueryInfo
 }
 
@@ -446,6 +442,17 @@ func (path *AccessPath) IsFullScanRange(tableInfo *model.TableInfo) bool {
 		}
 	}
 	if ranger.HasFullRange(path.Ranges, unsignedIntHandle) {
+		return true
+	}
+	return false
+}
+
+// IsUndetermined checks whether the usability of this path depends on the pushed down predicates.
+func (path *AccessPath) IsUndetermined() bool {
+	if path.IsTablePath() || path.Index == nil {
+		return false
+	}
+	if path.Index.MVIndex || path.Index.FullTextInfo != nil {
 		return true
 	}
 	return false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61185

Problem Summary:

We didn't implement the expected behavior when the index hint meets the tici index.

### What changed and how does it work?

This pr will
- Using an index hint will not cause SQL to throw an error.
- If the use index hint is used on the tici index without any filter. We'll throw warning and use table scan.
- If the use index hint is used on the normal index with fts_match functions. We'll throwing warning and use the corresponding tici index.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
