### PR TITLE
[WIP] backend/external: improve sort speed for external writer

### DIFF
--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -529,7 +529,6 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		zap.Int("id", task.ID), zap.Stringer("task", task))
 
 	var (
-		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
 	var scanCtx context.Context = w.ctx
@@ -574,20 +573,17 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 			execDetails = kvutil.ExecDetails{}
 
 			_, tableScanRowCount := distsqlCtx.RuntimeStatsColl.GetCopCountAndRows(tableScanCopID)
-			idxResults = append(idxResults, IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed})
+			idxResult := IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed}
 			lastTableScanRowCount = tableScanRowCount
+			sender(idxResult)
+			if w.cpOp != nil {
+				w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
+			}
+			w.totalCount.Add(idxResult.tableScanRowCount)
+			w.recycleChunk(srcChk)
 		}
 		return rs.Close()
 	})
-
-	for i, idxResult := range idxResults {
-		sender(idxResult)
-		if w.cpOp != nil {
-			done := i == len(idxResults)-1
-			w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
-		}
-		w.totalCount.Add(idxResult.tableScanRowCount)
-	}
 
 	return err
 }

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -254,6 +254,9 @@ type IndexRecordChunk struct {
 	Chunk *chunk.Chunk
 	Err   error
 	Done  bool
+	// releaseChunk releases the ownership of Chunk after the downstream consumer
+	// has finished using it.
+	releaseChunk func(*chunk.Chunk)
 
 	// tableScanRowCount is the number of rows scanned by the corresponding TableScanTask.
 	// If the index is a partial index, the number of rows in the Chunk may be less than tableScanRowCount.
@@ -529,7 +532,6 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		zap.Int("id", task.ID), zap.Stringer("task", task))
 
 	var (
-		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
 	var scanCtx context.Context = w.ctx
@@ -574,20 +576,24 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 			execDetails = kvutil.ExecDetails{}
 
 			_, tableScanRowCount := distsqlCtx.RuntimeStatsColl.GetCopCountAndRows(tableScanCopID)
-			idxResults = append(idxResults, IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed})
+			idxResult := IndexRecordChunk{
+				ID:               task.ID,
+				Chunk:            srcChk,
+				Done:             done,
+				ctx:              w.ctx,
+				tableScanRowCount: tableScanRowCount - lastTableScanRowCount,
+				conditionPushed:  conditionPushed,
+				releaseChunk:     w.recycleChunk,
+			}
 			lastTableScanRowCount = tableScanRowCount
+			sender(idxResult)
+			if w.cpOp != nil {
+				w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
+			}
+			w.totalCount.Add(idxResult.tableScanRowCount)
 		}
 		return rs.Close()
 	})
-
-	for i, idxResult := range idxResults {
-		sender(idxResult)
-		if w.cpOp != nil {
-			done := i == len(idxResults)-1
-			w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
-		}
-		w.totalCount.Add(idxResult.tableScanRowCount)
-	}
 
 	return err
 }
@@ -791,7 +797,11 @@ type indexIngestWorker struct {
 func (w *indexIngestWorker) HandleTask(ck IndexRecordChunk, send func(IndexWriteResult)) error {
 	defer func() {
 		if ck.Chunk != nil {
-			w.srcChunkPool.Put(ck.Chunk)
+			if ck.releaseChunk != nil {
+				ck.releaseChunk(ck.Chunk)
+			} else {
+				w.srcChunkPool.Put(ck.Chunk)
+			}
 		}
 	}()
 	failpoint.InjectCall("mockIndexIngestWorkerFault")

--- a/pkg/ddl/backfilling_operators.go
+++ b/pkg/ddl/backfilling_operators.go
@@ -529,6 +529,7 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 		zap.Int("id", task.ID), zap.Stringer("task", task))
 
 	var (
+		idxResults  []IndexRecordChunk
 		execDetails kvutil.ExecDetails
 	)
 	var scanCtx context.Context = w.ctx
@@ -573,17 +574,20 @@ func (w *tableScanWorker) scanRecords(task TableScanTask, sender func(IndexRecor
 			execDetails = kvutil.ExecDetails{}
 
 			_, tableScanRowCount := distsqlCtx.RuntimeStatsColl.GetCopCountAndRows(tableScanCopID)
-			idxResult := IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed}
+			idxResults = append(idxResults, IndexRecordChunk{ID: task.ID, Chunk: srcChk, Done: done, ctx: w.ctx, tableScanRowCount: tableScanRowCount - lastTableScanRowCount, conditionPushed: conditionPushed})
 			lastTableScanRowCount = tableScanRowCount
-			sender(idxResult)
-			if w.cpOp != nil {
-				w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
-			}
-			w.totalCount.Add(idxResult.tableScanRowCount)
-			w.recycleChunk(srcChk)
 		}
 		return rs.Close()
 	})
