### PR TITLE
ddl: still use write count for ingest worker

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -255,9 +255,6 @@ type IndexRecordChunk struct {
 	Err   error
 	Done  bool
 
-	// tableScanRowCount is the number of rows scanned by the corresponding TableScanTask.
-	// If the index is a partial index, the number of rows in the Chunk may be less than tableScanRowCount.
-	tableScanRowCount int64
 	// conditionPushed records whether the index condition has been pushed down. If it's true, the ingest worker
 	// can skip running the checker in TiDB side.
 	conditionPushed bool
@@ -529,8 +526,9 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		zap.Int("id", task.ID), zap.Stringer("task", task))
 
 	var (
-		idxResults  []IndexRecordChunk
-		execDetails kvutil.ExecDetails
+		idxResults             []IndexRecordChunk
+		idxReadSizeCheckpoints []int64
+		execDetails            kvutil.ExecDetails
 	)
 	var scanCtx context.Context = w.ctx
 	if scanCtx.Value(kvutil.ExecDetailsKey) == nil {
@@ -573,20 +571,26 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 			w.collector.Accepted(execDetails.UnpackedBytesReceivedKVTotal)
 			execDetails = kvutil.ExecDetails{}
 
+			// The `tableScanRowCount-lastTableScanRowCount` is not accurate because the internal cop request will read more rows than a single
+			// chunk. We still store the approximate value for progress reporting.
 			_, tableScanRowCount := distsqlCtx.RuntimeStatsColl.GetCopCountAndRows(tableScanCopID)
-			idxResults = append(idxResults, IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed})
+			idxResults = append(idxResults, IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, conditionPushed: conditionPushed})
+			idxReadSizeCheckpoints = append(idxReadSizeCheckpoints, tableScanRowCount-lastTableScanRowCount)
 			lastTableScanRowCount = tableScanRowCount
 		}
 		return rs.Close()
 	})
 
+	// At this step, all rows have been scanned successfully. However, we still update the checkpoint according to the scanned rows corresponding to
+	// each Chunk, instead of jumping the count from 0 to total scanned rows to represent the progress smoothly.
 	for i, idxResult := range idxResults {
 		sender(idxResult)
 		if w.cpOp != nil {
 			done := i == len(idxResults)-1
-			w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
+			w.cpOp.UpdateChunk(task.ID, int(idxReadSizeCheckpoints[i]), done)
 		}
-		w.totalCount.Add(idxResult.tableScanRowCount)
+		failpoint.InjectCall("afterSendChunk", w.totalCount.Load())
+		w.totalCount.Add(idxReadSizeCheckpoints[i])
 	}
 
 	return err
