### PR TITLE
unistore: support return _tidb_commit_ts for coprocessor request | tidb-test=feature/active-active tikv=feature/active-active

### DIFF
--- a/pkg/store/mockstore/unistore/cophandler/analyze.go
+++ b/pkg/store/mockstore/unistore/cophandler/analyze.go
@@ -191,7 +191,7 @@ type analyzeIndexProcessor struct {
 	topNCurValuePair statistics.TopNMeta
 }
 
-func (p *analyzeIndexProcessor) Process(key, _ []byte) error {
+func (p *analyzeIndexProcessor) Process(key, _ []byte, _ uint64) error {
 	decodedKey := key
 	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
 		// If the key is in API V2, then ignore the prefix
@@ -251,7 +251,7 @@ type analyzeCommonHandleProcessor struct {
 	rowBuf       []byte
 }
 
-func (p *analyzeCommonHandleProcessor) Process(key, value []byte) error {
+func (p *analyzeCommonHandleProcessor) Process(key, value []byte, _ uint64) error {
 	values, _, err := tablecodec.CutCommonHandle(key, p.colLen)
 	if err != nil {
 		return err
@@ -496,7 +496,7 @@ func (e *analyzeColumnsExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	return nil
 }
 
-func (e *analyzeColumnsExec) Process(key, value []byte) error {
+func (e *analyzeColumnsExec) Process(key, value []byte, _ uint64) error {
 	handle, err := tablecodec.DecodeRowKey(key)
 	if err != nil {
 		return errors.Trace(err)
@@ -628,7 +628,7 @@ type analyzeMixedExec struct {
 	topNCurValuePair statistics.TopNMeta
 }
 
-func (e *analyzeMixedExec) Process(key, value []byte) error {
+func (e *analyzeMixedExec) Process(key, value []byte, _ uint64) error {
 	decodedKey := key
 	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
 		// If the key is in API V2, then ignore the prefix
@@ -678,7 +678,7 @@ func (e *analyzeMixedExec) Process(key, value []byte) error {
 	}
 
 	// columns
-	err = e.analyzeColumnsExec.Process(key, value)
+	err = e.analyzeColumnsExec.Process(key, value, 0)
 	return err
 }
 

--- a/pkg/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/closure_exec.go
@@ -563,7 +563,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	for i, ran := range e.kvRanges {
 		e.curNdv = 0
 		if e.isPointGetRange(ran) {
-			val, _, err := dbReader.Get(ran.StartKey, e.startTS)
+			val, meta, err := dbReader.Get(ran.StartKey, e.startTS)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -574,7 +574,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 				e.counts[i]++
 				e.ndvs[i] = 1
 			}
-			err = e.processor.Process(ran.StartKey, val)
+			err = e.processor.Process(ran.StartKey, val, meta.CommitTS())
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -643,7 +643,7 @@ type countStarProcessor struct {
 }
 
 // countStarProcess is used for `count(*)`.
-func (e *countStarProcessor) Process(key, value []byte) error {
+func (e *countStarProcessor) Process(key, value []byte, _ uint64) error {
 	defer func(begin time.Time) {
 		if e.idxScanCtx != nil {
 			e.idxScanCtx.execDetail.update(begin, true)
@@ -679,7 +679,7 @@ type countColumnProcessor struct {
 	*closureExecutor
 }
 
-func (e *countColumnProcessor) Process(key, value []byte) error {
+func (e *countColumnProcessor) Process(key, value []byte, _ uint64) error {
 	gotRow := false
 	defer func(begin time.Time) {
 		if e.idxScanCtx != nil {
@@ -740,13 +740,13 @@ type tableScanProcessor struct {
 	*closureExecutor
 }
 
-func (e *tableScanProcessor) Process(key, value []byte) error {
+func (e *tableScanProcessor) Process(key, value []byte, commitTS uint64) error {
 	if e.rowCount == e.limit {
 		return dbreader.ErrScanBreak
 	}
 	e.rowCount++
 	e.curNdv++
-	err := e.tableScanProcessCore(key, value)
+	err := e.tableScanProcessCore(key, value, commitTS)
 	if e.scanCtx.chk.NumRows() == chunkMaxRows {
 		err = e.chunkToOldChunk(e.scanCtx.chk)
 	}
@@ -757,14 +757,14 @@ func (e *tableScanProcessor) Finish() error {
 	return e.scanFinish()
 }
 
-func (e *closureExecutor) processCore(key, value []byte) error {
+func (e *closureExecutor) processCore(key, value []byte, commitTS uint64) error {
 	if e.mockReader != nil {
 		return e.mockReadScanProcessCore(key, value)
 	}
 	if e.idxScanCtx != nil {
 		return e.indexScanProcessCore(key, value)
 	}
-	return e.tableScanProcessCore(key, value)
+	return e.tableScanProcessCore(key, value, commitTS)
 }
 
 func (e *closureExecutor) hasSelection() bool {
@@ -834,7 +834,7 @@ func (e *closureExecutor) mockReadScanProcessCore(key, value []byte) error {
 	return nil
 }
 
-func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
+func (e *closureExecutor) tableScanProcessCore(key, value []byte, commitTS uint64) error {
 	incRow := false
 	defer func(begin time.Time) {
 		e.scanCtx.execDetail.update(begin, incRow)
@@ -843,7 +843,7 @@ func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = e.scanCtx.decoder.DecodeToChunk(value, 0, handle, e.scanCtx.chk)
+	err = e.scanCtx.decoder.DecodeToChunk(value, commitTS, handle, e.scanCtx.chk)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -866,7 +866,7 @@ type indexScanProcessor struct {
 	*closureExecutor
 }
 
-func (e *indexScanProcessor) Process(key, value []byte) error {
+func (e *indexScanProcessor) Process(key, value []byte, commitTS uint64) error {
 	if e.rowCount == e.limit {
 		return dbreader.ErrScanBreak
 	}
@@ -983,7 +983,7 @@ type selectionProcessor struct {
 	*closureExecutor
 }
 
-func (e *selectionProcessor) Process(key, value []byte) error {
+func (e *selectionProcessor) Process(key, value []byte, commitTS uint64) error {
 	var gotRow bool
 	defer func(begin time.Time) {
 		e.selectionCtx.execDetail.update(begin, gotRow)
@@ -991,7 +991,7 @@ func (e *selectionProcessor) Process(key, value []byte) error {
 	if e.rowCount == e.limit {
 		return dbreader.ErrScanBreak
 	}
-	err := e.processCore(key, value)
+	err := e.processCore(key, value, commitTS)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1017,12 +1017,12 @@ type topNProcessor struct {
 	*closureExecutor
 }
 
-func (e *topNProcessor) Process(key, value []byte) (err error) {
+func (e *topNProcessor) Process(key, value []byte, commitTS uint64) (err error) {
 	gotRow := false
 	defer func(begin time.Time) {
 		e.topNCtx.execDetail.update(begin, gotRow)
 	}(time.Now())
-	if err = e.processCore(key, value); err != nil {
+	if err = e.processCore(key, value, commitTS); err != nil {
 		return err
 	}
 	if e.hasSelection() {
@@ -1066,7 +1066,7 @@ func (e *topNProcessor) Finish() error {
 	sort.Sort(&ctx.heap.topNSorter)
 	chk := e.scanCtx.chk
 	for _, row := range ctx.heap.rows {
-		err := e.processCore(row.data[0], row.data[1])
+		err := e.processCore(row.data[0], row.data[1], 0)
 		if err != nil {
 			return err
 		}
@@ -1090,12 +1090,12 @@ type hashAggProcessor struct {
 	aggCtxsMap   map[string][]*aggregation.AggEvaluateContext
 }
 
-func (e *hashAggProcessor) Process(key, value []byte) (err error) {
+func (e *hashAggProcessor) Process(key, value []byte, commitTS uint64) (err error) {
 	incRow := false
 	defer func(begin time.Time) {
 		e.aggCtx.execDetail.update(begin, incRow)
 	}(time.Now())
-	err = e.processCore(key, value)
+	err = e.processCore(key, value, commitTS)
 	if err != nil {
 		return err
 	}

--- a/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
+++ b/pkg/store/mockstore/unistore/cophandler/mpp_exec.go
@@ -153,13 +153,13 @@ type tableScanExec struct {
 
 func (e *tableScanExec) SkipValue() bool { return false }
 
-func (e *tableScanExec) Process(key, value []byte) error {
+func (e *tableScanExec) Process(key, value []byte, commitTS uint64) error {
 	handle, err := tablecodec.DecodeRowKey(key)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	err = e.decoder.DecodeToChunk(value, 0, handle, e.chk)
+	err = e.decoder.DecodeToChunk(value, commitTS, handle, e.chk)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -310,7 +310,7 @@ func (e *indexScanExec) isNewVals(values [][]byte) bool {
 	return false
 }
 
-func (e *indexScanExec) Process(key, value []byte) error {
+func (e *indexScanExec) Process(key, value []byte, _ uint64) error {
 	decodedKey := key
 	if !kv.Key(key).HasPrefix(tablecodec.TablePrefix()) {
 		// If the key is in API V2, then ignore the prefix

--- a/pkg/store/mockstore/unistore/tikv/dbreader/db_reader.go
+++ b/pkg/store/mockstore/unistore/tikv/dbreader/db_reader.go
@@ -236,7 +236,7 @@ type ScanFunc = func(key, value []byte) error
 type ScanProcessor interface {
 	// Process accepts key and value, should not keep reference to them.
 	// Returns ErrScanBreak will break the scan loop.
-	Process(key, value []byte) error
+	Process(key, value []byte, commitTS uint64) error
 	// SkipValue returns if we can skip the value.
 	SkipValue() bool
 }
@@ -278,7 +278,7 @@ func (r *DBReader) Scan(startKey, endKey []byte, limit int, startTS uint64, proc
 				return errors.Trace(err)
 			}
 		}
-		err = proc.Process(key, val)
+		err = proc.Process(key, val, item.Version())
 		if err != nil {
 			if err == ErrScanBreak {
 				break
@@ -344,7 +344,7 @@ func (r *DBReader) ReverseScan(startKey, endKey []byte, limit int, startTS uint6
 				return errors.Trace(err)
 			}
 		}
-		err = proc.Process(key, val)
+		err = proc.Process(key, val, item.Version())
 		if err != nil {
 			if err == ErrScanBreak {
 				break

--- a/pkg/store/mockstore/unistore/tikv/mvcc.go
+++ b/pkg/store/mockstore/unistore/tikv/mvcc.go
@@ -1963,7 +1963,7 @@ type kvScanProcessor struct {
 	scanCnt    uint32
 }
 
-func (p *kvScanProcessor) Process(key, value []byte) (err error) {
+func (p *kvScanProcessor) Process(key, value []byte, _ uint64) (err error) {
 	if p.sampleStep > 0 {
 		p.scanCnt++
 		if (p.scanCnt-1)%p.sampleStep != 0 {

--- a/tests/integrationtest/r/active_active/commit_ts.result
+++ b/tests/integrationtest/r/active_active/commit_ts.result
@@ -1,5 +1,5 @@
 drop table if exists t;
-create table t (id int primary key, v int);
+create table t (id int primary key, v int, index i_v(v));
 insert into t values (1, 1), (2, 2), (3, 3);
 insert into t values (4, 4);
 explain format = 'brief' select _tidb_commit_ts, id from t where id = 1;
@@ -62,8 +62,39 @@ _tidb_commit_ts	id
 TSO	1
 TSO	2
 TSO	3
-# TODO
-# coprocessor is not supported yet
+# coprocessor request should also return _tidb_commit_ts
+explain format = 'brief' select _tidb_commit_ts, id from t;
+id	estRows	task	access object	operator info
+Projection	10000.00	root		active_active__commit_ts.t._tidb_commit_ts, active_active__commit_ts.t.id
+└─TableReader	10000.00	root		data:TableFullScan
+  └─TableFullScan	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select _tidb_commit_ts, id from t;
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+TSO	4
+select _tidb_commit_ts, id from t where id < 5;
+_tidb_commit_ts	id
+TSO	1
+TSO	2
+TSO	3
+TSO	4
+select _tidb_commit_ts, id from t where id < 5 order by id desc;
+_tidb_commit_ts	id
+TSO	4
+TSO	3
+TSO	2
+TSO	1
+explain format = 'brief' select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+id	estRows	task	access object	operator info
+Projection	10.00	root		active_active__commit_ts.t._tidb_commit_ts, active_active__commit_ts.t.v
+└─IndexLookUp	10.00	root		
+  ├─IndexRangeScan(Build)	10.00	cop[tikv]	table:t, index:i_v(v)	range:[2,2], keep order:false, stats:pseudo
+  └─TableRowIDScan(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+_tidb_commit_ts	v
+TSO	2
 drop table if exists t;
 create table t (a bigint primary key, b int, c int) softdelete retention 7 day active_active = 'on';
 insert into t value (1,1,1) on duplicate key update a = _tidb_commit_ts;

--- a/tests/integrationtest/t/active_active/commit_ts.test
+++ b/tests/integrationtest/t/active_active/commit_ts.test
@@ -1,5 +1,5 @@
 drop table if exists t;
-create table t (id int primary key, v int);
+create table t (id int primary key, v int, index i_v(v));
 insert into t values (1, 1), (2, 2), (3, 3);
 insert into t values (4, 4);
 
@@ -59,11 +59,19 @@ select _tidb_commit_ts, id from t where id in (1, 2, 3);
 # --replace_regex /^[1-9][0-9]+/TSO/
 # select _tidb_commit_ts, id from t where id in (1, 2, 3);
 
---echo # TODO
---echo # coprocessor is not supported yet
-# explain format = 'brief' select _tidb_commit_ts, id from t;
-# select _tidb_commit_ts, id from t;
-# select _tidb_commit_ts, id from t where id < 5;
+--echo # coprocessor request should also return _tidb_commit_ts
+explain format = 'brief' select _tidb_commit_ts, id from t;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id < 5;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, id from t where id < 5 order by id desc;
+
+# index lookup should be used, index scan does not support _tidb_commit_ts
+explain format = 'brief' select _tidb_commit_ts, v from t use index (i_v) where v = 2;
+--replace_regex /^[1-9][0-9]+/TSO/
+select _tidb_commit_ts, v from t use index (i_v) where v = 2;
 
 drop table if exists t;
 create table t (a bigint primary key, b int, c int) softdelete retention 7 day active_active = 'on';


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65106


Problem Summary:

### What changed and how does it work?

tikv has supported _tidb_commt_ts https://github.com/tikv/tikv/pull/19166
now this commit handle the same thing in unistore


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
