### PR TITLE
planner: Only use column stats if loaded | tidb-test=pr/2629

### DIFF
--- a/pkg/planner/cardinality/row_count_column.go
+++ b/pkg/planner/cardinality/row_count_column.go
@@ -449,10 +449,7 @@ func getPseudoRowCountWithPartialStats(sctx planctx.PlanContext, coll *statistic
 			Collators: make([]collate.Collator, 1),
 		},
 	}
-	var (
-		count float64
-		colID int64
-	)
+	var count float64
 	totalCount = float64(0)
 	maxCount = float64(0)
 	for _, indexRange := range indexRanges {
@@ -466,7 +463,7 @@ func getPseudoRowCountWithPartialStats(sctx planctx.PlanContext, coll *statistic
 				tmpRan[0].LowExclude = indexRange.LowExclude
 				tmpRan[0].HighExclude = indexRange.HighExclude
 			}
-			colID = idxCols[i].UniqueID
+			colID := idxCols[i].UniqueID
 			col := coll.GetCol(colID)
 			// GetRowCountByColumnRanges handles invalid stats internally by using pseudo estimation
 			var countEst statistics.RowEstimate


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #64196 

Problem Summary:

### What changed and how does it work?

Since the optimizer will iterate through all available indexes - regardless of their relevance to a query, then columns with statistics that weren't sync loaded may be async loaded unnecessarily. Add checking here to only use column statistics in place of missing index statistics if the column statistics are loaded.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
