### PR TITLE
br: fix the bug that query can not be split

### DIFF
--- a/pkg/executor/brie_utils_test.go
+++ b/pkg/executor/brie_utils_test.go
@@ -17,18 +17,22 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/domain"
 	"github.com/pingcap/tidb/pkg/executor"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/session/sessionapi"
 	"github.com/pingcap/tidb/pkg/sessionctx"
+	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
@@ -38,8 +42,8 @@ func TestSplitBatchCreateTableWithTableId(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists table_id_resued1")
-	tk.MustExec("drop table if exists table_id_resued2")
+	tk.MustExec("drop table if exists table_id_reused1")
+	tk.MustExec("drop table if exists table_id_reused2")
 	tk.MustExec("drop table if exists table_id_new")
 
 	d := dom.DDL()
@@ -48,24 +52,28 @@ func TestSplitBatchCreateTableWithTableId(t *testing.T) {
 	infos1 := []*model.TableInfo{}
 	infos1 = append(infos1, &model.TableInfo{
 		ID:   124,
-		Name: ast.NewCIStr("table_id_resued1"),
+		Name: ast.NewCIStr("table_id_reused1"),
 	})
 	infos1 = append(infos1, &model.TableInfo{
 		ID:   125,
-		Name: ast.NewCIStr("table_id_resued2"),
+		Name: ast.NewCIStr("table_id_reused2"),
 	})
+	querys1 := []string{
+		"create table test.table_id_reused1 (id int)",
+		"create table test.table_id_reused2 (id int)",
+	}
 
 	sctx := tk.Session()
 
 	// keep/reused table id verification
-	sctx.SetValue(sessionctx.QueryString, "skip")
-	err := executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos1, ddl.WithIDAllocated(true))
+	sctx.SetValue(sessionctx.QueryString, "TODO")
+	err := executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos1, querys1, ddl.WithIDAllocated(true))
 	require.NoError(t, err)
-	require.Equal(t, "skip", sctx.Value(sessionctx.QueryString))
+	require.Equal(t, "create table test.table_id_reused1 (id int);create table test.table_id_reused2 (id int);", sctx.Value(sessionctx.QueryString))
 
-	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_resued1'").
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_reused1'").
 		Check(testkit.Rows("124"))
-	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_resued2'").
+	tk.MustQuery("select tidb_table_id from information_schema.tables where table_name = 'table_id_reused2'").
 		Check(testkit.Rows("125"))
 	ctx := kv.WithInternalSourceType(context.Background(), kv.InternalTxnOthers)
 
@@ -86,11 +94,12 @@ func TestSplitBatchCreateTableWithTableId(t *testing.T) {
 		ID:   124,
 		Name: ast.NewCIStr("table_id_new"),
 	})
+	querys2 := []string{"create table test.table_id_new (id int)"}
 
-	tk.Session().SetValue(sessionctx.QueryString, "skip")
-	err = executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos2)
+	tk.Session().SetValue(sessionctx.QueryString, "TODO")
+	err = executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos2, querys2)
 	require.NoError(t, err)
-	require.Equal(t, "skip", sctx.Value(sessionctx.QueryString))
+	require.Equal(t, "create table test.table_id_new (id int);", sctx.Value(sessionctx.QueryString))
 
 	idGen, ok := tk.MustQuery(
 		"select tidb_table_id from information_schema.tables where table_name = 'table_id_new'").
@@ -102,11 +111,11 @@ func TestSplitBatchCreateTableWithTableId(t *testing.T) {
 
 	// a empty table info with len(info3) = 0
 	infos3 := []*model.TableInfo{}
+	querys3 := []string{}
 
-	originQueryString := sctx.Value(sessionctx.QueryString)
-	err = executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos3, ddl.WithIDAllocated(true))
+	err = executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos3, querys3, ddl.WithIDAllocated(true))
 	require.NoError(t, err)
-	require.Equal(t, originQueryString, sctx.Value(sessionctx.QueryString))
+	require.Equal(t, "", sctx.Value(sessionctx.QueryString))
 }
 
 // batch create table with table id reused
@@ -134,15 +143,19 @@ func TestSplitBatchCreateTable(t *testing.T) {
 		ID:   1236,
 		Name: ast.NewCIStr("tables_3"),
 	})
+	querys := []string{
+		"create table test.tables_1 (id int)",
+		"create table test.tables_2 (id int)",
+		"create table test.tables_3 (id int)"}
 
 	sctx := tk.Session()
 
 	// keep/reused table id verification
-	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	tk.Session().SetValue(sessionctx.QueryString, "TODO")
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/RestoreBatchCreateTableEntryTooLarge", "return(1)"))
-	err := executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos, ddl.WithIDAllocated(true))
+	err := executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos, querys, ddl.WithIDAllocated(true))
 	require.NoError(t, err)
-	require.Equal(t, "skip", sctx.Value(sessionctx.QueryString))
+	require.Equal(t, "create table test.tables_3 (id int);", sctx.Value(sessionctx.QueryString))
 
 	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
 	jobs := tk.MustQuery("admin show ddl jobs").Rows()
