### PR TITLE
*: ignore .cursor and fix integration test command in AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ coverage.dat
 .golangci.bck.yml
 go.work
 go.work.sum
+.cursor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ The test set is located at `/tests/integrationtest/t`, and the result set is in 
 ```bash
 # in the root directory of the repository
 pushd tests/integrationtest
-./run-tests.sh -run <TestName>
+./run-tests.sh -r <TestName>
 popd
 ```
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65234

Problem Summary:
1. `.cursor` directory is being tracked by git which should be ignored as it's specific to the Cursor IDE.
2. The flag for running integration tests in `AGENTS.md` was incorrect (`-run` instead of `-r`).

### What changed and how does it work?

1. Added `.cursor` to `.gitignore`.
2. Updated `AGENTS.md` to use the correct `-r` flag for `run-tests.sh`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```
