### PR TITLE
planner: check select or restore-admin privilege for the refresh cmd

### DIFF
--- a/pkg/executor/simple_test.go
+++ b/pkg/executor/simple_test.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/stretchr/testify/require"
@@ -144,4 +146,75 @@ func TestRefreshStatsWhenDatabaseIsEmpty(t *testing.T) {
 	vars.StmtCtx.SetWarnings(nil)
 	tk.MustExec("refresh stats test.*")
 	require.Len(t, vars.StmtCtx.GetWarnings(), 0)
+}
+
+func TestRefreshStatsPrivilegeChecks(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t_refresh_priv")
+	tk.MustExec("create table t_refresh_priv (a int)")
+
+	t.Run("table scope requires select", func(t *testing.T) {
+		tk.MustExec("drop user if exists 'refresh_reader'@'%'")
+		tk.MustExec("create user 'refresh_reader'@'%'")
+		t.Cleanup(func() {
+			tk.MustExec("drop user if exists 'refresh_reader'@'%'")
+		})
+
+		tkUser := testkit.NewTestKit(t, store)
+		require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "refresh_reader", Hostname: "%"}, nil, nil, nil))
+		tkUser.MustGetErrCode("refresh stats test.t_refresh_priv", errno.ErrTableaccessDenied)
+
+		tk.MustExec("grant select on test.t_refresh_priv to 'refresh_reader'@'%'")
+		tkUser.MustExec("refresh stats test.t_refresh_priv")
+	})
+
+	t.Run("database scope requires select", func(t *testing.T) {
+		tk.MustExec("drop user if exists 'refresh_db_reader'@'%'")
+		tk.MustExec("create user 'refresh_db_reader'@'%'")
+		t.Cleanup(func() {
+			tk.MustExec("drop user if exists 'refresh_db_reader'@'%'")
+		})
+
+		tkUser := testkit.NewTestKit(t, store)
+		require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "refresh_db_reader", Hostname: "%"}, nil, nil, nil))
+		tkUser.MustGetErrCode("refresh stats test.*", errno.ErrDBaccessDenied)
+
+		tk.MustExec("grant select on test.* to 'refresh_db_reader'@'%'")
+		tkUser.MustExec("refresh stats test.*")
+	})
+
+	t.Run("global scope requires global select", func(t *testing.T) {
+		tk.MustExec("drop user if exists 'refresh_global_reader'@'%'")
+		tk.MustExec("create user 'refresh_global_reader'@'%'")
+		t.Cleanup(func() {
+			tk.MustExec("drop user if exists 'refresh_global_reader'@'%'")
+		})
+
+		tkUser := testkit.NewTestKit(t, store)
+		require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "refresh_global_reader", Hostname: "%"}, nil, nil, nil))
+		tkUser.MustGetErrCode("refresh stats *.*", errno.ErrPrivilegeCheckFail)
+
+		tk.MustExec("grant select on *.* to 'refresh_global_reader'@'%'")
+		tkUser.MustExec("refresh stats *.*")
+	})
+}
+
+func TestRefreshStatsWithRestoreAdmin(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	const user = "restore_admin_tester"
+	defer tk.MustExec("drop user if exists '" + user + "'@'%'")
+
+	tk.MustExec("drop user if exists '" + user + "'@'%'")
+	tk.MustExec("create user '" + user + "'@'%'")
+
+	tkUser := testkit.NewTestKit(t, store)
+	require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: user, Hostname: "%"}, nil, nil, nil))
+	tkUser.MustGetErrCode("refresh stats *.*", errno.ErrPrivilegeCheckFail)
+
+	tk.MustExec("grant restore_admin on *.* to '" + user + "'@'%'")
+	tkUser.MustExec("refresh stats *.*")
 }

--- a/pkg/executor/simple_test.go
+++ b/pkg/executor/simple_test.go
@@ -158,9 +158,6 @@ func TestRefreshStatsPrivilegeChecks(t *testing.T) {
 	t.Run("table scope requires select", func(t *testing.T) {
 		tk.MustExec("drop user if exists 'refresh_reader'@'%'")
 		tk.MustExec("create user 'refresh_reader'@'%'")
-		t.Cleanup(func() {
-			tk.MustExec("drop user if exists 'refresh_reader'@'%'")
-		})
 
 		tkUser := testkit.NewTestKit(t, store)
 		require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "refresh_reader", Hostname: "%"}, nil, nil, nil))
