### PR TITLE
planner: Remove redundant null check in matchProperty function (dead code)

### DIFF
--- a/pkg/planner/core/find_best_task.go
+++ b/pkg/planner/core/find_best_task.go
@@ -1019,9 +1019,6 @@ func matchProperty(ds *logicalop.DataSource, path *util.AccessPath, prop *proper
 		return property.PropNotMatched
 	}
 	if prop.VectorProp.VSInfo != nil && path.Index != nil && path.Index.VectorInfo != nil {
-		if path.Index == nil || path.Index.VectorInfo == nil {
-			return property.PropNotMatched
-		}
 		if ds.TableInfo.Columns[path.Index.Columns[0].Offset].ID != prop.VectorProp.Column.ID {
 			return property.PropNotMatched
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64997

Problem Summary:
Remove redundant null check in `matchProperty` function. The outer condition already ensures `path.Index != nil && path.Index.VectorInfo != nil`, making the inner check unreachable dead code.

### What changed and how does it work?

Removed redundant null check on lines 1022-1024 in `pkg/planner/core/find_best_task.go`. The inner condition `if path.Index == nil || path.Index.VectorInfo == nil` can never be true because it's inside a block that already requires both `path.Index != nil` and `path.Index.VectorInfo != nil` to be true.

The fix simplifies the code by removing unreachable code, making the logic clearer and easier to maintain.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```

