### PR TITLE
ddl: temporarily disable lossy ddl optimization

### DIFF
--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -114,7 +114,7 @@ func getModifyColumnType(
 	args *model.ModifyColumnArgs,
 	tblInfo *model.TableInfo,
 	oldCol *model.ColumnInfo,
-	sqlMode mysql.SQLMode) byte {
+	_ mysql.SQLMode) byte {
 	newCol := args.Column
 	if noReorgDataStrict(tblInfo, oldCol, args.Column) {
 		// It's not NULL->NOTNULL change
@@ -1829,7 +1829,7 @@ func GetModifiableColumnJob(
 
 // noReorgDataStrict is a strong check to decide whether we need to change the column data.
 // If it returns true, it means we don't need the reorg no matter what the data is.
-func noReorgDataStrict(tblInfo *model.TableInfo, oldCol, newCol *model.ColumnInfo) bool {
+func noReorgDataStrict(_ *model.TableInfo, oldCol, newCol *model.ColumnInfo) bool {
 	toUnsigned := mysql.HasUnsignedFlag(newCol.GetFlag())
 	originUnsigned := mysql.HasUnsignedFlag(oldCol.GetFlag())
 	needTruncationOrToggleSign := func() bool {

--- a/pkg/ddl/modify_column_test.go
+++ b/pkg/ddl/modify_column_test.go
@@ -171,14 +171,13 @@ func TestModifyColumnNullToNotNullWithChangingVal2(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 
-	// insert null value before modifying column
-	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeDoModifyColumnSkipReorgCheck", func() {
-		tk2 := testkit.NewTestKit(t, store)
-		tk2.MustExec("insert into test.tt values (NULL, NULL)")
-	})
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/pkg/ddl/mockInsertValueAfterCheckNull", `return("insert into test.tt values (NULL, NULL)")`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/pkg/ddl/mockInsertValueAfterCheckNull"))
+	}()
 
 	tk.MustExec("drop table if exists tt;")
-	tk.MustExec(`create table tt (a bigint, b int);`)
+	tk.MustExec(`create table tt (a bigint, b int, unique index idx(a));`)
 	tk.MustExec("insert into tt values (1,1),(2,2),(3,3);")
 	err := tk.ExecToErr("alter table tt modify a int not null;")
 	require.EqualError(t, err, "[ddl:1138]Invalid use of NULL value")
@@ -258,8 +257,7 @@ func TestModifyColumnNullToNotNullWithChangingVal(t *testing.T) {
 			return
 		}
 		once.Do(func() {
-			// Insert null value to make modify column fail.
-			require.NoError(t, tk2.ExecToErr("insert into t1 values ()"))
+			checkErr = tk2.ExecToErr("insert into t1 values ()")
 		})
 	})
 	err := tk1.ExecToErr("alter table t1 change c2 c2 tinyint not null")
@@ -274,6 +272,7 @@ func TestModifyColumnNullToNotNullWithChangingVal(t *testing.T) {
 		require.EqualError(t, checkErr, "[table:1048]Column 'c2' cannot be null")
 	})
 	tk1.MustExec("alter table t1 change c2 c2 tinyint not null")
+	require.EqualError(t, checkErr, "[table:1048]Column 'c2' cannot be null")
 
 	c2 := external.GetModifyColumn(t, tk1, "test", "t1", "c2", false)
 	require.True(t, mysql.HasNotNullFlag(c2.GetFlag()))

