### PR TITLE
ddl: use a separate pool to execute background jobs for next-gen

### DIFF
--- a/pkg/ddl/job_scheduler.go
+++ b/pkg/ddl/job_scheduler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/ddl/ingest"
 	"github.com/pingcap/tidb/pkg/ddl/logutil"
 	"github.com/pingcap/tidb/pkg/ddl/notifier"
@@ -151,6 +152,7 @@ type jobScheduler struct {
 	// those fields are created or initialized on start
 	reorgWorkerPool      *workerPool
 	generalDDLWorkerPool *workerPool
+	bgJobWorkerPool      *workerPool
 	seqAllocator         atomic.Uint64
 
 	// those fields are shared with 'ddl' instance
@@ -182,6 +184,9 @@ func (s *jobScheduler) start() {
 	reorgCnt := min(max(runtime.GOMAXPROCS(0)/4, 1), reorgWorkerCnt)
 	s.reorgWorkerPool = newDDLWorkerPool(pools.NewResourcePool(workerFactory(addIdxWorker), reorgCnt, reorgCnt, 0), jobTypeReorg)
 	s.generalDDLWorkerPool = newDDLWorkerPool(pools.NewResourcePool(workerFactory(generalWorker), generalWorkerCnt, generalWorkerCnt, 0), jobTypeGeneral)
+	if kerneltype.IsNextGen() {
+		s.bgJobWorkerPool = newDDLWorkerPool(pools.NewResourcePool(workerFactory(backgroundWorker), 20, 20, 0), jobTypeReorg)
+	}
 	s.wg.RunWithLog(s.scheduleLoop)
 	s.wg.RunWithLog(func() {
 		s.schemaVerSyncer.SyncJobSchemaVerLoop(s.schCtx)
@@ -196,6 +201,9 @@ func (s *jobScheduler) close() {
 	}
 	if s.generalDDLWorkerPool != nil {
 		s.generalDDLWorkerPool.close()
+	}
+	if s.bgJobWorkerPool != nil {
+		s.bgJobWorkerPool.close()
 	}
 	failpoint.InjectCall("afterSchedulerClose")
 }
@@ -374,7 +382,7 @@ func (s *jobScheduler) checkAndUpdateClusterState(needUpdate bool) error {
 }
 
 func (s *jobScheduler) loadAndDeliverJobs(se *sess.Session) error {
-	if s.generalDDLWorkerPool.available() == 0 && s.reorgWorkerPool.available() == 0 {
+	if s.workerPoolExhausted() {
 		return nil
 	}
 
@@ -392,10 +400,6 @@ func (s *jobScheduler) loadAndDeliverJobs(se *sess.Session) error {
 	}
 	for _, row := range rows {
 		reorgJob := row.GetInt64(0) == 1
-		targetPool := s.generalDDLWorkerPool
-		if reorgJob {
-			targetPool = s.reorgWorkerPool
-		}
 		jobBinary := row.GetBytes(1)
 
 		job := model.Job{}
@@ -405,6 +409,13 @@ func (s *jobScheduler) loadAndDeliverJobs(se *sess.Session) error {
 		}
 		intest.Assert(job.Version > 0, "job version should be greater than 0")
 
+		targetPool := s.generalDDLWorkerPool
+		if reorgJob {
+			targetPool = s.reorgWorkerPool
+			if kerneltype.IsNextGen() && (job.Type == model.ActionAddPrimaryKey || job.Type == model.ActionAddIndex) {
+				targetPool = s.bgJobWorkerPool
+			}
+		}
 		involving := job.GetInvolvingSchemaInfo()
 		if targetPool.available() == 0 {
 			s.runningJobs.addPending(involving)
@@ -439,7 +450,7 @@ func (s *jobScheduler) loadAndDeliverJobs(se *sess.Session) error {
 		}
 
 		s.deliveryJob(wk, targetPool, model.NewJobW(&job, jobBinary))
-		if s.generalDDLWorkerPool.available() == 0 && s.reorgWorkerPool.available() == 0 {
+		if s.workerPoolExhausted() {
 			break
 		}
 	}
@@ -652,6 +663,12 @@ func (s *jobScheduler) cleanMDLInfo(job *model.Job, ownerID string) {
 			logutil.DDLLogger().Warn("delete versions failed", zap.Int64("job ID", job.ID), zap.Error(err))
 		}
 	}
+}
+
+func (s *jobScheduler) workerPoolExhausted() bool {
+	return s.generalDDLWorkerPool.available() == 0 &&
+		s.reorgWorkerPool.available() == 0 &&
+		s.bgJobWorkerPool.available() == 0
 }
 
 func getTableByTxn(ctx context.Context, store kv.Storage, schemaID, tableID int64) (*model.DBInfo, table.Table, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61702

Problem Summary:

Before this PR, system TiDBs with 7c can only execute one adding index task at the same time:

```
|    134 | test    | sbtest1    | add index  | public       |         5 |      109 |  10000075 | 2025-10-29 07:07:37.326000 | 2025-10-29 07:15:30.577000 | 2025-10-29 07:17:58.026000 | synced |          |
|    133 | test    | sbtest3    | add index  | public       |         5 |      105 |  10000088 | 2025-10-29 07:07:37.326000 | 2025-10-29 07:12:51.077000 | 2025-10-29 07:15:30.526000 | synced |          |
|    132 | test    | sbtest2    | add index  | public       |         5 |       70 |  10000149 | 2025-10-29 07:07:37.277000 | 2025-10-29 07:10:14.526000 | 2025-10-29 07:12:51.027000 | synced |          |
|    131 | test    | sbtest4    | add index  | public       |         5 |      111 |  10000293 | 2025-10-29 07:07:36.477000 | 2025-10-29 07:07:36.527000 | 2025-10-29 07:10:14.477000 | synced |          |
```

It takes 10 min 21 sec to complete 4 indexes.

### What changed and how does it work?

Add a new pool to execute background jobs for next-gen.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  After this PR, it takes 9 min 14 sec to add 32 indexes.
  ```
  mysql> select job_id, job_type, table_name, start_time, end_time, state, timediff(end_time, start_time) as duration from information_schema.ddl_jobs limit 32;
  +--------+-----------+------------+----------------------------+----------------------------+--------+-----------------+
  | job_id | job_type  | table_name | start_time                 | end_time                   | state  | duration        |
  +--------+-----------+------------+----------------------------+----------------------------+--------+-----------------+
  |    178 | add index | sbtest30   | 2025-10-30 08:46:15.776000 | 2025-10-30 08:50:35.727000 | synced | 00:04:19.951000 |
  |    177 | add index | sbtest29   | 2025-10-30 08:46:11.726000 | 2025-10-30 08:50:32.677000 | synced | 00:04:20.951000 |
  |    176 | add index | sbtest19   | 2025-10-30 08:46:10.877000 | 2025-10-30 08:49:56.926000 | synced | 00:03:46.049000 |
  |    175 | add index | sbtest28   | 2025-10-30 08:46:08.727000 | 2025-10-30 08:49:53.977000 | synced | 00:03:45.250000 |
  |    174 | add index | sbtest4    | 2025-10-30 08:46:01.626000 | 2025-10-30 08:49:15.026000 | synced | 00:03:13.400000 |
  |    173 | add index | sbtest31   | 2025-10-30 08:44:22.877000 | 2025-10-30 08:49:29.726000 | synced | 00:05:06.849000 |
  |    172 | add index | sbtest3    | 2025-10-30 08:44:20.727000 | 2025-10-30 08:49:28.726000 | synced | 00:05:07.999000 |
  |    171 | add index | sbtest9    | 2025-10-30 08:44:18.776000 | 2025-10-30 08:49:15.026000 | synced | 00:04:56.250000 |
  |    170 | add index | sbtest22   | 2025-10-30 08:44:18.626000 | 2025-10-30 08:49:14.626000 | synced | 00:04:56.000000 |
  |    169 | add index | sbtest13   | 2025-10-30 08:44:18.177000 | 2025-10-30 08:49:14.477000 | synced | 00:04:56.300000 |
  |    168 | add index | sbtest27   | 2025-10-30 08:44:16.127000 | 2025-10-30 08:48:59.476000 | synced | 00:04:43.349000 |
  |    167 | add index | sbtest6    | 2025-10-30 08:44:12.276000 | 2025-10-30 08:47:46.927000 | synced | 00:03:34.651000 |
  |    166 | add index | sbtest23   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:47:53.077000 | synced | 00:06:30.950000 |
  |    165 | add index | sbtest17   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:10.827000 | synced | 00:04:48.700000 |
  |    164 | add index | sbtest16   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:47:53.077000 | synced | 00:06:30.950000 |
  |    163 | add index | sbtest20   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:47:49.626000 | synced | 00:06:27.499000 |
  |    162 | add index | sbtest21   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:47:45.176000 | synced | 00:06:23.049000 |
  |    161 | add index | sbtest8    | 2025-10-30 08:41:22.127000 | 2025-10-30 08:47:45.126000 | synced | 00:06:22.999000 |
  |    160 | add index | sbtest12   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:16.227000 | synced | 00:04:54.100000 |
  |    159 | add index | sbtest24   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:11.676000 | synced | 00:04:49.549000 |
  |    158 | add index | sbtest10   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:01.577000 | synced | 00:04:39.450000 |
  |    157 | add index | sbtest25   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:47:46.577000 | synced | 00:06:24.450000 |
  |    156 | add index | sbtest2    | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:08.676000 | synced | 00:04:46.549000 |
  |    155 | add index | sbtest26   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:15.677000 | synced | 00:04:53.550000 |
  |    154 | add index | sbtest7    | 2025-10-30 08:41:22.127000 | 2025-10-30 08:46:16.027000 | synced | 00:04:53.900000 |
  |    153 | add index | sbtest15   | 2025-10-30 08:41:22.127000 | 2025-10-30 08:44:22.827000 | synced | 00:03:00.700000 |
  |    152 | add index | sbtest1    | 2025-10-30 08:41:22.127000 | 2025-10-30 08:44:12.226000 | synced | 00:02:50.099000 |
  |    151 | add index | sbtest11   | 2025-10-30 08:41:22.077000 | 2025-10-30 08:44:18.727000 | synced | 00:02:56.650000 |
  |    150 | add index | sbtest32   | 2025-10-30 08:41:21.877000 | 2025-10-30 08:44:20.677000 | synced | 00:02:58.800000 |
  |    149 | add index | sbtest18   | 2025-10-30 08:41:21.877000 | 2025-10-30 08:44:16.077000 | synced | 00:02:54.200000 |
  |    148 | add index | sbtest14   | 2025-10-30 08:41:21.827000 | 2025-10-30 08:44:18.576000 | synced | 00:02:56.749000 |
  |    147 | add index | sbtest5    | 2025-10-30 08:41:20.927000 | 2025-10-30 08:44:18.177000 | synced | 00:02:57.250000 |
  +--------+-----------+------------+----------------------------+----------------------------+--------+-----------------+
  32 rows in set (0.28 sec)
  ```
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
