### PR TITLE
br: fix with sys check, check pass even privilege tables' schema are the same

### DIFF
--- a/br/pkg/restore/snap_client/systable_restore.go
+++ b/br/pkg/restore/snap_client/systable_restore.go
@@ -780,9 +780,9 @@ func (rc *SnapClient) checkPrivilegeTableRowsCollateCompatibility(
 	colCount := 0
 	for _, col := range upstreamTable.Columns {
 		if _, exists := collateCompatibilityColumnMap.columns[col.Name.L]; exists {
-			if col.GetCollate() != "utf8mb4_bin" {
+			if col.GetCollate() != "utf8mb4_bin" && col.GetCollate() != "utf8mb4_general_ci" {
 				return errors.Annotatef(berrors.ErrRestoreIncompatibleSys,
-					"incompatible column collate, upstream table %s.%s column %s collate should be %s",
+					"incompatible column collate, upstream table %s.%s column %s collate is %s but should be utf8mb4_bin",
 					dbNameL, tableNameL, col.Name.L, col.GetCollate())
 			}
 			colCount += 1

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1459,6 +1459,10 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 			log.Info("The system tables schema is not compatible. Fallback to logically load system tables.")
 			loadSysTablePhysical = false
 		}
+		if client.GetCheckPrivilegeTableRowsCollateCompatiblity() && canLoadSysTablePhysical {
+			log.Info("The system tables schema match so no need to set sys check collation")
+			client.SetCheckPrivilegeTableRowsCollateCompatiblity(false)
+		}
 	}
 
 	// preallocate the table id, because any ddl job or database creation(include checkpoint) also allocates the global ID

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -1185,7 +1185,7 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		cfg.UpstreamClusterID = backupMeta.ClusterId
 	}
 	schemaVersionPair := snapclient.SchemaVersionPairT{}
-	if loadStatsPhysical || loadSysTablePhysical || cfg.SysCheckCollation {
+	if loadStatsPhysical || loadSysTablePhysical {
 		upstreamClusterVersion := version.NormalizeBackupVersion(backupMeta.ClusterVersion)
 		if upstreamClusterVersion == nil {
 			log.Warn("The cluster version from backupmeta is invalid. Fallback to logically load system tables.",
@@ -1195,12 +1195,6 @@ func runSnapshotRestore(c context.Context, mgr *conn.Mgr, g glue.Glue, cmdName s
 		} else {
 			schemaVersionPair.UpstreamVersionMajor = upstreamClusterVersion.Major
 			schemaVersionPair.UpstreamVersionMinor = upstreamClusterVersion.Minor
-			if cfg.SysCheckCollation &&
-				(upstreamClusterVersion.Major > 7 || (upstreamClusterVersion.Major == 7 && upstreamClusterVersion.Minor >= 5)) {
-				log.Info("the upstream cluster version is >= v7.5, no need to check privilege system table collation",
-					zap.String("upstream cluster version", backupMeta.ClusterVersion))
-				cfg.SysCheckCollation = false
-			}
 		}
 		downstreamClusterVersionStr, err := mgr.GetClusterVersion(ctx)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64667

Problem Summary:
if the privilege tables' schema are the same, br will return error if specify the parameter `--sys-check-collation`.
### What changed and how does it work?
check pass if the privilege tables' schema are the same
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
