### PR TITLE
planner: fix binding usage for prepare query with order by clause

### DIFF
--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -347,6 +347,15 @@ var testSQLs = []struct {
 		memoryUsage: float64(166),
 	},
 	{
+		createSQL:   "binding for select min(i),s from t group by s order by min(i) using select min(i),s from t use index(index_t) group by s order by min(i)",
+		overlaySQL:  "",
+		querySQL:    "select min(i),s from t group by s order by min(t.i)",
+		originSQL:   "select min ( `i` ) , `s` from `test` . `t` group by `s` order by min ( `i` )",
+		bindSQL:     "SELECT min(`i`),`s` FROM `test`.`t` USE INDEX (`index_t`) GROUP BY `s` ORDER BY min(`i`)",
+		dropSQL:     "binding for select min(i),s from t group by s order by min(i)",
+		memoryUsage: float64(256),
+	},
+	{
 		createSQL:   "binding for delete from t where i = 1 using delete /*+ use_index(t,index_t) */ from t where i = 1",
 		overlaySQL:  "",
 		querySQL:    "delete    from t where   i = 2",

--- a/pkg/bindinfo/session_handle_test.go
+++ b/pkg/bindinfo/session_handle_test.go
@@ -89,7 +89,7 @@ func TestSessionBinding(t *testing.T) {
 		}
 
 		handle := tk.Session().Value(bindinfo.SessionBindInfoKeyType).(bindinfo.SessionBindingHandle)
-		stmt, err := parser.New().ParseOneStmt(testSQL.originSQL, "", "")
+		stmt, err := parser.New().ParseOneStmt(testSQL.querySQL, "", "")
 		require.NoErrorf(t, err, "testSQL %+v", testSQL)
 
 		_, noDBDigest := bindinfo.NormalizeStmtForBinding(stmt, "", true)

--- a/pkg/util/parser/ast.go
+++ b/pkg/util/parser/ast.go
@@ -145,7 +145,7 @@ func RestoreWithDefaultDB(node ast.StmtNode, defaultDB, origin string) string {
 // This function is customized for universal SQL binding.
 func RestoreWithoutDB(node ast.StmtNode) string {
 	var sb strings.Builder
-	ctx := format.NewRestoreCtx(defaultRestoreFlag|format.RestoreWithoutSchemaName, &sb)
+	ctx := format.NewRestoreCtx(defaultRestoreFlag|format.RestoreWithoutSchemaName|format.RestoreWithoutTableName, &sb)
 	if err := node.Restore(ctx); err != nil {
 		logutil.BgLogger().Debug("restore SQL failed", zap.String("category", "sql-bind"), zap.Error(err))
 		return ""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63805

Problem Summary:
Using prepare statement with ORDER BY doesn't use bindings

### What changed and how does it work?
Possible bindings are selected by comparing the normalized statement for the binding with the current running statement. Since the prepared statements are stored based on the plan from `GeneratePlanCacheStmtWithAST`, there is additional handling in `havingWindowAndOrderbyExprResolver` which changes the `ColumnNameExpr` in the AST.

This means that the normalized SQL is
```
binding:            "select min ( `id` ) , `a` from `t` where `a` = ? group by `a` order by min ( `id` )"
prepared statement: "select min ( `id` ) , `a` from `t` where `a` = ? group by `a` order by min ( `t` . `id` )"
```
Since there's a mismatch, the binding isn't used for the prepared statement.

By changing the normalization code (specifically `utilparser.RestoreWithoutDB`) to use the `format.RestoreWithoutTableName` flag, it makes sure that the prepared statement after normalization doesn't use the table name from the `ColumnNameExpr`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Manual testing was done by trying the reproduction from the attached issue. After this fix, the issue no longer reoccurs.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that prepare query with ORDER BY clause does not use SQL bindings
```
