### PR TITLE
stats: expose stats parameters as global session variable

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -3122,26 +3122,29 @@ var analyzeOptionLimit = map[ast.AnalyzeOptionType]uint64{
 	ast.AnalyzeOptSampleRate:    math.Float64bits(1),
 }
 
+// analyzeOptionDefaultV2 returns the default analyze options for version 2.
 // TopN reduced from 500 to 100 due to concerns over large number of TopN values collected for customers with many tables.
 // 100 is more inline with other databases. 100-256 is also common for NumBuckets with other databases.
-var analyzeOptionDefaultV2 = map[ast.AnalyzeOptionType]uint64{
-	ast.AnalyzeOptNumBuckets:    statistics.DefaultHistogramBuckets,
-	ast.AnalyzeOptNumTopN:       statistics.DefaultTopNValue,
-	ast.AnalyzeOptCMSketchWidth: 2048,
-	ast.AnalyzeOptCMSketchDepth: 5,
-	ast.AnalyzeOptNumSamples:    0,
-	ast.AnalyzeOptSampleRate:    math.Float64bits(-1),
+func analyzeOptionDefaultV2() map[ast.AnalyzeOptionType]uint64 {
+	return map[ast.AnalyzeOptionType]uint64{
+		ast.AnalyzeOptNumBuckets:    vardef.AnalyzeDefaultNumBuckets.Load(),
+		ast.AnalyzeOptNumTopN:       vardef.AnalyzeDefaultNumTopN.Load(),
+		ast.AnalyzeOptCMSketchWidth: vardef.AnalyzeDefaultCMSketchWidth.Load(),
+		ast.AnalyzeOptCMSketchDepth: vardef.AnalyzeDefaultCMSketchDepth.Load(),
+		ast.AnalyzeOptNumSamples:    vardef.AnalyzeDefaultNumSamples.Load(),
+		ast.AnalyzeOptSampleRate:    math.Float64bits(-1),
+	}
 }
 
 // GetAnalyzeOptionDefaultV2ForTest returns the default analyze options for test.
 func GetAnalyzeOptionDefaultV2ForTest() map[ast.AnalyzeOptionType]uint64 {
-	return analyzeOptionDefaultV2
+	return analyzeOptionDefaultV2()
 }
 
 // handleAnalyzeOptions validates analyze options and returns only the options
 // explicitly specified in the statement.
 func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint64, error) {
-	optMap := make(map[ast.AnalyzeOptionType]uint64, len(analyzeOptionDefaultV2))
+	optMap := make(map[ast.AnalyzeOptionType]uint64, len(analyzeOptionLimit))
 	sampleNum, sampleRate := uint64(0), 0.0
 	for _, opt := range opts {
 		datumValue := opt.Value.(*driver.ValueExpr).Datum
@@ -3183,8 +3186,9 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint
 }
 
 func fillAnalyzeOptionsV2(optMap map[ast.AnalyzeOptionType]uint64) map[ast.AnalyzeOptionType]uint64 {
-	filledMap := make(map[ast.AnalyzeOptionType]uint64, len(analyzeOptionDefaultV2))
-	for key, defaultVal := range analyzeOptionDefaultV2 {
+	defaultV2 := analyzeOptionDefaultV2()
+	filledMap := make(map[ast.AnalyzeOptionType]uint64, len(defaultV2))
+	for key, defaultVal := range defaultV2 {
 		if val, ok := optMap[key]; ok {
 			filledMap[key] = val
 		} else {

--- a/pkg/planner/core/planbuilder_test.go
+++ b/pkg/planner/core/planbuilder_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pingcap/tidb/pkg/planner/property"
 	"github.com/pingcap/tidb/pkg/planner/util"
 	"github.com/pingcap/tidb/pkg/planner/util/coretestsdk"
+	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/types"
 	driver "github.com/pingcap/tidb/pkg/types/parser_driver"
@@ -708,6 +709,62 @@ func TestHandleAnalyzeOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAnalyzeDefaultsFromGlobalVars(t *testing.T) {
+	// Save original values
+	origBuckets := vardef.AnalyzeDefaultNumBuckets.Load()
+	origTopN := vardef.AnalyzeDefaultNumTopN.Load()
+	origCMWidth := vardef.AnalyzeDefaultCMSketchWidth.Load()
+	origCMDepth := vardef.AnalyzeDefaultCMSketchDepth.Load()
+	origSamples := vardef.AnalyzeDefaultNumSamples.Load()
+
+	defer func() {
+		// Reset to original values
+		vardef.AnalyzeDefaultNumBuckets.Store(origBuckets)
+		vardef.AnalyzeDefaultNumTopN.Store(origTopN)
+		vardef.AnalyzeDefaultCMSketchWidth.Store(origCMWidth)
+		vardef.AnalyzeDefaultCMSketchDepth.Store(origCMDepth)
+		vardef.AnalyzeDefaultNumSamples.Store(origSamples)
+	}()
+
+	// Set custom values for the global variables
+	vardef.AnalyzeDefaultNumBuckets.Store(512)
+	vardef.AnalyzeDefaultNumTopN.Store(150)
+	vardef.AnalyzeDefaultCMSketchWidth.Store(4096)
+	vardef.AnalyzeDefaultCMSketchDepth.Store(10)
+	vardef.AnalyzeDefaultNumSamples.Store(20000)
+
+	// handleAnalyzeOptions only returns explicitly specified options; defaults
+	// are filled after validation.
+	optMap, err := handleAnalyzeOptions(nil)
+	require.NoError(t, err)
+	require.Empty(t, optMap)
+
+	filledMap := fillAnalyzeOptionsV2(optMap)
+	require.Equal(t, uint64(512), filledMap[ast.AnalyzeOptNumBuckets])
+	require.Equal(t, uint64(150), filledMap[ast.AnalyzeOptNumTopN])
+	require.Equal(t, uint64(4096), filledMap[ast.AnalyzeOptCMSketchWidth])
+	require.Equal(t, uint64(10), filledMap[ast.AnalyzeOptCMSketchDepth])
+	require.Equal(t, uint64(20000), filledMap[ast.AnalyzeOptNumSamples])
+
+	testDefaults := GetAnalyzeOptionDefaultV2ForTest()
+	require.Equal(t, uint64(512), testDefaults[ast.AnalyzeOptNumBuckets])
+	require.Equal(t, uint64(150), testDefaults[ast.AnalyzeOptNumTopN])
+	require.Equal(t, uint64(4096), testDefaults[ast.AnalyzeOptCMSketchWidth])
+	require.Equal(t, uint64(10), testDefaults[ast.AnalyzeOptCMSketchDepth])
+	require.Equal(t, uint64(20000), testDefaults[ast.AnalyzeOptNumSamples])
+
+	optMap, err = handleAnalyzeOptions([]ast.AnalyzeOpt{
+		{
+			Type:  ast.AnalyzeOptNumBuckets,
+			Value: ast.NewValueExpr(1024, "", ""),
+		},
+	})
+	require.NoError(t, err)
+	filledMap = fillAnalyzeOptionsV2(optMap)
+	require.Equal(t, uint64(1024), filledMap[ast.AnalyzeOptNumBuckets])
+	require.Equal(t, uint64(150), filledMap[ast.AnalyzeOptNumTopN])
 }
 
 func TestGetFullAnalyzeColumnsInfo(t *testing.T) {

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1171,6 +1171,16 @@ const (
 	// `PREDICATE`: Analyze only the columns that are used in the predicates of the query.
 	// `ALL`: Analyze all columns in the table.
 	TiDBAnalyzeColumnOptions = "tidb_analyze_column_options"
+	// TiDBAnalyzeDefaultNumBuckets sets the default number of histogram buckets for analyze operations
+	TiDBAnalyzeDefaultNumBuckets = "tidb_analyze_default_num_buckets"
+	// TiDBAnalyzeDefaultNumTopN sets the default number of TopN entries for analyze operations
+	TiDBAnalyzeDefaultNumTopN = "tidb_analyze_default_num_topn"
+	// TiDBAnalyzeDefaultCMSketchWidth sets the default CMSketch width for analyze operations
+	TiDBAnalyzeDefaultCMSketchWidth = "tidb_analyze_default_cmsketch_width"
+	// TiDBAnalyzeDefaultCMSketchDepth sets the default CMSketch depth for analyze operations
+	TiDBAnalyzeDefaultCMSketchDepth = "tidb_analyze_default_cmsketch_depth"
+	// TiDBAnalyzeDefaultNumSamples sets the default number of samples for analyze operations
+	TiDBAnalyzeDefaultNumSamples = "tidb_analyze_default_num_samples"
 	// TiDBDisableColumnTrackingTime records the last time TiDBEnableColumnTracking is set off.
 	// It is used to invalidate the collected predicate columns after turning off TiDBEnableColumnTracking, which avoids physical deletion.
 	// It doesn't have cache in memory, and we directly get/set the variable value from/to mysql.tidb.
@@ -1676,6 +1686,11 @@ const (
 	DefTiDBEnableAutoAnalyze                          = true
 	DefTiDBEnableAutoAnalyzePriorityQueue             = true
 	DefTiDBAnalyzeColumnOptions                       = "ALL"
+	DefTiDBAnalyzeDefaultNumBuckets                   = 256
+	DefTiDBAnalyzeDefaultNumTopN                      = 100
+	DefTiDBAnalyzeDefaultCMSketchWidth                = 2048
+	DefTiDBAnalyzeDefaultCMSketchDepth                = 5
+	DefTiDBAnalyzeDefaultNumSamples                   = 0
 	DefTiDBMemOOMAction                               = "CANCEL"
 	DefTiDBMaxAutoAnalyzeTime                         = 12 * 60 * 60
 	DefTiDBAutoAnalyzeConcurrency                     = 3
@@ -1849,7 +1864,18 @@ var (
 	//    the value of `tidb_analyze_column_options` determines the behavior of the analyze operation.
 	// 2. If `tidb_persist_analyze_options` is disabled, `tidb_analyze_column_options` is used directly to decide
 	//    whether to analyze all columns or just the predicate columns.
-	AnalyzeColumnOptions           = atomic.NewString(DefTiDBAnalyzeColumnOptions)
+	AnalyzeColumnOptions = atomic.NewString(DefTiDBAnalyzeColumnOptions)
+	// AnalyzeDefaultNumBuckets is the global default number of histogram buckets for analyze operations
+	AnalyzeDefaultNumBuckets = atomic.NewUint64(DefTiDBAnalyzeDefaultNumBuckets)
+	// AnalyzeDefaultNumTopN is the global default number of TopN entries for analyze operations
+	AnalyzeDefaultNumTopN = atomic.NewUint64(DefTiDBAnalyzeDefaultNumTopN)
+	// AnalyzeDefaultCMSketchWidth is the global default CMSketch width for analyze operations
+	AnalyzeDefaultCMSketchWidth = atomic.NewUint64(DefTiDBAnalyzeDefaultCMSketchWidth)
+	// AnalyzeDefaultCMSketchDepth is the global default CMSketch depth for analyze operations
+	AnalyzeDefaultCMSketchDepth = atomic.NewUint64(DefTiDBAnalyzeDefaultCMSketchDepth)
+	// AnalyzeDefaultNumSamples is the global default number of samples for analyze operations
+	AnalyzeDefaultNumSamples = atomic.NewUint64(DefTiDBAnalyzeDefaultNumSamples)
+
 	GlobalLogMaxDays               = atomic.NewInt32(int32(config.GetGlobalConfig().Log.File.MaxDays))
 	QueryLogMaxLen                 = atomic.NewInt32(DefTiDBQueryLogMaxLen)
 	EnablePProfSQLCPU              = atomic.NewBool(false)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -1208,6 +1208,91 @@ var defaultSysVars = []*SysVar{
 		},
 	},
 	{
+		Scope:    vardef.ScopeGlobal,
+		Name:     vardef.TiDBAnalyzeDefaultNumBuckets,
+		Value:    strconv.FormatUint(vardef.DefTiDBAnalyzeDefaultNumBuckets, 10),
+		Type:     vardef.TypeUnsigned,
+		MinValue: 1, MaxValue: 100000,
+		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			return strconv.FormatUint(vardef.AnalyzeDefaultNumBuckets.Load(), 10), nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			num, err := strconv.ParseUint(val, 10, 64)
+			if err == nil {
+				vardef.AnalyzeDefaultNumBuckets.Store(num)
+			}
+			return err
+		},
+	},
+	{
+		Scope:    vardef.ScopeGlobal,
+		Name:     vardef.TiDBAnalyzeDefaultNumTopN,
+		Value:    strconv.FormatUint(vardef.DefTiDBAnalyzeDefaultNumTopN, 10),
+		Type:     vardef.TypeUnsigned,
+		MinValue: 0, MaxValue: 100000,
+		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			return strconv.FormatUint(vardef.AnalyzeDefaultNumTopN.Load(), 10), nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			num, err := strconv.ParseUint(val, 10, 64)
+			if err == nil {
+				vardef.AnalyzeDefaultNumTopN.Store(num)
+			}
+			return err
+		},
+	},
+	{
+		Scope:    vardef.ScopeGlobal,
+		Name:     vardef.TiDBAnalyzeDefaultCMSketchWidth,
+		Value:    strconv.FormatUint(vardef.DefTiDBAnalyzeDefaultCMSketchWidth, 10),
+		Type:     vardef.TypeUnsigned,
+		MinValue: 1, MaxValue: 100000,
+		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			return strconv.FormatUint(vardef.AnalyzeDefaultCMSketchWidth.Load(), 10), nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			num, err := strconv.ParseUint(val, 10, 64)
+			if err == nil {
+				vardef.AnalyzeDefaultCMSketchWidth.Store(num)
+			}
+			return err
+		},
+	},
+	{
+		Scope:    vardef.ScopeGlobal,
+		Name:     vardef.TiDBAnalyzeDefaultCMSketchDepth,
+		Value:    strconv.FormatUint(vardef.DefTiDBAnalyzeDefaultCMSketchDepth, 10),
+		Type:     vardef.TypeUnsigned,
+		MinValue: 1, MaxValue: 100000,
+		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			return strconv.FormatUint(vardef.AnalyzeDefaultCMSketchDepth.Load(), 10), nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			num, err := strconv.ParseUint(val, 10, 64)
+			if err == nil {
+				vardef.AnalyzeDefaultCMSketchDepth.Store(num)
+			}
+			return err
+		},
+	},
+	{
+		Scope:    vardef.ScopeGlobal,
+		Name:     vardef.TiDBAnalyzeDefaultNumSamples,
+		Value:    strconv.FormatUint(vardef.DefTiDBAnalyzeDefaultNumSamples, 10),
+		Type:     vardef.TypeUnsigned,
+		MinValue: 0, MaxValue: 5000000,
+		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
+			return strconv.FormatUint(vardef.AnalyzeDefaultNumSamples.Load(), 10), nil
+		},
+		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
+			num, err := strconv.ParseUint(val, 10, 64)
+			if err == nil {
+				vardef.AnalyzeDefaultNumSamples.Store(num)
+			}
+			return err
+		},
+	},
+	{
 		Scope: vardef.ScopeGlobal,
 		Name:  vardef.TiDBEnableAutoAnalyzePriorityQueue,
 		Value: BoolToOnOff(vardef.DefTiDBEnableAutoAnalyzePriorityQueue),

--- a/pkg/sessionctx/variable/sysvar_test.go
+++ b/pkg/sessionctx/variable/sysvar_test.go
@@ -1908,6 +1908,119 @@ func TestTiDBAutoAnalyzeConcurrencyValidation(t *testing.T) {
 	}
 }
 
+func TestTiDBAnalyzeDefaultOptions(t *testing.T) {
+	ctx := context.Background()
+	vars := NewSessionVars(nil)
+	mock := NewMockGlobalAccessor4Tests()
+	mock.SessionVars = vars
+	vars.GlobalVarsAccessor = mock
+
+	origBuckets := vardef.AnalyzeDefaultNumBuckets.Load()
+	origTopN := vardef.AnalyzeDefaultNumTopN.Load()
+	origCMWidth := vardef.AnalyzeDefaultCMSketchWidth.Load()
+	origCMDepth := vardef.AnalyzeDefaultCMSketchDepth.Load()
+	origSamples := vardef.AnalyzeDefaultNumSamples.Load()
+	defer func() {
+		vardef.AnalyzeDefaultNumBuckets.Store(origBuckets)
+		vardef.AnalyzeDefaultNumTopN.Store(origTopN)
+		vardef.AnalyzeDefaultCMSketchWidth.Store(origCMWidth)
+		vardef.AnalyzeDefaultCMSketchDepth.Store(origCMDepth)
+		vardef.AnalyzeDefaultNumSamples.Store(origSamples)
+	}()
+
+	// Test TiDBAnalyzeDefaultNumBuckets
+	bucketsVar := GetSysVar(vardef.TiDBAnalyzeDefaultNumBuckets)
+	require.NotNil(t, bucketsVar)
+
+	// Test setting valid values
+	err := bucketsVar.SetGlobalFromHook(ctx, vars, "100", false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), vardef.AnalyzeDefaultNumBuckets.Load())
+
+	// Test getting the value
+	val, err := bucketsVar.GetGlobal(ctx, vars)
+	require.NoError(t, err)
+	require.Equal(t, "100", val)
+
+	// Test validation - value too small (should clamp to MinValue)
+	val, err = bucketsVar.Validate(vars, "0", vardef.ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, "1", val) // Clamped to MinValue
+
+	// Test validation - value too large (should clamp to MaxValue)
+	val, err = bucketsVar.Validate(vars, "100001", vardef.ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, "100000", val) // Clamped to MaxValue
+
+	// Test TiDBAnalyzeDefaultNumTopN
+	topnVar := GetSysVar(vardef.TiDBAnalyzeDefaultNumTopN)
+	require.NotNil(t, topnVar)
+
+	// Test setting valid values
+	err = topnVar.SetGlobalFromHook(ctx, vars, "50", false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), vardef.AnalyzeDefaultNumTopN.Load())
+
+	// Test getting the value
+	val, err = topnVar.GetGlobal(ctx, vars)
+	require.NoError(t, err)
+	require.Equal(t, "50", val)
+
+	// Test validation - minimum allowed value (0)
+	_, err = topnVar.Validate(vars, "0", vardef.ScopeGlobal)
+	require.NoError(t, err)
+
+	// Test validation - value too large (should clamp to MaxValue)
+	val, err = topnVar.Validate(vars, "100001", vardef.ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, "100000", val) // Clamped to MaxValue
+
+	// Test TiDBAnalyzeDefaultCMSketchWidth
+	cmWidthVar := GetSysVar(vardef.TiDBAnalyzeDefaultCMSketchWidth)
+	require.NotNil(t, cmWidthVar)
+
+	err = cmWidthVar.SetGlobalFromHook(ctx, vars, "4096", false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4096), vardef.AnalyzeDefaultCMSketchWidth.Load())
+
+	val, err = cmWidthVar.GetGlobal(ctx, vars)
+	require.NoError(t, err)
+	require.Equal(t, "4096", val)
+
+	// Test TiDBAnalyzeDefaultCMSketchDepth
+	cmDepthVar := GetSysVar(vardef.TiDBAnalyzeDefaultCMSketchDepth)
+	require.NotNil(t, cmDepthVar)
+
+	err = cmDepthVar.SetGlobalFromHook(ctx, vars, "10", false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), vardef.AnalyzeDefaultCMSketchDepth.Load())
+
+	val, err = cmDepthVar.GetGlobal(ctx, vars)
+	require.NoError(t, err)
+	require.Equal(t, "10", val)
+
+	// Test TiDBAnalyzeDefaultNumSamples
+	samplesVar := GetSysVar(vardef.TiDBAnalyzeDefaultNumSamples)
+	require.NotNil(t, samplesVar)
+
+	err = samplesVar.SetGlobalFromHook(ctx, vars, "20000", false)
+	require.NoError(t, err)
+	require.Equal(t, uint64(20000), vardef.AnalyzeDefaultNumSamples.Load())
+
+	val, err = samplesVar.GetGlobal(ctx, vars)
+	require.NoError(t, err)
+	require.Equal(t, "20000", val)
+
+	// Test validation - minimum allowed value for samples (0)
+	_, err = samplesVar.Validate(vars, "0", vardef.ScopeGlobal)
+	require.NoError(t, err)
+
+	// Test validation - value too large for samples (should clamp to MaxValue)
+	val, err = samplesVar.Validate(vars, "5000001", vardef.ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, "5000000", val) // Clamped to MaxValue
+}
+
 func TestTiDBOptSelectivityFactor(t *testing.T) {
 	ctx := context.Background()
 	vars := NewSessionVars(nil)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63432

Problem Summary:

### What changed and how does it work?
Expose these following stats related parameters to global var so user can set it once and don't need to do Analyze table t1 with 5 topN; to override the default 100;

```
TiDBAnalyzeDefaultNumBuckets = "tidb_analyze_default_num_buckets"
TiDBAnalyzeDefaultNumTopN = "tidb_analyze_default_num_topn"
TiDBAnalyzeDefaultCMSketchWidth = "tidb_analyze_default_cmsketch_width"
TiDBAnalyzeDefaultCMSketchDepth = "tidb_analyze_default_cmsketch_depth"
TiDBAnalyzeDefaultNumSamples = "tidb_analyze_default_num_samples"
```

also verified locally

```
mysql> SET GLOBAL tidb_analyze_default_num_topn = 10;
Query OK, 0 rows affected (0.03 sec)

mysql> Show stats_topn;
+---------+------------+----------------+-------------+----------+-----------+-------+
| Db_name | Table_name | Partition_name | Column_name | Is_index | Value     | Count |
+---------+------------+----------------+-------------+----------+-----------+-------+
| test    | t1         |                | a           |        0 | 1         | 10600 |
| test    | t1         |                | a           |        0 | 37        | 10537 |
| test    | t1         |                | a           |        0 | 44        | 10365 |
| test    | t1         |                | a           |        0 | 55        | 10410 |
| test    | t1         |                | a           |        0 | 70        | 10419 |
| test    | t1         |                | a           |        0 | 73        | 10492 |
| test    | t1         |                | a           |        0 | 85        | 10401 |
| test    | t1         |                | a           |        0 | 86        | 10908 |
| test    | t1         |                | a           |        0 | 90        | 10474 |
| test    | t1         |                | a           |        0 | 98        | 10455 |
| test    | t1         |                | iab         |        1 | (1, 401)  |  1223 |
| test    | t1         |                | iab         |        1 | (5, 405)  |  1259 |
| test    | t1         |                | iab         |        1 | (10, 910) |  1232 |
| test    | t1         |                | iab         |        1 | (24, 24)  |  1359 |
| test    | t1         |                | iab         |        1 | (26, 226) |  1232 |
| test    | t1         |                | iab         |        1 | (34, 534) |  1223 |
| test    | t1         |                | iab         |        1 | (41, 741) |  1232 |
| test    | t1         |                | iab         |        1 | (55, 355) |  1223 |
| test    | t1         |                | iab         |        1 | (86, 786) |  1250 |
| test    | t1         |                | iab         |        1 | (90, 190) |  1268 |
+---------+------------+----------------+-------------+----------+-----------+-------+
20 rows in set (0.02 sec)
```
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new global settings for ANALYZE defaults, including buckets, TopN, CMSketch width/depth, and sample count.
  * These settings can now be viewed and updated at runtime and are used when ANALYZE options are not explicitly provided.

* **Tests**
  * Added coverage for default values, overrides, and input bounds for the new ANALYZE settings.
  * Expanded validation to ensure ANALYZE option filling follows the configured global defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->