### PR TITLE
test: force to create table with "clustered" for index lookup push down tests

### DIFF
--- a/tests/integrationtest/r/executor/index_lookup_pushdown_partition.result
+++ b/tests/integrationtest/r/executor/index_lookup_pushdown_partition.result
@@ -79,7 +79,7 @@ id1 varchar(32),
 id2 int,
 a int,
 b int,
-primary key (id1, id2),
+primary key (id1, id2) CLUSTERED,
 index a(a)
 )
 PARTITION BY RANGE COLUMNS (id1) (
@@ -100,7 +100,7 @@ insert into tp2 values
 explain select /*+ index_lookup_pushdown(tp2, a) */ * from tp2 where a > 33 limit 5;
 id	estRows	task	access object	operator info
 IndexLookUp_16	5.00	root	partition:all	limit embedded(offset:0, count:5)
-├─LocalIndexLookUp_18(Build)	5.00	cop[tikv]		index handle offsets:[1]
+├─LocalIndexLookUp_18(Build)	5.00	cop[tikv]		index handle offsets:[]
 │ ├─Limit_15(Build)	5.00	cop[tikv]		offset:0, count:5
 │ │ └─IndexRangeScan_13	5.00	cop[tikv]	table:tp2, index:a(a)	range:(33,+inf], keep order:false, stats:pseudo
 │ └─TableRowIDScan_17(Probe)	5.00	cop[tikv]	table:tp2	keep order:false, stats:pseudo
@@ -115,7 +115,7 @@ e	5	55	50
 explain select /*+ index_lookup_pushdown(tp2, a) */ * from tp2 partition (p1);
 id	estRows	task	access object	operator info
 IndexLookUp_7	10000.00	root	partition:p1	
-├─LocalIndexLookUp_9(Build)	10000.00	cop[tikv]		index handle offsets:[1]
+├─LocalIndexLookUp_9(Build)	10000.00	cop[tikv]		index handle offsets:[]
 │ ├─IndexFullScan_5(Build)	10000.00	cop[tikv]	table:tp2, index:a(a)	keep order:false, stats:pseudo
 │ └─TableRowIDScan_8(Probe)	10000.00	cop[tikv]	table:tp2	keep order:false, stats:pseudo
 └─TableRowIDScan_6(Probe)	0.00	cop[tikv]	table:tp2	keep order:false, stats:pseudo

--- a/tests/integrationtest/t/executor/index_lookup_pushdown_partition.test
+++ b/tests/integrationtest/t/executor/index_lookup_pushdown_partition.test
@@ -36,7 +36,7 @@ create table tp2 (
     id2 int,
     a int,
     b int,
-    primary key (id1, id2),
+    primary key (id1, id2) CLUSTERED,
     index a(a)
 )
 PARTITION BY RANGE COLUMNS (id1) (

--- a/tests/realtikvtest/pushdowntest/index_lookup_pushdown_test.go
+++ b/tests/realtikvtest/pushdowntest/index_lookup_pushdown_test.go
@@ -232,7 +232,7 @@ func TestRealTiKVCommonHandleIndexLookUpPushDown(t *testing.T) {
 			"id2 bigint, " +
 			"a bigint, " +
 			"b bigint, " +
-			"primary key(" + primaryKey + "), " +
+			"primary key(" + primaryKey + ") CLUSTERED, " +
 			uniquePrefix + "index " + v.indexName + "(a)" +
 			") charset=" + charset + " collate=" + collation)
 		tk.MustExec("insert into " + v.tableName + " values " +


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #62575

Problem Summary:

In integration tests, `tidb_enable_clustered_index` is `INT_ONLY` and may cause some tests does not cover common handle.

### What changed and how does it work?

force use `CLUSTERED` for some tables when creating a table

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
