### PR TITLE
sessionctx: change @@tidb_trace_event default value from 'off' to 'base'

### DIFF
--- a/pkg/sessionctx/vardef/BUILD.bazel
+++ b/pkg/sessionctx/vardef/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/util/memory",
         "//pkg/util/paging",
         "//pkg/util/size",
+        "//pkg/util/traceevent",
         "@com_github_pingcap_tipb//go-tipb",
         "@org_uber_go_atomic//:atomic",
     ],

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/memory"
 	"github.com/pingcap/tidb/pkg/util/paging"
 	"github.com/pingcap/tidb/pkg/util/size"
+	"github.com/pingcap/tidb/pkg/util/traceevent"
 	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/atomic"
 )
@@ -1445,7 +1446,7 @@ const (
 	DefTiDBMemQuotaApplyCache               = 32 << 20 // 32MB.
 	DefTiDBMemQuotaBindingCache             = 64 << 20 // 64MB.
 	DefTiDBGeneralLog                       = false
-	DefTiDBTraceEvent                       = Off
+	DefTiDBTraceEvent                       = traceevent.ModeBase
 	DefTiDBPProfSQLCPU                      = 0
 	DefTiDBRetryLimit                       = 10
 	DefTiDBDisableTxnAutoRetry              = true

--- a/pkg/sessionctx/variable/varsutil_test.go
+++ b/pkg/sessionctx/variable/varsutil_test.go
@@ -379,6 +379,10 @@ func TestVarsutil(t *testing.T) {
 	require.Equal(t, "leader-and-follower", val)
 	require.Equal(t, kv.ReplicaReadMixed, v.replicaRead)
 
+	val, err = v.GetSessionOrGlobalSystemVar(context.Background(), vardef.TiDBTraceEvent)
+	require.NoError(t, err)
+	require.Equal(t, "BASE", val)
+
 	for _, c := range []struct {
 		a string
 		b string


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #64008

Problem Summary:

### What changed and how does it work?

https://github.com/pingcap/tidb/pull/64051 introduce this variable, but the default values should be 'base' rather than 'off'.

OFF: disable trace event
BASE: always enable flight recorder, discard trace events or dump on required, not logging
FULL: print trace event in logging

This is still experimental SQL variable, not exposed to user yet.
The big picture there are three orthogonal combination:

- probes: this is the source of trace event generation 
- control: what kinds of event should be recorded
- sink: dump to flight recorder, or logging ...

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
