### PR TITLE
br: add tool to clean up registry and checkpoints (#61977) | tidb-test=release-8.5-20250114-v8.5.0

### DIFF
--- a/br/pkg/stream/stream_metas.go
+++ b/br/pkg/stream/stream_metas.go
@@ -107,48 +107,51 @@ func (ms *StreamMetadataSet) LoadUntilAndCalculateShiftTS(
 	metadataMap.metas = make(map[string]*MetadataInfo)
 	// `shiftUntilTS` must be less than `until`
 	metadataMap.shiftUntilTS = until
-	err := FastUnmarshalMetaData(ctx, s, ms.MetadataDownloadBatchSize, func(path string, raw []byte) error {
-		m, err := ms.Helper.ParseToMetadataHard(raw)
-		if err != nil {
-			return err
-		}
-		// If the meta file contains only files with ts grater than `until`, when the file is from
-		// `Default`: it should be kept, because its corresponding `write` must has commit ts grater
-		//            than it, which should not be considered.
-		// `Write`: it should trivially not be considered.
-		if m.MinTs <= until {
-			// record these meta-information for statistics and filtering
-			fileGroupInfos := make([]*FileGroupInfo, 0, len(m.FileGroups))
-			for _, group := range m.FileGroups {
-				var kvCount int64 = 0
-				for _, file := range group.DataFilesInfo {
-					kvCount += file.NumberOfEntries
+	err := FastUnmarshalMetaData(ctx, s,
+		0,
+		until,
+		ms.MetadataDownloadBatchSize, func(path string, raw []byte) error {
+			m, err := ms.Helper.ParseToMetadataHard(raw)
+			if err != nil {
+				return err
+			}
+			// If the meta file contains only files with ts grater than `until`, when the file is from
+			// `Default`: it should be kept, because its corresponding `write` must has commit ts grater
+			//            than it, which should not be considered.
+			// `Write`: it should trivially not be considered.
+			if m.MinTs <= until {
+				// record these meta-information for statistics and filtering
+				fileGroupInfos := make([]*FileGroupInfo, 0, len(m.FileGroups))
+				for _, group := range m.FileGroups {
+					var kvCount int64 = 0
+					for _, file := range group.DataFilesInfo {
+						kvCount += file.NumberOfEntries
+					}
+					fileGroupInfos = append(fileGroupInfos, &FileGroupInfo{
+						MaxTS:   group.MaxTs,
+						Length:  group.Length,
+						KVCount: kvCount,
+					})
 				}
-				fileGroupInfos = append(fileGroupInfos, &FileGroupInfo{
-					MaxTS:   group.MaxTs,
-					Length:  group.Length,
-					KVCount: kvCount,
-				})
+				metadataMap.Lock()
+				metadataMap.metas[path] = &MetadataInfo{
+					MinTS:          m.MinTs,
+					FileGroupInfos: fileGroupInfos,
+				}
+				metadataMap.Unlock()
 			}
-			metadataMap.Lock()
-			metadataMap.metas[path] = &MetadataInfo{
-				MinTS:          m.MinTs,
-				FileGroupInfos: fileGroupInfos,
+			// filter out the metadatas whose ts-range is overlap with [until, +inf)
+			// and calculate their minimum begin-default-ts
+			ts, ok := UpdateShiftTS(m, until, mathutil.MaxUint)
+			if ok {
+				metadataMap.Lock()
+				if ts < metadataMap.shiftUntilTS {
+					metadataMap.shiftUntilTS = ts
+				}
+				metadataMap.Unlock()
 			}
-			metadataMap.Unlock()
-		}
-		// filter out the metadatas whose ts-range is overlap with [until, +inf)
-		// and calculate their minimum begin-default-ts
-		ts, ok := UpdateShiftTS(m, until, mathutil.MaxUint)
-		if ok {
-			metadataMap.Lock()
-			if ts < metadataMap.shiftUntilTS {
-				metadataMap.shiftUntilTS = ts
-			}
-			metadataMap.Unlock()
-		}
-		return nil
-	})
+			return nil
+		})
 	if err != nil {
 		return 0, errors.Trace(err)
 	}

--- a/br/pkg/stream/stream_mgr.go
+++ b/br/pkg/stream/stream_mgr.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
@@ -42,6 +44,20 @@ const (
 
 	streamBackupGlobalCheckpointPrefix = "v1/global_checkpoint"
 )
+
+// metaPattern is a regular expression used to match backup metadata filenames.
+// The expected filename format is:
+//
+//	{flushTs}-{minDefaultTs}-{minTs}-{maxTs}.meta
+//
+// where each part is a hexadecimal string (0-9, a-f, A-F).
+// Example:
+//
+//	0000000000000001-0000000000003039-065CCFF1D8AC0000-065CCFF1D8AC0006.meta
+//
+// The pattern captures all four parts as separate groups.
+// Leading zeros are necessary for the pattern to match.
+var metaPattern = regexp.MustCompile(`^([0-9a-fA-F]{16})-([0-9a-fA-F]{16})-([0-9a-fA-F]{16})-([0-9a-fA-F]{16})$`)
 
 func GetStreamBackupMetaPrefix() string {
 	return streamBackupMetaPrefix
@@ -365,11 +381,49 @@ func (m *MetadataHelper) Close() {
 	}
 }
 
+func FilterPathByTs(path string, left, right uint64) string {
+	filename := strings.TrimSuffix(path, ".meta")
+	filename = filename[strings.LastIndex(filename, "/")+1:]
+
+	if metaPattern.MatchString(filename) {
+		matches := metaPattern.FindStringSubmatch(filename)
+		if len(matches) < 5 {
+			log.Warn("invalid meta file name format", zap.String("file", path))
+			// consider compatible with future file path change
+			return path
+		}
+
+		flushTs, _ := strconv.ParseUint(matches[1], 16, 64)
+		minDefaultTs, _ := strconv.ParseUint(matches[2], 16, 64)
+		minTs, _ := strconv.ParseUint(matches[3], 16, 64)
+		maxTs, _ := strconv.ParseUint(matches[4], 16, 64)
+
+		if minDefaultTs == 0 || minDefaultTs > minTs {
+			log.Warn("minDefaultTs is not correct, fallback to minTs",
+				zap.String("file", path),
+				zap.Uint64("flushTs", flushTs),
+				zap.Uint64("minTs", minTs),
+				zap.Uint64("minDefaultTs", minDefaultTs),
+			)
+			minDefaultTs = minTs
+		}
+
+		if right < minDefaultTs || maxTs < left {
+			return ""
+		}
+	}
+
+	// keep consistency with old behaviour
+	return path
+}
+
 // FastUnmarshalMetaData used a 128 worker pool to speed up
 // read metadata content from external_storage.
 func FastUnmarshalMetaData(
 	ctx context.Context,
 	s storage.ExternalStorage,
+	startTS uint64,
+	endTS uint64,
 	metaDataWorkerPoolSize uint,
 	fn func(path string, rawMetaData []byte) error,
 ) error {
@@ -381,7 +435,15 @@ func FastUnmarshalMetaData(
 		if !strings.HasSuffix(path, metaSuffix) {
 			return nil
 		}
-		readPath := path
+		readPath := FilterPathByTs(path, startTS, endTS)
+		if len(readPath) == 0 {
+			log.Info("skip download meta file out of range",
+				zap.String("file", path),
+				zap.Uint64("startTs", startTS),
+				zap.Uint64("endTs", endTS),
+			)
+			return nil
+		}
 		pool.ApplyOnErrorGroup(eg, func() error {
 			b, err := s.ReadFile(ectx, readPath)
 			if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref https://github.com/pingcap/tidb/issues/61318

### What changed and how does it work?
Improved timestamp-based filtering logic for pitr .
Ensured compatibility with previous and future versions of TiKV by gracefully handling unexpected or legacy formats.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
