### PR TITLE
docs: fix typos

### DIFF
--- a/docs/design/2022-03-03-rc-read-tso-optimization.md
+++ b/docs/design/2022-03-03-rc-read-tso-optimization.md
@@ -10,7 +10,7 @@ For the `read-committed` isolation level, each read request in a single transact
 If the workload is a read-heavy one whose read QPS is significantly higher than writes or there're few read-write conflicts, fetching ts each time will increase the query lantecy.
 
 The new ts itself is used to ensure the most recent data will be returned, if the data version does not change frequently then it's unnecessary to fetch a new timestamp every time.
-The ts fetching could be processed in an optimistic way that ts fetching happens only when a more recent data version is encoutered, this saves the cost of many unncessary ts fetching.
+The ts fetching could be processed in an optimistic way that ts fetching happens only when a more recent data version is encoutered, this saves the cost of many unnecessary ts fetching.
 
 ## Detailed Design
 

--- a/docs/design/2024-01-09-pipelined-DML.md
+++ b/docs/design/2024-01-09-pipelined-DML.md
@@ -148,7 +148,7 @@ We need to provide a wrapper for the current memdb.
 
 We can mitigate the performance degeneration caused by O(NlogN) complexity of memdb.
 
-At any moment we allow at most 1 memdb to be in the process of flushing. Consider the following operation sequence. It may not be a TiDB case, but we don't want to add more dependency on how TiDB uses it. The final result is expected to be `(x, 2)`. But if there are multiple memdbs flushing concurrently, the handling of the mutations may be totally reversed(`put(x, 2) -> del(x) -> put(x, 1)`) . The final result becoms `(x, 1)`.
+At any moment we allow at most 1 memdb to be in the process of flushing. Consider the following operation sequence. It may not be a TiDB case, but we don't want to add more dependency on how TiDB uses it. The final result is expected to be `(x, 2)`. But if there are multiple memdbs flushing concurrently, the handling of the mutations may be totally reversed(`put(x, 2) -> del(x) -> put(x, 1)`) . The final result becomes `(x, 1)`.
 
 ```Prolog
 put(x, 1)

--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -88,7 +88,7 @@ ut run --race
 ut run --short
 
 // test with long flag
-// when the '--long' flag is set, ut will only run the long tests and have different strategies for concurreny to make them stabler.
+// when the '--long' flag is set, ut will only run the long tests and have different strategies for concurrency to make them stabler.
 ut run --long`
 
 	fmt.Println(msg)


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `becoms` → `becomes`
  - `unncessary` → `unnecessary`
  - `concurreny` → `concurrency`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.



<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
