### PR TITLE
planner: add the variable `PlanCacheMaxDecimalParamNums` to restrict the number of decimal values in plan cache

### DIFF
--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/metrics"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	core_metrics "github.com/pingcap/tidb/pkg/planner/core/metrics"
 	"github.com/pingcap/tidb/pkg/planner/core/operator/physicalop"
@@ -211,6 +212,22 @@ func GetPlanFromPlanCache(ctx context.Context, sctx sessionctx.Context,
 		stmtCtx.SetCacheType(contextutil.SessionPrepared)
 		cacheEnabled = sessVars.EnablePreparedPlanCache
 	}
+
+	paramTypes := parseParamTypes(sctx, params)
+	if cacheEnabled && sessVars.PlanCacheMaxDecimalParamNums >= 0 {
+		// Check the number of parameters' decimal types
+		decimalNums := 0
+		for _, param := range paramTypes {
+			if param.GetType() == mysql.TypeNewDecimal {
+				decimalNums++
+			}
+		}
+		if decimalNums > sessVars.PlanCacheMaxDecimalParamNums {
+			sctx.GetSessionVars().StmtCtx.AppendWarning(errors.NewNoStackError("skip prepared plan-cache: too many decimal parameters"))
+			cacheEnabled = false
+		}
+	}
+
 	if stmt.StmtCacheable && cacheEnabled {
 		stmtCtx.EnablePlanCache()
 	}
@@ -230,7 +247,6 @@ func GetPlanFromPlanCache(ctx context.Context, sctx sessionctx.Context,
 		}
 	}
 
