### PR TITLE
.gitignore: add files related to 'go work'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ test_coverage
 coverage.dat
 .specstory
 .golangci.bck.yml
+go.work
+go.work.sum


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
Problem Summary:

When I use `gopls` to find all references to a symbol in a submodule (for example, parser), it doesn't show the usages outside of the submodule. `go work` solves this issue (also restart `gopls`):

```
go work init
go work use .
go work use ./pkg/parser
```

These commands generate `go.work` and `go.work.sum`, which should not be tracked by the version-control system.

### What changed and how does it work?

Update `.gitignore`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
