### PR TITLE
util/sem: remove tidb_slow_txn_log_threshold from invisible variable list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,4 +111,4 @@ The PR title **must** strictly adhere to the following format. It uses the packa
 
 ### PR description
 
-The PR description **must** strictly follow the template located at @.github/pull_request_template.md and **must** keep HTML comment elements in the pull request description according to the pull request template. These elements are essential for CI and removing them will cause processing failures.
+The PR description **must** strictly follow the template located at @.github/pull_request_template.md and **must** keep the HTML comment elements like `Tests <!-- At least one of them must be included. -->` unchanged in the pull request description according to the pull request template. These elements are essential for CI and removing them will cause processing failures.

--- a/pkg/util/sem/compat/testhelper.go
+++ b/pkg/util/sem/compat/testhelper.go
@@ -121,7 +121,6 @@ var compatibleSEMV2Config = `{
 		{"name": "tidb_row_format_version", "hidden": true},
 		{"name": "tidb_slow_query_file", "hidden": true},
 		{"name": "tidb_slow_log_threshold", "hidden": true},
-		{"name": "tidb_slow_txn_log_threshold", "hidden": true},
 		{"name": "tidb_enable_collect_execution_info", "hidden": true},
 		{"name": "tidb_memory_usage_alarm_ratio", "hidden": true},
 		{"name": "tidb_redact_log", "hidden": true},

--- a/pkg/util/sem/sem.go
+++ b/pkg/util/sem/sem.go
@@ -150,7 +150,6 @@ func IsInvisibleSysVar(varNameInLower string) bool {
 		vardef.TiDBRowFormatVersion,
 		vardef.TiDBSlowQueryFile,
 		vardef.TiDBSlowLogThreshold,
-		vardef.TiDBSlowTxnLogThreshold,
 		vardef.TiDBEnableCollectExecutionInfo,
 		vardef.TiDBMemoryUsageAlarmRatio,
 		vardef.TiDBRedactLog,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64633

Problem Summary:

The session variable `tidb_slow_txn_log_threshold` was incorrectly added to the invisible variable list when it was introduced in PR #41864. This means users need `RESTRICTED_VARIABLES_ADMIN` privilege to view or modify it when Security Enhanced Mode (SEM) is enabled, which is unnecessarily restrictive.

### What changed and how does it work?

This PR removes `tidb_slow_txn_log_threshold` from the invisible variable list in:
- `pkg/util/sem/sem.go` - Removed from `IsInvisibleSysVar()` function
- `pkg/util/sem/compat/testhelper.go` - Removed from SEMv2 compatibility test config

The variable is session-scoped and only controls when to log slow transaction events for the current session. It doesn't expose sensitive information and poses no security risk, so it doesn't need privilege restrictions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```