### PR TITLE
executor: add more tests for refresh stats command

### DIFF
--- a/pkg/executor/simple_test.go
+++ b/pkg/executor/simple_test.go
@@ -235,6 +235,17 @@ func TestRefreshStatsWithFullMode(t *testing.T) {
 	statsAfterDefaultRefresh := handle.GetPhysicalTableStats(tbl1Meta.ID, tbl1Meta)
 	require.NotSame(t, statsBeforeRefresh, statsAfterDefaultRefresh)
 	require.Nil(t, statsAfterDefaultRefresh.GetIdx(1), "index stats should not be loaded in lite mode")
+
+	tk.MustExec("select * from t1 where a = 1")
+	statsAfterSelect := handle.GetPhysicalTableStats(tbl1Meta.ID, tbl1Meta)
+	require.NotSame(t, statsBeforeRefresh, statsAfterSelect, "stats versuon should not be changed after select")
+	require.NotNil(t, statsAfterSelect.GetIdx(1), "index stats will be loaded after select")
+
+	tk.MustExec("refresh stats t1")
+	statsAfterDefaultRefresh = handle.GetPhysicalTableStats(tbl1Meta.ID, tbl1Meta)
+	require.NotSame(t, statsBeforeRefresh, statsAfterDefaultRefresh)
+	require.Nil(t, statsAfterDefaultRefresh.GetIdx(1), "index stats should be removed in lite mode")
+
 	// Issue a full refresh to ensure the index stats are loaded.
 	tk.MustExec("refresh stats t1 full")
 	statsAfterFullRefresh := handle.GetPhysicalTableStats(tbl1Meta.ID, tbl1Meta)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/61273

Problem Summary:

### What changed and how does it work?

Add more tests to cover cases where the mode of the refresh stats command conflicts with the current configuration.

1. When lite-init-stats = false: lite refresh stats will not be retained for future loads. We respect the config, since there is no point in keeping lite stats in memory when lite-init-stats is false.
2. When lite-init-stats = true: full refresh stats will be retained for future loads. The purpose of a full load is to fetch all stats and use them later, so we will respect what is already in memory during future loads.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