-	paramTypes := parseParamTypes(sctx, params)
 	if stmtCtx.UseCache() {
 		plan, outputCols, stmtHints, hit := lookupPlanCache(ctx, sctx, cacheKey, paramTypes)
 		skipPrivCheck := stmt.PointGet.Executor != nil // this case is specially handled

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1734,7 +1734,7 @@ const (
 	DefTiDBSchemaCacheSize                            = 512 * 1024 * 1024
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefDivPrecisionIncrement                          = 4
-	DefTiDBPlanCacheMaxDecimalParamNums               = 2
+	DefTiDBPlanCacheMaxDecimalParamNums               = -1
 	DefTiDBDMLType                                    = "STANDARD"
 	DefGroupConcatMaxLen                              = uint64(1024)
 	DefDefaultWeekFormat                              = "0"

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -1073,6 +1073,9 @@ const (
 	// division operations performed with the / operator.
 	DivPrecisionIncrement = "div_precision_increment"
 
+	// TiDBPlanCacheMaxDecimalParamNums indicates the max number of decimal parameters which can use the plan cache
+	TiDBPlanCacheMaxDecimalParamNums = "tidb_plan_cache_max_decimal_param_nums"
+
 	// TiDBEnableSharedLockPromotion indicates whether the `select for share` statement would be executed
 	// as `select for update` statements which do acquire pessimistic locks.
 	TiDBEnableSharedLockPromotion = "tidb_enable_shared_lock_promotion"
@@ -1731,6 +1734,7 @@ const (
 	DefTiDBSchemaCacheSize                            = 512 * 1024 * 1024
 	DefTiDBLowResolutionTSOUpdateInterval             = 2000
 	DefDivPrecisionIncrement                          = 4
+	DefTiDBPlanCacheMaxDecimalParamNums               = 2
 	DefTiDBDMLType                                    = "STANDARD"
 	DefGroupConcatMaxLen                              = uint64(1024)
 	DefDefaultWeekFormat                              = "0"

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1790,6 +1790,9 @@ type SessionVars struct {
 		QueryReserved int64
 	}
 
+	// PlanCacheMaxDecimalParamNums indicates the max number of decimal parameters which can use the plan cache
+	PlanCacheMaxDecimalParamNums int
+
 	// InPacketBytes records the total incoming packet bytes from clients for current session.
 	InPacketBytes atomic.Uint64
 

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -3672,6 +3672,11 @@ var defaultSysVars = []*SysVar{
 			s.DivPrecisionIncrement = tidbOptPositiveInt32(val, vardef.DefDivPrecisionIncrement)
 			return nil
 		}},
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBPlanCacheMaxDecimalParamNums, Value: strconv.Itoa(vardef.DefTiDBPlanCacheMaxDecimalParamNums), Type: vardef.TypeInt, MinValue: math.MinInt, MaxValue: math.MaxInt,
+		SetSession: func(s *SessionVars, val string) error {
+			s.PlanCacheMaxDecimalParamNums = TidbOptInt(val, vardef.DefTiDBPlanCacheMaxDecimalParamNums)
+			return nil
+		}},
 	{Scope: vardef.ScopeSession, Name: vardef.TiDBDMLType, Value: vardef.DefTiDBDMLType, Type: vardef.TypeStr,
 		SetSession: func(s *SessionVars, val string) error {
 			lowerVal := strings.ToLower(val)

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -2602,6 +2602,7 @@ EXECUTE stmt;
 a
 1
 set @@tidb_enable_prepared_plan_cache=1;
+set @@session.tidb_plan_cache_max_decimal_param_nums = 2;
 drop table if exists t1;
 create table t1 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), b4 decimal(10,2), c varchar(10));
 prepare stmt from 'select * from t1 where a=? and c=?';
@@ -2802,4 +2803,13 @@ a	b1	b2	b3
 select @@last_plan_from_cache;
 @@last_plan_from_cache
 0
+set @@session.tidb_plan_cache_max_decimal_param_nums = default;
+select @@session.tidb_plan_cache_max_decimal_param_nums;
+@@session.tidb_plan_cache_max_decimal_param_nums
+-1
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
 deallocate prepare stmt;

--- a/tests/integrationtest/r/planner/core/plan_cache.result
+++ b/tests/integrationtest/r/planner/core/plan_cache.result
@@ -2601,3 +2601,205 @@ PREPARE stmt FROM 'SELECT a FROM t WHERE b=current_date()';
 EXECUTE stmt;
 a
 1
+set @@tidb_enable_prepared_plan_cache=1;
+drop table if exists t1;
+create table t1 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), b4 decimal(10,2), c varchar(10));
+prepare stmt from 'select * from t1 where a=? and c=?';
+set @p0 = 1, @p1 = 'test';
+execute stmt using @p0, @p1;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where b1=?';
+set @p0 = 1.5;
+execute stmt using @p0;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where a=? and b1=? and c=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 'test';
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where b1=? and b2=?';
+set @p0 = 1.5, @p1 = 2.5;
+execute stmt using @p0, @p1;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where a=? and b1=? and b2=? and c=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 3.5, @p3 = 'test';
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where b1=? and b2=? and b3=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5;
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where b1=? and b2=? and b3=? and a=? and c=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5, @p3 = 1, @p4 = 'test';
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare stmt;
+prepare stmt from 'select * from t1 where b1=? and b2=? and b3=? and b4=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5, @p3 = 4.5;
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare stmt;
+drop table if exists t2;
+create table t2 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), b4 decimal(10,2), c varchar(10));
+set @@session.tidb_plan_cache_max_decimal_param_nums = 0;
+prepare stmt from 'select * from t2 where a=? and c=?';
+set @p0 = 1, @p1 = 'test';
+execute stmt using @p0, @p1;
+a	b1	b2	b3	b4	c
+execute stmt using @p0, @p1;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t2 where b1=?';
+set @p0 = 1.5;
+execute stmt using @p0;
+a	b1	b2	b3	b4	c
+execute stmt using @p0;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare stmt;
+set @@session.tidb_plan_cache_max_decimal_param_nums = -1;
+prepare stmt from 'select * from t2 where b1=? and b2=? and b3=? and b4=? and a=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5, @p3 = 4.5, @p4 = 100;
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+a	b1	b2	b3	b4	c
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+a	b1	b2	b3	b4	c
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+drop table if exists t3;
+create table t3 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), c varchar(10), d decimal(5,2));
+prepare stmt from 'select * from t3 where a=? and b1=? and c=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 'test';
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	c	d
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	c	d
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t3 where b1=? and b2=? and b3=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5;
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	c	d
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3	c	d
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t3 where a=? and b1=? and c=? and d=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 'test', @p3 = 4.5;
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	c	d
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	c	d
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+prepare stmt from 'select * from t3 where a=? and b1=? and b2=? and b3=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 3.5, @p3 = 4.5;
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	c	d
+execute stmt using @p0, @p1, @p2, @p3;
+a	b1	b2	b3	c	d
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+deallocate prepare stmt;
+drop table if exists t5;
+create table t5 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2));
+set @@session.tidb_plan_cache_max_decimal_param_nums = 3;
+prepare stmt from 'select * from t5 where b1=? and b2=? and b3=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5;
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+set @@session.tidb_plan_cache_max_decimal_param_nums = 2;
+execute stmt using @p0, @p1, @p2;
+a	b1	b2	b3
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+0
+deallocate prepare stmt;

