### PR TITLE
ddl: maintain the affect columns for partial index affect columns

### DIFF
--- a/pkg/ddl/integration_test.go
+++ b/pkg/ddl/integration_test.go
@@ -15,10 +15,12 @@
 package ddl_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
@@ -140,4 +142,34 @@ func TestPartialIndex(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMaintainAffectColumns(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+
+	tk.MustExec("create table t (col2 int, key(col2) where col2 > 0);")
+	// Now, the offset of col2 is 0
+	tbl, err := dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.Equal(t, 0, tbl.Meta().Indices[0].AffectColumn[0].Offset)
+
+	tk.MustExec("alter table t add column col1 int first;")
+	// Now, the offset of col2 should be 1
+	tbl, err = dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.Equal(t, 1, tbl.Meta().Indices[0].AffectColumn[0].Offset)
+
+	tk.MustExec("alter table t add column col3 int after col1;")
+	// Now, the offset of col2 should be 2
+	tbl, err = dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.Equal(t, 2, tbl.Meta().Indices[0].AffectColumn[0].Offset)
+
+	tk.MustExec("alter table t drop column col1;")
+	// Now, the offset of col2 should be 1
+	tbl, err = dom.InfoSchema().TableByName(context.Background(), ast.NewCIStr("test"), ast.NewCIStr("t"))
+	require.NoError(t, err)
+	require.Equal(t, 1, tbl.Meta().Indices[0].AffectColumn[0].Offset)
 }

--- a/pkg/meta/model/table.go
+++ b/pkg/meta/model/table.go
@@ -426,6 +426,13 @@ func (t *TableInfo) MoveColumnInfo(from, to int) {
 				idxCol.Offset = newOffset
 			}
 		}
+
+		for _, affectedCol := range idx.AffectColumn {
+			newOffset, ok := updatedOffsets[affectedCol.Offset]
+			if ok {
+				affectedCol.Offset = newOffset
+			}
+		}
 	}
 
 	// Reconstruct the dependency column offsets.

--- a/tests/integrationtest/r/ddl/integration.result
+++ b/tests/integrationtest/r/ddl/integration.result
@@ -175,3 +175,8 @@ drop table t;
 create table t (a int, b int, key testidx(b) where a > 5);
 alter table t partition by range (b) (partition p0 values less than (5));
 Error 8200 (HY000): Unsupported add partial index: partial index is not supported on partitioned table
+drop table if exists t;
+create table t (col2 int, key (col2) where col2 > 0);
+alter table t add column col1 int first;
+insert into t values (1, 1);
+update t set col1 = 5;

--- a/tests/integrationtest/t/ddl/integration.test
+++ b/tests/integrationtest/t/ddl/integration.test
@@ -168,3 +168,10 @@ drop table t;
 create table t (a int, b int, key testidx(b) where a > 5);
 --error 8200
 alter table t partition by range (b) (partition p0 values less than (5));
+
+# TestUpdateAfterAddColumnForPartialIndex
+drop table if exists t;
+create table t (col2 int, key (col2) where col2 > 0);
+alter table t add column col1 int first;
+insert into t values (1, 1);
+update t set col1 = 5;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64472

Problem Summary:

### What changed and how does it work?

1. Also modify the `Offset` of affect columns for partial index condition in `MoveColumnInfo`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
