### PR TITLE
executor: record the wrong sql when to load bindings with plan replayer

### DIFF
--- a/pkg/executor/plan_replayer.go
+++ b/pkg/executor/plan_replayer.go
@@ -356,6 +356,7 @@ func loadBindings(ctx sessionctx.Context, f *zip.File, isSession bool) error {
 			c := context.Background()
 			_, err = ctx.GetSQLExecutor().Execute(c, sql)
 			if err != nil {
+				logutil.BgLogger().Warn("load bindings failed", zap.Error(err), zap.String("sql", sql))
 				return err
 			}
 		}
@@ -501,7 +502,6 @@ func (e *PlanReplayerLoadInfo) Update(data []byte) error {
 
 	err = loadAllBindings(e.Ctx, z)
 	if err != nil {
-		logutil.BgLogger().Warn("load bindings failed", zap.Error(err))
 		e.Ctx.GetSessionVars().StmtCtx.AppendWarning(fmt.Errorf("load bindings failed, err:%v", err))
 	}
 	return nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64737

Problem Summary:

### What changed and how does it work?

Improve the log to find the bug. It is only for the plan replayer. so it is safe.

<img width="901" height="220" alt="image" src="https://github.com/user-attachments/assets/80a79eb9-6ea6-4102-878d-028f766f9231" />


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
