### PR TITLE
parser: revert modification for partial index

### DIFF
--- a/pkg/parser/ast/ddl.go
+++ b/pkg/parser/ast/ddl.go
@@ -746,7 +746,6 @@ type IndexOption struct {
 	SplitOpt                   *SplitOption `json:"-"` // SplitOption contains expr nodes, which cannot marshal for DDL job arguments.
 	SecondaryEngineAttr        string
 	AddColumnarReplicaOnDemand int
-	Condition                  ExprNode `json:"-"` // Condition contains expr nodes, which cannot marshal for DDL job arguments. It's used for partial index.
 }
 
 // IsEmpty is true if only default options are given
@@ -760,8 +759,7 @@ func (n *IndexOption) IsEmpty() bool {
 		n.Global ||
 		n.Visibility != IndexVisibilityDefault ||
 		n.SplitOpt != nil ||
-		len(n.SecondaryEngineAttr) > 0 ||
-		n.Condition != nil {
+		len(n.SecondaryEngineAttr) > 0 {
 		return false
 	}
 	return true
@@ -876,16 +874,6 @@ func (n *IndexOption) Restore(ctx *format.RestoreCtx) error {
 		ctx.WriteString(n.SecondaryEngineAttr)
 		// If a new option is added after, please also uncomment:
 		//hasPrevOption = true
-	}
-
-	if n.Condition != nil {
-		if hasPrevOption {
-			ctx.WritePlain(" ")
-		}
-		ctx.WriteKeyWord("WHERE ")
-		if err := n.Condition.Restore(ctx); err != nil {
-			return errors.Annotate(err, "An error occurred while splicing IndexOption Condition")
-		}
 	}
 
 	return nil

--- a/pkg/parser/parser.y
+++ b/pkg/parser/parser.y
@@ -6780,8 +6780,6 @@ IndexOptionList:
 				opt1.SplitOpt = opt2.SplitOpt
 			} else if len(opt2.SecondaryEngineAttr) > 0 {
 				opt1.SecondaryEngineAttr = opt2.SecondaryEngineAttr
-			} else if opt2.Condition != nil {
-				opt1.Condition = opt2.Condition
 			}
 			$$ = opt1
 		}
@@ -6859,12 +6857,6 @@ IndexOption:
 |	"SECONDARY_ENGINE_ATTRIBUTE" EqOpt stringLit
 	{
 		$$ = &ast.IndexOption{SecondaryEngineAttr: $3}
-	}
-|	"WHERE" Expression
-	{
-		$$ = &ast.IndexOption{
-			Condition: $2.(ast.ExprNode),
-		}
 	}
 
 /*

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -8104,12 +8104,3 @@ func TestSecondaryEngineAttribute(t *testing.T) {
 
 	RunTest(t, table, false)
 }
-
-func TestPartialIndex(t *testing.T) {
-	cases := []testCase{
-		{"create table `t` (`id` int primary key,`col` int,index(`col`) where `col`>100)", true, "CREATE TABLE `t` (`id` INT PRIMARY KEY,`col` INT,INDEX(`col`) WHERE `col`>100)"},
-		{"create index `idx` on `t` (`col`) where `col`>100", true, "CREATE INDEX `idx` ON `t` (`col`) WHERE `col`>100"},
-		{"alter table `t` add index `idx`(`col`) where `col`>100", true, "ALTER TABLE `t` ADD INDEX `idx`(`col`) WHERE `col`>100"},
-	}
-	RunTest(t, cases, false)
-}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64600

Problem Summary:

`release-nextgen-20251011` branch doesn't have a full partial index support. We'd better revert it.

### What changed and how does it work?

Remove the modification on parser for partial index.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
