### PR TITLE
ddl: reorg indexes only once for multi schema change

### DIFF
--- a/pkg/ddl/column.go
+++ b/pkg/ddl/column.go
@@ -543,6 +543,7 @@ func (w *worker) updatePhysicalTableRow(
 	t table.Table,
 	reorgInfo *reorgInfo,
 ) error {
+	failpoint.InjectCall("beforeUpdatePhysicalTableRow", reorgInfo.Job)
 	logutil.DDLLogger().Info("start to update table row", zap.Stringer("job", reorgInfo.Job), zap.Stringer("reorgInfo", reorgInfo))
 	if tbl, ok := t.(table.PartitionedTable); ok {
 		done := false
@@ -607,8 +608,7 @@ func (w *worker) modifyTableColumn(
 
 type updateColumnWorker struct {
 	*backfillCtx
-	oldColInfo *model.ColumnInfo
-	newColInfo *model.ColumnInfo
+	colPairs []updateColumnPair
 
 	// The following attributes are used to reduce memory allocation.
 	rowRecords []*rowRecord
@@ -619,18 +619,62 @@ type updateColumnWorker struct {
 	checksumNeeded bool
 }
 
+type updateColumnPair struct {
+	oldColInfo *model.ColumnInfo
+	newColInfo *model.ColumnInfo
+}
+
 func getOldAndNewColumnsForUpdateColumn(t table.Table, currElementID int64) (oldCol, newCol *model.ColumnInfo) {
+	colPairs := getOldAndNewColumnsForUpdateColumns(t, currElementID, false)
+	if len(colPairs) == 0 {
+		return nil, nil
+	}
+	return colPairs[0].oldColInfo, colPairs[0].newColInfo
+}
+
+func getOldAndNewColumnsForUpdateColumns(t table.Table, currElementID int64, allChanging bool) []updateColumnPair {
+	colPairs := make([]updateColumnPair, 0, 1)
+	if allChanging {
+		colPairs = make([]updateColumnPair, 0, len(t.WritableCols()))
+		for _, col := range t.WritableCols() {
+			if !col.IsChanging() {
+				continue
+			}
+			changingColumn := table.FindCol(t.Cols(), col.GetChangingOriginName())
+			if changingColumn == nil {
+				continue
+			}
+			colPairs = append(colPairs, updateColumnPair{
+				oldColInfo: changingColumn.ColumnInfo,
+				newColInfo: col.ColumnInfo,
+			})
+		}
+		slices.SortFunc(colPairs, func(a, b updateColumnPair) int {
+			switch {
+			case a.newColInfo.ID < b.newColInfo.ID:
+				return -1
+			case a.newColInfo.ID > b.newColInfo.ID:
+				return 1
+			default:
+				return 0
+			}
+		})
+		return colPairs
+	}
+
 	for _, col := range t.WritableCols() {
 		if col.ID == currElementID {
 			changingColumn := table.FindCol(t.Cols(), col.GetChangingOriginName())
 			if changingColumn != nil {
-				newCol = col.ColumnInfo
-				oldCol = changingColumn.ColumnInfo
-				return
+				colPairs = append(colPairs, updateColumnPair{
+					oldColInfo: changingColumn.ColumnInfo,
+					newColInfo: col.ColumnInfo,
+				})
+				return colPairs
 			}
 		}
 	}
-	return
+	return colPairs
 }
 
 func newUpdateColumnWorker(id int, t table.PhysicalTable, decodeColMap map[int64]decoder.Column, reorgInfo *reorgInfo, jc *ReorgContext) (*updateColumnWorker, error) {
@@ -644,7 +688,12 @@ func newUpdateColumnWorker(id int, t table.PhysicalTable, decodeColMap map[int64
 			zap.Stringer("reorgInfo", reorgInfo))
 		return nil, nil
 	}
-	oldCol, newCol := getOldAndNewColumnsForUpdateColumn(t, reorgInfo.currElement.ID)
+	colPairs := getOldAndNewColumnsForUpdateColumns(t, reorgInfo.currElement.ID, reorgInfo.Job.Type == model.ActionMultiSchemaChange)
+	if len(colPairs) == 0 {
+		logutil.DDLLogger().Error("old/new columns for updateColumnWorker not found",
+			zap.String("jobQuery", reorgInfo.Query), zap.Stringer("reorgInfo", reorgInfo))
+		return nil, nil
+	}
 	rowDecoder := decoder.NewRowDecoder(t, t.WritableCols(), decodeColMap)
 	failpoint.Inject("forceRowLevelChecksumOnUpdateColumnBackfill", func() {
 		orig := vardef.EnableRowLevelChecksum.Load()
@@ -653,10 +702,9 @@ func newUpdateColumnWorker(id int, t table.PhysicalTable, decodeColMap map[int64
 	})
 	return &updateColumnWorker{
 		backfillCtx:    bCtx,
-		oldColInfo:     oldCol,
-		newColInfo:     newCol,
+		colPairs:       colPairs,
 		rowDecoder:     rowDecoder,
-		rowMap:         make(map[int64]types.Datum, len(decodeColMap)),
+		rowMap:         make(map[int64]types.Datum, len(decodeColMap)+len(colPairs)),
 		checksumNeeded: vardef.EnableRowLevelChecksum.Load(),
 	}, nil
 }
@@ -744,49 +792,59 @@ func (w *updateColumnWorker) getRowRecord(handle kv.Handle, recordKey []byte, ra
 		return errors.Trace(dbterror.ErrCantDecodeRecord.GenWithStackByArgs("column", err))
 	}
 
-	if _, ok := w.rowMap[w.newColInfo.ID]; ok {
-		// The column is already added by update or insert statement, skip it.
-		w.cleanRowMap()
-		return nil
-	}
-
 	var recordWarning *terror.Error
-	// Since every updateColumnWorker handle their own work individually, we can cache warning in statement context when casting datum.
+	// Since every updateColumnWorker handles its own work individually, we can cache warning
+	// in statement context when casting datum.
 	oldWarn := w.warnings.GetWarnings()
 	if oldWarn == nil {
 		oldWarn = []contextutil.SQLWarn{}
 	} else {
 		oldWarn = oldWarn[:0]
 	}
-	w.warnings.SetWarnings(oldWarn)
-	val := w.rowMap[w.oldColInfo.ID]
-	col := w.newColInfo
-	if val.Kind() == types.KindNull && col.FieldType.GetType() == mysql.TypeTimestamp && mysql.HasNotNullFlag(col.GetFlag()) {
-		if v, err := expression.GetTimeCurrentTimestamp(w.exprCtx.GetEvalCtx(), col.GetType(), col.GetDecimal()); err == nil {
-			// convert null value to timestamp should be substituted with current timestamp if NOT_NULL flag is set.
-			w.rowMap[w.oldColInfo.ID] = v
+	hasChanged := false
+	for _, colPair := range w.colPairs {
+		if _, ok := w.rowMap[colPair.newColInfo.ID]; ok {
+			// This column is already added by update or insert statement, skip this pair.
+			continue
 		}
-	}
-	newColVal, err := table.CastColumnValue(w.exprCtx, w.rowMap[w.oldColInfo.ID], w.newColInfo, false, false)
-	if err != nil {
-		return w.reformatErrors(err)
-	}
-	warn := w.warnings.GetWarnings()
-	if len(warn) != 0 {
-		//nolint:forcetypeassert
-		recordWarning = errors.Cause(w.reformatErrors(warn[0].Err)).(*terror.Error)
-	}
 
-	failpoint.Inject("MockReorgTimeoutInOneRegion", func(val failpoint.Value) {
-		//nolint:forcetypeassert
-		if val.(bool) {
-			if handle.IntValue() == 3000 && atomic.CompareAndSwapInt32(&testCheckReorgTimeout, 0, 1) {
-				failpoint.Return(errors.Trace(dbterror.ErrWaitReorgTimeout))
+		w.warnings.SetWarnings(oldWarn[:0])
+		val := w.rowMap[colPair.oldColInfo.ID]
+		col := colPair.newColInfo
+		if val.Kind() == types.KindNull && col.FieldType.GetType() == mysql.TypeTimestamp && mysql.HasNotNullFlag(col.GetFlag()) {
+			if v, err := expression.GetTimeCurrentTimestamp(w.exprCtx.GetEvalCtx(), col.GetType(), col.GetDecimal()); err == nil {
+				// convert null value to timestamp should be substituted with current timestamp if NOT_NULL flag is set.
+				w.rowMap[colPair.oldColInfo.ID] = v
 			}
 		}
-	})
 
-	w.rowMap[w.newColInfo.ID] = newColVal
+		newColVal, err := table.CastColumnValue(w.exprCtx, w.rowMap[colPair.oldColInfo.ID], colPair.newColInfo, false, false)
+		if err != nil {
+			return w.reformatErrors(err, colPair)
+		}
+		warn := w.warnings.GetWarnings()
+		if len(warn) != 0 && recordWarning == nil {
+			//nolint:forcetypeassert
+			recordWarning = errors.Cause(w.reformatErrors(warn[0].Err, colPair)).(*terror.Error)
+		}
+
+		failpoint.Inject("MockReorgTimeoutInOneRegion", func(val failpoint.Value) {
+			//nolint:forcetypeassert
+			if val.(bool) {
+				if handle.IntValue() == 3000 && atomic.CompareAndSwapInt32(&testCheckReorgTimeout, 0, 1) {
+					failpoint.Return(errors.Trace(dbterror.ErrWaitReorgTimeout))
+				}
+			}
+		})
+
+		w.rowMap[colPair.newColInfo.ID] = newColVal
+		hasChanged = true
+	}
+	if !hasChanged {
+		w.cleanRowMap()
+		return nil
+	}
+
 	_, err = w.rowDecoder.EvalRemainedExprColumnMap(w.exprCtx, w.rowMap)
 	if err != nil {
 		return errors.Trace(err)
@@ -815,16 +873,16 @@ func (w *updateColumnWorker) getRowRecord(handle kv.Handle, recordKey []byte, ra
 }
 
 // reformatErrors casted error because `convertTo` function couldn't package column name and datum value for some errors.
-func (w *updateColumnWorker) reformatErrors(err error) error {
+func (w *updateColumnWorker) reformatErrors(err error, colPair updateColumnPair) error {
 	// Since row count is not precious in concurrent reorganization, here we substitute row count with datum value.
 	if types.ErrTruncated.Equal(err) || types.ErrDataTooLong.Equal(err) {
-		dStr := datumToStringNoErr(w.rowMap[w.oldColInfo.ID])
-		err = types.ErrTruncated.GenWithStack("Data truncated for column '%s', value is '%s'", w.oldColInfo.Name, dStr)
+		dStr := datumToStringNoErr(w.rowMap[colPair.oldColInfo.ID])
+		err = types.ErrTruncated.GenWithStack("Data truncated for column '%s', value is '%s'", colPair.oldColInfo.Name, dStr)
 	}
 
 	if types.ErrWarnDataOutOfRange.Equal(err) {
-		dStr := datumToStringNoErr(w.rowMap[w.oldColInfo.ID])
-		err = types.ErrWarnDataOutOfRange.GenWithStack("Out of range value for column '%s', the value is '%s'", w.oldColInfo.Name, dStr)
+		dStr := datumToStringNoErr(w.rowMap[colPair.oldColInfo.ID])
+		err = types.ErrWarnDataOutOfRange.GenWithStack("Out of range value for column '%s', the value is '%s'", colPair.oldColInfo.Name, dStr)
 	}
 	return err
 }

--- a/pkg/ddl/column_test.go
+++ b/pkg/ddl/column_test.go
@@ -946,5 +946,5 @@ func TestModifyColumnWithIndex(t *testing.T) {
 	tk.MustExec("alter table t modify column b int UNSIGNED")
 	require.Equal(t, 6, cnt)
 	tk.MustExec("alter table t modify column a varchar(2), modify column b int")
-	require.Equal(t, 18, cnt)
+	require.Equal(t, 15, cnt)
 }

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2008,6 +2008,7 @@ func (e *executor) multiSchemaChange(ctx sessionctx.Context, ti ast.Ident, info 
 		return errors.Trace(err)
 	}
 	mergeAddIndex(info)
+	mergeModifyColumn(info)
 	return e.DoDDLJob(ctx, job)
 }
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1196,6 +1196,7 @@ SwitchIndexState:
 			if done {
 				checkAndUpdateNeedAnalyze(job, tblInfo)
 			}
+			return ver, err
 		case model.AnalyzeStateRunning:
 			intest.Assert(job.MultiSchemaInfo == nil, "multi schema change shouldn't reach here")
 			w.startAnalyzeAndWait(job, tblInfo)

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1716,13 +1716,11 @@ func pickBackfillType(job *model.Job) (model.ReorgType, error) {
 		return model.ReorgTypeTxn, nil
 	}
 	if ingest.LitInitialized {
-		if job.ReorgMeta.UseCloudStorage {
-			job.ReorgMeta.ReorgTp = model.ReorgTypeIngest
-			return model.ReorgTypeIngest, nil
-		}
-		if err := ingest.LitDiskRoot.PreCheckUsage(); err != nil {
-			logutil.DDLIngestLogger().Info("ingest backfill is not available", zap.Error(err))
-			return model.ReorgTypeNone, err
+		if !job.ReorgMeta.UseCloudStorage {
+			if err := ingest.LitDiskRoot.PreCheckUsage(); err != nil {
+				logutil.DDLIngestLogger().Info("ingest backfill is not available", zap.Error(err))
+				return model.ReorgTypeNone, err
+			}
 		}
 		job.ReorgMeta.ReorgTp = model.ReorgTypeIngest
 		return model.ReorgTypeIngest, nil

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1186,18 +1186,15 @@ SwitchIndexState:
 
 		switch job.ReorgMeta.AnalyzeState {
 		case model.AnalyzeStateNone:
+			if job.MultiSchemaInfo != nil {
+				return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
+			}
+
 			// reorg the index data.
 			var done bool
 			done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, allIndexInfos)
-			if !done {
-				return ver, err
-			}
-			// For multi-schema change, analyze is done by parent job.
-			if job.MultiSchemaInfo == nil && checkNeedAnalyze(job, tblInfo) {
-				job.ReorgMeta.AnalyzeState = model.AnalyzeStateRunning
-			} else {
-				job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
-				checkAndMarkNonRevertible(job)
+			if done {
+				checkAndUpdateNeedAnalyze(job, tblInfo)
 			}
 		case model.AnalyzeStateRunning:
 			intest.Assert(job.MultiSchemaInfo == nil, "multi schema change shouldn't reach here")
@@ -1399,28 +1396,6 @@ func (w *worker) analyzeStatusDecision(job *model.Job, dbName, tblName string, s
 	default:
 		// analyzeUnknown: caller should proceed to start ANALYZE locally.
 		return false, false, false, true
-	}
-}
-
-// doAnalyzeWithoutReorg performs analyze for the table if needed without the logic of
-// reorg and and returns whether the table info is updated.
-func (w *worker) doAnalyzeWithoutReorg(job *model.Job, tblInfo *model.TableInfo) (finished bool) {
-	switch job.ReorgMeta.AnalyzeState {
-	case model.AnalyzeStateNone:
-		if checkNeedAnalyze(job, tblInfo) {
-			// Start analyze for the next time.
-			job.ReorgMeta.AnalyzeState = model.AnalyzeStateRunning
-		} else {
-			job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
-		}
-		return false
-	case model.AnalyzeStateRunning:
-		w.startAnalyzeAndWait(job, tblInfo)
-		return false
-	default:
-		logutil.DDLLogger().Info("analyze skipped or finished for multi-schema change",
-			zap.Int64("job", job.ID), zap.Int8("state", job.ReorgMeta.AnalyzeState))
-		return true
 	}
 }
 

--- a/pkg/ddl/index.go
+++ b/pkg/ddl/index.go
@@ -1187,7 +1187,7 @@ SwitchIndexState:
 		switch job.ReorgMeta.AnalyzeState {
 		case model.AnalyzeStateNone:
 			if job.MultiSchemaInfo != nil {
-				return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
+				return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job, job.ReorgMeta.Stage)
 			}
 
 			// reorg the index data.

--- a/pkg/ddl/ingest/backend_mgr.go
+++ b/pkg/ddl/ingest/backend_mgr.go
@@ -121,13 +121,7 @@ func (b *BackendCtxBuilder) Build(cfg *local.BackendConfig, bd *local.Backend) (
 	if err != nil {
 		return nil, err
 	}
-	intest.Assert(
-		job.Type == model.ActionAddPrimaryKey ||
-			job.Type == model.ActionAddIndex ||
-			job.Type == model.ActionModifyColumn ||
-			job.Type == model.ActionMultiSchemaChange,
-	)
-	intest.Assert(job.ReorgMeta != nil)
+	checkJobTypeForReorg(job)
 
 	failpoint.Inject("beforeCreateLocalBackend", func() {
 		ResignOwnerForTest.Store(true)
@@ -198,6 +192,14 @@ func genJobSortPath(jobID int64, checkDup bool) (string, error) {
 	return filepath.Join(sortPath, encodeBackendTag(jobID, checkDup)), nil
 }
 
+func checkJobTypeForReorg(job *model.Job) {
+	intest.Assert(job.Type == model.ActionAddPrimaryKey ||
+		job.Type == model.ActionAddIndex ||
+		job.Type == model.ActionModifyColumn ||
+		job.Type == model.ActionMultiSchemaChange)
+	intest.Assert(job.ReorgMeta != nil)
+}
+
 // CreateLocalBackend creates a local backend for adding index.
 func CreateLocalBackend(ctx context.Context, store kv.Storage, job *model.Job, hasUnique, checkDup bool, adjustedWorkerConcurrency int) (*local.BackendConfig, *local.Backend, error) {
 	ctx = logutil.WithLogger(ctx, logutil.Logger(ctx))
@@ -205,11 +207,7 @@ func CreateLocalBackend(ctx context.Context, store kv.Storage, job *model.Job, h
 	if err != nil {
 		return nil, nil, err
 	}
-	intest.Assert(job.Type == model.ActionAddPrimaryKey ||
-		job.Type == model.ActionAddIndex ||
-		job.Type == model.ActionModifyColumn ||
-		job.Type == model.ActionMultiSchemaChange)
-	intest.Assert(job.ReorgMeta != nil)
+	checkJobTypeForReorg(job)
 
 	resGroupName := job.ReorgMeta.ResourceGroupName
 	concurrency := job.ReorgMeta.GetConcurrency()

--- a/pkg/ddl/ingest/backend_mgr.go
+++ b/pkg/ddl/ingest/backend_mgr.go
@@ -124,7 +124,8 @@ func (b *BackendCtxBuilder) Build(cfg *local.BackendConfig, bd *local.Backend) (
 	intest.Assert(
 		job.Type == model.ActionAddPrimaryKey ||
 			job.Type == model.ActionAddIndex ||
-			job.Type == model.ActionModifyColumn,
+			job.Type == model.ActionModifyColumn ||
+			job.Type == model.ActionMultiSchemaChange,
 	)
 	intest.Assert(job.ReorgMeta != nil)
 
@@ -206,7 +207,8 @@ func CreateLocalBackend(ctx context.Context, store kv.Storage, job *model.Job, h
 	}
 	intest.Assert(job.Type == model.ActionAddPrimaryKey ||
 		job.Type == model.ActionAddIndex ||
-		job.Type == model.ActionModifyColumn)
+		job.Type == model.ActionModifyColumn ||
+		job.Type == model.ActionMultiSchemaChange)
 	intest.Assert(job.ReorgMeta != nil)
 
 	resGroupName := job.ReorgMeta.ResourceGroupName

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1013,7 +1013,6 @@ func (w *worker) doModifyColumnTypeWithData(
 				}
 
 				if job.MultiSchemaInfo != nil {
-					job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
 					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
 				}
 
@@ -1226,7 +1225,6 @@ func (w *worker) doModifyColumnIndexReorg(
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
 			case model.ReorgStageModifyColumnRecreateIndex:
 				if job.MultiSchemaInfo != nil {
-					job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
 					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
 				}
 				var done bool

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1018,6 +1018,10 @@ func (w *worker) doModifyColumnTypeWithData(
 					job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
 				}
 			case model.ReorgStageModifyColumnRecreateIndex:
+				if job.MultiSchemaInfo != nil {
+					job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
+					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
+				}
 				var done bool
 				done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, changingIdxs)
 				if !done {
@@ -1025,13 +1029,7 @@ func (w *worker) doModifyColumnTypeWithData(
 				}
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
 			case model.ReorgStageModifyColumnCompleted:
-				// For multi-schema change, analyze is done by parent job.
-				if job.MultiSchemaInfo == nil && checkNeedAnalyze(job, tblInfo) {
-					job.ReorgMeta.AnalyzeState = model.AnalyzeStateRunning
-				} else {
-					job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
-					checkAndMarkNonRevertible(job)
-				}
+				checkAndUpdateNeedAnalyze(job, tblInfo)
 			}
 		case model.AnalyzeStateRunning:
 			intest.Assert(job.MultiSchemaInfo == nil, "multi schema change shouldn't reach here")
@@ -1222,10 +1220,12 @@ func (w *worker) doModifyColumnIndexReorg(
 		case model.AnalyzeStateNone:
 			switch job.ReorgMeta.Stage {
 			case model.ReorgStageModifyColumnUpdateColumn:
-				// Now row reorg
 				job.SnapshotVer = 0
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
 			case model.ReorgStageModifyColumnRecreateIndex:
+				if job.MultiSchemaInfo != nil {
+					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
+				}
 				var done bool
 				done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, changingIdxInfos)
 				if !done {
@@ -1233,13 +1233,8 @@ func (w *worker) doModifyColumnIndexReorg(
 				}
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
 			case model.ReorgStageModifyColumnCompleted:
-				// For multi-schema change, analyze is done by parent job.
-				if job.MultiSchemaInfo == nil && checkNeedAnalyze(job, tblInfo) {
-					job.ReorgMeta.AnalyzeState = model.AnalyzeStateRunning
-				} else {
-					job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
-					checkAndMarkNonRevertible(job)
-				}
+				intest.Assert(job.MultiSchemaInfo == nil, "multi schema change shouldn't reach here")
+				checkAndUpdateNeedAnalyze(job, tblInfo)
 			}
 		case model.AnalyzeStateRunning:
 			intest.Assert(job.MultiSchemaInfo == nil, "multi schema change shouldn't reach here")

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -1005,15 +1005,15 @@ func (w *worker) doModifyColumnTypeWithData(
 		case model.AnalyzeStateNone:
 			switch job.ReorgMeta.Stage {
 			case model.ReorgStageModifyColumnUpdateColumn:
+				if job.MultiSchemaInfo != nil {
+					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job, model.ReorgStageModifyColumnUpdateColumn)
+				}
+
 				var done bool
 				reorgElements := BuildElements(changingCol, changingIdxs)
 				done, ver, err = doReorgWorkForModifyColumn(jobCtx, w, job, tbl, oldCol, reorgElements)
 				if !done {
 					return ver, err
-				}
-
-				if job.MultiSchemaInfo != nil {
-					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
 				}
 
 				if len(changingIdxs) > 0 {
@@ -1225,7 +1225,7 @@ func (w *worker) doModifyColumnIndexReorg(
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
 			case model.ReorgStageModifyColumnRecreateIndex:
 				if job.MultiSchemaInfo != nil {
-					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job)
+					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job, model.ReorgStageModifyColumnRecreateIndex)
 				}
 				var done bool
 				done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, changingIdxInfos)

--- a/pkg/ddl/modify_column.go
+++ b/pkg/ddl/modify_column.go
@@ -206,16 +206,225 @@ func initializeChangingIndexes(
 	return nil
 }
 
+const (
+	mergedModifyColumnStatePrepare byte = iota
+	mergedModifyColumnStateFinalize
+)
+
+func isMergedModifyColumnsArgsJob(job *model.Job) bool {
+	return job.Version == model.JobVersion2 && bytes.Contains(job.RawArgs, []byte(`"modify_columns"`))
+}
+
+func decodeModifyColumnRunningArgs(job *model.Job) (
+	singleArgs *model.ModifyColumnArgs,
+	mergedArgs *model.ModifyColumnsArgs,
+	err error,
+) {
+	if isMergedModifyColumnsArgsJob(job) {
+		mergedArgs, err = model.GetModifyColumnsArgs(job)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		if len(mergedArgs.ModifyColumns) == 0 {
+			return nil, nil, errors.New("merged modify-column has no child args")
+		}
+		return nil, mergedArgs, nil
+	}
+	singleArgs, err = model.GetModifyColumnArgs(job)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return singleArgs, nil, nil
+}
+
+func isMergedChildPrepared(arg *model.ModifyColumnSubArgs) bool {
+	if arg == nil || arg.ModifyColumnArgs == nil {
+		return false
+	}
+	if arg.ChildDone {
+		return true
+	}
+	// For reorg-related modify-column, "prepared" means the child reaches
+	// write-reorg and reorg/analyze is skipped for parent orchestration.
+	return arg.ChildAnalyzeState == model.AnalyzeStateSkipped
+}
+
 func (w *worker) onModifyColumn(jobCtx *jobContext, job *model.Job) (ver int64, _ error) {
-	args, err := model.GetModifyColumnArgs(job)
+	args, mergedArgs, err := decodeModifyColumnRunningArgs(job)
 	defer func() {
-		failpoint.InjectCall("getModifyColumnType", args.ModifyColumnType)
+		modifyType := byte(model.ModifyTypeNone)
+		if args != nil {
+			modifyType = args.ModifyColumnType
+		} else if mergedArgs != nil && mergedArgs.MergedCurrent >= 0 && mergedArgs.MergedCurrent < len(mergedArgs.ModifyColumns) {
+			child := mergedArgs.ModifyColumns[mergedArgs.MergedCurrent]
+			if child != nil && child.ModifyColumnArgs != nil {
+				modifyType = child.ModifyColumnArgs.ModifyColumnType
+			}
+		}
+		failpoint.InjectCall("getModifyColumnType", modifyType)
 	}()
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)
 	}
+	if mergedArgs != nil {
+		return w.onModifyColumnsMerged(jobCtx, job, mergedArgs)
+	}
+	return w.onModifyColumnWithArgs(jobCtx, job, args, true)
+}
 
+func (w *worker) runModifyColumnChildStep(
+	jobCtx *jobContext,
+	job *model.Job,
+	arg *model.ModifyColumnSubArgs,
+) (ver int64, err error) {
+	intest.Assert(arg != nil && arg.ModifyColumnArgs != nil, "child modify-column args should not be empty")
+	childJob := *job
+	if childJob.ReorgMeta != nil {
+		childJob.ReorgMeta = childJob.ReorgMeta.ShallowCopy()
+		childJob.ReorgMeta.AnalyzeState = arg.ChildAnalyzeState
+		childJob.ReorgMeta.Stage = arg.ChildReorgStage
+	}
+	childJob.SchemaState = arg.ChildSchemaState
+	childJob.SnapshotVer = arg.ChildSnapshotVer
+	ver, err = w.onModifyColumnWithArgs(jobCtx, &childJob, arg.ModifyColumnArgs, false)
+	if childJob.ReorgMeta != nil {
+		arg.ChildAnalyzeState = childJob.ReorgMeta.AnalyzeState
+		arg.ChildReorgStage = childJob.ReorgMeta.Stage
+	}
+	arg.ChildSchemaState = childJob.SchemaState
+	arg.ChildSnapshotVer = childJob.SnapshotVer
+	if childJob.IsFinished() {
+		arg.ChildDone = true
+	}
+	if childJob.IsRollingback() || childJob.IsRollbackDone() || childJob.IsCancelled() {
+		job.State = childJob.State
+		job.Error = childJob.Error
+	}
+	job.SchemaState = childJob.SchemaState
+	job.SnapshotVer = childJob.SnapshotVer
+	if job.ReorgMeta != nil && childJob.ReorgMeta != nil {
+		job.ReorgMeta.Stage = childJob.ReorgMeta.Stage
+		job.ReorgMeta.AnalyzeState = childJob.ReorgMeta.AnalyzeState
+	}
+	return ver, err
+}
+
+func appendInt64NoDup(dst []int64, src ...int64) []int64 {
+	if len(src) == 0 {
+		return dst
+	}
+	exists := make(map[int64]struct{}, len(dst)+len(src))
+	for _, v := range dst {
+		exists[v] = struct{}{}
+	}
+	for _, v := range src {
+		if _, ok := exists[v]; ok {
+			continue
+		}
+		exists[v] = struct{}{}
+		dst = append(dst, v)
+	}
+	return dst
+}
+
+func (w *worker) onModifyColumnsMerged(
+	jobCtx *jobContext,
+	job *model.Job,
+	args *model.ModifyColumnsArgs,
+) (ver int64, _ error) {
+	intest.Assert(len(args.ModifyColumns) > 0, "merged modify-column has no children")
+	switch args.MergedState {
+	case mergedModifyColumnStatePrepare:
+		if args.MergedCurrent >= len(args.ModifyColumns) {
+			args.MergedState = mergedModifyColumnStateFinalize
+			args.MergedCurrent = 0
+			checkAndMarkNonRevertible(job)
+			job.FillArgs(args)
+			return ver, nil
+		}
+		arg := args.ModifyColumns[args.MergedCurrent]
+		if arg == nil || arg.ModifyColumnArgs == nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.New("merged modify-column child args is empty")
+		}
+		if isMergedChildPrepared(arg) {
+			args.MergedCurrent++
+			if args.MergedCurrent >= len(args.ModifyColumns) {
+				args.MergedState = mergedModifyColumnStateFinalize
+				args.MergedCurrent = 0
+				checkAndMarkNonRevertible(job)
+			}
+			job.FillArgs(args)
+			return ver, nil
+		}
+		ver, err := w.runModifyColumnChildStep(jobCtx, job, arg)
+		if err != nil {
+			return ver, err
+		}
+		if isMergedChildPrepared(arg) {
+			args.MergedCurrent++
+			if args.MergedCurrent >= len(args.ModifyColumns) {
+				args.MergedState = mergedModifyColumnStateFinalize
+				args.MergedCurrent = 0
+				checkAndMarkNonRevertible(job)
+			}
+		}
+		job.FillArgs(args)
+		return ver, nil
+	case mergedModifyColumnStateFinalize:
+		for args.MergedCurrent < len(args.ModifyColumns) && args.ModifyColumns[args.MergedCurrent].ChildDone {
+			args.MergedCurrent++
+		}
+		if args.MergedCurrent >= len(args.ModifyColumns) {
+			job.State = model.JobStateDone
+			job.SchemaState = model.StatePublic
+			job.FillFinishedArgs(&model.ModifyColumnArgs{
+				IndexIDs:     args.IndexIDs,
+				NewIndexIDs:  args.NewIndexIDs,
+				PartitionIDs: args.PartitionIDs,
+			})
+			return ver, nil
+		}
+		arg := args.ModifyColumns[args.MergedCurrent]
+		if arg == nil || arg.ModifyColumnArgs == nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.New("merged modify-column child args is empty")
+		}
+		ver, err := w.runModifyColumnChildStep(jobCtx, job, arg)
+		if err != nil {
+			return ver, err
+		}
+		if arg.ChildDone {
+			args.IndexIDs = appendInt64NoDup(args.IndexIDs, arg.ModifyColumnArgs.IndexIDs...)
+			args.NewIndexIDs = appendInt64NoDup(args.NewIndexIDs, arg.ModifyColumnArgs.NewIndexIDs...)
+			args.PartitionIDs = appendInt64NoDup(args.PartitionIDs, arg.ModifyColumnArgs.PartitionIDs...)
+			args.MergedCurrent++
+		}
+		if args.MergedCurrent >= len(args.ModifyColumns) {
+			job.State = model.JobStateDone
+			job.SchemaState = model.StatePublic
+			job.FillFinishedArgs(&model.ModifyColumnArgs{
+				IndexIDs:     args.IndexIDs,
+				NewIndexIDs:  args.NewIndexIDs,
+				PartitionIDs: args.PartitionIDs,
+			})
+			return ver, nil
+		}
+		job.FillArgs(args)
+		return ver, nil
+	default:
+		job.State = model.JobStateCancelled
+		return ver, errors.Errorf("invalid merged modify-column state %d", args.MergedState)
+	}
+}
+
+func (w *worker) onModifyColumnWithArgs(
+	jobCtx *jobContext,
+	job *model.Job,
+	args *model.ModifyColumnArgs,
+	markNonRevertible bool,
+) (ver int64, _ error) {
 	dbInfo, tblInfo, oldCol, err := getModifyColumnInfo(jobCtx.metaMut, job, args)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -307,9 +516,9 @@ func (w *worker) onModifyColumn(jobCtx *jobContext, job *model.Job) (ver int64, 
 	case model.ModifyTypePrecheck:
 		return w.precheckForVarcharToChar(jobCtx, job, args, dbInfo, tblInfo, oldCol)
 	case model.ModifyTypeNoReorgWithCheck:
-		return w.doModifyColumnWithCheck(jobCtx, job, dbInfo, tblInfo, args.Column, oldCol, args.Position)
+		return w.doModifyColumnWithCheck(jobCtx, job, dbInfo, tblInfo, args.Column, oldCol, args.Position, markNonRevertible)
 	case model.ModifyTypeNoReorg:
-		return w.doModifyColumnNoCheck(jobCtx, job, tblInfo, args.Column, oldCol, args.Position)
+		return w.doModifyColumnNoCheck(jobCtx, job, tblInfo, args.Column, oldCol, args.Position, markNonRevertible)
 	}
 
 	// Checks for ModifyTypeReorg and ModifyTypeIndexReorg.
@@ -341,7 +550,7 @@ func (w *worker) onModifyColumn(jobCtx *jobContext, job *model.Job) (ver int64, 
 			return ver, errors.Trace(err)
 		}
 		return w.doModifyColumnIndexReorg(
-			jobCtx, job, dbInfo, tblInfo, oldCol, args)
+			jobCtx, job, dbInfo, tblInfo, oldCol, args, markNonRevertible)
 	}
 
 	changingCol, err := getChangingCol(args, tblInfo, oldCol)
@@ -350,7 +559,7 @@ func (w *worker) onModifyColumn(jobCtx *jobContext, job *model.Job) (ver int64, 
 		return ver, errors.Trace(err)
 	}
 	return w.doModifyColumnTypeWithData(
-		jobCtx, job, dbInfo, tblInfo, changingCol, oldCol, args)
+		jobCtx, job, dbInfo, tblInfo, changingCol, oldCol, args, markNonRevertible)
 }
 
 func checkColumnAlreadyExists(tblInfo *model.TableInfo, args *model.ModifyColumnArgs) error {
@@ -532,13 +741,14 @@ func (*worker) doModifyColumnNoCheck(
 	tblInfo *model.TableInfo,
 	newCol, oldCol *model.ColumnInfo,
 	pos *ast.ColumnPosition,
+	markNonRevertible bool,
 ) (ver int64, _ error) {
 	if oldCol.ID != newCol.ID {
 		job.State = model.JobStateRollingback
 		return ver, dbterror.ErrColumnInChange.GenWithStackByArgs(oldCol.Name, newCol.ID)
 	}
 
-	if job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
+	if markNonRevertible && job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
 		job.MarkNonRevertible()
 		// Store the mark and enter the next DDL handling loop.
 		return updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, false)
@@ -622,6 +832,7 @@ func (w *worker) doModifyColumnWithCheck(
 	tblInfo *model.TableInfo,
 	newCol, oldCol *model.ColumnInfo,
 	pos *ast.ColumnPosition,
+	markNonRevertible bool,
 ) (ver int64, _ error) {
 	if oldCol.ID != newCol.ID {
 		job.State = model.JobStateRollingback
@@ -658,7 +869,7 @@ func (w *worker) doModifyColumnWithCheck(
 
 	failpoint.InjectCall("afterDoModifyColumnSkipReorgCheck")
 
-	if job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
+	if markNonRevertible && job.MultiSchemaInfo != nil && job.MultiSchemaInfo.Revertible {
 		job.MarkNonRevertible()
 		// Store the mark and enter the next DDL handling loop.
 		return updateVersionAndTableInfoWithCheck(jobCtx, job, tblInfo, false)
@@ -885,7 +1096,11 @@ func buildCheckRangeForIntegerTypes(oldCol, changingCol *model.ColumnInfo) strin
 }
 
 // reorderChangingIdx reorders the changing index infos to match the order of old index infos.
-func reorderChangingIdx(oldIdxInfos []*model.IndexInfo, changingIdxInfos []*model.IndexInfo) {
+// It drops unmatched pairs when old indexes are already handled by another merged modify-column.
+func reorderChangingIdx(
+	oldIdxInfos []*model.IndexInfo,
+	changingIdxInfos []*model.IndexInfo,
+) ([]*model.IndexInfo, []*model.IndexInfo) {
 	nameToChanging := make(map[string]*model.IndexInfo, len(changingIdxInfos))
 	for _, cIdx := range changingIdxInfos {
 		origName := cIdx.Name.O
@@ -895,9 +1110,17 @@ func reorderChangingIdx(oldIdxInfos []*model.IndexInfo, changingIdxInfos []*mode
 		nameToChanging[origName] = cIdx
 	}
 
-	for i, oldIdx := range oldIdxInfos {
-		changingIdxInfos[i] = nameToChanging[oldIdx.GetRemovingOriginName()]
+	orderedOld := make([]*model.IndexInfo, 0, len(oldIdxInfos))
+	orderedChanging := make([]*model.IndexInfo, 0, len(oldIdxInfos))
+	for _, oldIdx := range oldIdxInfos {
+		changingIdx, ok := nameToChanging[oldIdx.GetRemovingOriginName()]
+		if !ok || changingIdx == nil {
+			continue
+		}
+		orderedOld = append(orderedOld, oldIdx)
+		orderedChanging = append(orderedChanging, changingIdx)
 	}
+	return orderedOld, orderedChanging
 }
 
 func (w *worker) doModifyColumnTypeWithData(
@@ -907,6 +1130,7 @@ func (w *worker) doModifyColumnTypeWithData(
 	tblInfo *model.TableInfo,
 	changingCol, oldCol *model.ColumnInfo,
 	args *model.ModifyColumnArgs,
+	markNonRevertible bool,
 ) (ver int64, _ error) {
 	colName, pos := args.Column.Name, args.Position
 
@@ -1006,7 +1230,13 @@ func (w *worker) doModifyColumnTypeWithData(
 			switch job.ReorgMeta.Stage {
 			case model.ReorgStageModifyColumnUpdateColumn:
 				if job.MultiSchemaInfo != nil {
-					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job, model.ReorgStageModifyColumnUpdateColumn)
+					return skipReorgAndAnalyzeForSubJobWithMark(
+						jobCtx,
+						tbl.Meta(),
+						job,
+						model.ReorgStageModifyColumnUpdateColumn,
+						markNonRevertible,
+					)
 				}
 
 				var done bool
@@ -1046,7 +1276,7 @@ func (w *worker) doModifyColumnTypeWithData(
 
 			// In multi-schema change, the order of changingIdxInfos may not be the same as oldIdxInfos,
 			// because we will allocate new indexID for previous temp index.
-			reorderChangingIdx(oldIdxInfos, changingIdxInfos)
+			oldIdxInfos, changingIdxInfos = reorderChangingIdx(oldIdxInfos, changingIdxInfos)
 
 			updateObjectState(oldCol, oldIdxInfos, model.StateWriteOnly)
 			updateObjectState(changingCol, changingIdxInfos, model.StatePublic)
@@ -1116,6 +1346,7 @@ func (w *worker) doModifyColumnIndexReorg(
 	tblInfo *model.TableInfo,
 	oldCol *model.ColumnInfo,
 	args *model.ModifyColumnArgs,
+	markNonRevertible bool,
 ) (ver int64, err error) {
 	colName, pos := args.Column.Name, args.Position
 
@@ -1225,7 +1456,13 @@ func (w *worker) doModifyColumnIndexReorg(
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
 			case model.ReorgStageModifyColumnRecreateIndex:
 				if job.MultiSchemaInfo != nil {
-					return skipReorgAndAnalyzeForSubJob(jobCtx, tbl.Meta(), job, model.ReorgStageModifyColumnRecreateIndex)
+					return skipReorgAndAnalyzeForSubJobWithMark(
+						jobCtx,
+						tbl.Meta(),
+						job,
+						model.ReorgStageModifyColumnRecreateIndex,
+						markNonRevertible,
+					)
 				}
 				var done bool
 				done, ver, err = doReorgWorkForCreateIndex(w, jobCtx, job, tbl, changingIdxInfos)
@@ -1242,7 +1479,7 @@ func (w *worker) doModifyColumnIndexReorg(
 			w.startAnalyzeAndWait(job, tblInfo)
 		case model.AnalyzeStateDone, model.AnalyzeStateSkipped, model.AnalyzeStateTimeout, model.AnalyzeStateFailed:
 			failpoint.InjectCall("afterReorgWorkForModifyColumn")
-			reorderChangingIdx(oldIdxInfos, changingIdxInfos)
+			oldIdxInfos, changingIdxInfos = reorderChangingIdx(oldIdxInfos, changingIdxInfos)
 			oldTp := oldCol.FieldType
 			oldName := oldCol.Name
 			oldID := oldCol.ID

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -40,7 +40,11 @@ func skipReorgAndAnalyzeForSubJob(jobCtx *jobContext, tblInfo *model.TableInfo, 
 
 	job.SnapshotVer = v.Ver
 	// Although reorg is done by parent job, we still set the ReorgTp here.
-	job.ReorgMeta.ReorgTp = model.ReorgTypeIngest
+	// And we ignore the error from here because reorg is done by parent job.
+	if _, err := pickBackfillType(job); err != nil {
+		job.ReorgMeta.ReorgTp = model.ReorgTypeIngest
+	}
+	job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
 	job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
 	checkAndMarkNonRevertible(job)
 

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -30,9 +30,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// For multi-schema change, analyze and index reorg is done by parent job.
+// For multi-schema change, analyze and reorg are done by parent job.
 // So we just skip them for sub-jobs.
-func skipReorgAndAnalyzeForSubJob(jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job) (int64, error) {
+func skipReorgAndAnalyzeForSubJob(jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job, reorgStage model.ReorgStage) (int64, error) {
 	v, err := getValidCurrentVersion(jobCtx.store)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -44,7 +44,7 @@ func skipReorgAndAnalyzeForSubJob(jobCtx *jobContext, tblInfo *model.TableInfo, 
 	if _, err := pickBackfillType(job); err != nil {
 		job.ReorgMeta.ReorgTp = model.ReorgTypeIngest
 	}
-	job.ReorgMeta.Stage = model.ReorgStageModifyColumnCompleted
+	job.ReorgMeta.Stage = reorgStage
 	job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
 	checkAndMarkNonRevertible(job)
 
@@ -60,7 +60,12 @@ func (w *worker) reorgAndAnalyzeForMultiSchemaChange(
 	case model.AnalyzeStateNone:
 		switch job.ReorgMeta.Stage {
 		case model.ReorgStageNone:
-			if checkNeedReorg(tblInfo) {
+			if checkNeedRowReorg(tblInfo) {
+				job.SnapshotVer = 0
+				job.ReorgMeta.Stage = model.ReorgStageModifyColumnUpdateColumn
+				logutil.DDLLogger().Info("multi-schema change ready to reorg rows",
+					zap.Int64("job", job.ID), zap.Int8("state", job.ReorgMeta.AnalyzeState))
+			} else if checkNeedReorg(tblInfo) {
 				job.SnapshotVer = 0
 				job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
 				logutil.DDLLogger().Info("multi-schema change ready to reorg index",
@@ -71,6 +76,42 @@ func (w *worker) reorgAndAnalyzeForMultiSchemaChange(
 					zap.Int64("job", job.ID), zap.Int8("state", job.ReorgMeta.AnalyzeState))
 			}
 
+			return false, ver, err
+		case model.ReorgStageModifyColumnUpdateColumn:
+			dbInfo, err := checkSchemaExistAndCancelNotExistJob(jobCtx.metaMut, job)
+			if err != nil {
+				return false, ver, errors.Trace(err)
+			}
+
+			tbl, err := getTable(jobCtx.getAutoIDRequirement(), dbInfo.ID, tblInfo)
+			if err != nil {
+				return false, ver, errors.Trace(err)
+			}
+
+			oldCol, reorgElements := getReorgElementsForMultiSchemaUpdateColumn(tbl)
+			if len(reorgElements) == 0 || oldCol == nil {
+				intest.Assert(false, "multi-schema modify-column row reorg has no changing columns")
+				if checkNeedReorg(tblInfo) {
+					job.SnapshotVer = 0
+					job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
+				} else {
+					checkAndUpdateNeedAnalyze(job, tblInfo)
+				}
+				return false, ver, err
+			}
+
+			var done bool
+			done, ver, err = doReorgWorkForModifyColumn(jobCtx, w, job, tbl, oldCol, reorgElements)
+			if !done {
+				return false, ver, err
+			}
+
+			if checkNeedReorg(tblInfo) {
+				job.SnapshotVer = 0
+				job.ReorgMeta.Stage = model.ReorgStageModifyColumnRecreateIndex
+			} else {
+				checkAndUpdateNeedAnalyze(job, tblInfo)
+			}
 			return false, ver, err
 		case model.ReorgStageModifyColumnRecreateIndex:
 			dbInfo, err := checkSchemaExistAndCancelNotExistJob(jobCtx.metaMut, job)
@@ -462,6 +503,30 @@ func mergeAddIndex(info *model.MultiSchemaInfo) {
 	mergedSubJob.JobArgs = newAddIndexesArgs
 	newSubJobs = append(newSubJobs, mergedSubJob)
 	info.SubJobs = newSubJobs
+}
+
+func getReorgElementsForMultiSchemaUpdateColumn(tbl table.Table) (*model.ColumnInfo, []*meta.Element) {
+	colPairs := getOldAndNewColumnsForUpdateColumns(tbl, 0, true)
+	if len(colPairs) == 0 {
+		return nil, nil
+	}
+	reorgElements := make([]*meta.Element, 0, len(colPairs))
+	for _, colPair := range colPairs {
+		reorgElements = append(reorgElements, &meta.Element{
+			ID:      colPair.newColInfo.ID,
+			TypeKey: meta.ColumnElementKey,
+		})
+	}
+	return colPairs[0].oldColInfo, reorgElements
+}
+
+func checkNeedRowReorg(tblInfo *model.TableInfo) bool {
+	for _, col := range tblInfo.Columns {
+		if col.State == model.StateWriteReorganization && col.ChangeStateInfo != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func checkNeedReorg(tblInfo *model.TableInfo) bool {

--- a/pkg/ddl/multi_schema_change.go
+++ b/pkg/ddl/multi_schema_change.go
@@ -33,6 +33,16 @@ import (
 // For multi-schema change, analyze and reorg are done by parent job.
 // So we just skip them for sub-jobs.
 func skipReorgAndAnalyzeForSubJob(jobCtx *jobContext, tblInfo *model.TableInfo, job *model.Job, reorgStage model.ReorgStage) (int64, error) {
+	return skipReorgAndAnalyzeForSubJobWithMark(jobCtx, tblInfo, job, reorgStage, true)
+}
+
+func skipReorgAndAnalyzeForSubJobWithMark(
+	jobCtx *jobContext,
+	tblInfo *model.TableInfo,
+	job *model.Job,
+	reorgStage model.ReorgStage,
+	markNonRevertible bool,
+) (int64, error) {
 	v, err := getValidCurrentVersion(jobCtx.store)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -46,7 +56,9 @@ func skipReorgAndAnalyzeForSubJob(jobCtx *jobContext, tblInfo *model.TableInfo, 
 	}
 	job.ReorgMeta.Stage = reorgStage
 	job.ReorgMeta.AnalyzeState = model.AnalyzeStateSkipped
-	checkAndMarkNonRevertible(job)
+	if markNonRevertible {
+		checkAndMarkNonRevertible(job)
+	}
 
 	return updateVersionAndTableInfo(jobCtx, job, tblInfo, true)
 }
@@ -501,6 +513,51 @@ func mergeAddIndex(info *model.MultiSchemaInfo) {
 
 	// place the merged add index job at the end of the sub-jobs.
 	mergedSubJob.JobArgs = newAddIndexesArgs
+	newSubJobs = append(newSubJobs, mergedSubJob)
+	info.SubJobs = newSubJobs
+}
+
+func mergeModifyColumn(info *model.MultiSchemaInfo) {
+	var (
+		mergedSubJob *model.SubJob
+		mergeCnt     int
+	)
+	for _, subJob := range info.SubJobs {
+		if subJob.Type != model.ActionModifyColumn {
+			continue
+		}
+		mergeCnt++
+		if mergedSubJob == nil {
+			mergedSubJob = subJob.Clone()
+			mergedSubJob.RawArgs = nil
+		}
+	}
+	if mergeCnt <= 1 {
+		return
+	}
+
+	mergedArgs := &model.ModifyColumnsArgs{
+		ModifyColumns: make([]*model.ModifyColumnSubArgs, 0, mergeCnt),
+	}
+	newSubJobs := make([]*model.SubJob, 0, len(info.SubJobs)-mergeCnt+1)
+	for _, subJob := range info.SubJobs {
+		if subJob.Type != model.ActionModifyColumn {
+			newSubJobs = append(newSubJobs, subJob)
+			continue
+		}
+		args := subJob.JobArgs.(*model.ModifyColumnArgs)
+		cloneArg := *args
+		mergedArgs.ModifyColumns = append(mergedArgs.ModifyColumns, &model.ModifyColumnSubArgs{
+			ModifyColumnArgs:  &cloneArg,
+			ChildSchemaState:  model.StateNone,
+			ChildAnalyzeState: model.AnalyzeStateNone,
+			ChildReorgStage:   model.ReorgStageNone,
+		})
+		if subJob.NeedReorg {
+			mergedSubJob.NeedReorg = true
+		}
+	}
+	mergedSubJob.JobArgs = mergedArgs
 	newSubJobs = append(newSubJobs, mergedSubJob)
 	info.SubJobs = newSubJobs
 }

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -1019,3 +1019,11 @@ func assertMultiSchema(t *testing.T, job *model.Job, subJobLen int) {
 	assert.NotNil(t, job.MultiSchemaInfo, job)
 	assert.Len(t, job.MultiSchemaInfo.SubJobs, subJobLen, job)
 }
+
+func TestXxx(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("create table t (a int, b int, index i1(a));")
+	tk.MustExec("alter table t modify column a int unsigned, add index i2(b);")
+}

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -1020,10 +1020,41 @@ func assertMultiSchema(t *testing.T, job *model.Job, subJobLen int) {
 	assert.Len(t, job.MultiSchemaInfo.SubJobs, subJobLen, job)
 }
 
-func TestXxx(t *testing.T) {
+func TestMultiSchemaChangeReorgOnlyOnce(t *testing.T) {
+	type testCase struct {
+		alterSQL string
+		expected int
+	}
+
+	var reorgCount int
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterBackfillStateRunningDone", func(_ *model.Job) {
+		reorgCount++
+	})
+
 	store := testkit.CreateMockStore(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test;")
-	tk.MustExec("create table t (a int, b int, index i1(a));")
-	tk.MustExec("alter table t modify column a int unsigned, add index i2(b);")
+
+	for _, tc := range []testCase{
+		{
+			alterSQL: "alter table t add index i1(a), add index i2(b), modify column c int unsigned",
+			expected: 1,
+		},
+		{
+			alterSQL: "alter table t modify column a int unsigned, modify column c int unsigned",
+			expected: 1,
+		},
+		{
+			alterSQL: "alter table t modify column a int, modify column c int, drop index idx_b",
+			expected: 0,
+		},
+	} {
+		reorgCount = 0
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (a int, b int, c int, index idx_a(a), index idx_b(b), index idx_c(c))")
+		tk.MustExec("insert into t values (1, 2, 3), (2, 3, 4), (3, 4, 5)")
+		tk.MustExec(tc.alterSQL)
+		require.EqualValues(t, tc.expected, reorgCount)
+		tk.MustExec("admin check table t")
+	}
 }

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -1022,13 +1022,22 @@ func assertMultiSchema(t *testing.T, job *model.Job, subJobLen int) {
 
 func TestMultiSchemaChangeReorgOnlyOnce(t *testing.T) {
 	type testCase struct {
-		alterSQL string
-		expected int
+		alterSQL           string
+		expectedIndexReorg int
+		expectedRowReorg   int
 	}
 
-	var reorgCount int
+	var (
+		indexReorgCount int
+		rowReorgCount   int
+	)
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterBackfillStateRunningDone", func(_ *model.Job) {
-		reorgCount++
+		indexReorgCount++
+	})
+	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/beforeUpdatePhysicalTableRow", func(job *model.Job) {
+		if job.Type == model.ActionMultiSchemaChange {
+			rowReorgCount++
+		}
 	})
 
 	store := testkit.CreateMockStore(t)
@@ -1037,24 +1046,34 @@ func TestMultiSchemaChangeReorgOnlyOnce(t *testing.T) {
 
 	for _, tc := range []testCase{
 		{
-			alterSQL: "alter table t add index i1(a), add index i2(b), modify column c int unsigned",
-			expected: 1,
+			alterSQL:           "alter table t add index i1(a), add index i2(b), modify column c int unsigned",
+			expectedIndexReorg: 1,
+			expectedRowReorg:   0,
 		},
 		{
-			alterSQL: "alter table t modify column a int unsigned, modify column c int unsigned",
-			expected: 1,
+			alterSQL:           "alter table t modify column a int unsigned, modify column c int unsigned",
+			expectedIndexReorg: 1,
+			expectedRowReorg:   0,
 		},
 		{
-			alterSQL: "alter table t modify column a int, modify column c int, drop index idx_b",
-			expected: 0,
+			alterSQL:           "alter table t modify column a int, modify column c int, drop index idx_b",
+			expectedIndexReorg: 0,
+			expectedRowReorg:   0,
+		},
+		{
+			alterSQL:           "alter table t modify column a varchar(20), modify column c varchar(20)",
+			expectedIndexReorg: 1,
+			expectedRowReorg:   1,
 		},
 	} {
-		reorgCount = 0
+		indexReorgCount = 0
+		rowReorgCount = 0
 		tk.MustExec("drop table if exists t")
 		tk.MustExec("create table t (a int, b int, c int, index idx_a(a), index idx_b(b), index idx_c(c))")
 		tk.MustExec("insert into t values (1, 2, 3), (2, 3, 4), (3, 4, 5)")
 		tk.MustExec(tc.alterSQL)
-		require.EqualValues(t, tc.expected, reorgCount)
+		require.EqualValues(t, tc.expectedIndexReorg, indexReorgCount)
+		require.EqualValues(t, tc.expectedRowReorg, rowReorgCount)
 		tk.MustExec("admin check table t")
 	}
 }

--- a/pkg/ddl/multi_schema_change_test.go
+++ b/pkg/ddl/multi_schema_change_test.go
@@ -561,8 +561,8 @@ func TestMultiSchemaChangeModifyColumnsCancelled(t *testing.T) {
 		if job.Type != model.ActionMultiSchemaChange {
 			return false
 		}
-		assertMultiSchema(t, job, 3)
-		return job.MultiSchemaInfo.SubJobs[2].SchemaState == model.StateWriteReorganization
+		assertMultiSchema(t, job, 1)
+		return job.MultiSchemaInfo.SubJobs[0].SchemaState == model.StateWriteReorganization
 	})
 	testfailpoint.EnableCall(t, "github.com/pingcap/tidb/pkg/ddl/afterWaitSchemaSynced", hook.OnJobUpdated)
 	sql := "alter table t modify column a tinyint, modify column b bigint, modify column c char(20);"

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -64,6 +64,7 @@ func convertAddIdxJob2RollbackJob(
 	// sub-job individually. Therefore, we update the state of all sub-jobs
 	// so they can rollback correctly in subsequent loops.
 	if job.Type == model.ActionMultiSchemaChange {
+		//nolint: errcheck
 		rollingBackMultiSchemaChange(job)
 		return 0, err
 	}

--- a/pkg/ddl/rollingback.go
+++ b/pkg/ddl/rollingback.go
@@ -57,6 +57,10 @@ func convertAddIdxJob2RollbackJob(
 		job.State = model.JobStateRollingback
 		return 0, err
 	}
+	if job.Type == model.ActionMultiSchemaChange {
+		job.State = model.JobStateCancelling
+		return 0, err
+	}
 
 	dropArgs := &model.ModifyIndexArgs{
 		PartitionIDs: getPartitionIDs(tblInfo),

--- a/pkg/meta/model/job_args.go
+++ b/pkg/meta/model/job_args.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/pingcap/errors"
@@ -1753,6 +1754,38 @@ type ModifyColumnArgs struct {
 	PartitionIDs []int64 `json:"partition_ids,omitempty"`
 }
 
+// ModifyColumnSubArgs stores one modify-column argument and its execution state in merged mode.
+type ModifyColumnSubArgs struct {
+	ModifyColumnArgs *ModifyColumnArgs `json:"modify_column_args,omitempty"`
+
+	ChildSchemaState  SchemaState `json:"child_schema_state,omitempty"`
+	ChildSnapshotVer  uint64      `json:"child_snapshot_ver,omitempty"`
+	ChildAnalyzeState int8        `json:"child_analyze_state,omitempty"`
+	ChildReorgStage   ReorgStage  `json:"child_reorg_stage,omitempty"`
+	ChildDone         bool        `json:"child_done,omitempty"`
+}
+
+// ModifyColumnsArgs is used by multi-schema change to merge several modify-column sub-jobs.
+type ModifyColumnsArgs struct {
+	ModifyColumns []*ModifyColumnSubArgs `json:"modify_columns,omitempty"`
+	MergedState   byte                   `json:"merged_state,omitempty"`
+	MergedCurrent int                    `json:"merged_current,omitempty"`
+
+	// Finished args, merged from each child modify-column.
+	IndexIDs     []int64 `json:"index_ids,omitempty"`
+	NewIndexIDs  []int64 `json:"new_index_ids,omitempty"`
+	PartitionIDs []int64 `json:"partition_ids,omitempty"`
+}
+
+func (*ModifyColumnsArgs) getArgsV1(*Job) []any {
+	// Merged modify-column is only encoded as v2 args.
+	return nil
+}
+
+func (*ModifyColumnsArgs) decodeV1(*Job) error {
+	return errors.New("modify columns args doesn't support v1")
+}
+
 func (a *ModifyColumnArgs) getArgsV1(*Job) []any {
 	// during upgrade, if https://github.com/pingcap/tidb/issues/54689 triggered,
 	// older node might run the job submitted by new version, but it expects 5
@@ -1779,7 +1812,31 @@ func (a *ModifyColumnArgs) getFinishedArgsV1(*Job) []any {
 
 // GetModifyColumnArgs get the modify column argument from job.
 func GetModifyColumnArgs(job *Job) (*ModifyColumnArgs, error) {
+	if job.Version == JobVersion2 {
+		if len(job.args) > 0 {
+			switch args := job.args[0].(type) {
+			case *ModifyColumnArgs:
+				return args, nil
+			case *ModifyColumnsArgs:
+				return args.getCurrentModifyColumnArg()
+			default:
+				return nil, errors.Errorf("unexpected modify-column args type %T", args)
+			}
+		}
+		if bytes.Contains(job.RawArgs, []byte(`"modify_columns"`)) {
+			args, err := getOrDecodeArgsV2[*ModifyColumnsArgs](job)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			return args.getCurrentModifyColumnArg()
+		}
+	}
 	return getOrDecodeArgs(&ModifyColumnArgs{}, job)
+}
+
+// GetModifyColumnsArgs gets merged modify-columns args from job.
+func GetModifyColumnsArgs(job *Job) (*ModifyColumnsArgs, error) {
+	return getOrDecodeArgs(&ModifyColumnsArgs{}, job)
 }
 
 // GetFinishedModifyColumnArgs get the finished modify column argument from job.
@@ -1800,6 +1857,21 @@ func GetFinishedModifyColumnArgs(job *Job) (*ModifyColumnArgs, error) {
 		}, nil
 	}
 	return getOrDecodeArgsV2[*ModifyColumnArgs](job)
+}
+
+func (a *ModifyColumnsArgs) getCurrentModifyColumnArg() (*ModifyColumnArgs, error) {
+	if len(a.ModifyColumns) == 0 {
+		return nil, errors.New("merged modify-column has no child args")
+	}
+	offset := a.MergedCurrent
+	if offset < 0 || offset >= len(a.ModifyColumns) {
+		offset = 0
+	}
+	child := a.ModifyColumns[offset]
+	if child == nil || child.ModifyColumnArgs == nil {
+		return nil, errors.New("merged modify-column child args is empty")
+	}
+	return child.ModifyColumnArgs, nil
 }
 
 // RefreshMetaArgs is the argument for RefreshMeta.

--- a/pkg/meta/model/job_args_test.go
+++ b/pkg/meta/model/job_args_test.go
@@ -1212,3 +1212,41 @@ func TestModifyColumnsArgs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(j2.RawArgs, &rawArgs))
 	require.Len(t, rawArgs, 5)
 }
+
+func TestMergedModifyColumnsArgs(t *testing.T) {
+	inArgs := &ModifyColumnsArgs{
+		ModifyColumns: []*ModifyColumnSubArgs{
+			{
+				ModifyColumnArgs: &ModifyColumnArgs{
+					Column:        &ColumnInfo{ID: 11, Name: ast.NewCIStr("c1")},
+					OldColumnName: ast.NewCIStr("a"),
+				},
+				ChildSchemaState: StateWriteOnly,
+			},
+			{
+				ModifyColumnArgs: &ModifyColumnArgs{
+					Column:        &ColumnInfo{ID: 12, Name: ast.NewCIStr("c2")},
+					OldColumnName: ast.NewCIStr("b"),
+				},
+				ChildSchemaState: StateWriteReorganization,
+			},
+		},
+		MergedState:   1,
+		MergedCurrent: 1,
+	}
+
+	j2 := &Job{}
+	require.NoError(t, j2.Decode(getJobBytes(t, inArgs, JobVersion2, ActionModifyColumn)))
+
+	args, err := GetModifyColumnsArgs(j2)
+	require.NoError(t, err)
+	require.Equal(t, inArgs.MergedState, args.MergedState)
+	require.Equal(t, inArgs.MergedCurrent, args.MergedCurrent)
+	require.Len(t, args.ModifyColumns, 2)
+	require.Equal(t, "a", args.ModifyColumns[0].ModifyColumnArgs.OldColumnName.L)
+	require.Equal(t, "b", args.ModifyColumns[1].ModifyColumnArgs.OldColumnName.L)
+
+	singleArg, err := GetModifyColumnArgs(j2)
+	require.NoError(t, err)
+	require.Equal(t, "b", singleArg.OldColumnName.L)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #63595

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for merging multiple column modifications into a single multi-schema change for more efficient ALTER TABLE batches.

* **Refactor**
  * Reworked column-update and reorganization flow to handle multiple column pairs and unify analyze/reorg orchestration across multi-schema changes.
  * Centralized reorg job validation and streamlined analyze-state handling.

* **Tests**
  * Added tests ensuring reorganization phases run exactly once during multi-schema changes and adjusted related expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->