### PR TITLE
DO NOT MERGE: Revert "statistics: use infoschema api to get table info (#57574)"

### DIFF
--- a/pkg/statistics/handle/util/BUILD.bazel
+++ b/pkg/statistics/handle/util/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/infoschema",
+        "//pkg/infoschema/context",
         "//pkg/kv",
         "//pkg/meta/model",
         "//pkg/metrics",

--- a/pkg/statistics/handle/util/table_info.go
+++ b/pkg/statistics/handle/util/table_info.go
@@ -16,9 +16,12 @@ package util
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pingcap/tidb/pkg/infoschema"
+	infoschemacontext "github.com/pingcap/tidb/pkg/infoschema/context"
 	"github.com/pingcap/tidb/pkg/table"
+	"github.com/pingcap/tidb/pkg/util/intest"
 )
 
 // TableInfoGetter is used to get table meta info.
@@ -33,22 +36,46 @@ type TableInfoGetter interface {
 
 // tableInfoGetterImpl is used to get table meta info.
 type tableInfoGetterImpl struct {
+	// pid2tid is the map from partition ID to table ID.
+	pid2tid map[int64]int64
+	// schemaVersion is the version of information schema when `pid2tid` is built.
+	schemaVersion int64
+	mu            sync.RWMutex
 }
 
 // NewTableInfoGetter creates a TableInfoGetter.
 func NewTableInfoGetter() TableInfoGetter {
-	return &tableInfoGetterImpl{}
+	return &tableInfoGetterImpl{pid2tid: map[int64]int64{}}
 }
 
 // TableInfoByID returns the table info specified by the physicalID.
 // If the physicalID is corresponding to a partition, return its parent table.
-func (*tableInfoGetterImpl) TableInfoByID(is infoschema.InfoSchema, physicalID int64) (table.Table, bool) {
-	tbl, ok := is.TableByID(context.Background(), physicalID)
-	if ok {
-		return tbl, true
+func (c *tableInfoGetterImpl) TableInfoByID(is infoschema.InfoSchema, physicalID int64) (table.Table, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if is.SchemaMetaVersion() != c.schemaVersion {
+		c.schemaVersion = is.SchemaMetaVersion()
+		c.pid2tid = buildPartitionID2TableID(is)
 	}
-	tbl, _, _ = is.FindTableByPartitionID(physicalID)
-	return tbl, tbl != nil
+	if id, ok := c.pid2tid[physicalID]; ok {
+		return is.TableByID(context.Background(), id)
+	}
+	return is.TableByID(context.Background(), physicalID)
+}
+
+func buildPartitionID2TableID(is infoschema.InfoSchema) map[int64]int64 {
+	mapper := make(map[int64]int64)
+	rs := is.ListTablesWithSpecialAttribute(infoschemacontext.PartitionAttribute)
+	for _, db := range rs {
+		for _, tbl := range db.TableInfos {
+			pi := tbl.GetPartitionInfo()
+			intest.AssertNotNil(pi)
+			for _, def := range pi.Definitions {
+				mapper[def.ID] = tbl.ID
+			}
+		}
+	}
+	return mapper
 }
 
 // TableItemByID returns the lightweight table meta specified by the physicalID.


### PR DESCRIPTION
This reverts commit d42a36d59a3016764d31f47f27d79eb1e68404ce.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
