### PR TITLE
br: support restore privileges tables from v6.5 to v7.5

### DIFF
--- a/br/pkg/restore/snap_client/BUILD.bazel
+++ b/br/pkg/restore/snap_client/BUILD.bazel
@@ -93,7 +93,7 @@ go_test(
     ],
     embed = [":snap_client"],
     flaky = True,
-    shard_count = 41,
+    shard_count = 42,
     deps = [
         "//br/pkg/checkpoint",
         "//br/pkg/errors",

--- a/br/pkg/restore/snap_client/client.go
+++ b/br/pkg/restore/snap_client/client.go
@@ -169,6 +169,8 @@ type SnapClient struct {
 	// restoreUUID is the UUID of this restore.
 	// restore from a checkpoint inherits the same restoreUUID.
 	restoreUUID uuid.UUID
+
+	checkPrivilegeTableRowsCollateCompatiblity bool
 }
 
 // NewRestoreClient returns a new RestoreClient.
@@ -269,6 +271,18 @@ func (rc *SnapClient) GetTLSConfig() *tls.Config {
 // GetSupportPolicy tells whether target tidb support placement policy.
 func (rc *SnapClient) GetSupportPolicy() bool {
 	return rc.supportPolicy
+}
+
+// SetCheckPrivilegeTableRowsCollateCompatiblity set switch to check
+// privilege tables with different collate columns
+func (rc *SnapClient) SetCheckPrivilegeTableRowsCollateCompatiblity(v bool) {
+	rc.checkPrivilegeTableRowsCollateCompatiblity = v
+}
+
+// GetCheckPrivilegeTableRowsCollateCompatiblity get switch to check
+// privilege tables with different collate columns
+func (rc *SnapClient) GetCheckPrivilegeTableRowsCollateCompatiblity() bool {
+	return rc.checkPrivilegeTableRowsCollateCompatiblity
 }
 
 func (rc *SnapClient) updateConcurrency() {

--- a/br/pkg/restore/snap_client/export_test.go
+++ b/br/pkg/restore/snap_client/export_test.go
@@ -148,3 +148,11 @@ func (rc *SnapClient) ReplaceTables(
 func NewTemporaryTableChecker(loadStatsPhysical, loadSysTablePhysical bool) *TemporaryTableChecker {
 	return &TemporaryTableChecker{loadStatsPhysical: loadStatsPhysical, loadSysTablePhysical: loadSysTablePhysical}
 }
+
+func (rc *SnapClient) CheckPrivilegeTableRowsCollateCompatibility(
+	ctx context.Context,
+	dbNameL, tableNameL string,
+	upstreamTable, downstreamTable *model.TableInfo,
+) error {
+	return rc.checkPrivilegeTableRowsCollateCompatibility(ctx, dbNameL, tableNameL, upstreamTable, downstreamTable)
+}

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -704,11 +704,12 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table, co
 					col.Name, col.FieldType.String())
 			}
 			typeEq, collateEq := utils.IsTypeCompatible(backupCol.FieldType, col.FieldType)
-			canLoadSysTablePhysical = canLoadSysTablePhysical && collateEq
+			canLoadSysTablePhysical = canLoadSysTablePhysical && collateEq && typeEq
+			collateCompatible := collateEq
 			if typeEq && (!collateEq && collationCheck) {
-				collateEq = checkSysTableColumnCollateCompatibility(mysql.SystemDB, table.Info.Name.L, col.Name.L, backupCol.GetCollate(), col.GetCollate())
+				collateCompatible = checkSysTableColumnCollateCompatibility(mysql.SystemDB, table.Info.Name.L, col.Name.L, backupCol.GetCollate(), col.GetCollate())
 			}
-			if !(typeEq && collateEq) {
+			if !(typeEq && collateCompatible) {
 				log.Error("incompatible column",
 					zap.Stringer("table", table.Info.Name),
 					zap.String("col in cluster", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())),

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -704,6 +704,7 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table, co
 					col.Name, col.FieldType.String())
 			}
 			typeEq, collateEq := utils.IsTypeCompatible(backupCol.FieldType, col.FieldType)
+			canLoadSysTablePhysical = canLoadSysTablePhysical && collateEq
 			if typeEq && (!collateEq && collationCheck) {
 				collateEq = checkSysTableColumnCollateCompatibility(mysql.SystemDB, table.Info.Name.L, col.Name.L, backupCol.GetCollate(), col.GetCollate())
 			}
@@ -718,7 +719,6 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table, co
 					col.Name, col.FieldType.String(),
 					backupCol.Name, backupCol.FieldType.String())
 			}
