### PR TITLE
expression, planner: fix ambiguous column name in overflow error message

### DIFF
--- a/pkg/planner/core/expression_rewriter.go
+++ b/pkg/planner/core/expression_rewriter.go
@@ -2556,8 +2556,12 @@ func (er *expressionRewriter) toColumn(v *ast.ColumnName) {
 			er.err = plannererrors.ErrUnknownColumn.GenWithStackByArgs(v.Name, clauseMsg[er.clause()])
 			return
 		}
-		er.ctxStackAppend(&expression.Column{RetType: &colInfo.FieldType, ID: colInfo.ID, UniqueID: colInfo.ID},
-			&types.FieldName{ColName: v.Name})
+		er.ctxStackAppend(&expression.Column{
+			RetType:  &colInfo.FieldType,
+			ID:       colInfo.ID,
+			UniqueID: colInfo.ID,
+			OrigName: fmt.Sprintf("%s.%s", er.sourceTable.Name.L, colInfo.Name.L),
+		}, &types.FieldName{ColName: v.Name})
 		return
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #17993

Problem Summary:
When an arithmetic overflow occurs, the error message displays "Column#N" instead of the actual column name, making it difficult for users to identify which column caused the issue.

**Before:**
```sql
mysql> SELECT col3 from t5 where t5.col7 * ABS(-9223372036854775807);
ERROR 1690 (22003): BIGINT value is out of range in '(Column#0 * 9223372036854775807)'
```

**After:**
```sql
mysql> SELECT col3 from t5 where t5.col7 * ABS(-9223372036854775807);
ERROR 1690 (22003): BIGINT value is out of range in '(t5.col7 * 9223372036854775807)'
```

### What changed and how does it work?

The root cause is that the `OrigName` field of `Column` struct was not being set in certain code paths:

1. **`expression_rewriter.go`**: In the `toColumn()` function, when a column is resolved from table metadata directly (fallback path when `planCtx == nil`), the `OrigName` was not set.

2. **`task.go`**: In the `appendExpr()` function used for MPP projection columns, the `OrigName` was not set for newly created columns.

This fix ensures `OrigName` is properly set in both locations, so error messages display meaningful column names.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fix the issue that overflow error messages display "Column#N" instead of the actual column name, improving error message clarity for debugging.
```