--- a/tests/integrationtest/t/planner/core/plan_cache.test
+++ b/tests/integrationtest/t/planner/core/plan_cache.test
@@ -1661,6 +1661,7 @@ EXECUTE stmt;
 
 # TestPlanCacheMaxDecimalParamNums
 set @@tidb_enable_prepared_plan_cache=1;
+set @@session.tidb_plan_cache_max_decimal_param_nums = 2;
 drop table if exists t1;
 create table t1 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), b4 decimal(10,2), c varchar(10));
 
@@ -1819,4 +1820,10 @@ select @@last_plan_from_cache;
 set @@session.tidb_plan_cache_max_decimal_param_nums = 2;
 execute stmt using @p0, @p1, @p2;
 select @@last_plan_from_cache;
+
+set @@session.tidb_plan_cache_max_decimal_param_nums = default;
+select @@session.tidb_plan_cache_max_decimal_param_nums;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+
 deallocate prepare stmt;

--- a/tests/integrationtest/t/planner/core/plan_cache.test
+++ b/tests/integrationtest/t/planner/core/plan_cache.test
@@ -1658,3 +1658,165 @@ CREATE TABLE t (a int(11) DEFAULT NULL, b date DEFAULT NULL);
 INSERT INTO t VALUES (1, current_date());
 PREPARE stmt FROM 'SELECT a FROM t WHERE b=current_date()';
 EXECUTE stmt;
