### PR TITLE
planner: fix ExtractTableList to support UNION/INTERSECT/EXCEPT subqueries

### DIFF
--- a/pkg/planner/core/util_test.go
+++ b/pkg/planner/core/util_test.go
@@ -152,6 +152,73 @@ func TestExtractTableList(t *testing.T) {
 			},
 		},
 		{
+			sql: "SELECT * FROM (SELECT a FROM t1 UNION ALL SELECT b FROM t2) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT a FROM t1 UNION SELECT b FROM t2) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+			},
+		},
+		{
+			sql:    "SELECT * FROM (SELECT a FROM t1 UNION ALL SELECT b FROM t2) AS u",
+			asName: true,
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("u")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT a FROM t1 UNION ALL SELECT b FROM t2 UNION ALL SELECT c FROM t3) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+				{Name: ast.NewCIStr("t3")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT a FROM t1 UNION ALL (SELECT b FROM t2 UNION ALL SELECT c FROM t3)) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+				{Name: ast.NewCIStr("t3")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT a FROM db1.t1 UNION ALL SELECT b FROM db2.t2) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1"), Schema: ast.NewCIStr("db1")},
+				{Name: ast.NewCIStr("t2"), Schema: ast.NewCIStr("db2")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT t1.a, t2.b FROM t1 JOIN t2 ON t1.id = t2.id UNION ALL SELECT t3.a, t4.b FROM t3 JOIN t4 ON t3.id = t4.id) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+				{Name: ast.NewCIStr("t3")},
+				{Name: ast.NewCIStr("t4")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT a FROM t1 INTERSECT SELECT b FROM t2) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+			},
+		},
+		{
+			sql: "SELECT * FROM (SELECT a FROM t1 EXCEPT SELECT b FROM t2) AS u",
+			expect: []*ast.TableName{
+				{Name: ast.NewCIStr("t1")},
+				{Name: ast.NewCIStr("t2")},
+			},
+		},
+		{
 			sql: "LOAD DATA INFILE '/a.csv' FORMAT 'sql file' INTO TABLE `t`",
 			expect: []*ast.TableName{
 				{Name: ast.NewCIStr("t")},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64619

Problem Summary:

### What changed and how does it work?


`ExtractTableList` function fails to extract table names from UNION/UNION ALL/INTERSECT/EXCEPT subqueries, causing `SELECT ... FOR UPDATE` to not acquire locks on tables within these set operations. This also affects permission checks and partition table handling.

**Impact:**
- `SELECT ... FOR UPDATE` with UNION subqueries doesn't lock the underlying tables
- Concurrent transactions can modify data that should be locked
- Permission checks may fail to verify access to tables in UNION subqueries
- Partition table operations may not work correctly with UNION subqueries

**Reproduction:**
```sql
-- Session 1
BEGIN;
SELECT * FROM (SELECT * FROM t1 UNION ALL SELECT * FROM t2) AS u FOR UPDATE;
-- Should lock t1 and t2, but doesn't

-- Session 2 (succeeds immediately, should block)
UPDATE t1 SET id = 10 WHERE id = 1;
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
