### PR TITLE
cherry-pick: br: fix backup version parse from 7.x br

### DIFF
--- a/br/pkg/task/BUILD.bazel
+++ b/br/pkg/task/BUILD.bazel
@@ -74,7 +74,6 @@ go_library(
         "//pkg/util/collate",
         "//pkg/util/engine",
         "//pkg/util/table-filter",
-        "@com_github_coreos_go_semver//semver",
         "@com_github_docker_go_units//:go-units",
         "@com_github_fatih_color//:color",
         "@com_github_gogo_protobuf//proto",

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/opentracing/opentracing-go"
@@ -1135,10 +1134,10 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	}
 	schemaVersionPair := snapclient.SchemaVersionPairT{}
 	if loadStatsPhysical || loadSysTablePhysical {
-		upstreamClusterVersion, err := semver.NewVersion(backupMeta.ClusterVersion)
-		if err != nil {
+		upstreamClusterVersion := version.NormalizeBackupVersion(backupMeta.ClusterVersion)
+		if upstreamClusterVersion == nil {
 			log.Warn("The cluster version from backupmeta is invalid. Fallback to logically load system tables.",
-				zap.String("backupmeta cluster version", backupMeta.ClusterVersion), zap.Error(err))
+				zap.String("backupmeta cluster version", backupMeta.ClusterVersion))
 			loadStatsPhysical = false
 			loadSysTablePhysical = false
 		} else {
@@ -1152,10 +1151,10 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 			loadStatsPhysical = false
 			loadSysTablePhysical = false
 		} else {
-			downstreamClusterVersion, err := semver.NewVersion(downstreamClusterVersionStr)
-			if err != nil {
+			downstreamClusterVersion := version.NormalizeBackupVersion(downstreamClusterVersionStr)
+			if downstreamClusterVersion == nil {
 				log.Warn("The downstream cluster version is invalid. Fallback to logically load system tables.",
-					zap.String("downstream cluster version", downstreamClusterVersionStr), zap.Error(err))
+					zap.String("downstream cluster version", downstreamClusterVersionStr))
 				loadStatsPhysical = false
 				loadSysTablePhysical = false
 			} else {


### PR DESCRIPTION
close pingcap/tidb#63947

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #63947

Problem Summary:
the backup version from 7.x br can not be parsed by nightly br
### What changed and how does it work?
normalize the backup version at first.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
`NormalizeBackupVersion` has already unit tests `TestNormalizeBackupVersion`.
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
