### PR TITLE
metric: show import-into merge speed in nextgen

### DIFF
--- a/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
+++ b/pkg/metrics/nextgengrafana/tidb_with_keyspace_name.json
@@ -24082,7 +24082,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Total encode/deliver/merge/import-kv speed of distributed task.",
+          "description": "Total encode/deliver/import-kv speed of distributed task.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -24145,14 +24145,6 @@
               "interval": "",
               "legendFormat": "import kv - {{task_id}}",
               "refId": "C"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", keyspace_name=~\"$keyspace_name\", instance=~\"$instance\", state=\"merged\"}[1m])) by(task_id)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "merged - {{task_id}}",
-              "refId": "D"
             }
           ],
           "thresholds": [],

--- a/pkg/metrics/nextgengrafana/tidb_worker.json
+++ b/pkg/metrics/nextgengrafana/tidb_worker.json
@@ -24082,7 +24082,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Total encode/deliver/import-kv speed of distributed task.",
+          "description": "Total encode/deliver/merge/import-kv speed of distributed task.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []
@@ -24145,6 +24145,14 @@
               "interval": "",
               "legendFormat": "import kv - {{task_id}}",
               "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(rate(tidb_import_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", state=\"merged\"}[1m])) by(task_id)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "merged - {{task_id}}",
+              "refId": "D"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
merge speed is gathered after https://github.com/pingcap/tidb/pull/62550, but we forget to add it for nextgen when add panels for tidb-worker in https://github.com/pingcap/tidb/pull/63510
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
