### PR TITLE
executor: fix the order of printing TTL info in `show create table`

### DIFF
--- a/pkg/executor/show.go
+++ b/pkg/executor/show.go
@@ -1414,9 +1414,6 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *ast.CIStr,
 		fmt.Fprintf(buf, " /* CACHED ON */")
 	}
 
-	// add partition info here.
-	ddl.AppendPartitionInfo(tableInfo.Partition, buf, sqlMode)
-
 	if tableInfo.TTLInfo != nil {
 		restoreFlags := parserformat.RestoreStringSingleQuotes | parserformat.RestoreNameBackQuotes | parserformat.RestoreTiDBSpecialComment
 		restoreCtx := parserformat.NewRestoreCtx(restoreFlags, buf)
@@ -1471,6 +1468,9 @@ func constructResultOfShowCreateTable(ctx sessionctx.Context, dbName *ast.CIStr,
 			return err
 		}
 	}
+
+	// add partition info here.
+	ddl.AppendPartitionInfo(tableInfo.Partition, buf, sqlMode)
 	return nil
 }
 

--- a/tests/integrationtest/r/show.result
+++ b/tests/integrationtest/r/show.result
@@ -3,3 +3,13 @@ show tables like '%xx';
 Tables_in_show (%xx)
 show databases like '%xx';
 Database (%xx)
+drop table if exists t;
+create table t (id int, created_time datetime) TTL=created_time + interval 1 hour  partition by range columns(id) (partition p1 values less than (100));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int DEFAULT NULL,
+  `created_time` datetime DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![ttl] TTL=`created_time` + INTERVAL 1 HOUR */ /*T![ttl] TTL_ENABLE='ON' */ /*T![ttl] TTL_JOB_INTERVAL='24h' */
+PARTITION BY RANGE COLUMNS(`id`)
+(PARTITION `p1` VALUES LESS THAN (100))

--- a/tests/integrationtest/t/show.test
+++ b/tests/integrationtest/t/show.test
@@ -2,3 +2,8 @@ set tidb_cost_model_version=1;
 # test show output field name
 show tables like '%xx';
 show databases like '%xx';
+
+# test show TTL and Partition table
+drop table if exists t;
+create table t (id int, created_time datetime) TTL=created_time + interval 1 hour  partition by range columns(id) (partition p1 values less than (100));
+show create table t;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64876

Problem Summary:

The result of `show create table` of `TTL+PARTITION` table is not correct, which blocks the BR/CDC to synchronize the DDL event.

### What changed and how does it work?

1. Move the partition definition to the bottom part of the `show create table`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
