### PR TITLE
*: fix index lookup pushdown error for partition table + uncomitted rows

### DIFF
--- a/tests/integrationtest/r/executor/index_lookup_pushdown_partition.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown_partition.result
@@ -1,5 +1,9 @@
 drop table if exists tp1, tp2;
 set @@tidb_scatter_region='table';
+set @@tidb_partition_prune_mode = 'dynamic';
+select @@tidb_partition_prune_mode;
+@@tidb_partition_prune_mode
+dynamic
 create table tp1 (a int primary key, b int, c int, key b(b), key c(c) global) partition by hash(a) partitions 4;
 insert into tp1 values (1, 10, 10), (2, 9, 20), (3, 8, 30), (4, 7, 40), (5, 6, 50), (6, 5, 60);
 explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 where b < 10 and a > 1 limit 3;
@@ -136,4 +140,111 @@ a	b	c
 2	9	20
 6	5	60
 3	8	30
+begin;
+insert into tp1 values (10, 11, 12), (20, 21, 22), (30, 31, 32), (40, 41, 42);
+explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+id	estRows	task	access object	operator info
+Projection_7	5.00	root		executor__index_lookup_pushdown_partition.tp1.a, executor__index_lookup_pushdown_partition.tp1.b, executor__index_lookup_pushdown_partition.tp1.c
+└─TopN_10	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  └─UnionScan_15	10000.00	root		
+    └─IndexLookUp_18	10000.00	root	partition:all	
+      ├─LocalIndexLookUp_20(Build)	10000.00	cop[tikv]		index handle offsets:[1]
+      │ ├─IndexFullScan_16(Build)	10000.00	cop[tikv]	table:tp1, index:b(b)	keep order:false, stats:pseudo
+      │ └─TableRowIDScan_19(Probe)	10000.00	cop[tikv]	table:tp1	keep order:false, stats:pseudo
+      └─TableRowIDScan_17(Probe)	0.00	cop[tikv]	table:tp1	keep order:false, stats:pseudo
+select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+a	b	c
+1	10	10
+10	11	12
+2	9	20
+20	21	22
+3	8	30
+set @@tidb_partition_prune_mode = 'static';
+select @@tidb_partition_prune_mode;
+@@tidb_partition_prune_mode
+static
+explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+id	estRows	task	access object	operator info
+TopN_24	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+└─PartitionUnion_29	20.00	root		
+  ├─TopN_32	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │ └─UnionScan_37	10000.00	root		
+  │   └─IndexLookUp_40	10000.00	root		
+  │     ├─LocalIndexLookUp_42(Build)	10000.00	cop[tikv]		index handle offsets:[1]
+  │     │ ├─IndexFullScan_38(Build)	10000.00	cop[tikv]	table:tp1, partition:p0, index:b(b)	keep order:false, stats:pseudo
+  │     │ └─TableRowIDScan_41(Probe)	10000.00	cop[tikv]	table:tp1, partition:p0	keep order:false, stats:pseudo
+  │     └─TableRowIDScan_39(Probe)	0.00	cop[tikv]	table:tp1, partition:p0	keep order:false, stats:pseudo
+  ├─TopN_46	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │ └─UnionScan_51	10000.00	root		
+  │   └─IndexLookUp_54	10000.00	root		
+  │     ├─LocalIndexLookUp_56(Build)	10000.00	cop[tikv]		index handle offsets:[1]
+  │     │ ├─IndexFullScan_52(Build)	10000.00	cop[tikv]	table:tp1, partition:p1, index:b(b)	keep order:false, stats:pseudo
+  │     │ └─TableRowIDScan_55(Probe)	10000.00	cop[tikv]	table:tp1, partition:p1	keep order:false, stats:pseudo
+  │     └─TableRowIDScan_53(Probe)	0.00	cop[tikv]	table:tp1, partition:p1	keep order:false, stats:pseudo
+  ├─TopN_60	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │ └─UnionScan_65	10000.00	root		
+  │   └─IndexLookUp_68	10000.00	root		
+  │     ├─LocalIndexLookUp_70(Build)	10000.00	cop[tikv]		index handle offsets:[1]
+  │     │ ├─IndexFullScan_66(Build)	10000.00	cop[tikv]	table:tp1, partition:p2, index:b(b)	keep order:false, stats:pseudo
+  │     │ └─TableRowIDScan_69(Probe)	10000.00	cop[tikv]	table:tp1, partition:p2	keep order:false, stats:pseudo
+  │     └─TableRowIDScan_67(Probe)	0.00	cop[tikv]	table:tp1, partition:p2	keep order:false, stats:pseudo
+  └─TopN_74	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+    └─UnionScan_79	10000.00	root		
+      └─IndexLookUp_82	10000.00	root		
+        ├─LocalIndexLookUp_84(Build)	10000.00	cop[tikv]		index handle offsets:[1]
+        │ ├─IndexFullScan_80(Build)	10000.00	cop[tikv]	table:tp1, partition:p3, index:b(b)	keep order:false, stats:pseudo
+        │ └─TableRowIDScan_83(Probe)	10000.00	cop[tikv]	table:tp1, partition:p3	keep order:false, stats:pseudo
+        └─TableRowIDScan_81(Probe)	0.00	cop[tikv]	table:tp1, partition:p3	keep order:false, stats:pseudo
+select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+a	b	c
+1	10	10
+10	11	12
+2	9	20
+20	21	22
+3	8	30
+rollback;
+explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+id	estRows	task	access object	operator info
+TopN_19	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+└─PartitionUnion_24	20.00	root		
+  ├─TopN_26	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │ └─IndexLookUp_33	5.00	root		
+  │   ├─TopN_34(Build)	5.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │   │ └─LocalIndexLookUp_36	10000.00	cop[tikv]		index handle offsets:[1]
+  │   │   ├─IndexFullScan_30(Build)	10000.00	cop[tikv]	table:tp1, partition:p0, index:b(b)	keep order:false, stats:pseudo
+  │   │   └─TableRowIDScan_35(Probe)	10000.00	cop[tikv]	table:tp1, partition:p0	keep order:false, stats:pseudo
+  │   └─TopN_32(Probe)	0.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │     └─TableRowIDScan_31	0.00	cop[tikv]	table:tp1, partition:p0	keep order:false, stats:pseudo
+  ├─TopN_38	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │ └─IndexLookUp_45	5.00	root		
+  │   ├─TopN_46(Build)	5.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │   │ └─LocalIndexLookUp_48	10000.00	cop[tikv]		index handle offsets:[1]
+  │   │   ├─IndexFullScan_42(Build)	10000.00	cop[tikv]	table:tp1, partition:p1, index:b(b)	keep order:false, stats:pseudo
+  │   │   └─TableRowIDScan_47(Probe)	10000.00	cop[tikv]	table:tp1, partition:p1	keep order:false, stats:pseudo
+  │   └─TopN_44(Probe)	0.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │     └─TableRowIDScan_43	0.00	cop[tikv]	table:tp1, partition:p1	keep order:false, stats:pseudo
+  ├─TopN_50	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │ └─IndexLookUp_57	5.00	root		
+  │   ├─TopN_58(Build)	5.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │   │ └─LocalIndexLookUp_60	10000.00	cop[tikv]		index handle offsets:[1]
+  │   │   ├─IndexFullScan_54(Build)	10000.00	cop[tikv]	table:tp1, partition:p2, index:b(b)	keep order:false, stats:pseudo
+  │   │   └─TableRowIDScan_59(Probe)	10000.00	cop[tikv]	table:tp1, partition:p2	keep order:false, stats:pseudo
+  │   └─TopN_56(Probe)	0.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+  │     └─TableRowIDScan_55	0.00	cop[tikv]	table:tp1, partition:p2	keep order:false, stats:pseudo
+  └─TopN_62	5.00	root		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+    └─IndexLookUp_69	5.00	root		
+      ├─TopN_70(Build)	5.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+      │ └─LocalIndexLookUp_72	10000.00	cop[tikv]		index handle offsets:[1]
+      │   ├─IndexFullScan_66(Build)	10000.00	cop[tikv]	table:tp1, partition:p3, index:b(b)	keep order:false, stats:pseudo
+      │   └─TableRowIDScan_71(Probe)	10000.00	cop[tikv]	table:tp1, partition:p3	keep order:false, stats:pseudo
+      └─TopN_68(Probe)	0.00	cop[tikv]		executor__index_lookup_pushdown_partition.tp1.c, offset:0, count:5
+        └─TableRowIDScan_67	0.00	cop[tikv]	table:tp1, partition:p3	keep order:false, stats:pseudo
+select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+a	b	c
+1	10	10
+2	9	20
+3	8	30
+4	7	40
+5	6	50
 set @@tidb_scatter_region=default;
