### PR TITLE
Makefile: check failpoint-ctl existence before go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ tools/bin/failpoint-ctl:
 		echo "Installing $(FP_PKG)@$(FP_GITHASH)"; \
 		GOBIN=$$(pwd)/tools/bin $(GO) install $(FP_PKG)@$(FP_GITHASH) || { echo "failed to install $(FP_PKG)@$(FP_GITHASH)"; exit 1; }; \
 	else \
-		echo "Installed $(FP_PKG)@$(FP_GITHASH)"; \
+		echo "Using existing $(FP_PKG)@$(FP_GITHASH)"; \
 	fi
 
 .PHONY: tools/bin/errdoc-gen


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: N/A

Problem Summary:

### What changed and how does it work?

Avoiding redundant go install of failpoint-ctl speeds up local dev.
If it fails/prints nothing the rule will reinstall, which is a safe fallback.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
