### PR TITLE
*: fix incorrect handling meta key in IterateHashWithBoundedKey

### DIFF
--- a/pkg/structure/BUILD.bazel
+++ b/pkg/structure/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     ],
     embed = [":structure"],
     flaky = True,
-    shard_count = 4,
+    shard_count = 5,
     deps = [
         "//pkg/kv",
         "//pkg/parser/mysql",

--- a/pkg/structure/hash.go
+++ b/pkg/structure/hash.go
@@ -275,6 +275,10 @@ func (t *TxStructure) IterateHashWithBoundedKey(hashStartKey []byte, hashEndKey 
 	for it.Valid() {
 		key, field, err = t.decodeHashDataKey(it.Key())
 		if err != nil {
+			err = it.Next()
+			if err != nil {
+				return errors.Trace(err)
+			}
 			continue
 		}
 		if err = fn(key, field, it.Value()); err != nil {

--- a/pkg/structure/type.go
+++ b/pkg/structure/type.go
@@ -40,9 +40,6 @@ const (
 	ListData TypeFlag = 'l'
 )
 
-// Make linter happy, since encodeHashMetaKey is unused in this repo.
-var _ = (&TxStructure{}).encodeHashMetaKey
-
 // EncodeStringDataKey will encode string key.
 func (t *TxStructure) EncodeStringDataKey(key []byte) kv.Key {
 	// for codec Encode, we may add extra bytes data, so here and following encode
@@ -81,8 +78,8 @@ func (t *TxStructure) decodeStringDataKey(ek kv.Key) ([]byte, error) {
 	return key, errors.Trace(err)
 }
 
-// nolint:unused
-func (t *TxStructure) encodeHashMetaKey(key []byte) kv.Key {
+// EncodeHashMetaKey exports for tests. It's used in version v5.1 and earlier.
+func (t *TxStructure) EncodeHashMetaKey(key []byte) kv.Key {
 	ek := make([]byte, 0, len(t.prefix)+codec.EncodedBytesLength(len(key))+8)
 	ek = append(ek, t.prefix...)
 	ek = codec.EncodeBytes(ek, key)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64323

Problem Summary:
In TiDB version V5.1 and eailer, there is a meta key in hash struct.
We should skip this keys in TestIterateHashWithBoundedKey

### What changed and how does it work?
Skip meta keys in TestIterateHashWithBoundedKey

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix incorrect handling meta key in IterateHashWithBoundedKey
```
