### PR TITLE
coprocessor: handle paging result even if not enabled

### DIFF
--- a/pkg/ddl/reorg_util.go
+++ b/pkg/ddl/reorg_util.go
@@ -155,6 +155,7 @@ func initJobReorgMetaFromVariables(ctx context.Context, job *model.Job, tbl tabl
 	}
 	job.ReorgMeta = m
 	logutil.DDLLogger().Info("initialize reorg meta",
+		zap.Int64("jobID", job.ID),
 		zap.String("jobSchema", job.SchemaName),
 		zap.String("jobTable", job.TableName),
 		zap.Stringer("jobType", job.Type),

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1469,7 +1469,8 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 	}
 
 	var result *copTaskResult
-	if worker.req.Paging.Enable || copResp.GetRange() != nil {
+	if worker.req.Paging.Enable ||
+		copResp.GetRange() != nil { // For next-gen, the storage may return paging range even if paging is not enabled.
 		result, err = worker.handleCopPagingResult(bo, rpcCtx, &copResponse{pbResp: copResp}, cacheKey, cacheValue, task, costTime)
 	} else {
 		// Handles the response for non-paging copTask.

--- a/pkg/store/copr/coprocessor.go
+++ b/pkg/store/copr/coprocessor.go
@@ -1469,7 +1469,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask) (*
 	}
 
 	var result *copTaskResult
-	if worker.req.Paging.Enable {
+	if worker.req.Paging.Enable || copResp.GetRange() != nil {
 		result, err = worker.handleCopPagingResult(bo, rpcCtx, &copResponse{pbResp: copResp}, cacheKey, cacheValue, task, costTime)
 	} else {
 		// Handles the response for non-paging copTask.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61702

Problem Summary: 

> tikv-server may return paging range even if paging is not enabled. Then if the range is not handled, the result would be wrong.

### What changed and how does it work?

Cherry-pick https://github.com/tidbcloud/tidb-cse/pull/1194.

> handle paging result if `copResp` has Range, even if paging is not enabled.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Before this PR(the log is from TiDB built by https://github.com/pingcap/tidb/pull/63495:
```
[ERROR] [reporter.go:274] ["admin check found data inconsistency"] [keyspaceName=10708255509240425689] [conn=2936078708] [session_alias=] [table_name=t] [index_name=k] [row_id=28802665] [index=] [row="handle: 28802665, values: [KindInt64 83349]"] [row_mvcc="{\"decoded\":{\"460711990272720897\":{\"bigint_0\":\"63763\",\"bigint_1\":\"98976\",\"bigint_2\":\"41844\",\"c\":\"l6dHRhjDH2ZqOedf\",\"int_0\":\"83231\",\"int_1\":\"72771\",\"int_2\":\"72693\",\"k\":\"83349\",\"pad\":\"YNHPrCdJ6imopFHm\",\"text_0\":\"dgfmKbqpOFjARcR5\",\"varchar_0\":\"M7tghkSBWtsoJQzt\"}},\"key\":\"74800000000000000B5F728000000001B77E69\",\"mvcc\":{\"info\":{\"writes\":[{\"start_ts\":460711990272720897,\"commit_ts\":460711990272720897,\"short_value\":\"gAALAAAAAgMEBQYHCAkKCwwEABQAJAAoACwAMAA0ADgAPABMAFwAlUUBAGw2ZEhSaGpESDJacU9lZGZZTkhQckNkSjZpbW9wRkhtH0UBAEMcAQD1GwEAE/kAAKCCAQB0owAATTd0Z2hrU0JXdHNvSlF6dGRnZm1LYnFwT0ZqQVJjUjU=\"}]}},\"regionID\":1883}"]

[INFO] [index_cop.go:110] [fetchTableScanResult] [keyspaceName=SYSTEM] [rows=224] [columns=2] [firstKey=74800000000000000b5f728000000001bc0e36] [lastKey=74800000000000000b5f728000000001bc0f15]
[INFO] [coprocessor.go:1515] ["[TIME_COP_WAIT] resp_time:1.525922019s txnStartTS:460942369916452865 region_id:692 store_addr:db-dff78b4c-tikv-oq64hd.db-cluster.tidb1633599162411516:20160 stats:Cop:{num_rpc:1, total_time:1.53s} kv_process_ms:5 kv_wait_ms:0 kv_read_ms:490 processed_versions:908367 total_versions:0 rocksdb_delete_skipped_count:0 rocksdb_key_skipped_count:0 rocksdb_cache_hit_count:0 rocksdb_read_count:0 rocksdb_read_byte:0"] [keyspaceName=SYSTEM] [task-id=2] [task-key=10560875421529241256/ddl/backfill/13] [subtaskID=4] [step=read-index]
[INFO] [index_cop.go:110] [fetchTableScanResult] [keyspaceName=SYSTEM] [rows=1024] [columns=2] [firstKey=74800000000000000b5f728000000001b702aa] [lastKey=74800000000000000b5f728000000001b706a9]

[INFO] [backfilling_operators.go:679] ["write external storage operator total count"] [keyspaceName=SYSTEM] [task-id=2] [task-key=10708255509240425689/ddl/backfill/13] [subtaskID=4] [step=read-index] [count=90262661]
```
TiKV log:
```
[INFO] [tracker.rs:271] [slow-query] [perf_stats.internal_delete_skipped_count=0] [perf_stats.internal_key_skipped_count=0] [perf_stats.block_read_byte=0] [perf_stats.block_read_count=0] [perf_stats.block_cache_hit_count=0] [scan.range.first="Some(start: 7800000174800000000000000B5F728000000001970ECA end: 7800000174800000000000000B5F728000000001BC0E36)"] [scan.ranges=1] [scan.total=2095073] [scan.processed_size=314414976] [scan.processed=2095072] [scan.is_desc=false] [tag=select] [table_id=0] [txn_start_ts=460969938578833409] [total_suspend_time=6.96508ms] [total_process_time=1.542507015s] [handler_build_time=20.046µs] [wait_time.snapshot=533.886µs] [wait_time.schedule=15.957µs] [wait_time=549.843µs] [total_lifetime=1.550048905s] [remote_host=ipv4:10.0.24.17:47534] [region_id=692] [query_digest=] [session_alias=] [connection_id=0]
[INFO] [runner.rs:538] ["reach max response size, row count 2095072"]
```
After this PR:
```
mysql> alter table t add index idx(k);
Query OK, 0 rows affected (6 min 0.72 sec)

mysql> admin check table t;
Query OK, 0 rows affected (39.77 sec)
```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
