### PR TITLE
planner: fix TRUNCATE null handling with unsigned-flag check

### DIFF
--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2154,19 +2154,13 @@ func (b *builtinTruncateIntSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
 	x, isNull, err := b.args[0].EvalInt(ctx, row)
-	if err != nil {
+	if isNull || err != nil {
 		return 0, true, err
-	}
-	if isNull {
-		return 0, true, nil
 	}
 
 	d, isNull, err := b.args[1].EvalInt(ctx, row)
-	if err != nil {
+	if isNull || err != nil {
 		return 0, true, err
-	}
-	if isNull {
-		return 0, true, nil
 	}
 
 	if mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()) {
@@ -2203,28 +2197,22 @@ type builtinTruncateUintSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64, bool, error) {
 	x, isNull, err := b.args[0].EvalInt(ctx, row)
-	if err != nil {
+	if isNull || err != nil {
 		return 0, true, err
-	}
-	if isNull {
-		return 0, true, nil
 	}
 
 	if mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()) {
 		return x, false, nil
 	}
+	uintx := uint64(x)
 
 	d, isNull, err := b.args[1].EvalInt(ctx, row)
-	if err != nil {
+	if isNull || err != nil {
 		return 0, true, err
 	}
-	if isNull {
-		return 0, true, nil
-	}
 
-	uintx := uint64(x)
 	if d >= 0 {
-		return int64(uintx), false, nil
+		return x, false, nil
 	}
 
 	// -MinInt = MinInt, special case

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2219,10 +2219,6 @@ func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 		return 0, true, nil
 	}
 
-	if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
-		return x, false, nil
-	}
-
 	uintx := uint64(x)
 	if d >= 0 {
 		return int64(uintx), false, nil
@@ -2233,6 +2229,7 @@ func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 		return 0, false, nil
 	}
 
+	// Truncation logic for d < 0:
 	shift := uint64(math.Pow10(int(-d)))
 	return int64(uintx / shift * shift), false, nil
 }

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2169,8 +2169,7 @@ func (b *builtinTruncateIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 		return 0, true, nil
 	}
 
-	// unsigned doesn't affect truncation logic here
-	if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
+	if mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()) {
 		return x, false, nil
 	}
 
@@ -2209,6 +2208,10 @@ func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 	}
 	if isNull {
 		return 0, true, nil
+	}
+
+	if mysql.HasUnsignedFlag(b.args[1].GetType(ctx).GetFlag()) {
+		return x, false, nil
 	}
 
 	d, isNull, err := b.args[1].EvalInt(ctx, row)

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2174,13 +2174,9 @@ func (b *builtinTruncateIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 		return x, false, nil
 	}
 
-	if d >= 0 {
-		return x, false, nil
-	}
-
-	if d == mathutil.MinInt {
-		return 0, false, nil
-	}
+	if d >= 0 || d == mathutil.MinInt { 
+        return x, false, nil // or int64(uintx), false, nil for UintSig
+    }
 
 	shift := int64(math.Pow10(int(-d)))
 	return x / shift * shift, false, nil
@@ -2219,13 +2215,9 @@ func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 	}
 
 	uintx := uint64(x)
-	if d >= 0 {
-		return int64(uintx), false, nil
-	}
-
-	if d == mathutil.MinInt {
-		return 0, false, nil
-	}
+	if d >= 0 || d == mathutil.MinInt { 
+        return int64(uintx), false, nil
+    }
 
 	shift := uint64(math.Pow10(int(-d)))
 	return int64(uintx / shift * shift), false, nil

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2174,9 +2174,13 @@ func (b *builtinTruncateIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 		return x, false, nil
 	}
 
-	if d >= 0 || d == mathutil.MinInt { 
-        return x, false, nil
-    }
+	if d >= 0 {
+		return x, false, nil
+	}
+
+	if d == mathutil.MinInt {
+		return 0, false, nil
+	}
 
 	shift := int64(math.Pow10(int(-d)))
 	return x / shift * shift, false, nil
@@ -2215,9 +2219,13 @@ func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 	}
 
 	uintx := uint64(x)
-	if d >= 0 || d == mathutil.MinInt { 
-        return int64(uintx), false, nil
-    }
+	if d >= 0 {
+		return int64(uintx), false, nil
+	}
+
+	if d == mathutil.MinInt {
+		return 0, false, nil
+	}
 
 	shift := uint64(math.Pow10(int(-d)))
 	return int64(uintx / shift * shift), false, nil

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2175,7 +2175,7 @@ func (b *builtinTruncateIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 	}
 
 	if d >= 0 || d == mathutil.MinInt { 
-        return x, false, nil // or int64(uintx), false, nil for UintSig
+        return x, false, nil
     }
 
 	shift := int64(math.Pow10(int(-d)))

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -2178,6 +2178,7 @@ func (b *builtinTruncateIntSig) evalInt(ctx EvalContext, row chunk.Row) (int64, 
 		return x, false, nil
 	}
 
+	// -MinInt = MinInt, special case
 	if d == mathutil.MinInt {
 		return 0, false, nil
 	}
@@ -2218,11 +2219,16 @@ func (b *builtinTruncateUintSig) evalInt(ctx EvalContext, row chunk.Row) (int64,
 		return 0, true, nil
 	}
 
+	if mysql.HasUnsignedFlag(b.args[0].GetType(ctx).GetFlag()) {
+		return x, false, nil
+	}
+
 	uintx := uint64(x)
 	if d >= 0 {
 		return int64(uintx), false, nil
 	}
 
+	// -MinInt = MinInt, special case
 	if d == mathutil.MinInt {
 		return 0, false, nil
 	}

--- a/pkg/expression/builtin_math_test.go
+++ b/pkg/expression/builtin_math_test.go
@@ -525,6 +525,8 @@ func TestTruncate(t *testing.T) {
 		{[]any{0, 400}, 0},
 		{[]any{0, -400}, 0},
 		{[]any{0, 3}, 0},
+		// for issue #64095
+		{[]any{0, nil}, nil},
 	}
 
 	Dtbl := tblToDtbl(tbl)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64095 #64094


Problem Summary: Failed to check NULL parameters in TRUNCATE operation

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
This PR fixes an issue where `TRUNCATE(x, d)` failed to return `NULL` when `d` was `NULL`.
The function returned `true` flag when evaluating  (`args[1]`),
skipping proper `NULL` propagation.
Adds a regression test for `SELECT TRUNCATE(c1 = -1, -1.0 << NULL)`.
```
