### PR TITLE
ddl: fix flaky test TestColumnAdd

### DIFF
--- a/pkg/ddl/column_change_test.go
+++ b/pkg/ddl/column_change_test.go
@@ -42,12 +42,11 @@ func TestColumnAdd(t *testing.T) {
 	store := testkit.CreateMockStore(t)
 	ddl.SetWaitTimeWhenErrorOccurred(1 * time.Microsecond)
 	tk := testkit.NewTestKit(t, store)
-	internal := testkit.NewTestKit(t, store)
+	se := tk.Session()
 	tk.MustExec("use test")
 	tk.MustExec("create table t (c1 int, c2 int);")
 	tk.MustExec("insert t values (1, 2);")
 
-	ct := testNewContext(t, store)
 	var (
 		deleteOnlyTable table.Table
 		writeOnlyTable  table.Table
@@ -62,25 +61,25 @@ func TestColumnAdd(t *testing.T) {
 			return
 		}
 		jobID.Store(job.ID)
-		tbl := external.GetTableByName(t, internal, "test", "t")
+		tbl := external.GetTableByName(t, tk, "test", "t")
 		switch job.SchemaState {
 		case model.StateDeleteOnly:
 			deleteOnlyTable = tbl
 		case model.StateWriteOnly:
 			writeOnlyTable = tbl
-			require.NoError(t, checkAddWriteOnly(ct, deleteOnlyTable, writeOnlyTable, kv.IntHandle(1)))
+			require.NoError(t, checkAddWriteOnly(se, deleteOnlyTable, writeOnlyTable, kv.IntHandle(1)))
 		case model.StatePublic:
 			publicTable = tbl
-			require.NoError(t, checkAddPublic(ct, writeOnlyTable, publicTable))
+			require.NoError(t, checkAddPublic(se, writeOnlyTable, publicTable))
 		}
 	})
 	tk.MustExec("alter table t add column c3 int default 3")
-	checkJobWithHistory(t, tk.Session(), jobID.Load(), &finishedJobInfo{tbl: publicTable.Meta()})
+	checkJobWithHistory(t, se, jobID.Load(), nil, publicTable.Meta())
 
 	// Drop column.
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeRunOneJobStep", func(job *model.Job) {
 		if dropCol == nil {
-			tbl := external.GetTableByName(t, internal, "test", "t")
+			tbl := external.GetTableByName(t, tk, "test", "t")
 			dropCol = tbl.VisibleCols()[2]
 		}
 	})
@@ -89,7 +88,7 @@ func TestColumnAdd(t *testing.T) {
 			return
 		}
 		jobID.Store(job.ID)
-		tbl := external.GetTableByName(t, internal, "test", "t")
+		tbl := external.GetTableByName(t, tk, "test", "t")
 		if job.SchemaState != model.StatePublic {
 			for _, col := range tbl.Cols() {
 				require.NotEqualf(t, col.ID, dropCol.ID, "column is not dropped")
@@ -98,7 +97,7 @@ func TestColumnAdd(t *testing.T) {
 	})
 	tk.MustExec("alter table t drop column c3")
 	// checkJobWithHistory doesn't check column, so it's ok to use previous one.
-	checkJobWithHistory(t, tk.Session(), jobID.Load(), &finishedJobInfo{tbl: publicTable.Meta()})
+	checkJobWithHistory(t, se, jobID.Load(), nil, publicTable.Meta())
 
 	// Add column with no default value set.
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", func(job *model.Job) {
@@ -106,15 +105,14 @@ func TestColumnAdd(t *testing.T) {
 			return
 		}
 		jobID.Store(job.ID)
-		tbl := external.GetTableByName(t, internal, "test", "t")
+		tbl := external.GetTableByName(t, tk, "test", "t")
 		switch job.SchemaState {
 		case model.StateWriteOnly:
 			writeOnlyTable = tbl
 		case model.StatePublic:
-			sess := testNewContext(t, store)
-			txn, err := newTxn(sess)
+			txn, err := newTxn(se)
 			require.NoError(t, err)
-			_, err = writeOnlyTable.AddRecord(sess.GetTableCtx(), txn, types.MakeDatums(10, 10))
+			_, err = writeOnlyTable.AddRecord(se.GetTableCtx(), txn, types.MakeDatums(10, 10))
 			require.NoError(t, err)
 		}
 	})
