### PR TITLE
executor: fix wrong value stored in statistics during modify column with no row reorg

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -354,6 +354,8 @@ go_test(
         "//pkg/sessionctx/vardef",
         "//pkg/sessionctx/variable",
         "//pkg/sessiontxn",
+        "//pkg/statistics",
+        "//pkg/statistics/handle/storage",
         "//pkg/store/gcworker",
         "//pkg/store/helper",
         "//pkg/store/mockstore",

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1427,9 +1427,9 @@ func IsDDLAnalyzeCtx(ctx context.Context) bool {
 	return ok
 }
 
-// WithModifyingColumn checks if columns contain any column which is modifying.
+// ContainModifyingColumn checks if columns contain any column which is modifying.
 // If so, we should skip analyzing for this table except the final analyze after job is non-revertible.
-func WithModifyingColumn(columns []*model.ColumnInfo) bool {
+func ContainModifyingColumn(columns []*model.ColumnInfo) bool {
 	for _, col := range columns {
 		if col.ChangingFieldType != nil {
 			return true

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1415,6 +1415,30 @@ func (w *worker) analyzeStatusDecision(job *model.Job, dbName, tblName string, s
 	}
 }
 
+type ddlAnalyze struct{}
+
+func withDDLAnalyzeCtx(w *worker) context.Context {
+	return context.WithValue(w.ctx, ddlAnalyze{}, struct{}{})
+}
+
+// IsDDLAnalyzeCtx checks if the context is from DDL analyze.
+func IsDDLAnalyzeCtx(ctx context.Context) bool {
+	_, ok := ctx.Value(ddlAnalyze{}).(struct{})
+	return ok
+}
+
+// UnderOptimizedModifyColumn checks if the table is doing optimized modify column.
+// If so, we should skip analyzing for this table except the final analyze after job is non-revertible.
+func UnderOptimizedModifyColumn(tblInfo *model.TableInfo) bool {
+	for _, col := range tblInfo.Columns {
+		if col.ChangingFieldType != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // analyzeTableAfterCreateIndex analyzes the table after creating index.
 func (w *worker) analyzeTableAfterCreateIndex(job *model.Job, dbName, tblName string) (done, timedOut, failed bool) {
 	doneCh := w.ddlCtx.getAnalyzeDoneCh(job.ID)
@@ -1481,7 +1505,7 @@ func (w *worker) analyzeTableAfterCreateIndex(job *model.Job, dbName, tblName st
 				return err
 			}
 			failpoint.InjectCall("beforeAnalyzeTable")
-			_, _, err = exec.ExecRestrictedSQL(w.ctx, []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession, sqlexec.ExecOptionEnableDDLAnalyze}, "ANALYZE TABLE "+dbTable+";", "ddl analyze table")
+			_, _, err = exec.ExecRestrictedSQL(withDDLAnalyzeCtx(w), []sqlexec.OptionFuncAlias{sqlexec.ExecOptionUseCurSession, sqlexec.ExecOptionEnableDDLAnalyze}, "ANALYZE TABLE "+dbTable+";", "ddl analyze table")
 			failpoint.InjectCall("afterAnalyzeTable", &err)
 			if err != nil {
 				logutil.DDLLogger().Warn("analyze table failed",

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1427,10 +1427,10 @@ func IsDDLAnalyzeCtx(ctx context.Context) bool {
 	return ok
 }
 
-// UnderOptimizedModifyColumn checks if the table is doing optimized modify column.
+// WithModifyingColumn checks if columns contain any column which is modifying.
 // If so, we should skip analyzing for this table except the final analyze after job is non-revertible.
-func UnderOptimizedModifyColumn(tblInfo *model.TableInfo) bool {
-	for _, col := range tblInfo.Columns {
+func WithModifyingColumn(columns []*model.ColumnInfo) bool {
+	for _, col := range columns {
 		if col.ChangingFieldType != nil {
 			return true
 		}

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1421,7 +1421,7 @@ func withDDLAnalyzeCtx(w *worker) context.Context {
 	return context.WithValue(w.ctx, ddlAnalyze{}, struct{}{})
 }
 
-// IsDDLAnalyzeCtx checks if the context is from DDL analyze.
+// IsDDLAnalyzeCtx checks if the analyze is triggered by DDL.
 func IsDDLAnalyzeCtx(ctx context.Context) bool {
 	_, ok := ctx.Value(ddlAnalyze{}).(struct{})
 	return ok

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -1377,15 +1377,9 @@ func TestHistogramFromStorageWithPriority(t *testing.T) {
 	tk.MustExec("set tidb_stats_update_during_ddl = ON")
 
 	// Prepare data
-	tk.MustExec("create table t2(a int auto_increment, b int, c int, primary key(a), key idxb(b))")
+	tk.MustExec("create table t2(a int auto_increment, b int, c int, primary key(a), key idxb(b), key idxc(c))")
 	for i := range 200 {
 		tk.MustExec(fmt.Sprintf("insert into t2(b, c) values (%d, %d)", i, i))
-	}
-	for range 4 {
-		tk.MustExec(fmt.Sprintf("insert into t2(b, c) values (%d, %d)", 20, 20))
-		tk.MustExec(fmt.Sprintf("insert into t2(b, c) values (%d, %d)", 50, 50))
-		tk.MustExec(fmt.Sprintf("insert into t2(b, c) values (%d, %d)", 111, 111))
-		tk.MustExec(fmt.Sprintf("insert into t2(b, c) values (%d, %d)", 156, 156))
 	}
 	tk.MustExec("analyze table t2")
 
@@ -1449,6 +1443,7 @@ func TestHistogramFromStorageWithPriority(t *testing.T) {
 	oldTp := types.NewFieldType(mysql.TypeLong)
 	newTp := types.NewFieldType(mysql.TypeInt24)
 	newTp.AddFlag(mysql.UnsignedFlag)
+
 	// Check TopN
 	for i := range 3 {
 		oldTopN := oldTopNs[i]
@@ -1458,7 +1453,7 @@ func TestHistogramFromStorageWithPriority(t *testing.T) {
 		require.Equal(t, oldCount, newCount)
 	}
 
-	// Index historgram is stored as blob, we need to decode it.
+	// Index historgram is stored as blob from index value, we need to decode it.
 	decodeToInt := func(b *types.Datum) int64 {
 		d, err := codec.Decode(b.GetBytes(), 1)
 		require.NoError(t, err)

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -1423,10 +1423,10 @@ func TestHistogramFromStorageWithPriority(t *testing.T) {
 	}
 
 	var (
-		oldTopNs []*statistics.TopN
-		newTopNs []*statistics.TopN
-		oldHgs   []*statistics.Histogram
-		newHgs   []*statistics.Histogram
+		oldTopNs = make([]*statistics.TopN, 0, 3)
+		newTopNs = make([]*statistics.TopN, 0, 3)
+		oldHgs   = make([]*statistics.Histogram, 0, 3)
+		newHgs   = make([]*statistics.Histogram, 0, 3)
 	)
 	for _, check := range [][]int64{{1, 0}, {2, 0}, {0, 1}} {
 		oldTopN, oldHg := getTopNAndHg(check[0], int(check[1]))

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -1378,9 +1378,9 @@ func TestStatisticsAfterModifyColumn(t *testing.T) {
 	tk.MustExec("set tidb_stats_update_during_ddl = ON")
 
 	// Prepare data
-	tk.MustExec("create table t2(a int auto_increment, b int, c int, primary key(a), key idxb(b), key idxc(c))")
+	tk.MustExec("create table t2(a int auto_increment, b int, c int, d int, primary key(a), key idxb(b), key idxc(c))")
 	for i := range 200 {
-		tk.MustExec(fmt.Sprintf("insert into t2(b, c) values (%d, %d)", i, i))
+		tk.MustExec(fmt.Sprintf("insert into t2(b, c, d) values (%d, %d, %d)", i, i, i))
 	}
 	tk.MustExec("analyze table t2")
 

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -253,7 +253,7 @@ func filterAndCollectTasks(ctx context.Context, tasks []*analyzeTask, statsHandl
 		// Wen user does the analyze during modify column, it will use the new type to collect the statistics.
 		// However, if the modify column is rollbacked, the statistics collected is invalid. So we skip the
 		// analyze task during modify column.
-		if !isDDLAnalyze && task.colExec != nil && ddl.WithModifyingColumn(task.colExec.colsInfo) {
+		if !isDDLAnalyze && task.colExec != nil && ddl.ContainModifyingColumn(task.colExec.colsInfo) {
 			continue
 		}
 

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -250,9 +250,9 @@ func filterAndCollectTasks(ctx context.Context, tasks []*analyzeTask, statsHandl
 
 	isDDLAnalyze := ddl.IsDDLAnalyzeCtx(ctx)
 	for _, task := range tasks {
-		// Wen user does the analyze during modify column, it will use the new type to collect the statistics.
-		// However, if the modify column is rollbacked, the statistics collected is invalid. So we skip the
-		// analyze task during modify column.
+		// When a user runs ANALYZE during MODIFY COLUMN, it will use the new type to collect statistics.
+		// However, if the MODIFY COLUMN is rolled back, the collected statistics become invalid. Therefore,
+		// we skip the analyze during MODIFY COLUMN unless it's triggered by DDL.
 		if !isDDLAnalyze && task.colExec != nil && ddl.ContainModifyingColumn(task.colExec.colsInfo) {
 			continue
 		}

--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -253,7 +253,7 @@ func filterAndCollectTasks(ctx context.Context, tasks []*analyzeTask, statsHandl
 		// Wen user does the analyze during modify column, it will use the new type to collect the statistics.
 		// However, if the modify column is rollbacked, the statistics collected is invalid. So we skip the
 		// analyze task during modify column.
-		if !isDDLAnalyze && task.colExec != nil && ddl.UnderOptimizedModifyColumn(task.colExec.tableInfo) {
+		if !isDDLAnalyze && task.colExec != nil && ddl.WithModifyingColumn(task.colExec.colsInfo) {
 			continue
 		}
 

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -669,6 +669,29 @@ func (e *AnalyzeColumnsExecV2) subMergeWorker(resultCh chan<- *samplingMergeResu
 	resultCh <- &samplingMergeResult{collector: retCollector}
 }
 
+// buildChangingTypes builds the changing types to do necessary casting.
+func (e *AnalyzeColumnsExecV2) buildChangingTypes(task *samplingBuildTask) []*types.FieldType {
+	if task.isColumn {
+		if e.colsInfo[task.slicePos].ChangingFieldType != nil {
+			return []*types.FieldType{e.colsInfo[task.slicePos].ChangingFieldType}
+		}
+		return []*types.FieldType{nil}
+	}
+
+	idx := e.indexes[task.slicePos-len(e.colsInfo)]
+	changingTypes := make([]*types.FieldType, 0, len(idx.Columns))
+	for _, idxCol := range idx.Columns {
+		col := e.colsInfo[idxCol.Offset]
+		if idxCol.UseChangingType && col.ChangingFieldType != nil {
+			changingTypes = append(changingTypes, col.ChangingFieldType)
+		} else {
+			changingTypes = append(changingTypes, nil)
+		}
+	}
+
+	return changingTypes
+}
+
 func (e *AnalyzeColumnsExecV2) subBuildWorker(resultCh chan error, taskCh chan *samplingBuildTask, hists []*statistics.Histogram, topns []*statistics.TopN, collectors []*statistics.SampleCollector, exitCh chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -695,6 +718,7 @@ workLoop:
 				break workLoop
 			}
 			var collector *statistics.SampleCollector
+			changingTypes := e.buildChangingTypes(task)
 			if task.isColumn {
 				if e.colsInfo[task.slicePos].IsGenerated() && !e.colsInfo[task.slicePos].GeneratedStored {
 					hists[task.slicePos] = nil
@@ -714,6 +738,7 @@ workLoop:
 				if ft.EvalType() == types.ETString && ft.GetType() != mysql.TypeEnum && ft.GetType() != mysql.TypeSet {
 					collator = collate.GetCollator(ft.GetCollate())
 				}
+				var err error
 				for j, row := range task.rootRowCollector.Base().Samples {
 					if row.Columns[task.slicePos].IsNull() {
 						continue
@@ -722,6 +747,12 @@ workLoop:
 					// If this value is very big, we think that it is not a value that can occur many times. So we don't record it.
 					if len(val.GetBytes()) > statistics.MaxSampleValueLength {
 						continue
+					}
+					if changingTypes[0] != nil {
+						if val, err = table.CastColumnValueWithStrictMode(val, changingTypes[0]); err != nil {
+							resultCh <- err
+							continue workLoop
+						}
 					}
 					if collator != nil {
 						val.SetBytes(collator.Key(val.GetString()))
@@ -763,10 +794,17 @@ workLoop:
 						continue
 					}
 					b := make([]byte, 0, 8)
-					for _, col := range idx.Columns {
+					for i, col := range idx.Columns {
 						// If the index value contains one value which is too long, we think that it's a value that doesn't occur many times.
 						if len(row.Columns[col.Offset].GetBytes()) > statistics.MaxSampleValueLength {
 							continue indexSampleCollectLoop
+						}
+						if changingTypes[i] != nil {
+							row.Columns[col.Offset], err = table.CastColumnValueWithStrictMode(row.Columns[col.Offset], changingTypes[i])
+							if err != nil {
+								resultCh <- err
+								continue workLoop
+							}
 						}
 						if col.Length != types.UnspecifiedLength {
 							row.Columns[col.Offset].Copy(&tmpDatum)

--- a/pkg/executor/analyze_col_v2.go
+++ b/pkg/executor/analyze_col_v2.go
@@ -810,14 +810,10 @@ workLoop:
 							row.Columns[col.Offset].Copy(&tmpDatum)
 							ranger.CutDatumByPrefixLen(&tmpDatum, col.Length, &e.colsInfo[col.Offset].FieldType)
 							b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, tmpDatum)
-							err = errCtx.HandleError(err)
-							if err != nil {
-								resultCh <- err
-								continue workLoop
-							}
-							continue
+						} else {
+							b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, row.Columns[col.Offset])
 						}
-						b, err = codec.EncodeKey(e.ctx.GetSessionVars().StmtCtx.TimeZone(), b, row.Columns[col.Offset])
+
 						err = errCtx.HandleError(err)
 						if err != nil {
 							resultCh <- err

--- a/pkg/meta/model/column.go
+++ b/pkg/meta/model/column.go
@@ -62,8 +62,8 @@ type ColumnInfo struct {
 	Dependences         map[string]struct{} `json:"dependences"`
 	FieldType           types.FieldType     `json:"type"`
 	// ChangingFieldType stores the target field type during modify column that doesn't
-	// require row reorganization. Since we don't create a new column for such operations,
-	// this field substitutes the functionality of it to track both the old and new types
+	// require row reorg. Since we don't create a new column for such operations, this
+	// field substitutes the functionality of it to track both the old and new types
 	// simultaneously. Thus both old and new indexes can encode values with correct types.
 	// - Before backfill: FieldType=original type, ChangingFieldType=new type
 	// - After backfill: FieldType=new type, ChangingFieldType=original type

--- a/pkg/meta/model/column.go
+++ b/pkg/meta/model/column.go
@@ -61,7 +61,12 @@ type ColumnInfo struct {
 	GeneratedStored     bool                `json:"generated_stored"`
 	Dependences         map[string]struct{} `json:"dependences"`
 	FieldType           types.FieldType     `json:"type"`
-	// ChangingFieldType is used to store the new type of modify column.
+	// ChangingFieldType stores the target field type during modify column that doesn't
+	// require row reorganization. Since we don't create a new column for such operations,
+	// this field substitutes the functionality of it to track both the old and new types
+	// simultaneously. Thus both old and new indexes can encode values with correct types.
+	// - Before backfill: FieldType=original type, ChangingFieldType=new type
+	// - After backfill: FieldType=new type, ChangingFieldType=original type
 	ChangingFieldType *types.FieldType `json:"changing_type,omitempty"`
 	State             SchemaState      `json:"state"`
 	Comment           string           `json:"comment"`

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -363,7 +363,23 @@ type IndexColumn struct {
 	// for indexing;
 	// UnspecifedLength if not using prefix indexing
 	Length int `json:"length"`
-	// Whether this index column use changing type
+	// UseChangingType indicates which field type to use for this index column during
+	// modify column without row reorg, which works in conjunction with ChangingFieldType.
+	// When true, use ColumnInfo.ChangingFieldType, otherwise, usee ColumnInfo.FieldType.
+	//
+	// Example:
+	//   CREATE TABLE t (c1 CHAR(20), INDEX i1(c1));
+	//   ALTER TABLE t MODIFY COLUMN c1 VARCHAR(10);
+	//
+	// Before backfill:
+	//   ColumnInfo: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
+	//   i1.c1.UseChangingType=false
+	//   _Idx$_i1.c1.UseChangingType=true
+	//
+	// After backfill:
+	//   ColumnInfo: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
+	//   i1.c1.UseChangingType=true
+	//   _Idx$_i1.c1.UseChangingType=false
 	UseChangingType bool `json:"using_changing_type,omitempty"`
 }
 

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -364,8 +364,9 @@ type IndexColumn struct {
 	// UnspecifedLength if not using prefix indexing
 	Length int `json:"length"`
 	// UseChangingType indicates which field type to use for this index column during
-	// modify column without row reorg, which works in conjunction with ChangingFieldType.
-	// When true, use ColumnInfo.ChangingFieldType, otherwise, usee ColumnInfo.FieldType.
+	// modify column without row reorg, which works together with ChangingFieldType.
+	// When it's true, this index column uses ColumnInfo.ChangingFieldType, otherwise,
+	// use ColumnInfo.FieldType.
 	//
 	// Example:
 	//   CREATE TABLE t (c1 CHAR(20), c2 CHAR(20), INDEX i1(c1, c2));
@@ -374,20 +375,20 @@ type IndexColumn struct {
 	// After backfill:
 	//   c1: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
 	//   c2: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
-	//   i1(UseChangingType=false, UseChangingType=false)
-	//   _Idx$_i1(UseChangingType=true, UseChangingType=true)
+	//   i1(c1:false, c2:false)
+	//   _Idx$_i1(c1:true, c2:true)
 	//
-	// After subjob1 becomes public:
+	// After subjob 1's state becomes public:
 	//   c1: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
 	//   c2: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
-	//   i1(UseChangingType=true, UseChangingType=false)
-	//   _Idx$_i1(UseChangingType=false, UseChangingType=true)
+	//   i1(c1:true, c2:false)
+	//   _Idx$_i1(c1:false, c2:true)
 	//
-	// After subjob2 becomes public:
+	// After subjob 2's state becomes public:
 	//   c1: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
 	//   c2: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
-	//   _Tombstone$_i1(UseChangingType=true, UseChangingType=true)
-	//   i1(UseChangingType=false, UseChangingType=false)
+	//   _Tombstone$_i1(c1:true, c2:true)
+	//   i1(c1:false, c2:false)
 	UseChangingType bool `json:"using_changing_type,omitempty"`
 }
 

--- a/pkg/meta/model/index.go
+++ b/pkg/meta/model/index.go
@@ -368,18 +368,26 @@ type IndexColumn struct {
 	// When true, use ColumnInfo.ChangingFieldType, otherwise, usee ColumnInfo.FieldType.
 	//
 	// Example:
-	//   CREATE TABLE t (c1 CHAR(20), INDEX i1(c1));
-	//   ALTER TABLE t MODIFY COLUMN c1 VARCHAR(10);
-	//
-	// Before backfill:
-	//   ColumnInfo: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
-	//   i1.c1.UseChangingType=false
-	//   _Idx$_i1.c1.UseChangingType=true
+	//   CREATE TABLE t (c1 CHAR(20), c2 CHAR(20), INDEX i1(c1, c2));
+	//   ALTER TABLE t MODIFY COLUMN c1 VARCHAR(10), c2 VARCHAR(10);
 	//
 	// After backfill:
-	//   ColumnInfo: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
-	//   i1.c1.UseChangingType=true
-	//   _Idx$_i1.c1.UseChangingType=false
+	//   c1: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
+	//   c2: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
+	//   i1(UseChangingType=false, UseChangingType=false)
+	//   _Idx$_i1(UseChangingType=true, UseChangingType=true)
+	//
+	// After subjob1 becomes public:
+	//   c1: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
+	//   c2: FieldType=CHAR(20), ChangingFieldType=VARCHAR(10)
+	//   i1(UseChangingType=true, UseChangingType=false)
+	//   _Idx$_i1(UseChangingType=false, UseChangingType=true)
+	//
+	// After subjob2 becomes public:
+	//   c1: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
+	//   c2: FieldType=VARCHAR(10), ChangingFieldType=CHAR(20)
+	//   _Tombstone$_i1(UseChangingType=true, UseChangingType=true)
+	//   i1(UseChangingType=false, UseChangingType=false)
 	UseChangingType bool `json:"using_changing_type,omitempty"`
 }
 

--- a/pkg/statistics/cmsketch.go
+++ b/pkg/statistics/cmsketch.go
@@ -684,7 +684,7 @@ func (c *TopN) convert(d []byte) []byte {
 	case types.KindUint64:
 		return convertFromIntToUInt(d)
 	default:
-		// Signed/unsigned convertion is the only case we may meet.
+		// Signed/unsigned conversion is the only case we may meet.
 		return d
 	}
 }

--- a/pkg/statistics/histogram.go
+++ b/pkg/statistics/histogram.go
@@ -16,7 +16,6 @@ package statistics
 
 import (
 	"bytes"
-	"cmp"
 	"fmt"
 	"math"
 	"slices"
@@ -46,7 +45,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/mathutil"
 	"github.com/pingcap/tidb/pkg/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
-	"github.com/twmb/murmur3"
 	"go.uber.org/zap"
 )
 
@@ -1293,51 +1291,6 @@ func GetIndexPrefixLens(data []byte, numCols int) (prefixLens []int, err error) 
 		prefixLens = append(prefixLens, prefixLen)
 	}
 	return prefixLens, nil
-}
-
-// ExtractTopN extracts topn from histogram.
-func (hg *Histogram) ExtractTopN(cms *CMSketch, topN *TopN, numCols int, numTopN uint32) error {
-	if hg.Len() == 0 || cms == nil || numTopN == 0 {
-		return nil
-	}
-	dataSet := make(map[string]struct{}, hg.Bounds.NumRows())
-	dataCnts := make([]dataCnt, 0, hg.Bounds.NumRows())
-	hg.PreCalculateScalar()
-	// Set a limit on the frequency of boundary values to avoid extract values with low frequency.
-	limit := hg.NotNullCount() / float64(hg.Len())
-	// Since our histogram are equal depth, they must occurs on the boundaries of buckets.
-	for i := range hg.Bounds.NumRows() {
-		data := hg.Bounds.GetRow(i).GetBytes(0)
-		prefixLens, err := GetIndexPrefixLens(data, numCols)
-		if err != nil {
-			return err
-		}
-		for _, prefixLen := range prefixLens {
-			prefixColData := data[:prefixLen]
-			_, ok := dataSet[string(prefixColData)]
-			if ok {
-				continue
-			}
-			dataSet[string(prefixColData)] = struct{}{}
-			res := hg.BetweenRowCount(nil, types.NewBytesDatum(prefixColData), types.NewBytesDatum(kv.Key(prefixColData).PrefixNext())).Est
-			if res >= limit {
-				dataCnts = append(dataCnts, dataCnt{prefixColData, uint64(res)})
-			}
-		}
-	}
-	slices.SortStableFunc(dataCnts, func(a, b dataCnt) int { return -cmp.Compare(a.cnt, b.cnt) })
-	if len(dataCnts) > int(numTopN) {
-		dataCnts = dataCnts[:numTopN]
-	}
-	topN.TopN = make([]TopNMeta, 0, len(dataCnts))
-	for _, dataCnt := range dataCnts {
-		h1, h2 := murmur3.Sum128(dataCnt.data)
-		realCnt := cms.queryHashValue(nil, h1, h2)
-		cms.SubValue(h1, h2, realCnt)
-		topN.AppendTopN(dataCnt.data, realCnt)
-	}
-	topN.Sort()
-	return nil
 }
 
 var bucket4MergingPool = sync.Pool{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/63366

Problem Summary:

For modify column without row reorg, we store both old and new types in the same column (see the comment added in this PR for more detail). So when we do analyze during modify column, we should use the correct type to get the value for histogram and topN.

### What changed and how does it work?

Check the type we need when doing analyze.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