-			canLoadSysTablePhysical = canLoadSysTablePhysical && collateEq
 		}
 
 		if backupTi.Name.L == sysUserTableName {

--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/pkg/bindinfo"
 	"github.com/pingcap/tidb/pkg/domain"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -141,6 +142,32 @@ var unRecoverableTable = map[string]map[string]struct{}{
 	"sys": {
 		// replace into view is not supported now
 		"schema_unused_indexes": {},
+	},
+}
+
+type checkPrivilegeTableRowsCollateCompatiblitySQLPair struct {
+	upstreamCollateSQL   string
+	downstreamCollateSQL string
+	columns              map[string]struct{}
+}
+
+var collateCompatibilityTables = map[string]map[string]checkPrivilegeTableRowsCollateCompatiblitySQLPair{
+	"mysql": {
+		"db": {
+			upstreamCollateSQL:   "SELECT COUNT(1) FROM mysql.db",
+			downstreamCollateSQL: "SELECT COUNT(1) FROM (SELECT Host, DB COLLATE utf8mb4_general_ci, User FROM mysql.db GROUP BY Host, DB COLLATE utf8mb4_general_ci, User) as a",
+			columns:              map[string]struct{}{"db": {}},
+		},
+		"tables_priv": {
+			upstreamCollateSQL:   "SELECT COUNT(1) FROM mysql.tables_priv",
+			downstreamCollateSQL: "SELECT COUNT(1) FROM (SELECT Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci FROM mysql.tables_priv GROUP BY Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci) as a",
+			columns:              map[string]struct{}{"db": {}, "table_name": {}},
+		},
+		"columns_priv": {
+			upstreamCollateSQL:   "SELECT COUNT(1) FROM mysql.columns_priv",
+			downstreamCollateSQL: "SELECT COUNT(1) FROM (SELECT Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci, Column_name COLLATE utf8mb4_general_ci FROM mysql.columns_priv GROUP BY Host, DB COLLATE utf8mb4_general_ci, User, Table_name COLLATE utf8mb4_general_ci, Column_name COLLATE utf8mb4_general_ci) as a",
+			columns:              map[string]struct{}{"db": {}, "table_name": {}, "column_name": {}},
+		},
 	},
 }
 
@@ -585,6 +612,9 @@ func (rc *SnapClient) replaceTemporaryTableToSystable(ctx context.Context, ti *m
 		log.Info("replace into existing table",
 			zap.String("table", tableName),
 			zap.Stringer("schema", db.Name))
+		if err := rc.checkPrivilegeTableRowsCollateCompatibility(ctx, dbName, tableName, ti, db.ExistingTables[tableName]); err != nil {
+			return err
+		}
 		// target column order may different with source cluster
 		columnNames := make([]string, 0, len(ti.Columns))
 		for _, col := range ti.Columns {
@@ -617,8 +647,9 @@ func (rc *SnapClient) cleanTemporaryDatabase(ctx context.Context, originDB strin
 	}
 }
 
-func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table) error {
+func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table, skipCollationCheck bool) (canLoadSysTablePhysical bool, err error) {
 	log.Info("checking target cluster system table compatibility with backed up data")
+	canLoadSysTablePhysical = true
 	privilegeTablesInBackup := make([]*metautil.Table, 0)
 	for _, table := range tables {
 		decodedSysDBName, ok := utils.GetSysDBCIStrName(table.DB.Name)
@@ -631,7 +662,7 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table) er
 		ti, err := restore.GetTableSchema(dom, sysDB, table.Info.Name)
 		if err != nil {
 			log.Error("missing table on target cluster", zap.Stringer("table", table.Info.Name))
-			return errors.Annotate(berrors.ErrRestoreIncompatibleSys, "missed system table: "+table.Info.Name.O)
+			return false, errors.Annotate(berrors.ErrRestoreIncompatibleSys, "missed system table: "+table.Info.Name.O)
 		}
 		backupTi := table.Info
 		// skip checking the number of columns in mysql.user table,
@@ -641,7 +672,7 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table) er
 				zap.Stringer("table", table.Info.Name),
 				zap.Int("col in cluster", len(ti.Columns)),
 				zap.Int("col in backup", len(backupTi.Columns)))
