### PR TITLE
planner: optimize column lookups in PrepareIdxColsAndUnwrapArrayType with a map

### DIFF
--- a/pkg/planner/core/indexmerge_path_test.go
+++ b/pkg/planner/core/indexmerge_path_test.go
@@ -83,7 +83,7 @@ func TestCollectFilters4MVIndexMutations(t *testing.T) {
 	idxCols, ok := core.PrepareIdxColsAndUnwrapArrayType(
 		tbl.Meta(),
 		tbl.Meta().FindIndexByName("a_domains_b"),
-		ds.TblCols,
+		ds.TblColsByID,
 		true,
 	)
 	require.True(t, ok)

--- a/pkg/planner/core/indexmerge_unfinished_path.go
+++ b/pkg/planner/core/indexmerge_unfinished_path.go
@@ -183,7 +183,7 @@ func initUnfinishedPathsFromExpr(
 		if path.IsTablePath() {
 			continue
 		}
-		idxCols, ok := PrepareIdxColsAndUnwrapArrayType(ds.Table.Meta(), path.Index, ds.TblCols, false)
+		idxCols, ok := PrepareIdxColsAndUnwrapArrayType(ds.Table.Meta(), path.Index, ds.TblColsByID, false)
 		if !ok {
 			continue
 		}
@@ -359,7 +359,7 @@ func buildIntoAccessPath(
 				idxCols, ok := PrepareIdxColsAndUnwrapArrayType(
 					ds.Table.Meta(),
 					unfinishedPath.index,
-					ds.TblCols,
+					ds.TblColsByID,
 					true,
 				)
 				if !ok {

--- a/pkg/statistics/table.go
+++ b/pkg/statistics/table.go
@@ -990,10 +990,12 @@ func (coll *HistColl) ID2UniqueID(columns []*expression.Column) *HistColl {
 // GenerateHistCollFromColumnInfo generates a new HistColl whose ColUniqueID2IdxIDs and Idx2ColUniqueIDs is built from the given parameter.
 func (coll *HistColl) GenerateHistCollFromColumnInfo(tblInfo *model.TableInfo, columns []*expression.Column) *HistColl {
 	newColHistMap := make(map[int64]*Column)
+	colInfoID2Col := make(map[int64]*expression.Column, len(columns))
 	colInfoID2UniqueID := make(map[int64]int64, len(columns))
 	uniqueID2colInfoID := make(map[int64]int64, len(columns))
 	idxID2idxInfo := make(map[int64]*model.IndexInfo)
 	for _, col := range columns {
+		colInfoID2Col[col.ID] = col
 		colInfoID2UniqueID[col.ID] = col.UniqueID
 		uniqueID2colInfoID[col.UniqueID] = col.ID
 	}
@@ -1032,7 +1034,7 @@ func (coll *HistColl) GenerateHistCollFromColumnInfo(tblInfo *model.TableInfo, c
 		newIdxHistMap[idxHist.ID] = idxHist
 		idx2Columns[idxHist.ID] = ids
 		if idxInfo.MVIndex {
-			cols, ok := PrepareCols4MVIndex(tblInfo, idxInfo, columns, true)
+			cols, ok := PrepareCols4MVIndex(tblInfo, idxInfo, colInfoID2Col, true)
 			if ok {
 				mvIdx2Columns[id] = cols
 			}
@@ -1137,6 +1139,6 @@ func CheckAnalyzeVerOnTable(tbl *Table, version *int) bool {
 var PrepareCols4MVIndex func(
 	tableInfo *model.TableInfo,
 	mvIndex *model.IndexInfo,
-	tblCols []*expression.Column,
+	tblColsByID map[int64]*expression.Column,
 	checkOnly1ArrayTypeCol bool,
 ) (idxCols []*expression.Column, ok bool)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #63856 

Problem Summary: Profiling the time spent in the optimizer repeatedly executing, for 2 minutes, a [query on a table like this](https://github.com/pingcap/tidb/issues/63856#issue-3496225000), but with many more indexes (500) and columns (6,500), reveals that 7.8% of the time now is spent in `plannercore.PrepareIdxColsAndUnwrapArrayType()`, largely due to this function being passed a slice of columns that the function has to search linearly with a for loop. Instead of scanning this slice, we should be using a map to reduce lookups of column by ID from O(N) to O(1).

### What changed and how does it work?

This is a follow-up PR to #64053:

* Change `PrepareIdxColsAndUnwrapArrayType` to take a `tblColsByID` map rather than a `tblCols` slice, and use this to lookup columns instead of a for loop.
* Replace all `PrepareIdxColsAndUnwrapArrayType` call sites to pass `ds.TblColsByID` rather than `ds.TblCols`.

This change reduces the time spent in `PrepareIdxColsAndUnwrapArrayType`, over the course of a 2 minute test, from 7.8% to 4.4%: a 3.4% improvement.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