+
+	for i, idxResult := range idxResults {
+		sender(idxResult)
+		if w.cpOp != nil {
+			done := i == len(idxResults)-1
+			w.cpOp.UpdateChunk(task.ID, int(idxResult.tableScanRowCount), done)
+		}
+		w.totalCount.Add(idxResult.tableScanRowCount)
+	}
 
 	return err
 }

--- a/pkg/ddl/backfilling_txn_executor.go
+++ b/pkg/ddl/backfilling_txn_executor.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/sqlkiller"
 	"github.com/pingcap/tidb/pkg/util/tiflash"
 	tikvstore "github.com/tikv/client-go/v2/kv"
+	kvutil "github.com/tikv/client-go/v2/util"
 )
 
 // backfillExecutor is used to manage the lifetime of backfill workers.
@@ -185,6 +186,9 @@ func newReorgDistSQLCtxWithReorgMeta(kvClient kv.Client, reorgMeta *model.DDLReo
 	ctx.Location = loc
 	ctx.ErrCtx = errctx.NewContextWithLevels(reorgErrLevelsWithSQLMode(reorgMeta.SQLMode), ctx.WarnHandler)
 	ctx.ResourceGroupName = reorgMeta.ResourceGroupName
+	ctx.InRestrictedSQL = true
+	ctx.RequestSourceType = getDDLRequestSource(model.ActionAddIndex)
+	ctx.ExplicitRequestSourceType = kvutil.ExplicitTypeDDL
 	return ctx, nil
 }
 

--- a/pkg/ddl/ingest/engine.go
+++ b/pkg/ddl/ingest/engine.go
@@ -41,7 +41,6 @@ type Writer interface {
 	// To enable uniqueness check, the handle should be non-empty.
 	WriteRow(ctx context.Context, idxKey, idxVal []byte, handle tidbkv.Handle) error
 	LockForWrite() (unlock func())
-	WrittenBytes() int64
 }
 
 // engineInfo is the engine for one index reorg task, each task will create several new writers under the

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -58,6 +59,10 @@ var (
 )
 
 var reuseIntermChkLogCount atomic.Uint64
