### PR TITLE
planner: fix incorrect `TblColPosInfo` calculation in `buildDelete` after column pruning

### DIFF
--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -5265,7 +5265,7 @@ func pruneAndBuildColPositionInfoForDelete(
 			}
 		}
 		if skipPruning {
-			err = buildSingleTableColPosInfoForDelete(tbl, cols2PosInfo)
+			err = buildSingleTableColPosInfoForDelete(tbl, cols2PosInfo, prunedColCnt)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -5296,12 +5296,13 @@ func initColPosInfo(tid int64, names []*types.FieldName, handleCol util.HandleCo
 
 // buildSingleTableColPosInfoForDelete builds columns mapping for delete without pruning any columns.
 // It's temp code path for partition table, foreign key and point get plan.
-func buildSingleTableColPosInfoForDelete(
-	tbl table.Table,
-	colPosInfo *physicalop.TblColPosInfo,
-) error {
+func buildSingleTableColPosInfoForDelete(tbl table.Table, colPosInfo *physicalop.TblColPosInfo, prePrunedCount int) error {
 	tblLen := len(tbl.DeletableCols())
+	colPosInfo.Start -= prePrunedCount
 	colPosInfo.End = colPosInfo.Start + tblLen
+	for col := range colPosInfo.HandleCols.IterColumns() {
+		col.Index -= prePrunedCount
+	}
 	return nil
 }
 

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1340,7 +1340,7 @@ func buildPointDeletePlan(ctx base.PlanContext, pointPlan base.PhysicalPlan, dbN
 	if err != nil {
 		return nil
 	}
-	err = buildSingleTableColPosInfoForDelete(t, &colPosInfo)
+	err = buildSingleTableColPosInfoForDelete(t, &colPosInfo, 0)
 	if err != nil {
 		return nil
 	}

--- a/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
+++ b/tests/integrationtest/r/planner/core/issuetest/planner_issue.result
@@ -1422,3 +1422,10 @@ select @@global.tidb_stmt_summary_max_sql_length;
 32768
 set global tidb_enable_stmt_summary = DEFAULT;
 set global tidb_stmt_summary_refresh_interval = DEFAULT;
+drop table if exists t1, t2;
+create table t1(a int, b int);
+create table t2(a int, b int) partition by hash(a) partitions 2;
+insert into t1 value(1,1);
+insert into t2 value(1,1);
+delete t1, t2 from t1, t2 where t1.a = t2.a;
+drop table t1, t2;

--- a/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
+++ b/tests/integrationtest/t/planner/core/issuetest/planner_issue.test
@@ -851,3 +851,13 @@ set global tidb_stmt_summary_max_sql_length = DEFAULT;
 select @@global.tidb_stmt_summary_max_sql_length;
 set global tidb_enable_stmt_summary = DEFAULT;
 set global tidb_stmt_summary_refresh_interval = DEFAULT;
+
+
+# Issue64697
+drop table if exists t1, t2;
+create table t1(a int, b int);
+create table t2(a int, b int) partition by hash(a) partitions 2;
+insert into t1 value(1,1);
+insert into t2 value(1,1);
+delete t1, t2 from t1, t2 where t1.a = t2.a;
+drop table t1, t2;


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #64697

Problem Summary:

When one `DELETE` statement involves multiple tables, the calculation of `TblColPosInfo` is incorrect. When earlier tables are pruned, later tables need to adjust `TblColPosInfo.Start` and `Column.Index` of handle columns accordingly, but this is only done for the `!skipPruning` case, not for the `skipPruning` case.

### What changed and how does it work?

Adjust `TblColPosInfo.Start` and `Column.Index` of handle columns using `prunedColCnt` for the `skipPruning` case, which is implemented in `buildSingleTableColPosInfoForDelete()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