@@ -362,11 +360,6 @@ func datumsToInterfaces(datums []types.Datum) []any {
 	return ifs
 }
 
-type finishedJobInfo struct {
-	db  *model.DBInfo
-	tbl *model.TableInfo
-}
-
 func getSchemaVer(t *testing.T, ctx sessionctx.Context) int64 {
 	txn, err := newTxn(ctx)
 	require.NoError(t, err)
@@ -386,24 +379,21 @@ func checkEqualTable(t *testing.T, t1, t2 *model.TableInfo) {
 	require.Equal(t, t1.AutoIncID, t2.AutoIncID)
 }
 
-// checkJobWithHistory checks the history job info with the expected finishedJobInfo.
-func checkJobWithHistory(t *testing.T, ctx sessionctx.Context, id int64, job *finishedJobInfo) {
+// checkJobWithHistory checks the history job info with the expected one.
+func checkJobWithHistory(t *testing.T, ctx sessionctx.Context, id int64, dbInfo *model.DBInfo, tblInfo *model.TableInfo) {
 	ver := getSchemaVer(t, ctx)
 
 	historyJob, err := ddl.GetHistoryJobByID(ctx, id)
 	require.NoError(t, err)
 	require.Greater(t, historyJob.BinlogInfo.FinishedTS, uint64(0))
+	require.Equal(t, historyJob.BinlogInfo.SchemaVersion, ver)
 
-	// Check table job
-	if job.tbl != nil {
-		require.Equal(t, historyJob.BinlogInfo.SchemaVersion, ver)
-		checkEqualTable(t, historyJob.BinlogInfo.TableInfo, job.tbl)
+	if tblInfo != nil {
+		checkEqualTable(t, historyJob.BinlogInfo.TableInfo, tblInfo)
 	}
 
-	// Check DB job
-	if job.db != nil {
-		require.Equal(t, historyJob.BinlogInfo.SchemaVersion, ver)
-		require.Equal(t, historyJob.BinlogInfo.DBInfo, job.db)
+	if dbInfo != nil {
+		require.Equal(t, historyJob.BinlogInfo.DBInfo, dbInfo)
 	}
 }
 
@@ -423,10 +413,6 @@ func testCheckJobDone(t *testing.T, store kv.Storage, jobID int64, isAdd bool) {
 	} else {
 		require.Equal(t, historyJob.SchemaState, model.StateNone)
 	}
-}
-
-func testNewContext(t *testing.T, store kv.Storage) sessionctx.Context {
-	return testkit.NewSession(t, store)
 }
 
 func TestIssue40135(t *testing.T) {

--- a/pkg/ddl/column_test.go
+++ b/pkg/ddl/column_test.go
@@ -53,7 +53,7 @@ func testCreateColumn(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context,
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
 
-	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, nil, tblInfo.Meta())
 	return id
 }
 
@@ -75,7 +75,7 @@ func testCreateColumns(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, nil, tblInfo.Meta())
 	return id
 }
 
@@ -93,7 +93,7 @@ func testDropColumnInternal(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Co
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, nil, tblInfo.Meta())
 	return id
 }
 
@@ -123,7 +123,7 @@ func testCreateIndex(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context, 
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, nil, tblInfo.Meta())
 	return id
 }
 
@@ -147,7 +147,7 @@ func testDropColumns(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context, 
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, nil, tblInfo.Meta())
 	return id
 }
 