-			return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+			return false, errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
 				"column count mismatch, table: %s, col in cluster: %d, col in backup: %d",
 				table.Info.Name.O, len(ti.Columns), len(backupTi.Columns))
 		}
@@ -665,22 +696,27 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table) er
 				log.Error("missing column in backup data",
 					zap.Stringer("table", table.Info.Name),
 					zap.String("col", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())))
-				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+				return false, errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
 					"missing column in backup data, table: %s, col: %s %s",
 					table.Info.Name.O,
 					col.Name, col.FieldType.String())
 			}
-			if !utils.IsTypeCompatible(backupCol.FieldType, col.FieldType) {
+			typeEq, collateEq := utils.IsTypeCompatible(backupCol.FieldType, col.FieldType)
+			if typeEq && (!collateEq && skipCollationCheck) {
+				collateEq = checkSysTableColumnCollateCompatibility(mysql.SystemDB, table.Info.Name.L, col.Name.L, backupCol.GetCollate(), col.GetCollate())
+			}
+			if !(typeEq && collateEq) {
 				log.Error("incompatible column",
 					zap.Stringer("table", table.Info.Name),
 					zap.String("col in cluster", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())),
 					zap.String("col in backup", fmt.Sprintf("%s %s", backupCol.Name, backupCol.FieldType.String())))
-				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+				return false, errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
 					"incompatible column, table: %s, col in cluster: %s %s, col in backup: %s %s",
 					table.Info.Name.O,
 					col.Name, col.FieldType.String(),
 					backupCol.Name, backupCol.FieldType.String())
 			}
+			canLoadSysTablePhysical = canLoadSysTablePhysical && collateEq
 		}
 
 		if backupTi.Name.L == sysUserTableName {
@@ -698,13 +734,102 @@ func CheckSysTableCompatibility(dom *domain.Domain, tables []*metautil.Table) er
 					log.Error("missing column in cluster data",
 						zap.Stringer("table", table.Info.Name),
 						zap.String("col", fmt.Sprintf("%s %s", col.Name, col.FieldType.String())))
-					return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+					return false, errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
 						"missing column in cluster data, table: %s, col: %s %s",
 						table.Info.Name.O,
 						col.Name, col.FieldType.String())
 				}
 			}
 		}
