### PR TITLE
planner: avoid copying OutPutNames in the in rewriteExprNode

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -289,9 +289,9 @@ func rewriteExprNode(rewriter *expressionRewriter, exprNode ast.ExprNode, asScal
 	if planCtx != nil && planCtx.plan != nil {
 		curColLen := planCtx.plan.Schema().Len()
 		defer func() {
-			names := planCtx.plan.OutputNames().Shallow()[:curColLen]
+			outPutNames := planCtx.plan.OutputNames()
 			for i := curColLen; i < planCtx.plan.Schema().Len(); i++ {
-				names = append(names, types.EmptyName)
+				outPutNames = append(outPutNames, types.EmptyName)
 			}
 			// After rewriting finished, only old columns are visible.
 			// e.g. select * from t where t.a in (select t1.a from t1);
@@ -302,7 +302,7 @@ func rewriteExprNode(rewriter *expressionRewriter, exprNode ast.ExprNode, asScal
 			// the previous subquery.
 			// So here we just reset the names to empty to avoid this situation.
 			// TODO: implement ScalarSubQuery and resolve it during optimizing. In building phase, we will not change the plan's structure.
-			planCtx.plan.SetOutputNames(names)
+			planCtx.plan.SetOutputNames(outPutNames)
 		}()
 	}
 	exprNode.Accept(rewriter)

--- a/pkg/types/field_name.go
+++ b/pkg/types/field_name.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"bytes"
+	"slices"
 
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/util/size"
@@ -74,9 +75,7 @@ type NameSlice []*FieldName
 
 // Shallow is a shallow copy, only making a new slice.
 func (s NameSlice) Shallow() NameSlice {
-	ret := make(NameSlice, len(s))
-	copy(ret, s)
-	return ret
+	return slices.Clone(s)
 }
 
 // EmptyName is to occupy the position in the name slice. If it's set, that column's name is hidden.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63808

Problem Summary:

### What changed and how does it work?
Since that one can be fixed in place, let's just overwrite it.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
