### PR TITLE
planner: tolerate reasonable time lag between different TiDB nodes when updating binding cache

### DIFF
--- a/pkg/bindinfo/BUILD.bazel
+++ b/pkg/bindinfo/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/parser",
         "//pkg/util/sqlexec",
+        "//pkg/util/stringutil",
         "@com_github_dgraph_io_ristretto//:ristretto",
         "@com_github_pingcap_errors//:errors",
         "@com_github_pingcap_failpoint//:failpoint",
@@ -64,7 +65,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":bindinfo"],
     flaky = True,
-    shard_count = 45,
+    shard_count = 46,
     deps = [
         "//pkg/parser",
         "//pkg/parser/ast",

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -68,7 +68,8 @@ func (u *bindingCacheUpdater) LoadFromStorageToCache(fullLoad bool) (err error) 
 		// timeLagToleranceSec is used to tolerate the time lag between different TiDBs.
 		// See #64250 for more details.
 		// It's safe to load duplicated bindings, because we'll deduplicate them in `pickCachedBinding`.
-		timeLagToleranceSec := 10
+		// TODO: use PD TSO to avoid time synchronization issue thoroughly.
+		const timeLagToleranceSec = 10
 		lastUpdateTime = u.lastUpdateTime.Load().(types.Time)
 		timeCondition = fmt.Sprintf("USE INDEX (time_index) WHERE update_time>DATE_SUB('%s', INTERVAL %d SECOND)",
 			lastUpdateTime.String(), timeLagToleranceSec)

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -16,6 +16,10 @@ package bindinfo
 
 import (
 	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+
 	"github.com/dgraph-io/ristretto"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser"
@@ -25,9 +29,6 @@ import (
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
 	"go.uber.org/zap"
-	"slices"
-	"sync"
-	"sync/atomic"
 )
 
 // BindingCacheUpdater maintains the binding cache and provide update APIs.

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -69,8 +69,8 @@ func (u *bindingCacheUpdater) LoadFromStorageToCache(fullLoad bool) (err error) 
 		// See #64250 for more details.
 		timeLagToleranceSec := 10
 		lastUpdateTime = u.lastUpdateTime.Load().(types.Time)
-		whereCondition := `USE INDEX (time_index) WHERE update_time>DATE_SUB('%s', INTERVAL %d SECOND)`
-		timeCondition = fmt.Sprintf(whereCondition, lastUpdateTime.String(), timeLagToleranceSec)
+		timeCondition = fmt.Sprintf("USE INDEX (time_index) WHERE update_time>DATE_SUB('%s', INTERVAL %d SECOND)",
+			lastUpdateTime.String(), timeLagToleranceSec)
 	}
 	condition := fmt.Sprintf(`%s ORDER BY update_time, create_time`, timeCondition)
 	bindings, err := readBindingsFromStorage(u.sPool, condition)

--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -67,6 +67,7 @@ func (u *bindingCacheUpdater) LoadFromStorageToCache(fullLoad bool) (err error) 
 		// some bindings' update_time may be earlier than the lastUpdateTime of this TiDB.
 		// timeLagToleranceSec is used to tolerate the time lag between different TiDBs.
 		// See #64250 for more details.
+		// It's safe to load duplicated bindings, because we'll deduplicate them in `pickCachedBinding`.
 		timeLagToleranceSec := 10
 		lastUpdateTime = u.lastUpdateTime.Load().(types.Time)
 		timeCondition = fmt.Sprintf("USE INDEX (time_index) WHERE update_time>DATE_SUB('%s', INTERVAL %d SECOND)",

--- a/pkg/bindinfo/binding_operator.go
+++ b/pkg/bindinfo/binding_operator.go
@@ -75,7 +75,7 @@ func (op *bindingOperator) CreateBinding(sctx sessionctx.Context, bindings []*Bi
 
 	var mockTimeLag time.Duration // mock time lag between different TiDB instances for test, see #64250.
 	if intest.InTest && sctx.Value(TestTimeLagInLoadingBinding) != nil {
-		mockTimeLag = time.Second * time.Duration(sctx.Value(TestTimeLagInLoadingBinding).(int))
+		mockTimeLag = sctx.Value(TestTimeLagInLoadingBinding).(time.Duration)
 	}
 
 	return callWithSCtx(op.sPool, true, func(sctx sessionctx.Context) error {

--- a/pkg/bindinfo/binding_operator.go
+++ b/pkg/bindinfo/binding_operator.go
@@ -15,8 +15,6 @@
 package bindinfo
 
 import (
-	"github.com/pingcap/tidb/pkg/util/intest"
-	"github.com/pingcap/tidb/pkg/util/stringutil"
 	"strings"
 	"time"
 
@@ -26,6 +24,8 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util"
+	"github.com/pingcap/tidb/pkg/util/intest"
+	"github.com/pingcap/tidb/pkg/util/stringutil"
 )
 
 // BindingOperator is used to operate (create/drop/update/GC) bindings.

--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -420,7 +420,7 @@ func TestLoadBindingTimeLag(t *testing.T) {
 	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 15)
 	tk.MustExec(`create global binding using select * from t where a > 1`)
 	numBindings = len(tk.MustQuery(`show global bindings`).Rows())
-	require.Equal(t, 2, numBindings) // can't see the latest one since the time lag tolerance is 10s
+	require.Equal(t, 2, numBindings) // can't see the latest one since the time lag tolerance is only 10s
 }
 
 func TestGlobalBinding(t *testing.T) {

--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -402,6 +402,27 @@ var testSQLs = []struct {
 	},
 }
 
+func TestLoadBindingTimeLag(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (a int)`)
+	tk.MustExec(`create global binding using select * from t`)
+	numBindings := len(tk.MustQuery(`show global bindings`).Rows())
+	require.Equal(t, 1, numBindings)
+
+	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 5)
+	tk.MustExec(`create global binding using select * from t where a < 1`)
+	numBindings = len(tk.MustQuery(`show global bindings`).Rows())
+	require.Equal(t, 2, numBindings)
+
+	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 15)
+	tk.MustExec(`create global binding using select * from t where a > 1`)
+	numBindings = len(tk.MustQuery(`show global bindings`).Rows())
+	require.Equal(t, 2, numBindings) // can't see the latest one since the time lag tolerance is 10s
+}
+
 func TestGlobalBinding(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 

--- a/pkg/bindinfo/binding_operator_test.go
+++ b/pkg/bindinfo/binding_operator_test.go
@@ -412,12 +412,12 @@ func TestLoadBindingTimeLag(t *testing.T) {
 	numBindings := len(tk.MustQuery(`show global bindings`).Rows())
 	require.Equal(t, 1, numBindings)
 
-	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 5)
+	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 5*time.Second)
 	tk.MustExec(`create global binding using select * from t where a < 1`)
 	numBindings = len(tk.MustQuery(`show global bindings`).Rows())
 	require.Equal(t, 2, numBindings)
 
-	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 15)
+	tk.Session().SetValue(bindinfo.TestTimeLagInLoadingBinding, 15*time.Second)
 	tk.MustExec(`create global binding using select * from t where a > 1`)
 	numBindings = len(tk.MustQuery(`show global bindings`).Rows())
 	require.Equal(t, 2, numBindings) // can't see the latest one since the time lag tolerance is only 10s


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64250

Problem Summary: planner: tolerate reasonable time lag between different TiDB nodes when updating binding cache

### What changed and how does it work?

When updating binding cache, TiDB doesn't consider time lag between different nodes, which could cause inconsistency on binding cache. See more info in #64250.

Below is an simplified example, TiDB1's clock is consistent with the real time, while TiDB2's clock is 0.5s slower than the real time:

| Real Physical Time | Action of TiDB1 | Action of TiDB2 |
| -------- | -------- | ------- |
| t1 00:00:30.200000 | create the new binding, write it into `mysql.bind_info` with timestamp `00:00:30.200000` | - | 
| t2 00:00:30.300000 | update binding cache: 1) load latest binding from `mysql.bind_info` where `binding.update_time > LAST_UPDATE_TIME`, 2) set `LAST_UPDATE_TIME` to the latest `binding.update_time`, in this case its `00:00:30.200000` | - |
| t3 00:00:30.500000 | - | create a new binding with timestamp `00:00:30.000000` due to system lock issue  |
| t4 00:00:30.600000 | - | update its binding cache |
| t5 00:01:00.000000 | update binding cache, can't see the binding crated by TiDB2 ❌ | - |

In the case above, TiDB1 can never see the binding created by TiDB2 with timestamp `00:00:30.000000` because its `LAST_UPDATE_TIME = 00:00:30.200000` is larger than that binding's timestamp.

The solution is simple, set a tolerance interval (10s by default) when updating binding cache. And it's safe to load duplicated bindings, because we'll deduplicate them before actually putting them into the cache.

<img width="847" height="216" alt="image" src="https://github.com/user-attachments/assets/55303f47-c1db-4f74-aabb-5b359e7ef885" />

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
