### PR TITLE
perf: using globalColumnAllocator instead of new local column allocator

### DIFF
--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -133,7 +133,7 @@ func newBaseBuiltinFunc(ctx BuildContext, funcName string, args []Expression, tp
 	}
 
 	bf := baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
+		bufAllocator:           globalColumnAllocator,
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -225,7 +225,7 @@ func newBaseBuiltinFuncWithTp(ctx BuildContext, funcName string, args []Expressi
 
 	fieldType := newReturnFieldTypeForBaseBuiltinFunc(funcName, retType, ec)
 	bf = baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
+		bufAllocator:           globalColumnAllocator,
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -286,7 +286,7 @@ func newBaseBuiltinFuncWithFieldTypes(ctx BuildContext, funcName string, args []
 
 	fieldType := newReturnFieldTypeForBaseBuiltinFunc(funcName, retType, ec)
 	bf = baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
+		bufAllocator:           globalColumnAllocator,
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -305,7 +305,7 @@ func newBaseBuiltinFuncWithFieldTypes(ctx BuildContext, funcName string, args []
 // do not check and compute collation.
 func newBaseBuiltinFuncWithFieldType(tp *types.FieldType, args []Expression) (baseBuiltinFunc, error) {
 	bf := baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
+		bufAllocator:           globalColumnAllocator,
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -437,7 +437,7 @@ func (b *baseBuiltinFunc) cloneFrom(from *baseBuiltinFunc) {
 	}
 	b.tp = from.tp
 	b.pbCode = from.pbCode
-	b.bufAllocator = newLocalColumnPool()
+	b.bufAllocator = globalColumnAllocator
 	b.childrenVectorizedOnce = new(sync.Once)
 	if from.ctor != nil {
 		b.ctor = from.ctor.Clone()
@@ -481,7 +481,7 @@ func newBaseBuiltinCastFunc4String(ctx BuildContext, funcName string, args []Exp
 	var err error
 	if isExplicitCharset {
 		bf = baseBuiltinFunc{
-			bufAllocator:           newLocalColumnPool(),
+			bufAllocator:           globalColumnAllocator,
 			childrenVectorizedOnce: new(sync.Once),
 
 			args: args,

--- a/pkg/expression/builtin_time.go
+++ b/pkg/expression/builtin_time.go
@@ -4903,6 +4903,9 @@ func (c *addTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	}
 	switch tp1.GetType() {
 	case mysql.TypeDatetime, mysql.TypeTimestamp:
+		charset, collate := ctx.GetCharsetInfo()
+		bf.tp.SetCharset(charset)
+		bf.tp.SetCollate(collate)
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
 			sig = &builtinAddDatetimeAndDurationSig{bf}
@@ -5967,6 +5970,9 @@ func (c *subTimeFunctionClass) getFunction(ctx BuildContext, args []Expression) 
 	}
 	switch tp1.GetType() {
 	case mysql.TypeDatetime, mysql.TypeTimestamp:
+		charset, collate := ctx.GetCharsetInfo()
+		bf.tp.SetCharset(charset)
+		bf.tp.SetCollate(collate)
 		switch tp2.GetType() {
 		case mysql.TypeDuration:
 			sig = &builtinSubDatetimeAndDurationSig{bf}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63809

Problem Summary:

### What changed and how does it work?

using globalColumnAllocator instead of newLocalColumnPool

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [x] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
