### PR TITLE
sem: disable `IMPORT INTO ... FROM SELECT ... ` for semv2

### DIFF
--- a/pkg/executor/import_into_test.go
+++ b/pkg/executor/import_into_test.go
@@ -241,7 +241,7 @@ func testNextGenUnsupportedLocalSortAndOptions(t *testing.T, store kv.Storage, i
 		initFn(t, tk)
 		err := tk.ExecToErr("IMPORT INTO test.t FROM select 1")
 		require.ErrorIs(t, err, plannererrors.ErrNotSupportedWithSem)
-		require.Regexp(t, `IMPORT INTO .* select`, err.Error())
+		require.ErrorContains(t, err, "IMPORT INTO from select")
 	})
 
 	t.Run("local sort", func(t *testing.T) {

--- a/pkg/executor/importer/BUILD.bazel
+++ b/pkg/executor/importer/BUILD.bazel
@@ -74,7 +74,6 @@ go_library(
         "//pkg/util/logutil",
         "//pkg/util/naming",
         "//pkg/util/promutil",
-        "//pkg/util/sem",
         "//pkg/util/sem/compat",
         "//pkg/util/sqlexec",
         "//pkg/util/sqlkiller",

--- a/pkg/executor/importer/import.go
+++ b/pkg/executor/importer/import.go
@@ -69,7 +69,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/filter"
 	"github.com/pingcap/tidb/pkg/util/logutil"
 	"github.com/pingcap/tidb/pkg/util/naming"
-	semv1 "github.com/pingcap/tidb/pkg/util/sem"
 	sem "github.com/pingcap/tidb/pkg/util/sem/compat"
 	"github.com/pingcap/tidb/pkg/util/stringutil"
 	pd "github.com/tikv/pd/client"
@@ -693,14 +692,10 @@ func (p *Plan) initOptions(ctx context.Context, seCtx sessionctx.Context, option
 	}
 	p.specifiedOptions = specifiedOptions
 
-	// Only check `semv1.IsEnabled()` because in SEM v2, the statement will be limited by `RESTRICTED_SQL` configuration in
-	// `(b *PlanBuilder).Build`. `sql_rule.go` is used to define the highly customized SQL rules to filter these statements.
-	if kerneltype.IsNextGen() && semv1.IsEnabled() {
+	if kerneltype.IsNextGen() && sem.IsEnabled() {
 		if p.DataSourceType == DataSourceTypeQuery {
 			return plannererrors.ErrNotSupportedWithSem.GenWithStackByArgs("IMPORT INTO from select")
 		}
-	}
-	if kerneltype.IsNextGen() && sem.IsEnabled() {
 		// we put the check here, not in planner, to make sure the cloud_storage_uri
 		// won't change in between.
 		if p.IsLocalSort() {

--- a/pkg/util/sem/v2/sql_rule.go
+++ b/pkg/util/sem/v2/sql_rule.go
@@ -119,6 +119,10 @@ var SelectIntoFileRule SQLRule = func(stmt ast.StmtNode) bool {
 var ImportFromLocalRule SQLRule = func(stmt ast.StmtNode) bool {
 	switch stmt := stmt.(type) {
 	case *ast.ImportIntoStmt:
+		// Allow `IMPORT INTO ... FROM SELECT ...`, whose path is empty.
+		if stmt.Select != nil {
+			return false
+		}
 		u, err := url.Parse(stmt.Path)
 		if err != nil {
 			return false


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64983

Problem Summary:

Previously, the `IMPORT INTO FROM SELECT` is only forbidden when `semv1.IsEnabled()`. It'd be better to also avoid it when `sem.IsEnabled()`.

Magically, `IMPORT INTO FROM SELECT` is also protected by `import_from_local` rule 😆 , so we can actually use `import_from_local` to avoid this query. This PR is not necessary to be picked to other branches.

### What changed and how does it work?

1. Modify the `semv1.IsEnabled()` to `sem.IsEnabled()`.
2. Allow empty path in `import_from_local`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
