### PR TITLE
expression: remove bufAllocate in the function

### DIFF
--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -36,11 +36,11 @@ func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(ctx EvalContext, input *c
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -69,11 +69,11 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx EvalContext, inpu
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -121,11 +121,11 @@ func (b *builtinArithmeticModIntUnsignedUnsignedSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticModIntUnsignedUnsignedSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lh, err := b.bufAllocator.get()
+	lh, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lh)
+	defer globalColumnAllocator.put(lh)
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -162,11 +162,11 @@ func (b *builtinArithmeticModIntUnsignedSignedSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticModIntUnsignedSignedSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lh, err := b.bufAllocator.get()
+	lh, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lh)
+	defer globalColumnAllocator.put(lh)
 
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
@@ -207,11 +207,11 @@ func (b *builtinArithmeticModIntSignedUnsignedSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticModIntSignedUnsignedSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lh, err := b.bufAllocator.get()
+	lh, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lh)
+	defer globalColumnAllocator.put(lh)
 
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
@@ -252,11 +252,11 @@ func (b *builtinArithmeticModIntSignedSignedSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticModIntSignedSignedSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lh, err := b.bufAllocator.get()
+	lh, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lh)
+	defer globalColumnAllocator.put(lh)
 
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
@@ -297,11 +297,11 @@ func (b *builtinArithmeticMinusRealSig) vecEvalReal(ctx EvalContext, input *chun
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -330,11 +330,11 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(ctx EvalContext, input
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -363,11 +363,11 @@ func (b *builtinArithmeticMinusIntSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lh, err := b.bufAllocator.get()
+	lh, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lh)
+	defer globalColumnAllocator.put(lh)
 
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
@@ -416,11 +416,11 @@ func (b *builtinArithmeticModRealSig) vectorized() bool {
 
 func (b *builtinArithmeticModRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
@@ -456,11 +456,11 @@ func (b *builtinArithmeticModDecimalSig) vecEvalDecimal(ctx EvalContext, input *
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -498,11 +498,11 @@ func (b *builtinArithmeticPlusRealSig) vecEvalReal(ctx EvalContext, input *chunk
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -531,11 +531,11 @@ func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(ctx EvalContext, in
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -571,10 +571,10 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx EvalContext, input
 	var buf [2]*chunk.Column
 	var num [2][]types.MyDecimal
 	for i, arg := range b.args {
-		if buf[i], err = b.bufAllocator.get(); err != nil {
+		if buf[i], err = globalColumnAllocator.get(); err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(buf[i])
+		defer globalColumnAllocator.put(buf[i])
 
 		err = arg.VecEvalDecimal(ctx, input, buf[i])
 		if err != nil {
@@ -648,11 +648,11 @@ func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(ctx EvalContext, input *chu
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
@@ -687,11 +687,11 @@ func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx EvalContext, input *chu
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -724,11 +724,11 @@ func (b *builtinArithmeticIntDivideIntSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticIntDivideIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lhsBuf, err := b.bufAllocator.get()
+	lhsBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lhsBuf)
+	defer globalColumnAllocator.put(lhsBuf)
 
 	if err := b.args[0].VecEvalInt(ctx, input, lhsBuf); err != nil {
 		return err
@@ -854,11 +854,11 @@ func (b *builtinArithmeticPlusIntSig) vectorized() bool {
 }
 
 func (b *builtinArithmeticPlusIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	lh, err := b.bufAllocator.get()
+	lh, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lh)
+	defer globalColumnAllocator.put(lh)
 
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
@@ -975,11 +975,11 @@ func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1012,11 +1012,11 @@ func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(ctx EvalContext, in
 		return err
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err

--- a/pkg/expression/builtin_arithmetic_vec.go
+++ b/pkg/expression/builtin_arithmetic_vec.go
@@ -40,7 +40,11 @@ func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -73,7 +77,11 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(ctx EvalContext, inpu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -125,7 +133,11 @@ func (b *builtinArithmeticModIntUnsignedUnsignedSig) vecEvalInt(ctx EvalContext,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lh)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lh)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -166,8 +178,11 @@ func (b *builtinArithmeticModIntUnsignedSignedSig) vecEvalInt(ctx EvalContext, i
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lh)
-
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lh)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -211,8 +226,11 @@ func (b *builtinArithmeticModIntSignedUnsignedSig) vecEvalInt(ctx EvalContext, i
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lh)
-
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lh)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -256,8 +274,11 @@ func (b *builtinArithmeticModIntSignedSignedSig) vecEvalInt(ctx EvalContext, inp
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lh)
-
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lh)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -301,7 +322,11 @@ func (b *builtinArithmeticMinusRealSig) vecEvalReal(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -334,7 +359,11 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(ctx EvalContext, input
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -367,8 +396,11 @@ func (b *builtinArithmeticMinusIntSig) vecEvalInt(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lh)
-
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lh)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -420,7 +452,11 @@ func (b *builtinArithmeticModRealSig) vecEvalReal(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
@@ -460,7 +496,11 @@ func (b *builtinArithmeticModDecimalSig) vecEvalDecimal(ctx EvalContext, input *
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -502,7 +542,11 @@ func (b *builtinArithmeticPlusRealSig) vecEvalReal(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -535,7 +579,11 @@ func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(ctx EvalContext, in
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -574,7 +622,11 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(ctx EvalContext, input
 		if buf[i], err = globalColumnAllocator.get(); err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(buf[i])
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(buf[i])
+			}
+		}()
 
 		err = arg.VecEvalDecimal(ctx, input, buf[i])
 		if err != nil {
@@ -652,7 +704,11 @@ func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
@@ -691,7 +747,11 @@ func (b *builtinArithmeticDivideRealSig) vecEvalReal(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -728,7 +788,11 @@ func (b *builtinArithmeticIntDivideIntSig) vecEvalInt(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lhsBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lhsBuf)
+		}
+	}()
 
 	if err := b.args[0].VecEvalInt(ctx, input, lhsBuf); err != nil {
 		return err
@@ -858,8 +922,11 @@ func (b *builtinArithmeticPlusIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lh)
-
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lh)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, lh); err != nil {
 		return err
 	}
@@ -979,7 +1046,11 @@ func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1016,7 +1087,11 @@ func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(ctx EvalContext, in
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err

--- a/pkg/expression/builtin_cast.go
+++ b/pkg/expression/builtin_cast.go
@@ -1773,7 +1773,7 @@ func (*builtinCastStringAsIntSig) handleOverflow(ctx EvalContext, origRes int64,
 			uval := uint64(math.MaxUint64)
 			res = int64(uval)
 		}
-		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", origStr)
+		warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", strings.Clone(origStr))
 		err = ec.HandleErrorWithAlias(origErr, origErr, warnErr)
 	}
 	return
@@ -2489,7 +2489,7 @@ func (b *builtinCastJSONAsTimeSig) evalTime(ctx EvalContext, row chunk.Row) (res
 		return res, isNull, err
 	default:
 		ec := errCtx(ctx)
-		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
+		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), strings.Clone(val.String()))
 		return res, true, ec.HandleError(err)
 	}
 }

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -33,7 +33,11 @@ func (b *builtinCastIntAsDurationSig) vecEvalDuration(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -94,7 +98,11 @@ func (b *builtinCastIntAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -167,7 +175,11 @@ func (b *builtinCastTimeAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -199,7 +211,11 @@ func (b *builtinCastRealAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -249,7 +265,11 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -289,7 +309,11 @@ func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -325,7 +349,11 @@ func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -374,7 +402,11 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -424,7 +456,11 @@ func (b *builtinCastRealAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -451,7 +487,11 @@ func (b *builtinCastJSONAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -482,7 +522,11 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -552,7 +596,7 @@ func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 				times[i].SetCoreTime(types.FromDate(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0))
 			}
 		default:
-			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
+			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), strings.Clone(val.String()))
 			if err = handleInvalidTimeError(ctx, err); err != nil {
 				return err
 			}
@@ -572,7 +616,11 @@ func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -650,7 +698,11 @@ func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -700,7 +752,11 @@ func (b *builtinCastIntAsStringSig) vecEvalString(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -752,7 +808,11 @@ func (b *builtinCastRealAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -798,7 +858,11 @@ func (b *builtinCastTimeAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -837,7 +901,11 @@ func (b *builtinCastStringAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -901,7 +969,11 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -957,7 +1029,11 @@ func (b *builtinCastStringAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1010,7 +1086,11 @@ func (b *builtinCastStringAsDurationSig) vecEvalDuration(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1050,7 +1130,11 @@ func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1089,7 +1173,11 @@ func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1135,7 +1223,11 @@ func (b *builtinCastIntAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1188,7 +1280,11 @@ func (b *builtinCastJSONAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1219,7 +1315,11 @@ func (b *builtinCastDurationAsRealSig) vecEvalReal(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1258,7 +1358,11 @@ func (b *builtinCastJSONAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1289,7 +1393,11 @@ func (b *builtinCastRealAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1330,7 +1438,11 @@ func (b *builtinCastTimeAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(arg0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(arg0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, arg0); err != nil {
 		return err
 	}
@@ -1394,7 +1506,11 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1436,7 +1552,11 @@ func (b *builtinCastDecimalAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1483,7 +1603,11 @@ func (b *builtinCastDecimalAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1525,7 +1649,11 @@ func (b *builtinCastTimeAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1600,7 +1728,11 @@ func (b *builtinCastTimeAsStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1642,7 +1774,11 @@ func (b *builtinCastJSONAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1686,7 +1822,11 @@ func (b *builtinCastStringAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1729,7 +1869,11 @@ func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1768,7 +1912,11 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1820,7 +1968,11 @@ func (b *builtinCastDecimalAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1874,7 +2026,11 @@ func (b *builtinCastDecimalAsDurationSig) vecEvalDuration(ctx EvalContext, input
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1916,7 +2072,11 @@ func (b *builtinCastStringAsStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1957,7 +2117,11 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2003,7 +2167,7 @@ func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *c
 			}
 			ds[i] = dur.Duration
 		default:
-			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), val.String())
+			err = types.ErrTruncatedWrongVal.GenWithStackByArgs(types.TypeStr(b.tp.GetType()), strings.Clone(val.String()))
 			err = tc.HandleTruncate(err)
 			if err != nil {
 				return err
@@ -2026,7 +2190,11 @@ func (b *builtinCastDecimalAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2059,7 +2227,11 @@ func (b *builtinCastDurationAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_cast_vec.go
+++ b/pkg/expression/builtin_cast_vec.go
@@ -29,11 +29,11 @@ import (
 
 func (b *builtinCastIntAsDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -90,11 +90,11 @@ func (*builtinCastIntAsIntSig) vectorized() bool {
 
 func (b *builtinCastIntAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -163,11 +163,11 @@ func (*builtinCastTimeAsJSONSig) vectorized() bool {
 
 func (b *builtinCastTimeAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -195,11 +195,11 @@ func (*builtinCastRealAsStringSig) vectorized() bool {
 
 func (b *builtinCastRealAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -245,11 +245,11 @@ func (*builtinCastDecimalAsStringSig) vectorized() bool {
 
 func (b *builtinCastDecimalAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -285,11 +285,11 @@ func (*builtinCastTimeAsDecimalSig) vectorized() bool {
 
 func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -321,11 +321,11 @@ func (*builtinCastDurationAsIntSig) vectorized() bool {
 
 func (b *builtinCastDurationAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -370,11 +370,11 @@ func (*builtinCastIntAsTimeSig) vectorized() bool {
 
 func (b *builtinCastIntAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -420,11 +420,11 @@ func (*builtinCastRealAsJSONSig) vectorized() bool {
 
 func (b *builtinCastRealAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -447,11 +447,11 @@ func (*builtinCastJSONAsRealSig) vectorized() bool {
 
 func (b *builtinCastJSONAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -478,11 +478,11 @@ func (*builtinCastJSONAsTimeSig) vectorized() bool {
 
 func (b *builtinCastJSONAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -568,11 +568,11 @@ func (*builtinCastRealAsTimeSig) vectorized() bool {
 
 func (b *builtinCastRealAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -646,11 +646,11 @@ func (*builtinCastDurationAsTimeSig) vectorized() bool {
 
 func (b *builtinCastDurationAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -696,11 +696,11 @@ func (*builtinCastIntAsStringSig) vectorized() bool {
 
 func (b *builtinCastIntAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -748,11 +748,11 @@ func (*builtinCastRealAsIntSig) vectorized() bool {
 
 func (b *builtinCastRealAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -794,11 +794,11 @@ func (*builtinCastTimeAsRealSig) vectorized() bool {
 
 func (b *builtinCastTimeAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -833,11 +833,11 @@ func (*builtinCastStringAsJSONSig) vectorized() bool {
 
 func (b *builtinCastStringAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -897,11 +897,11 @@ func (*builtinCastRealAsDecimalSig) vectorized() bool {
 
 func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -953,11 +953,11 @@ func (b *builtinCastStringAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	}
 
 	result.ResizeInt64(n, false)
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1006,11 +1006,11 @@ func (*builtinCastStringAsDurationSig) vectorized() bool {
 
 func (b *builtinCastStringAsDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1046,11 +1046,11 @@ func (*builtinCastDurationAsDecimalSig) vectorized() bool {
 
 func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1085,11 +1085,11 @@ func (*builtinCastIntAsDecimalSig) vectorized() bool {
 
 func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1131,11 +1131,11 @@ func (*builtinCastIntAsJSONSig) vectorized() bool {
 
 func (b *builtinCastIntAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1184,11 +1184,11 @@ func (*builtinCastJSONAsStringSig) vectorized() bool {
 
 func (b *builtinCastJSONAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1215,11 +1215,11 @@ func (*builtinCastDurationAsRealSig) vectorized() bool {
 
 func (b *builtinCastDurationAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1254,11 +1254,11 @@ func (*builtinCastJSONAsIntSig) vectorized() bool {
 
 func (b *builtinCastJSONAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1285,11 +1285,11 @@ func (*builtinCastRealAsDurationSig) vectorized() bool {
 
 func (b *builtinCastRealAsDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1326,11 +1326,11 @@ func (*builtinCastTimeAsDurationSig) vectorized() bool {
 
 func (b *builtinCastTimeAsDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	arg0, err := b.bufAllocator.get()
+	arg0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(arg0)
+	defer globalColumnAllocator.put(arg0)
 	if err := b.args[0].VecEvalTime(ctx, input, arg0); err != nil {
 		return err
 	}
@@ -1390,11 +1390,11 @@ func (*builtinCastDurationAsStringSig) vectorized() bool {
 
 func (b *builtinCastDurationAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1432,11 +1432,11 @@ func (*builtinCastDecimalAsRealSig) vectorized() bool {
 
 func (b *builtinCastDecimalAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1479,11 +1479,11 @@ func (*builtinCastDecimalAsTimeSig) vectorized() bool {
 
 func (b *builtinCastDecimalAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1521,11 +1521,11 @@ func (*builtinCastTimeAsIntSig) vectorized() bool {
 
 func (b *builtinCastTimeAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1596,11 +1596,11 @@ func (*builtinCastTimeAsStringSig) vectorized() bool {
 
 func (b *builtinCastTimeAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1638,11 +1638,11 @@ func (*builtinCastJSONAsDecimalSig) vectorized() bool {
 
 func (b *builtinCastJSONAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1682,11 +1682,11 @@ func (b *builtinCastStringAsRealSig) vecEvalReal(ctx EvalContext, input *chunk.C
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1725,11 +1725,11 @@ func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(ctx EvalContext, input *c
 		return b.args[0].VecEvalDecimal(ctx, input, result)
 	}
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1764,11 +1764,11 @@ func (*builtinCastStringAsTimeSig) vectorized() bool {
 
 func (b *builtinCastStringAsTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1816,11 +1816,11 @@ func (*builtinCastDecimalAsIntSig) vectorized() bool {
 
 func (b *builtinCastDecimalAsIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1870,11 +1870,11 @@ func (*builtinCastDecimalAsDurationSig) vectorized() bool {
 
 func (b *builtinCastDecimalAsDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1912,11 +1912,11 @@ func (*builtinCastStringAsStringSig) vectorized() bool {
 
 func (b *builtinCastStringAsStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1953,11 +1953,11 @@ func (*builtinCastJSONAsDurationSig) vectorized() bool {
 
 func (b *builtinCastJSONAsDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2022,11 +2022,11 @@ func (*builtinCastDecimalAsJSONSig) vectorized() bool {
 
 func (b *builtinCastDecimalAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2055,11 +2055,11 @@ func (*builtinCastDurationAsJSONSig) vectorized() bool {
 
 func (b *builtinCastDurationAsJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_compare_vec.go
+++ b/pkg/expression/builtin_compare_vec.go
@@ -30,7 +30,11 @@ func (b *builtinGreatestDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
@@ -64,7 +68,11 @@ func (b *builtinLeastDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
@@ -99,7 +107,11 @@ func (b *builtinLeastIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
@@ -134,7 +146,11 @@ func (b *builtinGreatestIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
@@ -175,7 +191,11 @@ func (b *builtinGEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err = b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -183,7 +203,11 @@ func (b *builtinGEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err = b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -205,7 +229,11 @@ func (b *builtinLeastRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
@@ -244,13 +272,21 @@ func (b *builtinLeastStringSig) vecEvalString(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 
 	src := result
 	arg := buf1
@@ -295,7 +331,11 @@ func (b *builtinEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -303,7 +343,11 @@ func (b *builtinEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -327,7 +371,11 @@ func (b *builtinNEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -335,7 +383,11 @@ func (b *builtinNEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -359,7 +411,11 @@ func (b *builtinGTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -367,7 +423,11 @@ func (b *builtinGTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -389,7 +449,11 @@ func (b *builtinNullEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -397,7 +461,11 @@ func (b *builtinNullEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	result.ResizeInt64(n, false)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
@@ -458,7 +526,11 @@ func (b *builtinIntervalRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -497,7 +569,11 @@ func (b *builtinLEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -505,7 +581,11 @@ func (b *builtinLEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -529,7 +609,11 @@ func (b *builtinLTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -537,7 +621,11 @@ func (b *builtinLTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -684,7 +772,11 @@ func (b *builtinGreatestRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
@@ -768,12 +860,20 @@ func (b *builtinGreatestStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 
 	src := result
 	arg := buf1
@@ -816,7 +916,11 @@ func (b *builtinGreatestTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	result.ResizeTime(n, false)
 	for argIdx := range b.args {
@@ -857,7 +961,11 @@ func (b *builtinLeastTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	result.ResizeTime(n, false)
 	for argIdx := range b.args {
@@ -898,7 +1006,11 @@ func (b *builtinGreatestDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	result.ResizeGoDuration(n, false)
 	for argIdx := range b.args {
@@ -930,7 +1042,11 @@ func (b *builtinLeastDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	result.ResizeGoDuration(n, false)
 	for argIdx := range b.args {

--- a/pkg/expression/builtin_compare_vec.go
+++ b/pkg/expression/builtin_compare_vec.go
@@ -26,11 +26,11 @@ import (
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
@@ -60,11 +60,11 @@ func (b *builtinGreatestDecimalSig) vectorized() bool {
 
 func (b *builtinLeastDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
@@ -95,11 +95,11 @@ func (b *builtinLeastDecimalSig) vectorized() bool {
 
 func (b *builtinLeastIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
@@ -130,11 +130,11 @@ func (b *builtinLeastIntSig) vectorized() bool {
 
 func (b *builtinGreatestIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
@@ -171,19 +171,19 @@ func (b *builtinGEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	n := input.NumRows()
 	var err error
 	var buf0, buf1 *chunk.Column
-	buf0, err = b.bufAllocator.get()
+	buf0, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err = b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err = b.bufAllocator.get()
+	buf1, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err = b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -201,11 +201,11 @@ func (b *builtinLeastRealSig) vectorized() bool {
 
 func (b *builtinLeastRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
@@ -240,17 +240,17 @@ func (b *builtinLeastStringSig) vecEvalString(ctx EvalContext, input *chunk.Chun
 	}
 
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 
 	src := result
 	arg := buf1
@@ -291,19 +291,19 @@ func (b *builtinEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	n := input.NumRows()
 	var err error
 	var buf0, buf1 *chunk.Column
-	buf0, err = b.bufAllocator.get()
+	buf0, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err = b.bufAllocator.get()
+	buf1, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -323,19 +323,19 @@ func (b *builtinNEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	n := input.NumRows()
 	var err error
 	var buf0, buf1 *chunk.Column
-	buf0, err = b.bufAllocator.get()
+	buf0, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err = b.bufAllocator.get()
+	buf1, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -355,19 +355,19 @@ func (b *builtinGTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	n := input.NumRows()
 	var err error
 	var buf0, buf1 *chunk.Column
-	buf0, err = b.bufAllocator.get()
+	buf0, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err = b.bufAllocator.get()
+	buf1, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -385,19 +385,19 @@ func (b *builtinNullEQIntSig) vectorized() bool {
 
 func (b *builtinNullEQIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	result.ResizeInt64(n, false)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
@@ -454,11 +454,11 @@ func (b *builtinIntervalRealSig) vectorized() bool {
 
 func (b *builtinIntervalRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -493,19 +493,19 @@ func (b *builtinLEIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	n := input.NumRows()
 	var err error
 	var buf0, buf1 *chunk.Column
-	buf0, err = b.bufAllocator.get()
+	buf0, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err = b.bufAllocator.get()
+	buf1, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -525,19 +525,19 @@ func (b *builtinLTIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	n := input.NumRows()
 	var err error
 	var buf0, buf1 *chunk.Column
-	buf0, err = b.bufAllocator.get()
+	buf0, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err = b.bufAllocator.get()
+	buf1, err = globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -680,11 +680,11 @@ func (b *builtinGreatestRealSig) vectorized() bool {
 
 func (b *builtinGreatestRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
@@ -764,16 +764,16 @@ func (b *builtinGreatestStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	}
 
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
-	buf2, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf1)
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 
 	src := result
 	arg := buf1
@@ -812,11 +812,11 @@ func (b *builtinGreatestTimeSig) vectorized() bool {
 
 func (b *builtinGreatestTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	result.ResizeTime(n, false)
 	for argIdx := range b.args {
@@ -853,11 +853,11 @@ func (b *builtinLeastTimeSig) vectorized() bool {
 
 func (b *builtinLeastTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	result.ResizeTime(n, false)
 	for argIdx := range b.args {
@@ -894,11 +894,11 @@ func (b *builtinGreatestDurationSig) vectorized() bool {
 
 func (b *builtinGreatestDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	result.ResizeGoDuration(n, false)
 	for argIdx := range b.args {
@@ -926,11 +926,11 @@ func (b *builtinLeastDurationSig) vectorized() bool {
 
 func (b *builtinLeastDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	result.ResizeGoDuration(n, false)
 	for argIdx := range b.args {

--- a/pkg/expression/builtin_compare_vec_generated.go
+++ b/pkg/expression/builtin_compare_vec_generated.go
@@ -29,7 +29,11 @@ func (b *builtinLTRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -37,7 +41,11 @@ func (b *builtinLTRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -67,7 +75,11 @@ func (b *builtinLTDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -75,7 +87,11 @@ func (b *builtinLTDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -105,7 +121,11 @@ func (b *builtinLTStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -113,7 +133,11 @@ func (b *builtinLTStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -141,7 +165,11 @@ func (b *builtinLTTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -149,7 +177,11 @@ func (b *builtinLTTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -179,7 +211,11 @@ func (b *builtinLTDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -187,7 +223,11 @@ func (b *builtinLTDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -217,7 +257,11 @@ func (b *builtinLTJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -225,7 +269,11 @@ func (b *builtinLTJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -253,7 +301,11 @@ func (b *builtinLERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -261,7 +313,11 @@ func (b *builtinLERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -291,7 +347,11 @@ func (b *builtinLEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -299,7 +359,11 @@ func (b *builtinLEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -329,7 +393,11 @@ func (b *builtinLEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -337,7 +405,11 @@ func (b *builtinLEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -365,7 +437,11 @@ func (b *builtinLETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -373,7 +449,11 @@ func (b *builtinLETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -403,7 +483,11 @@ func (b *builtinLEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -411,7 +495,11 @@ func (b *builtinLEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -441,7 +529,11 @@ func (b *builtinLEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -449,7 +541,11 @@ func (b *builtinLEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -477,7 +573,11 @@ func (b *builtinGTRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -485,7 +585,11 @@ func (b *builtinGTRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -515,7 +619,11 @@ func (b *builtinGTDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -523,7 +631,11 @@ func (b *builtinGTDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -553,7 +665,11 @@ func (b *builtinGTStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -561,7 +677,11 @@ func (b *builtinGTStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -589,7 +709,11 @@ func (b *builtinGTTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -597,7 +721,11 @@ func (b *builtinGTTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -627,7 +755,11 @@ func (b *builtinGTDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -635,7 +767,11 @@ func (b *builtinGTDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -665,7 +801,11 @@ func (b *builtinGTJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -673,7 +813,11 @@ func (b *builtinGTJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -701,7 +845,11 @@ func (b *builtinGERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -709,7 +857,11 @@ func (b *builtinGERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -739,7 +891,11 @@ func (b *builtinGEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -747,7 +903,11 @@ func (b *builtinGEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -777,7 +937,11 @@ func (b *builtinGEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -785,7 +949,11 @@ func (b *builtinGEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -813,7 +981,11 @@ func (b *builtinGETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -821,7 +993,11 @@ func (b *builtinGETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -851,7 +1027,11 @@ func (b *builtinGEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -859,7 +1039,11 @@ func (b *builtinGEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -889,7 +1073,11 @@ func (b *builtinGEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -897,7 +1085,11 @@ func (b *builtinGEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -925,7 +1117,11 @@ func (b *builtinEQRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -933,7 +1129,11 @@ func (b *builtinEQRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -963,7 +1163,11 @@ func (b *builtinEQDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -971,7 +1175,11 @@ func (b *builtinEQDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1001,7 +1209,11 @@ func (b *builtinEQStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1009,7 +1221,11 @@ func (b *builtinEQStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1037,7 +1253,11 @@ func (b *builtinEQTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1045,7 +1265,11 @@ func (b *builtinEQTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1075,7 +1299,11 @@ func (b *builtinEQDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1083,7 +1311,11 @@ func (b *builtinEQDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1113,7 +1345,11 @@ func (b *builtinEQJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1121,7 +1357,11 @@ func (b *builtinEQJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1149,7 +1389,11 @@ func (b *builtinNERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1157,7 +1401,11 @@ func (b *builtinNERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1187,7 +1435,11 @@ func (b *builtinNEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1195,7 +1447,11 @@ func (b *builtinNEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1225,7 +1481,11 @@ func (b *builtinNEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1233,7 +1493,11 @@ func (b *builtinNEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1261,7 +1525,11 @@ func (b *builtinNETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1269,7 +1537,11 @@ func (b *builtinNETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1299,7 +1571,11 @@ func (b *builtinNEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1307,7 +1583,11 @@ func (b *builtinNEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1337,7 +1617,11 @@ func (b *builtinNEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1345,7 +1629,11 @@ func (b *builtinNEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1373,7 +1661,11 @@ func (b *builtinNullEQRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1381,7 +1673,11 @@ func (b *builtinNullEQRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1415,7 +1711,11 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1423,7 +1723,11 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1457,7 +1761,11 @@ func (b *builtinNullEQStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1465,7 +1773,11 @@ func (b *builtinNullEQStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1497,7 +1809,11 @@ func (b *builtinNullEQTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1505,7 +1821,11 @@ func (b *builtinNullEQTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1539,7 +1859,11 @@ func (b *builtinNullEQDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1547,7 +1871,11 @@ func (b *builtinNullEQDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1581,7 +1909,11 @@ func (b *builtinNullEQJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1589,7 +1921,11 @@ func (b *builtinNullEQJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1645,7 +1981,11 @@ func (b *builtinCoalesceIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalInt(ctx, input, buf1)
@@ -1701,7 +2041,11 @@ func (b *builtinCoalesceRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalReal(ctx, input, buf1)
@@ -1757,7 +2101,11 @@ func (b *builtinCoalesceDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalDecimal(ctx, input, buf1)
@@ -1814,7 +2162,11 @@ func (b *builtinCoalesceStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(buf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(buf)
+			}
+		}()
 		err = b.args[i].VecEvalString(ctx, input, buf)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -1875,7 +2227,11 @@ func (b *builtinCoalesceTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalTime(ctx, input, buf1)
@@ -1933,7 +2289,11 @@ func (b *builtinCoalesceDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalDuration(ctx, input, buf1)
@@ -1990,7 +2350,11 @@ func (b *builtinCoalesceJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(buf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(buf)
+			}
+		}()
 		err = b.args[i].VecEvalJSON(ctx, input, buf)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/builtin_compare_vec_generated.go
+++ b/pkg/expression/builtin_compare_vec_generated.go
@@ -25,19 +25,19 @@ import (
 
 func (b *builtinLTRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -63,19 +63,19 @@ func (b *builtinLTRealSig) vectorized() bool {
 
 func (b *builtinLTDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -101,19 +101,19 @@ func (b *builtinLTDecimalSig) vectorized() bool {
 
 func (b *builtinLTStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -137,19 +137,19 @@ func (b *builtinLTStringSig) vectorized() bool {
 
 func (b *builtinLTTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -175,19 +175,19 @@ func (b *builtinLTTimeSig) vectorized() bool {
 
 func (b *builtinLTDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -213,19 +213,19 @@ func (b *builtinLTDurationSig) vectorized() bool {
 
 func (b *builtinLTJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -249,19 +249,19 @@ func (b *builtinLTJSONSig) vectorized() bool {
 
 func (b *builtinLERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -287,19 +287,19 @@ func (b *builtinLERealSig) vectorized() bool {
 
 func (b *builtinLEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -325,19 +325,19 @@ func (b *builtinLEDecimalSig) vectorized() bool {
 
 func (b *builtinLEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -361,19 +361,19 @@ func (b *builtinLEStringSig) vectorized() bool {
 
 func (b *builtinLETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -399,19 +399,19 @@ func (b *builtinLETimeSig) vectorized() bool {
 
 func (b *builtinLEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -437,19 +437,19 @@ func (b *builtinLEDurationSig) vectorized() bool {
 
 func (b *builtinLEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -473,19 +473,19 @@ func (b *builtinLEJSONSig) vectorized() bool {
 
 func (b *builtinGTRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -511,19 +511,19 @@ func (b *builtinGTRealSig) vectorized() bool {
 
 func (b *builtinGTDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -549,19 +549,19 @@ func (b *builtinGTDecimalSig) vectorized() bool {
 
 func (b *builtinGTStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -585,19 +585,19 @@ func (b *builtinGTStringSig) vectorized() bool {
 
 func (b *builtinGTTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -623,19 +623,19 @@ func (b *builtinGTTimeSig) vectorized() bool {
 
 func (b *builtinGTDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -661,19 +661,19 @@ func (b *builtinGTDurationSig) vectorized() bool {
 
 func (b *builtinGTJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -697,19 +697,19 @@ func (b *builtinGTJSONSig) vectorized() bool {
 
 func (b *builtinGERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -735,19 +735,19 @@ func (b *builtinGERealSig) vectorized() bool {
 
 func (b *builtinGEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -773,19 +773,19 @@ func (b *builtinGEDecimalSig) vectorized() bool {
 
 func (b *builtinGEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -809,19 +809,19 @@ func (b *builtinGEStringSig) vectorized() bool {
 
 func (b *builtinGETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -847,19 +847,19 @@ func (b *builtinGETimeSig) vectorized() bool {
 
 func (b *builtinGEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -885,19 +885,19 @@ func (b *builtinGEDurationSig) vectorized() bool {
 
 func (b *builtinGEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -921,19 +921,19 @@ func (b *builtinGEJSONSig) vectorized() bool {
 
 func (b *builtinEQRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -959,19 +959,19 @@ func (b *builtinEQRealSig) vectorized() bool {
 
 func (b *builtinEQDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -997,19 +997,19 @@ func (b *builtinEQDecimalSig) vectorized() bool {
 
 func (b *builtinEQStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1033,19 +1033,19 @@ func (b *builtinEQStringSig) vectorized() bool {
 
 func (b *builtinEQTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1071,19 +1071,19 @@ func (b *builtinEQTimeSig) vectorized() bool {
 
 func (b *builtinEQDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1109,19 +1109,19 @@ func (b *builtinEQDurationSig) vectorized() bool {
 
 func (b *builtinEQJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1145,19 +1145,19 @@ func (b *builtinEQJSONSig) vectorized() bool {
 
 func (b *builtinNERealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1183,19 +1183,19 @@ func (b *builtinNERealSig) vectorized() bool {
 
 func (b *builtinNEDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1221,19 +1221,19 @@ func (b *builtinNEDecimalSig) vectorized() bool {
 
 func (b *builtinNEStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1257,19 +1257,19 @@ func (b *builtinNEStringSig) vectorized() bool {
 
 func (b *builtinNETimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1295,19 +1295,19 @@ func (b *builtinNETimeSig) vectorized() bool {
 
 func (b *builtinNEDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1333,19 +1333,19 @@ func (b *builtinNEDurationSig) vectorized() bool {
 
 func (b *builtinNEJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1369,19 +1369,19 @@ func (b *builtinNEJSONSig) vectorized() bool {
 
 func (b *builtinNullEQRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1411,19 +1411,19 @@ func (b *builtinNullEQRealSig) vectorized() bool {
 
 func (b *builtinNullEQDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1453,19 +1453,19 @@ func (b *builtinNullEQDecimalSig) vectorized() bool {
 
 func (b *builtinNullEQStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1493,19 +1493,19 @@ func (b *builtinNullEQStringSig) vectorized() bool {
 
 func (b *builtinNullEQTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1535,19 +1535,19 @@ func (b *builtinNullEQTimeSig) vectorized() bool {
 
 func (b *builtinNullEQDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1577,19 +1577,19 @@ func (b *builtinNullEQDurationSig) vectorized() bool {
 
 func (b *builtinNullEQJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalJSON(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1641,11 +1641,11 @@ func (b *builtinCoalesceIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	n := input.NumRows()
 	result.ResizeInt64(n, true)
 	i64s := result.Int64s()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalInt(ctx, input, buf1)
@@ -1697,11 +1697,11 @@ func (b *builtinCoalesceRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	n := input.NumRows()
 	result.ResizeFloat64(n, true)
 	i64s := result.Float64s()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalReal(ctx, input, buf1)
@@ -1753,11 +1753,11 @@ func (b *builtinCoalesceDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	n := input.NumRows()
 	result.ResizeDecimal(n, true)
 	i64s := result.Decimals()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalDecimal(ctx, input, buf1)
@@ -1810,11 +1810,11 @@ func (b *builtinCoalesceStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	bufs := make([]*chunk.Column, argLen)
 	beforeWarns := warningCount(ctx)
 	for i := 0; i < argLen; i++ {
-		buf, err := b.bufAllocator.get()
+		buf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(buf)
+		defer globalColumnAllocator.put(buf)
 		err = b.args[i].VecEvalString(ctx, input, buf)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -1871,11 +1871,11 @@ func (b *builtinCoalesceTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	n := input.NumRows()
 	result.ResizeTime(n, true)
 	i64s := result.Times()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalTime(ctx, input, buf1)
@@ -1929,11 +1929,11 @@ func (b *builtinCoalesceDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 	n := input.NumRows()
 	result.ResizeGoDuration(n, true)
 	i64s := result.GoDurations()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++ {
 		err := b.args[j].VecEvalDuration(ctx, input, buf1)
@@ -1986,11 +1986,11 @@ func (b *builtinCoalesceJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 	bufs := make([]*chunk.Column, argLen)
 	beforeWarns := warningCount(ctx)
 	for i := 0; i < argLen; i++ {
-		buf, err := b.bufAllocator.get()
+		buf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(buf)
+		defer globalColumnAllocator.put(buf)
 		err = b.args[i].VecEvalJSON(ctx, input, buf)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/builtin_control_vec_generated.go
+++ b/pkg/expression/builtin_control_vec_generated.go
@@ -63,7 +63,11 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -79,7 +83,11 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalInt(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -99,7 +107,11 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalInt(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -173,7 +185,11 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -189,7 +205,11 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalReal(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -209,7 +229,11 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalReal(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -283,7 +307,11 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -299,7 +327,11 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalDecimal(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -319,7 +351,11 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalDecimal(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -388,7 +424,11 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -404,7 +444,11 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalString(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -423,7 +467,11 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalString(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -501,7 +549,11 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -517,7 +569,11 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalTime(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -537,7 +593,11 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalTime(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -611,7 +671,11 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -627,7 +691,11 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalDuration(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -647,7 +715,11 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalDuration(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -716,7 +788,11 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -732,7 +808,11 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEvalJSON(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -751,7 +831,11 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEvalJSON(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -822,7 +906,11 @@ func (b *builtinIfNullIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalInt(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -876,7 +964,11 @@ func (b *builtinIfNullRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalReal(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -930,7 +1022,11 @@ func (b *builtinIfNullDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDecimal(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -978,7 +1074,11 @@ func (b *builtinIfNullStringSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -986,7 +1086,11 @@ func (b *builtinIfNullStringSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalString(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1043,7 +1147,11 @@ func (b *builtinIfNullTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalTime(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1097,7 +1205,11 @@ func (b *builtinIfNullDurationSig) vecEvalDuration(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDuration(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1145,7 +1257,11 @@ func (b *builtinIfNullJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1153,7 +1269,11 @@ func (b *builtinIfNullJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalJSON(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1207,7 +1327,11 @@ func (b *builtinIfIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1225,7 +1349,11 @@ func (b *builtinIfIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalInt(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1285,7 +1413,11 @@ func (b *builtinIfRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1303,7 +1435,11 @@ func (b *builtinIfRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalReal(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1363,7 +1499,11 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1381,7 +1521,11 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalDecimal(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1438,7 +1582,11 @@ func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1447,7 +1595,11 @@ func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	err = b.args[1].VecEvalString(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1461,7 +1613,11 @@ func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalString(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1524,7 +1680,11 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1542,7 +1702,11 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalTime(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1602,7 +1766,11 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1620,7 +1788,11 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalDuration(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1677,7 +1849,11 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1686,7 +1862,11 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	err = b.args[1].VecEvalJSON(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1700,7 +1880,11 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEvalJSON(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/builtin_control_vec_generated.go
+++ b/pkg/expression/builtin_control_vec_generated.go
@@ -59,11 +59,11 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -75,11 +75,11 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalInt(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -95,11 +95,11 @@ func (b *builtinCaseWhenIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalInt(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -169,11 +169,11 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -185,11 +185,11 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalReal(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -205,11 +205,11 @@ func (b *builtinCaseWhenRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalReal(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -279,11 +279,11 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -295,11 +295,11 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalDecimal(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -315,11 +315,11 @@ func (b *builtinCaseWhenDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalDecimal(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -384,11 +384,11 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -400,11 +400,11 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalString(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -419,11 +419,11 @@ func (b *builtinCaseWhenStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalString(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -497,11 +497,11 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -513,11 +513,11 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalTime(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -533,11 +533,11 @@ func (b *builtinCaseWhenTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalTime(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -607,11 +607,11 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -623,11 +623,11 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalDuration(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -643,11 +643,11 @@ func (b *builtinCaseWhenDurationSig) vecEvalDuration(ctx EvalContext, input *chu
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalDuration(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -712,11 +712,11 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j += 2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -728,11 +728,11 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEvalJSON(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -747,11 +747,11 @@ func (b *builtinCaseWhenJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEvalJSON(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -818,11 +818,11 @@ func (b *builtinIfNullIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err := b.args[0].VecEvalInt(ctx, input, result); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalInt(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -872,11 +872,11 @@ func (b *builtinIfNullRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 	if err := b.args[0].VecEvalReal(ctx, input, result); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalReal(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -926,11 +926,11 @@ func (b *builtinIfNullDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDecimal(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -974,19 +974,19 @@ func (b *builtinIfNullStringSig) fallbackEvalString(ctx EvalContext, input *chun
 
 func (b *builtinIfNullStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalString(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1039,11 +1039,11 @@ func (b *builtinIfNullTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, 
 	if err := b.args[0].VecEvalTime(ctx, input, result); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalTime(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1093,11 +1093,11 @@ func (b *builtinIfNullDurationSig) vecEvalDuration(ctx EvalContext, input *chunk
 	if err := b.args[0].VecEvalDuration(ctx, input, result); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalDuration(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1141,19 +1141,19 @@ func (b *builtinIfNullJSONSig) fallbackEvalJSON(ctx EvalContext, input *chunk.Ch
 
 func (b *builtinIfNullJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEvalJSON(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -1203,11 +1203,11 @@ func (b *builtinIfIntSig) fallbackEvalInt(ctx EvalContext, input *chunk.Chunk, r
 
 func (b *builtinIfIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1221,11 +1221,11 @@ func (b *builtinIfIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 		return b.fallbackEvalInt(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalInt(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1281,11 +1281,11 @@ func (b *builtinIfRealSig) fallbackEvalReal(ctx EvalContext, input *chunk.Chunk,
 
 func (b *builtinIfRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1299,11 +1299,11 @@ func (b *builtinIfRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, resu
 		return b.fallbackEvalReal(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalReal(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1359,11 +1359,11 @@ func (b *builtinIfDecimalSig) fallbackEvalDecimal(ctx EvalContext, input *chunk.
 
 func (b *builtinIfDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1377,11 +1377,11 @@ func (b *builtinIfDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk
 		return b.fallbackEvalDecimal(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalDecimal(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1434,20 +1434,20 @@ func (b *builtinIfStringSig) fallbackEvalString(ctx EvalContext, input *chunk.Ch
 
 func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	beforeWarns := warningCount(ctx)
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	err = b.args[1].VecEvalString(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1457,11 +1457,11 @@ func (b *builtinIfStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 		return b.fallbackEvalString(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalString(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1520,11 +1520,11 @@ func (b *builtinIfTimeSig) fallbackEvalTime(ctx EvalContext, input *chunk.Chunk,
 
 func (b *builtinIfTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1538,11 +1538,11 @@ func (b *builtinIfTimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, resu
 		return b.fallbackEvalTime(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalTime(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1598,11 +1598,11 @@ func (b *builtinIfDurationSig) fallbackEvalDuration(ctx EvalContext, input *chun
 
 func (b *builtinIfDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1616,11 +1616,11 @@ func (b *builtinIfDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chu
 		return b.fallbackEvalDuration(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalDuration(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1673,20 +1673,20 @@ func (b *builtinIfJSONSig) fallbackEvalJSON(ctx EvalContext, input *chunk.Chunk,
 
 func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
 	beforeWarns := warningCount(ctx)
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	err = b.args[1].VecEvalJSON(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {
@@ -1696,11 +1696,11 @@ func (b *builtinIfJSONSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, resu
 		return b.fallbackEvalJSON(ctx, input, result)
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEvalJSON(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/builtin_convert_charset.go
+++ b/pkg/expression/builtin_convert_charset.go
@@ -110,11 +110,11 @@ func (b *builtinInternalToBinarySig) vectorized() bool {
 
 func (b *builtinInternalToBinarySig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -210,11 +210,11 @@ func (b *builtinInternalFromBinarySig) vectorized() bool {
 
 func (b *builtinInternalFromBinarySig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_convert_charset.go
+++ b/pkg/expression/builtin_convert_charset.go
@@ -114,7 +114,11 @@ func (b *builtinInternalToBinarySig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -214,7 +218,11 @@ func (b *builtinInternalFromBinarySig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_encryption_vec.go
+++ b/pkg/expression/builtin_encryption_vec.go
@@ -54,7 +54,11 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
@@ -63,7 +67,11 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(keyBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(keyBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
@@ -122,7 +130,11 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
@@ -131,7 +143,11 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(keyBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(keyBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
@@ -140,7 +156,11 @@ func (b *builtinAesEncryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(ivBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(ivBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, ivBuf); err != nil {
 		return err
 	}
@@ -215,7 +235,11 @@ func (b *builtinDecodeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -223,7 +247,11 @@ func (b *builtinDecodeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err1 != nil {
 		return err1
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -254,7 +282,11 @@ func (b *builtinEncodeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -262,7 +294,11 @@ func (b *builtinEncodeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err1 != nil {
 		return err1
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -295,7 +331,11 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
@@ -304,7 +344,11 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(keyBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(keyBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
@@ -313,7 +357,11 @@ func (b *builtinAesDecryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(ivBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(ivBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, ivBuf); err != nil {
 		return err
 	}
@@ -388,7 +436,11 @@ func (b *builtinRandomBytesSig) vecEvalString(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -425,7 +477,11 @@ func (b *builtinMD5Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -460,7 +516,11 @@ func (b *builtinSHA2Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -468,7 +528,11 @@ func (b *builtinSHA2Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -536,7 +600,11 @@ func (b *builtinSM3Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return errors.Trace(err)
 	}
@@ -590,7 +658,11 @@ func (b *builtinCompressSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -653,7 +725,11 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
@@ -662,7 +738,11 @@ func (b *builtinAesEncryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(keyBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(keyBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
@@ -718,7 +798,11 @@ func (b *builtinPasswordSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -755,7 +839,11 @@ func (b *builtinSHA1Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -789,7 +877,11 @@ func (b *builtinUncompressSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -844,7 +936,11 @@ func (b *builtinUncompressedLengthSig) vecEvalInt(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(payloadBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(payloadBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, payloadBuf); err != nil {
 		return err
 	}
@@ -891,7 +987,11 @@ func (b *builtinValidatePasswordStrengthSig) vecEvalInt(ctx EvalContext, input *
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_encryption_vec.go
+++ b/pkg/expression/builtin_encryption_vec.go
@@ -50,20 +50,20 @@ func (b *builtinAesDecryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 		return nil
 	}
 
-	strBuf, err := b.bufAllocator.get()
+	strBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strBuf)
+	defer globalColumnAllocator.put(strBuf)
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
-	keyBuf, err := b.bufAllocator.get()
+	keyBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(keyBuf)
+	defer globalColumnAllocator.put(keyBuf)
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
@@ -118,29 +118,29 @@ func (b *builtinAesEncryptIVSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesEncryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	strBuf, err := b.bufAllocator.get()
+	strBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strBuf)
+	defer globalColumnAllocator.put(strBuf)
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
-	keyBuf, err := b.bufAllocator.get()
+	keyBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(keyBuf)
+	defer globalColumnAllocator.put(keyBuf)
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
 
-	ivBuf, err := b.bufAllocator.get()
+	ivBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(ivBuf)
+	defer globalColumnAllocator.put(ivBuf)
 	if err := b.args[2].VecEvalString(ctx, input, ivBuf); err != nil {
 		return err
 	}
@@ -211,19 +211,19 @@ func (b *builtinDecodeSig) vectorized() bool {
 
 func (b *builtinDecodeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err1 := b.bufAllocator.get()
+	buf1, err1 := globalColumnAllocator.get()
 	if err1 != nil {
 		return err1
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -250,19 +250,19 @@ func (b *builtinEncodeSig) vectorized() bool {
 
 func (b *builtinEncodeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err1 := b.bufAllocator.get()
+	buf1, err1 := globalColumnAllocator.get()
 	if err1 != nil {
 		return err1
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -291,29 +291,29 @@ func (b *builtinAesDecryptIVSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesDecryptIVSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	strBuf, err := b.bufAllocator.get()
+	strBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strBuf)
+	defer globalColumnAllocator.put(strBuf)
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
-	keyBuf, err := b.bufAllocator.get()
+	keyBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(keyBuf)
+	defer globalColumnAllocator.put(keyBuf)
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
 
-	ivBuf, err := b.bufAllocator.get()
+	ivBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(ivBuf)
+	defer globalColumnAllocator.put(ivBuf)
 	if err := b.args[2].VecEvalString(ctx, input, ivBuf); err != nil {
 		return err
 	}
@@ -384,11 +384,11 @@ func (b *builtinRandomBytesSig) vectorized() bool {
 
 func (b *builtinRandomBytesSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -421,11 +421,11 @@ func (b *builtinMD5Sig) vectorized() bool {
 
 func (b *builtinMD5Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -456,19 +456,19 @@ func (b *builtinSHA2Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_sha2
 func (b *builtinSHA2Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -532,11 +532,11 @@ func (b *builtinSM3Sig) vectorized() bool {
 // vecEvalString evals Sm3Hash(str).
 func (b *builtinSM3Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return errors.Trace(err)
 	}
@@ -586,11 +586,11 @@ func deallocateByteSlice(b []byte) {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_compress
 func (b *builtinCompressSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -649,20 +649,20 @@ func (b *builtinAesEncryptSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesEncryptSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	strBuf, err := b.bufAllocator.get()
+	strBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strBuf)
+	defer globalColumnAllocator.put(strBuf)
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
 
-	keyBuf, err := b.bufAllocator.get()
+	keyBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(keyBuf)
+	defer globalColumnAllocator.put(keyBuf)
 	if err := b.args[1].VecEvalString(ctx, input, keyBuf); err != nil {
 		return err
 	}
@@ -714,11 +714,11 @@ func (b *builtinPasswordSig) vectorized() bool {
 
 func (b *builtinPasswordSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -751,11 +751,11 @@ func (b *builtinSHA1Sig) vectorized() bool {
 
 func (b *builtinSHA1Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -785,11 +785,11 @@ func (b *builtinUncompressSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_uncompress
 func (b *builtinUncompressSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -840,11 +840,11 @@ func (b *builtinUncompressedLengthSig) vectorized() bool {
 func (b *builtinUncompressedLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	tc := typeCtx(ctx)
 	nr := input.NumRows()
-	payloadBuf, err := b.bufAllocator.get()
+	payloadBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(payloadBuf)
+	defer globalColumnAllocator.put(payloadBuf)
 	if err := b.args[0].VecEvalString(ctx, input, payloadBuf); err != nil {
 		return err
 	}
@@ -887,11 +887,11 @@ func (b *builtinValidatePasswordStrengthSig) vecEvalInt(ctx EvalContext, input *
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_func_param.go
+++ b/pkg/expression/builtin_func_param.go
@@ -86,7 +86,7 @@ func buildStringParam(ctx EvalContext, bf *baseBuiltinFunc, idx int, input *chun
 		return &pa, false, nil
 	}
 
-	pa.col, err = bf.bufAllocator.get()
+	pa.col, err = globalColumnAllocator.get()
 	if err != nil {
 		return nil, false, err
 	}
@@ -119,7 +119,7 @@ func buildIntParam(ctx EvalContext, bf *baseBuiltinFunc, idx int, input *chunk.C
 		return &pa, false, nil
 	}
 
-	pa.col, err = bf.bufAllocator.get()
+	pa.col, err = globalColumnAllocator.get()
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/expression/builtin_grouping.go
+++ b/pkg/expression/builtin_grouping.go
@@ -266,11 +266,11 @@ func (b *BuiltinGroupingImplSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	}
 	rowNum := input.NumRows()
 
-	bufVal, err := b.bufAllocator.get()
+	bufVal, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufVal)
+	defer globalColumnAllocator.put(bufVal)
 	if err = b.args[0].VecEvalInt(ctx, input, bufVal); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_grouping.go
+++ b/pkg/expression/builtin_grouping.go
@@ -270,7 +270,11 @@ func (b *BuiltinGroupingImplSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufVal)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufVal)
+		}
+	}()
 	if err = b.args[0].VecEvalInt(ctx, input, bufVal); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_info_vec.go
+++ b/pkg/expression/builtin_info_vec.go
@@ -269,11 +269,11 @@ func (b *builtinBenchmarkSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	loopCount := b.constLoopCount
 	arg := b.args[1]
 	evalType := arg.GetType(ctx).EvalType()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	var k int64
 	switch evalType {
@@ -415,11 +415,11 @@ func (b *builtinTiDBDecodeKeySig) vectorized() bool {
 
 func (b *builtinTiDBDecodeKeySig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_info_vec.go
+++ b/pkg/expression/builtin_info_vec.go
@@ -273,7 +273,11 @@ func (b *builtinBenchmarkSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	var k int64
 	switch evalType {
@@ -419,7 +423,11 @@ func (b *builtinTiDBDecodeKeySig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -109,11 +109,11 @@ func (b *builtinJSONStorageFreeSig) vectorized() bool {
 
 func (b *builtinJSONStorageFreeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -136,11 +136,11 @@ func (b *builtinJSONStorageSizeSig) vectorized() bool {
 
 func (b *builtinJSONStorageSizeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -164,11 +164,11 @@ func (b *builtinJSONDepthSig) vectorized() bool {
 
 func (b *builtinJSONDepthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -191,11 +191,11 @@ func (b *builtinJSONKeysSig) vectorized() bool {
 
 func (b *builtinJSONKeysSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func (b *builtinJSONInsertSig) vectorized() bool {
 }
 
 func (b *builtinJSONInsertSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	err := vecJSONModify(ctx, b.args, b.bufAllocator, input, result, types.JSONModifyInsert)
+	err := vecJSONModify(ctx, b.args, globalColumnAllocator, input, result, types.JSONModifyInsert)
 	return err
 }
 
@@ -232,7 +232,7 @@ func (b *builtinJSONReplaceSig) vectorized() bool {
 }
 
 func (b *builtinJSONReplaceSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	err := vecJSONModify(ctx, b.args, b.bufAllocator, input, result, types.JSONModifyReplace)
+	err := vecJSONModify(ctx, b.args, globalColumnAllocator, input, result, types.JSONModifyReplace)
 	return err
 }
 
@@ -247,11 +247,11 @@ func (b *builtinJSONArraySig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, r
 		jsons[i] = make([]any, 0, len(b.args))
 	}
 	for _, arg := range b.args {
-		j, err := b.bufAllocator.get()
+		j, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(j)
+		defer globalColumnAllocator.put(j)
 		if err = arg.VecEvalJSON(ctx, input, j); err != nil {
 			return err
 		}
@@ -281,21 +281,21 @@ func (b *builtinJSONMemberOfSig) vectorized() bool {
 func (b *builtinJSONMemberOfSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
 
-	targetCol, err := b.bufAllocator.get()
+	targetCol, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(targetCol)
+	defer globalColumnAllocator.put(targetCol)
 
 	if err := b.args[0].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
 	}
 
-	objCol, err := b.bufAllocator.get()
+	objCol, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(objCol)
+	defer globalColumnAllocator.put(objCol)
 
 	if err := b.args[1].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
@@ -334,21 +334,21 @@ func (b *builtinJSONContainsSig) vectorized() bool {
 func (b *builtinJSONContainsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
 
-	objCol, err := b.bufAllocator.get()
+	objCol, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(objCol)
+	defer globalColumnAllocator.put(objCol)
 
 	if err := b.args[0].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
 	}
 
-	targetCol, err := b.bufAllocator.get()
+	targetCol, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(targetCol)
+	defer globalColumnAllocator.put(targetCol)
 
 	if err := b.args[1].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
@@ -358,11 +358,11 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	resI64s := result.Int64s()
 
 	if len(b.args) == 3 {
-		pathCol, err := b.bufAllocator.get()
+		pathCol, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(pathCol)
+		defer globalColumnAllocator.put(pathCol)
 
 		if err := b.args[2].VecEvalString(ctx, input, pathCol); err != nil {
 			return err
@@ -419,21 +419,21 @@ func (b *builtinJSONOverlapsSig) vectorized() bool {
 func (b *builtinJSONOverlapsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
 
-	objCol, err := b.bufAllocator.get()
+	objCol, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(objCol)
+	defer globalColumnAllocator.put(objCol)
 
 	if err := b.args[0].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
 	}
 
-	targetCol, err := b.bufAllocator.get()
+	targetCol, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(targetCol)
+	defer globalColumnAllocator.put(targetCol)
 
 	if err := b.args[1].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
@@ -463,11 +463,11 @@ func (b *builtinJSONQuoteSig) vectorized() bool {
 
 func (b *builtinJSONQuoteSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -496,38 +496,38 @@ func (b *builtinJSONSearchSig) vectorized() bool {
 
 func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
-	typeBuf, err := b.bufAllocator.get()
+	typeBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(typeBuf)
+	defer globalColumnAllocator.put(typeBuf)
 	if err := b.args[1].VecEvalString(ctx, input, typeBuf); err != nil {
 		return err
 	}
-	searchBuf, err := b.bufAllocator.get()
+	searchBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(searchBuf)
+	defer globalColumnAllocator.put(searchBuf)
 	if err := b.args[2].VecEvalString(ctx, input, searchBuf); err != nil {
 		return err
 	}
 
 	var escapeBuf *chunk.Column
 	if len(b.args) >= 4 {
-		escapeBuf, err = b.bufAllocator.get()
+		escapeBuf, err = globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(escapeBuf)
+		defer globalColumnAllocator.put(escapeBuf)
 		if err := b.args[3].VecEvalString(ctx, input, escapeBuf); err != nil {
 			return err
 		}
@@ -538,11 +538,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 		pathBufs = make([]*chunk.Column, (len(b.args) - 4))
 		for i := 4; i < len(b.args); i++ {
 			index := i - 4
-			pathBufs[index], err = b.bufAllocator.get()
+			pathBufs[index], err = globalColumnAllocator.get()
 			if err != nil {
 				return err
 			}
-			defer b.bufAllocator.put(pathBufs[index])
+			defer globalColumnAllocator.put(pathBufs[index])
 			if err := b.args[i].VecEvalString(ctx, input, pathBufs[index]); err != nil {
 				return err
 			}
@@ -608,7 +608,7 @@ func (b *builtinJSONSetSig) vectorized() bool {
 }
 
 func (b *builtinJSONSetSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
-	err := vecJSONModify(ctx, b.args, b.bufAllocator, input, result, types.JSONModifySet)
+	err := vecJSONModify(ctx, b.args, globalColumnAllocator, input, result, types.JSONModifySet)
 	return err
 }
 
@@ -632,22 +632,22 @@ func (b *builtinJSONObjectSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	var err error
 	for i := range b.args {
 		if i&1 == 0 {
-			if argBuffers[i], err = b.bufAllocator.get(); err != nil {
+			if argBuffers[i], err = globalColumnAllocator.get(); err != nil {
 				return err
 			}
 			defer func(buf *chunk.Column) {
-				b.bufAllocator.put(buf)
+				globalColumnAllocator.put(buf)
 			}(argBuffers[i])
 
 			if err = b.args[i].VecEvalString(ctx, input, argBuffers[i]); err != nil {
 				return err
 			}
 		} else {
-			if argBuffers[i], err = b.bufAllocator.get(); err != nil {
+			if argBuffers[i], err = globalColumnAllocator.get(); err != nil {
 				return err
 			}
 			defer func(buf *chunk.Column) {
-				b.bufAllocator.put(buf)
+				globalColumnAllocator.put(buf)
 			}(argBuffers[i])
 
 			if err = b.args[i].VecEvalJSON(ctx, input, argBuffers[i]); err != nil {
@@ -695,11 +695,11 @@ func (b *builtinJSONArrayInsertSig) vectorized() bool {
 
 func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -707,20 +707,20 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 	valueBufs := make([]*chunk.Column, (len(b.args)-1)/2)
 	for i := 1; i < len(b.args); i++ {
 		if i&1 == 0 {
-			valueBufs[i/2-1], err = b.bufAllocator.get()
+			valueBufs[i/2-1], err = globalColumnAllocator.get()
 			if err != nil {
 				return err
 			}
-			defer b.bufAllocator.put(valueBufs[i/2-1])
+			defer globalColumnAllocator.put(valueBufs[i/2-1])
 			if err := b.args[i].VecEvalJSON(ctx, input, valueBufs[i/2-1]); err != nil {
 				return err
 			}
 		} else {
-			pathBufs[(i-1)/2], err = b.bufAllocator.get()
+			pathBufs[(i-1)/2], err = globalColumnAllocator.get()
 			if err != nil {
 				return err
 			}
-			defer b.bufAllocator.put(pathBufs[(i-1)/2])
+			defer globalColumnAllocator.put(pathBufs[(i-1)/2])
 			if err := b.args[i].VecEvalString(ctx, input, pathBufs[(i-1)/2]); err != nil {
 				return err
 			}
@@ -774,19 +774,19 @@ func (b *builtinJSONKeys2ArgsSig) vectorized() bool {
 
 func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
-	pathBuf, err := b.bufAllocator.get()
+	pathBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(pathBuf)
+	defer globalColumnAllocator.put(pathBuf)
 	if err := b.args[1].VecEvalString(ctx, input, pathBuf); err != nil {
 		return err
 	}
@@ -827,22 +827,22 @@ func (b *builtinJSONLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	result.ResizeInt64(nr, false)
 	resI64s := result.Int64s()
 
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 	result.MergeNulls(jsonBuf)
 
 	if len(b.args) == 2 {
-		pathBuf, err := b.bufAllocator.get()
+		pathBuf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(pathBuf)
+		defer globalColumnAllocator.put(pathBuf)
 		if err := b.args[1].VecEvalString(ctx, input, pathBuf); err != nil {
 			return err
 		}
@@ -897,11 +897,11 @@ func (b *builtinJSONTypeSig) vectorized() bool {
 
 func (b *builtinJSONTypeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -929,12 +929,12 @@ func (b *builtinJSONSumCRC32Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	}
 
 	nr := input.NumRows()
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
 
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err = b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -978,11 +978,11 @@ func (b *builtinJSONExtractSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk,
 	var err error
 
 	nr := input.NumRows()
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err = b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -990,11 +990,11 @@ func (b *builtinJSONExtractSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk,
 	pathArgs := b.args[1:]
 	pathBuffers := make([]*chunk.Column, len(pathArgs))
 	for k := range pathArgs {
-		if pathBuffers[k], err = b.bufAllocator.get(); err != nil {
+		if pathBuffers[k], err = globalColumnAllocator.get(); err != nil {
 			return err
 		}
 		defer func(buf *chunk.Column) {
-			b.bufAllocator.put(buf)
+			globalColumnAllocator.put(buf)
 		}(pathBuffers[k])
 
 		if err := pathArgs[k].VecEvalString(ctx, input, pathBuffers[k]); err != nil {
@@ -1043,22 +1043,22 @@ func (b *builtinJSONRemoveSig) vectorized() bool {
 
 func (b *builtinJSONRemoveSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
 
 	strBufs := make([]*chunk.Column, len(b.args)-1)
 	for i := 1; i < len(b.args); i++ {
-		strBufs[i-1], err = b.bufAllocator.get()
+		strBufs[i-1], err = globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(strBufs[i-1])
+		defer globalColumnAllocator.put(strBufs[i-1])
 		if err := b.args[i].VecEvalString(ctx, input, strBufs[i-1]); err != nil {
 			return err
 		}
@@ -1109,11 +1109,11 @@ func (b *builtinJSONMergeSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, r
 	argBuffers := make([]*chunk.Column, len(b.args))
 	var err error
 	for i, arg := range b.args {
-		if argBuffers[i], err = b.bufAllocator.get(); err != nil {
+		if argBuffers[i], err = globalColumnAllocator.get(); err != nil {
 			return err
 		}
 		defer func(buf *chunk.Column) {
-			b.bufAllocator.put(buf)
+			globalColumnAllocator.put(buf)
 		}(argBuffers[i])
 
 		if err := arg.VecEvalJSON(ctx, input, argBuffers[i]); err != nil {
@@ -1171,19 +1171,19 @@ func (b *builtinJSONContainsPathSig) vectorized() bool {
 
 func (b *builtinJSONContainsPathSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	jsonBuf, err := b.bufAllocator.get()
+	jsonBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBuf)
+	defer globalColumnAllocator.put(jsonBuf)
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
-	typeBuf, err := b.bufAllocator.get()
+	typeBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(typeBuf)
+	defer globalColumnAllocator.put(typeBuf)
 	if err := b.args[1].VecEvalString(ctx, input, typeBuf); err != nil {
 		return err
 	}
@@ -1191,12 +1191,12 @@ func (b *builtinJSONContainsPathSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	defer func() {
 		for i := range pathBufs {
 			if pathBufs[i] != nil {
-				b.bufAllocator.put(pathBufs[i])
+				globalColumnAllocator.put(pathBufs[i])
 			}
 		}
 	}()
 	for i := range pathBufs {
-		pathBuf, err := b.bufAllocator.get()
+		pathBuf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
@@ -1256,11 +1256,11 @@ func (b *builtinJSONArrayAppendSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 	n := input.NumRows()
 	m := (len(b.args) - 1) / 2
 
-	jsonBufs, err := b.bufAllocator.get()
+	jsonBufs, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(jsonBufs)
+	defer globalColumnAllocator.put(jsonBufs)
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBufs); err != nil {
 		return err
 	}
@@ -1269,14 +1269,14 @@ func (b *builtinJSONArrayAppendSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 	valBufs := make([]*chunk.Column, 0, m)
 	defer func() {
 		for _, buf := range pathBufs {
-			b.bufAllocator.put(buf)
+			globalColumnAllocator.put(buf)
 		}
 		for _, buf := range valBufs {
-			b.bufAllocator.put(buf)
+			globalColumnAllocator.put(buf)
 		}
 	}()
 	for i := 1; i < len(b.args)-1; i += 2 {
-		pathBuf, err := b.bufAllocator.get()
+		pathBuf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
@@ -1284,7 +1284,7 @@ func (b *builtinJSONArrayAppendSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 		if err := b.args[i].VecEvalString(ctx, input, pathBuf); err != nil {
 			return err
 		}
-		valBuf, err := b.bufAllocator.get()
+		valBuf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
@@ -1338,11 +1338,11 @@ func (b *builtinJSONUnquoteSig) vectorized() bool {
 
 func (b *builtinJSONUnquoteSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1372,11 +1372,11 @@ func (b *builtinJSONSPrettySig) vectorized() bool {
 
 func (b *builtinJSONSPrettySig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1411,11 +1411,11 @@ func (b *builtinJSONMergePatchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chu
 	argBuffers := make([]*chunk.Column, len(b.args))
 	var err error
 	for i, arg := range b.args {
-		if argBuffers[i], err = b.bufAllocator.get(); err != nil {
+		if argBuffers[i], err = globalColumnAllocator.get(); err != nil {
 			return err
 		}
 		defer func(buf *chunk.Column) {
-			b.bufAllocator.put(buf)
+			globalColumnAllocator.put(buf)
 		}(argBuffers[i])
 
 		if err := arg.VecEvalJSON(ctx, input, argBuffers[i]); err != nil {

--- a/pkg/expression/builtin_json_vec.go
+++ b/pkg/expression/builtin_json_vec.go
@@ -113,7 +113,11 @@ func (b *builtinJSONStorageFreeSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -140,7 +144,11 @@ func (b *builtinJSONStorageSizeSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -168,7 +176,11 @@ func (b *builtinJSONDepthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -195,7 +207,11 @@ func (b *builtinJSONKeysSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -251,7 +267,11 @@ func (b *builtinJSONArraySig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, r
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(j)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(j)
+			}
+		}()
 		if err = arg.VecEvalJSON(ctx, input, j); err != nil {
 			return err
 		}
@@ -285,7 +305,11 @@ func (b *builtinJSONMemberOfSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(targetCol)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(targetCol)
+		}
+	}()
 
 	if err := b.args[0].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
@@ -295,7 +319,11 @@ func (b *builtinJSONMemberOfSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(objCol)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(objCol)
+		}
+	}()
 
 	if err := b.args[1].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
@@ -338,7 +366,11 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(objCol)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(objCol)
+		}
+	}()
 
 	if err := b.args[0].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
@@ -348,7 +380,11 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(targetCol)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(targetCol)
+		}
+	}()
 
 	if err := b.args[1].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
@@ -362,7 +398,11 @@ func (b *builtinJSONContainsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(pathCol)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(pathCol)
+			}
+		}()
 
 		if err := b.args[2].VecEvalString(ctx, input, pathCol); err != nil {
 			return err
@@ -423,7 +463,11 @@ func (b *builtinJSONOverlapsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(objCol)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(objCol)
+		}
+	}()
 
 	if err := b.args[0].VecEvalJSON(ctx, input, objCol); err != nil {
 		return err
@@ -433,7 +477,11 @@ func (b *builtinJSONOverlapsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(targetCol)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(targetCol)
+		}
+	}()
 
 	if err := b.args[1].VecEvalJSON(ctx, input, targetCol); err != nil {
 		return err
@@ -467,7 +515,11 @@ func (b *builtinJSONQuoteSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -500,7 +552,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -508,7 +564,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(typeBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(typeBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, typeBuf); err != nil {
 		return err
 	}
@@ -516,7 +576,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(searchBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(searchBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, searchBuf); err != nil {
 		return err
 	}
@@ -527,7 +591,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(escapeBuf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(escapeBuf)
+			}
+		}()
 		if err := b.args[3].VecEvalString(ctx, input, escapeBuf); err != nil {
 			return err
 		}
@@ -542,7 +610,11 @@ func (b *builtinJSONSearchSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 			if err != nil {
 				return err
 			}
-			defer globalColumnAllocator.put(pathBufs[index])
+			defer func() {
+				if err == nil {
+					globalColumnAllocator.put(pathBufs[index])
+				}
+			}()
 			if err := b.args[i].VecEvalString(ctx, input, pathBufs[index]); err != nil {
 				return err
 			}
@@ -699,7 +771,11 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -711,7 +787,11 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 			if err != nil {
 				return err
 			}
-			defer globalColumnAllocator.put(valueBufs[i/2-1])
+			defer func() {
+				if err == nil {
+					globalColumnAllocator.put(valueBufs[i/2-1])
+				}
+			}()
 			if err := b.args[i].VecEvalJSON(ctx, input, valueBufs[i/2-1]); err != nil {
 				return err
 			}
@@ -720,7 +800,11 @@ func (b *builtinJSONArrayInsertSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 			if err != nil {
 				return err
 			}
-			defer globalColumnAllocator.put(pathBufs[(i-1)/2])
+			defer func() {
+				if err == nil {
+					globalColumnAllocator.put(pathBufs[(i-1)/2])
+				}
+			}()
 			if err := b.args[i].VecEvalString(ctx, input, pathBufs[(i-1)/2]); err != nil {
 				return err
 			}
@@ -778,7 +862,11 @@ func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -786,7 +874,11 @@ func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(pathBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(pathBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, pathBuf); err != nil {
 		return err
 	}
@@ -831,7 +923,11 @@ func (b *builtinJSONLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -842,7 +938,11 @@ func (b *builtinJSONLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(pathBuf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(pathBuf)
+			}
+		}()
 		if err := b.args[1].VecEvalString(ctx, input, pathBuf); err != nil {
 			return err
 		}
@@ -901,7 +1001,11 @@ func (b *builtinJSONTypeSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}
@@ -934,7 +1038,11 @@ func (b *builtinJSONSumCRC32Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 		return err
 	}
 
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err = b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -982,7 +1090,11 @@ func (b *builtinJSONExtractSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err = b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -1047,7 +1159,11 @@ func (b *builtinJSONRemoveSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -1058,7 +1174,11 @@ func (b *builtinJSONRemoveSig) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, 
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(strBufs[i-1])
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(strBufs[i-1])
+			}
+		}()
 		if err := b.args[i].VecEvalString(ctx, input, strBufs[i-1]); err != nil {
 			return err
 		}
@@ -1175,7 +1295,11 @@ func (b *builtinJSONContainsPathSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBuf); err != nil {
 		return err
 	}
@@ -1183,7 +1307,11 @@ func (b *builtinJSONContainsPathSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(typeBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(typeBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, typeBuf); err != nil {
 		return err
 	}
@@ -1260,7 +1388,11 @@ func (b *builtinJSONArrayAppendSig) vecEvalJSON(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(jsonBufs)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(jsonBufs)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, jsonBufs); err != nil {
 		return err
 	}
@@ -1342,7 +1474,11 @@ func (b *builtinJSONUnquoteSig) vecEvalString(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1376,7 +1512,11 @@ func (b *builtinJSONSPrettySig) vecEvalString(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_like_vec.go
+++ b/pkg/expression/builtin_like_vec.go
@@ -28,7 +28,11 @@ func (b *builtinLikeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufVal)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufVal)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, bufVal); err != nil {
 		return err
 	}
@@ -36,7 +40,11 @@ func (b *builtinLikeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufPattern)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufPattern)
+		}
+	}()
 	if err = b.args[1].VecEvalString(ctx, input, bufPattern); err != nil {
 		return err
 	}
@@ -45,7 +53,11 @@ func (b *builtinLikeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufEscape)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufEscape)
+		}
+	}()
 	if err = b.args[2].VecEvalInt(ctx, input, bufEscape); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_like_vec.go
+++ b/pkg/expression/builtin_like_vec.go
@@ -24,28 +24,28 @@ func (b *builtinLikeSig) vectorized() bool {
 
 func (b *builtinLikeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bufVal, err := b.bufAllocator.get()
+	bufVal, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufVal)
+	defer globalColumnAllocator.put(bufVal)
 	if err = b.args[0].VecEvalString(ctx, input, bufVal); err != nil {
 		return err
 	}
-	bufPattern, err := b.bufAllocator.get()
+	bufPattern, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufPattern)
+	defer globalColumnAllocator.put(bufPattern)
 	if err = b.args[1].VecEvalString(ctx, input, bufPattern); err != nil {
 		return err
 	}
 
-	bufEscape, err := b.bufAllocator.get()
+	bufEscape, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufEscape)
+	defer globalColumnAllocator.put(bufEscape)
 	if err = b.args[2].VecEvalInt(ctx, input, bufEscape); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -189,11 +189,11 @@ func (b *builtinAtan2ArgsSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, r
 		return err
 	}
 
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -408,11 +408,11 @@ func (b *builtinRoundDecSig) vectorized() bool {
 
 func (b *builtinPowSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[0].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -465,11 +465,11 @@ func (b *builtinLog2ArgsSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, re
 		return err
 	}
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -536,11 +536,11 @@ func (b *builtinRoundWithFracRealSig) vecEvalReal(ctx EvalContext, input *chunk.
 		return err
 	}
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -566,11 +566,11 @@ func (b *builtinTruncateRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 		return err
 	}
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -643,11 +643,11 @@ func (b *builtinRoundWithFracIntSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -673,11 +673,11 @@ func (b *builtinCRC32Sig) vectorized() bool {
 
 func (b *builtinCRC32Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -726,11 +726,11 @@ func (b *builtinRandWithSeedFirstGenSig) vectorized() bool {
 
 func (b *builtinRandWithSeedFirstGenSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -756,11 +756,11 @@ func (b *builtinCeilIntToDecSig) vectorized() bool {
 
 func (b *builtinCeilIntToDecSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -793,11 +793,11 @@ func (b *builtinTruncateIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 		return err
 	}
 
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
@@ -837,11 +837,11 @@ func (b *builtinTruncateUintSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
@@ -945,11 +945,11 @@ func (b *builtinTruncateDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -979,11 +979,11 @@ func (b *builtinRoundWithFracDecSig) vecEvalDecimal(ctx EvalContext, input *chun
 	if err := b.args[0].VecEvalDecimal(ctx, input, result); err != nil {
 		return err
 	}
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1011,11 +1011,11 @@ func (b *builtinFloorIntToDecSig) vectorized() bool {
 
 func (b *builtinFloorIntToDecSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1045,11 +1045,11 @@ func (b *builtinSignSig) vectorized() bool {
 
 func (b *builtinSignSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1079,21 +1079,21 @@ func (b *builtinConvSig) vectorized() bool {
 
 func (b *builtinConvSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
-	buf2, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf1)
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
-	buf3, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf2)
+	buf3, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf3)
+	defer globalColumnAllocator.put(buf3)
 	if err := b.args[0].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1138,11 +1138,11 @@ func (b *builtinCeilDecToIntSig) vectorized() bool {
 
 func (b *builtinCeilDecToIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1192,11 +1192,11 @@ func (b *builtinFloorDecToIntSig) vectorized() bool {
 
 func (b *builtinFloorDecToIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -193,7 +193,11 @@ func (b *builtinAtan2ArgsSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -412,7 +416,11 @@ func (b *builtinPowSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -469,7 +477,11 @@ func (b *builtinLog2ArgsSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -540,7 +552,11 @@ func (b *builtinRoundWithFracRealSig) vecEvalReal(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -570,7 +586,11 @@ func (b *builtinTruncateRealSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -647,7 +667,11 @@ func (b *builtinRoundWithFracIntSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -677,7 +701,11 @@ func (b *builtinCRC32Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -730,7 +758,11 @@ func (b *builtinRandWithSeedFirstGenSig) vecEvalReal(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -760,7 +792,11 @@ func (b *builtinCeilIntToDecSig) vecEvalDecimal(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -797,7 +833,11 @@ func (b *builtinTruncateIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
@@ -841,7 +881,11 @@ func (b *builtinTruncateUintSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
@@ -949,7 +993,11 @@ func (b *builtinTruncateDecimalSig) vecEvalDecimal(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -983,7 +1031,11 @@ func (b *builtinRoundWithFracDecSig) vecEvalDecimal(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1015,7 +1067,11 @@ func (b *builtinFloorIntToDecSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1049,7 +1105,11 @@ func (b *builtinSignSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1083,17 +1143,29 @@ func (b *builtinConvSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	buf3, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf3)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf3)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1142,7 +1214,11 @@ func (b *builtinCeilDecToIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1196,7 +1272,11 @@ func (b *builtinFloorDecToIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -35,7 +35,11 @@ func (b *builtinInetNtoaSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -71,7 +75,11 @@ func (b *builtinIsIPv4Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -128,7 +136,11 @@ func (b *builtinIsIPv6Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -159,7 +171,11 @@ func (b *builtinIsUUIDSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -253,7 +269,11 @@ func (b *builtinIsIPv4CompatSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -313,7 +333,11 @@ func (b *builtinSleepSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	err = b.args[0].VecEvalReal(ctx, input, buf)
 	if err != nil {
@@ -391,7 +415,11 @@ func (b *builtinIsIPv4MappedSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -446,7 +474,11 @@ func (b *builtinInet6AtonSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -523,7 +555,11 @@ func (b *builtinInetAtonSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -596,7 +632,11 @@ func (b *builtinInet6NtoaSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(val)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(val)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, val); err != nil {
 		return err
 	}
@@ -638,7 +678,11 @@ func (b *builtinVitessHashSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(column)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(column)
+		}
+	}()
 
 	if err := b.args[0].VecEvalInt(ctx, input, column); err != nil {
 		return err
@@ -675,7 +719,11 @@ func (b *builtinUUIDToBinSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(valBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(valBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, valBuf); err != nil {
 		return err
 	}
@@ -687,7 +735,11 @@ func (b *builtinUUIDToBinSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(flagBuf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(flagBuf)
+			}
+		}()
 		if err := b.args[1].VecEvalInt(ctx, input, flagBuf); err != nil {
 			return err
 		}
@@ -738,7 +790,11 @@ func (b *builtinBinToUUIDSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(valBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(valBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, valBuf); err != nil {
 		return err
 	}
@@ -750,7 +806,11 @@ func (b *builtinBinToUUIDSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(flagBuf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(flagBuf)
+			}
+		}()
 		if err := b.args[1].VecEvalInt(ctx, input, flagBuf); err != nil {
 			return err
 		}

--- a/pkg/expression/builtin_miscellaneous_vec.go
+++ b/pkg/expression/builtin_miscellaneous_vec.go
@@ -31,11 +31,11 @@ import (
 
 func (b *builtinInetNtoaSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -67,11 +67,11 @@ func (b *builtinInetNtoaSig) vectorized() bool {
 
 func (b *builtinIsIPv4Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -124,11 +124,11 @@ func (b *builtinIsIPv6Sig) vectorized() bool {
 
 func (b *builtinIsIPv6Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -155,11 +155,11 @@ func (b *builtinIsUUIDSig) vectorized() bool {
 
 func (b *builtinIsUUIDSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -249,11 +249,11 @@ func (b *builtinIsIPv4CompatSig) vectorized() bool {
 
 func (b *builtinIsIPv4CompatSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -309,11 +309,11 @@ func (b *builtinSleepSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	err = b.args[0].VecEvalReal(ctx, input, buf)
 	if err != nil {
@@ -387,11 +387,11 @@ func (b *builtinIsIPv4MappedSig) vectorized() bool {
 
 func (b *builtinIsIPv4MappedSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -442,11 +442,11 @@ func (b *builtinInet6AtonSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet6-aton
 func (b *builtinInet6AtonSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -519,11 +519,11 @@ func (b *builtinInetAtonSig) vectorized() bool {
 
 func (b *builtinInetAtonSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -592,11 +592,11 @@ func (b *builtinInet6NtoaSig) vectorized() bool {
 
 func (b *builtinInet6NtoaSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	val, err := b.bufAllocator.get()
+	val, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(val)
+	defer globalColumnAllocator.put(val)
 	if err := b.args[0].VecEvalString(ctx, input, val); err != nil {
 		return err
 	}
@@ -634,11 +634,11 @@ func (b *builtinVitessHashSig) vectorized() bool {
 
 func (b *builtinVitessHashSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	column, err := b.bufAllocator.get()
+	column, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(column)
+	defer globalColumnAllocator.put(column)
 
 	if err := b.args[0].VecEvalInt(ctx, input, column); err != nil {
 		return err
@@ -671,11 +671,11 @@ func (b *builtinUUIDToBinSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin
 func (b *builtinUUIDToBinSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	valBuf, err := b.bufAllocator.get()
+	valBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(valBuf)
+	defer globalColumnAllocator.put(valBuf)
 	if err := b.args[0].VecEvalString(ctx, input, valBuf); err != nil {
 		return err
 	}
@@ -683,11 +683,11 @@ func (b *builtinUUIDToBinSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	var flagBuf *chunk.Column
 	i64s := make([]int64, n)
 	if len(b.args) == 2 {
-		flagBuf, err = b.bufAllocator.get()
+		flagBuf, err = globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(flagBuf)
+		defer globalColumnAllocator.put(flagBuf)
 		if err := b.args[1].VecEvalInt(ctx, input, flagBuf); err != nil {
 			return err
 		}
@@ -734,11 +734,11 @@ func (b *builtinBinToUUIDSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_bin-to-uuid
 func (b *builtinBinToUUIDSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	valBuf, err := b.bufAllocator.get()
+	valBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(valBuf)
+	defer globalColumnAllocator.put(valBuf)
 	if err := b.args[0].VecEvalString(ctx, input, valBuf); err != nil {
 		return err
 	}
@@ -746,11 +746,11 @@ func (b *builtinBinToUUIDSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	var flagBuf *chunk.Column
 	i64s := make([]int64, n)
 	if len(b.args) == 2 {
-		flagBuf, err = b.bufAllocator.get()
+		flagBuf, err = globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(flagBuf)
+		defer globalColumnAllocator.put(flagBuf)
 		if err := b.args[1].VecEvalInt(ctx, input, flagBuf); err != nil {
 			return err
 		}

--- a/pkg/expression/builtin_op_vec.go
+++ b/pkg/expression/builtin_op_vec.go
@@ -33,7 +33,11 @@ func (b *builtinTimeIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
@@ -84,7 +88,11 @@ func (b *builtinLogicOrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	beforeArg1Warns := ctx.WarningCount()
 	err = b.args[1].VecEvalInt(ctx, input, buf)
@@ -133,7 +141,11 @@ func (b *builtinBitOrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -157,7 +169,11 @@ func (b *builtinDecimalIsFalseSig) vecEvalInt(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -293,7 +309,11 @@ func (b *builtinRealIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
@@ -321,7 +341,11 @@ func (b *builtinUnaryNotRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -376,7 +400,11 @@ func (b *builtinLogicAndSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	beforeArg1Warns := ctx.WarningCount()
 	err = b.args[1].VecEvalInt(ctx, input, buf1)
@@ -427,7 +455,11 @@ func (b *builtinBitXorSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -454,7 +486,11 @@ func (b *builtinLogicXorSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -492,7 +528,11 @@ func (b *builtinBitAndSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -515,7 +555,11 @@ func (b *builtinRealIsFalseSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -582,7 +626,11 @@ func (b *builtinUnaryNotDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -638,7 +686,11 @@ func (b *builtinDecimalIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
@@ -669,7 +721,11 @@ func (b *builtinLeftShiftSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -695,7 +751,11 @@ func (b *builtinRightShiftSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -718,7 +778,11 @@ func (b *builtinRealIsTrueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
@@ -751,7 +815,11 @@ func (b *builtinDecimalIsTrueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -810,7 +878,11 @@ func (b *builtinDurationIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err

--- a/pkg/expression/builtin_op_vec.go
+++ b/pkg/expression/builtin_op_vec.go
@@ -29,11 +29,11 @@ func (*builtinTimeIsNullSig) vectorized() bool {
 
 func (b *builtinTimeIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
@@ -80,11 +80,11 @@ func (b *builtinLogicOrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resu
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	beforeArg1Warns := ctx.WarningCount()
 	err = b.args[1].VecEvalInt(ctx, input, buf)
@@ -129,11 +129,11 @@ func (b *builtinBitOrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 		return err
 	}
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -153,11 +153,11 @@ func (b *builtinDecimalIsFalseSig) vectorized() bool {
 func (b *builtinDecimalIsFalseSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
 
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -289,11 +289,11 @@ func (b *builtinRealIsNullSig) vectorized() bool {
 
 func (b *builtinRealIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
@@ -317,11 +317,11 @@ func (b *builtinUnaryNotRealSig) vectorized() bool {
 
 func (b *builtinUnaryNotRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -372,11 +372,11 @@ func (b *builtinLogicAndSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	beforeArg1Warns := ctx.WarningCount()
 	err = b.args[1].VecEvalInt(ctx, input, buf1)
@@ -423,11 +423,11 @@ func (b *builtinBitXorSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 		return err
 	}
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -450,11 +450,11 @@ func (b *builtinLogicXorSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -488,11 +488,11 @@ func (b *builtinBitAndSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 		return err
 	}
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -511,11 +511,11 @@ func (b *builtinRealIsFalseSig) vectorized() bool {
 
 func (b *builtinRealIsFalseSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -578,11 +578,11 @@ func (b *builtinUnaryNotDecimalSig) vectorized() bool {
 
 func (b *builtinUnaryNotDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -634,11 +634,11 @@ func (b *builtinDecimalIsNullSig) vectorized() bool {
 
 func (b *builtinDecimalIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
@@ -665,11 +665,11 @@ func (b *builtinLeftShiftSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 		return err
 	}
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -691,11 +691,11 @@ func (b *builtinRightShiftSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 		return err
 	}
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -714,11 +714,11 @@ func (b *builtinRealIsTrueSig) vectorized() bool {
 
 func (b *builtinRealIsTrueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
@@ -747,11 +747,11 @@ func (b *builtinDecimalIsTrueSig) vectorized() bool {
 
 func (b *builtinDecimalIsTrueSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -806,11 +806,11 @@ func (b *builtinDurationIsNullSig) vectorized() bool {
 
 func (b *builtinDurationIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err

--- a/pkg/expression/builtin_other_vec.go
+++ b/pkg/expression/builtin_other_vec.go
@@ -131,7 +131,11 @@ func (b *builtinGetParamStringSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(idx)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(idx)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, idx); err != nil {
 		return err
 	}
@@ -168,7 +172,11 @@ func (b *builtinSetStringVarSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -176,7 +184,11 @@ func (b *builtinSetStringVarSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -209,7 +221,11 @@ func (b *builtinSetIntVarSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -217,7 +233,11 @@ func (b *builtinSetIntVarSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -250,7 +270,11 @@ func (b *builtinSetRealVarSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -258,7 +282,11 @@ func (b *builtinSetRealVarSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -291,7 +319,11 @@ func (b *builtinSetDecimalVarSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -299,7 +331,11 @@ func (b *builtinSetDecimalVarSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -340,7 +376,11 @@ func (b *builtinGetStringVarSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -375,7 +415,11 @@ func (b *builtinGetIntVarSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -409,7 +453,11 @@ func (b *builtinGetRealVarSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -447,7 +495,11 @@ func (b *builtinGetDecimalVarSig) vecEvalDecimal(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_other_vec.go
+++ b/pkg/expression/builtin_other_vec.go
@@ -127,11 +127,11 @@ func (b *builtinGetParamStringSig) vectorized() bool {
 
 func (b *builtinGetParamStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	idx, err := b.bufAllocator.get()
+	idx, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(idx)
+	defer globalColumnAllocator.put(idx)
 	if err := b.args[0].VecEvalInt(ctx, input, idx); err != nil {
 		return err
 	}
@@ -164,19 +164,19 @@ func (b *builtinSetStringVarSig) vectorized() bool {
 
 func (b *builtinSetStringVarSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -205,19 +205,19 @@ func (b *builtinSetIntVarSig) vectorized() bool {
 
 func (b *builtinSetIntVarSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -246,19 +246,19 @@ func (b *builtinSetRealVarSig) vectorized() bool {
 
 func (b *builtinSetRealVarSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -287,19 +287,19 @@ func (b *builtinSetDecimalVarSig) vectorized() bool {
 
 func (b *builtinSetDecimalVarSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -336,11 +336,11 @@ func (b *builtinGetStringVarSig) vectorized() bool {
 
 func (b *builtinGetStringVarSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -371,11 +371,11 @@ func (b *builtinGetIntVarSig) vectorized() bool {
 
 func (b *builtinGetIntVarSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -405,11 +405,11 @@ func (b *builtinGetRealVarSig) vectorized() bool {
 // https://github.com/pingcap/tidb/pull/8412
 func (b *builtinGetRealVarSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -443,11 +443,11 @@ func (b *builtinGetDecimalVarSig) vectorized() bool {
 // https://github.com/pingcap/tidb/pull/8412
 func (b *builtinGetDecimalVarSig) vecEvalDecimal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_other_vec_generated.go
+++ b/pkg/expression/builtin_other_vec_generated.go
@@ -27,19 +27,19 @@ import (
 
 func (b *builtinInIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	args0 := buf0.Int64s()
 	result.ResizeInt64(n, true)
@@ -132,19 +132,19 @@ func (b *builtinInIntSig) vectorized() bool {
 
 func (b *builtinInStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	result.ResizeInt64(n, true)
 	r64s := result.Int64s()
@@ -213,19 +213,19 @@ func (b *builtinInStringSig) vectorized() bool {
 
 func (b *builtinInDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	args0 := buf0.Decimals()
 	result.ResizeInt64(n, true)
@@ -303,19 +303,19 @@ func (b *builtinInDecimalSig) vectorized() bool {
 
 func (b *builtinInRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	args0 := buf0.Float64s()
 	result.ResizeInt64(n, true)
@@ -386,19 +386,19 @@ func (b *builtinInRealSig) vectorized() bool {
 
 func (b *builtinInTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	args0 := buf0.Times()
 	result.ResizeInt64(n, true)
@@ -469,19 +469,19 @@ func (b *builtinInTimeSig) vectorized() bool {
 
 func (b *builtinInDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	args0 := buf0.GoDurations()
 	result.ResizeInt64(n, true)
@@ -552,19 +552,19 @@ func (b *builtinInDurationSig) vectorized() bool {
 
 func (b *builtinInJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	result.ResizeInt64(n, true)
 	r64s := result.Int64s()

--- a/pkg/expression/builtin_other_vec_generated.go
+++ b/pkg/expression/builtin_other_vec_generated.go
@@ -31,7 +31,11 @@ func (b *builtinInIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -39,7 +43,11 @@ func (b *builtinInIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	args0 := buf0.Int64s()
 	result.ResizeInt64(n, true)
@@ -136,7 +144,11 @@ func (b *builtinInStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -144,7 +156,11 @@ func (b *builtinInStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	result.ResizeInt64(n, true)
 	r64s := result.Int64s()
@@ -217,7 +233,11 @@ func (b *builtinInDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -225,7 +245,11 @@ func (b *builtinInDecimalSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	args0 := buf0.Decimals()
 	result.ResizeInt64(n, true)
@@ -307,7 +331,11 @@ func (b *builtinInRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -315,7 +343,11 @@ func (b *builtinInRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	args0 := buf0.Float64s()
 	result.ResizeInt64(n, true)
@@ -390,7 +422,11 @@ func (b *builtinInTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -398,7 +434,11 @@ func (b *builtinInTimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	args0 := buf0.Times()
 	result.ResizeInt64(n, true)
@@ -473,7 +513,11 @@ func (b *builtinInDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -481,7 +525,11 @@ func (b *builtinInDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	args0 := buf0.GoDurations()
 	result.ResizeInt64(n, true)
@@ -556,7 +604,11 @@ func (b *builtinInJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalJSON(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -564,7 +616,11 @@ func (b *builtinInJSONSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	result.ResizeInt64(n, true)
 	r64s := result.Int64s()

--- a/pkg/expression/builtin_regexp_util.go
+++ b/pkg/expression/builtin_regexp_util.go
@@ -31,7 +31,7 @@ type regexpMemorizedSig struct {
 func releaseBuffers(bf *baseBuiltinFunc, params []*funcParam) {
 	for _, pa := range params {
 		if pa.getCol() != nil {
-			bf.bufAllocator.put(pa.getCol())
+			globalColumnAllocator.put(pa.getCol())
 		}
 	}
 }

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -48,7 +48,11 @@ func (b *builtinLowerUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -74,7 +78,11 @@ func (b *builtinRepeatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -83,7 +91,11 @@ func (b *builtinRepeatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -133,7 +145,11 @@ func (b *builtinStringIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -160,7 +176,11 @@ func (b *builtinUpperUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -194,7 +214,11 @@ func (b *builtinLeftUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -203,7 +227,11 @@ func (b *builtinLeftUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -239,7 +267,11 @@ func (b *builtinRightUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -248,7 +280,11 @@ func (b *builtinRightUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -287,7 +323,11 @@ func (b *builtinSpaceSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -354,7 +394,11 @@ func (b *builtinConcatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	strs := make([][]byte, n)
 	isNulls := make([]bool, n)
@@ -406,7 +450,11 @@ func (b *builtinLocate3ArgsUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -414,7 +462,11 @@ func (b *builtinLocate3ArgsUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -472,7 +524,11 @@ func (b *builtinHexStrArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -499,7 +555,11 @@ func (b *builtinLTrimSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -528,7 +588,11 @@ func (b *builtinQuoteSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -555,7 +619,11 @@ func (b *builtinInsertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(str)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(str)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
@@ -563,7 +631,11 @@ func (b *builtinInsertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(pos)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(pos)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, pos); err != nil {
 		return err
 	}
@@ -571,7 +643,11 @@ func (b *builtinInsertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(length)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(length)
+		}
+	}()
 	if err := b.args[2].VecEvalInt(ctx, input, length); err != nil {
 		return err
 	}
@@ -579,7 +655,11 @@ func (b *builtinInsertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(newstr)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(newstr)
+		}
+	}()
 	if err := b.args[3].VecEvalString(ctx, input, newstr); err != nil {
 		return err
 	}
@@ -633,7 +713,11 @@ func (b *builtinConcatWSSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufs[i])
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufs[i])
+			}
+		}()
 		if err := b.args[i].VecEvalString(ctx, input, bufs[i]); err != nil {
 			return err
 		}
@@ -705,7 +789,11 @@ func (b *builtinConvertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(expr)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(expr)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, expr); err != nil {
 		return err
 	}
@@ -776,7 +864,11 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -785,7 +877,11 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -794,7 +890,11 @@ func (b *builtinSubstringIndexSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -859,7 +959,11 @@ func (b *builtinUnHexSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -896,7 +1000,11 @@ func (b *builtinExportSet3ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bits)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bits)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
@@ -904,7 +1012,11 @@ func (b *builtinExportSet3ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(on)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(on)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
@@ -912,7 +1024,11 @@ func (b *builtinExportSet3ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(off)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(off)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
@@ -941,7 +1057,11 @@ func (b *builtinASCIISig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -974,7 +1094,11 @@ func (b *builtinLpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
@@ -982,7 +1106,11 @@ func (b *builtinLpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lenBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lenBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, lenBuf); err != nil {
 		return err
 	}
@@ -990,7 +1118,11 @@ func (b *builtinLpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(padBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(padBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, padBuf); err != nil {
 		return err
 	}
@@ -1050,7 +1182,11 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1058,7 +1194,11 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1066,7 +1206,11 @@ func (b *builtinLpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1123,7 +1267,11 @@ func (b *builtinFindInSetSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(str)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(str)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
@@ -1131,7 +1279,11 @@ func (b *builtinFindInSetSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strlist)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strlist)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, strlist); err != nil {
 		return err
 	}
@@ -1166,7 +1318,11 @@ func (b *builtinLeftSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1174,7 +1330,11 @@ func (b *builtinLeftSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1226,7 +1386,11 @@ func (b *builtinRTrimSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1255,7 +1419,11 @@ func (b *builtinStrcmpSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(leftBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(leftBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, leftBuf); err != nil {
 		return err
 	}
@@ -1263,7 +1431,11 @@ func (b *builtinStrcmpSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(rightBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(rightBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, rightBuf); err != nil {
 		return err
 	}
@@ -1290,12 +1462,20 @@ func (b *builtinLocate2ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1331,7 +1511,11 @@ func (b *builtinLocate3ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1339,7 +1523,11 @@ func (b *builtinLocate3ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1390,7 +1578,11 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bits)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bits)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
@@ -1398,7 +1590,11 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(on)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(on)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
@@ -1406,7 +1602,11 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(off)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(off)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
@@ -1414,7 +1614,11 @@ func (b *builtinExportSet4ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(separator)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(separator)
+		}
+	}()
 	if err := b.args[3].VecEvalString(ctx, input, separator); err != nil {
 		return err
 	}
@@ -1443,7 +1647,11 @@ func (b *builtinRpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(strBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(strBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
@@ -1451,7 +1659,11 @@ func (b *builtinRpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lenBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lenBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, lenBuf); err != nil {
 		return err
 	}
@@ -1459,7 +1671,11 @@ func (b *builtinRpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(padBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(padBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, padBuf); err != nil {
 		return err
 	}
@@ -1518,7 +1734,11 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, dBuf); err != nil {
 		return err
 	}
@@ -1528,7 +1748,11 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(localeBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(localeBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, localeBuf); err != nil {
 		return err
 	}
@@ -1539,7 +1763,11 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(xBuf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(xBuf)
+			}
+		}()
 		if err := b.args[0].VecEvalDecimal(ctx, input, xBuf); err != nil {
 			return err
 		}
@@ -1554,7 +1782,11 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(xBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(xBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, xBuf); err != nil {
 		return err
 	}
@@ -1574,7 +1806,11 @@ func (b *builtinSubstring2ArgsSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1582,7 +1818,11 @@ func (b *builtinSubstring2ArgsSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1623,7 +1863,11 @@ func (b *builtinSubstring2ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1632,7 +1876,11 @@ func (b *builtinSubstring2ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1676,7 +1924,11 @@ func (b *builtinTrim2ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1684,7 +1936,11 @@ func (b *builtinTrim2ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1714,7 +1970,11 @@ func (b *builtinInstrUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(str)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(str)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
@@ -1722,7 +1982,11 @@ func (b *builtinInstrUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(substr)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(substr)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, substr); err != nil {
 		return err
 	}
@@ -1763,7 +2027,11 @@ func (b *builtinOctStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1819,7 +2087,11 @@ func (b *builtinEltSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1843,7 +2115,11 @@ func (b *builtinEltSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resul
 			if err != nil {
 				return err
 			}
-			defer globalColumnAllocator.put(bufs[j])
+			defer func() {
+				if err == nil {
+					globalColumnAllocator.put(bufs[j])
+				}
+			}()
 			if err := b.args[j].VecEvalString(ctx, input, bufs[j]); err != nil {
 				return err
 			}
@@ -1869,7 +2145,11 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1877,7 +2157,11 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1885,7 +2169,11 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1893,7 +2181,11 @@ func (b *builtinInsertUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf3)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf3)
+		}
+	}()
 	if err := b.args[3].VecEvalString(ctx, input, buf3); err != nil {
 		return err
 	}
@@ -1949,7 +2241,11 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bits)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bits)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
@@ -1957,7 +2253,11 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(on)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(on)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
@@ -1965,7 +2265,11 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(off)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(off)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
@@ -1973,7 +2277,11 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(separator)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(separator)
+		}
+	}()
 	if err := b.args[3].VecEvalString(ctx, input, separator); err != nil {
 		return err
 	}
@@ -1981,7 +2289,11 @@ func (b *builtinExportSet5ArgSig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(numberOfBits)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(numberOfBits)
+		}
+	}()
 	if err := b.args[4].VecEvalInt(ctx, input, numberOfBits); err != nil {
 		return err
 	}
@@ -2015,7 +2327,11 @@ func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2024,7 +2340,11 @@ func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2033,7 +2353,11 @@ func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2084,17 +2408,29 @@ func (b *builtinTrim3ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -2136,7 +2472,11 @@ func (b *builtinOrdSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2174,7 +2514,11 @@ func (b *builtinInstrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(str)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(str)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
@@ -2182,7 +2526,11 @@ func (b *builtinInstrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(substr)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(substr)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, substr); err != nil {
 		return err
 	}
@@ -2213,7 +2561,11 @@ func (b *builtinLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2243,7 +2595,11 @@ func (b *builtinLocate2ArgsUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2251,7 +2607,11 @@ func (b *builtinLocate2ArgsUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2296,7 +2656,11 @@ func (b *builtinBitLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2328,7 +2692,11 @@ func (b *builtinCharSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 			return err
 		}
 		buf[i] = te
-		defer globalColumnAllocator.put(buf[i])
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(buf[i])
+			}
+		}()
 		if err := b.args[i].VecEvalInt(ctx, input, buf[i]); err != nil {
 			return err
 		}
@@ -2337,7 +2705,11 @@ func (b *builtinCharSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufstr)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufstr)
+		}
+	}()
 	bigints := make([]int64, 0, l-1)
 	result.ReserveString(n)
 	bufint := make([]([]int64), l-1)
@@ -2382,7 +2754,11 @@ func (b *builtinReplaceSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2390,7 +2766,11 @@ func (b *builtinReplaceSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2398,7 +2778,11 @@ func (b *builtinReplaceSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2434,7 +2818,11 @@ func (b *builtinMakeSetSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bitsBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bitsBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, bitsBuf); err != nil {
 		return err
 	}
@@ -2445,7 +2833,11 @@ func (b *builtinMakeSetSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(strBuf[i-1])
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(strBuf[i-1])
+			}
+		}()
 		if err := b.args[i].VecEvalString(ctx, input, strBuf[i-1]); err != nil {
 			return err
 		}
@@ -2482,7 +2874,11 @@ func (b *builtinOctIntSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2511,7 +2907,11 @@ func (b *builtinToBase64Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2558,7 +2958,11 @@ func (b *builtinTrim1ArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2589,7 +2993,11 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2597,7 +3005,11 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2605,7 +3017,11 @@ func (b *builtinRpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2662,7 +3078,11 @@ func (b *builtinCharLengthBinarySig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2689,7 +3109,11 @@ func (b *builtinBinSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2719,7 +3143,11 @@ func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, dBuf); err != nil {
 		return err
 	}
@@ -2731,7 +3159,11 @@ func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(xBuf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(xBuf)
+			}
+		}()
 		if err := b.args[0].VecEvalDecimal(ctx, input, xBuf); err != nil {
 			return err
 		}
@@ -2746,7 +3178,11 @@ func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(xBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(xBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, xBuf); err != nil {
 		return err
 	}
@@ -2766,7 +3202,11 @@ func (b *builtinRightSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2774,7 +3214,11 @@ func (b *builtinRightSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2809,7 +3253,11 @@ func (b *builtinSubstring3ArgsSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2818,7 +3266,11 @@ func (b *builtinSubstring3ArgsSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2827,7 +3279,11 @@ func (b *builtinSubstring3ArgsSig) vecEvalString(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2878,7 +3334,11 @@ func (b *builtinHexIntArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2906,7 +3366,11 @@ func (b *builtinFromBase64Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2954,7 +3418,11 @@ func (b *builtinCharLengthUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3070,17 +3538,29 @@ func (b *builtinTranslateBinarySig) vecEvalString(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -3143,17 +3623,29 @@ func (b *builtinTranslateUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_string_vec.go
+++ b/pkg/expression/builtin_string_vec.go
@@ -44,11 +44,11 @@ func (b *builtinLowerSig) vectorized() bool {
 
 func (b *builtinLowerUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -70,20 +70,20 @@ func (b *builtinLowerUTF8Sig) vectorized() bool {
 
 func (b *builtinRepeatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -129,11 +129,11 @@ func (b *builtinRepeatSig) vectorized() bool {
 
 func (b *builtinStringIsNullSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -156,11 +156,11 @@ func (b *builtinStringIsNullSig) vectorized() bool {
 
 func (b *builtinUpperUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -190,20 +190,20 @@ func (b *builtinUpperSig) vectorized() bool {
 
 func (b *builtinLeftUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -235,20 +235,20 @@ func (b *builtinLeftUTF8Sig) vectorized() bool {
 
 func (b *builtinRightUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -283,11 +283,11 @@ func (b *builtinRightUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_space
 func (b *builtinSpaceSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -350,11 +350,11 @@ func (b *builtinConcatSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_concat
 func (b *builtinConcatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	strs := make([][]byte, n)
 	isNulls := make([]bool, n)
@@ -402,19 +402,19 @@ func (b *builtinLocate3ArgsUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate3ArgsUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -468,11 +468,11 @@ func (b *builtinHexStrArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_hex
 func (b *builtinHexStrArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -495,11 +495,11 @@ func (b *builtinLTrimSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ltrim
 func (b *builtinLTrimSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -524,11 +524,11 @@ func (b *builtinQuoteSig) vectorized() bool {
 
 func (b *builtinQuoteSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -551,35 +551,35 @@ func (b *builtinInsertSig) vectorized() bool {
 
 func (b *builtinInsertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	str, err := b.bufAllocator.get()
+	str, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(str)
+	defer globalColumnAllocator.put(str)
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
-	pos, err := b.bufAllocator.get()
+	pos, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(pos)
+	defer globalColumnAllocator.put(pos)
 	if err := b.args[1].VecEvalInt(ctx, input, pos); err != nil {
 		return err
 	}
-	length, err := b.bufAllocator.get()
+	length, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(length)
+	defer globalColumnAllocator.put(length)
 	if err := b.args[2].VecEvalInt(ctx, input, length); err != nil {
 		return err
 	}
-	newstr, err := b.bufAllocator.get()
+	newstr, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(newstr)
+	defer globalColumnAllocator.put(newstr)
 	if err := b.args[3].VecEvalString(ctx, input, newstr); err != nil {
 		return err
 	}
@@ -629,11 +629,11 @@ func (b *builtinConcatWSSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, 
 	bufs := make([]*chunk.Column, argsLen)
 	var err error
 	for i := range argsLen {
-		bufs[i], err = b.bufAllocator.get()
+		bufs[i], err = globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufs[i])
+		defer globalColumnAllocator.put(bufs[i])
 		if err := b.args[i].VecEvalString(ctx, input, bufs[i]); err != nil {
 			return err
 		}
@@ -701,11 +701,11 @@ func (b *builtinConvertSig) vectorized() bool {
 
 func (b *builtinConvertSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	expr, err := b.bufAllocator.get()
+	expr, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(expr)
+	defer globalColumnAllocator.put(expr)
 	if err := b.args[0].VecEvalString(ctx, input, expr); err != nil {
 		return err
 	}
@@ -772,29 +772,29 @@ func (b *builtinSubstringIndexSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substring-index
 func (b *builtinSubstringIndexSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -855,11 +855,11 @@ func (b *builtinUnHexSig) vectorized() bool {
 
 func (b *builtinUnHexSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -892,27 +892,27 @@ func (b *builtinExportSet3ArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet3ArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bits, err := b.bufAllocator.get()
+	bits, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bits)
+	defer globalColumnAllocator.put(bits)
 	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
-	on, err := b.bufAllocator.get()
+	on, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(on)
+	defer globalColumnAllocator.put(on)
 	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
-	off, err := b.bufAllocator.get()
+	off, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(off)
+	defer globalColumnAllocator.put(off)
 	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
@@ -937,11 +937,11 @@ func (b *builtinASCIISig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ascii
 func (b *builtinASCIISig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -970,27 +970,27 @@ func (b *builtinLpadSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lpad
 func (b *builtinLpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	strBuf, err := b.bufAllocator.get()
+	strBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strBuf)
+	defer globalColumnAllocator.put(strBuf)
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
-	lenBuf, err := b.bufAllocator.get()
+	lenBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lenBuf)
+	defer globalColumnAllocator.put(lenBuf)
 	if err := b.args[1].VecEvalInt(ctx, input, lenBuf); err != nil {
 		return err
 	}
-	padBuf, err := b.bufAllocator.get()
+	padBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(padBuf)
+	defer globalColumnAllocator.put(padBuf)
 	if err := b.args[2].VecEvalString(ctx, input, padBuf); err != nil {
 		return err
 	}
@@ -1046,27 +1046,27 @@ func (b *builtinLpadUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lpad
 func (b *builtinLpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1119,19 +1119,19 @@ func (b *builtinFindInSetSig) vectorized() bool {
 
 func (b *builtinFindInSetSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	str, err := b.bufAllocator.get()
+	str, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(str)
+	defer globalColumnAllocator.put(str)
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
-	strlist, err := b.bufAllocator.get()
+	strlist, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strlist)
+	defer globalColumnAllocator.put(strlist)
 	if err := b.args[1].VecEvalString(ctx, input, strlist); err != nil {
 		return err
 	}
@@ -1162,19 +1162,19 @@ func (b *builtinLeftSig) vectorized() bool {
 
 func (b *builtinLeftSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1222,11 +1222,11 @@ func (b *builtinRTrimSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rtrim
 func (b *builtinRTrimSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1251,19 +1251,19 @@ func (b *builtinStrcmpSig) vectorized() bool {
 
 func (b *builtinStrcmpSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	leftBuf, err := b.bufAllocator.get()
+	leftBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(leftBuf)
+	defer globalColumnAllocator.put(leftBuf)
 	if err := b.args[0].VecEvalString(ctx, input, leftBuf); err != nil {
 		return err
 	}
-	rightBuf, err := b.bufAllocator.get()
+	rightBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(rightBuf)
+	defer globalColumnAllocator.put(rightBuf)
 	if err := b.args[1].VecEvalString(ctx, input, rightBuf); err != nil {
 		return err
 	}
@@ -1286,16 +1286,16 @@ func (b *builtinLocate2ArgsSig) vectorized() bool {
 
 func (b *builtinLocate2ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
-	buf1, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf0)
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1327,19 +1327,19 @@ func (b *builtinLocate3ArgsSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate3ArgsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1386,35 +1386,35 @@ func (b *builtinExportSet4ArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet4ArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bits, err := b.bufAllocator.get()
+	bits, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bits)
+	defer globalColumnAllocator.put(bits)
 	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
-	on, err := b.bufAllocator.get()
+	on, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(on)
+	defer globalColumnAllocator.put(on)
 	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
-	off, err := b.bufAllocator.get()
+	off, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(off)
+	defer globalColumnAllocator.put(off)
 	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
-	separator, err := b.bufAllocator.get()
+	separator, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(separator)
+	defer globalColumnAllocator.put(separator)
 	if err := b.args[3].VecEvalString(ctx, input, separator); err != nil {
 		return err
 	}
@@ -1439,27 +1439,27 @@ func (b *builtinRpadSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
 func (b *builtinRpadSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	strBuf, err := b.bufAllocator.get()
+	strBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(strBuf)
+	defer globalColumnAllocator.put(strBuf)
 	if err := b.args[0].VecEvalString(ctx, input, strBuf); err != nil {
 		return err
 	}
-	lenBuf, err := b.bufAllocator.get()
+	lenBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lenBuf)
+	defer globalColumnAllocator.put(lenBuf)
 	if err := b.args[1].VecEvalInt(ctx, input, lenBuf); err != nil {
 		return err
 	}
-	padBuf, err := b.bufAllocator.get()
+	padBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(padBuf)
+	defer globalColumnAllocator.put(padBuf)
 	if err := b.args[2].VecEvalString(ctx, input, padBuf); err != nil {
 		return err
 	}
@@ -1514,32 +1514,32 @@ func (b *builtinFormatWithLocaleSig) vectorized() bool {
 func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	dBuf, err := b.bufAllocator.get()
+	dBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dBuf)
+	defer globalColumnAllocator.put(dBuf)
 	if err := b.args[1].VecEvalInt(ctx, input, dBuf); err != nil {
 		return err
 	}
 	dInt64s := dBuf.Int64s()
 
-	localeBuf, err := b.bufAllocator.get()
+	localeBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(localeBuf)
+	defer globalColumnAllocator.put(localeBuf)
 	if err := b.args[2].VecEvalString(ctx, input, localeBuf); err != nil {
 		return err
 	}
 
 	// decimal x
 	if b.args[0].GetType(ctx).EvalType() == types.ETDecimal {
-		xBuf, err := b.bufAllocator.get()
+		xBuf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(xBuf)
+		defer globalColumnAllocator.put(xBuf)
 		if err := b.args[0].VecEvalDecimal(ctx, input, xBuf); err != nil {
 			return err
 		}
@@ -1550,11 +1550,11 @@ func (b *builtinFormatWithLocaleSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 
 	// real x
-	xBuf, err := b.bufAllocator.get()
+	xBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(xBuf)
+	defer globalColumnAllocator.put(xBuf)
 	if err := b.args[0].VecEvalReal(ctx, input, xBuf); err != nil {
 		return err
 	}
@@ -1570,19 +1570,19 @@ func (b *builtinSubstring2ArgsSig) vectorized() bool {
 
 func (b *builtinSubstring2ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1619,20 +1619,20 @@ func (b *builtinSubstring2ArgsUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring2ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1672,19 +1672,19 @@ func (b *builtinTrim2ArgsSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_trim
 func (b *builtinTrim2ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1710,19 +1710,19 @@ func (b *builtinInstrUTF8Sig) vectorized() bool {
 
 func (b *builtinInstrUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	str, err := b.bufAllocator.get()
+	str, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(str)
+	defer globalColumnAllocator.put(str)
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
-	substr, err := b.bufAllocator.get()
+	substr, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(substr)
+	defer globalColumnAllocator.put(substr)
 	if err := b.args[1].VecEvalString(ctx, input, substr); err != nil {
 		return err
 	}
@@ -1759,11 +1759,11 @@ func (b *builtinOctStringSig) vectorized() bool {
 
 func (b *builtinOctStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1815,11 +1815,11 @@ func (b *builtinEltSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_elt
 func (b *builtinEltSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1839,11 +1839,11 @@ func (b *builtinEltSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resul
 			continue
 		}
 		if bufs[j] == nil {
-			bufs[j], err = b.bufAllocator.get()
+			bufs[j], err = globalColumnAllocator.get()
 			if err != nil {
 				return err
 			}
-			defer b.bufAllocator.put(bufs[j])
+			defer globalColumnAllocator.put(bufs[j])
 			if err := b.args[j].VecEvalString(ctx, input, bufs[j]); err != nil {
 				return err
 			}
@@ -1865,35 +1865,35 @@ func (b *builtinInsertUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_insert
 func (b *builtinInsertUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
-	buf3, err := b.bufAllocator.get()
+	buf3, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf3)
+	defer globalColumnAllocator.put(buf3)
 	if err := b.args[3].VecEvalString(ctx, input, buf3); err != nil {
 		return err
 	}
@@ -1945,43 +1945,43 @@ func (b *builtinExportSet5ArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet5ArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bits, err := b.bufAllocator.get()
+	bits, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bits)
+	defer globalColumnAllocator.put(bits)
 	if err := b.args[0].VecEvalInt(ctx, input, bits); err != nil {
 		return err
 	}
-	on, err := b.bufAllocator.get()
+	on, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(on)
+	defer globalColumnAllocator.put(on)
 	if err := b.args[1].VecEvalString(ctx, input, on); err != nil {
 		return err
 	}
-	off, err := b.bufAllocator.get()
+	off, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(off)
+	defer globalColumnAllocator.put(off)
 	if err := b.args[2].VecEvalString(ctx, input, off); err != nil {
 		return err
 	}
-	separator, err := b.bufAllocator.get()
+	separator, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(separator)
+	defer globalColumnAllocator.put(separator)
 	if err := b.args[3].VecEvalString(ctx, input, separator); err != nil {
 		return err
 	}
-	numberOfBits, err := b.bufAllocator.get()
+	numberOfBits, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(numberOfBits)
+	defer globalColumnAllocator.put(numberOfBits)
 	if err := b.args[4].VecEvalInt(ctx, input, numberOfBits); err != nil {
 		return err
 	}
@@ -2011,29 +2011,29 @@ func (b *builtinSubstring3ArgsUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring3ArgsUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2080,21 +2080,21 @@ func (b *builtinTrim3ArgsSig) vectorized() bool {
 
 func (b *builtinTrim3ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
-	buf1, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf0)
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
-	buf2, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf1)
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -2132,11 +2132,11 @@ func (b *builtinOrdSig) vectorized() bool {
 
 func (b *builtinOrdSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2170,19 +2170,19 @@ func (b *builtinInstrSig) vectorized() bool {
 
 func (b *builtinInstrSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	str, err := b.bufAllocator.get()
+	str, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(str)
+	defer globalColumnAllocator.put(str)
 	if err := b.args[0].VecEvalString(ctx, input, str); err != nil {
 		return err
 	}
-	substr, err := b.bufAllocator.get()
+	substr, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(substr)
+	defer globalColumnAllocator.put(substr)
 	if err := b.args[1].VecEvalString(ctx, input, substr); err != nil {
 		return err
 	}
@@ -2209,11 +2209,11 @@ func (b *builtinLengthSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html
 func (b *builtinLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2239,19 +2239,19 @@ func (b *builtinLocate2ArgsUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate2ArgsUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2292,11 +2292,11 @@ func (b *builtinBitLengthSig) vectorized() bool {
 
 func (b *builtinBitLengthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2323,21 +2323,21 @@ func (b *builtinCharSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, resu
 	l := len(b.args)
 	buf := make([]*chunk.Column, l-1)
 	for i := range len(b.args) - 1 {
-		te, err := b.bufAllocator.get()
+		te, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
 		buf[i] = te
-		defer b.bufAllocator.put(buf[i])
+		defer globalColumnAllocator.put(buf[i])
 		if err := b.args[i].VecEvalInt(ctx, input, buf[i]); err != nil {
 			return err
 		}
 	}
-	bufstr, err := b.bufAllocator.get()
+	bufstr, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufstr)
+	defer globalColumnAllocator.put(bufstr)
 	bigints := make([]int64, 0, l-1)
 	result.ReserveString(n)
 	bufint := make([]([]int64), l-1)
@@ -2378,27 +2378,27 @@ func (b *builtinReplaceSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_replace
 func (b *builtinReplaceSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2430,22 +2430,22 @@ func (b *builtinMakeSetSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_make-set
 func (b *builtinMakeSetSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	nr := input.NumRows()
-	bitsBuf, err := b.bufAllocator.get()
+	bitsBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bitsBuf)
+	defer globalColumnAllocator.put(bitsBuf)
 	if err := b.args[0].VecEvalInt(ctx, input, bitsBuf); err != nil {
 		return err
 	}
 
 	strBuf := make([]*chunk.Column, len(b.args)-1)
 	for i := 1; i < len(b.args); i++ {
-		strBuf[i-1], err = b.bufAllocator.get()
+		strBuf[i-1], err = globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(strBuf[i-1])
+		defer globalColumnAllocator.put(strBuf[i-1])
 		if err := b.args[i].VecEvalString(ctx, input, strBuf[i-1]); err != nil {
 			return err
 		}
@@ -2478,11 +2478,11 @@ func (b *builtinOctIntSig) vectorized() bool {
 
 func (b *builtinOctIntSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2507,11 +2507,11 @@ func (b *builtinToBase64Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_to-base64
 func (b *builtinToBase64Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2554,11 +2554,11 @@ func (b *builtinTrim1ArgSig) vectorized() bool {
 
 func (b *builtinTrim1ArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2585,27 +2585,27 @@ func (b *builtinRpadUTF8Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
 func (b *builtinRpadUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2658,11 +2658,11 @@ func (b *builtinCharLengthBinarySig) vectorized() bool {
 
 func (b *builtinCharLengthBinarySig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2685,11 +2685,11 @@ func (b *builtinBinSig) vectorized() bool {
 
 func (b *builtinBinSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2715,11 +2715,11 @@ func (b *builtinFormatSig) vectorized() bool {
 func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	dBuf, err := b.bufAllocator.get()
+	dBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dBuf)
+	defer globalColumnAllocator.put(dBuf)
 	if err := b.args[1].VecEvalInt(ctx, input, dBuf); err != nil {
 		return err
 	}
@@ -2727,11 +2727,11 @@ func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 
 	// decimal x
 	if b.args[0].GetType(ctx).EvalType() == types.ETDecimal {
-		xBuf, err := b.bufAllocator.get()
+		xBuf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(xBuf)
+		defer globalColumnAllocator.put(xBuf)
 		if err := b.args[0].VecEvalDecimal(ctx, input, xBuf); err != nil {
 			return err
 		}
@@ -2742,11 +2742,11 @@ func (b *builtinFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, re
 	}
 
 	// real x
-	xBuf, err := b.bufAllocator.get()
+	xBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(xBuf)
+	defer globalColumnAllocator.put(xBuf)
 	if err := b.args[0].VecEvalReal(ctx, input, xBuf); err != nil {
 		return err
 	}
@@ -2762,19 +2762,19 @@ func (b *builtinRightSig) vectorized() bool {
 
 func (b *builtinRightSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2805,29 +2805,29 @@ func (b *builtinSubstring3ArgsSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring3ArgsSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -2874,11 +2874,11 @@ func (b *builtinHexIntArgSig) vectorized() bool {
 
 func (b *builtinHexIntArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2902,11 +2902,11 @@ func (b *builtinFromBase64Sig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_from-base64
 func (b *builtinFromBase64Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2950,11 +2950,11 @@ func (b *builtinCharLengthUTF8Sig) vectorized() bool {
 
 func (b *builtinCharLengthUTF8Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3066,21 +3066,21 @@ func formatReal(ctx EvalContext, xBuf *chunk.Column, dInt64s []int64, result *ch
 
 func (b *builtinTranslateBinarySig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
-	buf1, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf0)
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
-	buf2, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf1)
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -3139,21 +3139,21 @@ func (b *builtinTranslateBinarySig) vectorized() bool {
 
 func (b *builtinTranslateUTF8Sig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
-	buf1, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf0)
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
-	buf2, err := b.bufAllocator.get()
+	defer globalColumnAllocator.put(buf1)
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_string_vec_generated.go
+++ b/pkg/expression/builtin_string_vec_generated.go
@@ -28,7 +28,11 @@ func (b *builtinFieldIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -36,7 +40,11 @@ func (b *builtinFieldIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	arg0 := buf0.Int64s()
 
@@ -78,7 +86,11 @@ func (b *builtinFieldRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -86,7 +98,11 @@ func (b *builtinFieldRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	arg0 := buf0.Float64s()
 
@@ -128,7 +144,11 @@ func (b *builtinFieldStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -136,7 +156,11 @@ func (b *builtinFieldStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()

--- a/pkg/expression/builtin_string_vec_generated.go
+++ b/pkg/expression/builtin_string_vec_generated.go
@@ -24,19 +24,19 @@ import (
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	arg0 := buf0.Int64s()
 
@@ -74,19 +74,19 @@ func (b *builtinFieldIntSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldRealSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalReal(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	arg0 := buf0.Float64s()
 
@@ -124,19 +124,19 @@ func (b *builtinFieldRealSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -3252,11 +3252,11 @@ func (du *baseDateArithmetical) sub(ctx EvalContext, date types.Time, interval s
 
 func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3294,11 +3294,11 @@ func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, ctx EvalCo
 
 func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3336,11 +3336,11 @@ func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, ctx EvalC
 
 func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3378,11 +3378,11 @@ func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, ctx Ev
 
 func (du *baseDateArithmetical) vecGetDateFromString(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3450,11 +3450,11 @@ func (du *baseDateArithmetical) vecGetDateFromDatetime(b *baseBuiltinFunc, ctx E
 
 func (du *baseDateArithmetical) vecGetIntervalFromString(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3478,11 +3478,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromString(b *baseBuiltinFunc, ctx
 
 func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3587,11 +3587,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, ct
 
 func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3613,11 +3613,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, ctx Ev
 
 func (du *baseDateArithmetical) vecGetIntervalFromReal(b *baseBuiltinFunc, ctx EvalContext, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -3256,7 +3256,11 @@ func (du *baseDateArithmetical) vecGetDateFromInt(b *baseBuiltinFunc, ctx EvalCo
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3298,7 +3302,11 @@ func (du *baseDateArithmetical) vecGetDateFromReal(b *baseBuiltinFunc, ctx EvalC
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3340,7 +3348,11 @@ func (du *baseDateArithmetical) vecGetDateFromDecimal(b *baseBuiltinFunc, ctx Ev
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3382,7 +3394,11 @@ func (du *baseDateArithmetical) vecGetDateFromString(b *baseBuiltinFunc, ctx Eva
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3454,7 +3470,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromString(b *baseBuiltinFunc, ctx
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3482,7 +3502,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromDecimal(b *baseBuiltinFunc, ct
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3591,7 +3615,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromInt(b *baseBuiltinFunc, ctx Ev
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -3617,7 +3645,11 @@ func (du *baseDateArithmetical) vecGetIntervalFromReal(b *baseBuiltinFunc, ctx E
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -31,11 +31,11 @@ import (
 
 func (b *builtinMonthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -59,11 +59,11 @@ func (b *builtinMonthSig) vectorized() bool {
 
 func (b *builtinYearSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -117,20 +117,20 @@ func (b *builtinFromUnixTime2ArgSig) vectorized() bool {
 
 func (b *builtinFromUnixTime2ArgSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err = b.args[0].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err = b.args[1].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -188,20 +188,20 @@ func (b *builtinExtractDatetimeFromStringSig) vectorized() bool {
 
 func (b *builtinExtractDatetimeFromStringSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -229,11 +229,11 @@ func (b *builtinDayNameSig) vectorized() bool {
 
 func (b *builtinDayNameSig) vecEvalIndex(ctx EvalContext, input *chunk.Chunk, apply func(i int, res int), applyNull func(i int)) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -303,11 +303,11 @@ func (b *builtinWeekDaySig) vectorized() bool {
 
 func (b *builtinWeekDaySig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -338,11 +338,11 @@ func (b *builtinTimeFormatSig) vectorized() bool {
 
 func (b *builtinTimeFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		// If err != nil, then dur is ZeroDuration, outputs 00:00:00
 		// in this case which follows the behavior of mysql.
@@ -350,11 +350,11 @@ func (b *builtinTimeFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 		return vecEvalStringByRows(b, ctx, input, result)
 	}
 
-	buf1, err1 := b.bufAllocator.get()
+	buf1, err1 := globalColumnAllocator.get()
 	if err1 != nil {
 		return err1
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -382,11 +382,11 @@ func (b *builtinUTCTimeWithArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithArgSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -454,11 +454,11 @@ func (b *builtinYearWeekWithoutModeSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithoutModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -500,11 +500,11 @@ func (b *builtinPeriodDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -530,11 +530,11 @@ func (b *builtinNowWithArgSig) vectorized() bool {
 
 func (b *builtinNowWithArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bufFsp, err := b.bufAllocator.get()
+	bufFsp, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufFsp)
+	defer globalColumnAllocator.put(bufFsp)
 	if err = b.args[0].VecEvalInt(ctx, input, bufFsp); err != nil {
 		return err
 	}
@@ -577,19 +577,19 @@ func (b *builtinGetFormatSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_get-format
 func (b *builtinGetFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err = b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err = b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -689,20 +689,20 @@ func (b *builtinStrToDateDateSig) vectorized() bool {
 
 func (b *builtinStrToDateDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bufStrings, err := b.bufAllocator.get()
+	bufStrings, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufStrings)
+	defer globalColumnAllocator.put(bufStrings)
 	if err := b.args[0].VecEvalString(ctx, input, bufStrings); err != nil {
 		return err
 	}
 
-	bufFormats, err := b.bufAllocator.get()
+	bufFormats, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufFormats)
+	defer globalColumnAllocator.put(bufFormats)
 	if err := b.args[1].VecEvalString(ctx, input, bufFormats); err != nil {
 		return err
 	}
@@ -744,11 +744,11 @@ func (b *builtinSysDateWithFspSig) vectorized() bool {
 
 func (b *builtinSysDateWithFspSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -780,11 +780,11 @@ func (b *builtinTidbParseTsoSig) vectorized() bool {
 
 func (b *builtinTidbParseTsoSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -826,19 +826,19 @@ func (b *builtinTiDBBoundedStalenessSig) vecEvalTime(ctx EvalContext, input *chu
 	}
 
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err = b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err = b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -890,11 +890,11 @@ func (b *builtinFromDaysSig) vectorized() bool {
 
 func (b *builtinFromDaysSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -918,11 +918,11 @@ func (b *builtinMicroSecondSig) vectorized() bool {
 
 func (b *builtinMicroSecondSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -947,11 +947,11 @@ func (b *builtinQuarterSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_quarter
 func (b *builtinQuarterSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -976,23 +976,23 @@ func (b *builtinWeekWithModeSig) vectorized() bool {
 
 func (b *builtinWeekWithModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
 	if err := b.args[0].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
@@ -1028,19 +1028,19 @@ func (b *builtinExtractDatetimeSig) vectorized() bool {
 
 func (b *builtinExtractDatetimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unit, err := b.bufAllocator.get()
+	unit, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unit)
+	defer globalColumnAllocator.put(unit)
 	if err := b.args[0].VecEvalString(ctx, input, unit); err != nil {
 		return err
 	}
-	dt, err := b.bufAllocator.get()
+	dt, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dt)
+	defer globalColumnAllocator.put(dt)
 	if err = b.args[1].VecEvalTime(ctx, input, dt); err != nil {
 		return err
 	}
@@ -1069,19 +1069,19 @@ func (b *builtinExtractDurationSig) vectorized() bool {
 
 func (b *builtinExtractDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unit, err := b.bufAllocator.get()
+	unit, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unit)
+	defer globalColumnAllocator.put(unit)
 	if err := b.args[0].VecEvalString(ctx, input, unit); err != nil {
 		return err
 	}
-	dur, err := b.bufAllocator.get()
+	dur, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dur)
+	defer globalColumnAllocator.put(dur)
 	if err = b.args[1].VecEvalDuration(ctx, input, dur); err != nil {
 		return err
 	}
@@ -1111,20 +1111,20 @@ func (b *builtinStrToDateDurationSig) vectorized() bool {
 
 func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	bufStrings, err := b.bufAllocator.get()
+	bufStrings, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufStrings)
+	defer globalColumnAllocator.put(bufStrings)
 	if err := b.args[0].VecEvalString(ctx, input, bufStrings); err != nil {
 		return err
 	}
 
-	bufFormats, err := b.bufAllocator.get()
+	bufFormats, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(bufFormats)
+	defer globalColumnAllocator.put(bufFormats)
 	if err := b.args[1].VecEvalString(ctx, input, bufFormats); err != nil {
 		return err
 	}
@@ -1164,11 +1164,11 @@ func (b *builtinToSecondsSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_to-seconds
 func (b *builtinToSecondsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1201,11 +1201,11 @@ func (b *builtinMinuteSig) vectorized() bool {
 
 func (b *builtinMinuteSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -1228,11 +1228,11 @@ func (b *builtinSecondSig) vectorized() bool {
 
 func (b *builtinSecondSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -1291,20 +1291,20 @@ func (b *builtinMakeDateSig) vectorized() bool {
 
 func (b *builtinMakeDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[0].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1354,11 +1354,11 @@ func (b *builtinWeekOfYearSig) vectorized() bool {
 
 func (b *builtinWeekOfYearSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1391,11 +1391,11 @@ func (b *builtinUTCTimestampWithArgSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
 func (b *builtinUTCTimestampWithArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1435,11 +1435,11 @@ func (b *builtinTimeToSecSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time-to-sec
 func (b *builtinTimeToSecSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1470,20 +1470,20 @@ func (b *builtinStrToDateDatetimeSig) vectorized() bool {
 
 func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	dateBuf, err := b.bufAllocator.get()
+	dateBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateBuf)
+	defer globalColumnAllocator.put(dateBuf)
 	if err = b.args[0].VecEvalString(ctx, input, dateBuf); err != nil {
 		return err
 	}
 
-	formatBuf, err := b.bufAllocator.get()
+	formatBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(formatBuf)
+	defer globalColumnAllocator.put(formatBuf)
 	if err = b.args[1].VecEvalString(ctx, input, formatBuf); err != nil {
 		return err
 	}
@@ -1549,14 +1549,14 @@ func (b *builtinWeekWithoutModeSig) vectorized() bool {
 
 func (b *builtinWeekWithoutModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
@@ -1597,11 +1597,11 @@ func (b *builtinUnixTimestampDecSig) vecEvalDecimal(ctx EvalContext, input *chun
 	n := input.NumRows()
 	result.ResizeDecimal(n, false)
 	ts := result.Decimals()
-	timeBuf, err := b.bufAllocator.get()
+	timeBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeBuf)
+	defer globalColumnAllocator.put(timeBuf)
 	if err := b.args[0].VecEvalTime(ctx, input, timeBuf); err != nil {
 		for i := range n {
 			temp, isNull, err := b.evalDecimal(ctx, input.GetRow(i))
@@ -1646,11 +1646,11 @@ func (b *builtinPeriodAddSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	}
 
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1680,29 +1680,29 @@ func (b *builtinTimestampAddSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampadd
 func (b *builtinTimestampAddSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	if err := b.args[2].VecEvalTime(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1764,11 +1764,11 @@ func (b *builtinToDaysSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_to-days
 func (b *builtinToDaysSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1802,21 +1802,21 @@ func (b *builtinDateFormatSig) vectorized() bool {
 func (b *builtinDateFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	dateBuf, err := b.bufAllocator.get()
+	dateBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateBuf)
+	defer globalColumnAllocator.put(dateBuf)
 	if err := b.args[0].VecEvalTime(ctx, input, dateBuf); err != nil {
 		return err
 	}
 	times := dateBuf.Times()
 
-	formatBuf, err := b.bufAllocator.get()
+	formatBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(formatBuf)
+	defer globalColumnAllocator.put(formatBuf)
 	if err := b.args[1].VecEvalString(ctx, input, formatBuf); err != nil {
 		return err
 	}
@@ -1870,11 +1870,11 @@ func (b *builtinHourSig) vectorized() bool {
 
 func (b *builtinHourSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -1897,11 +1897,11 @@ func (b *builtinSecToTimeSig) vectorized() bool {
 
 func (b *builtinSecToTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1977,19 +1977,19 @@ func (b *builtinDateDiffSig) vectorized() bool {
 
 func (b *builtinDateDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err = b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err = b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2073,19 +2073,19 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk
 	if err = b.getVecIntParam(ctx, b.args[0], input, hoursBuf); err != nil {
 		return err
 	}
-	minutesBuf, err := b.bufAllocator.get()
+	minutesBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(minutesBuf)
+	defer globalColumnAllocator.put(minutesBuf)
 	if err = b.getVecIntParam(ctx, b.args[1], input, minutesBuf); err != nil {
 		return err
 	}
-	secondsBuf, err := b.bufAllocator.get()
+	secondsBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(secondsBuf)
+	defer globalColumnAllocator.put(secondsBuf)
 	if err = b.args[2].VecEvalReal(ctx, input, secondsBuf); err != nil {
 		return err
 	}
@@ -2118,11 +2118,11 @@ func (b *builtinDayOfYearSig) vectorized() bool {
 
 func (b *builtinDayOfYearSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2152,11 +2152,11 @@ func (b *builtinFromUnixTime1ArgSig) vectorized() bool {
 
 func (b *builtinFromUnixTime1ArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err = b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2190,14 +2190,14 @@ func (b *builtinYearWeekWithModeSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
 	if err := b.args[0].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
@@ -2243,27 +2243,27 @@ func (b *builtinTimestampDiffSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampdiff
 func (b *builtinTimestampDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	unitBuf, err := b.bufAllocator.get()
+	unitBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitBuf)
+	defer globalColumnAllocator.put(unitBuf)
 	if err := b.args[0].VecEvalString(ctx, input, unitBuf); err != nil {
 		return err
 	}
-	lhsBuf, err := b.bufAllocator.get()
+	lhsBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(lhsBuf)
+	defer globalColumnAllocator.put(lhsBuf)
 	if err := b.args[1].VecEvalTime(ctx, input, lhsBuf); err != nil {
 		return err
 	}
-	rhsBuf, err := b.bufAllocator.get()
+	rhsBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(rhsBuf)
+	defer globalColumnAllocator.put(rhsBuf)
 	if err := b.args[2].VecEvalTime(ctx, input, rhsBuf); err != nil {
 		return err
 	}
@@ -2303,11 +2303,11 @@ func (b *builtinUnixTimestampIntSig) vectorized() bool {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampIntSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
@@ -2380,11 +2380,11 @@ func (b *builtinTimeSig) vectorized() bool {
 
 func (b *builtinTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2460,11 +2460,11 @@ func (b *builtinTimeLiteralSig) vecEvalDuration(ctx EvalContext, input *chunk.Ch
 
 func (b *builtinMonthNameSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2502,11 +2502,11 @@ func (b *builtinDayOfWeekSig) vectorized() bool {
 
 func (b *builtinDayOfWeekSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2536,11 +2536,11 @@ func (b *builtinCurrentTime1ArgSig) vectorized() bool {
 
 func (b *builtinCurrentTime1ArgSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2599,20 +2599,20 @@ func (b *builtinConvertTzSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, r
 		return err
 	}
 
-	fromTzBuf, err := b.bufAllocator.get()
+	fromTzBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(fromTzBuf)
+	defer globalColumnAllocator.put(fromTzBuf)
 	if err := b.args[1].VecEvalString(ctx, input, fromTzBuf); err != nil {
 		return err
 	}
 
-	toTzBuf, err := b.bufAllocator.get()
+	toTzBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(toTzBuf)
+	defer globalColumnAllocator.put(toTzBuf)
 	if err := b.args[2].VecEvalString(ctx, input, toTzBuf); err != nil {
 		return err
 	}
@@ -2638,11 +2638,11 @@ func (b *builtinConvertTzSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, r
 
 func (b *builtinTimestamp1ArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2681,20 +2681,20 @@ func (b *builtinTimestamp1ArgSig) vectorized() bool {
 
 func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2758,11 +2758,11 @@ func (b *builtinTimestamp2ArgsSig) vectorized() bool {
 
 func (b *builtinDayOfMonthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2795,20 +2795,20 @@ func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx EvalContext, input *chu
 		return nil
 	}
 
-	intervalBuf, err := b.bufAllocator.get()
+	intervalBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalBuf)
+	defer globalColumnAllocator.put(intervalBuf)
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get()
+	dateBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateBuf)
+	defer globalColumnAllocator.put(dateBuf)
 	if err := b.vecGetDate(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
@@ -2854,11 +2854,11 @@ func (b *builtinAddSubDateDatetimeAnySig) vecEvalTime(ctx EvalContext, input *ch
 		return nil
 	}
 
-	intervalBuf, err := b.bufAllocator.get()
+	intervalBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalBuf)
+	defer globalColumnAllocator.put(intervalBuf)
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
@@ -2901,20 +2901,20 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx EvalContext, input *ch
 		return nil
 	}
 
-	intervalBuf, err := b.bufAllocator.get()
+	intervalBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalBuf)
+	defer globalColumnAllocator.put(intervalBuf)
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	durBuf, err := b.bufAllocator.get()
+	durBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durBuf)
+	defer globalColumnAllocator.put(durBuf)
 	if err := b.args[0].VecEvalDuration(ctx, input, durBuf); err != nil {
 		return err
 	}
@@ -2958,11 +2958,11 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalDuration(ctx EvalContext, input
 		return nil
 	}
 
-	intervalBuf, err := b.bufAllocator.get()
+	intervalBuf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalBuf)
+	defer globalColumnAllocator.put(intervalBuf)
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -129,7 +129,11 @@ func (b *builtinFromUnixTime2ArgSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err = b.args[0].VecEvalDecimal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -138,7 +142,11 @@ func (b *builtinFromUnixTime2ArgSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err = b.args[1].VecEvalString(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -213,7 +221,11 @@ func (b *builtinExtractDatetimeFromStringSig) vecEvalInt(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -378,7 +390,11 @@ func (b *builtinTimeFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err1 != nil {
 		return err1
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -570,7 +586,11 @@ func (b *builtinNowWithArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufFsp)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufFsp)
+		}
+	}()
 	if err = b.args[0].VecEvalInt(ctx, input, bufFsp); err != nil {
 		return err
 	}
@@ -617,7 +637,11 @@ func (b *builtinGetFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -625,7 +649,11 @@ func (b *builtinGetFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err = b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -729,7 +757,11 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufStrings)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufStrings)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, bufStrings); err != nil {
 		return err
 	}
@@ -738,7 +770,11 @@ func (b *builtinStrToDateDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufFormats)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufFormats)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, bufFormats); err != nil {
 		return err
 	}
@@ -874,7 +910,11 @@ func (b *builtinTiDBBoundedStalenessSig) vecEvalTime(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err = b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -882,7 +922,11 @@ func (b *builtinTiDBBoundedStalenessSig) vecEvalTime(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err = b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1039,7 +1083,11 @@ func (b *builtinWeekWithModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err := b.args[0].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	buf2, err := globalColumnAllocator.get()
 	if err != nil {
@@ -1048,7 +1096,11 @@ func (b *builtinWeekWithModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk,
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
@@ -1088,7 +1140,11 @@ func (b *builtinExtractDatetimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(unit)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(unit)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, unit); err != nil {
 		return err
 	}
@@ -1096,7 +1152,11 @@ func (b *builtinExtractDatetimeSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dt)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dt)
+		}
+	}()
 	if err = b.args[1].VecEvalTime(ctx, input, dt); err != nil {
 		return err
 	}
@@ -1129,7 +1189,11 @@ func (b *builtinExtractDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(unit)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(unit)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, unit); err != nil {
 		return err
 	}
@@ -1137,7 +1201,11 @@ func (b *builtinExtractDurationSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dur)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dur)
+		}
+	}()
 	if err = b.args[1].VecEvalDuration(ctx, input, dur); err != nil {
 		return err
 	}
@@ -1171,7 +1239,11 @@ func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufStrings)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufStrings)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, bufStrings); err != nil {
 		return err
 	}
@@ -1180,7 +1252,11 @@ func (b *builtinStrToDateDurationSig) vecEvalDuration(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(bufFormats)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(bufFormats)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, bufFormats); err != nil {
 		return err
 	}
@@ -1363,7 +1439,11 @@ func (b *builtinMakeDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1372,7 +1452,11 @@ func (b *builtinMakeDateSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1554,7 +1638,11 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dateBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dateBuf)
+		}
+	}()
 	if err = b.args[0].VecEvalString(ctx, input, dateBuf); err != nil {
 		return err
 	}
@@ -1563,7 +1651,11 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(formatBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(formatBuf)
+		}
+	}()
 	if err = b.args[1].VecEvalString(ctx, input, formatBuf); err != nil {
 		return err
 	}
@@ -1685,7 +1777,11 @@ func (b *builtinUnixTimestampDecSig) vecEvalDecimal(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(timeBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(timeBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, timeBuf); err != nil {
 		for i := range n {
 			temp, isNull, err := b.evalDecimal(ctx, input.GetRow(i))
@@ -1785,7 +1881,11 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalReal(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1794,7 +1894,11 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	if err := b.args[2].VecEvalTime(ctx, input, buf2); err != nil {
 		return err
 	}
@@ -1902,7 +2006,11 @@ func (b *builtinDateFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dateBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dateBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, dateBuf); err != nil {
 		return err
 	}
@@ -1912,7 +2020,11 @@ func (b *builtinDateFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(formatBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(formatBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, formatBuf); err != nil {
 		return err
 	}
@@ -2085,7 +2197,11 @@ func (b *builtinDateDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err = b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -2093,7 +2209,11 @@ func (b *builtinDateDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, res
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err = b.args[1].VecEvalTime(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2181,7 +2301,11 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(minutesBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(minutesBuf)
+		}
+	}()
 	if err = b.getVecIntParam(ctx, b.args[1], input, minutesBuf); err != nil {
 		return err
 	}
@@ -2189,7 +2313,11 @@ func (b *builtinMakeTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(secondsBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(secondsBuf)
+		}
+	}()
 	if err = b.args[2].VecEvalReal(ctx, input, secondsBuf); err != nil {
 		return err
 	}
@@ -2359,7 +2487,11 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(unitBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(unitBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, unitBuf); err != nil {
 		return err
 	}
@@ -2367,7 +2499,11 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(lhsBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(lhsBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalTime(ctx, input, lhsBuf); err != nil {
 		return err
 	}
@@ -2375,7 +2511,11 @@ func (b *builtinTimestampDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(rhsBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(rhsBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalTime(ctx, input, rhsBuf); err != nil {
 		return err
 	}
@@ -2735,7 +2875,11 @@ func (b *builtinConvertTzSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(fromTzBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(fromTzBuf)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, fromTzBuf); err != nil {
 		return err
 	}
@@ -2744,7 +2888,11 @@ func (b *builtinConvertTzSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(toTzBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(toTzBuf)
+		}
+	}()
 	if err := b.args[2].VecEvalString(ctx, input, toTzBuf); err != nil {
 		return err
 	}
@@ -2821,7 +2969,11 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -2830,7 +2982,11 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -2939,7 +3095,11 @@ func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(intervalBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(intervalBuf)
+		}
+	}()
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
@@ -2948,7 +3108,11 @@ func (b *builtinAddSubDateAsStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(dateBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(dateBuf)
+		}
+	}()
 	if err := b.vecGetDate(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
@@ -2998,7 +3162,11 @@ func (b *builtinAddSubDateDatetimeAnySig) vecEvalTime(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(intervalBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(intervalBuf)
+		}
+	}()
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
@@ -3045,7 +3213,11 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(intervalBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(intervalBuf)
+		}
+	}()
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
@@ -3054,7 +3226,11 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalTime(ctx EvalContext, input *ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(durBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(durBuf)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, durBuf); err != nil {
 		return err
 	}
@@ -3102,7 +3278,11 @@ func (b *builtinAddSubDateDurationAnySig) vecEvalDuration(ctx EvalContext, input
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(intervalBuf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(intervalBuf)
+		}
+	}()
 	if err := b.vecGetInterval(&b.baseDateArithmetical, ctx, &b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time_vec.go
+++ b/pkg/expression/builtin_time_vec.go
@@ -35,7 +35,11 @@ func (b *builtinMonthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -63,7 +67,11 @@ func (b *builtinYearSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -192,7 +200,11 @@ func (b *builtinExtractDatetimeFromStringSig) vecEvalInt(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -233,7 +245,11 @@ func (b *builtinDayNameSig) vecEvalIndex(ctx EvalContext, input *chunk.Chunk, ap
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -307,7 +323,11 @@ func (b *builtinWeekDaySig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -342,7 +362,11 @@ func (b *builtinTimeFormatSig) vecEvalString(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		// If err != nil, then dur is ZeroDuration, outputs 00:00:00
 		// in this case which follows the behavior of mysql.
@@ -386,7 +410,11 @@ func (b *builtinUTCTimeWithArgSig) vecEvalDuration(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -458,7 +486,11 @@ func (b *builtinYearWeekWithoutModeSig) vecEvalInt(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -504,7 +536,11 @@ func (b *builtinPeriodDiffSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -748,7 +784,11 @@ func (b *builtinSysDateWithFspSig) vecEvalTime(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -784,7 +824,11 @@ func (b *builtinTidbParseTsoSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -894,7 +938,11 @@ func (b *builtinFromDaysSig) vecEvalTime(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -922,7 +970,11 @@ func (b *builtinMicroSecondSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -951,7 +1003,11 @@ func (b *builtinQuarterSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1168,7 +1224,11 @@ func (b *builtinToSecondsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1205,7 +1265,11 @@ func (b *builtinMinuteSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -1232,7 +1296,11 @@ func (b *builtinSecondSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -1358,7 +1426,11 @@ func (b *builtinWeekOfYearSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1395,7 +1467,11 @@ func (b *builtinUTCTimestampWithArgSig) vecEvalTime(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1439,7 +1515,11 @@ func (b *builtinTimeToSecSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1556,7 +1636,11 @@ func (b *builtinWeekWithoutModeSig) vecEvalInt(ctx EvalContext, input *chunk.Chu
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
@@ -1650,7 +1734,11 @@ func (b *builtinPeriodAddSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[1].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1684,7 +1772,11 @@ func (b *builtinTimestampAddSig) vecEvalString(ctx EvalContext, input *chunk.Chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1768,7 +1860,11 @@ func (b *builtinToDaysSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resul
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -1874,7 +1970,11 @@ func (b *builtinHourSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDuration(ctx, input, buf); err != nil {
 		return vecEvalIntByRows(ctx, b, input, result)
 	}
@@ -1901,7 +2001,11 @@ func (b *builtinSecToTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalReal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2122,7 +2226,11 @@ func (b *builtinDayOfYearSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2156,7 +2264,11 @@ func (b *builtinFromUnixTime1ArgSig) vecEvalTime(ctx EvalContext, input *chunk.C
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err = b.args[0].VecEvalDecimal(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2307,7 +2419,11 @@ func (b *builtinUnixTimestampIntSig) vecEvalInt(ctx EvalContext, input *chunk.Ch
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
@@ -2384,7 +2500,11 @@ func (b *builtinTimeSig) vecEvalDuration(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2464,7 +2584,11 @@ func (b *builtinMonthNameSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2506,7 +2630,11 @@ func (b *builtinDayOfWeekSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, re
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2540,7 +2668,11 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2642,7 +2774,11 @@ func (b *builtinTimestamp1ArgSig) vecEvalTime(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -2762,7 +2898,11 @@ func (b *builtinDayOfMonthSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -35,7 +35,11 @@ func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -97,7 +101,11 @@ func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -172,7 +180,11 @@ func (b *builtinAddDurationAndDurationSig) vecEvalDuration(ctx EvalContext, inpu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -228,7 +240,11 @@ func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -305,7 +321,11 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -400,7 +420,11 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -492,7 +516,11 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -570,7 +598,11 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -689,7 +721,11 @@ func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -753,7 +789,11 @@ func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -827,7 +867,11 @@ func (b *builtinSubDurationAndDurationSig) vecEvalDuration(ctx EvalContext, inpu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -883,7 +927,11 @@ func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -960,7 +1008,11 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1055,7 +1107,11 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1147,7 +1203,11 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1225,7 +1285,11 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -37,7 +37,7 @@ func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -103,7 +103,7 @@ func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -182,7 +182,7 @@ func (b *builtinAddDurationAndDurationSig) vecEvalDuration(ctx EvalContext, inpu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -242,7 +242,7 @@ func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -310,7 +310,7 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
@@ -323,7 +323,7 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -400,7 +400,7 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
@@ -422,7 +422,7 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -505,7 +505,7 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
@@ -518,7 +518,7 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -587,7 +587,7 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
@@ -600,7 +600,7 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -723,7 +723,7 @@ func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -791,7 +791,7 @@ func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -869,7 +869,7 @@ func (b *builtinSubDurationAndDurationSig) vecEvalDuration(ctx EvalContext, inpu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -929,7 +929,7 @@ func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -997,7 +997,7 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
@@ -1010,7 +1010,7 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -1087,7 +1087,7 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
@@ -1109,7 +1109,7 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -1192,7 +1192,7 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
@@ -1205,7 +1205,7 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
@@ -1274,7 +1274,7 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
@@ -1287,7 +1287,7 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
@@ -1416,7 +1416,7 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 
@@ -1426,7 +1426,7 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 
@@ -1481,7 +1481,7 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 
@@ -1541,7 +1541,7 @@ func (b *builtinDurationDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, in
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 
@@ -1592,7 +1592,7 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 
@@ -1602,7 +1602,7 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 
@@ -1657,7 +1657,7 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 
@@ -1716,7 +1716,7 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input 
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 
@@ -1726,7 +1726,7 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input 
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 
@@ -1790,7 +1790,7 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 
@@ -1800,7 +1800,7 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -292,7 +292,11 @@ func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -374,7 +378,11 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -471,7 +479,11 @@ func (b *builtinAddDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -545,7 +557,11 @@ func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -931,7 +947,11 @@ func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1013,7 +1033,11 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1110,7 +1134,11 @@ func (b *builtinSubDateAndDurationSig) vecEvalString(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1184,7 +1212,11 @@ func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -1414,13 +1414,21 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
@@ -1471,7 +1479,11 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
@@ -1527,7 +1539,11 @@ func (b *builtinDurationDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, in
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
@@ -1574,13 +1590,21 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
@@ -1631,7 +1655,11 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
@@ -1686,13 +1714,21 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input 
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
@@ -1752,13 +1788,21 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err

--- a/pkg/expression/builtin_time_vec_generated.go
+++ b/pkg/expression/builtin_time_vec_generated.go
@@ -31,11 +31,11 @@ func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -93,11 +93,11 @@ func (b *builtinAddDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -168,11 +168,11 @@ func (b *builtinAddDurationAndDurationSig) vecEvalDuration(ctx EvalContext, inpu
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -224,11 +224,11 @@ func (b *builtinAddDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -288,20 +288,20 @@ func (b *builtinAddDurationAndStringSig) vectorized() bool {
 func (b *builtinAddStringAndDurationSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -370,11 +370,11 @@ func (b *builtinAddStringAndDurationSig) vectorized() bool {
 func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -388,11 +388,11 @@ func (b *builtinAddStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 		return nil
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -467,20 +467,20 @@ func (b *builtinAddStringAndStringSig) vectorized() bool {
 func (b *builtinAddDateAndDurationSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -541,20 +541,20 @@ func (b *builtinAddDateAndDurationSig) vectorized() bool {
 func (b *builtinAddDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -669,11 +669,11 @@ func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(ctx EvalContext, input *c
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -733,11 +733,11 @@ func (b *builtinSubDatetimeAndStringSig) vecEvalTime(ctx EvalContext, input *chu
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -807,11 +807,11 @@ func (b *builtinSubDurationAndDurationSig) vecEvalDuration(ctx EvalContext, inpu
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -863,11 +863,11 @@ func (b *builtinSubDurationAndStringSig) vecEvalDuration(ctx EvalContext, input 
 	}
 	buf0 := result
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -927,20 +927,20 @@ func (b *builtinSubDurationAndStringSig) vectorized() bool {
 func (b *builtinSubStringAndDurationSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1009,11 +1009,11 @@ func (b *builtinSubStringAndDurationSig) vectorized() bool {
 func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -1027,11 +1027,11 @@ func (b *builtinSubStringAndStringSig) vecEvalString(ctx EvalContext, input *chu
 		return nil
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1106,20 +1106,20 @@ func (b *builtinSubStringAndStringSig) vectorized() bool {
 func (b *builtinSubDateAndDurationSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalDuration(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1180,20 +1180,20 @@ func (b *builtinSubDateAndDurationSig) vectorized() bool {
 func (b *builtinSubDateAndStringSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
 	}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEvalString(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -1314,17 +1314,17 @@ func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	n := input.NumRows()
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err
@@ -1371,11 +1371,11 @@ func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
 	buf0 := result
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
@@ -1427,11 +1427,11 @@ func (b *builtinDurationDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, in
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
 	buf0 := result
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	if err := b.args[0].VecEvalDuration(ctx, input, buf0); err != nil {
 		return err
@@ -1474,17 +1474,17 @@ func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *c
 	n := input.NumRows()
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
@@ -1531,11 +1531,11 @@ func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(ctx EvalContext, inpu
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
 	buf1 := result
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
@@ -1586,17 +1586,17 @@ func (b *builtinStringStringTimeDiffSig) vecEvalDuration(ctx EvalContext, input 
 	n := input.NumRows()
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	if err := b.args[0].VecEvalString(ctx, input, buf0); err != nil {
 		return err
@@ -1652,17 +1652,17 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(ctx EvalContext, input *chu
 	n := input.NumRows()
 	result.ResizeGoDuration(n, false)
 	r64s := result.GoDurations()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 
 	if err := b.args[0].VecEvalTime(ctx, input, buf0); err != nil {
 		return err

--- a/pkg/expression/builtin_vec_vec.go
+++ b/pkg/expression/builtin_vec_vec.go
@@ -29,11 +29,11 @@ func (b *builtinVecDimsSig) vectorized() bool {
 
 func (b *builtinVecDimsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, buf); err != nil {
 		return err
 	}
@@ -56,20 +56,20 @@ func (b *builtinVecL1DistanceSig) vectorized() bool {
 
 func (b *builtinVecL1DistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	col1, err := b.bufAllocator.get()
+	col1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col1)
+	defer globalColumnAllocator.put(col1)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
 
-	col2, err := b.bufAllocator.get()
+	col2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col2)
+	defer globalColumnAllocator.put(col2)
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -101,20 +101,20 @@ func (b *builtinVecL2DistanceSig) vectorized() bool {
 
 func (b *builtinVecL2DistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	col1, err := b.bufAllocator.get()
+	col1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col1)
+	defer globalColumnAllocator.put(col1)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
 
-	col2, err := b.bufAllocator.get()
+	col2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col2)
+	defer globalColumnAllocator.put(col2)
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -146,20 +146,20 @@ func (b *builtinVecNegativeInnerProductSig) vectorized() bool {
 
 func (b *builtinVecNegativeInnerProductSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	col1, err := b.bufAllocator.get()
+	col1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col1)
+	defer globalColumnAllocator.put(col1)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
 
-	col2, err := b.bufAllocator.get()
+	col2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col2)
+	defer globalColumnAllocator.put(col2)
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -191,20 +191,20 @@ func (b *builtinVecCosineDistanceSig) vectorized() bool {
 
 func (b *builtinVecCosineDistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	col1, err := b.bufAllocator.get()
+	col1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col1)
+	defer globalColumnAllocator.put(col1)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
 
-	col2, err := b.bufAllocator.get()
+	col2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col2)
+	defer globalColumnAllocator.put(col2)
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -236,11 +236,11 @@ func (b *builtinVecL2NormSig) vectorized() bool {
 
 func (b *builtinVecL2NormSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	col1, err := b.bufAllocator.get()
+	col1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(col1)
+	defer globalColumnAllocator.put(col1)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
@@ -268,11 +268,11 @@ func (b *builtinVecFromTextSig) vectorized() bool {
 
 func (b *builtinVecFromTextSig) vecEvalVectorFloat32(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -301,11 +301,11 @@ func (b *builtinVecAsTextSig) vectorized() bool {
 
 func (b *builtinVecAsTextSig) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.bufAllocator.get()
+	buf, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
+	defer globalColumnAllocator.put(buf)
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_vec_vec.go
+++ b/pkg/expression/builtin_vec_vec.go
@@ -33,7 +33,11 @@ func (b *builtinVecDimsSig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, resu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, buf); err != nil {
 		return err
 	}
@@ -60,7 +64,11 @@ func (b *builtinVecL1DistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col1)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
@@ -69,7 +77,11 @@ func (b *builtinVecL1DistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col2)
+		}
+	}()
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -105,7 +117,11 @@ func (b *builtinVecL2DistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col1)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
@@ -114,7 +130,11 @@ func (b *builtinVecL2DistanceSig) vecEvalReal(ctx EvalContext, input *chunk.Chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col2)
+		}
+	}()
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -150,7 +170,11 @@ func (b *builtinVecNegativeInnerProductSig) vecEvalReal(ctx EvalContext, input *
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col1)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
@@ -159,7 +183,11 @@ func (b *builtinVecNegativeInnerProductSig) vecEvalReal(ctx EvalContext, input *
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col2)
+		}
+	}()
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -195,7 +223,11 @@ func (b *builtinVecCosineDistanceSig) vecEvalReal(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col1)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
@@ -204,7 +236,11 @@ func (b *builtinVecCosineDistanceSig) vecEvalReal(ctx EvalContext, input *chunk.
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col2)
+		}
+	}()
 	if err := b.args[1].VecEvalVectorFloat32(ctx, input, col2); err != nil {
 		return err
 	}
@@ -240,7 +276,11 @@ func (b *builtinVecL2NormSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, r
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(col1)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(col1)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, col1); err != nil {
 		return err
 	}
@@ -272,7 +312,11 @@ func (b *builtinVecFromTextSig) vecEvalVectorFloat32(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalString(ctx, input, buf); err != nil {
 		return err
 	}
@@ -305,7 +349,11 @@ func (b *builtinVecAsTextSig) vecEvalString(ctx EvalContext, input *chunk.Chunk,
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf)
+		}
+	}()
 	if err := b.args[0].VecEvalVectorFloat32(ctx, input, buf); err != nil {
 		return err
 	}

--- a/pkg/expression/builtin_vectorized.go
+++ b/pkg/expression/builtin_vectorized.go
@@ -51,6 +51,13 @@ func newColumnPool() *columnPool {
 
 var globalColumnAllocator = newColumnPool()
 
+func init() {
+	// Pre-allocate some column buffers to avoid frequent memory allocation when to startup.
+	for i := 0; i < 16; i++ {
+		globalColumnAllocator.put(columnTempl.CopyConstruct(nil))
+	}
+}
+
 // GetColumn allocates a column. The allocator is not responsible for initializing the column, so please initialize it before using.
 func GetColumn(_ types.EvalType, _ int) (*chunk.Column, error) {
 	return globalColumnAllocator.get()

--- a/pkg/expression/builtin_vectorized.go
+++ b/pkg/expression/builtin_vectorized.go
@@ -70,7 +70,9 @@ func (r *localColumnPool) get() (*chunk.Column, error) {
 }
 
 func (r *localColumnPool) put(col *chunk.Column) {
-	r.Pool.Put(col)
+	if col.TryReset() {
+		r.Pool.Put(col)
+	}
 }
 
 // vecEvalIntByRows uses the non-vectorized(row-based) interface `evalInt` to eval the expression.

--- a/pkg/expression/builtin_vectorized.go
+++ b/pkg/expression/builtin_vectorized.go
@@ -53,7 +53,8 @@ var globalColumnAllocator = newColumnPool()
 
 func init() {
 	// Pre-allocate some column buffers to avoid frequent memory allocation when to startup.
-	for i := 0; i < 16; i++ {
+	for range 64 {
+		// align to the 64 cpu-core server.
 		globalColumnAllocator.put(columnTempl.CopyConstruct(nil))
 	}
 }

--- a/pkg/expression/builtin_vectorized.go
+++ b/pkg/expression/builtin_vectorized.go
@@ -16,7 +16,6 @@ package expression
 
 import (
 	"sync"
-	"unsafe"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -30,8 +29,6 @@ type columnBufferAllocator interface {
 	get() (*chunk.Column, error)
 	// put releases a column buffer.
 	put(buf *chunk.Column)
-	// MemoryUsage return the memory usage of columnBufferAllocator
-	MemoryUsage() int64
 }
 
 // localColumnPool implements columnBufferAllocator interface.
@@ -74,12 +71,6 @@ func (r *localColumnPool) get() (*chunk.Column, error) {
 
 func (r *localColumnPool) put(col *chunk.Column) {
 	r.Pool.Put(col)
-}
-
-const emptyLocalColumnPoolSize = int64(unsafe.Sizeof(localColumnPool{}))
-
-func (r *localColumnPool) MemoryUsage() (sum int64) {
-	return emptyLocalColumnPoolSize
 }
 
 // vecEvalIntByRows uses the non-vectorized(row-based) interface `evalInt` to eval the expression.

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -38,7 +38,7 @@ type mockVecPlusIntBuiltinFunc struct {
 
 func (p *mockVecPlusIntBuiltinFunc) allocBuf(n int) (*chunk.Column, error) {
 	if p.enableAlloc {
-		return p.bufAllocator.get()
+		return globalColumnAllocator.get()
 	}
 	if p.buf == nil {
 		p.buf = chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), n)
@@ -48,7 +48,7 @@ func (p *mockVecPlusIntBuiltinFunc) allocBuf(n int) (*chunk.Column, error) {
 
 func (p *mockVecPlusIntBuiltinFunc) releaseBuf(buf *chunk.Column) {
 	if p.enableAlloc {
-		p.bufAllocator.put(buf)
+		globalColumnAllocator.put(buf)
 	}
 }
 
@@ -242,7 +242,7 @@ func (p *mockBuiltinDouble) vecEvalReal(ctx EvalContext, input *chunk.Chunk, res
 func (p *mockBuiltinDouble) vecEvalString(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	var buf *chunk.Column
 	var err error
-	if buf, err = p.baseBuiltinFunc.bufAllocator.get(); err != nil {
+	if buf, err = globalColumnAllocator.get(); err != nil {
 		return err
 	}
 	if err := p.args[0].VecEvalString(ctx, input, buf); err != nil {
@@ -253,7 +253,7 @@ func (p *mockBuiltinDouble) vecEvalString(ctx EvalContext, input *chunk.Chunk, r
 		str := buf.GetString(i)
 		result.AppendString(str + str)
 	}
-	p.baseBuiltinFunc.bufAllocator.put(buf)
+	globalColumnAllocator.put(buf)
 	return nil
 }
 
@@ -303,7 +303,7 @@ func (p *mockBuiltinDouble) vecEvalDuration(ctx EvalContext, input *chunk.Chunk,
 func (p *mockBuiltinDouble) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	var buf *chunk.Column
 	var err error
-	if buf, err = p.baseBuiltinFunc.bufAllocator.get(); err != nil {
+	if buf, err = globalColumnAllocator.get(); err != nil {
 		return err
 	}
 	if err := p.args[0].VecEvalJSON(ctx, input, buf); err != nil {
@@ -325,7 +325,7 @@ func (p *mockBuiltinDouble) vecEvalJSON(ctx EvalContext, input *chunk.Chunk, res
 		}
 		result.AppendJSON(j)
 	}
-	p.baseBuiltinFunc.bufAllocator.put(buf)
+	globalColumnAllocator.put(buf)
 	return nil
 }
 

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -143,7 +143,7 @@ const (
 )
 
 func BenchmarkColumnPoolGet(b *testing.B) {
-	allocator := newLocalColumnPool()
+	allocator := globalColumnAllocator
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for range numColumnPoolOp {
@@ -153,7 +153,7 @@ func BenchmarkColumnPoolGet(b *testing.B) {
 }
 
 func BenchmarkColumnPoolGetParallel(b *testing.B) {
-	allocator := newLocalColumnPool()
+	allocator := globalColumnAllocator
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -165,7 +165,7 @@ func BenchmarkColumnPoolGetParallel(b *testing.B) {
 }
 
 func BenchmarkColumnPoolGetPut(b *testing.B) {
-	allocator := newLocalColumnPool()
+	allocator := globalColumnAllocator
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for range numColumnPoolOp {
@@ -176,7 +176,7 @@ func BenchmarkColumnPoolGetPut(b *testing.B) {
 }
 
 func BenchmarkColumnPoolGetPutParallel(b *testing.B) {
-	allocator := newLocalColumnPool()
+	allocator := globalColumnAllocator
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -143,46 +143,42 @@ const (
 )
 
 func BenchmarkColumnPoolGet(b *testing.B) {
-	allocator := globalColumnAllocator
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for range numColumnPoolOp {
-			_, _ = allocator.get()
+			_, _ = globalColumnAllocator.get()
 		}
 	}
 }
 
 func BenchmarkColumnPoolGetParallel(b *testing.B) {
-	allocator := globalColumnAllocator
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			for range numColumnPoolOp {
-				_, _ = allocator.get()
+				_, _ = globalColumnAllocator.get()
 			}
 		}
 	})
 }
 
 func BenchmarkColumnPoolGetPut(b *testing.B) {
-	allocator := globalColumnAllocator
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for range numColumnPoolOp {
-			col, _ := allocator.get()
-			allocator.put(col)
+			col, _ := globalColumnAllocator.get()
+			globalColumnAllocator.put(col)
 		}
 	}
 }
 
 func BenchmarkColumnPoolGetPutParallel(b *testing.B) {
-	allocator := globalColumnAllocator
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			for range numColumnPoolOp {
-				col, _ := allocator.get()
-				allocator.put(col)
+				col, _ := globalColumnAllocator.get()
+				globalColumnAllocator.put(col)
 			}
 		}
 	})

--- a/pkg/expression/generator/compare_vec.go
+++ b/pkg/expression/generator/compare_vec.go
@@ -61,19 +61,19 @@ const builtinCompareImports = `import (
 var builtinCompareVecTpl = template.Must(template.New("").Parse(`
 func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -115,19 +115,19 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vectorized() 
 var builtinNullEQCompareVecTpl = template.Must(template.New("").Parse(`
 func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -216,11 +216,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 	n := input.NumRows()
 	result.Resize{{ .type.TypeNameInColumn }}(n, true)
 	i64s := result.{{ .type.TypeNameInColumn }}s()
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++{
 		err := b.args[j].VecEval{{ .type.TypeName }}(ctx, input, buf1)
@@ -255,11 +255,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 	bufs := make([]*chunk.Column, argLen)
 	beforeWarns := warningCount(ctx)
 	for i := 0; i < argLen; i++ {
-		buf, err := b.bufAllocator.get()
+		buf, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(buf)
+		defer globalColumnAllocator.put(buf)
 		err = b.args[i].VecEval{{ .type.TypeName }}(ctx, input, buf)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/generator/compare_vec.go
+++ b/pkg/expression/generator/compare_vec.go
@@ -67,7 +67,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
@@ -79,7 +79,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
@@ -129,7 +129,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
@@ -141,7 +141,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
@@ -238,7 +238,7 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	beforeWarns := warningCount(ctx)
@@ -279,7 +279,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(buf)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(buf)
+			}
+		}()
 		err = b.args[i].VecEval{{ .type.TypeName }}(ctx, input, buf)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/generator/compare_vec.go
+++ b/pkg/expression/generator/compare_vec.go
@@ -65,7 +65,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -73,7 +77,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -119,7 +127,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEval{{ .type.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -127,7 +139,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEvalInt(ct
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEval{{ .type.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -220,7 +236,11 @@ func (b *builtin{{ .compare.CompareName }}{{ .type.TypeName }}Sig) vecEval{{ .ty
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	for j := 0; j < len(b.args); j++{
 		err := b.args[j].VecEval{{ .type.TypeName }}(ctx, input, buf1)

--- a/pkg/expression/generator/control_vec.go
+++ b/pkg/expression/generator/control_vec.go
@@ -275,7 +275,11 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -298,7 +302,11 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -306,7 +314,11 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -385,7 +397,11 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -397,7 +413,11 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 {{- end }}
 	afterWarns := warningCount(ctx)

--- a/pkg/expression/generator/control_vec.go
+++ b/pkg/expression/generator/control_vec.go
@@ -118,7 +118,11 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufWhen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufWhen)
+			}
+		}()
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -134,7 +138,11 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufThen)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufThen)
+			}
+		}()
 		err = args[j+1].VecEval{{ .TypeName }}(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -156,7 +164,11 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		if err != nil {
 			return err
 		}
-		defer globalColumnAllocator.put(bufElse)
+		defer func() {
+			if err == nil {
+				globalColumnAllocator.put(bufElse)
+			}
+		}()
 		err = args[l-1].VecEval{{ .TypeName }}(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -277,7 +289,7 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	beforeWarns := warningCount(ctx)
@@ -304,7 +316,7 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
@@ -316,7 +328,7 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	beforeWarns := warningCount(ctx)
@@ -399,7 +411,7 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
@@ -415,7 +427,7 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
@@ -432,7 +444,11 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf2)
+	defer func() {
+		if err == nil {
+			globalColumnAllocator.put(buf2)
+		}
+	}()
 	err = b.args[2].VecEval{{ .TypeName }}(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/generator/control_vec.go
+++ b/pkg/expression/generator/control_vec.go
@@ -114,11 +114,11 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 	beforeWarns := warningCount(ctx)
 
 	for j := 0; j < l-1; j+=2 {
-		bufWhen, err := b.bufAllocator.get()
+		bufWhen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufWhen)
+		defer globalColumnAllocator.put(bufWhen)
 		err = args[j].VecEvalInt(ctx, input, bufWhen)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -130,11 +130,11 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 		whens[j/2] = bufWhen
 		whensSlice[j/2] = bufWhen.Int64s()
 
-		bufThen, err := b.bufAllocator.get()
+		bufThen, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufThen)
+		defer globalColumnAllocator.put(bufThen)
 		err = args[j+1].VecEval{{ .TypeName }}(ctx, input, bufThen)
 		afterWarns = warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -152,11 +152,11 @@ func (b *builtinCaseWhen{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalConte
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2==1 {
-		bufElse, err := b.bufAllocator.get()
+		bufElse, err := globalColumnAllocator.get()
 		if err != nil {
 			return err
 		}
-		defer b.bufAllocator.put(bufElse)
+		defer globalColumnAllocator.put(bufElse)
 		err = args[l-1].VecEval{{ .TypeName }}(ctx, input, bufElse)
 		afterWarns := warningCount(ctx)
 		if err != nil || afterWarns > beforeWarns {
@@ -271,11 +271,11 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, result); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -294,19 +294,19 @@ func (b *builtinIfNull{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext
 		}
 	}
 	{{ else }}
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	beforeWarns := warningCount(ctx)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 	afterWarns := warningCount(ctx)
@@ -381,11 +381,11 @@ func (b *builtinIf{{ .TypeName }}Sig) fallbackEval{{ .TypeName }}(ctx EvalContex
 
 func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEvalInt(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -393,11 +393,11 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
 {{- if .Fixed }}
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, result)
 {{- else }}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	err = b.args[1].VecEval{{ .TypeName }}(ctx, input, buf1)
 {{- end }}
 	afterWarns := warningCount(ctx)
@@ -408,11 +408,11 @@ func (b *builtinIf{{ .TypeName }}Sig) vecEval{{ .TypeName }}(ctx EvalContext, in
       	return b.fallbackEval{{ .TypeName }}(ctx, input, result)
    	}
 
-	buf2, err := b.bufAllocator.get()
+	buf2, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf2)
+	defer globalColumnAllocator.put(buf2)
 	err = b.args[2].VecEval{{ .TypeName }}(ctx, input, buf2)
 	afterWarns = warningCount(ctx)
 	if err != nil || afterWarns > beforeWarns {

--- a/pkg/expression/generator/other_vec.go
+++ b/pkg/expression/generator/other_vec.go
@@ -61,19 +61,19 @@ const builtinOtherImports = `import (
 
 var builtinInTmpl = template.Must(template.New("builtinInTmpl").Parse(`
 {{ define "BufAllocator" }}
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEval{{ .Input.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 {{ end }}
 {{ define "SetHasNull" }}
 	for i := 0; i < n; i++ {

--- a/pkg/expression/generator/other_vec.go
+++ b/pkg/expression/generator/other_vec.go
@@ -67,7 +67,7 @@ var builtinInTmpl = template.Must(template.New("builtinInTmpl").Parse(`
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEval{{ .Input.TypeName }}(ctx, input, buf0); err != nil {
@@ -79,7 +79,7 @@ var builtinInTmpl = template.Must(template.New("builtinInTmpl").Parse(`
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 {{ end }}

--- a/pkg/expression/generator/other_vec.go
+++ b/pkg/expression/generator/other_vec.go
@@ -65,7 +65,11 @@ var builtinInTmpl = template.Must(template.New("builtinInTmpl").Parse(`
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEval{{ .Input.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -73,7 +77,11 @@ var builtinInTmpl = template.Must(template.New("builtinInTmpl").Parse(`
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 {{ end }}
 {{ define "SetHasNull" }}
 	for i := 0; i < n; i++ {

--- a/pkg/expression/generator/string_vec.go
+++ b/pkg/expression/generator/string_vec.go
@@ -66,7 +66,7 @@ func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chun
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
@@ -78,7 +78,7 @@ func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chun
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 {{ if .Fixed }}

--- a/pkg/expression/generator/string_vec.go
+++ b/pkg/expression/generator/string_vec.go
@@ -64,7 +64,11 @@ func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -72,7 +76,11 @@ func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chun
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 {{ if .Fixed }}
 	arg0 := buf0.{{ .TypeNameInColumn }}s()
 {{ end }}

--- a/pkg/expression/generator/string_vec.go
+++ b/pkg/expression/generator/string_vec.go
@@ -60,19 +60,19 @@ var builtinStringVecTpl = template.Must(template.New("").Parse(`
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinField{{ .TypeName }}Sig) vecEvalInt(ctx EvalContext, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEval{{ .TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 {{ if .Fixed }}
 	arg0 := buf0.{{ .TypeNameInColumn }}s()
 {{ end }}

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -107,7 +107,11 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -372,14 +372,22 @@ var timeDiff = template.Must(template.New("").Parse(`
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf0)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf0)
+		}
+	}()
 {{ end }}
 {{ define "BufAllocator1" }}
 	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 {{ end }}
 {{ define "ArgsVecEval" }}
 	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -132,7 +132,11 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	if err != nil {
 		return err
 	}
-	defer globalColumnAllocator.put(buf1)
+	defer func() {
+		if err == nil {
+			defer globalColumnAllocator.put(buf1)
+		}
+	}()
 	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -109,7 +109,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {
@@ -134,7 +134,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(ctx, input, buf1); err != nil {
@@ -374,7 +374,7 @@ var timeDiff = template.Must(template.New("").Parse(`
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf0)
+			globalColumnAllocator.put(buf0)
 		}
 	}()
 {{ end }}
@@ -385,7 +385,7 @@ var timeDiff = template.Must(template.New("").Parse(`
 	}
 	defer func() {
 		if err == nil {
-			defer globalColumnAllocator.put(buf1)
+			globalColumnAllocator.put(buf1)
 		}
 	}()
 {{ end }}

--- a/pkg/expression/generator/time_vec.go
+++ b/pkg/expression/generator/time_vec.go
@@ -103,11 +103,11 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	}
 	buf0 := result
 {{ else }}
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {
 		return err
 	}
@@ -124,11 +124,11 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(ctx EvalContext, input *chu
 	}
 {{ end }}
 
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 	if err := b.args[1].VecEval{{ .TypeB.TypeName }}(ctx, input, buf1); err != nil {
 		return err
 	}
@@ -360,18 +360,18 @@ func (b *{{.SigName}}) vectorized() bool {
 
 var timeDiff = template.Must(template.New("").Parse(`
 {{ define "BufAllocator0" }}
-	buf0, err := b.bufAllocator.get()
+	buf0, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
+	defer globalColumnAllocator.put(buf0)
 {{ end }}
 {{ define "BufAllocator1" }}
-	buf1, err := b.bufAllocator.get()
+	buf1, err := globalColumnAllocator.get()
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
+	defer globalColumnAllocator.put(buf1)
 {{ end }}
 {{ define "ArgsVecEval" }}
 	if err := b.args[0].VecEval{{ .TypeA.TypeName }}(ctx, input, buf0); err != nil {

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -348,7 +348,7 @@ func castColumnValue(tc types.Context, ec errctx.Context, sqlMode mysql.SQLMode,
 		if err1 != nil {
 			logutil.BgLogger().Warn("Datum ToString failed", zap.Stringer("Datum", val), zap.Error(err1))
 		}
-		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(col.FieldType.CompactStr(), str)
+		err = types.ErrTruncatedWrongVal.GenWithStackByArgs(col.FieldType.CompactStr(), strings.Clone(str))
 	} else if !casted.IsNull() &&
 		(col.GetType() == mysql.TypeDate || col.GetType() == mysql.TypeDatetime || col.GetType() == mysql.TypeTimestamp) {
 		str, err1 := val.ToString()

--- a/pkg/types/convert.go
+++ b/pkg/types/convert.go
@@ -410,7 +410,7 @@ func getValidIntPrefix(ctx Context, str string, isFuncCast bool) (string, error)
 		valid = "0"
 	}
 	if validLen == 0 || validLen != len(str) {
-		return valid, errors.Trace(ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", str)))
+		return valid, errors.Trace(ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", strings.Clone(str))))
 	}
 	return valid, nil
 }
@@ -560,7 +560,7 @@ func StrToFloat(ctx Context, str string, isFuncCast bool) (float64, error) {
 		if err2, ok := err1.(*strconv.NumError); ok {
 			// value will truncate to MAX/MIN if out of range.
 			if err2.Err == strconv.ErrRange {
-				err1 = ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("DOUBLE", str))
+				err1 = ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("DOUBLE", strings.Clone(str)))
 				if math.IsInf(f, 1) {
 					f = math.MaxFloat64
 				} else if math.IsInf(f, -1) {
@@ -582,13 +582,13 @@ func ConvertJSONToInt64(ctx Context, j BinaryJSON, unsigned bool) (int64, error)
 func ConvertJSONToInt(ctx Context, j BinaryJSON, unsigned bool, tp byte) (int64, error) {
 	switch j.TypeCode {
 	case JSONTypeCodeObject, JSONTypeCodeArray, JSONTypeCodeOpaque, JSONTypeCodeDate, JSONTypeCodeDatetime, JSONTypeCodeTimestamp, JSONTypeCodeDuration:
-		return 0, ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", j.String()))
+		return 0, ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", strings.Clone(j.String())))
 	case JSONTypeCodeLiteral:
 		switch j.Value[0] {
 		case JSONLiteralFalse:
 			return 0, nil
 		case JSONLiteralNil:
-			return 0, ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", j.String()))
+			return 0, ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("INTEGER", strings.Clone(j.String())))
 		default:
 			return 1, nil
 		}
@@ -748,7 +748,7 @@ func getValidFloatPrefix(ctx Context, s string, isFuncCast bool) (valid string, 
 		valid = "0"
 	}
 	if validLen == 0 || validLen != len(s) {
-		err = errors.Trace(ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("DOUBLE", s)))
+		err = errors.Trace(ctx.HandleTruncate(ErrTruncatedWrongVal.GenWithStackByArgs("DOUBLE", strings.Clone(s))))
 	}
 	return valid, err
 }

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -1827,17 +1827,17 @@ func ParseDuration(ctx Context, str string, fsp int) (Duration, bool, error) {
 		return d, isNull, nil
 	}
 	if !canFallbackToDateTime(rest) {
-		return d, isNull, ErrTruncatedWrongVal.GenWithStackByArgs("time", str)
+		return d, isNull, ErrTruncatedWrongVal.GenWithStackByArgs("time", strings.Clone(str))
 	}
 
 	datetime, err := ParseDatetime(ctx, rest)
 	if err != nil {
-		return ZeroDuration, true, ErrTruncatedWrongVal.GenWithStackByArgs("time", str)
+		return ZeroDuration, true, ErrTruncatedWrongVal.GenWithStackByArgs("time", strings.Clone(str))
 	}
 
 	d, err = datetime.ConvertToDuration()
 	if err != nil {
-		return ZeroDuration, true, ErrTruncatedWrongVal.GenWithStackByArgs("time", str)
+		return ZeroDuration, true, ErrTruncatedWrongVal.GenWithStackByArgs("time", strings.Clone(str))
 	}
 
 	d, err = d.RoundFrac(fsp, ctx.Location())

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -892,3 +892,11 @@ func (c *Column) ContainsVeryLargeElement() bool {
 	}
 	return false
 }
+
+func (c *Column) TryReset() bool {
+	if c.avoidReusing {
+		return false
+	}
+	c.reset()
+	return true
+}

--- a/pkg/util/chunk/column.go
+++ b/pkg/util/chunk/column.go
@@ -893,6 +893,7 @@ func (c *Column) ContainsVeryLargeElement() bool {
 	return false
 }
 
+// TryReset tries to reset this Column.
 func (c *Column) TryReset() bool {
 	if c.avoidReusing {
 		return false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63809

Problem Summary:

### What changed and how does it work?

The local thread does not need to be independently implemented, as this has already been done in `sync.Pool`. Moreover, this leads to an issue where each goroutine, upon creation, allocates memory here, and upon termination, this memory cannot be reused, resulting in performance problems.

Note: When a problem occurs, this part of the memory cannot be reused, especially the strings in the warnings need to be copied additionally to avoid extra problems caused by memory reuse.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)

Before 

```
[
  {
    "Name": "BenchmarkCastIntAsIntRow",
    "NsPerOp": 6663,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkCastIntAsIntVec",
    "NsPerOp": 151,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkVectorizedExecute",
    "NsPerOp": 2876124,
    "AllocsPerOp": 8192,
    "BytesPerOp": 1312836
  },
  {
    "Name": "BenchmarkScalarFunctionClone",
    "NsPerOp": 568,
    "AllocsPerOp": 15,
    "BytesPerOp": 1584
  },
  {
    "Name": "BenchmarkColumnPoolGet",
    "NsPerOp": 419317,
    "AllocsPerOp": 8192,
    "BytesPerOp": 491545
  },
  {
    "Name": "BenchmarkColumnPoolGetParallel",
    "NsPerOp": 115518,
    "AllocsPerOp": 8192,
    "BytesPerOp": 491537
  },
  {
    "Name": "BenchmarkColumnPoolGetPut",
    "NsPerOp": 47423,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkColumnPoolGetPutParallel",
    "NsPerOp": 5891,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkPlusIntBufAllocator",
    "NsPerOp": 3304,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkVectorizedBuiltinMiscellaneousEvalOneVec",
    "NsPerOp": 65762008,
    "AllocsPerOp": 22123,
    "BytesPerOp": 4277981
  }
]
```
after 

```
[
  {
    "Name": "BenchmarkCastIntAsIntRow",
    "NsPerOp": 6423,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkCastIntAsIntVec",
    "NsPerOp": 69,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkVectorizedExecute",
    "NsPerOp": 2701215,
    "AllocsPerOp": 8192,
    "BytesPerOp": 1312758
  },
  {
    "Name": "BenchmarkScalarFunctionClone",
    "NsPerOp": 462,
    "AllocsPerOp": 13,
    "BytesPerOp": 1456
  },
  {
    "Name": "BenchmarkColumnPoolGet",
    "NsPerOp": 377102,
    "AllocsPerOp": 8192,
    "BytesPerOp": 491545
  },
  {
    "Name": "BenchmarkColumnPoolGetParallel",
    "NsPerOp": 107511,
    "AllocsPerOp": 8192,
    "BytesPerOp": 491538
  },
  {
    "Name": "BenchmarkColumnPoolGetPut",
    "NsPerOp": 52911,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkColumnPoolGetPutParallel",
    "NsPerOp": 6641,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkPlusIntBufAllocator",
    "NsPerOp": 2626,
    "AllocsPerOp": 0,
    "BytesPerOp": 0
  },
  {
    "Name": "BenchmarkVectorizedBuiltinMiscellaneousEvalOneVec",
    "NsPerOp": 40522487,
    "AllocsPerOp": 22265,
    "BytesPerOp": 4239893
  }
]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
