### PR TITLE
statistics: avoid memory in the convertBytesToScalar

### DIFF
--- a/pkg/statistics/scalar.go
+++ b/pkg/statistics/scalar.go
@@ -175,6 +175,8 @@ func commonPrefixLength(strs ...[]byte) int {
 func convertBytesToScalar(value []byte) float64 {
 	// Bytes type is viewed as a base-256 value, so we only consider at most 8 bytes.
 	switch len(value) {
+	case 0:
+		return 0
 	case 1:
 		return float64(uint64(value[0]) << 56)
 	case 2:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64020

Problem Summary:

### What changed and how does it work?

I find it in the profiler.

<img width="1909" height="252" alt="image" src="https://github.com/user-attachments/assets/978730ab-f771-41c0-bb25-0e76fe2e0057" />


<img width="644" height="165" alt="Image" src="https://github.com/user-attachments/assets/66f72c48-56c1-4bfe-83d2-1c0ae6e02b8b" />

convertBytesToScalar will create a new buffer to get scale. it is unnecessary.

<img width="780" height="136" alt="Image" src="https://github.com/user-attachments/assets/fd98ce4b-1d29-42fc-9258-a8fbb816a732" />

```bigEndian.Uint64``` will not break the origin buffer.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
