### PR TITLE
util/chunk: Simplified the code, by handling IsNull first.

### DIFF
--- a/pkg/util/chunk/row.go
+++ b/pkg/util/chunk/row.go
@@ -145,79 +145,54 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 
 // DatumWithBuffer gets datum using the buffer d.
 func (r Row) DatumWithBuffer(colIdx int, tp *types.FieldType, d *types.Datum) {
+	if r.IsNull(colIdx) {
+		d.SetNull()
+		return
+	}
 	switch tp.GetType() {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
-		if !r.IsNull(colIdx) {
-			if mysql.HasUnsignedFlag(tp.GetFlag()) {
-				d.SetUint64(r.GetUint64(colIdx))
-			} else {
-				d.SetInt64(r.GetInt64(colIdx))
-			}
+		if mysql.HasUnsignedFlag(tp.GetFlag()) {
+			d.SetUint64(r.GetUint64(colIdx))
+		} else {
+			d.SetInt64(r.GetInt64(colIdx))
 		}
 	case mysql.TypeYear:
 		// FIXBUG: because insert type of TypeYear is definite int64, so we regardless of the unsigned flag.
-		if !r.IsNull(colIdx) {
-			d.SetInt64(r.GetInt64(colIdx))
-		}
+		d.SetInt64(r.GetInt64(colIdx))
 	case mysql.TypeFloat:
-		if !r.IsNull(colIdx) {
-			d.SetFloat32(r.GetFloat32(colIdx))
-		}
+		d.SetFloat32(r.GetFloat32(colIdx))
 	case mysql.TypeDouble:
-		if !r.IsNull(colIdx) {
-			d.SetFloat64(r.GetFloat64(colIdx))
-		}
+		d.SetFloat64(r.GetFloat64(colIdx))
 	case mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
-		if !r.IsNull(colIdx) {
-			d.SetString(r.GetString(colIdx), tp.GetCollate())
-		}
+		d.SetString(r.GetString(colIdx), tp.GetCollate())
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
-		if !r.IsNull(colIdx) {
-			d.SetMysqlTime(r.GetTime(colIdx))
-		}
+		d.SetMysqlTime(r.GetTime(colIdx))
 	case mysql.TypeDuration:
-		if !r.IsNull(colIdx) {
-			duration := r.GetDuration(colIdx, tp.GetDecimal())
-			d.SetMysqlDuration(duration)
-		}
+		duration := r.GetDuration(colIdx, tp.GetDecimal())
+		d.SetMysqlDuration(duration)
 	case mysql.TypeNewDecimal:
-		if !r.IsNull(colIdx) {
-			dec := r.GetMyDecimal(colIdx)
-			d.SetMysqlDecimal(dec)
-			d.SetLength(tp.GetFlen())
-			// If tp.decimal is unspecified(-1), we should set it to the real
-			// fraction length of the decimal value, if not, the d.Frac will
-			// be set to MAX_UINT16 which will cause unexpected BadNumber error
-			// when encoding.
-			if tp.GetDecimal() == types.UnspecifiedLength {
-				d.SetFrac(int(dec.GetDigitsFrac()))
-			} else {
-				d.SetFrac(tp.GetDecimal())
-			}
+		dec := r.GetMyDecimal(colIdx)
+		d.SetMysqlDecimal(dec)
+		d.SetLength(tp.GetFlen())
+		// If tp.decimal is unspecified(-1), we should set it to the real
+		// fraction length of the decimal value, if not, the d.Frac will
+		// be set to MAX_UINT16 which will cause unexpected BadNumber error
+		// when encoding.
+		if tp.GetDecimal() == types.UnspecifiedLength {
+			d.SetFrac(int(dec.GetDigitsFrac()))
+		} else {
+			d.SetFrac(tp.GetDecimal())
 		}
 	case mysql.TypeEnum:
-		if !r.IsNull(colIdx) {
-			d.SetMysqlEnum(r.GetEnum(colIdx), tp.GetCollate())
-		}
+		d.SetMysqlEnum(r.GetEnum(colIdx), tp.GetCollate())
 	case mysql.TypeSet:
-		if !r.IsNull(colIdx) {
-			d.SetMysqlSet(r.GetSet(colIdx), tp.GetCollate())
-		}
+		d.SetMysqlSet(r.GetSet(colIdx), tp.GetCollate())
 	case mysql.TypeBit:
-		if !r.IsNull(colIdx) {
-			d.SetMysqlBit(r.GetBytes(colIdx))
-		}
+		d.SetMysqlBit(r.GetBytes(colIdx))
 	case mysql.TypeJSON:
-		if !r.IsNull(colIdx) {
-			d.SetMysqlJSON(r.GetJSON(colIdx))
-		}
+		d.SetMysqlJSON(r.GetJSON(colIdx))
 	case mysql.TypeTiDBVectorFloat32:
-		if !r.IsNull(colIdx) {
-			d.SetVectorFloat32(r.GetVectorFloat32(colIdx))
-		}
-	}
-	if r.IsNull(colIdx) {
-		d.SetNull()
+		d.SetVectorFloat32(r.GetVectorFloat32(colIdx))
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64578

Problem Summary:
Readability and maintenance, since instead of checking for `IsNull()` first, it is done for every case in the switch.

### What changed and how does it work?
Moved the handling of `IsNull()` first and return, so the rest of the function could be simplified.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > No logic changed, just reordered the check for `IsNull()`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
