### PR TITLE
stats: SHOW INDEX now tries to read NDV from TiKV if not in cache.

### DIFF
--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -64,6 +64,8 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/vardef"
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/sessiontxn"
+	"github.com/pingcap/tidb/pkg/statistics"
+	statsutil "github.com/pingcap/tidb/pkg/statistics/handle/util"
 	"github.com/pingcap/tidb/pkg/store/helper"
 	"github.com/pingcap/tidb/pkg/table"
 	"github.com/pingcap/tidb/pkg/table/tables"
@@ -797,19 +799,23 @@ func (e *ShowExec) fetchShowIndex() error {
 		return e.tableAccessDenied("SELECT", tb.Meta().Name.O)
 	}
 
+	// determine pk column if clustered
+	var pkCol *table.Column
 	if tb.Meta().PKIsHandle {
-		var pkCol *table.Column
 		for _, col := range tb.Cols() {
 			if mysql.HasPriKeyFlag(col.GetFlag()) {
 				pkCol = col
 				break
 			}
 		}
-		colStats := statsTbl.GetCol(pkCol.ID)
-		var ndv int64
-		if colStats != nil {
-			ndv = colStats.NDV
-		}
+	}
+
+	// check cache first; if all exist use cache, otherwise fetch all from storage for consistency
+	ndvByColID := e.prefetchColumnNDVs(tb, statsTbl, pkCol)
+
+	if pkCol != nil {
+		pkColInfo := tb.Meta().GetColumnByID(pkCol.ID)
+		ndv := ndvByColID[pkColInfo.ID]
 		e.appendRow([]any{
 			tb.Meta().Name.O, // Table
 			0,                // Non_unique
@@ -874,11 +880,7 @@ func (e *ShowExec) fetchShowIndex() error {
 				expression = tblCol.GeneratedExprString
 			}
 
-			colStats := statsTbl.GetCol(tblCol.ID)
-			var ndv int64
-			if colStats != nil {
-				ndv = colStats.NDV
-			}
+			ndv := ndvByColID[tblCol.ID]
 
 			e.appendRow([]any{
 				tb.Meta().Name.O,       // Table
@@ -902,6 +904,80 @@ func (e *ShowExec) fetchShowIndex() error {
 		}
 	}
 	return nil
+}
+
+// prefetchColumnNDVs checks cache first; if all exist uses cache, otherwise fetches all from storage for consistency
+func (e *ShowExec) prefetchColumnNDVs(tb table.Table, statsTbl *statistics.Table, pkCol *table.Column) map[int64]int64 {
+	var colIDs []int64
+
+	// collect pk column
+	if pkCol != nil {
+		colIDs = append(colIDs, pkCol.ID)
+	}
+
+	// collect index columns
+	for _, idx := range tb.Indices() {
+		idxInfo := idx.Meta()
+		if idxInfo.State != model.StatePublic {
+			continue
+		}
+		for _, ic := range idxInfo.Columns {
+			tblCol := tb.Meta().Columns[ic.Offset]
+			if tblCol.Hidden {
+				continue
+			}
+			colIDs = append(colIDs, tblCol.ID)
+		}
+	}
+
+	// check if all columns exist in cache
+	allInCache := !statsTbl.Pseudo
+	if allInCache {
+		for _, colID := range colIDs {
+			if statsTbl.GetCol(colID) == nil {
+				allInCache = false
+				break
+			}
+		}
+	}
+
+	ndvByColID := make(map[int64]int64)
+	if allInCache {
+		// fast path: all in cache, use cache
+		for _, colID := range colIDs {
+			ndvByColID[colID] = statsTbl.GetCol(colID).NDV
+		}
+	} else {
+		// fetch all from storage for consistency
+		colIDStrs := make([]string, len(colIDs))
+		for i, colID := range colIDs {
+			colIDStrs[i] = strconv.FormatInt(colID, 10)
+		}
+		ndvByColID, _ = fetchColumnNDVs(e.Ctx(), tb.Meta().ID, colIDStrs)
+	}
+
+	return ndvByColID
+}
+
+const selectNDVForColumnsQuery = "SELECT hist_id, distinct_count FROM mysql.stats_histograms WHERE table_id = %? AND is_index = 0 AND hist_id IN (%?)"
+
+// fetchColumnNDVs loads NDVs for the given column IDs from storage in one round-trip without mutating stats cache
+func fetchColumnNDVs(ctx sessionctx.Context, tableID int64, columnIDs []string) (map[int64]int64, error) {
+	ndvByColID := make(map[int64]int64, len(columnIDs))
+	if len(columnIDs) == 0 {
+		return ndvByColID, nil
+	}
+	// use session pool instead of current session to avoid transaction conflicts
+	rows, _, err := statsutil.ExecWithOpts(ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseSessionPool}, selectNDVForColumnsQuery, tableID, columnIDs)
+	if err != nil {
+		return ndvByColID, err
+	}
+	for _, r := range rows {
+		histID := r.GetInt64(0)
+		distinctCnt := r.GetInt64(1)
+		ndvByColID[histID] = distinctCnt
+	}
+	return ndvByColID, nil
 }
 
 // fetchShowCharset gets all charset information and fill them into e.rows.

--- a/pkg/executor/show_test.go
+++ b/pkg/executor/show_test.go
@@ -15,6 +15,7 @@
 package executor_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/executor/importer"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/auth"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -166,4 +168,43 @@ func TestShowSessionStates(t *testing.T) {
 	tk1 := testkit.NewTestKit(t, store)
 	require.NoError(t, tk1.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil, nil))
 	tk1.MustQuery("show session_states").CheckAt([]int{1}, testkit.Rows("<nil>"))
+}
+
+func TestShowIndexNDVFetchFromStorageWithoutCachePollution(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	// disable auto analyze to prevent race conditions
+	originalAutoAnalyze := tk.MustQuery("select @@global.tidb_enable_auto_analyze").Rows()[0][0].(string)
+	tk.MustExec("set global tidb_enable_auto_analyze = 0")
+	defer tk.MustExec("set global tidb_enable_auto_analyze = " + originalAutoAnalyze)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int primary key, b int, c int, index ib(b, c))")
+	tk.MustExec("insert into t values (1,10,100),(2,20,200),(3,30,300),(4,40,400),(5,50,500)")
+	tk.MustExec("analyze table t")
+
+	dom.StatsHandle().Clear()
+
+	// when cache is empty, show index fetches all NDVs from storage
+	rows := tk.MustQuery("show index from t").Rows()
+	require.GreaterOrEqual(t, len(rows), 3)
+	ndvs := map[string]string{}
+	for _, r := range rows {
+		keyName := r[2].(string)
+		colName := r[4].(string)
+		card := r[6].(string)
+		ndvs[keyName+":"+colName] = card
+	}
+	require.NotEqual(t, "0", ndvs["PRIMARY:a"])
+	require.NotEqual(t, "0", ndvs["ib:b"])
+	require.NotEqual(t, "0", ndvs["ib:c"])
+
+	// verify cache remains unpolluted after show index
+	is := dom.InfoSchema()
+	tbl, err := is.TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	statsTbl := dom.StatsHandle().GetPhysicalTableStats(tbl.Meta().ID, tbl.Meta())
+	require.True(t, statsTbl.Pseudo)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63215
Clone from #63479.

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
for SHOW INDEX's cardinality, if there are no stats in cache, try to fetch it directly from TiKV, if fails, set to 0
```