+set @@tidb_partition_prune_mode = default;

--- a/tests/integrationtest/t/executor/index_lookup_pushdown_partition.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown_partition.test
@@ -2,6 +2,8 @@ drop table if exists tp1, tp2;
 
 # wait regions split after create table to make the test stable
 set @@tidb_scatter_region='table';
+set @@tidb_partition_prune_mode = 'dynamic';
+select @@tidb_partition_prune_mode;
 
 # int handle
 create table tp1 (a int primary key, b int, c int, key b(b), key c(c) global) partition by hash(a) partitions 4;
@@ -65,5 +67,22 @@ insert into tp3 values (1, 10, 10), (2, 9, 20), (3, 8, 30), (4, 7, 40), (5, 6, 5
 explain select /*+ index_lookup_pushdown(tp3, b) */ * from tp3;
 select /*+ index_lookup_pushdown(tp3, b) */ * from tp3;
 
-# restore tidb_scatter_region
+# in UnionScan
+begin;
+insert into tp1 values (10, 11, 12), (20, 21, 22), (30, 31, 32), (40, 41, 42);
+explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+
+# test static partition prune mode
+set @@tidb_partition_prune_mode = 'static';
+select @@tidb_partition_prune_mode;
+explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+rollback;
+explain select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+select /*+ index_lookup_pushdown(tp1, b) */ * from tp1 order by c limit 5;
+
+# restore tidb_scatter_region and prune mode
 set @@tidb_scatter_region=default;
+set @@tidb_partition_prune_mode = default;
+


### PR DESCRIPTION
This is a cherry-pick for PR: #65157

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65155

Problem Summary:

When IndexLookUp is in a UnionScan for a partition table, the extra physicalTableID column will be the last. This is not handled in the current index lookup push down implementation.

### What changed and how does it work?

Consider extra column in partition

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
