### PR TITLE
next-gen: fix tablesample test and null keyspace test

### DIFF
--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2591,7 +2591,9 @@ func makeStore(t *testing.T, keyspaceMeta *keyspacepb.KeyspaceMeta, isHasPrefix 
 			mockstore.WithStoreType(mockstore.EmbedUnistore),
 		)
 	} else {
-		store, err = mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
+		store, err = mockstore.NewMockStore(
+			mockstore.WithStoreType(mockstore.EmbedUnistore),
+			mockstore.WithKeyspaceMeta(nil))
 	}
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2579,7 +2579,7 @@ func TestKeyspaceEtcdNamespace(t *testing.T) {
 
 func TestNullKeyspaceEtcdNamespace(t *testing.T) {
 	if kerneltype.IsNextGen() {
-		t.Skip("keyspace is required in next-gen kernel")
+		t.Skip("next-gen kernel doesn't have the NULL keyspace concept")
 	}
 	makeStore(t, nil, false)
 }

--- a/pkg/session/bootstrap_test.go
+++ b/pkg/session/bootstrap_test.go
@@ -2578,6 +2578,9 @@ func TestKeyspaceEtcdNamespace(t *testing.T) {
 }
 
 func TestNullKeyspaceEtcdNamespace(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("keyspace is required in next-gen kernel")
+	}
 	makeStore(t, nil, false)
 }
 
@@ -2591,9 +2594,7 @@ func makeStore(t *testing.T, keyspaceMeta *keyspacepb.KeyspaceMeta, isHasPrefix 
 			mockstore.WithStoreType(mockstore.EmbedUnistore),
 		)
 	} else {
-		store, err = mockstore.NewMockStore(
-			mockstore.WithStoreType(mockstore.EmbedUnistore),
-			mockstore.WithKeyspaceMeta(nil))
+		store, err = mockstore.NewMockStore(mockstore.WithStoreType(mockstore.EmbedUnistore))
 	}
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/store/mockstore/mockstore.go
+++ b/pkg/store/mockstore/mockstore.go
@@ -222,9 +222,6 @@ func NewMockStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 		},
 		storeType: defaultStoreType,
 	}
-	for _, f := range options {
-		f(&opt)
-	}
 	if kerneltype.IsNextGen() {
 		// in nextgen, all stores must have a keyspace meta set. to simplify the
 		// test, we set the default keyspace meta to system keyspace.
@@ -234,6 +231,9 @@ func NewMockStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 				Name: keyspace.System,
 			}
 		}
+	}
+	for _, f := range options {
+		f(&opt)
 	}
 
 	var (

--- a/pkg/store/mockstore/mockstore.go
+++ b/pkg/store/mockstore/mockstore.go
@@ -222,6 +222,9 @@ func NewMockStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 		},
 		storeType: defaultStoreType,
 	}
+	for _, f := range options {
+		f(&opt)
+	}
 	if kerneltype.IsNextGen() {
 		// in nextgen, all stores must have a keyspace meta set. to simplify the
 		// test, we set the default keyspace meta to system keyspace.
@@ -231,9 +234,6 @@ func NewMockStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 				Name: keyspace.System,
 			}
 		}
-	}
-	for _, f := range options {
-		f(&opt)
 	}
 
 	var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61702

Problem Summary:

### What changed and how does it work?

- Skip null keyspace test in next-gen.
- Set tablesample end key to table end key if the length is zero.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
