### PR TITLE
dxf: fix meter data overflow if we register recorder of the same task again after unregister

### DIFF
--- a/pkg/disttask/framework/metering/metering.go
+++ b/pkg/disttask/framework/metering/metering.go
@@ -184,7 +184,8 @@ func (m *Meter) cleanupUnregisteredRecorders() []*Recorder {
 			// some non-flushed data even the recorder is unregistered, so we check
 			// current data too.
 			if fd.equals(r.currData()) {
-				delete(m.recorders, r.taskID)
+				delete(m.recorders, taskID)
+				delete(m.lastFlushedData, taskID)
 				removed = append(removed, r.Recorder)
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #61702

Problem Summary:

### What changed and how does it work?
on unregister, we should remove it from lastFlushedData too
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
