### PR TITLE
planner: only call `TableInfo.Cols()` once, rather than for every column

### DIFF
--- a/pkg/planner/core/indexmerge_path.go
+++ b/pkg/planner/core/indexmerge_path.go
@@ -983,10 +983,11 @@ func PrepareIdxColsAndUnwrapArrayType(
 	tblCols []*expression.Column,
 	checkOnly1ArrayTypeCol bool,
 ) (idxCols []*expression.Column, ok bool) {
+	colInfos := tableInfo.Cols()
 	var virColNum = 0
 	for i := range idxInfo.Columns {
 		colOffset := idxInfo.Columns[i].Offset
-		colMeta := tableInfo.Cols()[colOffset]
+		colMeta := colInfos[colOffset]
 		var col *expression.Column
 		for _, c := range tblCols {
 			if c.ID == colMeta.ID {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #63856 

Problem Summary: Profiling the time spent in the optimizer repeatedly executing, for 2 minutes, a [query on a table like this](https://github.com/pingcap/tidb/issues/63856#issue-3496225000), but with many more indexes (500) and columns (6,500), reveals that ~24% of the time is spent in `plannercore.PrepareIdxColsAndUnwrapArrayType()`, largely due to this function repeatedly calling `TableInfo.Cols()` once for every column in a table. Instead, we should just call this function once and reuse the returned result for every column.

### What changed and how does it work?

Hoist `TableInfo.Cols()` out of the for loop and into a local variable, which is used inside the for loop. Over the course of a two minute test, this change reduces the cumulative time spent in `plannercore.PrepareIdxColsAndUnwrapArrayType()` from ~24 seconds (~24%) to ~7.3 seconds (~8%).

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```