### PR TITLE
executor: tici range may be wrong, casued by resolving merge conflict

### DIFF
--- a/pkg/distsql/request_builder.go
+++ b/pkg/distsql/request_builder.go
@@ -926,7 +926,15 @@ func appendRanges(tbl *model.TableInfo, tblID int64) ([]kv.KeyRange, error) {
 // FulltextIndexRangesToKVRanges converts fulltext index ranges to "KeyRange".
 // This is a temporary solution, and we should implement the fulltext index
 // ranges conversion in the future.
-func FulltextIndexRangesToKVRanges(dctx *distsqlctx.DistSQLContext, tids []int64, ranges []*ranger.Range) (*kv.KeyRanges, error) {
+func FulltextIndexRangesToKVRanges(_ *distsqlctx.DistSQLContext, tids []int64, _ []*ranger.Range) (*kv.KeyRanges, error) {
 	// Mocking the fulltext index ranges to be the same as the table ranges.
-	return CommonHandleRangesToKVRanges(dctx, tids, ranges)
+	kvRanges := make([][]kv.KeyRange, 0, len(tids))
+	for _, id := range tids {
+		startKey := tablecodec.EncodeTablePrefix(id)
+		endKey := tablecodec.EncodeTablePrefix(id + 1)
+		kvRange := kv.KeyRange{StartKey: startKey, EndKey: endKey}
+		kvRanges = kvRanges[:0]
+		kvRanges = append(kvRanges, []kv.KeyRange{kvRange})
+	}
+	return kv.NewPartitionedKeyRanges(kvRanges), nil
 }

--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -903,13 +903,6 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, initBatchSiz
 				builder.FullTextInfo.TableID = e.table.Meta().ID
 				builder.FullTextInfo.IndexID = e.index.ID
 				builder.FullTextInfo.ExecutorID = e.idxPlans[0].ExplainID().String()
-
-				id := e.Table().Meta().ID
-				startKey := tablecodec.EncodeTablePrefix(id)
-				endKey := tablecodec.EncodeTablePrefix(id + 1)
-				modifiedKvRange := kv.KeyRange{StartKey: startKey, EndKey: endKey}
-				kvRange = kvRange[:0]
-				kvRange = append(kvRange, modifiedKvRange)
 			}
 
 			if e.indexLookUpPushDown {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/61185

Problem Summary:

### What changed and how does it work?

The master has implemented a complex feature that changed the way IndexLookupExecutor opens the KV ranges.

When we merged with the master, the code diff is fixed in a wrong way.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
