### PR TITLE
pkg/util/redact: add RedactAny and RedactArgs helper functions

### DIFF
--- a/pkg/util/redact/BUILD.bazel
+++ b/pkg/util/redact/BUILD.bazel
@@ -19,5 +19,8 @@ go_test(
     srcs = ["redact_test.go"],
     embed = [":redact"],
     flaky = True,
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_pingcap_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/util/redact/redact_test.go
+++ b/pkg/util/redact/redact_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,4 +88,116 @@ func TestRedactInitAndValueAndKey(t *testing.T) {
 	InitRedact(true)
 	require.Equal(t, Value(secret), redacted)
 	require.Equal(t, Key([]byte(secret)), redacted)
+}
+
+func TestAny(t *testing.T) {
+	redacted := "?"
+
+	// Test with redaction OFF
+	InitRedact(false)
+	require.Equal(t, "123", Any(123))
+	require.Equal(t, "true", Any(true))
+	require.Equal(t, "sensitive-data", Any("sensitive-data"))
+	require.Equal(t, "NULL", Any(nil))
+
+	// Test with redaction ON
+	InitRedact(true)
+	require.Equal(t, redacted, Any(123))
+	require.Equal(t, redacted, Any(true))
+	require.Equal(t, redacted, Any("sensitive-data"))
+	require.Equal(t, "NULL", Any(nil)) // nil is always "NULL"
+}
+
+func TestArgs(t *testing.T) {
+	redacted := "?"
+
+	// Test with redaction OFF
+	InitRedact(false)
+	require.Equal(t, "()", Args([]any{}))
+	require.Equal(t, "(NULL)", Args([]any{nil}))
+	require.Equal(t, "(123)", Args([]any{123}))
+	require.Equal(t, "(password123)", Args([]any{"password123"}))
+	require.Equal(t, "(1, user@example.com, password123, NULL)",
+		Args([]any{1, "user@example.com", "password123", nil}))
+
+	// Test with redaction ON
+	InitRedact(true)
+	require.Equal(t, "()", Args([]any{}))
+	require.Equal(t, "(NULL)", Args([]any{nil}))
+	require.Equal(t, "("+redacted+")", Args([]any{123}))
+	require.Equal(t, "("+redacted+")", Args([]any{"password123"}))
+	require.Equal(t, "("+redacted+", "+redacted+", "+redacted+", NULL)",
+		Args([]any{1, "user@example.com", "password123", nil}))
+}
+
+func TestParseRedactMode(t *testing.T) {
+	// Test ON variants
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("ON"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("on"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("TRUE"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("true"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("1"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("ENABLE"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("enable"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("ENABLED"))
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("enabled"))
+
+	// Test MARKER variants
+	require.Equal(t, errors.RedactLogMarker, ParseRedactMode("MARKER"))
+	require.Equal(t, errors.RedactLogMarker, ParseRedactMode("marker"))
+	require.Equal(t, errors.RedactLogMarker, ParseRedactMode("MARK"))
+	require.Equal(t, errors.RedactLogMarker, ParseRedactMode("mark"))
+
+	// Test OFF variants
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("OFF"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("off"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("FALSE"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("false"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("0"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("DISABLE"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("disable"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("DISABLED"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("disabled"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode(""))
+
+	// Test with whitespace
+	require.Equal(t, errors.RedactLogEnable, ParseRedactMode("  ON  "))
+	require.Equal(t, errors.RedactLogMarker, ParseRedactMode("  MARKER  "))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("  OFF  "))
+
+	// Test unknown values default to OFF
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("INVALID"))
+	require.Equal(t, errors.RedactLogDisable, ParseRedactMode("unknown"))
+}
+
+func TestIsValidRedactMode(t *testing.T) {
+	// Test valid ON modes
+	require.True(t, IsValidRedactMode("ON", ParseRedactMode("ON")))
+	require.True(t, IsValidRedactMode("on", ParseRedactMode("on")))
+	require.True(t, IsValidRedactMode("TRUE", ParseRedactMode("TRUE")))
+	require.True(t, IsValidRedactMode("true", ParseRedactMode("true")))
+	require.True(t, IsValidRedactMode("1", ParseRedactMode("1")))
+	require.True(t, IsValidRedactMode("ENABLE", ParseRedactMode("ENABLE")))
+	require.True(t, IsValidRedactMode("ENABLED", ParseRedactMode("ENABLED")))
+
+	// Test valid MARKER modes
+	require.True(t, IsValidRedactMode("MARKER", ParseRedactMode("MARKER")))
+	require.True(t, IsValidRedactMode("marker", ParseRedactMode("marker")))
+	require.True(t, IsValidRedactMode("MARK", ParseRedactMode("MARK")))
+	require.True(t, IsValidRedactMode("mark", ParseRedactMode("mark")))
+
+	// Test valid OFF modes
+	require.True(t, IsValidRedactMode("OFF", ParseRedactMode("OFF")))
+	require.True(t, IsValidRedactMode("off", ParseRedactMode("off")))
+	require.True(t, IsValidRedactMode("FALSE", ParseRedactMode("FALSE")))
+	require.True(t, IsValidRedactMode("false", ParseRedactMode("false")))
+	require.True(t, IsValidRedactMode("0", ParseRedactMode("0")))
+	require.True(t, IsValidRedactMode("DISABLE", ParseRedactMode("DISABLE")))
+	require.True(t, IsValidRedactMode("DISABLED", ParseRedactMode("DISABLED")))
+	require.True(t, IsValidRedactMode("", ParseRedactMode("")))
+
+	// Test with whitespace
+	require.True(t, IsValidRedactMode("  ON  ", ParseRedactMode("  ON  ")))
+	require.True(t, IsValidRedactMode("  MARKER  ", ParseRedactMode("  MARKER  ")))
+	require.True(t, IsValidRedactMode("  OFF  ", ParseRedactMode("  OFF  ")))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64410

Problem Summary:

TiCDC requires additional helper functions in the TiDB redact package to support comprehensive log redaction across different data types and SQL operations. Currently, the redact package provides `Value()` and `Key()` functions, but TiCDC needs generic redaction support for arbitrary types and formatted SQL argument lists.

### What changed and how does it work?

This PR adds two new helper functions to `pkg/util/redact`:

**1. `RedactAny(value any) string`**
- Redacts any value type by converting to string and applying the current redaction mode
- Handles nil values gracefully (returns "NULL")
- Useful for generic value redaction when the exact type is not known
- Example:
  ```go
  redact.RedactAny(123)           // "?" when redaction ON
  redact.RedactAny("password")    // "?" when redaction ON
  redact.RedactAny(nil)           // "NULL" always
  ```

**2. `RedactArgs(args []interface{}) string`**
- Formats and redacts SQL arguments/parameters for logging
- Wraps arguments in parentheses with comma separation: `(?, ?, ?)`
- Particularly useful for logging SQL execution details while protecting sensitive data
- Example:
  ```go
  // When redaction OFF:
  redact.RedactArgs([]interface{}{1, "user@example.com", "password123"})
  // Returns: "(1, user@example.com, password123)"

  // When redaction ON:
  // Returns: "(?, ?, ?)"
  ```

**Implementation Details:**
- Both functions use the existing `Value()` function for consistency
- Respect the global redaction mode (`errors.RedactLogEnabled`)
- Support all three redaction modes: OFF, ON, MARKER
- Include comprehensive unit tests covering all modes and edge cases

**Why these functions are needed:**
- TiCDC logs various types of data (numbers, strings, booleans, etc.) and needs a generic redaction function
- SQL error messages often include query parameters that need formatted redaction
- Centralizing these helpers in TiDB ensures consistency across the ecosystem

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```