### PR TITLE
importinto: enhance encode error msg

### DIFF
--- a/pkg/executor/importer/chunk_process_testkit_test.go
+++ b/pkg/executor/importer/chunk_process_testkit_test.go
@@ -190,7 +190,7 @@ func TestFileChunkProcess(t *testing.T) {
 		)
 		err2 := processor.Process(ctx)
 		require.ErrorIs(t, err2, common.ErrEncodeKV)
-		require.ErrorContains(t, err2, "encoding 2-th row in this chunk")
+		require.ErrorContains(t, err2, "encoding 2-th data row in this chunk")
 		require.ErrorContains(t, err2, "at offset 6")
 		require.True(t, ctrl.Satisfied())
 	})

--- a/pkg/executor/importer/chunk_process_testkit_test.go
+++ b/pkg/executor/importer/chunk_process_testkit_test.go
@@ -169,7 +169,7 @@ func TestFileChunkProcess(t *testing.T) {
 
 	t.Run("encode error", func(t *testing.T) {
 		fileName := path.Join(tempDir, "test.csv")
-		sourceData := []byte(`1,2,3\n4,aa,6\n7,8,9\n`)
+		sourceData := []byte("1,2,3\n4,aa,6\n7,8,9\n")
 		require.NoError(t, os.WriteFile(fileName, sourceData, 0o644))
 		csvParser := getCSVParser(ctx, t, fileName)
 		defer func() {
@@ -188,7 +188,10 @@ func TestFileChunkProcess(t *testing.T) {
 			csvParser, encoder, nil,
 			chunkInfo, logger.Logger, diskQuotaLock, dataWriter, indexWriter, nil, nil,
 		)
-		require.ErrorIs(t, processor.Process(ctx), common.ErrEncodeKV)
+		err2 := processor.Process(ctx)
+		require.ErrorIs(t, err2, common.ErrEncodeKV)
+		require.ErrorContains(t, err2, "encoding 2-th row in this chunk")
+		require.ErrorContains(t, err2, "at offset 6")
 		require.True(t, ctrl.Satisfied())
 	})
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63763

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
mysql> import into t from '/data/t.00000028.csv' with skip_rows=1;
ERROR 1105 (HY000): when encoding 210-th row in this chunk: encode kv error in file test.t.1.csv:0 at offset 313609: DECIMAL value is out of range in '(38, 18)'
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
