### PR TITLE
expression: Clone scalar function when to check the equivalence of the expression

### DIFF
--- a/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
+++ b/pkg/planner/core/casetest/instanceplancache/concurrency_test.go
@@ -889,7 +889,7 @@ func TestInstancePlanCacheConcurrencyComp(t *testing.T) {
 	}
 	stmts = append(stmts, &testStmt{normalStmt: "commit"})
 
-	nConcurrency := 12
+	nConcurrency := 10
 	TKs := make([]*testkit.TestKit, nConcurrency)
 	for i := range TKs {
 		TKs[i] = testkit.NewTestKit(t, store)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64156

Problem Summary:

### What changed and how does it work?

When performing rehashcode, the assertion must copy the expr before rehashing it. Otherwise, a data race will occur because the expr might be used in the plan cache, which could lead to additional issues.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
