### PR TITLE
br: fix build error on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ lightning_web: ## Build Lightning web UI
 
 .PHONY: build_br
 build_br: ## Build BR (backup and restore) tool 
-ifeq ($(ARCH),$(MAC))
+ifeq ($(shell echo $(GOOS) | tr A-Z a-z),darwin)
 	@echo "Detected macOS ($(ARCH)), enabling CGO"
 	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) ./br/cmd/br
 else

--- a/Makefile.common
+++ b/Makefile.common
@@ -15,6 +15,7 @@
 PROJECT=tidb
 GOPATH ?= $(shell go env GOPATH)
 GOMODCACHE ?= $(shell go env GOMODCACHE)
+GOOS ?= $(shell go env GOOS)
 P=8
 
 # Ensure GOPATH is set before running build process.
@@ -60,9 +61,9 @@ ifneq "$(TIDB_EDITION)" "Enterprise"
 endif
 endif
 
-ARCH      := $(shell uname -s)
-LINUX     := Linux
-MAC       := Darwin
+ARCH      := "`uname -s`"
+LINUX     := "Linux"
+MAC       := "Darwin"
 
 PACKAGE_LIST  := go list ./...
 PACKAGE_LIST_TIDB_TESTS  := go list ./... | grep -vE "github.com\/pingcap\/tidb\/br|github.com\/pingcap\/tidb\/cmd|github.com\/pingcap\/tidb\/dumpling"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/64152

Problem Summary:

when disable cgo and complie on mac.
it will report error
```
../../../go/pkg/mod/github.com/cloudfoundry/gosigar@v1.3.6/concrete_sigar.go:20:12: cpuUsage.Get undefined (type Cpu has no field or method Get)
```

### What changed and how does it work?
enable cgo in makefile.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
