### PR TITLE
planner: fix hint `index_lookup_pushdown` may affect other hint even pushdown is not allowed

### DIFF
--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -1400,9 +1400,11 @@ func getPossibleAccessPaths(ctx base.PlanContext, tableHints *hint.PlanHints, in
 			if i >= indexHintsLen {
 				// Currently we only support to hint the index look up push down for comment-style sql hints.
 				// So only i >= indexHintsLen may have the hints here.
-				_, path.IsIndexLookUpPushDown = indexLookUpPushDownHints[i]
-				if path.IsIndexLookUpPushDown && !checkIndexLookUpPushDownSupported(ctx, tblInfo, path.Index) {
-					continue
+				if _, ok := indexLookUpPushDownHints[i]; ok {
+					if !checkIndexLookUpPushDownSupported(ctx, tblInfo, path.Index) {
+						continue
+					}
+					path.IsIndexLookUpPushDown = true
 				}
 			}
 			available = append(available, path)

--- a/tests/integrationtest/r/executor/index_lookup_pushdown.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown.result
@@ -374,3 +374,16 @@ TableReader_8	10.00	root		data:Selection_7
   └─TableFullScan_6	10000.00	cop[tikv]	table:t7	keep order:false, stats:pseudo
 Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, multi-valued index is not supported
+insert into t3 values(1, 2, 3);
+explain select /*+ index_lookup_pushdown(t3, a) */ * from t3 use index(a);
+id	estRows	task	access object	operator info
+IndexLookUp_7	10000.00	root	partition:all	
+├─IndexFullScan_5(Build)	10000.00	cop[tikv]	table:t3, index:a(a)	keep order:false, stats:pseudo
+└─TableRowIDScan_6(Probe)	10000.00	cop[tikv]	table:t3	keep order:false, stats:pseudo
+Level	Code	Message
+Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, partition table is not supported
+select /*+ index_lookup_pushdown(t3, a) */ * from t3 use index(a);
+id	a	b
+1	2	3
+Level	Code	Message
+Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, partition table is not supported

--- a/tests/integrationtest/t/executor/index_lookup_pushdown.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown.test
@@ -134,3 +134,10 @@ create table t7 (j json, index idx((cast(j->'$.path' as signed array))));
 explain select /*+ index_lookup_pushdown(t7, idx) */ * from t7 where (1 member of (j->'$.path'));
 
 --disable_warnings
+
+## issue #64519, the index_lookup_pushdown hint should not affect other hints in a same index.
+insert into t3 values(1, 2, 3);
+--enable_warnings
+explain select /*+ index_lookup_pushdown(t3, a) */ * from t3 use index(a);
+select /*+ index_lookup_pushdown(t3, a) */ * from t3 use index(a);
+--disable_warnings


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64519

Problem Summary:

When `index_lookup_pushdown` and `use index` both exist and use the same index, they may share the same `AccessPath` object and it will be force set the `AccessPath. IsIndexLookUpPushDown` as true even if it is not allowed.

### What changed and how does it work?

Does not set `AccessPath. IsIndexLookUpPushDown` before `checkIndexLookUpPushDownSupported` passed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
