### PR TITLE
plugin: add retry information in the plugin completed event.

### DIFF
--- a/pkg/executor/adapter.go
+++ b/pkg/executor/adapter.go
@@ -1381,6 +1381,7 @@ func (a *ExecStmt) logAudit() {
 			if execStmt, ok := a.StmtNode.(*ast.ExecuteStmt); ok {
 				ctx = context.WithValue(ctx, plugin.PrepareStmtIDCtxKey, execStmt.PrepStmtId)
 			}
+			ctx = context.WithValue(ctx, plugin.IsRetryingCtxKey, a.retryCount > 0 || sessVars.RetryInfo.Retrying)
 			if intest.InTest && (cmdBin == mysql.ComStmtPrepare ||
 				cmdBin == mysql.ComStmtExecute || cmdBin == mysql.ComStmtClose) {
 				intest.Assert(ctx.Value(plugin.PrepareStmtIDCtxKey) != nil, "prepare statement id should not be nil")

--- a/pkg/plugin/audit.go
+++ b/pkg/plugin/audit.go
@@ -131,3 +131,8 @@ type prepareStmtIDCtxKeyType struct{}
 
 // PrepareStmtIDCtxKey indicates the prepared statement ID.
 var PrepareStmtIDCtxKey = prepareStmtIDCtxKeyType{}
+
+type isRetryingCtx struct{}
+
+// IsRetryingCtxKey indicates whether the current execution is a retry.
+var IsRetryingCtxKey = isRetryingCtx{}

--- a/pkg/server/tests/commontest/BUILD.bazel
+++ b/pkg/server/tests/commontest/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//pkg/sessionctx/variable",
         "//pkg/store/mockstore/unistore",
         "//pkg/testkit",
+        "//pkg/testkit/testfailpoint",
         "//pkg/testkit/testsetup",
         "//pkg/util",
         "//pkg/util/plancodec",

--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/pingcap/tidb/pkg/sessionctx/variable"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/plancodec"
 	"github.com/pingcap/tidb/pkg/util/resourcegrouptag"
@@ -3652,5 +3653,165 @@ func TestAuditPluginInfoForStarting(t *testing.T) {
 		})
 
 		testResults = testResults[:0]
+	})
+}
+
+func TestAuditPluginRetrying(t *testing.T) {
+	ts := servertestkit.CreateTidbTestSuite(t)
+	type normalTest struct {
+		sql      string
+		retrying bool
+	}
+	testResults := make([]normalTest, 0)
+
+	onGeneralEvent := func(ctx context.Context, sctx *variable.SessionVars, event plugin.GeneralEvent, cmd string) {
+		// Only consider the Completed event
+		if event != plugin.Completed || cmd != "Query" {
+			return
+		}
+
+		audit := normalTest{}
+		if retrying := ctx.Value(plugin.IsRetryingCtxKey); retrying != nil {
+			audit.retrying = retrying.(bool)
+		}
+		audit.sql = sctx.StmtCtx.OriginalSQL
+		testResults = append(testResults, audit)
+	}
+	plugin.LoadPluginForTest(t, onGeneralEvent)
+	defer plugin.Shutdown(context.Background())
+
+	// We have these possible paths to retry:
+	// 1. Auto-commit retry
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		db := dbt.GetDB()
+
+		_, err := db.Exec("DROP TABLE IF EXISTS auto_retry_test")
+		require.NoError(t, err)
+		_, err = db.Exec("CREATE TABLE auto_retry_test (id INT PRIMARY KEY, val INT)")
+		require.NoError(t, err)
+		_, err = db.Exec("INSERT INTO auto_retry_test VALUES (1, 0)")
+		require.NoError(t, err)
+
+		testResults = testResults[:0]
+		// a big enough concurrency to trigger retries
+		concurrency := 500
+		var wg sync.WaitGroup
+		for range concurrency {
+			wg.Add(1)
+			conn, err := db.Conn(context.Background())
+			require.NoError(t, err)
+			go func() {
+				defer wg.Done()
+				_, err := conn.QueryContext(context.Background(), "UPDATE auto_retry_test SET val = val + 1 WHERE id = 1")
+				require.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+
+		require.Greater(t, len(testResults), concurrency)
+		nonRetryingCount := 0
+		for _, res := range testResults {
+			if !res.retrying {
+				nonRetryingCount++
+			}
+		}
+		require.Equal(t, concurrency, nonRetryingCount)
+	})
+
+	runExplicitTransactionRetry := func(db *sql.DB, isOptimistic bool) {
+		_, err := db.Exec("DROP TABLE IF EXISTS retry_test")
+		require.NoError(t, err)
+		_, err = db.Exec("CREATE TABLE retry_test (id INT PRIMARY KEY, val INT)")
+		require.NoError(t, err)
+		_, err = db.Exec("INSERT INTO retry_test VALUES (1, 0)")
+		require.NoError(t, err)
+
+		step1T1Started := make(chan struct{})
+		step2T2Committed := make(chan struct{})
+
+		connect := func() *sql.Conn {
+			conn, err := db.Conn(context.Background())
+			require.NoError(t, err)
+			if isOptimistic {
+				_, err = conn.ExecContext(context.Background(), "SET tidb_txn_mode = 'optimistic'")
+				require.NoError(t, err)
+				// We cannot set `tidb_disable_txn_auto_retry` to `OFF` because it's already deprecated.
+				// For the test, we just use failpoint to workaround this limitation.
+				testfailpoint.Enable(t, "github.com/pingcap/tidb/pkg/sessiontxn/isolation/injectOptimisticTxnRetryable", "return(true)")
+			}
+
+			return conn
+		}
+
+		testResults = testResults[:0]
+		var wg sync.WaitGroup
+		wg.Add(2)
+		// Transaction 1
+		go func() {
+			defer wg.Done()
+			conn := connect()
+			defer conn.Close()
+
+			_, err = conn.ExecContext(context.Background(), "BEGIN")
+			require.NoError(t, err)
+			close(step1T1Started)
+			<-step2T2Committed
+			_, err = conn.ExecContext(context.Background(), "UPDATE retry_test SET val = val + 10 WHERE id = 1")
+			require.NoError(t, err)
+			_, err = conn.ExecContext(context.Background(), "COMMIT")
+			require.NoError(t, err)
+		}()
+		// Transaction 2
+		go func() {
+			defer wg.Done()
+			<-step1T1Started
+			conn := connect()
+			defer conn.Close()
+
+			_, err = conn.ExecContext(context.Background(), "BEGIN")
+			require.NoError(t, err)
+			_, err = conn.ExecContext(context.Background(), "UPDATE retry_test SET val = val + 20 WHERE id = 1")
+			require.NoError(t, err)
+			_, err = conn.ExecContext(context.Background(), "COMMIT")
+			require.NoError(t, err)
+
+			close(step2T2Committed)
+		}()
+		wg.Wait()
+
+		retryingCount := 0
+		nonRetryingCount := 0
+		for _, res := range testResults {
+			if res.retrying {
+				retryingCount++
+			} else {
+				nonRetryingCount++
+			}
+		}
+
+		require.Greater(t, retryingCount, 0)
+		// (BEGIN + UPDATE + COMMIT) * 2 transactions = 6
+		expectedSQLCount := 6
+		if isOptimistic {
+			expectedSQLCount += 2 // extra `SET` variable SQL
+		}
+		require.Equal(t, expectedSQLCount, nonRetryingCount)
+	}
+
+	// 2. Pessimistic DML retry
+	// Ref `handleAfterPessimisticLockError` for RC and RR
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		db := dbt.GetDB()
+
+		runExplicitTransactionRetry(db, false)
+	})
+
+	// 3. Optimistic transaction commit retry
+	// This branch is already deprecated. If we remove it in the future, this test can be removed too.
+	ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
+		db := dbt.GetDB()
+
+		testResults = testResults[:0]
+		runExplicitTransactionRetry(db, true)
 	})
 }

--- a/pkg/sessiontxn/isolation/optimistic.go
+++ b/pkg/sessiontxn/isolation/optimistic.go
@@ -17,6 +17,7 @@ package isolation
 import (
 	"math"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	plannercore "github.com/pingcap/tidb/pkg/planner/core"
@@ -52,6 +53,9 @@ func (p *OptimisticTxnContextProvider) onTxnActive(
 ) {
 	sessVars := p.sctx.GetSessionVars()
 	sessVars.TxnCtx.CouldRetry = isOptimisticTxnRetryable(sessVars, tp, txn.IsPipelined())
+	failpoint.Inject("injectOptimisticTxnRetryable", func(val failpoint.Value) {
+		sessVars.TxnCtx.CouldRetry = val.(bool)
+	})
 }
 
 // isOptimisticTxnRetryable (if returns true) means the transaction could retry.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64691

Problem Summary:

1. The general event doesn't have enough information to decide whether this statement is retrying.

### What changed and how does it work?

1. Add a new context key for plugin.
2. The value is `true` iff the statement is a retry.

I've tested three cases:

1. Optimistic commit retry.
2. Pessimistic DML retry.
3. Auto-commit retry.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
