### PR TITLE
ddl: fix flaky TestAddGlobalIndexInIngestWithUpdate 

### DIFF
--- a/pkg/ddl/ingest/integration_test.go
+++ b/pkg/ddl/ingest/integration_test.go
@@ -576,7 +576,7 @@ func TestAddGlobalIndexInIngestWithUpdate(t *testing.T) {
 			_, err := tk2.Exec(fmt.Sprintf("insert into test.t values (%d, %d)", tmp, tmp))
 			assert.Nil(t, err)
 
-			_, err = tk2.Exec(fmt.Sprintf("update test.t set b = b + 11, a = b where b = %d", tmp-1))
+			_, err = tk2.Exec(fmt.Sprintf("update test.t set b = b + 20, a = b where b = %d", tmp-1))
 			assert.Nil(t, err)
 		}
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64000

Problem Summary:

### What changed and how does it work?
add index might slow on CI env, so transitOneJobStepAndWaitSync might be called >= 11 times, and cause the case fail, we enlarge the allowed count to 20

**And I don't think this case test anything about update, it only checks that the query result from global index or scanning the table is the same, the code about update only want to make sure the add-index can finished in certain time. but let's fix it anyway**
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