--- a/pkg/ddl/tests/fail/fail_db_test.go
+++ b/pkg/ddl/tests/fail/fail_db_test.go
@@ -400,7 +400,7 @@ func TestModifyColumn(t *testing.T) {
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 	tk.MustExec("admin check table t")
 	tk.MustExec("insert into t values(111, 222, 333)")
-	tk.MustGetErrMsg("alter table t change column a aa tinyint after c", "[types:1265]Data truncated for column 'a', value is '222'")
+	tk.MustGetErrMsg("alter table t change column a aa tinyint after c", "[types:1690]constant 222 overflows tinyint")
 	tk.MustExec("alter table t change column a aa mediumint after c")
 	tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
 		"  `bb` mediumint(9) DEFAULT NULL,\n" +

--- a/tests/integrationtest/r/ddl/column_type_change.result
+++ b/tests/integrationtest/r/ddl/column_type_change.result
@@ -38,13 +38,13 @@ drop table if exists t;
 create table t (a bigint);
 insert into t(a) values (9223372036854775807);
 alter table t modify column a int;
-Error 1265 (01000): Data truncated for column 'a', value is '9223372036854775807'
+Error 1690 (22003): constant 9223372036854775807 overflows int
 alter table t modify column a mediumint;
-Error 1265 (01000): Data truncated for column 'a', value is '9223372036854775807'
+Error 1690 (22003): constant 9223372036854775807 overflows mediumint
 alter table t modify column a smallint;
-Error 1265 (01000): Data truncated for column 'a', value is '9223372036854775807'
+Error 1690 (22003): constant 9223372036854775807 overflows smallint
 alter table t modify column a tinyint;
-Error 1265 (01000): Data truncated for column 'a', value is '9223372036854775807'
+Error 1690 (22003): constant 9223372036854775807 overflows tinyint
 admin check table t;
 drop table if exists t;
 create table t(a tinyint, b smallint, c mediumint, d int, e bigint, f bigint);

--- a/tests/integrationtest/r/ddl/multi_schema_change.result
+++ b/tests/integrationtest/r/ddl/multi_schema_change.result
@@ -345,7 +345,7 @@ drop table if exists t;
 create table t (a BIGINT NULL DEFAULT '-283977870758975838', b double);
 insert into t values (-283977870758975838, 0);
 alter table t change column a c tinyint null default '111' after b, modify column b time null default '13:51:02' FIRST;
-Error 1265 (01000): Data truncated for column 'a', value is '-283977870758975838'
+Error 1690 (22003): constant -283977870758975838 overflows tinyint
 drop table if exists t;
 create table t(a int, b int);
 insert into t values (1, 2);

--- a/tests/integrationtest/t/ddl/column_type_change.test
+++ b/tests/integrationtest/t/ddl/column_type_change.test
@@ -38,13 +38,13 @@ alter table t modify column a tinyint;
 drop table if exists t;
 create table t (a bigint);
 insert into t(a) values (9223372036854775807);
--- error 1265
+-- error 1690
 alter table t modify column a int;
--- error 1265
+-- error 1690
 alter table t modify column a mediumint;
--- error 1265
+-- error 1690
 alter table t modify column a smallint;
--- error 1265
+-- error 1690
 alter table t modify column a tinyint;
 admin check table t;
 

--- a/tests/integrationtest/t/ddl/multi_schema_change.test
+++ b/tests/integrationtest/t/ddl/multi_schema_change.test
@@ -283,7 +283,7 @@ select count(distinct KEY_NAME) from information_schema.TIDB_INDEXES where TABLE
 drop table if exists t;
 create table t (a BIGINT NULL DEFAULT '-283977870758975838', b double);
 insert into t values (-283977870758975838, 0);
--- error 1265
+-- error 1690
 alter table t change column a c tinyint null default '111' after b, modify column b time null default '13:51:02' FIRST;
 drop table if exists t;
 create table t(a int, b int);


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/64671

Problem Summary:

For optimized lossy modify column, we change the column type in place, without creating a new column. So when collecting stats after reorg, we are still using the old type to calculate histogram and topN. Thus the stats collected is invalid, and it may cause worse estimation than using pseudo stats.

### What changed and how does it work?

Currently, we disable all lossy ddl optimization, and we will reopen it again after we find a good way to solve with stats problem.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test **remove newly added tests**
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test 
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
