### PR TITLE
executor: nonclustered partitioned table could miss updates due to duplicate _tidb_rowid from EXCHANGE PARTITION

### DIFF
--- a/pkg/executor/update.go
+++ b/pkg/executor/update.go
@@ -90,6 +90,16 @@ func (e *UpdateExec) prepare(row []types.Datum) (err error) {
 	e.changed = e.changed[:0]
 	e.matches = e.matches[:0]
 	for _, content := range e.tblColPosInfos {
+		// Partitioned tables can have duplicate _tidb_rowid between different partitions
+		// due to EXCHANGE PARTITION, if so, do not optimize skipping rows with multiple changes
+		skipMultipleChangesOnSameRow := true
+		tbl := e.tblID2table[content.TblID]
+		if _, ok := tbl.(table.PartitionedTable); ok {
+			if !tbl.Meta().HasClusteredIndex() {
+				skipMultipleChangesOnSameRow = false
+			}
+		}
+
 		if e.updatedRowKeys[content.Start] == nil {
 			e.updatedRowKeys[content.Start] = kv.NewMemAwareHandleMap[bool]()
 		}
@@ -114,7 +124,7 @@ func (e *UpdateExec) prepare(row []types.Datum) (err error) {
 
 		changed, ok := e.updatedRowKeys[content.Start].Get(handle)
 		if ok {
-			e.changed = append(e.changed, changed)
+			e.changed = append(e.changed, changed && skipMultipleChangesOnSameRow)
 			e.matches = append(e.matches, false)
 		} else {
 			e.changed = append(e.changed, false)

--- a/tests/integrationtest/r/executor/update.result
+++ b/tests/integrationtest/r/executor/update.result
@@ -903,3 +903,55 @@ Warning	1452	Cannot add or update a child row: a foreign key constraint fails (`
 update parent set ref = 3 where id = 2;
 Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`executor__update`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`ref`) REFERENCES `parent` (`ref`))
 update ignore parent set ref = 3 where id = 2;
+DROP TABLE IF EXISTS t, tp;
+CREATE TABLE t (a INT, b INT, dt DATE, PRIMARY KEY (a) NONCLUSTERED);
+CREATE TABLE tp (a INT, b INT, dt DATE, PRIMARY KEY (a) NONCLUSTERED)
+PARTITION BY RANGE (a) (
+PARTITION p0 VALUES LESS THAN (5),
+PARTITION p1 VALUES LESS THAN (11),
+PARTITION p2 VALUES LESS THAN (20)
+);
+INSERT INTO tp(a,b) VALUES (2,2),(4,4),(6,6);
+INSERT INTO t(a,b) VALUES (12,12),(14,14),(15,15),(16,16);
+SELECT *, _tidb_rowid FROM t ORDER BY a;
+a	b	dt	_tidb_rowid
+12	12	NULL	1
+14	14	NULL	2
+15	15	NULL	3
+16	16	NULL	4
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+a	b	dt	_tidb_rowid
+2	2	NULL	1
+4	4	NULL	2
+6	6	NULL	3
+ALTER TABLE tp EXCHANGE PARTITION p2 WITH TABLE t;
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+a	b	dt	_tidb_rowid
+2	2	NULL	1
+4	4	NULL	2
+6	6	NULL	3
+12	12	NULL	1
+14	14	NULL	2
+15	15	NULL	3
+16	16	NULL	4
+UPDATE tp SET dt = '2025-12-16';
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+a	b	dt	_tidb_rowid
+2	2	2025-12-16	1
+4	4	2025-12-16	2
+6	6	2025-12-16	3
+12	12	2025-12-16	1
+14	14	2025-12-16	2
+15	15	2025-12-16	3
+16	16	2025-12-16	4
+UPDATE tp SET b = 333;
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+a	b	dt	_tidb_rowid
+2	333	2025-12-16	1
+4	333	2025-12-16	2
+6	333	2025-12-16	3
+12	333	2025-12-16	1
+14	333	2025-12-16	2
+15	333	2025-12-16	3
+16	333	2025-12-16	4
+DROP TABLE t, tp;

--- a/tests/integrationtest/t/executor/update.test
+++ b/tests/integrationtest/t/executor/update.test
@@ -713,3 +713,44 @@ update parent set ref = 3 where id = 2;
 --enable_warnings
 update ignore parent set ref = 3 where id = 2;
 --disable_warnings
+
+# Issue 65067
+# Create tables with nonclustered primary key
+DROP TABLE IF EXISTS t, tp;
+CREATE TABLE t (a INT, b INT, dt DATE, PRIMARY KEY (a) NONCLUSTERED);
+CREATE TABLE tp (a INT, b INT, dt DATE, PRIMARY KEY (a) NONCLUSTERED) 
+PARTITION BY RANGE (a) (
+    PARTITION p0 VALUES LESS THAN (5),
+    PARTITION p1 VALUES LESS THAN (11),
+    PARTITION p2 VALUES LESS THAN (20)
+);
+
+# Insert test data
+INSERT INTO tp(a,b) VALUES (2,2),(4,4),(6,6);
+INSERT INTO t(a,b) VALUES (12,12),(14,14),(15,15),(16,16);
+
+# Check _tidb_rowid before exchange
+SELECT *, _tidb_rowid FROM t ORDER BY a;
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+
+# Exchange partition
+ALTER TABLE tp EXCHANGE PARTITION p2 WITH TABLE t;
+
+# Verify _tidb_rowid conflicts exist
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+# Shows duplicate _tidb_rowid values: (a=2,12 both have rowid=1), (a=4,14 both have rowid=2), (a=6,15 both have rowid=3)
+
+# Attempt to update all rows
+UPDATE tp SET dt = '2025-12-16';
+# Expected: 7 rows affected
+# Bug: Only 4 rows affected
+
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+
+# Another update to confirm the issue
+UPDATE tp SET b = 333;
+# Expected: 7 rows affected
+# Bug: Only 4 rows affected
+
+SELECT *, _tidb_rowid FROM tp ORDER BY a;
+DROP TABLE t, tp;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65067

Problem Summary:
There is an optimization to avoid updating the same row multiple times if it matches several conditions, but there is an issue with nonclustered partitioned tables, since they can have duplicate _tidb_rowid's between partitions after EXCHANGE PARTITION.
And the way it checks for already changed rows, is through a map over Handles, but those handles are not partitioning aware (which is what should be fixed, but that would be a much bigger change, so I opted for a smaller, hence safer fix).

### What changed and how does it work?
If the table to be updated is both partitioned and non-clustered, skip the optimization to check if the row already been updated, since that check is currently based on non partitioning aware handle's, which can be duplicate in this scenario.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Non-clustered partitioned tables that has previously done EXCHANGE PARTITION, could miss some rows during UPDATE
```
