### PR TITLE
pkg/parser/ast: (Fix) Propagate error correctly

### DIFF
--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -3379,7 +3379,9 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WritePlainf("%d", *n.ImportJobID)
 		} else {
 			ctx.WriteKeyWord("IMPORT JOBS")
-			restoreShowLikeOrWhereOpt()
+			if err := restoreShowLikeOrWhereOpt(); err != nil {
+				return err
+			}
 		}
 	case ShowImportGroups:
 		if n.ShowGroupKey != "" {
@@ -3387,7 +3389,9 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WriteString(n.ShowGroupKey)
 		} else {
 			ctx.WriteKeyWord("IMPORT GROUPS")
-			restoreShowLikeOrWhereOpt()
+			if err := restoreShowLikeOrWhereOpt(); err != nil {
+				return err
+			}
 		}
 	case ShowDistributionJobs:
 		if n.DistributionJobID != nil {
@@ -3395,7 +3399,9 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 			ctx.WritePlainf("%d", *n.DistributionJobID)
 		} else {
 			ctx.WriteKeyWord("DISTRIBUTION JOBS")
-			restoreShowLikeOrWhereOpt()
+			if err := restoreShowLikeOrWhereOpt(); err != nil {
+				return err
+			}
 		}
 	// ShowTargetFilterable
 	default:
@@ -3522,7 +3528,9 @@ func (n *ShowStmt) Restore(ctx *format.RestoreCtx) error {
 		default:
 			return errors.New("Unknown ShowStmt type")
 		}
-		restoreShowLikeOrWhereOpt()
+		if err := restoreShowLikeOrWhereOpt(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fix a problem in the parser to return errors from nested functions correctly.

Please create an issue first to describe the problem.

Issue Number: close #64183 

Tests:
-  [X] Unit test

No side effect.

No documentation change.