@@ -201,13 +214,17 @@ func TestSplitBatchCreateTableFailWithEntryTooLarge(t *testing.T) {
 	infos = append(infos, &model.TableInfo{
 		Name: ast.NewCIStr("tables_3"),
 	})
+	querys := []string{
+		"create table test.tables_1 (id int)",
+		"create table test.tables_2 (id int)",
+		"create table test.tables_3 (id int)"}
 
 	sctx := tk.Session()
 
-	tk.Session().SetValue(sessionctx.QueryString, "skip")
+	tk.Session().SetValue(sessionctx.QueryString, "TODO")
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/RestoreBatchCreateTableEntryTooLarge", "return(0)"))
-	err := executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos)
-	require.Equal(t, "skip", sctx.Value(sessionctx.QueryString))
+	err := executor.SplitBatchCreateTableForTest(sctx, ast.NewCIStr("test"), infos, querys)
+	require.Equal(t, "create table test.tables_1 (id int);", sctx.Value(sessionctx.QueryString))
 	require.True(t, kv.ErrEntryTooLarge.Equal(err))
 
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/RestoreBatchCreateTableEntryTooLarge"))
@@ -309,4 +326,89 @@ func TestBRIECreateTables(t *testing.T) {
 	for i := range tableInfos {
 		tk.MustExec(fmt.Sprintf("desc table_%d", i))
 	}
+}
+
+type fakeDDLExecutor struct {
+	ddl.Executor
+	queryList        []string
+	successQueryList []string
+	maxCount         int
+}
+
+func (f *fakeDDLExecutor) BatchCreateTableWithInfo(
+	sctx sessionctx.Context,
+	schema ast.CIStr,
+	info []*model.TableInfo,
+	cs ...ddl.CreateTableOption,
+) error {
+	f.queryList = append(f.queryList, sctx.Value(sessionctx.QueryString).(string))
+	if len(info) > f.maxCount {
+		switch rand.Int() % 2 {
+		case 0:
+			return kv.ErrTxnTooLarge
+		case 1:
+			return kv.ErrEntryTooLarge
+		}
+	}
+	f.successQueryList = append(f.successQueryList, sctx.Value(sessionctx.QueryString).(string))
+	return nil
+}
+
+type fakeSessionContext struct {
+	sessionapi.Session
+	ddlexecutor *fakeDDLExecutor
+	values      map[string]any
+	vars        *variable.SessionVars
+}
+
+func newFakeSessionContext(ddlexecutor *fakeDDLExecutor) *fakeSessionContext {
+	return &fakeSessionContext{
+		ddlexecutor: ddlexecutor,
+		values:      make(map[string]any),
+		vars:        &variable.SessionVars{},
+	}
+}
+
+func (f *fakeSessionContext) GetDomain() any {
+	dom := &domain.Domain{}
+	dom.SetDDL(nil, f.ddlexecutor)
+	return dom
+}
+
+func (f *fakeSessionContext) Value(key fmt.Stringer) any {
+	return f.values[key.String()]
+}
+
+func (f *fakeSessionContext) SetValue(key fmt.Stringer, value any) {
+	f.values[key.String()] = value
+}
+
+func (f *fakeSessionContext) GetSessionVars() *variable.SessionVars {
+	return f.vars
+}
+
+func TestSplitTablesQueryMatch(t *testing.T) {
+	ddlexecutor := &fakeDDLExecutor{maxCount: 1}
+	sctx := newFakeSessionContext(ddlexecutor)
+	tables := map[string][]*model.TableInfo{
+		"test": {
+			{Name: ast.NewCIStr("t1")},
+			{Name: ast.NewCIStr("t2")},
+		},
+		"test2": {
+			{Name: ast.NewCIStr("t3")},
+		},
+	}
+
+	err := executor.BRIECreateTables(sctx, tables, "/*from(br)*/")
+	require.NoError(t, err)
+	require.Len(t, ddlexecutor.queryList, 4)
+	require.Equal(t, "/*from(br)*/CREATE TABLE `t1` (\n\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;/*from(br)*/CREATE TABLE `t2` (\n\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;", ddlexecutor.queryList[0])
+	require.Equal(t, "/*from(br)*/CREATE TABLE `t1` (\n\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;", ddlexecutor.queryList[1])
+	require.Equal(t, "/*from(br)*/CREATE TABLE `t2` (\n\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;", ddlexecutor.queryList[2])
+	require.Equal(t, "/*from(br)*/CREATE TABLE `t3` (\n\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;", ddlexecutor.queryList[3])
+	require.Len(t, ddlexecutor.successQueryList, 3)
+	require.Equal(t, ddlexecutor.queryList[1], ddlexecutor.successQueryList[0])
+	require.Equal(t, ddlexecutor.queryList[2], ddlexecutor.successQueryList[1])
+	require.Equal(t, ddlexecutor.queryList[3], ddlexecutor.successQueryList[2])
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64492

Problem Summary:
br cannot handle the error `Transaction is too large` when batch create tables. And after it split batch, the query is not updated.
### What changed and how does it work?
split batch if meet the error `Transaction is too large` and split query too.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
