### PR TITLE
tests: small fix of test of index_lookup_pushdown.test

### DIFF
--- a/tests/integrationtest/r/executor/index_lookup_pushdown.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown.result
@@ -1,5 +1,5 @@
 drop table if exists t1, t2, t3, t4, t5, t6, t7, tmp1, tmp2;
-create table t1(id int, a varchar(32), b int, c int, index i(a, b));
+create table t1(id int primary key, a varchar(32), b int, c int, index i(a, b));
 create table t2(a int, b int, c int, d int, primary key(a, b) CLUSTERED, index i(c));
 create table t3 (
 id int primary key,
@@ -61,7 +61,7 @@ id	a	b	c
 9	1i	90	900
 explain select /*+ index_lookup_pushdown(t1, i) */ id, a, b + 1, c + 2 from t1 where a < '8' and b < 90 and c != 500 limit 4;
 id	estRows	task	access object	operator info
-Projection_7	4.00	root		executor__index_lookup_pushdown.t1.id, executor__index_lookup_pushdown.t1.a, plus(executor__index_lookup_pushdown.t1.b, 1)->Column#6, plus(executor__index_lookup_pushdown.t1.c, 2)->Column#7
+Projection_7	4.00	root		executor__index_lookup_pushdown.t1.id, executor__index_lookup_pushdown.t1.a, plus(executor__index_lookup_pushdown.t1.b, 1)->Column#5, plus(executor__index_lookup_pushdown.t1.c, 2)->Column#6
 └─Limit_10	4.00	root		offset:0, count:4
   └─IndexLookUp_18	4.00	root		
     ├─Limit_19(Build)	4.00	cop[tikv]		offset:0, count:4
@@ -167,14 +167,14 @@ select @@last_plan_from_cache;
 1
 explain select /*+ index_lookup_pushdown(t1, i) agg_to_cop() */ count(1) from t1 where a > '1i' and c > 300;
 id	estRows	task	access object	operator info
-HashAgg_16	1.00	root		funcs:count(Column#9)->Column#6
+HashAgg_16	1.00	root		funcs:count(Column#8)->Column#5
 └─IndexLookUp_17	1.00	root		
-  ├─HashAgg_18(Build)	1.00	cop[tikv]		funcs:count(1)->Column#9
+  ├─HashAgg_18(Build)	1.00	cop[tikv]		funcs:count(1)->Column#8
   │ └─Selection_19	1111.11	cop[tikv]		gt(executor__index_lookup_pushdown.t1.c, 300)
   │   └─LocalIndexLookUp_21	3333.33	cop[tikv]		index handle offsets:[2]
   │     ├─IndexRangeScan_13(Build)	3333.33	cop[tikv]	table:t1, index:i(a, b)	range:("1i",+inf], keep order:false, stats:pseudo
   │     └─TableRowIDScan_20(Probe)	3333.33	cop[tikv]	table:t1	keep order:false, stats:pseudo
-  └─HashAgg_8(Probe)	0.00	cop[tikv]		funcs:count(1)->Column#9
+  └─HashAgg_8(Probe)	0.00	cop[tikv]		funcs:count(1)->Column#8
     └─Selection_15	0.00	cop[tikv]		gt(executor__index_lookup_pushdown.t1.c, 300)
       └─TableRowIDScan_14	0.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 select /*+ index_lookup_pushdown(t1, i) agg_to_cop() */ count(1) from t1 where a > '1i' and c > 300;
@@ -220,10 +220,9 @@ Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, common handle table is not supported
 explain select /*+ index_lookup_pushdown(t1, i) */ * from t1 where a > 'a' order by a asc;
 id	estRows	task	access object	operator info
-Projection_19	3333.33	root		executor__index_lookup_pushdown.t1.id, executor__index_lookup_pushdown.t1.a, executor__index_lookup_pushdown.t1.b, executor__index_lookup_pushdown.t1.c
-└─IndexLookUp_18	3333.33	root		
-  ├─IndexRangeScan_16(Build)	3333.33	cop[tikv]	table:t1, index:i(a, b)	range:("a",+inf], keep order:true, stats:pseudo
-  └─TableRowIDScan_17(Probe)	3333.33	cop[tikv]	table:t1	keep order:false, stats:pseudo
+IndexLookUp_18	3333.33	root		
+├─IndexRangeScan_16(Build)	3333.33	cop[tikv]	table:t1, index:i(a, b)	range:("a",+inf], keep order:true, stats:pseudo
+└─TableRowIDScan_17(Probe)	3333.33	cop[tikv]	table:t1	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, keep order is not supported.
 explain select /*+ index_lookup_pushdown(t3, a) */ * from t3 where id < 100 and a = 1;

--- a/tests/integrationtest/t/executor/index_lookup_pushdown.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown.test
@@ -1,5 +1,5 @@
 drop table if exists t1, t2, t3, t4, t5, t6, t7, tmp1, tmp2;
-create table t1(id int, a varchar(32), b int, c int, index i(a, b));
+create table t1(id int primary key, a varchar(32), b int, c int, index i(a, b));
 create table t2(a int, b int, c int, d int, primary key(a, b) CLUSTERED, index i(c));
 create table t3 (
     id int primary key,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63745

Problem Summary:

The test table t1 in `index_lookup_pushdown.test` does not set id as primary key, fix it.

### What changed and how does it work?

see proble summary

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
