### PR TITLE
stats: show index should load stats when cache miss

### DIFF
--- a/pkg/executor/show_test.go
+++ b/pkg/executor/show_test.go
@@ -182,7 +182,7 @@ func TestShowIndexNDVFetchFromStorageWithoutCachePollution(t *testing.T) {
 
 	dom.StatsHandle().Clear()
 
-	// show index fetches all NDVs from storage for consistency
+	// when cache is empty, show index fetches all NDVs from storage
 	rows := tk.MustQuery("show index from t").Rows()
 	require.GreaterOrEqual(t, len(rows), 3)
 	ndvs := map[string]string{}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63215
Clone from #63479.

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
for SHOW INDEX's cardinality, if there are no stats in cache, try to fetch it directly from TiKV, if fails, set to 0
```
