### PR TITLE
tool: upgrade mysql-tester to show the diff  | tidb-test=pr/2637

### DIFF
--- a/tests/clusterintegrationtest/README.md
+++ b/tests/clusterintegrationtest/README.md
@@ -48,7 +48,7 @@ After changing `t` or changing optimizer plans, `r` need to be updated.
 
    ```shell
    # cd clusterintegrationtest
-   GOBIN=$(realpath .)/gobin go install github.com/pingcap/mysql-tester/src@314107b26aa8fce86beb0dd48e75827fb269b365
+   GOBIN=$(realpath .)/gobin go install github.com/pingcap/mysql-tester/src@12f37562a884a2d680d5ca619df80c8d0a080aff
    ./gobin/src -retry-connection-count 5 -record
    ```
 

--- a/tests/clusterintegrationtest/_include.sh
+++ b/tests/clusterintegrationtest/_include.sh
@@ -81,7 +81,7 @@ function start_tidb_fixed_version() {
 
 function build_mysql_tester() {
   echo "+ Installing mysql-tester"
-  GOBIN=$PWD go install github.com/pingcap/mysql-tester/src@0d83955ea569706e5296cd3e2f54efb7f1206d0b
+  GOBIN=$PWD go install github.com/pingcap/mysql-tester/src@12f37562a884a2d680d5ca619df80c8d0a080aff
   mv src mysql-tester
 }
 

--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -118,7 +118,7 @@ function build_mysql_tester()
 {
     echo "building mysql-tester binary: $mysql_tester"
     rm -rf $mysql_tester
-    GOBIN=$PWD go install github.com/pingcap/mysql-tester/src@0d83955ea569706e5296cd3e2f54efb7f1206d0b
+    GOBIN=$PWD go install github.com/pingcap/mysql-tester/src@12f37562a884a2d680d5ca619df80c8d0a080aff
     mv src mysql_tester
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What changed and how does it work?

When your result set changes significantly, it's not easy to directly discern the differences from the logs. I've modified the log format so that it can print the diff.

before

<img width="1273" height="371" alt="image" src="https://github.com/user-attachments/assets/0b671538-8964-4c70-b9b7-4cf37ffb5b99" />


after the improvement

<img width="1268" height="520" alt="image" src="https://github.com/user-attachments/assets/ccdefb7a-b473-440b-9a1b-793cf960a892" />


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
