### PR TITLE
ddl: add more integration test case for database read only | tidb-test=release-8.5.2

### DIFF
--- a/tests/integrationtest/r/ddl/db_read_only.result
+++ b/tests/integrationtest/r/ddl/db_read_only.result
@@ -350,42 +350,62 @@ execute stmt_select using @a;
 a	b
 execute stmt_select using @a;
 a	b
-select @@last_plan_from_cache; # should be 1
+select @@last_plan_from_cache;
 @@last_plan_from_cache
 1
 alter schema read_only read only 1;
 execute stmt_select using @a;
 a	b
-select @@last_plan_from_cache; # should be 0
+select @@last_plan_from_cache;
 @@last_plan_from_cache
 0
+execute stmt_select using @a;
+a	b
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
 alter schema read_only read only 0;
 execute stmt_select using @a;
 a	b
-select @@last_plan_from_cache; # should be 0
+select @@last_plan_from_cache;
 @@last_plan_from_cache
 0
+execute stmt_select using @a;
+a	b
+select @@last_plan_from_cache;
+@@last_plan_from_cache
+1
 SET tidb_enable_non_prepared_plan_cache = ON;
 select * from read_only.t1 where a = 1;
 a	b
 select * from read_only.t1 where a = 1;
 a	b
-SELECT @@last_plan_from_cache; # should be 1
+SELECT @@last_plan_from_cache;
 @@last_plan_from_cache
 1
 alter schema read_only read only 1;
 select * from read_only.t1 where a = 1;
 a	b
-SELECT @@last_plan_from_cache; # should be 0
+SELECT @@last_plan_from_cache;
 @@last_plan_from_cache
 0
+select * from read_only.t1 where a = 1;
+a	b
+SELECT @@last_plan_from_cache;
+@@last_plan_from_cache
+1
 alter schema read_only read only 0;
 select * from read_only.t1 where a = 1;
 a	b
-SELECT @@last_plan_from_cache; # should be 0
-SET tidb_enable_non_prepared_plan_cache = OFF;
+SELECT @@last_plan_from_cache;
 @@last_plan_from_cache
 0
+select * from read_only.t1 where a = 1;
+a	b
+SELECT @@last_plan_from_cache;
+@@last_plan_from_cache
+1
+SET tidb_enable_non_prepared_plan_cache = OFF;
 alter schema read_only read only 1;
 create binding for select * from t1 where b = 1 using select /*+ use_index(t1, idx_b) */ * from t1 where b = 1;
 create binding for update t1 set b = 2 where a = 1 using update /*+ use_index(t1, idx_b) */ t1 set b = 2 where a = 1;

--- a/tests/integrationtest/t/ddl/db_read_only.test
+++ b/tests/integrationtest/t/ddl/db_read_only.test
@@ -360,29 +360,47 @@ alter schema read_only read only 0;
 set @a = 1;
 execute stmt_select using @a;
 execute stmt_select using @a;
-select @@last_plan_from_cache; # should be 1
+# should be 1
+select @@last_plan_from_cache;
 # read only 0 -> 1, can't use plan cache
 alter schema read_only read only 1;
 execute stmt_select using @a;
-select @@last_plan_from_cache; # should be 0
+# should be 0
+select @@last_plan_from_cache;
+execute stmt_select using @a;
+# should be 1
+select @@last_plan_from_cache;
 # read only 1 -> 0, can use plan cache
 alter schema read_only read only 0;
 execute stmt_select using @a;
-select @@last_plan_from_cache; # should be 0
+# should be 0
+select @@last_plan_from_cache;
+execute stmt_select using @a;
+# should be 1
+select @@last_plan_from_cache;
 
 ## test non-prepared plan cache
 SET tidb_enable_non_prepared_plan_cache = ON;
 select * from read_only.t1 where a = 1;
 select * from read_only.t1 where a = 1;
-SELECT @@last_plan_from_cache; # should be 1
+# should be 1
+SELECT @@last_plan_from_cache;
 # read only 0 -> 1, can't use plan cache
 alter schema read_only read only 1;
 select * from read_only.t1 where a = 1;
-SELECT @@last_plan_from_cache; # should be 0
+# should be 0
+SELECT @@last_plan_from_cache;
+select * from read_only.t1 where a = 1;
+# should be 1
+SELECT @@last_plan_from_cache;
 # read only 1 -> 0, can use plan cache
 alter schema read_only read only 0;
 select * from read_only.t1 where a = 1;
-SELECT @@last_plan_from_cache; # should be 0
+# should be 0
+SELECT @@last_plan_from_cache;
+select * from read_only.t1 where a = 1;
+# should be 1
+SELECT @@last_plan_from_cache;
 SET tidb_enable_non_prepared_plan_cache = OFF;
 
 ## test create binding in read only mode


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62122

Problem Summary:

### What changed and how does it work?
Add test case about temporary table, prepare statement, plan cache, explain in read only database. 
* For the PREPARE statement,  if executing a SQL statement without PREPARE triggers a db read only error, wrapping it with PREPARE will still result in the same error, because TiDB need to build the SQL when execute the PREPARE statement. 
* For the plan cache, after setting the read only status, the SQL will miss the cache.
* EXPLAIN, EXPLAN ANALYZE and CRETAE BINDING behave the same as PREPARE, if the sql execute fail with triggering db read only error, wrapped in these statement will also fail.
* The PREPARE and EXPLAIN/ANALYZE statement has incompatible behavior with MySQL. MySQL can execute PREPARE and EXPLAIN SELECT FOR UPDATE success.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
