### PR TITLE
session: fix test cases `TestBootstrapWithError`, `TestTableReaderChunk`, `TestIndexLookUpReaderChunk`  for nextgen

### DIFF
--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -179,6 +179,10 @@ func TestBootstrapWithError(t *testing.T) {
 		require.NoError(t, store.Close())
 	}()
 
+	// system tables are not created in `doDDLWorks` for next-gen.
+	if kerneltype.IsNextGen() {
+		require.NoError(t, bootstrapSchemas(store))
+	}
 	// bootstrap
 	{
 		se := &session{

--- a/pkg/session/test/schematest/schema_test.go
+++ b/pkg/session/test/schematest/schema_test.go
@@ -120,6 +120,9 @@ func TestTableReaderChunk(t *testing.T) {
 	tbl, err := domain.GetDomain(tk.Session()).InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("chk"))
 	require.NoError(t, err)
 	tableStart := tablecodec.GenTableRecordPrefix(tbl.Meta().ID)
+	if kerneltype.IsNextGen() {
+		tableStart = store.GetCodec().EncodeKey(tableStart)
+	}
 	cluster.SplitKeys(tableStart, tableStart.PrefixNext(), 10)
 
 	tk.Session().GetSessionVars().SetDistSQLScanConcurrency(1)
@@ -325,6 +328,9 @@ func TestIndexLookUpReaderChunk(t *testing.T) {
 	tbl, err := domain.GetDomain(tk.Session()).InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("chk"))
 	require.NoError(t, err)
 	indexStart := tablecodec.EncodeTableIndexPrefix(tbl.Meta().ID, tbl.Indices()[0].Meta().ID)
+	if kerneltype.IsNextGen() {
+		indexStart = store.GetCodec().EncodeKey(indexStart)
+	}
 	cluster.SplitKeys(indexStart, indexStart.PrefixNext(), 10)
 
 	tk.Session().GetSessionVars().IndexLookupSize = 10


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63538

Problem Summary:

The three test cases failed for `nextgen`. 

### What changed and how does it work?

Fix them :+1:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
