### PR TITLE
dxf: fix incorrect worker count metric when total task count exceed schedule limit

### DIFF
--- a/pkg/disttask/framework/scheduler/scheduler_manager.go
+++ b/pkg/disttask/framework/scheduler/scheduler_manager.go
@@ -514,7 +514,7 @@ func (sm *Manager) collectWorkerMetrics(tasks []*proto.TaskBase) {
 	slices.SortFunc(scheduledTasks, func(i, j *proto.TaskBase) int {
 		return i.Compare(j)
 	})
-	requiredNodes := handle.CalculateRequiredNodes(tasks, nodeCPU)
+	requiredNodes := handle.CalculateRequiredNodes(scheduledTasks, nodeCPU)
 	dxfmetric.WorkerCount.WithLabelValues("required").Set(float64(requiredNodes))
 	dxfmetric.WorkerCount.WithLabelValues("current").Set(float64(nodeCount))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
we pass the wrong tasks param when calculate for the worker count metric
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

<details><summary>apply this diff, we we can only run at most 2 task at the same time, force the task concurrency = node CPU, and let the task wait</summary>
<p>

```diff
diff --git a/pkg/disttask/framework/proto/task.go b/pkg/disttask/framework/proto/task.go
index 0ca1162f22..cd3e5bd18a 100644
--- a/pkg/disttask/framework/proto/task.go
+++ b/pkg/disttask/framework/proto/task.go
@@ -65,7 +65,7 @@ const (
 
 // MaxConcurrentTask is the max concurrency of task.
 // TODO: remove this limit later.
-var MaxConcurrentTask = 16
+var MaxConcurrentTask = 2
 
 // ExtraParams is the extra params of task.
 // Note: only store params that's not used for filter or sort in this struct.
diff --git a/pkg/disttask/importinto/task_executor.go b/pkg/disttask/importinto/task_executor.go
index 4a57bbfd00..4f633f80ae 100644
--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -183,6 +183,7 @@ func (s *importStepExecutor) Processed(bytes, rowCnt int64) {
 }
 
 func (s *importStepExecutor) RunSubtask(ctx context.Context, subtask *proto.Subtask) (err error) {
+	time.Sleep(time.Minute)
 	logger := s.logger.With(zap.Int64("subtask-id", subtask.ID))
 	task := log.BeginTask(logger, "run subtask")
 	defer func() {
diff --git a/pkg/executor/importer/import.go b/pkg/executor/importer/import.go
index e3f78ff6a9..56e1151251 100644
--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -1422,7 +1422,7 @@ func (e *LoadDataController) CalResourceParams(ctx context.Context, ksCodec []by
 		}
 	}
 	cal := scheduler.NewRCCalc(totalSize, targetNodeCPUCnt, indexSizeRatio, factors)
-	e.ThreadCnt = cal.CalcConcurrency()
+	e.ThreadCnt = targetNodeCPUCnt
 	e.MaxNodeCnt = cal.CalcMaxNodeCountForImportInto()
 	e.DistSQLScanConcurrency = scheduler.CalcDistSQLConcurrency(e.ThreadCnt, e.MaxNodeCnt, targetNodeCPUCnt)
 	e.logger.Info("auto calculate resource related params",
```

</p>
</details> 

previously
```
# HELP tidb_dxf_worker_count Gauge of DXF worker count.
# TYPE tidb_dxf_worker_count gauge
tidb_dxf_worker_count{keyspace_name="SYSTEM",type="current"} 1
tidb_dxf_worker_count{keyspace_name="SYSTEM",type="required"} 3
```
after
```
# HELP tidb_dxf_worker_count Gauge of DXF worker count.
# TYPE tidb_dxf_worker_count gauge
tidb_dxf_worker_count{keyspace_name="SYSTEM",type="current"} 1
tidb_dxf_worker_count{keyspace_name="SYSTEM",type="required"} 2
```

- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