@@ -163,7 +163,7 @@ func TestColumnBasic(t *testing.T) {
 		tk.MustExec(fmt.Sprintf("insert into t1 values(%d, %d, %d)", i, 10*i, 100*i))
 	}
 
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	txn, err := newTxn(ctx)
 	require.NoError(t, err)
 
@@ -510,8 +510,6 @@ func checkReorganizationColumn(t *testing.T, ctx sessionctx.Context, tableID int
 	require.NoError(t, err)
 	err = txn.Commit(context.Background())
 	require.NoError(t, err)
-	txn, err = newTxn(ctx)
-	require.NoError(t, err)
 
 	rows := [][]types.Datum{row, newRow}
 
@@ -620,7 +618,7 @@ func checkPublicColumn(t *testing.T, ctx sessionctx.Context, tableID int64, newC
 }
 
 func checkAddColumn(t *testing.T, state model.SchemaState, tableID int64, handle kv.Handle, newCol *table.Column, oldRow []types.Datum, columnValue any, dom *domain.Domain, store kv.Storage, columnCnt int) {
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	switch state {
 	case model.StateNone:
 		checkNoneColumn(t, ctx, tableID, handle, newCol, columnValue, dom)
@@ -662,7 +660,7 @@ func TestAddColumn(t *testing.T) {
 	tableID = int64(tableIDi)
 	tbl := testGetTable(t, dom, tableID)
 
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	txn, err := newTxn(ctx)
 	require.NoError(t, err)
 	oldRow := types.MakeDatums(int64(1), int64(2), int64(3))
@@ -727,7 +725,7 @@ func TestAddColumns(t *testing.T) {
 	tableID = int64(tableIDi)
 	tbl := testGetTable(t, dom, tableID)
 
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	txn, err := newTxn(ctx)
 	require.NoError(t, err)
 	oldRow := types.MakeDatums(int64(1), int64(2), int64(3))
@@ -784,7 +782,7 @@ func TestDropColumnInColumnTest(t *testing.T) {
 	tableID = int64(tableIDi)
 	tbl := testGetTable(t, dom, tableID)
 
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	colName := "c4"
 	defaultColValue := int64(4)
 	row := types.MakeDatums(int64(1), int64(2), int64(3))
@@ -838,7 +836,7 @@ func TestDropColumns(t *testing.T) {
 	tableID = int64(tableIDi)
 	tbl := testGetTable(t, dom, tableID)
 
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	txn, err := newTxn(ctx)
 	require.NoError(t, err)
 

--- a/pkg/ddl/column_test.go
+++ b/pkg/ddl/column_test.go
@@ -510,7 +510,8 @@ func checkReorganizationColumn(t *testing.T, ctx sessionctx.Context, tableID int
 	require.NoError(t, err)
 	err = txn.Commit(context.Background())
 	require.NoError(t, err)
-
+	_, err = newTxn(ctx)
+	require.NoError(t, err)
 	rows := [][]types.Datum{row, newRow}
 
 	i = 0
@@ -533,7 +534,7 @@ func checkReorganizationColumn(t *testing.T, ctx sessionctx.Context, tableID int
 	require.NoError(t, err)
 	err = txn.Commit(context.Background())
 	require.NoError(t, err)
-	txn, err = newTxn(ctx)
+	_, err = newTxn(ctx)
 	require.NoError(t, err)
 
 	i = 0

--- a/pkg/ddl/column_test.go
+++ b/pkg/ddl/column_test.go
@@ -49,11 +49,11 @@ func testCreateColumn(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context,
 	tk.MustExec(sql)
 	idi, _ := strconv.Atoi(tk.MustQuery("admin show ddl jobs 1;").Rows()[0][0].(string))
 	id := int64(idi)
-	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
+
+	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
 	return id
 }
 
@@ -72,11 +72,10 @@ func testCreateColumns(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context
 	tk.MustExec(sql)
 	idi, _ := strconv.Atoi(tk.MustQuery("admin show ddl jobs 1;").Rows()[0][0].(string))
 	id := int64(idi)
-	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
 	return id
 }
 
@@ -91,11 +90,10 @@ func testDropColumnInternal(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Co
 
 	idi, _ := strconv.Atoi(tk.MustQuery("admin show ddl jobs 1;").Rows()[0][0].(string))
 	id := int64(idi)
-	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
 	return id
 }
 
@@ -122,11 +120,10 @@ func testCreateIndex(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context, 
 
 	idi, _ := strconv.Atoi(tk.MustQuery("admin show ddl jobs 1;").Rows()[0][0].(string))
 	id := int64(idi)
-	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
 	return id
 }
 
@@ -147,11 +144,10 @@ func testDropColumns(tk *testkit.TestKit, t *testing.T, ctx sessionctx.Context, 
 
 	idi, _ := strconv.Atoi(tk.MustQuery("admin show ddl jobs 1;").Rows()[0][0].(string))
 	id := int64(idi)
-	v := getSchemaVer(t, ctx)
 	require.NoError(t, dom.Reload())
 	tblInfo, exist := dom.InfoSchema().TableByID(context.Background(), tblID)
 	require.True(t, exist)
-	checkHistoryJobArgs(t, ctx, id, &historyJobArgs{ver: v, tbl: tblInfo.Meta()})
+	checkJobWithHistory(t, ctx, id, &finishedJobInfo{tbl: tblInfo.Meta()})
 	return id
 }
 

--- a/pkg/ddl/foreign_key_test.go
+++ b/pkg/ddl/foreign_key_test.go
@@ -90,7 +90,7 @@ func testDropForeignKey(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForT
 	args := &model.DropForeignKeyArgs{FkName: ast.NewCIStr(foreignKeyName)}
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 	return job
 }
 
@@ -163,7 +163,7 @@ func TestForeignKey(t *testing.T) {
 	mu.Unlock()
 	require.NoError(t, hErr)
 	require.True(t, ok)
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 
 	mu.Lock()
 	checkOK = false

--- a/pkg/ddl/foreign_key_test.go
+++ b/pkg/ddl/foreign_key_test.go
@@ -90,8 +90,7 @@ func testDropForeignKey(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForT
 	args := &model.DropForeignKeyArgs{FkName: ast.NewCIStr(foreignKeyName)}
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 	return job
 }
 
@@ -164,8 +163,7 @@ func TestForeignKey(t *testing.T) {
 	mu.Unlock()
 	require.NoError(t, hErr)
 	require.True(t, ok)
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 
 	mu.Lock()
 	checkOK = false

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -93,8 +93,7 @@ func TestIndexChange(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	v := getSchemaVer(t, tk.Session())
-	checkHistoryJobArgs(t, tk.Session(), jobID.Load(), &historyJobArgs{ver: v, tbl: publicTable.Meta()})
+	checkJobWithHistory(t, tk.Session(), jobID.Load(), &finishedJobInfo{tbl: publicTable.Meta()})
 
 	prevState = model.StateNone
 	var noneTable table.Table
@@ -124,8 +123,7 @@ func TestIndexChange(t *testing.T) {
 		}
 	})
 	tk.MustExec("alter table t drop index c2")
-	v = getSchemaVer(t, tk.Session())
-	checkHistoryJobArgs(t, tk.Session(), jobID.Load(), &historyJobArgs{ver: v, tbl: noneTable.Meta()})
+	checkJobWithHistory(t, tk.Session(), jobID.Load(), &finishedJobInfo{tbl: noneTable.Meta()})
 }
 
 func checkIndexExists(ctx sessionctx.Context, tbl table.Table, indexValue any, handle int64, exists bool) error {

--- a/pkg/ddl/index_change_test.go
+++ b/pkg/ddl/index_change_test.go
@@ -61,7 +61,7 @@ func TestIndexChange(t *testing.T) {
 			return
 		}
 		jobID.Store(job.ID)
-		ctx1 := testNewContext(t, store)
+		ctx1 := testkit.NewSession(t, store)
 		prevState = job.SchemaState
 		require.NoError(t, dom.Reload())
 		tbl, exist := dom.InfoSchema().TableByID(context.Background(), job.TableID)
@@ -93,7 +93,7 @@ func TestIndexChange(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	checkJobWithHistory(t, tk.Session(), jobID.Load(), &finishedJobInfo{tbl: publicTable.Meta()})
+	checkJobWithHistory(t, tk.Session(), jobID.Load(), nil, publicTable.Meta())
 
 	prevState = model.StateNone
 	var noneTable table.Table
@@ -107,7 +107,7 @@ func TestIndexChange(t *testing.T) {
 		require.NoError(t, dom.Reload())
 		tbl, exist := dom.InfoSchema().TableByID(context.Background(), job.TableID)
 		require.True(t, exist)
-		ctx1 := testNewContext(t, store)
+		ctx1 := testkit.NewSession(t, store)
 		switch job.SchemaState {
 		case model.StateWriteOnly:
 			writeOnlyTable = tbl
@@ -123,7 +123,7 @@ func TestIndexChange(t *testing.T) {
 		}
 	})
 	tk.MustExec("alter table t drop index c2")
-	checkJobWithHistory(t, tk.Session(), jobID.Load(), &finishedJobInfo{tbl: noneTable.Meta()})
+	checkJobWithHistory(t, tk.Session(), jobID.Load(), nil, noneTable.Meta())
 }
 
 func checkIndexExists(ctx sessionctx.Context, tbl table.Table, indexValue any, handle int64, exists bool) error {

--- a/pkg/ddl/job_worker_test.go
+++ b/pkg/ddl/job_worker_test.go
@@ -53,7 +53,7 @@ func TestInvalidDDLJob(t *testing.T) {
 		BinlogInfo:          &model.HistoryInfo{},
 		InvolvingSchemaInfo: []model.InvolvingSchemaInfo{{Database: "db", Table: "table"}},
 	}
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	de := dom.DDLExecutor().(ddl.ExecutorForTest)
 	err := de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true))
@@ -62,7 +62,7 @@ func TestInvalidDDLJob(t *testing.T) {
 
 func TestAddBatchJobError(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomainWithSchemaLease(t, testLease)
-	ctx := testNewContext(t, store)
+	ctx := testkit.NewSession(t, store)
 
 	require.Nil(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockAddBatchDDLJobsErr", `return(true)`))
 	// Test the job runner should not hang forever.

--- a/pkg/ddl/partition_test.go
+++ b/pkg/ddl/partition_test.go
@@ -124,7 +124,7 @@ func testDropPartition(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTe
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 	return job
 }
 
@@ -146,7 +146,7 @@ func testTruncatePartition(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorF
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 	return job
 }
 

--- a/pkg/ddl/partition_test.go
+++ b/pkg/ddl/partition_test.go
@@ -124,8 +124,7 @@ func testDropPartition(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTe
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 	return job
 }
 
@@ -147,8 +146,7 @@ func testTruncatePartition(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorF
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 	return job
 }
 

--- a/pkg/ddl/placement_policy_ddl_test.go
+++ b/pkg/ddl/placement_policy_ddl_test.go
@@ -57,9 +57,8 @@ func testCreatePlacementPolicy(t *testing.T, ctx sessionctx.Context, d ddl.Execu
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, false))
 	require.NoError(t, err)
 
-	v := getSchemaVer(t, ctx)
 	policyInfo.State = model.StatePublic
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
 	policyInfo.State = model.StateNone
 	return job
 }

--- a/pkg/ddl/placement_policy_ddl_test.go
+++ b/pkg/ddl/placement_policy_ddl_test.go
@@ -57,9 +57,7 @@ func testCreatePlacementPolicy(t *testing.T, ctx sessionctx.Context, d ddl.Execu
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, false))
 	require.NoError(t, err)
 
-	policyInfo.State = model.StatePublic
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
-	policyInfo.State = model.StateNone
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 	return job
 }
 

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -54,7 +54,7 @@ func testCreateTable(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTest
 	require.NoError(t, err)
 
 	tblInfo.State = model.StatePublic
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 	tblInfo.State = model.StateNone
 	return job
 }
@@ -149,7 +149,7 @@ func testCreateSchema(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTes
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.CreateSchemaArgs{DBInfo: dbInfo}, true)))
 
 	dbInfo.State = model.StatePublic
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{db: dbInfo})
+	checkJobWithHistory(t, ctx, job.ID, dbInfo, nil)
 	dbInfo.State = model.StateNone
 	return job
 }
@@ -265,7 +265,7 @@ func TestSchema(t *testing.T) {
 	ids := make(map[int64]struct{})
 	ids[tblInfo1.ID] = struct{}{}
 	ids[tblInfo2.ID] = struct{}{}
-	checkJobWithHistory(t, tk3.Session(), job.ID, &finishedJobInfo{db: dbInfo})
+	checkJobWithHistory(t, tk3.Session(), job.ID, dbInfo, nil)
 
 	// Drop a non-existent database.
 	job = &model.Job{

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -53,9 +53,8 @@ func testCreateTable(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTest
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
 
-	v := getSchemaVer(t, ctx)
 	tblInfo.State = model.StatePublic
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 	tblInfo.State = model.StateNone
 	return job
 }
@@ -149,9 +148,8 @@ func testCreateSchema(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTes
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.CreateSchemaArgs{DBInfo: dbInfo}, true)))
 
-	v := getSchemaVer(t, ctx)
 	dbInfo.State = model.StatePublic
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, db: dbInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{db: dbInfo})
 	dbInfo.State = model.StateNone
 	return job
 }
@@ -170,13 +168,12 @@ func buildDropSchemaJob(dbInfo *model.DBInfo) *model.Job {
 	return j
 }
 
-func testDropSchema(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTest, dbInfo *model.DBInfo) (*model.Job, int64) {
+func testDropSchema(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTest, dbInfo *model.DBInfo) *model.Job {
 	job := buildDropSchemaJob(dbInfo)
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.DropSchemaArgs{FKCheck: true}, true))
 	require.NoError(t, err)
-	ver := getSchemaVer(t, ctx)
-	return job, ver
+	return job
 }
 
 func isDDLJobDone(test *testing.T, t *meta.Mutator, store kv.Storage) bool {
@@ -263,12 +260,12 @@ func TestSchema(t *testing.T) {
 		require.NoError(t, err)
 	}
 	tk3 := testkit.NewTestKit(t, store)
-	job, v := testDropSchema(t, tk3.Session(), de, dbInfo)
+	job = testDropSchema(t, tk3.Session(), de, dbInfo)
 	testCheckSchemaState(t, store, dbInfo, model.StateNone)
 	ids := make(map[int64]struct{})
 	ids[tblInfo1.ID] = struct{}{}
 	ids[tblInfo2.ID] = struct{}{}
-	checkHistoryJobArgs(t, tk3.Session(), job.ID, &historyJobArgs{ver: v, db: dbInfo, tblIDs: ids})
+	checkJobWithHistory(t, tk3.Session(), job.ID, &finishedJobInfo{db: dbInfo})
 
 	// Drop a non-existent database.
 	job = &model.Job{
@@ -289,7 +286,7 @@ func TestSchema(t *testing.T) {
 	job = testCreateSchema(t, ctx, de, dbInfo1)
 	testCheckSchemaState(t, store, dbInfo1, model.StatePublic)
 	testCheckJobDone(t, store, job.ID, true)
-	job, _ = testDropSchema(t, ctx, de, dbInfo1)
+	job = testDropSchema(t, ctx, de, dbInfo1)
 	testCheckSchemaState(t, store, dbInfo1, model.StateNone)
 	testCheckJobDone(t, store, job.ID, false)
 }

--- a/pkg/ddl/table_test.go
+++ b/pkg/ddl/table_test.go
@@ -73,7 +73,7 @@ func testRenameTable(
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true)))
 
 	tblInfo.State = model.StatePublic
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 	tblInfo.State = model.StateNone
 	return job
 }