@@ -173,9 +170,6 @@ func TestRefreshStatsPrivilegeChecks(t *testing.T) {
 	t.Run("database scope requires select", func(t *testing.T) {
 		tk.MustExec("drop user if exists 'refresh_db_reader'@'%'")
 		tk.MustExec("create user 'refresh_db_reader'@'%'")
-		t.Cleanup(func() {
-			tk.MustExec("drop user if exists 'refresh_db_reader'@'%'")
-		})
 
 		tkUser := testkit.NewTestKit(t, store)
 		require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "refresh_db_reader", Hostname: "%"}, nil, nil, nil))
@@ -188,9 +182,6 @@ func TestRefreshStatsPrivilegeChecks(t *testing.T) {
 	t.Run("global scope requires global select", func(t *testing.T) {
 		tk.MustExec("drop user if exists 'refresh_global_reader'@'%'")
 		tk.MustExec("create user 'refresh_global_reader'@'%'")
-		t.Cleanup(func() {
-			tk.MustExec("drop user if exists 'refresh_global_reader'@'%'")
-		})
 
 		tkUser := testkit.NewTestKit(t, store)
 		require.NoError(t, tkUser.Session().Auth(&auth.UserIdentity{Username: "refresh_global_reader", Hostname: "%"}, nil, nil, nil))

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -4870,7 +4870,7 @@ func (b *PlanBuilder) buildRefreshStats(rs *ast.RefreshStatsStmt) (base.Plan, er
 		return nil, err
 	}
 	rs.Dedup()
-	// TODO: We need to check the select privilege here.
+	b.requireSelectOrRestoreAdminPrivForRefreshStats(rs)
 	p := &Simple{
 		Statement:    rs,
 		IsFromRemote: false,
@@ -4898,6 +4898,49 @@ func fillDefaultDBForRefreshStats(ctx base.PlanContext, rs *ast.RefreshStatsStmt
 		obj.DBName = ast.NewCIStr(currentDB)
 	}
 	return nil
+}
+
+func (b *PlanBuilder) requireSelectOrRestoreAdminPrivForRefreshStats(rs *ast.RefreshStatsStmt) {
+	if len(rs.RefreshObjects) == 0 {
+		intest.Assert(len(rs.RefreshObjects) > 0, "RefreshStatsStmt.RefreshObjects should not be empty")
+		return
+	}
+
+	checker := privilege.GetPrivilegeManager(b.ctx)
+	if checker != nil {
+		activeRoles := b.ctx.GetSessionVars().ActiveRoles
+		if checker.RequestDynamicVerification(activeRoles, "RESTORE_ADMIN", false) {
+			return
+		}
+	}
+
+	user := b.ctx.GetSessionVars().User
+	for _, obj := range rs.RefreshObjects {
+		switch obj.RefreshObjectScope {
+		case ast.RefreshObjectScopeGlobal:
+			var err error
+			if user != nil {
+				err = plannererrors.ErrPrivilegeCheckFail.GenWithStackByArgs("SELECT")
+			} else {
+				err = plannererrors.ErrPrivilegeCheckFail
+			}
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, "", "", "", err)
+			return
+		case ast.RefreshObjectScopeDatabase:
+			var err error
+			if user != nil {
+				err = plannererrors.ErrDBaccessDenied.GenWithStackByArgs(user.AuthUsername, user.AuthHostname, obj.DBName.O)
+			}
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, obj.DBName.L, "", "", err)
+		case ast.RefreshObjectScopeTable:
+			dbName := obj.DBName.L
+			var err error
+			if user != nil {
+				err = plannererrors.ErrTableaccessDenied.GenWithStackByArgs("SELECT", user.AuthUsername, user.AuthHostname, obj.TableName.O)
+			}
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName, obj.TableName.L, "", err)
+		}
+	}
 }
 
 // buildLockStats requires INSERT and SELECT privilege for the tables same as buildAnalyze.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/61273

Problem Summary:

### What changed and how does it work?

Do privilege checks for the refresh cmd. We require the select privilege for all tables.

So we require the select privilege for this command, and because this command is mainly for BR, we also add the restore admin permission as a special case.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
