### PR TITLE
expression: don't allocate column every time when to newLocalColumnPool

### DIFF
--- a/pkg/expression/builtin_vectorized.go
+++ b/pkg/expression/builtin_vectorized.go
@@ -40,13 +40,13 @@ type localColumnPool struct {
 	sync.Pool
 }
 
-var newColumn = chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), chunk.InitialCapacity)
+var columnTempl = chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), chunk.InitialCapacity)
 
 func newLocalColumnPool() *localColumnPool {
 	return &localColumnPool{
 		sync.Pool{
 			New: func() any {
-				return newColumn.CopyConstruct(nil)
+				return columnTempl.CopyConstruct(nil)
 			},
 		},
 	}

--- a/pkg/expression/builtin_vectorized.go
+++ b/pkg/expression/builtin_vectorized.go
@@ -40,8 +40,9 @@ type localColumnPool struct {
 	sync.Pool
 }
 
+var newColumn = chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), chunk.InitialCapacity)
+
 func newLocalColumnPool() *localColumnPool {
-	newColumn := chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), chunk.InitialCapacity)
 	return &localColumnPool{
 		sync.Pool{
 			New: func() any {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/63809

Problem Summary:

### What changed and how does it work?

<img width="1810" height="134" alt="image" src="https://github.com/user-attachments/assets/f166e6b2-8537-4d54-80e7-f01b56ce6bdd" />

It should use the global object to copy the new object. 
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