+
+func shouldLogReadIndexChunkPath(r *selectResult) bool {
+	return strings.HasPrefix(r.ctx.RequestSourceType, kv.InternalTxnBackfillDDLPrefix+"add_index")
+}
 
 var (
 	_ SelectResult = (*selectResult)(nil)
@@ -569,17 +574,31 @@ func (r *selectResult) readFromChunk(ctx context.Context, chk *chunk.Chunk) erro
 			if chk.NumRows() > 0 {
 				return nil
 			}
-			if cnt := reuseIntermChkLogCount.Add(1); cnt <= 20 || cnt%1000 == 0 {
-				logutil.BgLogger().Info("selectResult reuse intermediate chunk",
+			if shouldLogReadIndexChunkPath(r) {
+				cnt := reuseIntermChkLogCount.Add(1)
+				logutil.BgLogger().Info("selectResult chunk path",
 					zap.Uint64("count", cnt),
+					zap.String("mode", "reuse-interm"),
 					zap.Int("remainedRows", r.respChunkDecoder.RemainedRows()),
 					zap.Int("requiredRows", chk.RequiredRows()),
+					zap.Int("chkNumRows", chk.NumRows()),
 					zap.Int("respChkIdx", r.respChkIdx),
 					zap.Int("selectRespChunks", len(r.selectResp.Chunks)))
 			}
 			r.respChunkDecoder.ReuseIntermChk(chk)
 			r.respChkIdx++
 			return nil
+		}
+		if shouldLogReadIndexChunkPath(r) {
+			cnt := reuseIntermChkLogCount.Add(1)
+			logutil.BgLogger().Info("selectResult chunk path",
+				zap.Uint64("count", cnt),
+				zap.String("mode", "decode-into-chk"),
+				zap.Int("remainedRows", r.respChunkDecoder.RemainedRows()),
+				zap.Int("requiredRows", chk.RequiredRows()),
+				zap.Int("chkNumRows", chk.NumRows()),
+				zap.Int("respChkIdx", r.respChkIdx),
+				zap.Int("selectRespChunks", len(r.selectResp.Chunks)))
 		}
 		r.respChunkDecoder.Decode(chk)
 		if r.respChunkDecoder.IsFinished() {

--- a/pkg/distsql/select_result.go
+++ b/pkg/distsql/select_result.go
@@ -57,6 +57,8 @@ var (
 	telemetryStoreBatchedFallbackCnt = metrics.TelemetryStoreBatchedFallbackCnt
 )
 
+var reuseIntermChkLogCount atomic.Uint64
+
 var (
 	_ SelectResult = (*selectResult)(nil)
 	_ SelectResult = (*serialSelectResults)(nil)
@@ -566,6 +568,14 @@ func (r *selectResult) readFromChunk(ctx context.Context, chk *chunk.Chunk) erro
 		if r.respChunkDecoder.RemainedRows() > int(float64(chk.RequiredRows())*0.8) {
 			if chk.NumRows() > 0 {
 				return nil
+			}
+			if cnt := reuseIntermChkLogCount.Add(1); cnt <= 20 || cnt%1000 == 0 {
+				logutil.BgLogger().Info("selectResult reuse intermediate chunk",
+					zap.Uint64("count", cnt),
+					zap.Int("remainedRows", r.respChunkDecoder.RemainedRows()),
+					zap.Int("requiredRows", chk.RequiredRows()),
+					zap.Int("respChkIdx", r.respChkIdx),
+					zap.Int("selectRespChunks", len(r.selectResp.Chunks)))
 			}
 			r.respChunkDecoder.ReuseIntermChk(chk)
 			r.respChkIdx++

--- a/pkg/lightning/backend/external/writer.go
+++ b/pkg/lightning/backend/external/writer.go
@@ -351,6 +351,12 @@ func (b *WriterBuilder) BuildOneFile(
 	return ret
 }
 
+type compactedLocation struct {
+	bufIndex int32
+	offset   int32
+	keyHint  uint32
+}
+
 // MultipleFilesStat is the statistic information of multiple files (currently
 // every 500 files). It is used to estimate the data overlapping, and per-file
 // statistic information maybe too big to loaded into memory.
@@ -435,8 +441,10 @@ type Writer struct {
 	rc *rangePropertiesCollector
 
 	kvBuffer    *membuf.Buffer
-	kvLocations []membuf.SliceLocation
-	kvSize      int64
+	kvLocations []compactedLocation
+	kvSize      int64 // calculated during writing to store
+
+	commonPrefix []byte
 
 	onClose OnWriterCloseFunc
 	onDup   engineapi.OnDuplicateKey
@@ -463,6 +471,37 @@ type Writer struct {
 	conflictInfo engineapi.ConflictInfo
 }
 
+func (w *Writer) updateCommonPrefix(key []byte) {
+	// We can guarantee that common prefix length must be > 0, so we use 0 to
+	// determine if it's the first key.
+	if len(w.commonPrefix) == 0 {
+		w.commonPrefix = slices.Clone(key)
+		return
+	}
+
+	commonLen := min(len(w.commonPrefix), len(key))
+	for i := range commonLen {
+		if w.commonPrefix[i] != key[i] {
+			w.commonPrefix = w.commonPrefix[:i]
+			return
+		}
+	}
+	w.commonPrefix = w.commonPrefix[:commonLen]
+}
+
+func (w *Writer) updateKeyHints() {
+	for i := range w.kvLocations {
+		key := w.getKeyByLoc(&w.kvLocations[i])
+		if len(key) >= len(w.commonPrefix)+4 {
+			w.kvLocations[i].keyHint = binary.BigEndian.Uint32(key[len(w.commonPrefix):])
+		} else {
+			var tempBuf [4]byte
+			copy(tempBuf[:], key[len(w.commonPrefix):])
+			w.kvLocations[i].keyHint = binary.BigEndian.Uint32(tempBuf[:])
+		}
+	}
+}
+
 // WriteRow implements ingest.Writer.
 func (w *Writer) WriteRow(ctx context.Context, key, val []byte, handle tidbkv.Handle) error {
 	if w.tikvCodec != nil {
@@ -487,9 +526,9 @@ func (w *Writer) WriteRow(ctx context.Context, key, val []byte, handle tidbkv.Ha
 	copy(dataBuf[2*lengthBytes:], key)
 	copy(dataBuf[2*lengthBytes+keyLen:], val)
 
-	w.kvLocations = append(w.kvLocations, loc)
-	// TODO: maybe we can unify the size calculation during write to store.
-	w.kvSize += int64(keyLen + len(val))
+	w.updateCommonPrefix(key)
+	w.kvLocations = append(w.kvLocations, compactedLocation{
+		bufIndex: loc.BufIdx, offset: loc.Offset})
 	w.batchSize += uint64(length)
 	return nil
 }
@@ -568,10 +607,19 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 	sortStart := time.Now()
 	var (
 		dupFound bool
-		dupLoc   membuf.SliceLocation
+		dupLoc   compactedLocation
 	)
-	slices.SortFunc(w.kvLocations, func(i, j membuf.SliceLocation) int {
-		res := bytes.Compare(w.getKeyByLoc(&i), w.getKeyByLoc(&j))
+	w.updateKeyHints()
+	slices.SortFunc(w.kvLocations, func(i, j compactedLocation) int {
+		if i.keyHint != j.keyHint {
+			if i.keyHint < j.keyHint {
+				return -1
+			}
+			return 1
+		}
+		res := bytes.Compare(
+			w.getKeyByLoc(&i)[len(w.commonPrefix):],
+			w.getKeyByLoc(&j)[len(w.commonPrefix):])
 		if res == 0 && !dupFound {
 			dupFound = true
 			dupLoc = i
@@ -584,7 +632,7 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 
 	batchKVCnt := len(w.kvLocations)
 	var (
-		dupLocs []membuf.SliceLocation
+		dupLocs []compactedLocation
 		dupCnt  int
 	)
 	if dupFound {
@@ -594,10 +642,8 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 			// we don't have a global view, so need to keep duplicates with duplicate
 			// count <= 2, so later we can find them.
 			w.kvLocations, dupLocs, dupCnt = removeDuplicatesMoreThanTwo(w.kvLocations, w.getKeyByLoc)
-			w.kvSize = w.reCalculateKVSize()
 		case engineapi.OnDuplicateKeyRemove:
 			w.kvLocations, _, dupCnt = removeDuplicates(w.kvLocations, w.getKeyByLoc, false)
-			w.kvSize = w.reCalculateKVSize()
 		case engineapi.OnDuplicateKeyError:
 			dupKey := slices.Clone(w.getKeyByLoc(&dupLoc))
 			dupValue := slices.Clone(w.getValueByLoc(&dupLoc))
@@ -665,6 +711,7 @@ func (w *Writer) flushKVs(ctx context.Context, fromClose bool) (err error) {
 
 	w.kvLocations = w.kvLocations[:0]
 	w.kvSize = 0
+	w.commonPrefix = nil
 	w.kvBuffer.Reset()
 	w.batchSize = 0
 	w.currentSeq++
@@ -693,7 +740,7 @@ func (w *Writer) addNewKVFile2MultiFileStats(dataFile, statFile string, minKey, 
 	w.fileMaxKeys = append(w.fileMaxKeys, tidbkv.Key(maxKey).Clone())
 }
 
-func (w *Writer) flushSortedKVs(ctx context.Context, dupLocs []membuf.SliceLocation) (string, string, string, error) {
+func (w *Writer) flushSortedKVs(ctx context.Context, dupLocs []compactedLocation) (string, string, string, error) {
 	logger := logutil.Logger(ctx).With(
 		zap.String("writer-id", w.writerID),
 		zap.Int("sequence-number", w.currentSeq),
@@ -716,8 +763,11 @@ func (w *Writer) flushSortedKVs(ctx context.Context, dupLocs []membuf.SliceLocat
 	w.rc.reset()
 	kvStore := NewKeyValueStore(ctx, dataWriter, w.rc)
 
+	w.kvSize = 0
 	for _, pair := range w.kvLocations {
-		err = kvStore.addEncodedData(w.kvBuffer.GetSlice(&pair))
+		s := w.getSlice(pair)
+		w.kvSize += int64(len(s) - 2*lengthBytes)
+		err = kvStore.addEncodedData(s)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -762,7 +812,7 @@ func (w *Writer) flushSortedKVs(ctx context.Context, dupLocs []membuf.SliceLocat
 	return dataFile, statFile, dupPath, nil
 }
 
-func (w *Writer) writeDupKVs(ctx context.Context, kvLocs []membuf.SliceLocation) (string, error) {
+func (w *Writer) writeDupKVs(ctx context.Context, kvLocs []compactedLocation) (string, error) {
 	dupPath, dupWriter, err := w.createDupWriter(ctx)
 	if err != nil {
 		return "", err
@@ -776,7 +826,7 @@ func (w *Writer) writeDupKVs(ctx context.Context, kvLocs []membuf.SliceLocation)
 	}()
 	dupStore := NewKeyValueStore(ctx, dupWriter, nil)
 	for _, pair := range kvLocs {
-		err = dupStore.addEncodedData(w.kvBuffer.GetSlice(&pair))
+		err = dupStore.addEncodedData(w.getSlice(pair))
 		if err != nil {
 			return "", err
 		}
@@ -790,24 +840,23 @@ func (w *Writer) writeDupKVs(ctx context.Context, kvLocs []membuf.SliceLocation)
 	return dupPath, nil
 }
 
-func (w *Writer) getKeyByLoc(loc *membuf.SliceLocation) []byte {
-	block := w.kvBuffer.GetSlice(loc)
+func (w *Writer) getKeyByLoc(loc *compactedLocation) []byte {
+	block := w.kvBuffer.GetSliceWithoutLength(loc.bufIndex, loc.offset)
 	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
 	return block[2*lengthBytes : 2*lengthBytes+keyLen]
 }
 
-func (w *Writer) getValueByLoc(loc *membuf.SliceLocation) []byte {
-	block := w.kvBuffer.GetSlice(loc)
+func (w *Writer) getValueByLoc(loc *compactedLocation) []byte {
+	block := w.kvBuffer.GetSliceWithoutLength(loc.bufIndex, loc.offset)
 	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
 	return block[2*lengthBytes+keyLen:]
 }
 
-func (w *Writer) reCalculateKVSize() int64 {
-	s := int64(0)
-	for _, loc := range w.kvLocations {
-		s += int64(loc.Length) - 2*lengthBytes
-	}
-	return s
+func (w *Writer) getSlice(loc compactedLocation) []byte {
+	block := w.kvBuffer.GetSliceWithoutLength(loc.bufIndex, loc.offset)
+	valLen := binary.BigEndian.Uint64(block[lengthBytes : 2*lengthBytes])
+	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
+	return block[:2*lengthBytes+keyLen+valLen]
 }
 
 func (w *Writer) createStorageWriter(ctx context.Context) (

--- a/pkg/lightning/backend/external/writer.go
+++ b/pkg/lightning/backend/external/writer.go
@@ -842,20 +842,21 @@ func (w *Writer) writeDupKVs(ctx context.Context, kvLocs []compactedLocation) (s
 
 func (w *Writer) getKeyByLoc(loc *compactedLocation) []byte {
 	block := w.kvBuffer.GetSliceWithoutLength(loc.bufIndex, loc.offset)
-	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
+	keyLen := binary.BigEndian.Uint32(block[4:lengthBytes])
 	return block[2*lengthBytes : 2*lengthBytes+keyLen]
 }
 
 func (w *Writer) getValueByLoc(loc *compactedLocation) []byte {
 	block := w.kvBuffer.GetSliceWithoutLength(loc.bufIndex, loc.offset)
-	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
-	return block[2*lengthBytes+keyLen:]
+	keyLen := binary.BigEndian.Uint32(block[4:lengthBytes])
+	valLen := binary.BigEndian.Uint32(block[lengthBytes+4 : 2*lengthBytes])
+	return block[2*lengthBytes+keyLen : 2*lengthBytes+keyLen+valLen]
 }
 
 func (w *Writer) getSlice(loc compactedLocation) []byte {
 	block := w.kvBuffer.GetSliceWithoutLength(loc.bufIndex, loc.offset)
-	valLen := binary.BigEndian.Uint64(block[lengthBytes : 2*lengthBytes])
-	keyLen := binary.BigEndian.Uint64(block[:lengthBytes])
+	valLen := binary.BigEndian.Uint32(block[lengthBytes+4 : 2*lengthBytes])
+	keyLen := binary.BigEndian.Uint32(block[4:lengthBytes])
 	return block[:2*lengthBytes+keyLen+valLen]
 }
 

--- a/pkg/lightning/membuf/buffer.go
+++ b/pkg/lightning/membuf/buffer.go
@@ -323,8 +323,8 @@ func (b *Buffer) GetSlice(loc *SliceLocation) []byte {
 	return b.blocks[loc.BufIdx][loc.Offset : loc.Offset+loc.Length]
 }
 
-// GetSliceWithoutLength returns the byte slice from offset to the end.
-func (b *Buffer) GetSliceWithoutLength(bufIdx, offset int32) []byte {
+// GetUnboundedSlice returns the byte slice from offset to the end.
+func (b *Buffer) GetUnboundedSlice(bufIdx, offset int32) []byte {
 	return b.blocks[bufIdx][offset:]
 }
 

--- a/pkg/lightning/membuf/buffer.go
+++ b/pkg/lightning/membuf/buffer.go
@@ -263,8 +263,8 @@ func (b *Buffer) AllocBytes(n int) []byte {
 // Buffer. The advantage is that it's smaller than a slice, and it doesn't
 // contain a pointer thus more GC-friendly.
 type SliceLocation struct {
-	bufIdx int32
-	offset int32
+	BufIdx int32
+	Offset int32
 	Length int32
 }
 
@@ -283,7 +283,7 @@ func (b *Buffer) allocBytesWithSliceLocation(n int) ([]byte, SliceLocation) {
 	}
 	blockIdx := int32(b.curBlockIdx)
 	offset := int32(b.curIdx)
-	loc := SliceLocation{bufIdx: blockIdx, offset: offset, Length: int32(n)}
+	loc := SliceLocation{BufIdx: blockIdx, Offset: offset, Length: int32(n)}
 
 	idx := b.curIdx
 	b.curIdx += n
@@ -320,7 +320,12 @@ func (b *Buffer) addBlock() {
 
 // GetSlice returns the byte slice for the slice location.
 func (b *Buffer) GetSlice(loc *SliceLocation) []byte {
-	return b.blocks[loc.bufIdx][loc.offset : loc.offset+loc.Length]
+	return b.blocks[loc.BufIdx][loc.Offset : loc.Offset+loc.Length]
+}
+
+// GetSliceWithoutLength returns the byte slice from offset to the end.
+func (b *Buffer) GetSliceWithoutLength(bufIdx, offset int32) []byte {
+	return b.blocks[bufIdx][offset:]
 }
 
 // AddBytes adds the bytes into this Buffer's managed memory and return it.

--- a/pkg/objstore/objectio/writer.go
+++ b/pkg/objstore/objectio/writer.go
@@ -72,7 +72,6 @@ func newPlainBuffer(chunkSize int) *plainBuffer {
 // BufferedWriter is a buffered writer
 type BufferedWriter struct {
 	buf       interceptBuffer
-	written   int
 	writer    Writer
 	accessRec *recording.AccessStats
 }
@@ -80,6 +79,7 @@ type BufferedWriter struct {
 // Write implements Writer.
 func (u *BufferedWriter) Write(ctx context.Context, p []byte) (int, error) {
 	n, err := u.write0(ctx, p)
+	u.accessRec.RecWrite(n)
 	return n, errors.Trace(err)
 }
 
@@ -95,7 +95,6 @@ func (u *BufferedWriter) write0(ctx context.Context, p []byte) (int, error) {
 			prewrite := p[0:chunkToFill]
 			w, err := u.buf.Write(prewrite)
 			bytesWritten += w
-			u.written += w
 			if err != nil {
 				return bytesWritten, errors.Trace(err)
 			}
@@ -113,13 +112,10 @@ func (u *BufferedWriter) write0(ctx context.Context, p []byte) (int, error) {
 	}
 	w, err := u.buf.Write(p)
 	bytesWritten += w
-	u.written += w
 	return bytesWritten, errors.Trace(err)
 }
 
 func (u *BufferedWriter) uploadChunk(ctx context.Context) error {
-	u.accessRec.RecWrite(u.written)
-	u.written = 0
 	if u.buf.Len() == 0 {
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

This PR is used to do some tests.

~~**This PR enlarge the size of `SliceLocation` by 33%(12 bytes -> 16 bytes), which may increase memory usage of each subtask by 77MiB at most (for CPU/Mem = 1C/2GiB). Considering that memory usage of read step is an issue, this PR is just used to illustrate the cost of getting byte slice during sort.**~~

Problem Summary:

### What changed and how does it work?

**Encapsulate 4 bytes key hint in `SliceLocation` to speed up sorting without enlarging the memory usage.**

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Below are the manual test of encode(read) speed

**Add Index**

- row count: 
- 8B random string: 00:12:15 -> 00:08:29
- 120B random string: 00:13:15 -> 00:08:41

We also test some worst case for this PR, to verify that there are no degradation.

**Import Into with index**

- Table size: 500GiB
- 01:00:54 -> 00:55:20

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced backfilling operations with streamlined chunk processing and progress tracking
  * Optimized key-value ingestion with improved duplicate detection and sorting efficiency

* **Diagnostics**
  * Added detailed logging for index chunk read operations to provide better visibility into data processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->