@@ -102,7 +102,7 @@ func testRenameTables(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTes
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true)))
 
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: nil})
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 	return job
 }
 
@@ -137,7 +137,7 @@ func testLockTable(
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
 
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 	return job
 }
 
@@ -180,7 +180,7 @@ func testTruncateTable(t *testing.T, ctx sessionctx.Context, store kv.Storage, d
 	require.NoError(t, err)
 
 	tblInfo.ID = newTableID
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, nil, tblInfo)
 	return job
 }
 
@@ -319,7 +319,7 @@ func TestCreateView(t *testing.T) {
 	require.NoError(t, err)
 
 	tblInfo.State = model.StatePublic
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: newTblInfo0})
+	checkJobWithHistory(t, ctx, job.ID, nil, newTblInfo0)
 	tblInfo.State = model.StateNone
 	testCheckTableState(t, store, dbInfo, tblInfo, model.StatePublic)
 	testCheckJobDone(t, store, job.ID, true)
@@ -342,7 +342,7 @@ func TestCreateView(t *testing.T) {
 	require.NoError(t, err)
 
 	tblInfo.State = model.StatePublic
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: newTblInfo1})
+	checkJobWithHistory(t, ctx, job.ID, nil, newTblInfo1)
 	tblInfo.State = model.StateNone
 	testCheckTableState(t, store, dbInfo, tblInfo, model.StatePublic)
 	testCheckJobDone(t, store, job.ID, true)
