### PR TITLE
executor: data race in TestIndexNestedLoopHashJoin

### DIFF
--- a/pkg/executor/distsql.go
+++ b/pkg/executor/distsql.go
@@ -1012,7 +1012,7 @@ func (e *IndexLookUpExecutor) Close() error {
 	if e.stats != nil {
 		defer func() {
 			e.stmtRuntimeStatsColl.RegisterStats(e.ID(), e.stats)
-			indexScanCopTasks := e.stmtRuntimeStatsColl.GetCopStatsTaskNum(e.getIndexPlanRootID())
+			indexScanCopTasks, _ := e.stmtRuntimeStatsColl.GetCopCountAndRows(e.getIndexPlanRootID())
 			if e.indexLookUpPushDown {
 				metrics.IndexLookUpExecutorWithPushDownEnabledRowNumber.Observe(float64(e.stats.indexScanBasicStats.GetActRows()))
 				metrics.IndexLookUpIndexScanCopTasksWithPushDownEnabled.Add(float64(indexScanCopTasks))

--- a/pkg/util/execdetails/runtime_stats.go
+++ b/pkg/util/execdetails/runtime_stats.go
@@ -558,17 +558,6 @@ func (e *RuntimeStatsColl) GetCopStats(planID int) *CopRuntimeStats {
 	return copStats
 }
 
-// GetCopStatsTaskNum returns total tasks of CopRuntimeStats that specified by planID
-func (e *RuntimeStatsColl) GetCopStatsTaskNum(planID int) int32 {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	copStats, ok := e.copStats[planID]
-	if !ok {
-		return 0
-	}
-	return copStats.GetTasks()
-}
-
 // GetCopCountAndRows returns the total cop-tasks count and total rows of all cop-tasks.
 func (e *RuntimeStatsColl) GetCopCountAndRows(planID int) (int32, int64) {
 	e.mu.Lock()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #64542

Problem Summary:

`stmtRuntimeStatsColl` in `indexLookUpExecutorContext` is assigned by `sctx.GetSessionVars().StmtCtx.RuntimeStatsColl`. So if one query has several indexLookUpExecutors, they will share the same `stmtRuntimeStatsColl` and this may cause data race.

### What changed and how does it work?

We add the lock when getting fields in `RuntimeStatsColl`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the data race in TestIndexNestedLoopHashJoin
```
