### PR TITLE
privileges,planner: implement checks for `RESTRICTED_USER_ADMIN` for granting privileges and roles

### DIFF
--- a/pkg/privilege/privileges/privileges_test.go
+++ b/pkg/privilege/privileges/privileges_test.go
@@ -2269,3 +2269,79 @@ func TestGrantOptionWithSEMv2(t *testing.T) {
 	err = tk4.ExecToErr("GRANT FILE ON *.* TO grantee")
 	require.NoError(t, err)
 }
+
+func testProtectUserAndRoleWithRestrictedPrivileges(t *testing.T, semVer string) {
+	store := createStoreAndPrepareDB(t)
+
+	rootTk := testkit.NewTestKit(t, store)
+	rootTk.MustExec("CREATE USER restricted_user")
+	rootTk.MustExec("GRANT RESTRICTED_USER_ADMIN, SUPER, CREATE USER, SELECT ON *.* TO restricted_user WITH GRANT OPTION")
+	rootTk.MustExec("CREATE USER normal_user")
+	rootTk.MustExec("GRANT SUPER, CREATE USER, SELECT ON *.* TO normal_user WITH GRANT OPTION")
+
+	rootTk.MustExec("CREATE USER restricted_user_1")
+	rootTk.MustExec("GRANT RESTRICTED_USER_ADMIN ON *.* TO restricted_user_1")
+	rootTk.MustExec("CREATE USER restricted_user_2")
+	rootTk.MustExec("GRANT RESTRICTED_USER_ADMIN ON *.* TO restricted_user_2")
+	rootTk.MustExec("CREATE USER restricted_user_3")
+	rootTk.MustExec("GRANT RESTRICTED_USER_ADMIN ON *.* TO restricted_user_3")
+	rootTk.MustExec("CREATE USER normal_user_1")
+
+	defer sem.SwitchToSEMForTest(t, semVer)()
+	// Accounts with RESTRICTED_USER_ADMIN are not allowed to be deleted unless we also have the
+	// RESTRICTED_USER_ADMIN privilege
+	tk1 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk1.Session().Auth(&auth.UserIdentity{Username: "normal_user", Hostname: "%"}, nil, nil, nil))
+	err := tk1.ExecToErr("DROP USER restricted_user_1")
+	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_USER_ADMIN privilege(s) for this operation")
+	tk2 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk2.Session().Auth(&auth.UserIdentity{Username: "restricted_user", Hostname: "%"}, nil, nil, nil))
+	err = tk2.ExecToErr("DROP USER restricted_user_1")
+	require.NoError(t, err)
+
+	// Accounts with RESTRICTED_USER_ADMIN are not allowed to be altered unless we also have the
+	// RESTRICTED_USER_ADMIN privilege
+	tk3 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk3.Session().Auth(&auth.UserIdentity{Username: "normal_user", Hostname: "%"}, nil, nil, nil))
+	err = tk3.ExecToErr("ALTER USER restricted_user_2 IDENTIFIED BY 'new_password'")
+	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_USER_ADMIN privilege(s) for this operation")
+	tk4 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk4.Session().Auth(&auth.UserIdentity{Username: "restricted_user", Hostname: "%"}, nil, nil, nil))
+	err = tk4.ExecToErr("ALTER USER restricted_user_2 IDENTIFIED BY 'new_password'")
+	require.NoError(t, err)
+
+	// Accounts with RESTRICTED_USER_ADMIN are not allowed to be granted or revoked unless we also
+	// have the RESTRICTED_USER_ADMIN privilege
+	tk5 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk5.Session().Auth(&auth.UserIdentity{Username: "normal_user", Hostname: "%"}, nil, nil, nil))
+	err = tk5.ExecToErr("GRANT SELECT ON test.* TO restricted_user_3")
+	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_USER_ADMIN privilege(s) for this operation")
+	err = tk5.ExecToErr("REVOKE SELECT ON test.* FROM restricted_user_3")
+	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_USER_ADMIN privilege(s) for this operation")
+	tk6 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk6.Session().Auth(&auth.UserIdentity{Username: "restricted_user", Hostname: "%"}, nil, nil, nil))
+	err = tk6.ExecToErr("GRANT SELECT ON test.* TO restricted_user_3")
+	require.NoError(t, err)
+	err = tk6.ExecToErr("REVOKE SELECT ON test.* FROM restricted_user_3")
+	require.NoError(t, err)
+
+	// Accounts with RESTRICTED_USER_ADMIN are not allowed to be granted/revoked as a role unless we
+	// also have the RESTRICTED_USER_ADMIN privilege
+	tk7 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk7.Session().Auth(&auth.UserIdentity{Username: "normal_user", Hostname: "%"}, nil, nil, nil))
+	err = tk7.ExecToErr("GRANT restricted_user TO normal_user_1")
+	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_USER_ADMIN privilege(s) for this operation")
+	err = tk7.ExecToErr("REVOKE restricted_user FROM normal_user_1")
+	require.EqualError(t, err, "[planner:1227]Access denied; you need (at least one of) the RESTRICTED_USER_ADMIN privilege(s) for this operation")
+	tk8 := testkit.NewTestKit(t, store)
+	require.NoError(t, tk8.Session().Auth(&auth.UserIdentity{Username: "restricted_user", Hostname: "%"}, nil, nil, nil))
+	err = tk8.ExecToErr("GRANT restricted_user TO normal_user_1")
+	require.NoError(t, err)
+	err = tk8.ExecToErr("REVOKE restricted_user FROM normal_user_1")
+	require.NoError(t, err)
+}
+
+func TestProtectUserAndRoleWithRestrictedPrivileges(t *testing.T) {
+	testProtectUserAndRoleWithRestrictedPrivileges(t, sem.V1)
+	testProtectUserAndRoleWithRestrictedPrivileges(t, sem.V2)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64295 

Problem Summary:

The current implementation of SEM is not good enough (for both v1 and v2). We'll need to restrict the granting and revoking of roles which have `RESTRICTED_USER_ADMIN`, or the user with `ROLE ADMIN` permission can easily take the higher privilege.

### What changed and how does it work?

1. Users with `RESTRICTED_USER_ADMIN` are not allowed to be deleted
2. Users with `RESTRICTED_USER_ADMIN` are not allowed to have their names modified
3. Users with the `RESTRICTED_USER_ADMIN` permission are not allowed to change permissions.
4. An user with the `RESTRICTED_USER_ADMIN` attribute is not allowed to be used as a role.

Users with `RESTRICTED_USER_ADMIN` are not limited by these four rules.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
