### PR TITLE
traceevent: enable bazel shard_count

### DIFF
--- a/pkg/util/traceevent/BUILD.bazel
+++ b/pkg/util/traceevent/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     ],
     embed = [":traceevent"],
     flaky = True,
-    shard_count = 20,
+    shard_count = 1,
     deps = [
         "//pkg/config",
         "//pkg/config/kerneltype",

--- a/tools/tazel/util.go
+++ b/tools/tazel/util.go
@@ -45,8 +45,7 @@ func skipShardCount(path string) bool {
 		(strings.HasPrefix(path, "pkg/util") &&
 			!strings.HasPrefix(path, "pkg/util/admin") &&
 			!strings.HasPrefix(path, "pkg/util/chunk") &&
-			!strings.HasPrefix(path, "pkg/util/stmtsummary") &&
 			!strings.HasPrefix(path, "pkg/util/topsql") &&
-			!strings.HasPrefix(path, "pkg/util/traceevent") &&
+			!strings.HasPrefix(path, "pkg/util/stmtsummary") &&
 			!strings.HasPrefix(path, "pkg/util/workloadrepo"))
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65081 

Problem Summary:

### What changed and how does it work?

Because traceevent did not enable share count, it led to a lack of isolation between different tests.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