@@ -803,20 +807,19 @@ func (w *indexIngestWorker) HandleTask(ck IndexRecordChunk, send func(IndexWrite
 		return err
 	}
 	// TODO: find a place to display the added count
-	_, bytes, err := w.WriteChunk(&ck)
+	count, bytes, err := w.WriteChunk(&ck)
 	if err != nil {
 		return err
 	}
-	w.collector.Processed(int64(bytes), ck.tableScanRowCount)
-	scannedCount := ck.tableScanRowCount
-	if scannedCount == 0 {
+	w.collector.Processed(int64(bytes), int64(ck.Chunk.NumRows()))
+	if count == 0 {
 		logutil.Logger(w.ctx).Info("finish a index ingest task", zap.Int("id", ck.ID))
 		return nil
 	}
 	if w.totalCount != nil {
-		w.totalCount.Add(scannedCount)
+		w.totalCount.Add(int64(count))
 	}
-	result.RowCnt = int(ck.tableScanRowCount)
+	result.RowCnt = count
 	if ResultCounterForTest != nil {
 		ResultCounterForTest.Add(1)
 	}

--- a/pkg/ddl/backfilling_read_index.go
+++ b/pkg/ddl/backfilling_read_index.go
@@ -484,8 +484,9 @@ func newDistTaskRowCntCollector(
 	}
 }
 
-func (d *distTaskRowCntCollector) Accepted(bytes int64) {
+func (d *distTaskRowCntCollector) Accepted(bytes, rows int64) {
 	d.summary.ReadBytes.Add(bytes)
+	d.summary.ReadRowCnt.Add(rows)
 	d.meterRec.IncClusterReadBytes(uint64(bytes))
 }
 

--- a/pkg/ddl/index_cop.go
+++ b/pkg/ddl/index_cop.go
@@ -87,6 +87,7 @@ func buildTableScan(ctx context.Context, c *copr.CopContextBase, distSQLCtx *dis
 	kvReq.RequestSource.RequestSourceInternal = true
 	kvReq.RequestSource.RequestSourceType = getDDLRequestSource(model.ActionAddIndex)
 	kvReq.RequestSource.ExplicitRequestSourceType = kvutil.ExplicitTypeDDL
+	failpoint.InjectCall("modifyKvReqForTableScan", kvReq)
 	if err != nil {
 		return nil, conditionPushed, err
 	}

--- a/pkg/disttask/framework/storage/table_test.go
+++ b/pkg/disttask/framework/storage/table_test.go
@@ -653,7 +653,7 @@ func TestSubTaskTable(t *testing.T) {
 	rowCount, err := sm.GetSubtaskRowCount(ctx, 2, proto.StepOne)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), rowCount)
-	require.NoError(t, sm.UpdateSubtaskSummary(ctx, subtaskID, &execute.SubtaskSummary{RowCnt: *atomic.NewInt64(100)}))
+	require.NoError(t, sm.UpdateSubtaskSummary(ctx, subtaskID, &execute.SubtaskSummary{ReadRowCnt: *atomic.NewInt64(100)}))
 	rowCount, err = sm.GetSubtaskRowCount(ctx, 2, proto.StepOne)
 	require.NoError(t, err)
 	require.EqualValues(t, 100, rowCount)

--- a/pkg/disttask/importinto/task_executor.go
+++ b/pkg/disttask/importinto/task_executor.go
@@ -172,8 +172,9 @@ func (s *importStepExecutor) Init(ctx context.Context) (err error) {
 }
 
 // Accepted implements Collector.Accepted interface.
-func (s *importStepExecutor) Accepted(bytes int64) {
+func (s *importStepExecutor) Accepted(bytes, rows int64) {
 	s.summary.Bytes.Add(bytes)
+	s.summary.ReadRowCnt.Add(rows)
 }
 
 // Processed implements Collector.Processed interface.

--- a/pkg/executor/importer/chunk_process.go
+++ b/pkg/executor/importer/chunk_process.go
@@ -293,7 +293,7 @@ func (p *chunkEncoder) encodeLoop(ctx context.Context) error {
 			}
 		}
 		if p.collector != nil {
-			p.collector.Accepted(delta)
+			p.collector.Accepted(delta, int64(rowCount))
 		}
 
 		if metrics != nil {

--- a/pkg/lightning/backend/external/merge.go
+++ b/pkg/lightning/backend/external/merge.go
@@ -65,7 +65,7 @@ func NewMergeCollector(ctx context.Context, summary *execute.SubtaskSummary) *me
 	}
 }
 
-func (*mergeCollector) Accepted(_ int64) {}
+func (*mergeCollector) Accepted(_, _ int64) {}
 
 func (c *mergeCollector) Processed(bytes, rowCnt int64) {
 	if c.summary != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64602 

Problem Summary:

### What changed and how does it work?

1. Revert the counting part for index ingest worker. Let it still use the count of indexes.
2. Remove the `totalCount` in `tableScanWorker`, because it's not used.
3. Add `ReadRowCnt` in `SubtaskSummary`.
3. Add a test for `scanRecords` to show that the count depends on how cops are handled.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
