### PR TITLE
planner: fix the possble wrong plan for dp join reorder

### DIFF
--- a/pkg/planner/core/rule_join_reorder_dp.go
+++ b/pkg/planner/core/rule_join_reorder_dp.go
@@ -107,6 +107,10 @@ func (s *joinReorderDPSolver) solve(joinGroup []base.LogicalPlan, tracer *joinRe
 		if visited[i] {
 			continue
 		}
+		// Reset the visited ID map.
+		for i := range nodeID2VisitID {
+			nodeID2VisitID[i] = -1
+		}
 		visitID2NodeID := s.bfsGraph(i, visited, adjacents, nodeID2VisitID)
 		nodeIDMask := uint(0)
 		for _, nodeID := range visitID2NodeID {
@@ -219,6 +223,10 @@ func (*joinReorderDPSolver) nodesAreConnected(leftMask, rightMask uint, oldPos2N
 	totalEqEdges []joinGroupEqEdge, totalNonEqEdges []joinGroupNonEqEdge) ([]joinGroupEqEdge, []expression.Expression) {
 	var usedEqEdges []joinGroupEqEdge
 	for _, edge := range totalEqEdges {
+		// If one of the two nodes are not in the current subgraph, skip it.
+		if oldPos2NewPos[edge.nodeIDs[0]] < 0 || oldPos2NewPos[edge.nodeIDs[1]] < 0 {
+			continue
+		}
 		lIdx := uint(oldPos2NewPos[edge.nodeIDs[0]])
 		rIdx := uint(oldPos2NewPos[edge.nodeIDs[1]])
 		if ((leftMask&(1<<lIdx)) > 0 && (rightMask&(1<<rIdx)) > 0) || ((leftMask&(1<<rIdx)) > 0 && (rightMask&(1<<lIdx)) > 0) {

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -946,3 +946,28 @@ HashJoin	root		inner join, equal:[eq(test.t5.a, test.t1.e)]
     └─TableReader(Probe)	root		data:Selection
       └─Selection	cop[tikv]		not(isnull(test.t3.b))
         └─TableFullScan	cop[tikv]	table:t3	keep order:false, stats:pseudo
+drop table if exists t1,t2,t3,t4;
+create table t1(a int, b int);
+create table t2 like t1;
+create table t3 like t1;
+create table t4 like t1;
+set @@tidb_opt_join_reorder_threshold=5;
+explain format='plan_tree' select 1 from t1,t2,t3,t4 where t1.a=t2.a and t3.b=t4.b;
+id	task	access object	operator info
+Projection	root		1->Column#13
+└─HashJoin	root		CARTESIAN inner join
+  ├─HashJoin(Build)	root		inner join, equal:[eq(test.t3.b, test.t4.b)]
+  │ ├─TableReader(Build)	root		data:Selection
+  │ │ └─Selection	cop[tikv]		not(isnull(test.t4.b))
+  │ │   └─TableFullScan	cop[tikv]	table:t4	keep order:false, stats:pseudo
+  │ └─TableReader(Probe)	root		data:Selection
+  │   └─Selection	cop[tikv]		not(isnull(test.t3.b))
+  │     └─TableFullScan	cop[tikv]	table:t3	keep order:false, stats:pseudo
+  └─HashJoin(Probe)	root		inner join, equal:[eq(test.t1.a, test.t2.a)]
+    ├─TableReader(Build)	root		data:Selection
+    │ └─Selection	cop[tikv]		not(isnull(test.t2.a))
+    │   └─TableFullScan	cop[tikv]	table:t2	keep order:false, stats:pseudo
+    └─TableReader(Probe)	root		data:Selection
+      └─Selection	cop[tikv]		not(isnull(test.t1.a))
+        └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
+set @@tidb_opt_join_reorder_threshold=default;

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -601,3 +601,17 @@ explain format = 'plan_tree' select tmp4.b
   left join
     (select a, b, c, (row_number() over (partition by b order by e asc)) from t4) tmp4 on tmp4.b = t2.c and tmp4.c = t3.c
   join t5 on t5.a = t1.e;
+
+
+# TestIssue63353
+drop table if exists t1,t2,t3,t4;
+create table t1(a int, b int);
+create table t2 like t1;
+create table t3 like t1;
+create table t4 like t1;
+
+# enable reorder by dp
+set @@tidb_opt_join_reorder_threshold=5;
+
+explain format='plan_tree' select 1 from t1,t2,t3,t4 where t1.a=t2.a and t3.b=t4.b;
+set @@tidb_opt_join_reorder_threshold=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63353 

Problem Summary:

### What changed and how does it work?
When the join graph is not totally connected, we may do BFS multiple times to get the connected subgraph.
During each bfs, we'll assign the node in the subgraph with an ID that is its BFS order.
So two nodes in different subgraphs can have the same BFS order ID.
But we don't reset the BFS order ID map after each BFS, we may put the join edge into wrong subgraph.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
