### PR TITLE
expression: lazy init `bufAllocator` in `baseBuiltinFunc`

### DIFF
--- a/pkg/expression/bench_test.go
+++ b/pkg/expression/bench_test.go
@@ -1338,6 +1338,10 @@ func genVecExprBenchCase(ctx BuildContext, funcName string, testCase vecExprBenc
 	}
 
 	output = chunk.New([]*types.FieldType{eType2FieldType(expr.GetType(ctx.GetEvalCtx()).EvalType())}, testCase.chunkSize, testCase.chunkSize)
+
+	if !expr.Vectorized() {
+		panic(fmt.Sprintf("func %s is not vectorized", funcName))
+	}
 	return expr, fts, input, output
 }
 
@@ -1591,6 +1595,9 @@ func testVectorizedBuiltinFunc(t *testing.T, vecExprCases vecExprBenchCases) {
 			baseFuncName := fmt.Sprintf("%v", reflect.TypeOf(baseFunc))
 			tmp := strings.Split(baseFuncName, ".")
 			baseFuncName = tmp[len(tmp)-1]
+			if !baseFunc.vectorized() || !baseFunc.isChildrenVectorized() {
+				t.Fatalf("func %s is not vectorized", baseFuncName)
+			}
 
 			if !testAll && (!testFunc[baseFuncName] && !testFunc[funcName]) {
 				continue
@@ -1834,6 +1841,9 @@ func benchmarkVectorizedBuiltinFunc(b *testing.B, vecExprCases vecExprBenchCases
 			baseFuncName := fmt.Sprintf("%v", reflect.TypeOf(baseFunc))
 			tmp := strings.Split(baseFuncName, ".")
 			baseFuncName = tmp[len(tmp)-1]
+			if !baseFunc.vectorized() || !baseFunc.isChildrenVectorized() {
+				panic(fmt.Sprintf("func %s is not vectorized", funcName))
+			}
 
 			if !testAll && !testFunc[baseFuncName] && !testFunc[funcName] {
 				continue

--- a/pkg/expression/builtin.go
+++ b/pkg/expression/builtin.go
@@ -133,7 +133,6 @@ func newBaseBuiltinFunc(ctx BuildContext, funcName string, args []Expression, tp
 	}
 
 	bf := baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -225,7 +224,6 @@ func newBaseBuiltinFuncWithTp(ctx BuildContext, funcName string, args []Expressi
 
 	fieldType := newReturnFieldTypeForBaseBuiltinFunc(funcName, retType, ec)
 	bf = baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -286,7 +284,6 @@ func newBaseBuiltinFuncWithFieldTypes(ctx BuildContext, funcName string, args []
 
 	fieldType := newReturnFieldTypeForBaseBuiltinFunc(funcName, retType, ec)
 	bf = baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -305,7 +302,6 @@ func newBaseBuiltinFuncWithFieldTypes(ctx BuildContext, funcName string, args []
 // do not check and compute collation.
 func newBaseBuiltinFuncWithFieldType(tp *types.FieldType, args []Expression) (baseBuiltinFunc, error) {
 	bf := baseBuiltinFunc{
-		bufAllocator:           newLocalColumnPool(),
 		childrenVectorizedOnce: new(sync.Once),
 
 		args: args,
@@ -397,6 +393,10 @@ func (b *baseBuiltinFunc) isChildrenVectorized() bool {
 				break
 			}
 		}
+		if b.childrenVectorized {
+			// only init this when all children are vectorized
+			b.bufAllocator = newLocalColumnPool()
+		}
 	})
 	return b.childrenVectorized
 }
@@ -437,7 +437,6 @@ func (b *baseBuiltinFunc) cloneFrom(from *baseBuiltinFunc) {
 	}
 	b.tp = from.tp
 	b.pbCode = from.pbCode
-	b.bufAllocator = newLocalColumnPool()
 	b.childrenVectorizedOnce = new(sync.Once)
 	if from.ctor != nil {
 		b.ctor = from.ctor.Clone()
@@ -481,7 +480,6 @@ func newBaseBuiltinCastFunc4String(ctx BuildContext, funcName string, args []Exp
 	var err error
 	if isExplicitCharset {
 		bf = baseBuiltinFunc{
-			bufAllocator:           newLocalColumnPool(),
 			childrenVectorizedOnce: new(sync.Once),
 
 			args: args,

--- a/pkg/expression/builtin_arithmetic_vec_test.go
+++ b/pkg/expression/builtin_arithmetic_vec_test.go
@@ -229,6 +229,7 @@ func TestVectorizedDecimalErrOverflow(t *testing.T) {
 		input.AppendMyDecimal(1, dec2)
 		cols := []Expression{&Column{Index: 0, RetType: fts[0]}, &Column{Index: 1, RetType: fts[1]}}
 		baseFunc, err := funcs[tt.funcName].getFunction(ctx, cols)
+		require.True(t, baseFunc.vectorized() && baseFunc.isChildrenVectorized())
 		require.NoError(t, err)
 		result := chunk.NewColumn(eType2FieldType(types.ETDecimal), 1)
 		err = vecEvalType(ctx, baseFunc, types.ETDecimal, input, result)

--- a/pkg/expression/builtin_cast_vec_test.go
+++ b/pkg/expression/builtin_cast_vec_test.go
@@ -163,8 +163,8 @@ func TestVectorizedCastRealAsTime(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	require.True(t, baseFunc.vectorized() && baseFunc.isChildrenVectorized())
 	cast := &builtinCastRealAsTimeSig{baseFunc}
+	require.True(t, cast.vectorized() && cast.isChildrenVectorized())
 
 	inputChunk, expect := genCastRealAsTime()
 	inputs := []*chunk.Chunk{

--- a/pkg/expression/builtin_cast_vec_test.go
+++ b/pkg/expression/builtin_cast_vec_test.go
@@ -256,8 +256,8 @@ func TestVectorizedCastStringAsDecimalWithUnsignedFlagInUnion(t *testing.T) {
 	baseCast := newBaseBuiltinCastFunc(baseFunc, true)
 	// set the `UnsignedFlag` bit
 	baseCast.tp.AddFlag(mysql.UnsignedFlag)
-	require.True(t, baseCast.vectorized() && baseCast.isChildrenVectorized())
 	cast := &builtinCastStringAsDecimalSig{baseCast}
+	require.True(t, cast.vectorized() && cast.isChildrenVectorized())
 
 	inputs := []*chunk.Chunk{
 		genCastStringAsDecimal(false),

--- a/pkg/expression/builtin_cast_vec_test.go
+++ b/pkg/expression/builtin_cast_vec_test.go
@@ -163,6 +163,7 @@ func TestVectorizedCastRealAsTime(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	require.True(t, baseFunc.vectorized() && baseFunc.isChildrenVectorized())
 	cast := &builtinCastRealAsTimeSig{baseFunc}
 
 	inputChunk, expect := genCastRealAsTime()
@@ -255,6 +256,7 @@ func TestVectorizedCastStringAsDecimalWithUnsignedFlagInUnion(t *testing.T) {
 	baseCast := newBaseBuiltinCastFunc(baseFunc, true)
 	// set the `UnsignedFlag` bit
 	baseCast.tp.AddFlag(mysql.UnsignedFlag)
+	require.True(t, baseCast.vectorized() && baseCast.isChildrenVectorized())
 	cast := &builtinCastStringAsDecimalSig{baseCast}
 
 	inputs := []*chunk.Chunk{

--- a/pkg/expression/builtin_miscellaneous_vec_test.go
+++ b/pkg/expression/builtin_miscellaneous_vec_test.go
@@ -147,6 +147,7 @@ func TestSleepVectorized(t *testing.T) {
 	col0 := &Column{RetType: ft, Index: 0}
 	f, err := fc.getFunction(ctx, []Expression{col0})
 	require.NoError(t, err)
+	require.True(t, f.vectorized() && f.isChildrenVectorized())
 	input := chunk.NewChunkWithCapacity([]*types.FieldType{ft}, 1024)
 	result := chunk.NewColumn(ft, 1024)
 	warnCnt := counter{}

--- a/pkg/expression/builtin_op_vec_test.go
+++ b/pkg/expression/builtin_op_vec_test.go
@@ -169,6 +169,7 @@ func TestBuiltinUnaryMinusIntSig(t *testing.T) {
 	col0 := &Column{RetType: ft, Index: 0}
 	f, err := funcs[ast.UnaryMinus].getFunction(ctx, []Expression{col0})
 	require.NoError(t, err)
+	require.True(t, f.vectorized() && f.isChildrenVectorized())
 	input := chunk.NewChunkWithCapacity([]*types.FieldType{ft}, 1024)
 	result := chunk.NewColumn(ft, 1024)
 

--- a/pkg/expression/builtin_other_test.go
+++ b/pkg/expression/builtin_other_test.go
@@ -339,6 +339,7 @@ func TestInFunc(t *testing.T) {
 	chk1 := chunk.NewChunkWithCapacity(nil, 1)
 	chk1.SetNumVirtualRows(1)
 	chk2 := chunk.NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeTiny)}, 1)
+	require.True(t, fn.vectorized() && fn.isChildrenVectorized())
 	err = vecEvalType(ctx, fn, types.ETInt, chk1, chk2.Column(0))
 	require.NoError(t, err)
 	require.Equal(t, int64(1), chk2.Column(0).GetInt64(0))

--- a/pkg/expression/builtin_other_vec_test.go
+++ b/pkg/expression/builtin_other_vec_test.go
@@ -101,6 +101,7 @@ func TestGetParamVec(t *testing.T) {
 	col := &Column{RetType: ft, Index: 0}
 	fn, err := funcs[ast.GetParam].getFunction(ctx, []Expression{col})
 	require.NoError(t, err)
+	require.True(t, fn.vectorized() && fn.isChildrenVectorized())
 
 	input := chunk.NewChunkWithCapacity([]*types.FieldType{ft}, 3)
 	for i := range params {

--- a/pkg/expression/builtin_other_vec_test.go
+++ b/pkg/expression/builtin_other_vec_test.go
@@ -70,6 +70,7 @@ func TestInDecimal(t *testing.T) {
 	col1 := &Column{RetType: ft, Index: 1}
 	inFunc, err := funcs[ast.In].getFunction(ctx, []Expression{col0, col1})
 	require.NoError(t, err)
+	require.True(t, inFunc.vectorized() && inFunc.isChildrenVectorized())
 
 	input := chunk.NewChunkWithCapacity([]*types.FieldType{ft, ft}, 1024)
 	for i := range 1024 {

--- a/pkg/expression/builtin_regexp_vec_const_test.go
+++ b/pkg/expression/builtin_regexp_vec_const_test.go
@@ -63,6 +63,7 @@ func genVecBuiltinRegexpBenchCaseForConstants(ctx BuildContext) (baseFunc builti
 func TestVectorizedBuiltinRegexpForConstants(t *testing.T) {
 	ctx := mock.NewContext()
 	bf, childrenFieldTypes, input, output := genVecBuiltinRegexpBenchCaseForConstants(ctx)
+	require.True(t, bf.vectorized() && bf.isChildrenVectorized())
 	err := vecEvalType(ctx, bf, types.ETInt, input, output)
 	require.NoError(t, err)
 	i64s := output.Int64s()

--- a/pkg/expression/builtin_regexp_vec_const_test.go
+++ b/pkg/expression/builtin_regexp_vec_const_test.go
@@ -88,6 +88,9 @@ func TestVectorizedBuiltinRegexpForConstants(t *testing.T) {
 func BenchmarkVectorizedBuiltinRegexpForConstants(b *testing.B) {
 	ctx := mock.NewContext()
 	bf, _, input, output := genVecBuiltinRegexpBenchCaseForConstants(ctx)
+	if !bf.vectorized() || !bf.isChildrenVectorized() {
+		panic("builtinRegexpUTF8Sig is not vectorized")
+	}
 	b.Run("builtinRegexpUTF8Sig-Constants-VecBuiltinFunc", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/pkg/expression/builtin_time_vec_test.go
+++ b/pkg/expression/builtin_time_vec_test.go
@@ -588,6 +588,7 @@ func TestVecMonth(t *testing.T) {
 	input.AppendTime(0, types.ZeroDate)
 
 	f, _, _, result := genVecBuiltinFuncBenchCase(ctx, ast.Month, vecExprBenchCase{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}})
+	require.True(t, f.vectorized() && f.isChildrenVectorized())
 	require.True(t, ctx.GetSessionVars().SQLMode.HasStrictMode())
 	require.NoError(t, vecEvalType(ctx, f, types.ETInt, input, result))
 	require.Equal(t, 0, len(ctx.GetSessionVars().StmtCtx.GetWarnings()))

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -95,7 +95,7 @@ func genMockVecPlusIntBuiltinFunc(ctx BuildContext) (*mockVecPlusIntBuiltinFunc,
 		input.AppendInt64(0, int64(i))
 		input.AppendInt64(1, int64(i))
 	}
-	if plus.isChildrenVectorized() == false {
+	if !plus.isChildrenVectorized() {
 		panic("mockVecPlusIntBuiltinFunc's children should be vectorized")
 	}
 	return plus, input, buf
@@ -472,7 +472,7 @@ func genMockRowDouble(ctx BuildContext, eType types.EvalType, enableVec bool) (b
 			input.AppendTime(0, types.NewTime(t, mysqlType, 0))
 		}
 	}
-	if rowDouble.isChildrenVectorized() == false {
+	if !rowDouble.isChildrenVectorized() {
 		return nil, nil, nil, errors.New("mockBuiltinDouble's children should be vectorized")
 	}
 	return rowDouble, input, buf, nil

--- a/pkg/expression/builtin_vectorized_test.go
+++ b/pkg/expression/builtin_vectorized_test.go
@@ -95,6 +95,9 @@ func genMockVecPlusIntBuiltinFunc(ctx BuildContext) (*mockVecPlusIntBuiltinFunc,
 		input.AppendInt64(0, int64(i))
 		input.AppendInt64(1, int64(i))
 	}
+	if plus.isChildrenVectorized() == false {
+		panic("mockVecPlusIntBuiltinFunc's children should be vectorized")
+	}
 	return plus, input, buf
 }
 
@@ -468,6 +471,9 @@ func genMockRowDouble(ctx BuildContext, eType types.EvalType, enableVec bool) (b
 			t := types.FromDate(i, 0, 0, 0, 0, 0, 0)
 			input.AppendTime(0, types.NewTime(t, mysqlType, 0))
 		}
+	}
+	if rowDouble.isChildrenVectorized() == false {
+		return nil, nil, nil, errors.New("mockBuiltinDouble's children should be vectorized")
 	}
 	return rowDouble, input, buf, nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65003

Problem Summary:

### What changed and how does it work?
`bufAllocator` is only used in `VecEval` mode, however, currently, TiDB will always init `bufAllocator` when construct a `baseBuiltinFunc`. Although we can assume that almost all the `baseBuiltinFunc` should support vec evaluation, some code path just does not use `VecEval` mode, for example:
https://github.com/pingcap/tidb/blob/7dea15e880c7eebc39e844ffb22055502c346e06/pkg/executor/insert_common.go#L221

For the pure insert workload described in #65003 

Before this pr, the heap profile in alloc_objects space
![img_v3_02t9_131b3029-07ff-4f5b-9778-6fe8540c2d7g](https://github.com/user-attachments/assets/766c948d-581e-4c28-bc22-45b1c0540e2e)

After this pr, the heap profile in alloc_objects space
![img_v3_02ta_76b6d2bc-375f-42d1-bc2c-7d70a8e8ec4g](https://github.com/user-attachments/assets/7e24e580-db14-402a-bc7e-2f0828bfba84)

As it shows, `expression.newLocalColumnPool` disappears completely, which mean we save `8.32%` allocations.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
run the workload in #65003, and all the existing test will cover the code path
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
