### PR TITLE
planner: handle the selection between the join group

### DIFF
--- a/pkg/planner/core/rule_join_reorder.go
+++ b/pkg/planner/core/rule_join_reorder.go
@@ -51,7 +51,7 @@ func extractJoinGroup(p base.LogicalPlan) *joinGroupResult {
 	// Join reorder may distribute/push down conditions during constructing the new join tree.
 	// For volatile or side-effect expressions, moving them can change evaluation times/orders
 	// thus may change query results, so we skip reordering through Selection in such cases.
-	if selection, isSelection := p.(*logicalop.LogicalSelection); isSelection && p.SCtx().GetSessionVars().TiDBOptJoinReorderSel &&
+	if selection, isSelection := p.(*logicalop.LogicalSelection); isSelection && p.SCtx().GetSessionVars().TiDBOptJoinReorderThroughSel &&
 		!slices.ContainsFunc(selection.Conditions, expression.IsMutableEffectsExpr) {
 		child := selection.Children()[0]
 		if _, isChildJoin := child.(*logicalop.LogicalJoin); isChildJoin {

--- a/pkg/sessionctx/vardef/tidb_vars.go
+++ b/pkg/sessionctx/vardef/tidb_vars.go
@@ -660,9 +660,9 @@ const (
 	// we'll choose a rather time-consuming algorithm to calculate the join order.
 	TiDBOptJoinReorderThreshold = "tidb_opt_join_reorder_threshold"
 
-	// TiDBOptJoinReorderSel enables pushing selection conditions down to
+	// TiDBOptJoinReorderThroughSel enables pushing selection conditions down to
 	// reordered join trees when applicable.
-	TiDBOptJoinReorderSel = "tidb_opt_join_reorder_sel"
+	TiDBOptJoinReorderThroughSel = "tidb_opt_join_reorder_through_sel"
 
 	// TiDBSlowQueryFile indicates which slow query log file for SLOW_QUERY table to parse.
 	TiDBSlowQueryFile = "tidb_slow_query_file"
@@ -1519,7 +1519,7 @@ const (
 	DefEnableStrictDoubleTypeCheck          = true
 	DefEnableVectorizedExpression           = true
 	DefTiDBOptJoinReorderThreshold          = 0
-	DefTiDBOptJoinReorderSel                = false
+	DefTiDBOptJoinReorderThroughSel         = false
 	DefTiDBDDLSlowOprThreshold              = 300
 	DefTiDBUseFastAnalyze                   = false
 	DefTiDBSkipIsolationLevelCheck          = false

--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -1207,9 +1207,9 @@ type SessionVars struct {
 	// to use the greedy join reorder algorithm.
 	TiDBOptJoinReorderThreshold int
 
-	// TiDBOptJoinReorderSel enables pushing selection conditions down to
+	// TiDBOptJoinReorderThroughSel enables pushing selection conditions down to
 	// reordered join trees when applicable.
-	TiDBOptJoinReorderSel bool
+	TiDBOptJoinReorderThroughSel bool
 
 	// SlowQueryFile indicates which slow query log file for SLOW_QUERY table to parse.
 	SlowQueryFile string
@@ -2317,7 +2317,7 @@ func NewSessionVars(hctx HookContext) *SessionVars {
 		EnableVectorizedExpression:    vardef.DefEnableVectorizedExpression,
 		CommandValue:                  uint32(mysql.ComSleep),
 		TiDBOptJoinReorderThreshold:   vardef.DefTiDBOptJoinReorderThreshold,
-		TiDBOptJoinReorderSel:         vardef.DefTiDBOptJoinReorderSel,
+		TiDBOptJoinReorderThroughSel:  vardef.DefTiDBOptJoinReorderThroughSel,
 		SlowQueryFile:                 config.GetGlobalConfig().Log.SlowQueryFile,
 		WaitSplitRegionFinish:         vardef.DefTiDBWaitSplitRegionFinish,
 		WaitSplitRegionTimeout:        vardef.DefWaitSplitRegionTimeout,

--- a/pkg/sessionctx/variable/sysvar.go
+++ b/pkg/sessionctx/variable/sysvar.go
@@ -2582,8 +2582,8 @@ var defaultSysVars = []*SysVar{
 		s.TiDBOptJoinReorderThreshold = tidbOptPositiveInt32(val, vardef.DefTiDBOptJoinReorderThreshold)
 		return nil
 	}},
-	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBOptJoinReorderSel, Value: BoolToOnOff(vardef.DefTiDBOptJoinReorderSel), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
-		s.TiDBOptJoinReorderSel = TiDBOptOn(val)
+	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBOptJoinReorderThroughSel, Value: BoolToOnOff(vardef.DefTiDBOptJoinReorderThroughSel), Type: vardef.TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.TiDBOptJoinReorderThroughSel = TiDBOptOn(val)
 		return nil
 	}},
 	{Scope: vardef.ScopeGlobal | vardef.ScopeSession, Name: vardef.TiDBEnableNoopFuncs, Value: vardef.DefTiDBEnableNoopFuncs, Type: vardef.TypeEnum, PossibleValues: []string{vardef.Off, vardef.On, vardef.Warn}, Depended: true, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope vardef.ScopeFlag) (string, error) {

--- a/tests/integrationtest/r/planner/core/join_reorder2.result
+++ b/tests/integrationtest/r/planner/core/join_reorder2.result
@@ -4,7 +4,7 @@ create table t2(id int not null primary key, name varchar(100));
 create table t3(id int not null primary key, name varchar(100));
 create table t4(id int not null primary key, name varchar(100));
 create table t5(id int not null primary key, name varchar(100));
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1, t2) */ * from t1 inner join t3 on t1.id=t3.id left join t4 on t4.id=t3.id join t2 on t1.id=t2.id where t3.name like 'test3' or t4.name like 'test4';
 id	task	access object	operator info
 Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder2.t1.name, planner__core__join_reorder2.t3.id, planner__core__join_reorder2.t3.name, planner__core__join_reorder2.t4.id, planner__core__join_reorder2.t4.name, planner__core__join_reorder2.t2.id, planner__core__join_reorder2.t2.name
@@ -35,7 +35,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t3	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1, t2) */ * from t1 inner join t3 on t1.id=t3.id left join t4 on t4.id=t3.id join t2 on t1.id=t2.id where t3.name like 'test3' or t4.name like 'test4';
 id	task	access object	operator info
 Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder2.t1.name, planner__core__join_reorder2.t3.id, planner__core__join_reorder2.t3.name, planner__core__join_reorder2.t4.id, planner__core__join_reorder2.t4.name, planner__core__join_reorder2.t2.id, planner__core__join_reorder2.t2.name
@@ -66,7 +66,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t4	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t3	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub
 inner join t4 on sub.id=t4.id;
@@ -84,7 +84,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub
 inner join t4 on sub.id=t4.id;
@@ -102,7 +102,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t4	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select * from t1 where exists (
 select 1
 from t2 inner join t3 on t2.id=t3.id left join t4 on t4.id=t3.id join t5 on t2.id=t5.id
@@ -124,7 +124,7 @@ HashJoin	root		semi join, left side:TableReader, equal:[eq(planner__core__join_r
 │         └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
 └─TableReader(Probe)	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select * from t1 where exists (
 select 1
 from t2 inner join t3 on t2.id=t3.id left join t4 on t4.id=t3.id join t5 on t2.id=t5.id
@@ -146,7 +146,7 @@ HashJoin	root		semi join, left side:TableReader, equal:[eq(planner__core__join_r
 │         └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
 └─TableReader(Probe)	root		data:TableFullScan
   └─TableFullScan	cop[tikv]	table:t1	keep order:false, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or rand() < 0.5) sub
 inner join t4 on sub.id=t4.id;
@@ -164,7 +164,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or rand() < 0.5) sub
 inner join t4 on sub.id=t4.id;
@@ -182,7 +182,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or sleep(0) = 0) sub
 inner join t4 on sub.id=t4.id;
@@ -200,7 +200,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or sleep(0) = 0) sub
 inner join t4 on sub.id=t4.id;
@@ -218,7 +218,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
         │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
         └─TableReader(Probe)	root		data:TableFullScan
           └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_3, t5, t4@sel_2, t2@sel_3, t3@sel_3) */ * from
 (select sub1.id, sub1.n1, sub1.n2, sub1.n3, t4.name as n4 from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub1
@@ -242,7 +242,7 @@ Projection	root		planner__core__join_reorder2.t1.id, planner__core__join_reorder
           │ └─TableFullScan	cop[tikv]	table:t2	keep order:true, stats:pseudo
           └─TableReader(Probe)	root		data:TableFullScan
             └─TableFullScan	cop[tikv]	table:t1	keep order:true, stats:pseudo
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_3, t5, t4@sel_2, t2@sel_3, t3@sel_3) */ * from
 (select sub1.id, sub1.n1, sub1.n2, sub1.n3, t4.name as n4 from
 (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub1

--- a/tests/integrationtest/t/planner/core/join_reorder2.test
+++ b/tests/integrationtest/t/planner/core/join_reorder2.test
@@ -9,35 +9,35 @@ create table t4(id int not null primary key, name varchar(100));
 create table t5(id int not null primary key, name varchar(100));
 
 # Selection with non null-reject OR condition blocks join reorder
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1, t2) */ * from t1 inner join t3 on t1.id=t3.id left join t4 on t4.id=t3.id join t2 on t1.id=t2.id where t3.name like 'test3' or t4.name like 'test4';
 explain format = 'plan_tree' select /*+ leading(t3, t4, t1, t2) */ * from t1 inner join t3 on t1.id=t3.id left join t4 on t4.id=t3.id join t2 on t1.id=t2.id where t3.name like 'test3' or t4.name like 'test4';
 
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1, t2) */ * from t1 inner join t3 on t1.id=t3.id left join t4 on t4.id=t3.id join t2 on t1.id=t2.id where t3.name like 'test3' or t4.name like 'test4';
 explain format = 'plan_tree' select /*+ leading(t3, t4, t1, t2) */ * from t1 inner join t3 on t1.id=t3.id left join t4 on t4.id=t3.id join t2 on t1.id=t2.id where t3.name like 'test3' or t4.name like 'test4';
 
 # Subquery with Selection inside blocks outer join reorder
 # Use leading(t1, t4, t2, t3) to require t4 join before t2,t3 - only possible when sel=1
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
     (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub
     inner join t4 on sub.id=t4.id;
 
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
     (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub
     inner join t4 on sub.id=t4.id;
 
 # Correlated subquery with Selection between joins.
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select * from t1 where exists (
     select 1
     from t2 inner join t3 on t2.id=t3.id left join t4 on t4.id=t3.id join t5 on t2.id=t5.id
     where (t3.name like 'test3' or t4.name like 'test4') and t2.id = t1.id
 );
 
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select * from t1 where exists (
     select 1
     from t2 inner join t3 on t2.id=t3.id left join t4 on t4.id=t3.id join t5 on t2.id=t5.id
@@ -45,29 +45,29 @@ explain format = 'plan_tree' select * from t1 where exists (
 );
 
 # Volatile/side-effect functions in Selection should block join reorder through selection
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
     (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or rand() < 0.5) sub
     inner join t4 on sub.id=t4.id;
 
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
     (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or rand() < 0.5) sub
     inner join t4 on sub.id=t4.id;
 
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
     (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or sleep(0) = 0) sub
     inner join t4 on sub.id=t4.id;
 
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_2, t4, t2@sel_2, t3@sel_2) */ * from
     (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3' or sleep(0) = 0) sub
     inner join t4 on sub.id=t4.id;
 
 # Deeper nesting - subquery in subquery with Selection blocking
 # Use leading(t1, t5, t4, t2, t3) to require t5 join before t4,t2,t3
-set @@tidb_opt_join_reorder_sel = 0;
+set @@tidb_opt_join_reorder_through_sel = 0;
 explain format = 'plan_tree' select /*+ leading(t1@sel_3, t5, t4@sel_2, t2@sel_3, t3@sel_3) */ * from
     (select sub1.id, sub1.n1, sub1.n2, sub1.n3, t4.name as n4 from
         (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub1
@@ -75,7 +75,7 @@ explain format = 'plan_tree' select /*+ leading(t1@sel_3, t5, t4@sel_2, t2@sel_3
     ) sub2
     inner join t5 on sub2.id=t5.id;
 
-set @@tidb_opt_join_reorder_sel = 1;
+set @@tidb_opt_join_reorder_through_sel = 1;
 explain format = 'plan_tree' select /*+ leading(t1@sel_3, t5, t4@sel_2, t2@sel_3, t3@sel_3) */ * from
     (select sub1.id, sub1.n1, sub1.n2, sub1.n3, t4.name as n4 from
         (select t1.id, t1.name as n1, t2.name as n2, t3.name as n3 from t1 inner join t2 on t1.id=t2.id left join t3 on t2.id=t3.id where t2.name like 'test2' or t3.name like 'test3') sub1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/59972

Problem Summary:
Handle the selection between the join group. Let more join group to participate the join order phase.

### What changed and how does it work?
The `selection` plan node prevent the function `extractJoinGroup` to get more join groups.
So when we detect the `selection` node in the `extractJoinGroup`, we'll store them.
And we'll add them in the correct position(as low as possible) when we rebuild the join node.
Add the variables to keep the default behavior.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
