### PR TITLE
add-index: use max-node-count as hint when split subtasks on nextgen

### DIFF
--- a/pkg/ddl/backfilling_dist_scheduler.go
+++ b/pkg/ddl/backfilling_dist_scheduler.go
@@ -116,7 +116,7 @@ func (sch *LitBackfillScheduler) OnNextSubtasksBatch(
 		// in nextgen, node resource are scaled out automatically, we only consider
 		// the max allowed node for the task, and ignore how many node currently
 		// available.
-		// in some UT, task.MaxNodeCount might be initialized due to below check,
+		// in some UT, task.MaxNodeCount might not initialize due to below check,
 		// so we add a max(1, ...) to avoid nodeCnt being 0:
 		// https://github.com/pingcap/tidb/blob/f13d6599e37d7f660d413c481892e57af418c77d/pkg/ddl/reorg_util.go#L82-L83
 		nodeCnt = max(task.MaxNodeCount, 1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
as title, as in nextgen, node resource are scaled out automatically
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

before this PR, we only have 1 node currently, and only split 1 subtask, even if the max-node-count is 12
```
["initialize reorg meta"] [keyspaceName=10915712792865637958] [category=ddl] [jobID=0] [jobSchema=test] [jobTable=test_01] [jobType="add index"] [enableDistTask=true] [enableFastReorg=true] [targetScope=dxf_service] [maxNodeCount=12] [tableSizeInBytes=698.1GiB] [concurrency=7] [batchSize=256] [amplifyFactor=3]

["calculate region batch"] [keyspaceName=SYSTEM] [category=ddl] [type=backfill] [task-id=450004] [curr-step=init] [next-step=read-index] [totalRegionCnt=2001] [regionBatch=2001] [instanceCnt=1] [useCloud=true]
["schedule subtasks"] [keyspaceName=SYSTEM] [task-id=450004] [task-key=10915712792865637958/ddl/backfill/20] [state=pending] [step=read-index] [concurrency=7] [subtasks=1]
```

after this PR, we mock max-node to be 10, 2 subtasks are splitted, as we only have 2 regions on local environment
```
["calculate region batch"] [keyspaceName=SYSTEM] [category=ddl] [type=backfill] [task-id=6] [node-count=10] [curr-step=init] [next-step=read-index] [totalRegionCnt=2] [regionBatch=1] [instanceCnt=10] [useCloud=false]
["schedule subtasks"] [keyspaceName=SYSTEM] [task-id=6] [task-key=SYSTEM/ddl/backfill/17] [state=pending] [step=read-index] [concurrency=1] [subtasks=2]
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
