### PR TITLE
expression: fix TiFlash division boolean conversion inconsistency

### DIFF
--- a/pkg/executor/test/tiflashtest/tiflash_division_test.go
+++ b/pkg/executor/test/tiflashtest/tiflash_division_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiflashtest
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/external"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTiFlashDivisionAsPredicate(t *testing.T) {
+	store := testkit.CreateMockStore(t, withMockTiFlash(2))
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	// checkConsistency is a helper function to check if a query returns the same result in TiDB and TiFlash(MPP).
+	checkConsistency := func(query string) {
+		tk.MustExec("set tidb_enforce_mpp = 0")
+		tidbResult := tk.MustQuery(query).Rows()
+		tk.MustExec("set tidb_enforce_mpp = 1")
+		tiflashResult := tk.MustQuery(query).Rows()
+		require.Equal(t, tidbResult, tiflashResult, "Query should return consistent results: %s", query)
+	}
+
+	tk.MustExec(`drop table if exists t_div`)
+	tk.MustExec(`create table t_div (
+		c_int int,
+		c_decimal decimal(10,5),
+		c_float float,
+		c_double double
+	)`)
+	tk.MustExec("alter table t_div set tiflash replica 1")
+	tb := external.GetTableByName(t, tk, "test", "t_div")
+	err := domain.GetDomain(tk.Session()).DDLExecutor().UpdateTableReplicaInfo(tk.Session(), tb.Meta().ID, true)
+	require.NoError(t, err)
+
+	tk.MustExec(`insert into t_div values
+		(65535, 65535.00001, 65535.5, 65535.123456),
+		(1, 1.00001, 1.5, 1.123456),
+		(2, 2.00001, 2.5, 2.123456),
+		(100, 100.123, 100.5, 100.987),
+		(32767, 32767.1, 32767.5, 32767.4)
+	`)
+
+	queries := []string{
+		"select c_int from t_div where (1/c_int)",
+		"select count(*) from t_div where (1/c_int)",
+		"select count(*) from t_div where (1/c_decimal)",
+		"select count(*) from t_div where (1/c_float)",
+		"select count(*) from t_div where (1/c_double)",
+		"select count(*) from t_div where (1/c_int) > 0",
+		"select count(*) from t_div where (1/c_int) and (2/c_int)",
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			checkConsistency(query)
+		})
+	}
+
+	t.Run("DivisionByZero", func(t *testing.T) {
+		tk.MustExec("insert into t_div (c_int) values(0)")
+		// In non-strict SQL mode, division by zero returns NULL. NULL as a boolean predicate is FALSE.
+		tk.MustExec("set sql_mode = ''")
+		checkConsistency("select count(*) from t_div where (1/c_int)")
+
+		// In strict SQL mode, division by zero should produce a warning in TiDB, but the query will still complete.
+		// We check for consistency of the final result.
+		tk.MustExec("set sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO'")
+		checkConsistency("select count(*) from t_div where (1/c_int)")
+	})
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63818

Problem Summary:

TiFlash behaves differently from TiDB when using division expressions as predicates in WHERE clauses. For example:

```sql
create table t0 (c1 int);
insert into t0 (c1) values(65535);

select c1 from t0 where (1/c1); -- Returns (65535) in TiDB
alter table t0 set tiflash replica 1;
SET SESSION tidb_enforce_mpp = ON;
select c1 from t0 where (1/c1); -- Returns empty set in TiFlash
```

The root cause is that TiFlash handles float-to-boolean conversion differently from TiDB. In TiDB, `0.000001` evaluates to `TRUE`, but in TiFlash it evaluates to `FALSE`.

### What changed and how does it work?

This PR modifies the expression pushdown logic in `pkg/expression/infer_pushdown.go` to prevent division expressions that return `float` or `decimal` types from being pushed down to TiFlash when used as predicates.

**Key changes:**
1. Added a check in `canExprPushDown()` function to detect division (`ast.Div`) expressions
2. When the division result type is `ETReal` or `ETDecimal` and the target store is TiFlash, the expression is not pushed down
3. This ensures TiDB handles the boolean conversion, maintaining consistency

**Logic:**
```go
// TiFlash's behavior of converting a float to a bool is different from TiDB.
// e.g. `select 1 where 0.000001` returns 1 in TiDB, but empty in TiFlash.
// So we disable push down for division that returns float/decimal and is used as a predicate.
if sf, ok := expr.(*ScalarFunction); ok && sf.FuncName.L == ast.Div {
    if sf.RetType.EvalType() == types.ETReal || sf.RetType.EvalType() == types.ETDecimal {
        return false
    }
}
```

### Check List

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility
### Release note

```release-note
Fix TiFlash division boolean conversion inconsistency where division expressions used as WHERE predicates returned different results between TiDB and TiFlash.
```