### PR TITLE
planner: fix wrong binding cache status when adding duplicated bindings

### DIFF
--- a/pkg/bindinfo/binding_cache.go
+++ b/pkg/bindinfo/binding_cache.go
@@ -204,7 +204,16 @@ func (fbc *fuzzyBindingCache) SetBinding(sqlDigest string, bindings Bindings) (e
 	}
 
 	for i, binding := range bindings {
-		fbc.fuzzy2SQLDigests[fuzzyDigests[i]] = append(fbc.fuzzy2SQLDigests[fuzzyDigests[i]], binding.SQLDigest)
+		exist := false
+		for _, d := range fbc.fuzzy2SQLDigests[fuzzyDigests[i]] {
+			if d == sqlDigest {
+				exist = true
+				break
+			}
+		}
+		if !exist { // avoid adding duplicated binding digests
+			fbc.fuzzy2SQLDigests[fuzzyDigests[i]] = append(fbc.fuzzy2SQLDigests[fuzzyDigests[i]], binding.SQLDigest)
+		}
 		fbc.sql2FuzzyDigest[binding.SQLDigest] = fuzzyDigests[i]
 	}
 	// NOTE: due to LRU eviction, the underlying BindingCache state might be inconsistent with fuzzy2SQLDigests and


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

cherry-pick for https://github.com/pingcap/tidb/pull/64497


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64495

Problem Summary: planner: fix wrong binding cache status when adding duplicated bindings

### What changed and how does it work?

See the code, just check whether the binding digest already exists in the `digestMap`, if yes just skip putting it into the map.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