@@ -413,7 +413,7 @@ func testAlterCacheTable(
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true))
 	require.NoError(t, err)
 
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 	return job
 }
 
@@ -438,7 +438,7 @@ func testAlterNoCacheTable(
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true)))
 
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 	return job
 }
 
@@ -590,7 +590,7 @@ func TestAlterTTL(t *testing.T) {
 	}
 	require.NoError(t, de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true)))
 
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: nil})
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 
 	// assert the ddlInfo as expected
 	historyJob, err := ddl.GetHistoryJobByID(testkit.NewTestKit(t, store).Session(), job.ID)
@@ -610,7 +610,7 @@ func TestAlterTTL(t *testing.T) {
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true)))
 
-	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: nil})
+	checkJobWithHistory(t, ctx, job.ID, nil, nil)
 
 	// assert the ddlInfo as expected
 	historyJob, err = ddl.GetHistoryJobByID(testkit.NewTestKit(t, store).Session(), job.ID)

--- a/pkg/ddl/table_test.go
+++ b/pkg/ddl/table_test.go
@@ -72,9 +72,8 @@ func testRenameTable(
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true)))
 
-	v := getSchemaVer(t, ctx)
 	tblInfo.State = model.StatePublic
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 	tblInfo.State = model.StateNone
 	return job
 }
