### PR TITLE
importinto: make ErrPDServerTimeout retryable which might meet during checksum

### DIFF
--- a/pkg/lightning/common/retry.go
+++ b/pkg/lightning/common/retry.go
@@ -100,12 +100,17 @@ var retryableErrorIDs = map[errors.ErrorID]struct{}{
 	errdef.ErrKVRaftProposalDropped.ID(): {},
 	// litBackendCtxMgr.Register may return the error.
 	ErrCreatePDClient.ID(): {},
-	// during checksum coprocessor will transform error into driver error in handleCopResponse using ToTiDBErr
-	// met ErrRegionUnavailable on free-tier import during checksum, others hasn't met yet
+	// during checksum coprocessor, either through ADMIN CHECKSUM TABLE or by calling
+	// distsql directly, we will transform error into driver error in handleCopResponse
+	// using ToTiDBErr. we ever met ErrRegionUnavailable on free-tier import during
+	// checksum, and meet: "[tikv:9001]PD server timeout: start timestamp may fall
+	// behind safe point" when the TiDB doing checksum and network partitioned
+	// with the cluster, others hasn't met yet
 	drivererr.ErrRegionUnavailable.ID(): {},
 	drivererr.ErrTiKVStaleCommand.ID():  {},
 	drivererr.ErrTiKVServerTimeout.ID(): {},
 	drivererr.ErrTiKVServerBusy.ID():    {},
+	drivererr.ErrPDServerTimeout.ID():   {},
 	drivererr.ErrUnknown.ID():           {},
 }
 

--- a/pkg/lightning/common/retry_test.go
+++ b/pkg/lightning/common/retry_test.go
@@ -86,12 +86,17 @@ func TestIsRetryableError(t *testing.T) {
 	require.True(t, IsRetryableError(errdef.ErrKVRaftProposalDropped.GenWithStack("test")))
 	require.False(t, IsRetryableError(errdef.ErrKVDiskFull.GenWithStack("test")))
 
-	// tidb error
-	require.True(t, IsRetryableError(drivererr.ErrRegionUnavailable))
-	require.True(t, IsRetryableError(drivererr.ErrTiKVStaleCommand))
-	require.True(t, IsRetryableError(drivererr.ErrTiKVServerTimeout))
-	require.True(t, IsRetryableError(drivererr.ErrTiKVServerBusy))
-	require.True(t, IsRetryableError(drivererr.ErrUnknown))
+	for _, err := range []error{
+		// tidb error
+		drivererr.ErrRegionUnavailable,
+		drivererr.ErrTiKVStaleCommand,
+		drivererr.ErrTiKVServerTimeout,
+		drivererr.ErrTiKVServerBusy,
+		drivererr.ErrPDServerTimeout,
+		drivererr.ErrUnknown,
+	} {
+		require.True(t, IsRetryableError(errors.Annotate(err, "failed")))
+	}
 
 	// net: connection refused
 	_, err := net.Dial("tcp", "localhost:65533")
@@ -103,33 +108,41 @@ func TestIsRetryableError(t *testing.T) {
 
 	// MySQL Errors
 	require.False(t, IsRetryableError(&mysql.MySQLError{}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrUnknown}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrLockDeadlock}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrPDServerTimeout}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrTiKVServerTimeout}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrTiKVServerBusy}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrResolveLockTimeout}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrRegionUnavailable}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrWriteConflictInTiDB}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrWriteConflict}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrInfoSchemaExpired}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrInfoSchemaChanged}))
-	require.True(t, IsRetryableError(&mysql.MySQLError{Number: tmysql.ErrTxnRetryable}))
+	for _, errNumber := range []uint16{
+		tmysql.ErrUnknown,
+		tmysql.ErrLockDeadlock,
+		tmysql.ErrPDServerTimeout,
+		tmysql.ErrTiKVServerTimeout,
+		tmysql.ErrTiKVServerBusy,
+		tmysql.ErrResolveLockTimeout,
+		tmysql.ErrRegionUnavailable,
+		tmysql.ErrWriteConflictInTiDB,
+		tmysql.ErrWriteConflict,
+		tmysql.ErrInfoSchemaExpired,
+		tmysql.ErrInfoSchemaChanged,
+		tmysql.ErrTxnRetryable,
+	} {
+		require.True(t, IsRetryableError(&mysql.MySQLError{Number: errNumber}))
+	}
 
 	// gRPC Errors
 	require.False(t, IsRetryableError(status.Error(codes.Canceled, "")))
 	require.True(t, IsRetryableError(status.Error(codes.Unknown, "region 1234 is not fully replicated")))
 	require.True(t, IsRetryableError(status.Error(codes.Unknown, "No such file or directory: while stat a file "+
 		"for size: /...../63992d9c-fbc8-4708-b963-32495b299027_32279707_325_5280_write.sst: No such file or directory")))
-	require.True(t, IsRetryableError(status.Error(codes.DeadlineExceeded, "")))
-	require.True(t, IsRetryableError(status.Error(codes.NotFound, "")))
-	require.True(t, IsRetryableError(status.Error(codes.AlreadyExists, "")))
-	require.True(t, IsRetryableError(status.Error(codes.PermissionDenied, "")))
-	require.True(t, IsRetryableError(status.Error(codes.ResourceExhausted, "")))
-	require.True(t, IsRetryableError(status.Error(codes.Aborted, "")))
-	require.True(t, IsRetryableError(status.Error(codes.OutOfRange, "")))
-	require.True(t, IsRetryableError(status.Error(codes.Unavailable, "")))
-	require.True(t, IsRetryableError(status.Error(codes.DataLoss, "")))
+	for _, code := range []codes.Code{
+		codes.DeadlineExceeded,
+		codes.NotFound,
+		codes.AlreadyExists,
+		codes.PermissionDenied,
+		codes.ResourceExhausted,
+		codes.Aborted,
+		codes.OutOfRange,
+		codes.Unavailable,
+		codes.DataLoss,
+	} {
+		require.True(t, IsRetryableError(status.Error(code, "")))
+	}
 
 	// sqlmock errors
 	require.False(t, IsRetryableError(fmt.Errorf("call to database Close was not expected")))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65080

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
