### PR TITLE
chunk: fix the issue that the last_sql_use_alloc is not correct if it only reuses the chunk for results

### DIFF
--- a/pkg/server/conn.go
+++ b/pkg/server/conn.go
@@ -2352,7 +2352,7 @@ func (cc *clientConn) writeColumnInfo(columns []*column.Info) error {
 // The first return value indicates whether error occurs at the first call of ResultSet.Next.
 func (cc *clientConn) writeChunks(ctx context.Context, rs resultset.ResultSet, binary bool, serverStatus uint16) (bool, error) {
 	data := cc.alloc.AllocWithLen(4, 1024)
-	req := rs.NewChunk(cc.chunkAlloc)
+	req := rs.NewChunk(cc.ctx.GetSessionVars().GetChunkAllocator())
 	gotColumnInfo := false
 	firstNext := true
 	validNextCount := 0

--- a/tests/integrationtest/r/executor/chunk_reuse.result
+++ b/tests/integrationtest/r/executor/chunk_reuse.result
@@ -336,3 +336,12 @@ select @@last_sql_use_alloc;
 @@last_sql_use_alloc
 0
 set tidb_enable_clustered_index = default;
+drop table if exists t;
+create table t(id int primary key, col int);
+insert into t values (1, 1);
+select * from t where id = 1;
+id	col
+1	1
+select @@last_sql_use_alloc;
+@@last_sql_use_alloc
+1

--- a/tests/integrationtest/t/executor/chunk_reuse.test
+++ b/tests/integrationtest/t/executor/chunk_reuse.test
@@ -130,3 +130,9 @@ select id1 from t3 where id2 > '3' or id8 < 10 union (select id2 from t3 where i
 select @@last_sql_use_alloc;
 set tidb_enable_clustered_index = default;
 
+# TestPointGetReuseChunk
+drop table if exists t;
+create table t(id int primary key, col int);
+insert into t values (1, 1);
+select * from t where id = 1;
+select @@last_sql_use_alloc;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65253 

Problem Summary:

### What changed and how does it work?

1. Use the allocator on session to record whether the chunk is reused.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
