### PR TITLE
planner: GetParamSQLFromAST Optimization

### DIFF
--- a/pkg/parser/ast/dml.go
+++ b/pkg/parser/ast/dml.go
@@ -752,6 +752,12 @@ type SelectField struct {
 
 // Restore implements Node interface.
 func (n *SelectField) Restore(ctx *format.RestoreCtx) error {
+	// For non-prepared plan cache: skip param collection in select fields
+	// to keep output field names corresponding to literal values.
+	oldSkip := ctx.SkipCollectingParams
+	ctx.SkipCollectingParams = true
+	defer func() { ctx.SkipCollectingParams = oldSkip }()
+
 	if n.WildCard != nil {
 		if err := n.WildCard.Restore(ctx); err != nil {
 			return errors.Annotate(err, "An error occurred while restore SelectField.WildCard")
@@ -919,6 +925,12 @@ type GroupByClause struct {
 
 // Restore implements Node interface.
 func (n *GroupByClause) Restore(ctx *format.RestoreCtx) error {
+	// For non-prepared plan cache: skip param collection in GROUP BY clause
+	// to avoid breaking the full_group_by check.
+	oldSkip := ctx.SkipCollectingParams
+	ctx.SkipCollectingParams = true
+	defer func() { ctx.SkipCollectingParams = oldSkip }()
+
 	ctx.WriteKeyWord("GROUP BY ")
 	for i, v := range n.Items {
 		if i != 0 {
@@ -990,6 +1002,12 @@ type OrderByClause struct {
 
 // Restore implements Node interface.
 func (n *OrderByClause) Restore(ctx *format.RestoreCtx) error {
+	// For non-prepared plan cache: skip param collection in ORDER BY clause
+	// to avoid breaking the full_group_by check.
+	oldSkip := ctx.SkipCollectingParams
+	ctx.SkipCollectingParams = true
+	defer func() { ctx.SkipCollectingParams = oldSkip }()
+
 	ctx.WriteKeyWord("ORDER BY ")
 	for i, item := range n.Items {
 		if i != 0 {
@@ -3000,6 +3018,12 @@ type Limit struct {
 
 // Restore implements Node interface.
 func (n *Limit) Restore(ctx *format.RestoreCtx) error {
+	// For non-prepared plan cache: skip param collection in LIMIT clause
+	// to generate different plans for queries with different limit values.
+	oldSkip := ctx.SkipCollectingParams
+	ctx.SkipCollectingParams = true
+	defer func() { ctx.SkipCollectingParams = oldSkip }()
+
 	ctx.WriteKeyWord("LIMIT ")
 	if n.Offset != nil {
 		if err := n.Offset.Restore(ctx); err != nil {

--- a/pkg/parser/ast/functions.go
+++ b/pkg/parser/ast/functions.go
@@ -491,8 +491,23 @@ func (n *FuncCallExpr) Restore(ctx *format.RestoreCtx) error {
 			if i != 0 {
 				ctx.WritePlain(", ")
 			}
-			if err := argv.Restore(ctx); err != nil {
-				return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.Args %d", i)
+			// For non-prepared plan cache: skip param collection for the format argument
+			// of date_format, str_to_date, time_format, from_unixtime (2nd argument).
+			// These format strings should not be parameterized.
+			skipFormatArg := i == 1 && (n.FnName.L == DateFormat || n.FnName.L == StrToDate ||
+				n.FnName.L == TimeFormat || n.FnName.L == FromUnixTime)
+			if skipFormatArg {
+				oldSkip := ctx.SkipCollectingParams
+				ctx.SkipCollectingParams = true
+				if err := argv.Restore(ctx); err != nil {
+					ctx.SkipCollectingParams = oldSkip
+					return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.Args %d", i)
+				}
+				ctx.SkipCollectingParams = oldSkip
+			} else {
+				if err := argv.Restore(ctx); err != nil {
+					return errors.Annotatef(err, "An error occurred while restore FuncCallExpr.Args %d", i)
+				}
 			}
 		}
 	}

--- a/pkg/parser/format/format.go
+++ b/pkg/parser/format/format.go
@@ -370,6 +370,18 @@ type RestoreCtx struct {
 	In        RestoreWriter
 	DefaultDB string
 	CTERestorer
+
+	// ParamCollector is used to collect parameters during restore when
+	// RestoreForNonPrepPlanCache flag is set. If non-nil, ValueExpr.Restore
+	// will write '?' and append the ValueExpr to this slice instead of writing
+	// the literal value. This enables single-pass parameterization without
+	// modifying the AST.
+	ParamCollector *[]any
+
+	// SkipCollectingParams is used to temporarily disable param collection
+	// in certain contexts (e.g., SelectField, Limit, GroupByClause, OrderByClause)
+	// where values should not be parameterized.
+	SkipCollectingParams bool
 }
 
 // NewRestoreCtx returns a new `RestoreCtx`.

--- a/pkg/planner/core/plan_cache_param.go
+++ b/pkg/planner/core/plan_cache_param.go
@@ -114,7 +114,7 @@ func (pr *paramReplacer) Reset() {
 // GetParamSQLFromAST returns the parameterized SQL of this AST.
 // NOTICE: this function does not modify the original AST.
 // paramVals are copied from this AST.
-// TODO: update the related test cases and remove this function
+// keep this only for testing.
 func GetParamSQLFromAST(stmt ast.StmtNode) (paramSQL string, paramVals []types.Datum, err error) {
 	var params []*driver.ValueExpr
 	paramSQL, params, err = ParameterizeAST(stmt)
@@ -131,8 +131,7 @@ func GetParamSQLFromAST(stmt ast.StmtNode) (paramSQL string, paramVals []types.D
 }
 
 // GetParamSQLFromASTWithoutMutation returns the parameterized SQL and param values
-// WITHOUT modifying the original AST. This is more efficient than GetParamSQLFromAST
-// as it performs a single AST traversal via Restore instead of 3 traversals
+// without modifying the original AST. It performs a single AST traversal via Restore
 // (replace values -> restore SQL -> restore values).
 //
 // The optimization works by setting ParamCollector on RestoreCtx, which causes

--- a/pkg/planner/core/plan_cache_param_test.go
+++ b/pkg/planner/core/plan_cache_param_test.go
@@ -189,3 +189,164 @@ func BenchmarkGetParamSQL(b *testing.B) {
 		GetParamSQLFromAST(stmt)
 	}
 }
+
+// TestGetParamSQLFromASTWithoutMutation tests that the optimized function
+// produces the same results as the original function.
+func TestGetParamSQLFromASTWithoutMutation(t *testing.T) {
+	cases := []struct {
+		sql      string
+		paramSQL string
+		params   []any
+	}{
+		{
+			"select * from t where a<10",
+			"SELECT * FROM `t` WHERE `a`<?",
+			[]any{int64(10)},
+		},
+		{
+			"select * from t",
+			"SELECT * FROM `t`",
+			[]any{},
+		},
+		{
+			"select * from t where a<10 and b<20 and c=30 and d>40",
+			"SELECT * FROM `t` WHERE `a`<? AND `b`<? AND `c`=? AND `d`>?",
+			[]any{int64(10), int64(20), int64(30), int64(40)},
+		},
+		{
+			"select * from t where a='a' and b='bbbbbbbbbbbbbbbbbbbbbbbb'",
+			"SELECT * FROM `t` WHERE `a`=? AND `b`=?",
+			[]any{"a", "bbbbbbbbbbbbbbbbbbbbbbbb"},
+		},
+		{
+			"select 1, 2, 3 from t where a<10",
+			"SELECT 1,2,3 FROM `t` WHERE `a`<?",
+			[]any{int64(10)},
+		},
+		{
+			"select a+1 from t where a<10",
+			"SELECT a+1 FROM `t` WHERE `a`<?",
+			[]any{int64(10)},
+		},
+		{
+			`insert into t (a, B, c) values (1, 2, 3), (4, 5, 6)`,
+			"INSERT INTO `t` (`a`,`B`,`c`) VALUES (?,?,?),(?,?,?)",
+			[]any{int64(1), int64(2), int64(3), int64(4), int64(5), int64(6)},
+		},
+		{
+			`select * from t where a < date_format('2020-02-02', '%Y-%m-%d')`,
+			"SELECT * FROM `t` WHERE `a`<date_format(?, '%Y-%m-%d')",
+			[]any{"2020-02-02"},
+		},
+		// keep the original format for limit clauses
+		{
+			`select * from t limit 10`,
+			"SELECT * FROM `t` LIMIT 10",
+			[]any{},
+		},
+		{
+			`select * from t limit 10, 20`,
+			"SELECT * FROM `t` LIMIT 10,20",
+			[]any{},
+		},
+		// group by and order by should not be parameterized
+		{
+			`select * from t group by 1 order by 2`,
+			"SELECT * FROM `t` GROUP BY 1 ORDER BY 2",
+			[]any{},
+		},
+	}
+
+	for _, c := range cases {
+		stmt, err := parser.New().ParseOneStmt(c.sql, "", "")
+		require.Nil(t, err)
+		paramSQL, params, err := GetParamSQLFromASTWithoutMutation(stmt)
+		require.Nil(t, err)
+		require.Equal(t, c.paramSQL, paramSQL, "sql: %s", c.sql)
+		require.Equal(t, len(c.params), len(params), "sql: %s", c.sql)
+		for i := range params {
+			require.Equal(t, c.params[i], params[i].GetValue(), "sql: %s, param %d", c.sql, i)
+		}
+	}
+}
+
+// TestGetParamSQLWithoutMutationConsistency verifies that the optimized function
+// produces results consistent with the original function.
+func TestGetParamSQLWithoutMutationConsistency(t *testing.T) {
+	sqls := []string{
+		"select * from t where a < 10 and b = 'hello'",
+		"insert into t values (1, 2, 3)",
+		"update t set a = 10 where b = 20",
+		"delete from t where a > 5",
+		"select * from t where a < date_format('2020-02-02', '%Y-%m-%d')",
+	}
+
+	for _, sql := range sqls {
+		stmt, err := parser.New().ParseOneStmt(sql, "", "")
+		require.Nil(t, err)
+
+		// Get results from optimized function
+		paramSQL1, params1, err := GetParamSQLFromASTWithoutMutation(stmt)
+		require.Nil(t, err)
+
+		// Get results from original function
+		paramSQL2, params2, err := GetParamSQLFromAST(stmt)
+		require.Nil(t, err)
+
+		// Compare
+		require.Equal(t, paramSQL2, paramSQL1, "sql: %s", sql)
+		require.Equal(t, len(params2), len(params1), "sql: %s", sql)
+		for i := range params1 {
+			require.Equal(t, params2[i].GetValue(), params1[i].GetValue(), "sql: %s, param %d", sql, i)
+		}
+	}
+}
+
+// BenchmarkGetParamSQLWithoutMutation benchmarks the optimized single-pass function.
+func BenchmarkGetParamSQLWithoutMutation(b *testing.B) {
+	paymentInsertHistory := `INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES (1, 2, 3, 4, 5, 6, 7, 8)`
+	stmt, err := parser.New().ParseOneStmt(paymentInsertHistory, "", "")
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GetParamSQLFromASTWithoutMutation(stmt)
+	}
+}
+
+// BenchmarkGetParamSQLComparison provides side-by-side benchmark comparison.
+func BenchmarkGetParamSQLComparison(b *testing.B) {
+	// Short SELECT query
+	shortSelect := `SELECT * FROM t WHERE a = 1 AND b = 2`
+	shortStmt, err := parser.New().ParseOneStmt(shortSelect, "", "")
+	require.Nil(b, err)
+
+	// Long SELECT query with multiple conditions and columns
+	longSelect := `SELECT c_first, c_middle, c_last, c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_credit, c_credit_lim, c_discount, c_balance, c_since FROM customer WHERE c_w_id = 10 AND c_d_id = 20 AND c_id = 30 AND c_balance > 100 AND c_discount < 0.5 AND c_credit_lim >= 5000`
+	longStmt, err := parser.New().ParseOneStmt(longSelect, "", "")
+	require.Nil(b, err)
+
+	b.Run("Short-Original", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GetParamSQLFromAST(shortStmt)
+		}
+	})
+
+	b.Run("Short-Optimized", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GetParamSQLFromASTWithoutMutation(shortStmt)
+		}
+	})
+
+	b.Run("Long-Original", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GetParamSQLFromAST(longStmt)
+		}
+	})
+
+	b.Run("Long-Optimized", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			GetParamSQLFromASTWithoutMutation(longStmt)
+		}
+	})
+}

--- a/pkg/planner/core/plan_cache_param_test.go
+++ b/pkg/planner/core/plan_cache_param_test.go
@@ -120,7 +120,7 @@ func TestParameterize(t *testing.T) {
 	}
 }
 
-func TestGetParamSQLFromASTConcurrently(t *testing.T) {
+func TestGetParamSQLFromASTWithoutMutationConcurrently(t *testing.T) {
 	n := 50
 	sqls := make([]string, 0, n)
 	for i := range n {
@@ -138,7 +138,7 @@ func TestGetParamSQLFromASTConcurrently(t *testing.T) {
 		wg.Add(1)
 		go func(id int) {
 			for range 100 {
-				_, vals, err := GetParamSQLFromAST(stmts[id])
+				_, vals, err := GetParamSQLFromASTWithoutMutation(stmts[id])
 				require.Nil(t, err)
 				require.Equal(t, len(vals), 3)
 				require.Equal(t, vals[0].GetValue(), int64(id*3+0))
@@ -186,7 +186,7 @@ func BenchmarkGetParamSQL(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		GetParamSQLFromAST(stmt)
+		GetParamSQLFromASTWithoutMutation(stmt)
 	}
 }
 

--- a/pkg/planner/core/plan_cache_param_test.go
+++ b/pkg/planner/core/plan_cache_param_test.go
@@ -302,18 +302,6 @@ func TestGetParamSQLWithoutMutationConsistency(t *testing.T) {
 	}
 }
 
-// BenchmarkGetParamSQLWithoutMutation benchmarks the optimized single-pass function.
-func BenchmarkGetParamSQLWithoutMutation(b *testing.B) {
-	paymentInsertHistory := `INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES (1, 2, 3, 4, 5, 6, 7, 8)`
-	stmt, err := parser.New().ParseOneStmt(paymentInsertHistory, "", "")
-	require.Nil(b, err)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		GetParamSQLFromASTWithoutMutation(stmt)
-	}
-}
-
 // BenchmarkGetParamSQLComparison provides side-by-side benchmark comparison.
 func BenchmarkGetParamSQLComparison(b *testing.B) {
 	// Short SELECT query

--- a/pkg/planner/core/planbuilder.go
+++ b/pkg/planner/core/planbuilder.go
@@ -5821,7 +5821,7 @@ func getHintedStmtThroughPlanDigest(ctx base.PlanContext, planDigest string) (st
 				return err
 			}
 			if query == "" {
-				return errors.NewNoStackErrorf("can't find any plans for '" + planDigest + "'")
+				return errors.NewNoStackErrorf("can't find any plans for '%s'", planDigest)
 			}
 
 			p := parser.New()

--- a/pkg/planner/optimize.go
+++ b/pkg/planner/optimize.go
@@ -73,7 +73,7 @@ func getPlanFromNonPreparedPlanCache(ctx context.Context, sctx sessionctx.Contex
 		return nil, nil, false, nil
 	}
 
-	paramSQL, paramsVals, err := core.GetParamSQLFromAST(stmt)
+	paramSQL, paramsVals, err := core.GetParamSQLFromASTWithoutMutation(stmt)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/types/parser_driver/value_expr.go
+++ b/pkg/types/parser_driver/value_expr.go
@@ -81,6 +81,14 @@ func (n *ValueExpr) SetValue(res any) {
 
 // Restore implements Node interface.
 func (n *ValueExpr) Restore(ctx *format.RestoreCtx) error {
+	// For non-prepared plan cache: collect the value and write '?' instead.
+	// This enables single-pass parameterization without modifying the AST.
+	if ctx.Flags.HasRestoreForNonPrepPlanCache() && ctx.ParamCollector != nil && !ctx.SkipCollectingParams {
+		*ctx.ParamCollector = append(*ctx.ParamCollector, n)
+		ctx.WritePlain("?")
+		return nil
+	}
+
 	switch n.Kind() {
 	case types.KindNull:
 		ctx.WriteKeyWord("NULL")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/65117

Problem Summary:
Optimize the `GetParamSQLFromAST` function. 

### What changed and how does it work?
Implemented `GetParamSQLFromASTWithoutMutation`, an optimized method that generates parameterized SQL (e.g., WHERE a=?) via a single-pass Restore traversal, eliminating the need to clone or mutate the AST.

Key improvements include:
* Direct Parameterization: Extended RestoreCtx with a ParamCollector to write ? and capture values on the fly, replacing the legacy 3-step (clone -> mutate -> restore) process.
* Context Awareness: Added logic to preserve literals in specific clauses (e.g., LIMIT, GROUP BY, ORDER BY) where parameterization would break plan caching.
* Memory Efficiency: Utilized sync.Pool to reuse buffers and argument slices, minimizing allocation overhead.

```
                                         │ result.txt  │
                                         │   sec/op    │
GetParamSQLComparison/Short-Original-14    311.1n ± 2%
GetParamSQLComparison/Short-Optimized-14   174.0n ± 2%
GetParamSQLComparison/Long-Original-14     937.0n ± 4%
GetParamSQLComparison/Long-Optimized-14    471.2n ± 1%
geomean                                    393.2n

                                         │ result.txt │
                                         │    B/op    │
GetParamSQLComparison/Short-Original-14    224.0 ± 0%
GetParamSQLComparison/Short-Optimized-14   272.0 ± 0%
GetParamSQLComparison/Long-Original-14     896.0 ± 0%
GetParamSQLComparison/Long-Optimized-14    832.0 ± 0%
geomean                                    461.6

                                         │ result.txt │
                                         │ allocs/op  │
GetParamSQLComparison/Short-Original-14    3.000 ± 0%
GetParamSQLComparison/Short-Optimized-14   3.000 ± 0%
GetParamSQLComparison/Long-Original-14     6.000 ± 0%
GetParamSQLComparison/Long-Optimized-14    4.000 ± 0%
geomean                                    3.834
```
1. Latency (sec/op) - Significant Improvement
  * Short Queries: Reduced from 311ns to 174ns (~44% faster).
  * Long Queries: Reduced from 937ns to 471ns (~50% faster).
  * Overall: The geometric mean indicates the new method is roughly 2x faster than the original.
2. Memory Allocations (allocs/op) - Efficiency Gains
  * Short Queries: Remained distinctively constant (3 allocs/op).
  * Long Queries: Reduced from 6 to 4 allocs/op.
3. Bytes Allocated (B/op) - Trade-off
  * Short Queries: Slight increase (224B -> 272B). This is likely due to the pre-allocation size of the buffer/slice in the pool (256 bytes) being slightly larger than what a very tiny query needs.
  * Long Queries: Decrease (896B -> 832B). For realistic/complex queries, the new method uses less memory.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
