### PR TITLE
variable: tweak set instance for all instance variables 

### DIFF
--- a/cmd/tidb-server/main.go
+++ b/cmd/tidb-server/main.go
@@ -875,7 +875,7 @@ func setGlobalVars() {
 		old := variable.GetSysVar(name)
 		tmp := *old
 		tmp.Value = value
-		tmp.Scope |= vardef.ScopeInstance
+		tmp.IsInitedFromConfig = true
 		variable.RegisterSysVar(&tmp)
 	}
 	{

--- a/pkg/domain/sysvar_cache.go
+++ b/pkg/domain/sysvar_cache.go
@@ -125,7 +125,7 @@ func (do *Domain) rebuildSysVarCache(ctx sessionctx.Context) error {
 	for _, sv := range variable.GetSysVars() {
 		sVal := sv.Value
 		// NOTE: instance variable use values stored in this instance
-		if _, ok := tableContents[sv.Name]; ok && !sv.HasInstanceScope() {
+		if _, ok := tableContents[sv.Name]; ok && !sv.IsInitedFromConfig {
 			sVal = tableContents[sv.Name]
 		}
 		// session cache stores non-skippable variables, which essentially means session scope.

--- a/pkg/executor/set.go
+++ b/pkg/executor/set.go
@@ -157,19 +157,22 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 		v.IsGlobal = true
 		sessionVars.StmtCtx.AppendWarning(exeerrors.ErrInstanceScope.FastGenByArgs(sysVar.Name))
 	}
-	// TODO: this should be a standalone method of session, like SetGlobalSysVar
-	if v.IsInstance && !sysVar.HasInstanceScope() {
-		return variable.ErrIncorrectScope.GenWithStackByArgs(name, "GLOBAL or SESSION")
-	}
 
 	if v.IsGlobal || v.IsInstance {
 		valStr, err := e.getVarValue(ctx, v, sysVar)
 		if err != nil {
 			return err
 		}
-		err = sessionVars.GlobalVarsAccessor.SetGlobalSysVar(ctx, name, valStr)
-		if err != nil {
-			return err
+		if v.IsGlobal {
+			err = sessionVars.GlobalVarsAccessor.SetGlobalSysVar(ctx, name, valStr)
+			if err != nil {
+				return err
+			}
+		} else if v.IsInstance {
+			err = sessionVars.GlobalVarsAccessor.SetInstanceSysVar(ctx, name, valStr)
+			if err != nil {
+				return err
+			}
 		}
 		err = plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
 			auditPlugin := plugin.DeclareAuditManifest(p.Manifest)
@@ -182,7 +185,11 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 		if name == vardef.TiDBCloudStorageURI {
 			showValStr = ast.RedactURL(showValStr)
 		}
-		logutil.BgLogger().Info("set global var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", showValStr))
+		logstr := "set global var"
+		if v.IsInstance {
+			logstr = "set instance var"
+		}
+		logutil.BgLogger().Info(logstr, zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", showValStr))
 		if name == vardef.TiDBServiceScope {
 			dom := domain.GetDomain(e.Ctx())
 			oldConfig := config.GetGlobalConfig()

--- a/pkg/executor/set_test.go
+++ b/pkg/executor/set_test.go
@@ -447,7 +447,10 @@ func TestSetVar(t *testing.T) {
 	// test for instance
 	tk.MustExec("set @@instance.ddl_slow_threshold=1234")
 	tk.MustQuery("select @@instance.ddl_slow_threshold").Check(testkit.Rows("1234"))
-	tk.MustGetErrCode("set @@instance.tidb_redact_log=1", errno.ErrIncorrectGlobalLocalVar)
+	tk.MustGetErrCode("set @@instance.tidb_redact_log=1", errno.ErrLocalVariable)
+	// set instance variable, but global variable is still the old value
+	tk.MustExec("set @@instance.tidb_stmt_summary_max_stmt_count=1234")
+	tk.MustQuery("select @@global.tidb_stmt_summary_max_stmt_count").Check(testkit.Rows("3000"))
 
 	// test for tidb_redact_log
 	tk.MustQuery(`select @@global.tidb_redact_log;`).Check(testkit.Rows("OFF"))

--- a/pkg/sessionctx/variable/mock_globalaccessor.go
+++ b/pkg/sessionctx/variable/mock_globalaccessor.go
@@ -90,6 +90,11 @@ func (m *MockGlobalAccessor) SetGlobalSysVar(ctx context.Context, name string, v
 	return nil
 }
 
+// SetInstanceSysVar implements GlobalVarAccessor.SetInstanceSysVar interface.
+func (m *MockGlobalAccessor) SetInstanceSysVar(ctx context.Context, name string, value string) (err error) {
+	return m.SetGlobalSysVar(ctx, name, value)
+}
+
 // SetGlobalSysVarOnly implements GlobalVarAccessor.SetGlobalSysVarOnly interface.
 func (m *MockGlobalAccessor) SetGlobalSysVarOnly(ctx context.Context, name string, value string, _ bool) error {
 	sv := GetSysVar(name)

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -769,7 +769,7 @@ var defaultSysVars = []*SysVar{
 	},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBAutoAnalyzeStartTime, Value: vardef.DefAutoAnalyzeStartTime, Type: vardef.TypeTime},
 	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBAutoAnalyzeEndTime, Value: vardef.DefAutoAnalyzeEndTime, Type: vardef.TypeTime},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBMemQuotaBindingCache, Value: strconv.FormatInt(vardef.DefTiDBMemQuotaBindingCache, 10), Type: vardef.TypeUnsigned, MaxValue: math.MaxInt32, GetGlobal: func(_ context.Context, sv *SessionVars) (string, error) {
+	{Scope: vardef.ScopeGlobal | vardef.ScopeInstance, Name: vardef.TiDBMemQuotaBindingCache, Value: strconv.FormatInt(vardef.DefTiDBMemQuotaBindingCache, 10), Type: vardef.TypeUnsigned, MaxValue: math.MaxInt32, GetGlobal: func(_ context.Context, sv *SessionVars) (string, error) {
 		return strconv.FormatInt(vardef.MemQuotaBindingCache.Load(), 10), nil
 	}, SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 		vardef.MemQuotaBindingCache.Store(TidbOptInt64(val, vardef.DefTiDBMemQuotaBindingCache))
@@ -850,7 +850,7 @@ var defaultSysVars = []*SysVar{
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 			return stmtsummaryv2.SetHistorySize(TidbOptInt(val, vardef.DefTiDBStmtSummaryHistorySize))
 		}},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBStmtSummaryMaxStmtCount, Value: strconv.Itoa(vardef.DefTiDBStmtSummaryMaxStmtCount), Type: vardef.TypeInt, MinValue: 1, MaxValue: math.MaxInt16, AllowEmpty: true,
+	{Scope: vardef.ScopeGlobal | vardef.ScopeInstance, Name: vardef.TiDBStmtSummaryMaxStmtCount, Value: strconv.Itoa(vardef.DefTiDBStmtSummaryMaxStmtCount), Type: vardef.TypeInt, MinValue: 1, MaxValue: math.MaxInt16, AllowEmpty: true,
 		SetGlobal: func(_ context.Context, s *SessionVars, val string) error {
 			return stmtsummaryv2.SetMaxStmtCount(TidbOptInt(val, vardef.DefTiDBStmtSummaryMaxStmtCount))
 		}},
@@ -1156,7 +1156,7 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBServerMemoryLimit, Value: vardef.DefTiDBServerMemoryLimit, Type: vardef.TypeStr,
+	{Scope: vardef.ScopeGlobal | vardef.ScopeInstance, Name: vardef.TiDBServerMemoryLimit, Value: vardef.DefTiDBServerMemoryLimit, Type: vardef.TypeStr,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 			return memory.ServerMemoryLimitOriginText.Load(), nil
 		},
@@ -1208,7 +1208,7 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBServerMemoryLimitGCTrigger, Value: strconv.FormatFloat(vardef.DefTiDBServerMemoryLimitGCTrigger, 'f', -1, 64), Type: vardef.TypeStr,
+	{Scope: vardef.ScopeGlobal | vardef.ScopeInstance, Name: vardef.TiDBServerMemoryLimitGCTrigger, Value: strconv.FormatFloat(vardef.DefTiDBServerMemoryLimitGCTrigger, 'f', -1, 64), Type: vardef.TypeStr,
 		GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 			return strconv.FormatFloat(gctuner.GlobalMemoryLimitTuner.GetPercentage(), 'f', -1, 64), nil
 		},
@@ -1298,7 +1298,7 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(_ context.Context, s *SessionVars) (string, error) {
 		return BoolToOnOff(vardef.EnableBatchDML.Load()), nil
 	}},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBStatsCacheMemQuota, Value: strconv.Itoa(vardef.DefTiDBStatsCacheMemQuota),
+	{Scope: vardef.ScopeGlobal | vardef.ScopeInstance, Name: vardef.TiDBStatsCacheMemQuota, Value: strconv.Itoa(vardef.DefTiDBStatsCacheMemQuota),
 		MinValue: 0, MaxValue: vardef.MaxTiDBStatsCacheMemQuota, Type: vardef.TypeInt,
 		GetGlobal: func(_ context.Context, vars *SessionVars) (string, error) {
 			return strconv.FormatInt(vardef.StatsCacheMemQuota.Load(), 10), nil
@@ -1391,7 +1391,7 @@ var defaultSysVars = []*SysVar{
 		appendDeprecationWarning(vars, vardef.TiDBNonPreparedPlanCacheSize, vardef.TiDBSessionPlanCacheSize)
 		return normalizedValue, nil
 	}},
-	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBPlanCacheMaxPlanSize, Value: strconv.FormatUint(vardef.DefTiDBPlanCacheMaxPlanSize, 10), Type: vardef.TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession | vardef.ScopeInstance, Name: vardef.TiDBPlanCacheMaxPlanSize, Value: strconv.FormatUint(vardef.DefTiDBPlanCacheMaxPlanSize, 10), Type: vardef.TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {
 		uVal, err := strconv.ParseUint(val, 10, 64)
 		if err == nil {
 			s.PlanCacheMaxPlanSize = uVal
@@ -3446,7 +3446,7 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(ctx context.Context, vars *SessionVars) (string, error) {
 		return BoolToOnOff(vardef.EnableCheckConstraint.Load()), nil
 	}},
-	{Scope: vardef.ScopeGlobal, Name: vardef.TiDBSchemaCacheSize, Value: strconv.Itoa(vardef.DefTiDBSchemaCacheSize), Type: vardef.TypeStr,
+	{Scope: vardef.ScopeGlobal | vardef.ScopeInstance, Name: vardef.TiDBSchemaCacheSize, Value: strconv.Itoa(vardef.DefTiDBSchemaCacheSize), Type: vardef.TypeStr,
 		Validation: func(s *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {
 			_, str, err := parseSchemaCacheSize(s, normalizedValue, originalValue)
 			if err != nil {

--- a/pkg/sessionctx/variable/variable.go
+++ b/pkg/sessionctx/variable/variable.go
@@ -264,6 +264,9 @@ func (sv *SysVar) validateScope(scope vardef.ScopeFlag) error {
 	if scope == vardef.ScopeGlobal && !(sv.HasGlobalScope() || sv.HasInstanceScope()) {
 		return errLocalVariable.FastGenByArgs(sv.Name)
 	}
+	if scope == vardef.ScopeInstance && !sv.HasInstanceScope() {
+		return errLocalVariable.FastGenByArgs(sv.Name)
+	}
 	if scope == vardef.ScopeSession && !sv.HasSessionScope() {
 		return errGlobalVariable.FastGenByArgs(sv.Name)
 	}
@@ -570,6 +573,8 @@ type GlobalVarAccessor interface {
 	GetGlobalSysVar(name string) (string, error)
 	// SetGlobalSysVar sets the global system variable name to value.
 	SetGlobalSysVar(ctx context.Context, name string, value string) error
+	// SetInstanceSysVar sets the instance system variable name to value.
+	SetInstanceSysVar(ctx context.Context, name string, value string) error
 	// SetGlobalSysVarOnly sets the global system variable without calling the validation function or updating aliases.
 	SetGlobalSysVarOnly(ctx context.Context, name string, value string, updateLocal bool) error
 	// GetTiDBTableValue gets a value from mysql.tidb for the key 'name'

--- a/pkg/sessionctx/variable/variable.go
+++ b/pkg/sessionctx/variable/variable.go
@@ -90,6 +90,8 @@ type SysVar struct {
 	skipInit bool
 	// IsNoop defines if the sysvar is a noop included for MySQL compatibility
 	IsNoop bool
+	// IsInitedFromConfig defines if the sysvar is inited from the config file.
+	IsInitedFromConfig bool
 	// GlobalConfigName is the global config name of this global variable.
 	// If the global variable has the global config name,
 	// it should store the global config into PD(etcd) too when set global variable.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63614

Problem Summary: Previously, `SET INSTANCE` only works for old instance variables, and will only work for new instance variables if they are set from config file. Now it works for all variables with `ScopeInstance`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