@@ -103,8 +102,7 @@ func testRenameTables(t *testing.T, ctx sessionctx.Context, d ddl.ExecutorForTes
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true)))
 
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: nil})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: nil})
 	return job
 }
 
@@ -139,8 +137,7 @@ func testLockTable(
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
 
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
 	return job
 }
 
@@ -182,9 +179,8 @@ func testTruncateTable(t *testing.T, ctx sessionctx.Context, store kv.Storage, d
 	err = d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
 
-	v := getSchemaVer(t, ctx)
 	tblInfo.ID = newTableID
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: tblInfo})
 	return job
 }
 
@@ -322,9 +318,8 @@ func TestCreateView(t *testing.T) {
 	err = de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
 
-	v := getSchemaVer(t, ctx)
 	tblInfo.State = model.StatePublic
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: newTblInfo0})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: newTblInfo0})
 	tblInfo.State = model.StateNone
 	testCheckTableState(t, store, dbInfo, tblInfo, model.StatePublic)
 	testCheckJobDone(t, store, job.ID, true)
@@ -346,9 +341,8 @@ func TestCreateView(t *testing.T) {
 	err = de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true))
 	require.NoError(t, err)
 
-	v = getSchemaVer(t, ctx)
 	tblInfo.State = model.StatePublic
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: newTblInfo1})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: newTblInfo1})
 	tblInfo.State = model.StateNone
 	testCheckTableState(t, store, dbInfo, tblInfo, model.StatePublic)
 	testCheckJobDone(t, store, job.ID, true)
