### PR TITLE
planner: consider magnified seeking cost in IndexJoin

### DIFF
--- a/pkg/planner/core/plan_cost_ver2.go
+++ b/pkg/planner/core/plan_cost_ver2.go
@@ -973,10 +973,11 @@ func getPlanCostVer24PhysicalCTE(pp base.PhysicalPlan, taskType property.TaskTyp
 func indexJoinSeekingCostVer2(option *optimizetrace.PlanCostOption, buildRows, numRanges float64, scanFactor costusage.CostVer2Factor) costusage.CostVer2 {
 	// Large IN lists like `a in (1, 2, 3...)` could generate a large number of ranges and seeking operations, which could be magnified by IndexJoin
 	// and slow down the query performance obviously, we need to consider this part of cost. Please see a case in issue #62499.
-	// To simplify the calculation of seeking cost, we treat a seeking operation as a scan of 20 rows with 64 row size.
+	// To simplify the calculation of seeking cost, we treat a seeking operation as a scan of 10 rows with 8 row-width.
+	// 10 is based on a simple experiment, please see https://github.com/pingcap/tidb/issues/62499#issuecomment-3301796153.
 	return costusage.NewCostVer2(option, scanFactor,
-		buildRows*20*math.Log2(64)*numRanges*scanFactor.Value,
-		func() string { return fmt.Sprintf("seeking(%v*%v*20*log2(64)*%v)", buildRows, numRanges, scanFactor) })
+		buildRows*10*math.Log2(8)*numRanges*scanFactor.Value,
+		func() string { return fmt.Sprintf("seeking(%v*%v*10*log2(8)*%v)", buildRows, numRanges, scanFactor) })
 }
 
 func scanCostVer2(option *optimizetrace.PlanCostOption, rows, rowSize float64, scanFactor costusage.CostVer2Factor) costusage.CostVer2 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62499

Problem Summary: planner: consider magnified seeking cost in IndexJoin

### What changed and how does it work?

Our current cost model doesn't consider the cost of seeking operation, which is usually cased by IN predicate like `where a = (1, 2, 3, ...10000)`.
In most cases its cost could be negligible, but if its under `IndexJoin`, its cost could be magnified by the `IndexJoin` significantly (depending on the number of build rows), please see an simplified and concrete case here: https://github.com/pingcap/tidb/issues/62499#issuecomment-3301610024

So to mitigate this problem, we'll consider the magnified seeking cost in `IndexJoin`, and treat one seeking operation as a 10-row scan, here is a simple experiment of how we get `10` here: https://github.com/pingcap/tidb/issues/62499#issuecomment-3301796153

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
