### PR TITLE
tici: support write to TICI S3 on blkStoreRegionJobWorker and fix path join

### DIFF
--- a/pkg/lightning/backend/local/job_worker_test.go
+++ b/pkg/lightning/backend/local/job_worker_test.go
@@ -189,6 +189,7 @@ func TestCloudRegionJobWorker(t *testing.T) {
 		ingestCli:           mockIngestCli,
 		writeBatchSize:      8,
 		bufPool:             nil,
+		ticiWriteGroup:      nil,
 	}
 	cloudW.regionJobBaseWorker.writeFn = cloudW.write
 	cloudW.regionJobBaseWorker.ingestFn = cloudW.ingest

--- a/pkg/lightning/backend/local/local.go
+++ b/pkg/lightning/backend/local/local.go
@@ -1628,6 +1628,7 @@ func (local *Backend) newRegionJobWorker(
 			writeBatchSize: local.KVWriteBatchSize,
 			bufPool:        local.engineMgr.getBufferPool(),
 			collector:      local.collector,
+			ticiWriteGroup: local.ticiWriteGroup,
 		}
 		base.writeFn = cloudW.write
 		base.ingestFn = cloudW.ingest

--- a/pkg/tici/tici_file_writer.go
+++ b/pkg/tici/tici_file_writer.go
@@ -17,7 +17,7 @@ package tici
 import (
 	"context"
 	"encoding/binary"
-	"path"
+	"net/url"
 	"time"
 
 	"github.com/docker/go-units"
@@ -93,8 +93,8 @@ func NewTICIFileWriter(ctx context.Context, store storage.ExternalStorage, dataF
 }
 
 // URI returns the URI of the key stored in external storage.
-func (w *FileWriter) URI() string {
-	return path.Join(w.store.URI(), w.dataFile)
+func (w *FileWriter) URI() (string, error) {
+	return url.JoinPath(w.store.URI(), w.dataFile)
 }
 
 // WriteRow writes a key-value pair to the S3 file.

--- a/pkg/tici/tici_write.go
+++ b/pkg/tici/tici_write.go
@@ -17,6 +17,7 @@ package tici
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -312,13 +313,12 @@ func (g *DataWriterGroup) FinishPartitionUpload(
 	if fileWriter == nil {
 		return errors.New("TICIFileWriter is not initialized")
 	}
-	uri := fileWriter.URI()
-	if uri == "" {
-		g.logger.Warn("no uri set for FinishPartitionUpload")
-		return nil // or return an error if uri is required
+	uri, err := fileWriter.URI()
+	if err != nil || uri == "" {
+		return fmt.Errorf("uri is empty or Error occurred: %v", err)
 	}
 
-	err := g.mgrCtx.FinishPartitionUpload(ctx, g.indexMeta.tidbTaskID, lowerBound, upperBound, uri)
+	err = g.mgrCtx.FinishPartitionUpload(ctx, g.indexMeta.tidbTaskID, lowerBound, upperBound, uri)
 	if err != nil {
 		g.logger.Error("failed to finish partition upload",
 			zap.String("uri", uri),


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

1. Support write to TICI S3 on `blkStoreRegionJobWorker`
2. Fix path join for S3 path.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
