### PR TITLE
planner: Consistent ordering for constant propagation

### DIFF
--- a/pkg/expression/constant_propagation.go
+++ b/pkg/expression/constant_propagation.go
@@ -301,9 +301,15 @@ func (s *propConstSolver) propagateConstantEQ() {
 		}
 		cols = slices.Grow(cols, len(mapper))
 		cons = slices.Grow(cons, len(mapper))
-		for id, con := range mapper {
+		// Sort map keys to ensure deterministic iteration order
+		ids := make([]int, 0, len(mapper))
+		for id := range mapper {
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		for _, id := range ids {
 			cols = append(cols, s.columns[id])
-			cons = append(cons, con)
+			cons = append(cons, mapper[id])
 		}
 		for i, cond := range s.conditions {
 			if !visited[i] {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63501 

Problem Summary:

### What changed and how does it work?

Prior PR https://github.com/pingcap/tidb/pull/64121 appears to have created an unpredictability in the order of the application of predicates - which resulted in the join_outer mysql-tests becoming flaky. This PR will sort the new map to maintain consistency in the order of predicate pushdown across executions of the same query.

AI based (cursor) review of the performance implications of this change are:
Original: O(n) per iteration
With sorting: O(n) + O(n log n) + O(n) = O(n log n) per iteration
Typical case: n = 5-10 columns with constants → sorting ~10 integers is negligible (~100 nanoseconds)
Worst case: n = 100 → sorting adds ~664 comparisons, still very fast

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Here is a copy of the DDL and SQL used for the test that was failing prior to this PR:
```
CREATE TABLE t1 (a int PRIMARY KEY, b int);
CREATE TABLE t2 (a int PRIMARY KEY, b int);
INSERT INTO t1 VALUES (1,2), (2,1), (3,2), (4,3), (5,6), (6,5), (7,8), (8,7), (9,10);
INSERT INTO t2 VALUES (3,0), (4,1), (6,4), (7,5);
EXPLAIN FORMAT='plan_tree' SELECT STRAIGHT_JOIN * FROM t1 LEFT JOIN t2 ON t1.a = t2.a WHERE t1.a = t2.a OR t1.a = t2.b;
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
