### PR TITLE
session: initialize MDL if start in normal mode during bootstrap

### DIFF
--- a/pkg/session/bootstrap.go
+++ b/pkg/session/bootstrap.go
@@ -840,7 +840,7 @@ func bootstrap(s sessionapi.Session) {
 	startTime := time.Now()
 	err := InitMDLVariableForBootstrap(s.GetStore())
 	if err != nil {
-		logutil.BgLogger().Fatal("[bootstrap] init metadata lock failed", zap.Error(err))
+		logutil.BgLogger().Fatal("init metadata lock failed during bootstrap", zap.Error(err))
 	}
 	dom := domain.GetDomain(s)
 	bootLogger := logutil.SampleLoggerFactory(30*time.Second, 1)()
@@ -1007,7 +1007,7 @@ func upgrade(s sessionapi.Session) {
 	// Do upgrade works then update bootstrap version.
 	isNull, err := InitMDLVariableForUpgrade(s.GetStore())
 	if err != nil {
-		logutil.BgLogger().Fatal("[upgrade] init metadata lock failed", zap.Error(err))
+		logutil.BgLogger().Fatal("init metadata lock failed during upgrade", zap.Error(err))
 	}
 
 	var ver int64


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/64539

Problem Summary:

### What changed and how does it work?

Initialize MDL after upgrade is skipped.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Test with the reproduce step in https://github.com/pingcap/tidb/issues/64539#issuecomment-3547162712

**Before** 

```
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:07:10.923 -05:00] [INFO] [syncer.go:456] ["syncer check all versions, someone is not synced"] [category=ddl] [info="instance ip 127.0.0.1, port 4001, id 2f3b51bc-5dfd-4f07-a780-b8b52fa011a2"] ["ddl job id"=149] [ver=175]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:07:11.924 -05:00] [INFO] [syncer.go:456] ["syncer check all versions, someone is not synced"] [category=ddl] [info="instance ip 127.0.0.1, port 4001, id 2f3b51bc-5dfd-4f07-a780-b8b52fa011a2"] ["ddl job id"=149] [ver=175]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:07:12.925 -05:00] [INFO] [syncer.go:456] ["syncer check all versions, someone is not synced"] [category=ddl] [info="instance ip 127.0.0.1, port 4001, id 2f3b51bc-5dfd-4f07-a780-b8b52fa011a2"] ["ddl job id"=149] [ver=175]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:07:13.926 -05:00] [INFO] [syncer.go:456] ["syncer check all versions, someone is not synced"] [category=ddl] [info="instance ip 127.0.0.1, port 4001, id 2f3b51bc-5dfd-4f07-a780-b8b52fa011a2"] ["ddl job id"=149] [ver=175]
```

**After**

Both nodes can start successfully, there is no stuck problem.

```
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:14:43.934 -05:00] [INFO] [job_worker.go:836] ["run one job step"] [category=ddl] [jobID=149] [job="ID:149, Type:create schema, State:queueing, SchemaState:none, SchemaID:148, TableID:0, RowCount:0, ArgLen:0, start time: 2025-11-19 01:14:43.881 -0500 EST, Err:<nil>, ErrCount:0, SnapshotVersion:0, Version: v2"]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:14:43.944 -05:00] [INFO] [syncer.go:280] ["mdl gets lock, update self version to owner"] [jobID=149] [version=175]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:14:43.983 -05:00] [INFO] [job_worker.go:435] ["finish DDL job"] [category=ddl] [jobID=149] [job="ID:149, Type:create schema, State:synced, SchemaState:public, SchemaID:148, TableID:0, RowCount:0, ArgLen:0, start time: 2025-11-19 01:14:43.881 -0500 EST, Err:<nil>, ErrCount:0, SnapshotVersion:0, Version: v2"]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-0/tidb.log:[2025/11/19 01:14:43.990 -05:00] [INFO] [executor.go:6867] ["DDL job is finished"] [category=ddl] [jobID=149]
/mnt/data/joechenrh/.tiup/data/test-upgrade/tidb-1/tidb.log:[2025/11/19 01:14:43.973 -05:00] [INFO] [syncer.go:280] ["mdl gets lock, update self version to owner"] [jobID=149] [version=175]
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
