### PR TITLE
executor, sessionctx: remove MemArbitrator from slow log rules

### DIFF
--- a/pkg/executor/adapter_slow_log.go
+++ b/pkg/executor/adapter_slow_log.go
@@ -263,6 +263,7 @@ func SetSlowLogItems(a *ExecStmt, txnTS uint64, hasMoreResults bool, items *vari
 	items.CPUUsages = sessVars.SQLCPUUsages.GetCPUUsages()
 	items.StorageKV = stmtCtx.IsTiKV.Load()
 	items.StorageMPP = stmtCtx.IsTiFlash.Load()
+	items.MemArbitration = stmtCtx.MemTracker.MemArbitration().Seconds()
 
 	if a.retryCount > 0 {
 		items.ExecRetryTime = items.TimeTotal - sessVars.DurationParse - sessVars.DurationCompile - time.Since(a.retryStartTime)

--- a/pkg/sessionctx/variable/slow_log.go
+++ b/pkg/sessionctx/variable/slow_log.go
@@ -751,15 +751,6 @@ var SlowLogRuleFieldAccessors = map[string]SlowLogFieldAccessor{
 			return matchGE(threshold, items.MemMax)
 		},
 	},
-	strings.ToLower(SlowLogMemArbitration): {
-		Parse: parseFloat64,
-		Setter: func(_ context.Context, seVars *SessionVars, items *SlowQueryLogItems) {
-			items.MemArbitration = seVars.StmtCtx.MemTracker.MemArbitration().Seconds()
-		},
-		Match: func(_ *SessionVars, items *SlowQueryLogItems, threshold any) bool {
-			return matchGE(threshold, items.MemArbitration)
-		},
-	},
 	strings.ToLower(SlowLogDiskMax): {
 		Parse: parseInt64,
 		Setter: func(_ context.Context, seVars *SessionVars, items *SlowQueryLogItems) {

--- a/pkg/sessionctx/variable/slow_log_test.go
+++ b/pkg/sessionctx/variable/slow_log_test.go
@@ -272,7 +272,7 @@ func TestMatchDifferentTypesAfterParse(t *testing.T) {
 }
 
 func TestParseSingleSlowLogField(t *testing.T) {
-	require.Equal(t, len(variable.SlowLogRuleFieldAccessors), 39)
+	require.Equal(t, len(variable.SlowLogRuleFieldAccessors), 38)
 	accessor, ok := variable.SlowLogRuleFieldAccessors[strings.ToLower(variable.SlowLogPlanDigest)]
 	require.True(t, ok)
 	require.NotNil(t, accessor.Setter)
@@ -304,10 +304,6 @@ func TestParseSingleSlowLogField(t *testing.T) {
 
 	_, err = variable.ParseSlowLogFieldValue(variable.SlowLogQueryTimeStr, "abc")
 	require.Error(t, err)
-
-	v, err = variable.ParseSlowLogFieldValue(variable.SlowLogMemArbitration, "1.2345")
-	require.NoError(t, err)
-	require.Equal(t, 1.2345, v)
 
 	// string fields
 	v, err = variable.ParseSlowLogFieldValue(variable.SlowLogDBStr, "testdb")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

This field was originally introduced in PR [memory: global mem resources arbitrator](https://github.com/pingcap/tidb/pull/63073) as a key in the slow log rules.
However, the Global Memory Resources Arbitrator is still an experimental feature, and its behavior and semantics are not yet stable enough to serve as a control key for slow log rules.

### What changed and how does it work?
Therefore, this PR removes the key of `MemArbitrator` for now. It can be reconsidered once the related functionality becomes mature and stable.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