+
+# TestPlanCacheMaxDecimalParamNums
+set @@tidb_enable_prepared_plan_cache=1;
+drop table if exists t1;
+create table t1 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), b4 decimal(10,2), c varchar(10));
+
+# Test case 1: Decimal params <= default limit (2) should be cached
+# 0 decimal params - should cache
+prepare stmt from 'select * from t1 where a=? and c=?';
+set @p0 = 1, @p1 = 'test';
+execute stmt using @p0, @p1;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 1 decimal param - should cache
+prepare stmt from 'select * from t1 where b1=?';
+set @p0 = 1.5;
+execute stmt using @p0;
+select @@last_plan_from_cache;
+execute stmt using @p0;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 1 decimal param mixed - should cache
+prepare stmt from 'select * from t1 where a=? and b1=? and c=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 'test';
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 2 decimal params - should cache (default limit)
+prepare stmt from 'select * from t1 where b1=? and b2=?';
+set @p0 = 1.5, @p1 = 2.5;
+execute stmt using @p0, @p1;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 2 decimal params mixed - should cache
+prepare stmt from 'select * from t1 where a=? and b1=? and b2=? and c=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 3.5, @p3 = 'test';
+execute stmt using @p0, @p1, @p2, @p3;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1, @p2, @p3;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 3 decimal params - should not cache (exceeds default limit of 2)
+prepare stmt from 'select * from t1 where b1=? and b2=? and b3=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 3 decimal params mixed - should not cache
+prepare stmt from 'select * from t1 where b1=? and b2=? and b3=? and a=? and c=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5, @p3 = 1, @p4 = 'test';
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# 4 decimal params - should not cache
+prepare stmt from 'select * from t1 where b1=? and b2=? and b3=? and b4=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5, @p3 = 4.5;
+execute stmt using @p0, @p1, @p2, @p3;
+select @@last_plan_from_cache;
+execute stmt using @p0, @p1, @p2, @p3;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# TestPlanCacheMaxDecimalParamNumsWithDifferentLimits
+drop table if exists t2;
+create table t2 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), b4 decimal(10,2), c varchar(10));
+
+# Test with limit = 0 (no decimal params allowed)
+set @@session.tidb_plan_cache_max_decimal_param_nums = 0;
+prepare stmt from 'select * from t2 where a=? and c=?';
+set @p0 = 1, @p1 = 'test';
+execute stmt using @p0, @p1;
+execute stmt using @p0, @p1;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# Test with limit = 0, one decimal not allowed
+prepare stmt from 'select * from t2 where b1=?';
+set @p0 = 1.5;
+execute stmt using @p0;
+execute stmt using @p0;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# Test with limit = -1 (disable check, always allow)
+set @@session.tidb_plan_cache_max_decimal_param_nums = -1;
+prepare stmt from 'select * from t2 where b1=? and b2=? and b3=? and b4=? and a=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5, @p3 = 4.5, @p4 = 100;
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+execute stmt using @p0, @p1, @p2, @p3, @p4;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# TestPlanCacheMaxDecimalParamNumsBoundaryCases
+drop table if exists t3;
+create table t3 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2), c varchar(10), d decimal(5,2));
+
+# Total params = 3, decimal params = 2 (within limit)
+prepare stmt from 'select * from t3 where a=? and b1=? and c=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 'test';
+execute stmt using @p0, @p1, @p2;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# Total params = 3, decimal params = 3 (exceeds limit)
+prepare stmt from 'select * from t3 where b1=? and b2=? and b3=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5;
+execute stmt using @p0, @p1, @p2;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# Total params = 4, decimal params = 2 (within limit)
+prepare stmt from 'select * from t3 where a=? and b1=? and c=? and d=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 'test', @p3 = 4.5;
+execute stmt using @p0, @p1, @p2, @p3;
+execute stmt using @p0, @p1, @p2, @p3;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# Total params = 4, decimal params = 3 (exceeds limit)
+prepare stmt from 'select * from t3 where a=? and b1=? and b2=? and b3=?';
+set @p0 = 1, @p1 = 2.5, @p2 = 3.5, @p3 = 4.5;
+execute stmt using @p0, @p1, @p2, @p3;
+execute stmt using @p0, @p1, @p2, @p3;
+select @@last_plan_from_cache;
+deallocate prepare stmt;
+
+# TestPlanCacheMaxDecimalParamNumsResetSessionVar
+drop table if exists t5;
+create table t5 (a int, b1 decimal(10,2), b2 decimal(10,2), b3 decimal(10,2));
+
+# Test that changing session variable affects caching behavior
+set @@session.tidb_plan_cache_max_decimal_param_nums = 3;
+prepare stmt from 'select * from t5 where b1=? and b2=? and b3=?';
+set @p0 = 1.5, @p1 = 2.5, @p2 = 3.5;
+execute stmt using @p0, @p1, @p2;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+
+# Change limit to 2, should not cache anymore
+set @@session.tidb_plan_cache_max_decimal_param_nums = 2;
+execute stmt using @p0, @p1, @p2;
+select @@last_plan_from_cache;
+deallocate prepare stmt;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/58576

Problem Summary:
Add an variable to control how many decimal values allowed in the plan cache.

### What changed and how does it work?
We'll check the parameter's type. If the number of decimal values more than the settings. We'll skip the plan cache for this case

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
