### PR TITLE
tests: make some index lookup push down test stable

### DIFF
--- a/tests/integrationtest/r/executor/index_lookup_pushdown.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown.result
@@ -1,4 +1,5 @@
 drop table if exists t1, t2, t3, t4, t5, t6, t7, tmp1, tmp2;
+set @@tidb_scatter_region='table';
 create table t1(id int primary key, a varchar(32), b int, c int, index i(a, b));
 create table t2(a varchar(32), b int, c int, d int, e int, primary key(a, b) CLUSTERED, index i(c), unique index u(e)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table t3 (
@@ -472,3 +473,4 @@ id	a	b
 1	2	3
 Level	Code	Message
 Warning	1815	hint INDEX_LOOKUP_PUSHDOWN is inapplicable, only leader read is supported
+set @@tidb_scatter_region=default;

--- a/tests/integrationtest/r/executor/index_lookup_pushdown_partition.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown_partition.result
@@ -1,4 +1,5 @@
 drop table if exists tp1, tp2;
+set @@tidb_scatter_region='table';
 create table tp1 (a int primary key, b int, c int, key b(b), key c(c) global) partition by hash(a) partitions 4;
 insert into tp1 values (1, 10, 10), (2, 9, 20), (3, 8, 30), (4, 7, 40), (5, 6, 50), (6, 5, 60);
 explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 where b < 10 and a > 1 limit 3;
@@ -101,3 +102,4 @@ a	b	c
 2	9	20
 6	5	60
 3	8	30
+set @@tidb_scatter_region=default;

--- a/tests/integrationtest/t/executor/index_lookup_pushdown.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown.test
@@ -1,4 +1,8 @@
 drop table if exists t1, t2, t3, t4, t5, t6, t7, tmp1, tmp2;
+
+# wait regions split after create table to make the test stable
+set @@tidb_scatter_region='table';
+
 create table t1(id int primary key, a varchar(32), b int, c int, index i(a, b));
 create table t2(a varchar(32), b int, c int, d int, e int, primary key(a, b) CLUSTERED, index i(c), unique index u(e)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 create table t3 (
@@ -168,3 +172,6 @@ insert into t3 values(1, 2, 3);
 explain select /*+ index_lookup_pushdown(t3, a) */ * from t3 use index(a);
 select /*+ index_lookup_pushdown(t3, a) */ * from t3 use index(a);
 --disable_warnings
+
+# restore tidb_scatter_region
+set @@tidb_scatter_region=default;

--- a/tests/integrationtest/t/executor/index_lookup_pushdown_partition.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown_partition.test
@@ -1,5 +1,8 @@
 drop table if exists tp1, tp2;
 
+# wait regions split after create table to make the test stable
+set @@tidb_scatter_region='table';
+
 # int handle
 create table tp1 (a int primary key, b int, c int, key b(b), key c(c) global) partition by hash(a) partitions 4;
 insert into tp1 values (1, 10, 10), (2, 9, 20), (3, 8, 30), (4, 7, 40), (5, 6, 50), (6, 5, 60);
@@ -49,3 +52,6 @@ create table tp3 (a int, b int, c int, key b(b)) partition by hash(a) partitions
 insert into tp3 values (1, 10, 10), (2, 9, 20), (3, 8, 30), (4, 7, 40), (5, 6, 50), (6, 5, 60);
 explain select /*+ index_lookup_pushdown(tp3, b) */ * from tp3;
 select /*+ index_lookup_pushdown(tp3, b) */ * from tp3;
+
+# restore tidb_scatter_region
+set @@tidb_scatter_region=default;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62575

Problem Summary:

By default, the create table will split the region but will not wait for it to finish. It may cause some test cases to be unstable for the index lookup pushdown test .

### What changed and how does it work?

`set @@tidb_scatter_region='table';` before the index lookup pushdown test to make sure the create table statement will wait for the region split.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
