### PR TITLE
util/collate: fix the issue that '�'(\uFFFD) was treated as invalid sequence

### DIFF
--- a/pkg/util/collate/gb18030_chinese_ci.go
+++ b/pkg/util/collate/gb18030_chinese_ci.go
@@ -19,7 +19,6 @@ import (
 	"encoding/binary"
 	"unicode/utf8"
 
-	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 )
 
@@ -41,29 +40,7 @@ func (*gb18030ChineseCICollator) Clone() Collator {
 
 // Compare implements Collator interface.
 func (*gb18030ChineseCICollator) Compare(a, b string) int {
-	a = truncateTailingSpace(a)
-	b = truncateTailingSpace(b)
-
-	r1, r2 := rune(0), rune(0)
-	ai, bi := 0, 0
-	r1Len, r2Len := 0, 0
-	for ai < len(a) && bi < len(b) {
-		r1, r1Len = utf8.DecodeRune(hack.Slice(a[ai:]))
-		r2, r2Len = utf8.DecodeRune(hack.Slice(b[bi:]))
-
-		if r1 == utf8.RuneError || r2 == utf8.RuneError {
-			return 0
-		}
-
-		ai = ai + r1Len
-		bi = bi + r2Len
-
-		cmp := int(gb18030ChineseCISortKey(r1)) - int(gb18030ChineseCISortKey(r2))
-		if cmp != 0 {
-			return sign(cmp)
-		}
-	}
-	return sign((len(a) - ai) - (len(b) - bi))
+	return compareCommon(a, b, gb18030ChineseCISortKey)
 }
 
 // Key implements Collator interface.
@@ -82,9 +59,12 @@ func (*gb18030ChineseCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	i, rLen := 0, 0
 	r := rune(0)
 	for i < len(str) {
-		r, rLen = utf8.DecodeRune(hack.Slice(str[i:]))
-
-		if r == utf8.RuneError {
+		// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+		// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+		// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+		r, rLen = utf8.DecodeRuneInString(str[i:])
+		invalid := r == utf8.RuneError && rLen == 1
+		if invalid {
 			return buf
 		}
 

--- a/pkg/util/collate/gbk_chinese_ci.go
+++ b/pkg/util/collate/gbk_chinese_ci.go
@@ -17,7 +17,6 @@ package collate
 import (
 	"unicode/utf8"
 
-	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 )
 
@@ -26,29 +25,7 @@ type gbkChineseCICollator struct {
 
 // Compare implements Collator interface.
 func (*gbkChineseCICollator) Compare(a, b string) int {
-	a = truncateTailingSpace(a)
-	b = truncateTailingSpace(b)
-
-	r1, r2 := rune(0), rune(0)
-	ai, bi := 0, 0
-	r1Len, r2Len := 0, 0
-	for ai < len(a) && bi < len(b) {
-		r1, r1Len = utf8.DecodeRune(hack.Slice(a[ai:]))
-		r2, r2Len = utf8.DecodeRune(hack.Slice(b[bi:]))
-
-		if r1 == utf8.RuneError || r2 == utf8.RuneError {
-			return 0
-		}
-
-		ai = ai + r1Len
-		bi = bi + r2Len
-
-		cmp := int(gbkChineseCISortKey(r1)) - int(gbkChineseCISortKey(r2))
-		if cmp != 0 {
-			return sign(cmp)
-		}
-	}
-	return sign((len(a) - ai) - (len(b) - bi))
+	return compareCommon(a, b, gbkChineseCISortKey)
 }
 
 // Key implements Collator interface.
@@ -67,9 +44,12 @@ func (*gbkChineseCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	i, rLen := 0, 0
 	r := rune(0)
 	for i < len(str) {
-		r, rLen = utf8.DecodeRune(hack.Slice(str[i:]))
-
-		if r == utf8.RuneError {
+		// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+		// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+		// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+		r, rLen = utf8.DecodeRuneInString(str[i:])
+		invalid := r == utf8.RuneError && rLen == 1
+		if invalid {
 			return buf
 		}
 
@@ -110,10 +90,10 @@ func (p *gbkChineseCIPattern) DoMatch(str string) bool {
 	})
 }
 
-func gbkChineseCISortKey(r rune) uint16 {
+func gbkChineseCISortKey(r rune) uint32 {
 	if r > 0xFFFF {
 		return 0x3F
 	}
 
-	return gbkChineseCISortKeyTable[r]
+	return uint32(gbkChineseCISortKeyTable[r])
 }

--- a/pkg/util/collate/general_ci.go
+++ b/pkg/util/collate/general_ci.go
@@ -17,7 +17,6 @@ package collate
 import (
 	"unicode/utf8"
 
-	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 )
 
@@ -26,28 +25,7 @@ type generalCICollator struct {
 
 // Compare implements Collator interface.
 func (*generalCICollator) Compare(a, b string) int {
-	a = truncateTailingSpace(a)
-	b = truncateTailingSpace(b)
-	r1, r2 := rune(0), rune(0)
-	ai, bi := 0, 0
-	r1Len, r2Len := 0, 0
-	for ai < len(a) && bi < len(b) {
-		r1, r1Len = utf8.DecodeRune(hack.Slice(a[ai:]))
-		r2, r2Len = utf8.DecodeRune(hack.Slice(b[bi:]))
-
-		if r1 == utf8.RuneError || r2 == utf8.RuneError {
-			return 0
-		}
-
-		ai = ai + r1Len
-		bi = bi + r2Len
-
-		cmp := int(convertRuneGeneralCI(r1)) - int(convertRuneGeneralCI(r2))
-		if cmp != 0 {
-			return sign(cmp)
-		}
-	}
-	return sign((len(a) - ai) - (len(b) - bi))
+	return compareCommon(a, b, convertRuneGeneralCI)
 }
 
 // Key implements Collator interface.
@@ -66,9 +44,12 @@ func (*generalCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	i, rLen := 0, 0
 	r := rune(0)
 	for i < len(str) {
-		r, rLen = utf8.DecodeRune(hack.Slice(str[i:]))
-
-		if r == utf8.RuneError {
+		// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+		// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+		// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+		r, rLen = utf8.DecodeRuneInString(str[i:])
+		invalid := r == utf8.RuneError && rLen == 1
+		if invalid {
 			return buf
 		}
 
@@ -106,15 +87,15 @@ func (p *ciPattern) DoMatch(str string) bool {
 	})
 }
 
-func convertRuneGeneralCI(r rune) uint16 {
+func convertRuneGeneralCI(r rune) uint32 {
 	if r > 0xFFFF {
 		return 0xFFFD
 	}
 	plane := planeTable[r>>8]
 	if plane == nil {
-		return uint16(r)
+		return uint32(r)
 	}
-	return plane[r&0xFF]
+	return uint32(plane[r&0xFF])
 }
 
 var (

--- a/pkg/util/collate/ucaimpl/unicode_ci.go.tpl
+++ b/pkg/util/collate/ucaimpl/unicode_ci.go.tpl
@@ -18,11 +18,7 @@
 
 package collate
 
-import (
-	"unicode/utf8"
-
-	"github.com/pingcap/tidb/pkg/util/hack"
-)
+import "unicode/utf8"
 
 // {{.Name}} implements UCA. see http://unicode.org/reports/tr10/
 type {{.Name}} struct {
@@ -51,8 +47,12 @@ func (uc *{{.Name}}) Compare(a, b string) int {
 		if an == 0 {
 			if as == 0 {
 				for an == 0 && ai < len(a) {
-					ar, arLen = utf8.DecodeRune(hack.Slice(a[ai:]))
-					if ar == utf8.RuneError {
+					// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+					// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+					// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+					ar, arLen = utf8.DecodeRuneInString(a[ai:])
+					invalid := ar == utf8.RuneError && arLen == 1
+					if invalid {
 						return 0
 					}
 					ai = ai + arLen
@@ -67,8 +67,12 @@ func (uc *{{.Name}}) Compare(a, b string) int {
 		if bn == 0 {
 			if bs == 0 {
 				for bn == 0 && bi < len(b) {
-					br, brLen = utf8.DecodeRune(hack.Slice(b[bi:]))
-					if br == utf8.RuneError {
+					// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+					// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+					// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+					br, brLen = utf8.DecodeRuneInString(b[bi:])
+					invalid := br == utf8.RuneError && brLen == 1
+					if invalid {
 						return 0
 					}
 					bi = bi + brLen
@@ -118,9 +122,9 @@ func (uc *{{.Name}}) KeyWithoutTrimRightSpace(str string) []byte {
 	rLen := 0
 
 	for si < len(str) {
-		r, rLen = utf8.DecodeRune(hack.Slice(str[si:]))
-
-		if r == utf8.RuneError {
+		r, rLen = utf8.DecodeRuneInString(str[si:])
+		invalid := r == utf8.RuneError && rLen == 1
+		if invalid {
 			return buf
 		}
 

--- a/pkg/util/collate/unicode_0400_ci_generated.go
+++ b/pkg/util/collate/unicode_0400_ci_generated.go
@@ -18,11 +18,7 @@
 
 package collate
 
-import (
-	"unicode/utf8"
-
-	"github.com/pingcap/tidb/pkg/util/hack"
-)
+import "unicode/utf8"
 
 // unicodeCICollator implements UCA. see http://unicode.org/reports/tr10/
 type unicodeCICollator struct {
@@ -51,8 +47,12 @@ func (uc *unicodeCICollator) Compare(a, b string) int {
 		if an == 0 {
 			if as == 0 {
 				for an == 0 && ai < len(a) {
-					ar, arLen = utf8.DecodeRune(hack.Slice(a[ai:]))
-					if ar == utf8.RuneError {
+					// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+					// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+					// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+					ar, arLen = utf8.DecodeRuneInString(a[ai:])
+					invalid := ar == utf8.RuneError && arLen == 1
+					if invalid {
 						return 0
 					}
 					ai = ai + arLen
@@ -67,8 +67,12 @@ func (uc *unicodeCICollator) Compare(a, b string) int {
 		if bn == 0 {
 			if bs == 0 {
 				for bn == 0 && bi < len(b) {
-					br, brLen = utf8.DecodeRune(hack.Slice(b[bi:]))
-					if br == utf8.RuneError {
+					// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+					// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+					// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+					br, brLen = utf8.DecodeRuneInString(b[bi:])
+					invalid := br == utf8.RuneError && brLen == 1
+					if invalid {
 						return 0
 					}
 					bi = bi + brLen
@@ -118,9 +122,9 @@ func (uc *unicodeCICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	rLen := 0
 
 	for si < len(str) {
-		r, rLen = utf8.DecodeRune(hack.Slice(str[si:]))
-
-		if r == utf8.RuneError {
+		r, rLen = utf8.DecodeRuneInString(str[si:])
+		invalid := r == utf8.RuneError && rLen == 1
+		if invalid {
 			return buf
 		}
 

--- a/pkg/util/collate/unicode_0900_ai_ci_generated.go
+++ b/pkg/util/collate/unicode_0900_ai_ci_generated.go
@@ -18,11 +18,7 @@
 
 package collate
 
-import (
-	"unicode/utf8"
-
-	"github.com/pingcap/tidb/pkg/util/hack"
-)
+import "unicode/utf8"
 
 // unicode0900AICICollator implements UCA. see http://unicode.org/reports/tr10/
 type unicode0900AICICollator struct {
@@ -51,8 +47,12 @@ func (uc *unicode0900AICICollator) Compare(a, b string) int {
 		if an == 0 {
 			if as == 0 {
 				for an == 0 && ai < len(a) {
-					ar, arLen = utf8.DecodeRune(hack.Slice(a[ai:]))
-					if ar == utf8.RuneError {
+					// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+					// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+					// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+					ar, arLen = utf8.DecodeRuneInString(a[ai:])
+					invalid := ar == utf8.RuneError && arLen == 1
+					if invalid {
 						return 0
 					}
 					ai = ai + arLen
@@ -67,8 +67,12 @@ func (uc *unicode0900AICICollator) Compare(a, b string) int {
 		if bn == 0 {
 			if bs == 0 {
 				for bn == 0 && bi < len(b) {
-					br, brLen = utf8.DecodeRune(hack.Slice(b[bi:]))
-					if br == utf8.RuneError {
+					// When the byte sequence is not a valid UTF-8 encoding of a rune, Golang returns RuneError('�') and size 1.
+					// See https://pkg.go.dev/unicode/utf8#DecodeRune for more details.
+					// Here we check both the size and rune to distinguish between invalid byte sequence and valid '�'.
+					br, brLen = utf8.DecodeRuneInString(b[bi:])
+					invalid := br == utf8.RuneError && brLen == 1
+					if invalid {
 						return 0
 					}
 					bi = bi + brLen
@@ -118,9 +122,9 @@ func (uc *unicode0900AICICollator) KeyWithoutTrimRightSpace(str string) []byte {
 	rLen := 0
 
 	for si < len(str) {
-		r, rLen = utf8.DecodeRune(hack.Slice(str[si:]))
-
-		if r == utf8.RuneError {
+		r, rLen = utf8.DecodeRuneInString(str[si:])
+		invalid := r == utf8.RuneError && rLen == 1
+		if invalid {
 			return buf
 		}
 

--- a/tests/integrationtest/r/new_character_set.result
+++ b/tests/integrationtest/r/new_character_set.result
@@ -125,3 +125,76 @@ select * from t61085 where a = cast(0x41414180424242 as char charset gbk);
 a
 AAA
 DROP TABLE t61085;
+create table a (id bigint primary key, name varchar(10) collate utf8mb4_general_ci, key(name));
+insert into a values (1, 'A�B');
+select hex(weight_string(name)) from a;
+hex(weight_string(name))
+0041FFFD0042
+select name, hex(weight_string(name)) from a where id = 1;
+name	hex(weight_string(name))
+A�B	0041FFFD0042
+select * from a where name = (select name from a where id = 1);
+id	name
+1	A�B
+delete from a where id = 1;
+DROP TABLE IF EXISTS t_fffd;
+CREATE TABLE t_fffd (
+id INT PRIMARY KEY AUTO_INCREMENT,
+c_utf8mb4_general_ci VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+c_utf8mb4_unicode_ci VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+c_utf8mb4_bin VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+INDEX idx_general (c_utf8mb4_general_ci),
+INDEX idx_unicode (c_utf8mb4_unicode_ci),
+INDEX idx_bin (c_utf8mb4_bin)
+);
+INSERT INTO t_fffd (c_utf8mb4_general_ci, c_utf8mb4_unicode_ci, c_utf8mb4_bin)
+VALUES ('a�b', '�', 'test�string');
+SELECT * FROM t_fffd ORDER BY id;
+id	c_utf8mb4_general_ci	c_utf8mb4_unicode_ci	c_utf8mb4_bin
+1	a�b	�	test�string
+EXPLAIN SELECT id FROM t_fffd WHERE c_utf8mb4_general_ci = 'a�b';
+id	estRows	task	access object	operator info
+IndexReader_10	10.00	root		index:Projection_6
+└─Projection_6	10.00	cop[tikv]		new_character_set.t_fffd.id
+  └─IndexRangeScan_9	10.00	cop[tikv]	table:t_fffd, index:idx_general(c_utf8mb4_general_ci)	range:["\x00A\xff\xfd\x00B","\x00A\xff\xfd\x00B"], keep order:false, stats:pseudo
+SELECT id FROM t_fffd WHERE c_utf8mb4_general_ci = 'a�b';
+id
+1
+EXPLAIN SELECT id FROM t_fffd WHERE c_utf8mb4_unicode_ci = '�';
+id	estRows	task	access object	operator info
+IndexReader_10	10.00	root		index:Projection_6
+└─Projection_6	10.00	cop[tikv]		new_character_set.t_fffd.id
+  └─IndexRangeScan_9	10.00	cop[tikv]	table:t_fffd, index:idx_unicode(c_utf8mb4_unicode_ci)	range:["\r\xc6","\r\xc6"], keep order:false, stats:pseudo
+SELECT id FROM t_fffd WHERE c_utf8mb4_unicode_ci = '�';
+id
+1
+EXPLAIN SELECT id FROM t_fffd WHERE c_utf8mb4_bin = 'test�string';
+id	estRows	task	access object	operator info
+IndexReader_10	10.00	root		index:Projection_6
+└─Projection_6	10.00	cop[tikv]		new_character_set.t_fffd.id
+  └─IndexRangeScan_9	10.00	cop[tikv]	table:t_fffd, index:idx_bin(c_utf8mb4_bin)	range:["test�string","test�string"], keep order:false, stats:pseudo
+SELECT id FROM t_fffd WHERE c_utf8mb4_bin = 'test�string';
+id
+1
+UPDATE t_fffd SET c_utf8mb4_general_ci = 'X�Y' WHERE c_utf8mb4_general_ci = 'a�b';
+UPDATE t_fffd SET c_utf8mb4_unicode_ci = 'UPDATED�' WHERE c_utf8mb4_unicode_ci = '�';
+UPDATE t_fffd SET c_utf8mb4_bin = 'bin�updated' WHERE c_utf8mb4_bin = 'test�string';
+SELECT * FROM t_fffd ORDER BY id;
+id	c_utf8mb4_general_ci	c_utf8mb4_unicode_ci	c_utf8mb4_bin
+1	X�Y	UPDATED�	bin�updated
+DELETE FROM t_fffd WHERE c_utf8mb4_general_ci = 'X�Y';
+SELECT COUNT(*) FROM t_fffd;
+COUNT(*)
+0
+INSERT INTO t_fffd (c_utf8mb4_general_ci, c_utf8mb4_unicode_ci, c_utf8mb4_bin)
+VALUES ('another�row', 'multi�char', 'end�case');
+SELECT * FROM t_fffd ORDER BY id;
+id	c_utf8mb4_general_ci	c_utf8mb4_unicode_ci	c_utf8mb4_bin
+2	another�row	multi�char	end�case
+SELECT id FROM t_fffd WHERE c_utf8mb4_bin = 'end�case';
+id
+2
+SELECT id FROM t_fffd WHERE c_utf8mb4_unicode_ci = 'multi�char';
+id
+2
+DROP TABLE t_fffd;

--- a/tests/integrationtest/t/new_character_set.test
+++ b/tests/integrationtest/t/new_character_set.test
@@ -94,3 +94,59 @@ insert into t61085 values ('AAA');
 set SESSION sql_mode = '';
 select * from t61085 where a = cast(0x41414180424242 as char charset gbk);
 DROP TABLE t61085;
+
+# TestIssue64144
+create table a (id bigint primary key, name varchar(10) collate utf8mb4_general_ci, key(name));
+insert into a values (1, 'A�B');
+select hex(weight_string(name)) from a;
+
+select name, hex(weight_string(name)) from a where id = 1;
+select * from a where name = (select name from a where id = 1);
+
+delete from a where id = 1;
+
+--disable_warnings
+DROP TABLE IF EXISTS t_fffd;
+--enable_warnings
+
+CREATE TABLE t_fffd (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    c_utf8mb4_general_ci VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+    c_utf8mb4_unicode_ci VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    c_utf8mb4_bin VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+    INDEX idx_general (c_utf8mb4_general_ci),
+    INDEX idx_unicode (c_utf8mb4_unicode_ci),
+    INDEX idx_bin (c_utf8mb4_bin)
+);
+
+INSERT INTO t_fffd (c_utf8mb4_general_ci, c_utf8mb4_unicode_ci, c_utf8mb4_bin)
+VALUES ('a�b', '�', 'test�string');
+
+SELECT * FROM t_fffd ORDER BY id;
+
+EXPLAIN SELECT id FROM t_fffd WHERE c_utf8mb4_general_ci = 'a�b';
+SELECT id FROM t_fffd WHERE c_utf8mb4_general_ci = 'a�b';
+
+EXPLAIN SELECT id FROM t_fffd WHERE c_utf8mb4_unicode_ci = '�';
+SELECT id FROM t_fffd WHERE c_utf8mb4_unicode_ci = '�';
+
+EXPLAIN SELECT id FROM t_fffd WHERE c_utf8mb4_bin = 'test�string';
+SELECT id FROM t_fffd WHERE c_utf8mb4_bin = 'test�string';
+
+UPDATE t_fffd SET c_utf8mb4_general_ci = 'X�Y' WHERE c_utf8mb4_general_ci = 'a�b';
+UPDATE t_fffd SET c_utf8mb4_unicode_ci = 'UPDATED�' WHERE c_utf8mb4_unicode_ci = '�';
+UPDATE t_fffd SET c_utf8mb4_bin = 'bin�updated' WHERE c_utf8mb4_bin = 'test�string';
+
+SELECT * FROM t_fffd ORDER BY id;
+
+DELETE FROM t_fffd WHERE c_utf8mb4_general_ci = 'X�Y';
+SELECT COUNT(*) FROM t_fffd;
+
+INSERT INTO t_fffd (c_utf8mb4_general_ci, c_utf8mb4_unicode_ci, c_utf8mb4_bin)
+VALUES ('another�row', 'multi�char', 'end�case');
+SELECT * FROM t_fffd ORDER BY id;
+
+SELECT id FROM t_fffd WHERE c_utf8mb4_bin = 'end�case';
+SELECT id FROM t_fffd WHERE c_utf8mb4_unicode_ci = 'multi�char';
+
+DROP TABLE t_fffd;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64144

Problem Summary:

### What changed and how does it work?

To be added

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - The steps described in #64144, I tried both '�' and a "real invalid byte sequence".
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- NA

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that '�'(\uFFFD) is incorrectly treated as a invalid sequence
```
