### PR TITLE
ddl: correct the errno of database read only | tidb-test=release-8.5.2

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -2871,14 +2871,14 @@ error = '''
 Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
 '''
 
-["schema:3809"]
-error = '''
-Schema '%s' is in read only mode.
-'''
-
 ["schema:3822"]
 error = '''
 Duplicate check constraint name '%s'.
+'''
+
+["schema:3989"]
+error = '''
+Schema '%s' is in read only mode.
 '''
 
 ["schema:4139"]

--- a/pkg/ddl/schema_test.go
+++ b/pkg/ddl/schema_test.go
@@ -578,7 +578,7 @@ func TestSchemaReadOnlyAffectAllUsers(t *testing.T) {
 		tk.MustExec(fmt.Sprintf("create user '%s'@'%%'", tc.user))
 		tk.MustExec(fmt.Sprintf("grant %s on *.* to '%s'@'%%'", tc.priv, tc.user))
 		require.NoError(t, se.Auth(&auth.UserIdentity{Username: tc.user, Hostname: "%"}, nil, nil, nil))
-		tk.MustGetErrMsg("insert into test.t values (1)", "[schema:3809]Schema 'test' is in read only mode.")
+		tk.MustGetErrMsg("insert into test.t values (1)", "[schema:3989]Schema 'test' is in read only mode.")
 	}
 	tk.MustExec("alter database test read only = 0")
 	for _, tc := range tcs {
@@ -691,7 +691,7 @@ func TestReadOnlyInMiddleState(t *testing.T) {
 	dbInfo, ok := is.SchemaByName(pmodel.NewCIStr("test_db"))
 	require.True(t, ok)
 	require.True(t, dbInfo.ReadOnly)
-	tk3.MustGetErrMsg("insert into test_db.t values (1)", "[schema:3809]Schema 'test_db' is in read only mode.")
+	tk3.MustGetErrMsg("insert into test_db.t values (1)", "[schema:3989]Schema 'test_db' is in read only mode.")
 	tk1.MustExec("commit")
 	wg.Wait()
 }

--- a/pkg/errno/errcode.go
+++ b/pkg/errno/errcode.go
@@ -920,7 +920,6 @@ const (
 	ErrDefValGeneratedNamedFunctionIsNotAllowed              = 3770
 	ErrFKIncompatibleColumns                                 = 3780
 	ErrFunctionalIndexRowValueIsNotAllowed                   = 3800
-	ErrSchemaInReadOnlyMode                                  = 3809
 	ErrNonBooleanExprForCheckConstraint                      = 3812
 	ErrColumnCheckConstraintReferencesOtherColumn            = 3813
 	ErrCheckConstraintNamedFunctionIsNotAllowed              = 3814
@@ -944,6 +943,7 @@ const (
 	ErUserAccessDeniedForUserAccountBlockedByPasswordLock    = 3955
 	ErrDependentByCheckConstraint                            = 3959
 	ErrJSONInBooleanContext                                  = 3986
+	ErrSchemaInReadOnlyMode                                  = 3989
 	ErrTableWithoutPrimaryKey                                = 3750
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed         = 4030

--- a/tests/integrationtest/r/ddl/db_read_only.result
+++ b/tests/integrationtest/r/ddl/db_read_only.result
@@ -67,98 +67,98 @@ def	sys
 def	test	
 alter schema db_read_only read only 1;
 alter database db_read_only charset gbk;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter database db_read_only collate utf8mb4_roman_ci;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create placement policy p1 followers=4;
 alter database db_read_only placement policy p1;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter database db_read_only set tiflash replica 1;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 drop database db_read_only;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create table t1(c1 int);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create table t2 like t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create table pt (a int, b int) partition by hash(a) partitions 4;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create temporary table t1(a int);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create global temporary table t1(a int) on commit delete rows;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t add column cc int not null;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t add index (a);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create index c1 on t(a);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t alter index b invisible;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t change column c c varchar(10);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t drop column c;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t drop index b;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 drop index b on t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t modify column c varchar(10);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t rename index b to b_1;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t drop foreign key fk_a;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t add foreign key fk_a1(b) references s(a);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t add foreign key fk_a2(b) references db_read_only_1.s(a);
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t partition by hash(a) partitions 4;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table members drop partition p1990;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table members truncate partition p1980;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table members add partition (partition `p1990to2010` values less than (2010));
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table members reorganize partition `p1990to2010` into
 (partition p1990 values less than (2000),
 partition p2000 values less than (2010),
 partition p2010 values less than (2020),
 partition p2020 values less than (2030),
 partition pMax values less than (maxvalue));
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 rename table t to t_old;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 rename table db_read_only.t to db_read_only_1.t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter schema db_read_only read only 0;
 alter schema db_read_only_1 read only 1;
 rename table db_read_only.t to db_read_only_1.t;
-Error 3809 (HY000): Schema 'db_read_only_1' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only_1' is in read only mode.
 alter schema db_read_only read only 1;
 truncate table t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 truncate table temp;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 drop table t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 drop table temp;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 drop table temp_global;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 drop view v1;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 load data local infile '' into table t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 import into t from '';
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create view v as select * from t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 create or replace view v as select * from t;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t auto_increment = 10000;
-Error 3809 (HY000): Schema 'db_read_only' is in read only mode.
+Error 3989 (HY000): Schema 'db_read_only' is in read only mode.
 alter table t compact tiflash replica;
 alter schema db_read_only read only 0;
 alter schema db_read_only_1 read only 0;
@@ -194,99 +194,99 @@ insert into db1.child_3 values (3);
 alter schema db1 read only 1;
 use db1;
 insert into t1 values(1, 1);
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 insert into t1 select * from t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 insert into db2.t1 select * from t1; # pass
 insert into t1 table t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 insert into t1 set a=1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 insert into temp values (1);
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 replace into t1 values (1, 2);
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 replace into t1 table t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 replace t1 set a = default;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 replace into temp values (1);
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from t1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from temp where a = 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete t1, t2 from t1, t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete db1.t1, db2.t2 from db1.t1, db2.t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete t1,t2,t3 from t1, t2, t3 where t3.a < 5 and t1.a = 3;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete t2 from t1, t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete db2.t2 from db1.t1, db2.t2;
 delete db1.t1 from db1.t1, db2.t2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete t1 from t1, t1 as t2 where t1.b = t2.b and t1.a > t2.a;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from t1,t2,t3 using t1,t2,t3 where t3.a = 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from t1,db2.t2,db2.t3 using t1,db2.t2,db2.t3 where db2.t3.a = 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from t2,t3 using t1,t2,t3 where t1.a = 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from t2,db2.t3 using t1,t2,db2.t3 where t1.a = 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 with cte as (select * from t1) delete from t2 where t2.a in (select a from cte);
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 update t1 set a = a + 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 update temp set a = 1;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 update t1, t2 set t1.a = 1, t2.a = 1 where t1.a = t2.a;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 update t1 join db2.t2 set t1.a=1 where t1.b=db2.t2.b;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 analyze table t1; #pass
 with cte as (select * from t1) update t2 set a = 1 where t2.a in (select a from cte);
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on delete restrict;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on update restrict;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on delete cascade;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on update cascade;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on delete set null;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on update set null;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1 for update;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1 for update of t1 nowait;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1 for update of t1 wait 5;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1 join t2 on t1.a= t2.a for update;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select t1.a from t1 join t2 on t1.a= t2.a for update;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 table t1 for update;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 set @@session.tidb_enable_shared_lock_promotion = 1;
 select * from t1 for share;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1 for share nowait;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1 join t2 on t1.a= t2.a for share;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select t1.a from t1 join t2 on t1.a= t2.a for share;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 table t1 for share;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from temp for update;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 select * from t1;
 id	a
 select * from t1 join t2 on t1.a= t2.a;
@@ -294,13 +294,13 @@ id	a	id	a
 table t1;
 id	a
 delete from db2.parent_0;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 update db2.parent_1 set id_0 = 10;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 delete from db2.parent_2;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 update db2.parent_3 set id_3 = 10;
-Error 3809 (HY000): Schema 'db1' is in read only mode.
+Error 3989 (HY000): Schema 'db1' is in read only mode.
 alter schema db1 read only 0;
 drop database if exists read_only;
 create database read_only;
@@ -321,29 +321,29 @@ set @a = 1;
 set @b = 2;
 alter schema read_only read only 1;
 prepare stmt from 'insert into t1 values(?, ?)';  # different from mysql, mysql allows prepare in read only mode
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
-execute stmt_insert using @a, @b; # error 3809 is wrapped by prepare/execute as 8113
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
+execute stmt_insert using @a, @b; # error 3989 is wrapped by prepare/execute as 8113
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_update using @b, @a;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_delete using @a;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_select_for_update using @a;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_select using @a;
 a	b
 execute stmt_truncate;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_drop_database;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_alter_database;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_create_table;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_drop_table;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 execute stmt_alter_table;
-Error 8113 (HY000): Schema change caused error: [schema:3809]Schema 'read_only' is in read only mode.
+Error 8113 (HY000): Schema change caused error: [schema:3989]Schema 'read_only' is in read only mode.
 alter schema read_only read only 0;
 set @a = 1;
 execute stmt_select using @a;
@@ -409,23 +409,23 @@ SET tidb_enable_non_prepared_plan_cache = OFF;
 alter schema read_only read only 1;
 create binding for select * from t1 where b = 1 using select /*+ use_index(t1, idx_b) */ * from t1 where b = 1;
 create binding for update t1 set b = 2 where a = 1 using update /*+ use_index(t1, idx_b) */ t1 set b = 2 where a = 1;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 create binding for delete from t1 where a = 1 using delete /*+ use_index(t1, idx_b) */ from t1 where a = 1;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain select * from t1 where b = 1 for update;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain insert into t1 values(1, 2);
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain update t1 set b = 2 where a = 1;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain delete from t1 where a = 1;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain analyze select * from t1 where b = 1 for update;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain analyze insert into t1 values(1, 2);
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain analyze update t1 set b = 2 where a = 1;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 explain analyze delete from t1 where a = 1;
-Error 3809 (HY000): Schema 'read_only' is in read only mode.
+Error 3989 (HY000): Schema 'read_only' is in read only mode.
 alter schema read_only read only 0;

--- a/tests/integrationtest/t/ddl/db_read_only.test
+++ b/tests/integrationtest/t/ddl/db_read_only.test
@@ -38,66 +38,66 @@ select * from information_schema.schemata_extensions;
 alter schema db_read_only read only 1;
 
 # alter database
--- error 3809
+-- error 3989
 alter database db_read_only charset gbk;
--- error 3809
+-- error 3989
 alter database db_read_only collate utf8mb4_roman_ci;
 create placement policy p1 followers=4;
--- error 3809
+-- error 3989
 alter database db_read_only placement policy p1;
--- error 3809
+-- error 3989
 alter database db_read_only set tiflash replica 1;
--- error 3809
+-- error 3989
 drop database db_read_only;
 
 # create table
--- error 3809
+-- error 3989
 create table t1(c1 int);
--- error 3809
+-- error 3989
 create table t2 like t;
--- error 3809
+-- error 3989
 create table pt (a int, b int) partition by hash(a) partitions 4;
--- error 3809
+-- error 3989
 create temporary table t1(a int);
--- error 3809
+-- error 3989
 create global temporary table t1(a int) on commit delete rows;
 
 # alter table
--- error 3809
+-- error 3989
 alter table t add column cc int not null;
--- error 3809
+-- error 3989
 alter table t add index (a);
--- error 3809
+-- error 3989
 create index c1 on t(a);
--- error 3809
+-- error 3989
 alter table t alter index b invisible;
--- error 3809
+-- error 3989
 alter table t change column c c varchar(10);
--- error 3809
+-- error 3989
 alter table t drop column c;
--- error 3809
+-- error 3989
 alter table t drop index b;
--- error 3809
+-- error 3989
 drop index b on t;
--- error 3809
+-- error 3989
 alter table t modify column c varchar(10);
--- error 3809
+-- error 3989
 alter table t rename index b to b_1;
--- error 3809
+-- error 3989
 alter table t drop foreign key fk_a;
--- error 3809
+-- error 3989
 alter table t add foreign key fk_a1(b) references s(a);
--- error 3809
+-- error 3989
 alter table t add foreign key fk_a2(b) references db_read_only_1.s(a);
--- error 3809
+-- error 3989
 alter table t partition by hash(a) partitions 4;
--- error 3809
+-- error 3989
 alter table members drop partition p1990;
--- error 3809
+-- error 3989
 alter table members truncate partition p1980;
--- error 3809
+-- error 3989
 alter table members add partition (partition `p1990to2010` values less than (2010));
--- error 3809
+-- error 3989
 alter table members reorganize partition `p1990to2010` into
 (partition p1990 values less than (2000),
  partition p2000 values less than (2010),
@@ -106,40 +106,40 @@ alter table members reorganize partition `p1990to2010` into
  partition pMax values less than (maxvalue));
 
 # rename table
--- error 3809
+-- error 3989
 rename table t to t_old;
 # db_read_only is read only
--- error 3809
+-- error 3989
 rename table db_read_only.t to db_read_only_1.t;
 # db_read_only_1 is read only
 alter schema db_read_only read only 0;
 alter schema db_read_only_1 read only 1;
--- error 3809
+-- error 3989
 rename table db_read_only.t to db_read_only_1.t;
 alter schema db_read_only read only 1;
 
 # truncate/drop table and view, load data, import, create/replace view, alter table auto_increment
--- error 3809
+-- error 3989
 truncate table t;
--- error 3809
+-- error 3989
 truncate table temp;
--- error 3809
+-- error 3989
 drop table t;
--- error 3809
+-- error 3989
 drop table temp;
--- error 3809
+-- error 3989
 drop table temp_global;
--- error 3809
+-- error 3989
 drop view v1;
--- error 3809
+-- error 3989
 load data local infile '' into table t;
--- error 3809
+-- error 3989
 import into t from '';
--- error 3809
+-- error 3989
 create view v as select * from t;
--- error 3809
+-- error 3989
 create or replace view v as select * from t;
--- error 3809
+-- error 3989
 alter table t auto_increment = 10000;
 
 # DDL can be executed in read-only mode
@@ -187,110 +187,110 @@ alter schema db1 read only 1;
 use db1;
 
 # insert
--- error 3809
+-- error 3989
 insert into t1 values(1, 1);
--- error 3809
+-- error 3989
 insert into t1 select * from t2;
 insert into db2.t1 select * from t1; # pass
--- error 3809
+-- error 3989
 insert into t1 table t2;
--- error 3809
+-- error 3989
 insert into t1 set a=1;
--- error 3809
+-- error 3989
 insert into temp values (1);
 
 # replace
--- error 3809
+-- error 3989
 replace into t1 values (1, 2);
--- error 3809
+-- error 3989
 replace into t1 table t2;
--- error 3809
+-- error 3989
 replace t1 set a = default;
--- error 3809
+-- error 3989
 replace into temp values (1);
 
 # delete
--- error 3809
+-- error 3989
 delete from t1;
--- error 3809
+-- error 3989
 delete from temp where a = 1;
--- error 3809
+-- error 3989
 delete t1, t2 from t1, t2;
--- error 3809
+-- error 3989
 delete db1.t1, db2.t2 from db1.t1, db2.t2;
--- error 3809
+-- error 3989
 delete t1,t2,t3 from t1, t2, t3 where t3.a < 5 and t1.a = 3;
--- error 3809
+-- error 3989
 delete t2 from t1, t2;
 delete db2.t2 from db1.t1, db2.t2;
--- error 3809
+-- error 3989
 delete db1.t1 from db1.t1, db2.t2;
--- error 3809
+-- error 3989
 delete t1 from t1, t1 as t2 where t1.b = t2.b and t1.a > t2.a;
--- error 3809
+-- error 3989
 delete from t1,t2,t3 using t1,t2,t3 where t3.a = 1;
--- error 3809
+-- error 3989
 delete from t1,db2.t2,db2.t3 using t1,db2.t2,db2.t3 where db2.t3.a = 1;
--- error 3809
+-- error 3989
 delete from t2,t3 using t1,t2,t3 where t1.a = 1;
--- error 3809
+-- error 3989
 delete from t2,db2.t3 using t1,t2,db2.t3 where t1.a = 1;
--- error 3809
+-- error 3989
 with cte as (select * from t1) delete from t2 where t2.a in (select a from cte);
 
 # update
--- error 3809
+-- error 3989
 update t1 set a = a + 1;
--- error 3809
+-- error 3989
 update temp set a = 1;
--- error 3809
+-- error 3989
 update t1, t2 set t1.a = 1, t2.a = 1 where t1.a = t2.a;
--- error 3809
+-- error 3989
 update t1 join db2.t2 set t1.a=1 where t1.b=db2.t2.b;
 analyze table t1; #pass
--- error 3809
+-- error 3989
 with cte as (select * from t1) update t2 set a = 1 where t2.a in (select a from cte);
 
 # modify columns with foreign key
--- error 3809
+-- error 3989
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on delete restrict;
--- error 3809
+-- error 3989
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on update restrict;
--- error 3809
+-- error 3989
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on delete cascade;
--- error 3809
+-- error 3989
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on update cascade;
--- error 3809
+-- error 3989
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on delete set null;
--- error 3809
+-- error 3989
 alter table t1 add constraint fk_1 foreign key (id) references t2(id) on update set null;
--- error 3809
+-- error 3989
 
 # for update / for share + tidb_enable_shared_lock_promotion
--- error 3809
+-- error 3989
 select * from t1 for update;
--- error 3809
+-- error 3989
 select * from t1 for update of t1 nowait;
--- error 3809
+-- error 3989
 select * from t1 for update of t1 wait 5;
--- error 3809
+-- error 3989
 select * from t1 join t2 on t1.a= t2.a for update;
--- error 3809
+-- error 3989
 select t1.a from t1 join t2 on t1.a= t2.a for update;
--- error 3809
+-- error 3989
 table t1 for update;
 set @@session.tidb_enable_shared_lock_promotion = 1;
--- error 3809
+-- error 3989
 select * from t1 for share;
--- error 3809
+-- error 3989
 select * from t1 for share nowait;
--- error 3809
+-- error 3989
 select * from t1 join t2 on t1.a= t2.a for share;
--- error 3809
+-- error 3989
 select t1.a from t1 join t2 on t1.a= t2.a for share;
--- error 3809
+-- error 3989
 table t1 for share;
--- error 3809
+-- error 3989
 select * from temp for update;
 
 # select should be ok
@@ -299,13 +299,13 @@ select * from t1 join t2 on t1.a= t2.a;
 table t1;
 
 # fk, schema of child table is read only
--- error 3809
+-- error 3989
 delete from db2.parent_0;
--- error 3809
+-- error 3989
 update db2.parent_1 set id_0 = 10;
--- error 3809
+-- error 3989
 delete from db2.parent_2;
--- error 3809
+-- error 3989
 update db2.parent_3 set id_3 = 10;
 
 # finish test
@@ -331,10 +331,10 @@ set @a = 1;
 set @b = 2;
 alter schema read_only read only 1;
 
--- error 3809
+-- error 3989
 prepare stmt from 'insert into t1 values(?, ?)';  # different from mysql, mysql allows prepare in read only mode
 -- error 8113
-execute stmt_insert using @a, @b; # error 3809 is wrapped by prepare/execute as 8113
+execute stmt_insert using @a, @b; # error 3989 is wrapped by prepare/execute as 8113
 -- error 8113
 execute stmt_update using @b, @a;
 -- error 8113
@@ -406,27 +406,27 @@ SET tidb_enable_non_prepared_plan_cache = OFF;
 ## test create binding in read only mode
 alter schema read_only read only 1;
 create binding for select * from t1 where b = 1 using select /*+ use_index(t1, idx_b) */ * from t1 where b = 1;
--- error 3809
+-- error 3989
 create binding for update t1 set b = 2 where a = 1 using update /*+ use_index(t1, idx_b) */ t1 set b = 2 where a = 1;
--- error 3809
+-- error 3989
 create binding for delete from t1 where a = 1 using delete /*+ use_index(t1, idx_b) */ from t1 where a = 1;
 
 ## test explain/explain analyze in read only mode
--- error 3809
+-- error 3989
 explain select * from t1 where b = 1 for update;
--- error 3809
+-- error 3989
 explain insert into t1 values(1, 2);
--- error 3809
+-- error 3989
 explain update t1 set b = 2 where a = 1;
--- error 3809
+-- error 3989
 explain delete from t1 where a = 1;
--- error 3809
+-- error 3989
 explain analyze select * from t1 where b = 1 for update;
--- error 3809
+-- error 3989
 explain analyze insert into t1 values(1, 2);
--- error 3809
+-- error 3989
 explain analyze update t1 set b = 2 where a = 1;
--- error 3809
+-- error 3989
 explain analyze delete from t1 where a = 1;
 
 alter schema read_only read only 0;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62122 

Problem Summary:

### What changed and how does it work?
It's my mistake use the error number `3809` of db read only which is incorrect and inconsistent with mysql 🤦‍♂️. Should follow mysql's `3989`:
```
mysql> alter schema test read only 1;
Query OK, 1 row affected (0.01 sec)

mysql> drop database test;
ERROR 3989 (HY000): Schema 'test' is in read only mode.
mysql> select version();
+-----------+
| version() |
+-----------+
| 8.0.31    |
+-----------+
1 row in set (0.00 sec)
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