+	}
+	return canLoadSysTablePhysical, nil
+}
+
+func checkSysTableColumnCollateCompatibility(dbNameL, tableNameL, columnNameL, upstreamCollate, downstreamCollate string) bool {
+	if upstreamCollate != "utf8mb4_bin" || downstreamCollate != "utf8mb4_general_ci" {
+		return false
+	}
+	collateCompatibilityTableMap, exists := collateCompatibilityTables[dbNameL]
+	if !exists {
+		return false
+	}
+	collateCompatibilityColumnMap, exists := collateCompatibilityTableMap[tableNameL]
+	if !exists {
+		return false
+	}
+	_, exists = collateCompatibilityColumnMap.columns[columnNameL]
+	return exists
+}
+
+func (rc *SnapClient) checkPrivilegeTableRowsCollateCompatibility(ctx context.Context, dbNameL, tableNameL string, upstreamTable, downstreamTable *model.TableInfo) error {
+	collateCompatiblityTableMap, exists := collateCompatibilityTables[dbNameL]
+	if !exists {
+		return nil
+	}
+	collateCompatibilityColumnMap, exists := collateCompatiblityTableMap[tableNameL]
+	if !exists {
+		return nil
+	}
+	colCount := 0
+	for _, col := range upstreamTable.Columns {
+		if _, exists := collateCompatibilityColumnMap.columns[col.Name.L]; exists {
+			if col.GetCollate() != "utf8mb4_bin" {
+				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+					"incompatible column collate, upstream table %s.%s column %s collate should be %s",
+					dbNameL, tableNameL, col.Name.L, col.GetCollate())
+			}
+			colCount += 1
+		}
+	}
+	if colCount != len(collateCompatibilityColumnMap.columns) {
+		return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+			"incompatible column collate, upstream table %s.%s has only %d columns with collate utf8mb4_bin",
+			dbNameL, tableNameL, colCount)
+	}
+	colCount = 0
+	for _, col := range downstreamTable.Columns {
+		if _, exists := collateCompatibilityColumnMap.columns[col.Name.L]; exists {
+			if col.GetCollate() != "utf8mb4_general_ci" {
+				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+					"incompatible column collate, downstream table %s.%s column %s collate should be %s",
+					dbNameL, tableNameL, col.Name.L, col.GetCollate())
+			}
+			colCount += 1
+		}
+	}
+	if colCount != len(collateCompatibilityColumnMap.columns) {
+		return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
+			"incompatible column collate, downstream table %s.%s has only %d columns with collate utf8mb4_bin",
+			dbNameL, tableNameL, colCount)
+	}
+	ectx := rc.db.Session().GetSessionCtx().GetRestrictedSQLExecutor()
+	rows, _, err := ectx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(ctx, kv.InternalTxnBR),
+		nil,
+		collateCompatibilityColumnMap.upstreamCollateSQL,
+	)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get the count of privilege rows")
+	}
+	if len(rows) == 0 {
+		return errors.Errorf("failed to get the count of privilege rows")
+	}
+	upstreamCount := rows[0].GetInt64(0)
+	rows, _, err = ectx.ExecRestrictedSQL(
+		kv.WithInternalSourceType(ctx, kv.InternalTxnBR),
+		nil,
+		collateCompatibilityColumnMap.downstreamCollateSQL,
+	)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get the count of privilege rows")
+	}
+	if len(rows) == 0 {
+		return errors.Errorf("failed to get the count of privilege rows")
+	}
+	downstreamCount := rows[0].GetInt64(0)
+	if upstreamCount != downstreamCount {
+		return errors.Errorf("there are duplicated rows with collate utf8mb4_general_ci [upstream count %d != downstream count %d]",
+			upstreamCount, downstreamCount)
 	}
 	return nil
 }

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -16,11 +16,13 @@ package snapclient_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
 	"github.com/pingcap/errors"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/gluetidb"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/restore"
@@ -149,6 +151,225 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 		Info: mockedDBTI,
 	}}, true)
 	require.True(t, berrors.ErrRestoreIncompatibleSys.Equal(err))
