### PR TITLE
br: fixed set-file on `CopiedSST` may cause panic

### DIFF
--- a/br/pkg/restore/log_client/ssts.go
+++ b/br/pkg/restore/log_client/ssts.go
@@ -123,9 +123,11 @@ func (s *CopiedSST) GetSSTs() []*backuppb.File {
 func (s *CopiedSST) SetSSTs(fs []*backuppb.File) {
 	if len(fs) == 0 {
 		s.File = nil
+		return
 	}
 	if len(fs) == 1 {
 		s.File = fs[0]
+		return
 	}
 	log.Panic("Too many files passed to AddedSSTs.SetSSTs.", zap.Any("input", fs))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65109 

Problem Summary:

The `SetSSTs` method in `CopiedSST` has a control flow issue where the `log.Panic()` call at the end executes even when valid input is provided (either an empty slice or a single file). This causes the function to panic unexpectedly after successfully setting the file, rather than only panicking when multiple files are passed.

### What changed and how does it work?

Added `return` statements in the `SetSSTs` method to ensure the function exits after handling valid cases:
- Added `return` after setting `s.File = nil` when the input slice is empty
- Added `return` after setting `s.File = fs[0]` when the input slice has exactly one file

This prevents the panic at the end of the function from being executed when the input is valid, ensuring the function only panics when multiple files are passed (the error case).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] This is a simple control flow fix that corrects unreachable code execution. The panic should only trigger for invalid input (multiple files), not for valid cases.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Fixed a bug that may cause `restore point` from checkpoint panic when the log backup was mixed with a full backup.
```