### PR TITLE
Title: metrics, store/copr: expose tidb_tikvclient_region_cache_operations_total

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -81,6 +81,7 @@ func InitMetrics() {
 	InitBindInfoMetrics()
 	InitDDLMetrics()
 	InitDistSQLMetrics()
+	InitTiKVClientRegionCacheMetrics()
 	InitDomainMetrics()
 	InitExecutorMetrics()
 	InitGCWorkerMetrics()
@@ -314,6 +315,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(ActiveUser)
 
 	prometheus.MustRegister(NetworkTransmissionStats)
+
+	prometheus.MustRegister(RegionCacheOperationsCounter)
 
 	prometheus.MustRegister(RestoreTableCreatedCount)
 	prometheus.MustRegister(RestoreImportFileSeconds)

--- a/pkg/metrics/tikvclient_region_cache.go
+++ b/pkg/metrics/tikvclient_region_cache.go
@@ -1,0 +1,41 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	metricscommon "github.com/pingcap/tidb/pkg/metrics/common"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TiKV client region cache metrics.
+var (
+	// RegionCacheOperationsCounter counts TiDB-side region cache operations, labeled by:
+	// - type: operation kind (batch_locate|split_locations|split_buckets|on_send_fail|build_task|other)
+	// - result: ok|err
+	RegionCacheOperationsCounter *prometheus.CounterVec
+)
+
+// InitTiKVClientRegionCacheMetrics initializes metrics for TiKV client region cache usage in TiDB.
+func InitTiKVClientRegionCacheMetrics() {
+	RegionCacheOperationsCounter = metricscommon.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: TiKVClient,
+			Name:      "region_cache_operations_total",
+			Help:      "TiDB region cache operations count.",
+		}, []string{LblType, LblResult})
+}
+
+

--- a/pkg/metrics/tikvclient_region_cache_test.go
+++ b/pkg/metrics/tikvclient_region_cache_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegionCacheOperationsCounter(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, RegionCacheOperationsCounter, "RegionCacheOperationsCounter should be initialized")
+
+	// Increase a couple of labeled series and validate values.
+	RegionCacheOperationsCounter.WithLabelValues("batch_locate", "ok").Add(1)
+	RegionCacheOperationsCounter.WithLabelValues("on_send_fail", "err").Add(2)
+
+	ok := testutil.ToFloat64(RegionCacheOperationsCounter.WithLabelValues("batch_locate", "ok"))
+	err := testutil.ToFloat64(RegionCacheOperationsCounter.WithLabelValues("on_send_fail", "err"))
+	require.Equal(t, 1.0, ok)
+	require.Equal(t, 2.0, err)
+}
+
+


### PR DESCRIPTION
Title: metrics, store/copr: expose tidb_tikvclient_region_cache_operations_total

### What problem does this PR solve?
Issue Number: close #6815

Problem Summary:
Grafana panels reference tidb_tikvclient_region_cache_operations_total, but TiDB didn’t export it. Operators can’t observe TiDB-side region cache operation activity and error rates.

### What changed and how does it work?
- Add RegionCacheOperationsCounter under tikvclient subsystem.
- Emit counters for key region cache operations:
  - type=batch_locate, result=ok|err (after BatchLocateKeyRanges)
  - type=split_locations, result=ok (after successful SplitKeyRangesByLocations)
  - type=split_buckets, result=ok (after successful SplitKeyRangesByBuckets)
  - type=split_buckets, result=err (panic-defer path during bucket split)
  - type=on_send_fail, result=err (+len(regionInfos) in OnSendFailForBatchRegions)
- Register metric at startup with existing metrics init/registration.

Files:
- pkg/metrics/tikvclient_region_cache.go (new): define/init metric
- pkg/metrics/metrics.go: call init and MustRegister
- pkg/store/copr/region_cache.go: emit increments at the points above
- pkg/metrics/tikvclient_region_cache_test.go (new): unit test