@@ -419,8 +413,7 @@ func testAlterCacheTable(
 	err := d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true))
 	require.NoError(t, err)
 
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
 	return job
 }
 
@@ -445,8 +438,7 @@ func testAlterNoCacheTable(
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, d.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true)))
 
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{})
 	return job
 }
 
@@ -598,8 +590,7 @@ func TestAlterTTL(t *testing.T) {
 	}
 	require.NoError(t, de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, args, true)))
 
-	v := getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: nil})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: nil})
 
 	// assert the ddlInfo as expected
 	historyJob, err := ddl.GetHistoryJobByID(testkit.NewTestKit(t, store).Session(), job.ID)
@@ -619,8 +610,7 @@ func TestAlterTTL(t *testing.T) {
 	ctx.SetValue(sessionctx.QueryString, "skip")
 	require.NoError(t, de.DoDDLJobWrapper(ctx, ddl.NewJobWrapperWithArgs(job, &model.EmptyArgs{}, true)))
 
-	v = getSchemaVer(t, ctx)
-	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: nil})
+	checkJobWithHistory(t, ctx, job.ID, &finishedJobInfo{tbl: nil})
 
 	// assert the ddlInfo as expected
 	historyJob, err = ddl.GetHistoryJobByID(testkit.NewTestKit(t, store).Session(), job.ID)