+}
+
+type mustExecuteSession struct {
+	ctx context.Context
+	se  glue.Session
+	t   *testing.T
+}
+
+func (se *mustExecuteSession) MustExecute(sql string) {
+	err := se.se.ExecuteInternal(se.ctx, sql)
+	require.NoError(se.t, err)
+}
+
+const (
+	CreateDBSQL = `CREATE TABLE __TiDB_BR_Temporary_mysql.db (
+  Host char(255) NOT NULL,
+  DB char(64) NOT NULL,
+  User char(32) NOT NULL,
+  Select_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Insert_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Update_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Delete_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Drop_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Grant_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  References_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Index_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Alter_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_tmp_table_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Lock_tables_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_view_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Show_view_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Create_routine_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Alter_routine_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Execute_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Event_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  Trigger_priv enum('N','Y') NOT NULL DEFAULT 'N',
+  PRIMARY KEY (Host,DB,User) /*T![clustered_index] NONCLUSTERED */
+)`
+
+	CreateTableSQL = `CREATE TABLE __TiDB_BR_Temporary_mysql.tables_priv (
+  Host char(255) NOT NULL,
+  DB char(64) NOT NULL,
+  User char(32) NOT NULL,
+  Table_name char(64) NOT NULL,
+  Grantor char(77) DEFAULT NULL,
+  Timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+  Table_priv set('Select','Insert','Update','Delete','Create','Drop','Grant','Index','Alter','Create View','Show View','Trigger','References') DEFAULT NULL,
+  Column_priv set('Select','Insert','Update','References') DEFAULT NULL,
+  PRIMARY KEY (Host,DB,User,Table_name) /*T![clustered_index] NONCLUSTERED */
+)`
+
+	CreateColumnSQL = `CREATE TABLE __TiDB_BR_Temporary_mysql.columns_priv (
+  Host char(255) NOT NULL,
+  DB char(64) NOT NULL,
+  User char(32) NOT NULL,
+  Table_name char(64) NOT NULL,
+  Column_name char(64) NOT NULL,
+  Timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+  Column_priv set('Select','Insert','Update','References') DEFAULT NULL,
+  PRIMARY KEY (Host,DB,User,Table_name,Column_name) /*T![clustered_index] NONCLUSTERED */
+)`
+)
+
+func TestCheckPrivilegeTableRowsCollateCompatibility(t *testing.T) {
+	cluster := mc
+	ctx := context.Background()
+	g := gluetidb.New()
+	rc := snapclient.SnapClient{}
+	defer rc.Close()
+	err := rc.InitConnections(g, cluster.Storage)
+	require.NoError(t, err)
+	rc.SetCheckPrivilegeTableRowsCollateCompatiblity(true)
+
+	se, err := g.CreateSession(cluster.Storage)
+	require.NoError(t, err)
+	defer se.Close()
+	mse := &mustExecuteSession{ctx, se, t}
+	mse.MustExecute("CREATE USER newroot")
+	mse.MustExecute("CREATE USER oldroot")
+	mse.MustExecute("CREATE DATABASE __TiDB_BR_Temporary_mysql")
+	defer mse.MustExecute("DROP DATABASE __TiDB_BR_Temporary_mysql")
+
+	downstreamDBTable, err := restore.GetTableSchema(cluster.Domain, ast.NewCIStr("mysql"), ast.NewCIStr("db"))
+	require.NoError(t, err)
+	downstreamTablesTable, err := restore.GetTableSchema(cluster.Domain, ast.NewCIStr("mysql"), ast.NewCIStr("tables_priv"))
+	require.NoError(t, err)
+	downstreamColumnsTable, err := restore.GetTableSchema(cluster.Domain, ast.NewCIStr("mysql"), ast.NewCIStr("columns_priv"))
+	require.NoError(t, err)
+	// case 1: privilege db
+	mse.MustExecute(CreateDBSQL)
+	backupTable, err := restore.GetTableSchema(cluster.Domain, ast.NewCIStr("__TiDB_BR_Temporary_mysql"), ast.NewCIStr("db"))
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','test','newroot')")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','test','oldroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','Test','newroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.Error(t, err)
+	mse.MustExecute("DELETE FROM __TiDB_BR_Temporary_mysql.db WHERE DB = 'Test'")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','cafe','newroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.db (Host,DB,User) VALUES ('%','café','newroot')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.Error(t, err)
+	mse.MustExecute("DELETE FROM __TiDB_BR_Temporary_mysql.db WHERE DB = 'cafe'")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "db", backupTable, downstreamDBTable)
+	require.NoError(t, err)
+	mse.MustExecute("DROP TABLE __TiDB_BR_Temporary_mysql.db")
+
+	// case 2: privilege table
+	type privCase struct {
+		insertValues []string
+		deleteCond   []string
+	}
+	mse.MustExecute(CreateTableSQL)
+	backupTable, err = restore.GetTableSchema(cluster.Domain, ast.NewCIStr("__TiDB_BR_Temporary_mysql"), ast.NewCIStr("tables_priv"))
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.tables_priv (Host,DB,User,Table_name) VALUES ('%','test','newroot','ta1')")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.tables_priv (Host,DB,User,Table_name) VALUES ('%','test','oldroot','ta1')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "tables_priv", backupTable, downstreamTablesTable)
+	require.NoError(t, err)
+	cases := []privCase{
+		{
+			insertValues: []string{"('%','test','newroot','Ta1')"},
+			deleteCond:   []string{"Table_name = 'Ta1'"},
+		},
+		{
+			insertValues: []string{"('%','tEst','newroot','ta1')"},
+			deleteCond:   []string{"DB = 'tEst'"},
+		},
+		{
+			insertValues: []string{"('%','tEst','newroot','Ta1')"},
+			deleteCond:   []string{"DB = 'tEst'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','tá1')"},
+			deleteCond:   []string{"Table_name = 'tá1'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','ta1')"},
+			deleteCond:   []string{"DB = 'tést'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','tá1')"},
+			deleteCond:   []string{"DB = 'tést'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','tá1')", "('%','tEst','newroot','Ta1')"},
+			deleteCond:   []string{"DB = 'tést'", "DB = 'tEst'"},
+		},
+	}
+	for _, cs := range cases {
+		for _, v := range cs.insertValues {
+			mse.MustExecute(fmt.Sprintf("INSERT INTO __TiDB_BR_Temporary_mysql.tables_priv (Host,DB,User,Table_name) VALUES %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "tables_priv", backupTable, downstreamTablesTable)
+		require.Error(t, err)
+		for _, v := range cs.deleteCond {
+			mse.MustExecute(fmt.Sprintf("DELETE FROM __TiDB_BR_Temporary_mysql.tables_priv WHERE %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "tables_priv", backupTable, downstreamTablesTable)
+		require.NoError(t, err)
+	}
+	mse.MustExecute("DROP TABLE __TiDB_BR_Temporary_mysql.tables_priv")
+
+	// case 3: privilege column
+	mse.MustExecute(CreateColumnSQL)
+	backupTable, err = restore.GetTableSchema(cluster.Domain, ast.NewCIStr("__TiDB_BR_Temporary_mysql"), ast.NewCIStr("columns_priv"))
+	require.NoError(t, err)
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.columns_priv (Host,DB,User,Table_name,Column_name) VALUES ('%','test','newroot','ta1','ca1')")
+	mse.MustExecute("INSERT INTO __TiDB_BR_Temporary_mysql.columns_priv (Host,DB,User,Table_name,Column_name) VALUES ('%','test','oldroot','ta1','ca1')")
+	err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "columns_priv", backupTable, downstreamColumnsTable)
+	require.NoError(t, err)
+	cases = []privCase{
+		{
+			insertValues: []string{"('%','test','newroot','ta1','Ca1')"},
+			deleteCond:   []string{"Column_name = 'Ca1'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','Ta1','ca1')"},
+			deleteCond:   []string{"Table_name = 'Ta1'"},
+		},
+		{
+			insertValues: []string{"('%','Test','newroot','ta1','ca1')"},
+			deleteCond:   []string{"DB = 'Test'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','ta1','cá1')"},
+			deleteCond:   []string{"Column_name = 'cá1'"},
+		},
+		{
+			insertValues: []string{"('%','test','newroot','tá1','ca1')"},
+			deleteCond:   []string{"Table_name = 'tá1'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','ta1','ca1')"},
+			deleteCond:   []string{"DB = 'tést'"},
+		},
+		{
+			insertValues: []string{"('%','tést','newroot','ta1','ca1')", "('%','Test','newroot','ta1','ca1')"},
+			deleteCond:   []string{"DB = 'tést'", "DB = 'Test'"},
+		},
+	}
+	for _, cs := range cases {
+		for _, v := range cs.insertValues {
+			mse.MustExecute(fmt.Sprintf("INSERT INTO __TiDB_BR_Temporary_mysql.columns_priv (Host,DB,User,Table_name,Column_name) VALUES %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "columns_priv", backupTable, downstreamColumnsTable)
+		require.Error(t, err)
+		for _, v := range cs.deleteCond {
+			mse.MustExecute(fmt.Sprintf("DELETE FROM __TiDB_BR_Temporary_mysql.columns_priv WHERE %s", v))
+		}
+		err = rc.CheckPrivilegeTableRowsCollateCompatibility(ctx, "mysql", "columns_priv", backupTable, downstreamColumnsTable)
+		require.NoError(t, err)
+	}
+	mse.MustExecute("DROP TABLE __TiDB_BR_Temporary_mysql.columns_priv")
 }
 
 // NOTICE: Once there is a new system table, BR needs to ensure that it is correctly classified:

--- a/br/pkg/restore/snap_client/systable_restore_test.go
+++ b/br/pkg/restore/snap_client/systable_restore_test.go
@@ -134,6 +134,16 @@ func TestCheckSysTableCompatibility(t *testing.T) {
 	}}, true)
 	require.NoError(t, err)
 
+	// skip check collate but type mismatch
+	mockedDBTI = dbTI.Clone()
+	mockedDBTI.Columns[1].SetCollate("utf8mb4_bin")
+	mockedUserTI.Columns[1].FieldType.SetFlen(2000) // Columns[1] is `DB` char(64)
+	_, err = snapclient.CheckSysTableCompatibility(cluster.Domain, []*metautil.Table{{
+		DB:   tmpSysDB,
+		Info: mockedDBTI,
+	}}, true)
+	require.NoError(t, err)
+
 	// another column collate mismatch
 	mockedDBTI = dbTI.Clone()
 	mockedDBTI.Columns[0].SetCollate("utf8mb4_general_ci")

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1399,8 +1399,13 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	}
 
 	if client.IsFullClusterRestore() && client.HasBackedUpSysDB() {
-		if err = snapclient.CheckSysTableCompatibility(mgr.GetDomain(), tables); err != nil {
+		canLoadSysTablePhysical, err := snapclient.CheckSysTableCompatibility(mgr.GetDomain(), tables, false)
+		if err != nil {
 			return errors.Trace(err)
+		}
+		if loadSysTablePhysical && !canLoadSysTablePhysical {
+			log.Info("The system tables schema is not compatible. Fallback to logically load system tables.")
+			loadSysTablePhysical = false
 		}
 	}
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -112,6 +112,8 @@ const (
 
 	FlagResetSysUsers = "reset-sys-users"
 
+	FlagSysCheckCollation = "sys-check-collation"
+
 	defaultPiTRBatchCount     = 8
 	defaultPiTRBatchSize      = 16 * 1024 * 1024
 	defaultRestoreConcurrency = 128
@@ -147,6 +149,8 @@ type RestoreCommonConfig struct {
 	WithSysTable bool `json:"with-sys-table" toml:"with-sys-table"`
 
 	ResetSysUsers []string `json:"reset-sys-users" toml:"reset-sys-users"`
+
+	SysCheckCollation bool `json:"sys-check-collation" toml:"sys-check-collation"`
 }
 
 // adjust adjusts the abnormal config value in the current config.
@@ -359,6 +363,8 @@ func DefineRestoreFlags(flags *pflag.FlagSet) {
 		" default is true, the incremental restore will not perform rewrite on the incremental data"+
 		" meanwhile the incremental restore will not allow to restore 3 backfilled type ddl jobs,"+
 		" these ddl jobs are Add index, Modify column and Reorganize partition")
+	flags.Bool(FlagSysCheckCollation, false, "whether check the privileges table rows to permit to restore the privilege data"+
+		" from utf8mb4_bin collate column to utf8mb4_general_ci collate column")
 
 	DefineRestoreCommonFlags(flags)
 }
@@ -489,7 +495,10 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet, skipCommonConfig 
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", FlagWaitTiFlashReady)
 	}
-
+	cfg.SysCheckCollation, err = flags.GetBool(FlagSysCheckCollation)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get flag %s", FlagSysCheckCollation)
+	}
 	cfg.AllowPITRFromIncremental, err = flags.GetBool(flagAllowPITRFromIncremental)
 	if err != nil {
 		return errors.Annotatef(err, "failed to get flag %s", flagAllowPITRFromIncremental)
@@ -729,6 +738,7 @@ func configureRestoreClient(ctx context.Context, client *snapclient.SnapClient, 
 	client.SetPlacementPolicyMode(cfg.WithPlacementPolicy)
 	client.SetWithSysTable(cfg.WithSysTable)
 	client.SetRewriteMode(ctx)
+	client.SetCheckPrivilegeTableRowsCollateCompatiblity(cfg.SysCheckCollation)
 	return nil
 }
 
@@ -1399,7 +1409,7 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 	}
 
 	if client.IsFullClusterRestore() && client.HasBackedUpSysDB() {
-		canLoadSysTablePhysical, err := snapclient.CheckSysTableCompatibility(mgr.GetDomain(), tables, false)
+		canLoadSysTablePhysical, err := snapclient.CheckSysTableCompatibility(mgr.GetDomain(), tables, client.GetCheckPrivilegeTableRowsCollateCompatiblity())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/utils/misc_test.go
+++ b/br/pkg/utils/misc_test.go
@@ -32,34 +32,46 @@ func TestIsTypeCompatible(t *testing.T) {
 		src := types.NewFieldType(mysql.TypeInt24)
 		src.AddFlag(mysql.UnsignedFlag)
 		target := types.NewFieldType(mysql.TypeInt24)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 
 		src.DelFlag(mysql.UnsignedFlag)
 		target.AddFlag(mysql.UnsignedFlag)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq = IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// different not null flag
 		src := types.NewFieldType(mysql.TypeInt24)
 		src.AddFlag(mysql.NotNullFlag)
 		target := types.NewFieldType(mysql.TypeInt24)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 
 		src.DelFlag(mysql.NotNullFlag)
 		target.AddFlag(mysql.NotNullFlag)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq = IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// different evaluation type
 		src := types.NewFieldType(mysql.TypeInt24)
 		target := types.NewFieldType(mysql.TypeFloat)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src flen > target
 		src := types.NewFieldType(mysql.TypeInt24)
 		target := types.NewFieldType(mysql.TypeTiny)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src flen > target
@@ -67,7 +79,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetFlen(100)
 		target := types.NewFieldType(mysql.TypeVarchar)
 		target.SetFlag(99)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src decimal > target
@@ -75,7 +89,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetDecimal(5)
 		target := types.NewFieldType(mysql.TypeNewDecimal)
 		target.SetDecimal(4)
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// src has more elements
@@ -83,7 +99,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetElems([]string{"a", "b"})
 		target := types.NewFieldType(mysql.TypeEnum)
 		target.SetElems([]string{"a"})
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// incompatible enum
@@ -91,7 +109,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetElems([]string{"a", "b"})
 		target := types.NewFieldType(mysql.TypeEnum)
 		target.SetElems([]string{"a", "c", "d"})
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// incompatible charset
@@ -99,7 +119,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		src.SetCharset("gbk")
 		target := types.NewFieldType(mysql.TypeVarchar)
 		target.SetCharset("utf8")
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.False(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		// incompatible collation
@@ -109,7 +131,9 @@ func TestIsTypeCompatible(t *testing.T) {
 		target := types.NewFieldType(mysql.TypeVarchar)
 		target.SetCharset("utf8")
 		target.SetCollate("utf8_general_ci")
-		require.False(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.False(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeVarchar)
@@ -120,25 +144,33 @@ func TestIsTypeCompatible(t *testing.T) {
 		target.SetFlen(11)
 		target.SetCharset("utf8")
 		target.SetCollate("utf8_bin")
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeBlob)
 		target := types.NewFieldType(mysql.TypeLongBlob)
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeEnum)
 		src.SetElems([]string{"a", "b"})
 		target := types.NewFieldType(mysql.TypeEnum)
 		target.SetElems([]string{"a", "b", "c"})
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 	{
 		src := types.NewFieldType(mysql.TypeTimestamp)
 		target := types.NewFieldType(mysql.TypeTimestamp)
 		target.SetDecimal(3)
-		require.True(t, IsTypeCompatible(*src, *target))
+		typeEq, collateEq := IsTypeCompatible(*src, *target)
+		require.True(t, typeEq)
+		require.True(t, collateEq)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64667

Problem Summary:
It is needed to restore privileges tables backed up from v6.5 to newly created v7.2+ clusters.
### What changed and how does it work?
permit to restore privileges tables from v6.5 to v7.2+ if all the data have the same behavior in `utf8mb4_bin` and `utf8mb4_general_ci`.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
