### PR TITLE
planner: Adjust risk assessment for plan choice (#64419)

### DIFF
--- a/pkg/planner/cardinality/selectivity_test.go
+++ b/pkg/planner/cardinality/selectivity_test.go
@@ -588,7 +588,8 @@ func TestNewIndexWithoutStats(t *testing.T) {
 	testKit.MustExec("drop table if exists t")
 	testKit.MustExec("create table t(a int, b int, c int, index idxa(a), index idxca(c,a))")
 	testKit.MustExec("set @@tidb_analyze_version=2")
-	testKit.MustExec("set @@global.tidb_enable_auto_analyze='OFF'")
+	testKit.MustExec("set @@global.tidb_enable_auto_analyze='OFF'")     // Disable auto analyze to control when stats are collected
+	testKit.MustExec("set @@tidb_opt_table_full_scan_cost_factor=1000") // Discourage full table scans - this is an index test
 	testKit.MustExec("insert into t values (1, 1, 1)")
 	testKit.MustExec("insert into t select mod(a,250), mod(a,10), mod(a,100) from (with recursive x as (select 1 as a union all select a + 1 AS a from x where a < 500) select a from x) as subquery")
 	testKit.MustExec("analyze table t")

--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -950,6 +950,7 @@ func compareCandidates(sctx base.PlanContext, statsTbl *statistics.Table, prop *
 
 	// predicateResult is separated out. An index may "win" because it has a better
 	// accessResult - but that access has high risk.
+	// accessResult does not differentiate between range or equal/IN predicates.
 	// Summing these 3 metrics ensures that a "high risk" index wont win ONLY on
 	// accessResult. The high risk will negate that accessResult with erOrIn being the
 	// tiebreaker or equalizer.
@@ -994,16 +995,19 @@ func compareCandidates(sctx base.PlanContext, statsTbl *statistics.Table, prop *
 
 	leftDidNotLose := predicateResult >= 0 && scanResult >= 0 && matchResult >= 0 && globalResult >= 0
 	rightDidNotLose := predicateResult <= 0 && scanResult <= 0 && matchResult <= 0 && globalResult <= 0
-	if !comparable1 && !comparable2 {
-		// These aren't comparable - but compare risk and other metrics to see if we
-		// can determine a clear winner. Checking > 1 and < -1 means that the winner
-		// must win on at least 2 of the metrics below.
-		// This is to prevent a case where x wins on 1 metric but loses badly on another.
-		// Other checks in this logic only require > 0 or < 0 (1 metric is enough).
-		if riskResult > 0 && leftDidNotLose && totalSum > 1 {
+	if !comparable1 || !comparable2 {
+		// These aren't comparable - meaning that they have different combinations of columns in
+		// the access conditions or filters.
+		// One or more predicates could carry high risk - so we want to compare that risk and other
+		// metrics to see if we can determine a clear winner.
+		// The 2 key metrics here are riskResult and predicateResult.
+		// - riskResult tells us which candidate has lower risk
+		// - predicateResult already includes risk - we need ">1" or "<-1" to counteract the risk factor.
+		// "DidNotLose" and totalSum are also factored in to ensure that the winner is better overall."
+		if riskResult > 0 && leftDidNotLose && totalSum >= 0 && predicateResult > 1 {
 			return 1, lhsPseudo // left wins - also return whether it has statistics (pseudo) or not
 		}
-		if riskResult < 0 && rightDidNotLose && totalSum < -1 {
+		if riskResult < 0 && rightDidNotLose && totalSum <= 0 && predicateResult < 1 {
 			return -1, rhsPseudo // right wins - also return whether it has statistics (pseudo) or not
 		}
 		return 0, false // No winner (0). Do not return the pseudo result
@@ -1578,7 +1582,7 @@ func skylinePruning(ds *logicalop.DataSource, prop *property.PhysicalProperty) [
 			}
 			// Preference plans with equals/IN predicates or where there is more filtering in the index than against the table
 			indexFilters := c.equalPredicateCount() > 0 || len(c.path.TableFilters) < len(c.path.IndexFilters)
-			if preferMerge || (indexFilters && (prop.IsSortItemEmpty() || c.matchPropResult.Matched())) {
+			if preferMerge || ((c.path.IsSingleScan || indexFilters) && (prop.IsSortItemEmpty() || c.matchPropResult.Matched())) {
 				if !c.path.IsFullScanRange(ds.TableInfo) {
 					preferredPaths = append(preferredPaths, c)
 					hasRangeScanPath = true

--- a/pkg/planner/core/logical_plans_test.go
+++ b/pkg/planner/core/logical_plans_test.go
@@ -1996,7 +1996,7 @@ func TestSkylinePruning(t *testing.T) {
 		},
 		{
 			sql:    "select * from t where d = 1 and f > 1 and g > 1 order by c, e",
-			result: "PRIMARY_KEY,c_d_e,f_g",
+			result: "PRIMARY_KEY,c_d_e,g,f_g",
 		},
 		{
 			sql:    "select * from pt2_global_index where b > 1 order by b",
@@ -2012,7 +2012,7 @@ func TestSkylinePruning(t *testing.T) {
 		},
 		{
 			sql:    "select * from pt2_global_index where b > 1 and c > 1",
-			result: "PRIMARY_KEY,b_c_global",
+			result: "PRIMARY_KEY,c_d_e,b_c_global",
 		},
 		{
 			sql:    "select * from pt2_global_index where b > 1 and c > 1 and d > 1",

--- a/tests/integrationtest/r/planner/core/plan_cost_ver2.result
+++ b/tests/integrationtest/r/planner/core/plan_cost_ver2.result
@@ -169,15 +169,15 @@ HashJoin_23	11.00	64549.37	root		inner join, equal:[eq(planner__core__plan_cost_
 ├─TableReader_26(Build)	11.00	5140.17	root		data:Selection_25
 │ └─Selection_25	11.00	3049.29	cop[tikv]		not(isnull(planner__core__plan_cost_ver2.t.b))
 │   └─TableRangeScan_24	11.00	2500.39	cop[tikv]	table:t1	range:[-inf,10), keep order:false
-└─TableReader_29(Probe)	100.00	46728.80	root		data:Selection_28
-  └─Selection_28	100.00	27720.80	cop[tikv]		not(isnull(planner__core__plan_cost_ver2.t.b))
-    └─TableFullScan_27	100.00	22730.80	cop[tikv]	table:t2	keep order:false
+└─TableReader_33(Probe)	100.00	46728.80	root		data:Selection_32
+  └─Selection_32	100.00	27720.80	cop[tikv]		not(isnull(planner__core__plan_cost_ver2.t.b))
+    └─TableFullScan_31	100.00	22730.80	cop[tikv]	table:t2	keep order:false
 explain format='verbose' select /*+ hash_join_build(t2) */ * from t t1, t t2 where t1.b=t2.b and t1.a<10;
 id	estRows	estCost	task	access object	operator info
 HashJoin_23	11.00	65403.77	root		inner join, equal:[eq(planner__core__plan_cost_ver2.t.b, planner__core__plan_cost_ver2.t.b)]
-├─TableReader_29(Build)	100.00	46728.80	root		data:Selection_28
-│ └─Selection_28	100.00	27720.80	cop[tikv]		not(isnull(planner__core__plan_cost_ver2.t.b))
-│   └─TableFullScan_27	100.00	22730.80	cop[tikv]	table:t2	keep order:false
+├─TableReader_33(Build)	100.00	46728.80	root		data:Selection_32
+│ └─Selection_32	100.00	27720.80	cop[tikv]		not(isnull(planner__core__plan_cost_ver2.t.b))
+│   └─TableFullScan_31	100.00	22730.80	cop[tikv]	table:t2	keep order:false
 └─TableReader_26(Probe)	11.00	5140.17	root		data:Selection_25
   └─Selection_25	11.00	3049.29	cop[tikv]		not(isnull(planner__core__plan_cost_ver2.t.b))
     └─TableRangeScan_24	11.00	2500.39	cop[tikv]	table:t1	range:[-inf,10), keep order:false


### PR DESCRIPTION
Manually cherry-pick #64419 
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64378

Problem Summary:

### What changed and how does it work?

compareCandidates logic in skylinePruning now includes a riskFactor - to identify higher risk indexes, and use other metrics to counteract that high risk. This issue (64378) exposed that accessConds does not differentiate equal vs range predicates. The prior check that utilizes totalSum < -1 or > 1 was changed to instead check predicateResult (which does include EqOrInCondCount).

A 2nd issue was found and resolved in this PR. A prior PR (https://github.com/pingcap/tidb/pull/63349) added the "risk" assessment to compareCandidates logic - and it changed the behavior of "comparable1" && "comparable2". The prior behavior exited if either was false. PR 63349 allowed the risk assessment if both were false - but allowed the code to drop through if only 1 was false. This was inconsistent with the prior compareCandidates logic.

This new PR changes the !comparable2/!comparable2 to an OR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