--- a/pkg/ddl/tests/indexmerge/BUILD.bazel
+++ b/pkg/ddl/tests/indexmerge/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "indexmerge_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "merge_test.go",

--- a/pkg/lightning/backend/external/concurrent_reader_test.go
+++ b/pkg/lightning/backend/external/concurrent_reader_test.go
@@ -85,5 +85,5 @@ func TestConcurrentRead(t *testing.T) {
 	}
 
 	require.Equal(t, data[offset:], got)
-	require.Equal(t, int64((fileSize-offset+readBufferSize-1)/readBufferSize), reqCnt.Load())
+	require.Equal(t, int64((fileSize-offset)/readBufferSize+1), reqCnt.Load())
 }

--- a/pkg/lightning/backend/external/concurrent_reader_test.go
+++ b/pkg/lightning/backend/external/concurrent_reader_test.go
@@ -85,5 +85,5 @@ func TestConcurrentRead(t *testing.T) {
 	}
 
 	require.Equal(t, data[offset:], got)
-	require.Equal(t, int64((fileSize-offset)/readBufferSize+1), reqCnt.Load())
+	require.Equal(t, int64((fileSize-offset+readBufferSize-1)/readBufferSize), reqCnt.Load())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/64559

Problem Summary:

**TestColumnAdd**

See https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/44383/artifact/bazel-test.log for the failed test.

(Also found this in release 8.5 CI 😢)

The problem is caused by the usage of `afterWaitSchemaSynced` failpoint in `transitOneJobStepAndWaitSync`:

https://github.com/pingcap/tidb/blob/d059a7de1b1a1c4f06c0fd39bd832b6048f6177f/pkg/ddl/column_change_test.go#L60

We expect it to work after `CREATE TABLE` finished. But we may enter this failpoint before `ADD COLUMN` is executed.

### What changed and how does it work?

Skip synced state in failpoint, so the check of `first` is also unecessary.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- Fix existing test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
