### PR TITLE
ddl: allow DDL on the system table in BDR mode

### DIFF
--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -69,6 +69,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror/exeerrors"
 	"github.com/pingcap/tidb/pkg/util/dbutil"
 	"github.com/pingcap/tidb/pkg/util/domainutil"
+	"github.com/pingcap/tidb/pkg/util/filter"
 	"github.com/pingcap/tidb/pkg/util/generic"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 	"github.com/pingcap/tidb/pkg/util/tracing"
@@ -2147,7 +2148,7 @@ func (e *executor) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.Alt
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if bdrRole == string(ast.BDRRolePrimary) && deniedByBDRWhenAddColumn(specNewColumn.Options) {
+	if bdrRole == string(ast.BDRRolePrimary) && deniedByBDRWhenAddColumn(specNewColumn.Options) && !filter.IsSystemSchema(schema.Name.L) {
 		return dbterror.ErrBDRRestrictedDDL.FastGenByArgs(bdrRole)
 	}
 

--- a/pkg/ddl/job_submitter.go
+++ b/pkg/ddl/job_submitter.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/filter"
 	"github.com/pingcap/tidb/pkg/util/generic"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"github.com/pingcap/tidb/pkg/util/mathutil"
@@ -311,11 +312,11 @@ func (s *JobSubmitter) addBatchDDLJobs2Table(jobWs []*JobWrapper) error {
 		if job.CDCWriteSource == 0 && bdrRole != string(ast.BDRRoleNone) {
 			if job.Type == model.ActionMultiSchemaChange && job.MultiSchemaInfo != nil {
 				for _, subJob := range job.MultiSchemaInfo.SubJobs {
-					if DeniedByBDR(ast.BDRRole(bdrRole), subJob.Type, subJob.JobArgs) {
+					if DeniedByBDR(ast.BDRRole(bdrRole), subJob.Type, subJob.JobArgs) && !filter.IsSystemSchema(job.SchemaName) {
 						return dbterror.ErrBDRRestrictedDDL.FastGenByArgs(bdrRole)
 					}
 				}
-			} else if DeniedByBDR(ast.BDRRole(bdrRole), job.Type, jobW.JobArgs) {
+			} else if DeniedByBDR(ast.BDRRole(bdrRole), job.Type, jobW.JobArgs) && !filter.IsSystemSchema(job.SchemaName) {
 				return dbterror.ErrBDRRestrictedDDL.FastGenByArgs(bdrRole)
 			}
 		}

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"github.com/pingcap/tidb/pkg/util/filter"
 	"github.com/pingcap/tidb/pkg/util/intest"
 	"go.uber.org/zap"
 )
@@ -996,7 +997,7 @@ func GetModifiableColumnJob(
 		return nil, errors.Trace(err)
 	}
 	if bdrRole == string(ast.BDRRolePrimary) &&
-		deniedByBDRWhenModifyColumn(newCol.FieldType, col.FieldType, specNewColumn.Options) {
+		deniedByBDRWhenModifyColumn(newCol.FieldType, col.FieldType, specNewColumn.Options) && !filter.IsSystemSchema(schema.Name.L) {
 		return nil, dbterror.ErrBDRRestrictedDDL.FastGenByArgs(bdrRole)
 	}
 

--- a/pkg/session/test/bootstraptest/BUILD.bazel
+++ b/pkg/session/test/bootstraptest/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "main_test.go",
     ],
     flaky = True,
-    shard_count = 12,
+    shard_count = 14,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -897,10 +897,6 @@ func TestUpgradeWithCrossJoinDisabled(t *testing.T) {
 }
 
 func TestUpgradeVersion245Primary(t *testing.T) {
-	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
-	}
-
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 	seV244 := session.CreateSessionAndSetID(t, store)
@@ -927,10 +923,6 @@ func TestUpgradeVersion245Primary(t *testing.T) {
 }
 
 func TestUpgradeVersion245Secondary(t *testing.T) {
-	if kerneltype.IsNextGen() {
-		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
-	}
-
 	store, dom := session.CreateStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 	seV244 := session.CreateSessionAndSetID(t, store)

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -922,7 +922,7 @@ func TestUpgradeVersion245Primary(t *testing.T) {
 	require.NoError(t, err)
 	ver, err = session.GetBootstrapVersion(seV244)
 	require.NoError(t, err)
-	require.Equal(t, int64(252), ver)
+	require.Equal(t, session.CurrentBootstrapVersion, ver)
 	newVer.Close()
 }
 
@@ -952,6 +952,6 @@ func TestUpgradeVersion245Secondary(t *testing.T) {
 	require.NoError(t, err)
 	ver, err = session.GetBootstrapVersion(seV244)
 	require.NoError(t, err)
-	require.Equal(t, int64(252), ver)
+	require.Equal(t, session.CurrentBootstrapVersion, ver)
 	newVer.Close()
 }

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -926,7 +926,7 @@ func TestUpgradeVersion245Primary(t *testing.T) {
 	newVer.Close()
 }
 
-func TestUpgradeVersion245SECONDARY(t *testing.T) {
+func TestUpgradeVersion245Secondary(t *testing.T) {
 	if kerneltype.IsNextGen() {
 		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
 	}

--- a/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
+++ b/pkg/session/test/bootstraptest/bootstrap_upgrade_test.go
@@ -895,3 +895,33 @@ func TestUpgradeWithCrossJoinDisabled(t *testing.T) {
 		require.NoError(t, store.Close())
 	}()
 }
+
+func TestUpgradeVersion245(t *testing.T) {
+	if kerneltype.IsNextGen() {
+		t.Skip("Skip this case because there is no upgrade in the first release of next-gen kernel")
+	}
+
+	store, dom := session.CreateStoreAndBootstrap(t)
+	defer func() { require.NoError(t, store.Close()) }()
+	seV244 := session.CreateSessionAndSetID(t, store)
+	txn, err := store.Begin()
+	require.NoError(t, err)
+	m := meta.NewMutator(txn)
+	err = m.FinishBootstrap(int64(244))
+	require.NoError(t, err)
+	err = txn.Commit(context.Background())
+	revertVersionAndVariables(t, seV244, 244)
+	require.NoError(t, err)
+	session.MustExec(t, seV244, "ADMIN SET BDR ROLE PRIMARY")
+	store.SetOption(session.StoreBootstrappedKey, nil)
+	ver, err := session.GetBootstrapVersion(seV244)
+	require.NoError(t, err)
+	require.Equal(t, int64(244), ver)
+	dom.Close()
+	newVer, err := session.BootstrapSession(store)
+	require.NoError(t, err)
+	ver, err = session.GetBootstrapVersion(seV244)
+	require.NoError(t, err)
+	require.Equal(t, int64(252), ver)
+	newVer.Close()
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #60042

Problem Summary:
During the upgrade, TiDB needs to do some DDL on the system table.
Some of them are non-replicable, such as 
```
ALTER TABLE mysql.bind_info MODIFY COLUMN original_sql LONGTEXT NOT NULL
```
In upgradeToVer245(),

```
ALTER TABLE mysql.tidb_pitr_id_map ADD PRIMARY KEY(restore_id, restored_ts, upstream_cluster_id, segment_id)
```
In upgradeToVer248().
If BDR mode is enabled, TiDB would fail to upgrade. 


### What changed and how does it work?
If the DDL is on a system table, we should not report an error.
Since the CDC would not sync the system table, it's ok to execute in BDR mode.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] 
Start an upstream cluster and a downstream cluster. (v8.1.0)

Upstream:
```
ADMIN SET BDR ROLE PRIMARY;
```  

Downstream:
```
ADMIN SET BDR ROLE SECONDARY;
```

Upgrade the upstream cluster to master.
Fail to start:
```
upstream-tidb-0                         0/1     Running     3 (2m6s ago)   3m23s
```
Upgrade the upstream cluster and the downstream cluster to this PR.
Upgrade success.
```
➜  ~ kubectl get pods
NAME                                    READY   STATUS      RESTARTS   AGE
collect-z6zhs-collect-logs-rb2pj        0/1     Completed   0          10m
collect-z6zhs-collect-metrics-8gj57     0/1     Completed   0          10m
downstream-discovery-544858bb56-tvrnb   1/1     Running     0          18m
downstream-monitor-0                    3/3     Running     0          18m
downstream-pd-0                         1/1     Running     0          18m
downstream-tidb-0                       1/1     Running     0          30s
downstream-tidb-1                       1/1     Running     0          56s
downstream-tikv-0                       1/1     Running     0          17m
sdkserver-0                             1/1     Running     0          18m
syncdiff-0                              1/1     Running     0          18m
upstream-discovery-9464fcc66-7l2db      1/1     Running     0          18m
upstream-monitor-0                      3/3     Running     0          18m
upstream-pd-0                           1/1     Running     0          18m
upstream-ticdc-0                        1/1     Running     0          17m
upstream-tidb-0                         1/1     Running     0          2m27s
upstream-tikv-0                         1/1     Running     0          17m
workload-0                              1/1     Running     0          18m
```


- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
