### PR TITLE
ci: make Bazel output root configurable and fix next-gen bootstrap data-dir/cleanup

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -70,8 +70,8 @@ PACKAGES  ?= $$($(PACKAGE_LIST))
 PACKAGES_TIDB_TESTS ?= $$($(PACKAGE_LIST_TIDB_TESTS))
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/$(PROJECT)/||'
 PACKAGE_DIRECTORIES_TIDB_TESTS := $(PACKAGE_LIST_TIDB_TESTS) | sed 's|github.com/pingcap/$(PROJECT)/||'
-FILES     := $$(find $$($(PACKAGE_DIRECTORIES)) -name "*.go")
-FILES_TIDB_TESTS := $$(find $$($(PACKAGE_DIRECTORIES_TIDB_TESTS)) -name "*.go")
+FILES     := $$($(PACKAGE_DIRECTORIES))
+FILES_TIDB_TESTS := $$($(PACKAGE_DIRECTORIES_TIDB_TESTS))
 
 UNCONVERT_PACKAGES_LIST := go list ./...| grep -vE "lightning\/checkpoints|lightning\/manual|lightning\/common|tidb-binlog\/proto\/go-binlog"
 UNCONVERT_PACKAGES := $$($(UNCONVERT_PACKAGES_LIST))
@@ -139,9 +139,11 @@ DUMPLING_GOTEST  := CGO_ENABLED=1 GO111MODULE=on go test -ldflags '$(DUMPLING_LD
 TEST_COVERAGE_DIR := "test_coverage"
 
 ifneq ("$(CI)", "")
-	BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp
-	BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp
-	BAZEL_SYNC_CONFIG := --repository_cache=/home/jenkins/.tidb/tmp
+	# Prefer WORKSPACE (Jenkins) then HOME for Bazel caches/output; avoids hardcoding /home/jenkins
+	BAZEL_OUTPUT_ROOT ?= $(if $(WORKSPACE),$(WORKSPACE),$(HOME))/.tidb/tmp
+	BAZEL_GLOBAL_CONFIG := --output_user_root=$(BAZEL_OUTPUT_ROOT)
+	BAZEL_CMD_CONFIG := --config=ci --repository_cache=$(BAZEL_OUTPUT_ROOT)
+	BAZEL_SYNC_CONFIG := --repository_cache=$(BAZEL_OUTPUT_ROOT)
 endif
 BAZEL_INSTRUMENTATION_FILTER := --instrument_test_targets --instrumentation_filter=//pkg/...,//br/...,//dumpling/...
 

--- a/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
+++ b/tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh
@@ -38,9 +38,9 @@ function main() {
     bin/pd-server --name=pd-0 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd0.log &
     bin/pd-server --name=pd-1 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd1.log &
     bin/pd-server --name=pd-2 --config=${config_dir}/pd.toml --data-dir=${data_base_dir}/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster --log-file=pd2.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
-    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}/tikv-0/data --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv0.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}/tikv-1/data --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv1.log &
+    bin/tikv-server --config=${config_dir}/tikv.toml --data-dir=${data_base_dir}/tikv-2/data --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv2.log &
     bin/tikv-worker --config=${config_dir}/tikv-worker.toml --data-dir=${data_base_dir}/tikv-worker/data --addr=127.0.0.1:19000 --pd-endpoints=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --log-file=tikv-worker.log &
 
     sleep 10
@@ -104,14 +104,17 @@ function cleanup() {
         killall -9 -r -q minio || true
     fi
 
-    make failpoint-disable
+    # Ensure we run from repo root even if invoked from a subdir
+    local repo_root
+    repo_root="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../../.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+    make -C "${repo_root}" failpoint-disable || true
 }
 
 exit_code=0
 { # try block
     main "$@"
 } || { # catch block
-   exit_code="$?"  # exit code of last command which is 44
+   exit_code="$?"  # exit code of last command
 }
 # finally block:
 cleanup


### PR DESCRIPTION
What
- Make Bazel output/cache root configurable via BAZEL_OUTPUT_ROOT in CI instead of hardcoding /home/jenkins/.tidb/tmp.
  - Default to $WORKSPACE/.tidb/tmp when WORKSPACE is set (Jenkins), otherwise $HOME/.tidb/tmp.
  - Derive BAZEL_GLOBAL_CONFIG / BAZEL_CMD_CONFIG / BAZEL_SYNC_CONFIG from it.
- Fix tests/realtikvtest/scripts/next-gen/bootstrap-test-with-cluster.sh:
  - Add missing slashes for TiKV --data-dir paths: ${data_base_dir}/tikv-{0,1,2}/data
  - Ensure cleanup runs failpoint-disable from the repo root even when invoked from subdirectories.

Why
- Recent CI runs in Jenkins show Bazel failing with:
  FATAL: mkdir('/home/jenkins/.tidb/tmp'): (error: 13): Permission denied
  This happens when /home/jenkins is not writable in the k8s agent containers. Allowing the cache/output root to fall back to $WORKSPACE or $HOME resolves this class of failures.
- The bootstrap script had incorrect TiKV data-dir paths (missing slash) and would sometimes fail to find the Makefile for failpoint-disable during cleanup when invoked from nested directories.

Impact
- CI stability improvements for Bazel-based tasks across diverse Jenkins pod templates.
- Corrected real TiKV test environment and more robust cleanup regardless of working directory.

Notes
- No behavior change for local dev environments.
- If downstream jobs override BAZEL_OUTPUT_ROOT explicitly, that continues to work.
