### PR TITLE
types: speedup error generation to improve performance

### DIFF
--- a/pkg/types/mydecimal.go
+++ b/pkg/types/mydecimal.go
@@ -401,7 +401,7 @@ func (d *MyDecimal) FromString(str []byte) error {
 	}
 	if len(str) == 0 {
 		*d = zeroMyDecimal
-		return ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", str)
+		return ErrTruncatedWrongVal.FastGenByArgs("DECIMAL", str)
 	}
 	switch str[0] {
 	case '-':
@@ -429,7 +429,7 @@ func (d *MyDecimal) FromString(str []byte) error {
 	}
 	if digitsInt+digitsFrac == 0 {
 		*d = zeroMyDecimal
-		return ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", str)
+		return ErrTruncatedWrongVal.FastGenByArgs("DECIMAL", str)
 	}
 	wordsInt := digitsToWords(digitsInt)
 	wordsFrac := digitsToWords(digitsFrac)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/64270

Problem Summary:

### What changed and how does it work?
- change GenWithStackByArgs to FastGenByArgs

before this pr
<img width="1488" height="368" alt="image" src="https://github.com/user-attachments/assets/0ff8962a-61f6-4668-b58f-cbd5c2f416fa" />
after this pr
<img width="1466" height="340" alt="image" src="https://github.com/user-attachments/assets/0079309c-40f4-4867-a9ac-aa5763e18b8b" />
See https://github.com/toddstoffel/analytics_benchmark/pull/5 for more details.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
orignal test covert it.
https://github.com/pingcap/tidb/blob/e2d602a2298ecf0c79651a19039876c67d038fce/pkg/expression/builtin_cast_test.go#L112
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

 
Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
