### PR TITLE
executor: Use fakeSel to avoid memory allocate when chunk has no `sel` field in hash join v2

### DIFF
--- a/pkg/executor/join/base_join_probe.go
+++ b/pkg/executor/join/base_join_probe.go
@@ -192,12 +192,12 @@ func (j *baseJoinProbe) SetChunkForProbe(chk *chunk.Chunk) (err error) {
 	physicalRows := chk.Column(0).Rows()
 	j.usedRows = chk.Sel()
 	if j.usedRows == nil {
-		if cap(j.selRows) >= logicalRows {
-			j.selRows = j.selRows[:logicalRows]
+		if logicalRows <= fakeSelLength {
+			j.selRows = fakeSel[:logicalRows]
 		} else {
-			j.selRows = make([]int, 0, logicalRows)
+			j.selRows = make([]int, logicalRows)
 			for i := range logicalRows {
-				j.selRows = append(j.selRows, i)
+				j.selRows[i] = i
 			}
 		}
 		j.usedRows = j.selRows

--- a/pkg/executor/join/hash_join_v2.go
+++ b/pkg/executor/join/hash_join_v2.go
@@ -53,7 +53,19 @@ var (
 	DisableHashJoinV2 = "set tidb_hash_join_version = " + joinversion.HashJoinVersionLegacy
 	// HashJoinV2Strings is used for test
 	HashJoinV2Strings = []string{DisableHashJoinV2, EnableHashJoinV2}
+	// fakeSel is used when chunk does not have sel field
+	fakeSel []int
+	// the length of fakeSelLength, default max_chunk_size is 1024,
+	// we set fakeSel size to 4*max_chunk_size so it should be enough for most cases
+	fakeSelLength = 4096
 )
+
+func init() {
+	fakeSel = make([]int, fakeSelLength)
+	for i := range fakeSel {
+		fakeSel[i] = i
+	}
+}
 
 type hashTableContext struct {
 	// rowTables is used during split partition stage, each buildWorker has

--- a/pkg/executor/join/row_table_builder.go
+++ b/pkg/executor/join/row_table_builder.go
@@ -160,9 +160,13 @@ func (b *rowTableBuilder) ResetBuffer(chk *chunk.Chunk) {
 	physicalRows := chk.Column(0).Rows()
 
 	if b.usedRows == nil {
-		b.selRows = resizeSlice(b.selRows, logicalRows)
-		for i := range logicalRows {
-			b.selRows[i] = i
+		if logicalRows <= fakeSelLength {
+			b.selRows = fakeSel[:logicalRows]
+		} else {
+			b.selRows = make([]int, logicalRows)
+			for i := range logicalRows {
+				b.selRows[i] = i
+			}
 		}
 		b.usedRows = b.selRows
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #53127

Problem Summary:

In most of the cases, `chunk` does not have `sel` field, in this case hash join v2 need to allocate a `sel` explicitly for each chunk, in this pr, it use a pre-defined `fakeSel` to avoid this allocation.
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
The existing ut already covered this case.
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
