### PR TITLE
Revert "executor: run idxlookup workers in a pool (#58033) (#62104)"

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -21,7 +21,6 @@ import (
 	"runtime/trace"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -77,7 +76,6 @@ var LookupTableTaskChannelSize int32 = 50
 // lookupTableTask is created from a partial result of an index request which
 // contains the handles in those index keys.
 type lookupTableTask struct {
-	id      int
 	handles []kv.Handle
 	rowIdx  []int // rowIdx represents the handle index for every row. Only used when keep order.
 	rows    []chunk.Row
@@ -505,8 +503,6 @@ type IndexLookUpExecutor struct {
 
 	// cancelFunc is called when close the executor
 	cancelFunc context.CancelFunc
-	workerCtx  context.Context
-	pool       *workerPool
 
 	// If dummy flag is set, this is not a real IndexLookUpReader, it just provides the KV ranges for UnionScan.
 	// Used by the temporary table, cached table.
@@ -639,17 +635,15 @@ func (e *IndexLookUpExecutor) open(_ context.Context) error {
 }
 
 func (e *IndexLookUpExecutor) startWorkers(ctx context.Context, initBatchSize int) error {
-	// indexWorker will submit lookup-table tasks (processed by tableWorker) to the pool,
+	// indexWorker will write to workCh and tableWorker will read from workCh,
 	// so fetching index and getting table data can run concurrently.
-	e.workerCtx, e.cancelFunc = context.WithCancel(ctx)
-	e.pool = &workerPool{
-		needSpawn: func(workers, tasks uint32) bool {
-			return workers < uint32(e.indexLookupConcurrency) && tasks > 1
-		},
-	}
-	if err := e.startIndexWorker(ctx, initBatchSize); err != nil {
+	ctx, cancel := context.WithCancel(ctx)
+	e.cancelFunc = cancel
+	workCh := make(chan *lookupTableTask, 1)
+	if err := e.startIndexWorker(ctx, workCh, initBatchSize); err != nil {
 		return err
 	}
+	e.startTableWorker(ctx, workCh)
 	e.workerStarted = true
 	return nil
 }
@@ -709,8 +703,8 @@ func (e *IndexLookUpExecutor) getRetTpsForIndexReader() []*types.FieldType {
 	return tps
 }
 
-// startIndexWorker launch a background goroutine to fetch handles, submit lookup-table tasks to the pool.
-func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSize int) error {
+// startIndexWorker launch a background goroutine to fetch handles, send the results to workCh.
+func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, workCh chan<- *lookupTableTask, initBatchSize int) error {
 	if e.RuntimeStats() != nil {
 		collExec := true
 		e.dagPB.CollectExecutionSummaries = &collExec
@@ -731,11 +725,11 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 	tps := e.getRetTpsForIndexReader()
 	idxID := e.getIndexPlanRootID()
 	e.idxWorkerWg.Add(1)
-	e.pool.submit(func() {
-		defer trace.StartRegion(ctx, "IndexLookUpIndexTask").End()
-		growWorkerStack16K()
+	go func() {
+		defer trace.StartRegion(ctx, "IndexLookUpIndexWorker").End()
 		worker := &indexWorker{
 			idxLookup:       e,
+			workCh:          workCh,
 			finished:        e.finished,
 			resultCh:        e.resultCh,
 			keepOrder:       e.keepOrder,
@@ -812,9 +806,10 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 				logutil.Logger(ctx).Error("close Select result failed", zap.Error(err))
 			}
 		}
+		close(workCh)
 		close(e.resultCh)
 		e.idxWorkerWg.Done()
-	})
+	}()
 	return nil
 }
 
@@ -845,6 +840,32 @@ func CalculateBatchSize(estRows, initBatchSize, maxBatchSize int) int {
 		}
 	}
 	return batchSize
+}
+
+// startTableWorker launches some background goroutines which pick tasks from workCh and execute the task.
+func (e *IndexLookUpExecutor) startTableWorker(ctx context.Context, workCh <-chan *lookupTableTask) {
+	lookupConcurrencyLimit := e.indexLookupConcurrency
+	e.tblWorkerWg.Add(lookupConcurrencyLimit)
+	for i := 0; i < lookupConcurrencyLimit; i++ {
+		workerID := i
+		worker := &tableWorker{
+			idxLookup:       e,
+			workCh:          workCh,
+			finished:        e.finished,
+			keepOrder:       e.keepOrder,
+			handleIdx:       e.handleIdx,
+			checkIndexValue: e.checkIndexValue,
+			memTracker:      memory.NewTracker(workerID, -1),
+		}
+		worker.memTracker.AttachTo(e.memTracker)
+		ctx1, cancel := context.WithCancel(ctx)
+		go func() {
+			defer trace.StartRegion(ctx1, "IndexLookUpTableWorker").End()
+			worker.pickAndExecTask(ctx1)
+			cancel()
+			e.tblWorkerWg.Done()
+		}()
+	}
 }
 
 func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, task *lookupTableTask) (*TableReaderExecutor, error) {
@@ -1011,6 +1032,7 @@ func (e *IndexLookUpExecutor) getTableRootPlanID() int {
 // indexWorker is used by IndexLookUpExecutor to maintain index lookup background goroutines.
 type indexWorker struct {
 	idxLookup *IndexLookUpExecutor
+	workCh    chan<- *lookupTableTask
 	finished  <-chan struct{}
 	resultCh  chan<- *lookupTableTask
 	keepOrder bool
@@ -1037,7 +1059,7 @@ func (w *indexWorker) syncErr(err error) {
 }
 
 // fetchHandles fetches a batch of handles from index data and builds the index lookup tasks.
-// The tasks are submitted to the pool and processed by tableWorker, and sent to e.resultCh
+// The tasks are sent to workCh to be further processed by tableWorker, and sent to e.resultCh
 // at the same time to keep data ordered.
 func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.SelectResult) (err error) {
 	defer func() {
@@ -1057,7 +1079,6 @@ func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.Select
 			w.idxLookup.stats.indexScanBasicStats = w.idxLookup.stmtRuntimeStatsColl.GetBasicRuntimeStats(idxID)
 		}
 	}
-	taskID := 0
 	for i := 0; i < len(results); {
 		result := results[i]
 		if w.PushedLimit != nil && w.scannedKeys >= w.PushedLimit.Count+w.PushedLimit.Offset {
@@ -1075,8 +1096,6 @@ func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.Select
 			continue
 		}
 		task := w.buildTableTask(handles, retChunk)
-		task.id = taskID
-		taskID++
 		finishBuild := time.Now()
 		if w.idxLookup.partitionTableMode {
 			task.partitionTable = w.idxLookup.prunedPartitions[i]
@@ -1086,19 +1105,7 @@ func (w *indexWorker) fetchHandles(ctx context.Context, results []distsql.Select
 			return nil
 		case <-w.finished:
 			return nil
-		default:
-			e := w.idxLookup
-			e.tblWorkerWg.Add(1)
-			e.pool.submit(func() {
-				defer e.tblWorkerWg.Done()
-				select {
-				case <-e.finished:
-					return
-				default:
-					growWorkerStack16K()
-					execTableTask(e, task)
-				}
-			})
+		case w.workCh <- task:
 			w.resultCh <- task
 		}
 		if w.idxLookup.stats != nil {
@@ -1221,46 +1228,10 @@ func (w *indexWorker) buildTableTask(handles []kv.Handle, retChk *chunk.Chunk) *
 	return task
 }
 
-func execTableTask(e *IndexLookUpExecutor, task *lookupTableTask) {
-	var (
-		ctx    = e.workerCtx
-		region *trace.Region
-	)
-	if trace.IsEnabled() {
-		region = trace.StartRegion(ctx, "IndexLookUpTableTask"+strconv.Itoa(task.id))
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			logutil.Logger(ctx).Error("TableWorker in IndexLookUpExecutor panicked", zap.Any("recover", r), zap.Stack("stack"))
-			err := util.GetRecoverError(r)
-			task.doneCh <- err
-		}
-		if region != nil {
-			region.End()
-		}
-	}()
-	tracker := memory.NewTracker(task.id, -1)
-	tracker.AttachTo(e.memTracker)
-	w := &tableWorker{
-		idxLookup:       e,
-		finished:        e.finished,
-		keepOrder:       e.keepOrder,
-		handleIdx:       e.handleIdx,
-		checkIndexValue: e.checkIndexValue,
-		memTracker:      tracker,
-	}
-	startTime := time.Now()
-	err := w.executeTask(ctx, task)
-	if e.stats != nil {
-		atomic.AddInt64(&e.stats.TableRowScan, int64(time.Since(startTime)))
-		atomic.AddInt64(&e.stats.TableTaskNum, 1)
-	}
-	task.doneCh <- err
-}
-
 // tableWorker is used by IndexLookUpExecutor to maintain table lookup background goroutines.
 type tableWorker struct {
 	idxLookup *IndexLookUpExecutor
+	workCh    <-chan *lookupTableTask
 	finished  <-chan struct{}
 	keepOrder bool
 	handleIdx []int
@@ -1270,6 +1241,39 @@ type tableWorker struct {
 
 	// checkIndexValue is used to check the consistency of the index data.
 	*checkIndexValue
+}
+
+// pickAndExecTask picks tasks from workCh, and execute them.
+func (w *tableWorker) pickAndExecTask(ctx context.Context) {
+	var task *lookupTableTask
+	var ok bool
+	defer func() {
+		if r := recover(); r != nil {
+			logutil.Logger(ctx).Error("tableWorker in IndexLookUpExecutor panicked", zap.Any("recover", r), zap.Stack("stack"))
+			err := util.GetRecoverError(r)
+			task.doneCh <- err
+		}
+	}()
+	for {
+		// Don't check ctx.Done() on purpose. If background worker get the signal and all
+		// exit immediately, session's goroutine doesn't know this and still calling Next(),
+		// it may block reading task.doneCh forever.
+		select {
+		case task, ok = <-w.workCh:
+			if !ok {
+				return
+			}
+		case <-w.finished:
+			return
+		}
+		startTime := time.Now()
+		err := w.executeTask(ctx, task)
+		if w.idxLookup.stats != nil {
+			atomic.AddInt64(&w.idxLookup.stats.TableRowScan, int64(time.Since(startTime)))
+			atomic.AddInt64(&w.idxLookup.stats.TableTaskNum, 1)
+		}
+		task.doneCh <- err
+	}
 }
 
 func (e *IndexLookUpExecutor) getHandle(row chunk.Row, handleIdx []int,

--- a/pkg/executor/utils.go
+++ b/pkg/executor/utils.go
@@ -15,9 +15,7 @@
 package executor
 
 import (
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/pingcap/tidb/pkg/extension"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -120,72 +118,4 @@ func encodePassword(u *ast.UserSpec, authPlugin *extension.AuthPlugin) (string, 
 		return "", false
 	}
 	return u.EncodedPassword()
-}
-
-var globalTaskPool = sync.Pool{
-	New: func() any { return &workerTask{} },
-}
-
-type workerTask struct {
-	f    func()
-	next *workerTask
-}
-
-type workerPool struct {
-	lock sync.Mutex
-	head *workerTask
-	tail *workerTask
-
-	tasks     uint32
-	workers   uint32
-	needSpawn func(workers, tasks uint32) bool
-}
-
-func (p *workerPool) submit(f func()) {
-	task := globalTaskPool.Get().(*workerTask)
-	task.f, task.next = f, nil
-
-	spawn := false
-	p.lock.Lock()
-	if p.head == nil {
-		p.head = task
-	} else {
-		p.tail.next = task
-	}
-	p.tail = task
-	p.tasks++
-	if p.workers == 0 || p.needSpawn == nil || p.needSpawn(p.workers, p.tasks) {
-		p.workers++
-		spawn = true
-	}
-	p.lock.Unlock()
-
-	if spawn {
-		go p.run()
-	}
-}
-
-func (p *workerPool) run() {
-	for {
-		var task *workerTask
-
-		p.lock.Lock()
-		if p.head == nil {
-			p.workers--
-			p.lock.Unlock()
-			return
-		}
-		task, p.head = p.head, p.head.next
-		p.tasks--
-		p.lock.Unlock()
-
-		task.f()
-		globalTaskPool.Put(task)
-	}
-}
-
-//go:noinline
-func growWorkerStack16K() {
-	var data [8192]byte
-	runtime.KeepAlive(&data)
 }

--- a/pkg/executor/utils_test.go
+++ b/pkg/executor/utils_test.go
@@ -15,8 +15,6 @@
 package executor
 
 import (
-	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -178,99 +176,4 @@ func TestEncodePasswordWithPlugin(t *testing.T) {
 	pwd, ok = encodePassword(u, p)
 	require.True(t, ok)
 	require.Equal(t, "", pwd)
-}
-
-func TestWorkerPool(t *testing.T) {
-	var (
-		list []int
-		lock sync.Mutex
-	)
-	push := func(i int) {
-		lock.Lock()
-		list = append(list, i)
-		lock.Unlock()
-	}
-	clean := func() {
-		lock.Lock()
-		list = list[:0]
-		lock.Unlock()
-	}
-
-	t.Run("SingleWorker", func(t *testing.T) {
-		clean()
-		pool := &workerPool{
-			needSpawn: func(workers, tasks uint32) bool {
-				return workers < 1 && tasks > 0
-			},
-		}
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		pool.submit(func() {
-			push(1)
-			wg.Add(1)
-			pool.submit(func() {
-				push(3)
-				runtime.Gosched()
-				push(4)
-				wg.Done()
-			})
-			runtime.Gosched()
-			push(2)
-			wg.Done()
-		})
-		wg.Wait()
-		require.Equal(t, []int{1, 2, 3, 4}, list)
-	})
-
-	t.Run("TwoWorkers", func(t *testing.T) {
-		clean()
-		pool := &workerPool{
-			needSpawn: func(workers, tasks uint32) bool {
-				return workers < 2 && tasks > 0
-			},
-		}
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		pool.submit(func() {
-			push(1)
-			wg.Add(1)
-			pool.submit(func() {
-				push(3)
-				runtime.Gosched()
-				push(4)
-				wg.Done()
-			})
-			runtime.Gosched()
-			push(2)
-			wg.Done()
-		})
-		wg.Wait()
-		require.Equal(t, []int{1, 3, 2, 4}, list)
-	})
-
-	t.Run("TolerateOnePendingTask", func(t *testing.T) {
-		clean()
-		pool := &workerPool{
-			needSpawn: func(workers, tasks uint32) bool {
-				return workers < 2 && tasks > 1
-			},
-		}
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		pool.submit(func() {
-			push(1)
-			wg.Add(1)
-			pool.submit(func() {
-				push(3)
-				runtime.Gosched()
-				push(4)
-				wg.Done()
-			})
-			runtime.Gosched()
-			push(2)
-			wg.Done()
-		})
-		wg.Wait()
-		require.Equal(t, []int{1, 2, 3, 4}, list)
-	})
 }


### PR DESCRIPTION
This reverts commit 62b9f4c147e8d9417d39786a64ebb71fde805dcc.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64629 

Problem Summary:
Revert 62b9f4c147e8d9417d39786a64ebb71fde805dcc on release-8.5

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
