### PR TITLE
dumpling: use GO variable when building

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -133,8 +133,8 @@ DUMPLING_LDFLAGS += -X "github.com/pingcap/tidb/dumpling/cli.GitHash=$(shell git
 DUMPLING_LDFLAGS += -X "github.com/pingcap/tidb/dumpling/cli.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
 DUMPLING_LDFLAGS += -X "github.com/pingcap/tidb/dumpling/cli.GoVersion=$(shell go version)"
 
-DUMPLING_GOBUILD := CGO_ENABLED=1 GO111MODULE=on go build -trimpath -ldflags '$(DUMPLING_LDFLAGS)'
-DUMPLING_GOTEST  := CGO_ENABLED=1 GO111MODULE=on go test -ldflags '$(DUMPLING_LDFLAGS)'
+DUMPLING_GOBUILD := CGO_ENABLED=1 ${GO} build -trimpath -ldflags '$(DUMPLING_LDFLAGS)'
+DUMPLING_GOTEST  := CGO_ENABLED=1 ${GO} test -ldflags '$(DUMPLING_LDFLAGS)'
 
 TEST_COVERAGE_DIR := "test_coverage"
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->



Problem Summary:

This makes it easier to build with `gotip` or a specific version of Go.

```
$ make build_dumpling 
CGO_ENABLED=1 GO111MODULE=on go build -trimpath -ldflags '-X "github.com/pingcap/tidb/dumpling/cli.ReleaseVersion=v9.0.0-beta.2.pre-746-g05e3e88bd6" -X "github.com/pingcap/tidb/dumpling/cli.BuildTimestamp=2025-11-09 08:37:03" -X "github.com/pingcap/tidb/dumpling/cli.GitHash=05e3e88bd616e959ef44db813b09f08c21ec61ad" -X "github.com/pingcap/tidb/dumpling/cli.GitBranch=dumpling_gotip" -X "github.com/pingcap/tidb/dumpling/cli.GoVersion=go version go1.25.4 X:nodwarf5 linux/amd64"'  -tags codes -o bin/dumpling dumpling/cmd/dumpling/main.go
```

```
$ make GO=gotip build_dumpling 
CGO_ENABLED=1 gotip build -trimpath -ldflags '-X "github.com/pingcap/tidb/dumpling/cli.ReleaseVersion=v9.0.0-beta.2.pre-746-g05e3e88bd6" -X "github.com/pingcap/tidb/dumpling/cli.BuildTimestamp=2025-11-09 08:35:23" -X "github.com/pingcap/tidb/dumpling/cli.GitHash=05e3e88bd616e959ef44db813b09f08c21ec61ad" -X "github.com/pingcap/tidb/dumpling/cli.GitBranch=dumpling_gotip" -X "github.com/pingcap/tidb/dumpling/cli.GoVersion=go version go1.25.4 X:nodwarf5 linux/amd64"'  -tags codes -o bin/dumpling dumpling/cmd/dumpling/main.go
```

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
