### PR TITLE
test: fix analyze tests for next-gen

### DIFF
--- a/pkg/planner/core/casetest/cbotest/BUILD.bazel
+++ b/pkg/planner/core/casetest/cbotest/BUILD.bazel
@@ -9,9 +9,8 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     flaky = True,
-    shard_count = 22,
+    shard_count = 21,
     deps = [
-        "//pkg/config/kerneltype",
         "//pkg/domain",
         "//pkg/executor",
         "//pkg/meta/model",

--- a/pkg/planner/core/casetest/cbotest/cbo_test.go
+++ b/pkg/planner/core/casetest/cbotest/cbo_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -564,16 +563,6 @@ func testInconsistentEstimation(t *testing.T, testKit *testkit.TestKit, dom *dom
 }
 
 func TestInconsistentEstimation(t *testing.T) {
-	if kerneltype.IsNextGen() {
-		t.Skip("Please run TestInconsistentEstimationForNextGen under the next-gen mode")
-	}
-	testkit.RunTestUnderCascadesWithDomain(t, testInconsistentEstimation)
-}
-
-func TestInconsistentEstimationForNextGen(t *testing.T) {
-	if !kerneltype.IsNextGen() {
-		t.Skip("Please run TestInconsistentEstimation under the non next-gen mode")
-	}
 	testkit.RunTestUnderCascadesWithDomain(t, testInconsistentEstimation)
 }
 

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
@@ -52,14 +52,6 @@
       "explain format = 'brief' select * from t use index(ab) where a = 5 and c = 5"
     ]
   },
-    {
-    "name": "TestInconsistentEstimationForNextGen",
-    "cases": [
-      // Using the histogram (a, b) to estimate `a = 5` will get 1.22, while using the CM Sketch to estimate
-      // the `a = 5 and c = 5` will get 10, it is not consistent.
-      "explain format = 'brief' select * from t use index(ab) where a = 5 and c = 5"
-    ]
-  },
   {
     "name": "TestLimitCrossEstimation",
     "cases": [

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
@@ -113,20 +113,6 @@
     ]
   },
   {
-    "Name": "TestInconsistentEstimationForNextGen",
-    "Cases": [
-      {
-        "SQL": "explain format = 'brief' select * from t use index(ab) where a = 5 and c = 5",
-        "Plan": [
-          "IndexLookUp 1.00 root  ",
-          "├─IndexRangeScan(Build) 1.00 cop[tikv] table:t, index:ab(a, b) range:[5,5], keep order:false, stats:partial[ab:unInitialized, ac:unInitialized]",
-          "└─Selection(Probe) 1.00 cop[tikv]  eq(test.t.c, 5)",
-          "  └─TableRowIDScan 1.00 cop[tikv] table:t keep order:false, stats:partial[ab:unInitialized, ac:unInitialized]"
-        ]
-      }
-    ]
-  },
-  {
     "Name": "TestLimitCrossEstimation",
     "Cases": [
       {

--- a/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+++ b/pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
@@ -113,20 +113,6 @@
     ]
   },
   {
-    "Name": "TestInconsistentEstimationForNextGen",
-    "Cases": [
-      {
-        "SQL": "explain format = 'brief' select * from t use index(ab) where a = 5 and c = 5",
-        "Plan": [
-          "IndexLookUp 1.00 root  ",
-          "├─IndexRangeScan(Build) 1.00 cop[tikv] table:t, index:ab(a, b) range:[5,5], keep order:false, stats:partial[ab:unInitialized, ac:unInitialized]",
-          "└─Selection(Probe) 1.00 cop[tikv]  eq(test.t.c, 5)",
-          "  └─TableRowIDScan 1.00 cop[tikv] table:t keep order:false, stats:partial[ab:unInitialized, ac:unInitialized]"
-        ]
-      }
-    ]
-  },
-  {
     "Name": "TestLimitCrossEstimation",
     "Cases": [
       {

--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/badger/y"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/charset"
@@ -41,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/collate"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"github.com/pingcap/tipb/go-tipb"
+	"github.com/tikv/client-go/v2/tikv"
 	"github.com/twmb/murmur3"
 )
 
@@ -190,7 +192,19 @@ type analyzeIndexProcessor struct {
 }
 
 func (p *analyzeIndexProcessor) Process(key, _ []byte) error {
-	values, _, err := tablecodec.CutIndexKeyNew(key, p.colLen)
+	decodedKey := key
+	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
+		// If the key is in API V2, then ignore the prefix
+		_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		decodedKey = k
+		if !kv.Key(decodedKey).HasPrefix(tablecodec.TablePrefix()) {
+			return errors.Errorf("invalid index key %q after decoded", key)
+		}
+	}
+	values, _, err := tablecodec.CutIndexKeyNew(decodedKey, p.colLen)
 	if err != nil {
 		return err
 	}
@@ -615,8 +629,20 @@ type analyzeMixedExec struct {
 }
 
 func (e *analyzeMixedExec) Process(key, value []byte) error {
+	decodedKey := key
+	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
+		// If the key is in API V2, then ignore the prefix
+		_, k, err := tikv.DecodeKey(key, kvrpcpb.APIVersion_V2)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		decodedKey = k
+		if !kv.Key(decodedKey).HasPrefix(tablecodec.TablePrefix()) {
+			return errors.Errorf("invalid index key %q after decoded", key)
+		}
+	}
 	// common handle
-	values, _, err := tablecodec.CutCommonHandle(key, e.colLen)
+	values, _, err := tablecodec.CutCommonHandle(decodedKey, e.colLen)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61702

Problem Summary:

Unistore's analyze index processor cannot handle encoded index keys.

### What changed and how does it work?

- Strip the prefixed keyspace before decoding index key.
- Fix `TestAnalyzeColumnsWithVirtualColumnIndex`, `TestAnalyzeMVIndex` and `TestNormalAnalyzeOnCommonHandle`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
