### PR TITLE
stats: do not close the priority queue in DDL handler

### DIFF
--- a/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
+++ b/pkg/statistics/handle/autoanalyze/refresher/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
         "worker_test.go",
     ],
     flaky = True,
-    shard_count = 11,
+    shard_count = 12,
     deps = [
         ":refresher",
         "//pkg/parser/ast",

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher.go
@@ -92,14 +92,6 @@ func (r *Refresher) UpdateConcurrency() {
 // Usually, this is done by the caller through `util.CallWithSCtx`.
 func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 	parameters := exec.GetAutoAnalyzeParameters(sctx)
-	err := r.setAutoAnalysisTimeWindow(parameters)
-	if err != nil {
-		statslogutil.StatsErrVerboseSampleLogger().Error("Set auto analyze time window failed", zap.Error(err))
-		return false
-	}
-	if !r.isWithinTimeWindow() {
-		return false
-	}
 	currentAutoAnalyzeRatio := exec.ParseAutoAnalyzeRatio(parameters[vardef.TiDBAutoAnalyzeRatio])
 	currentPruneMode := variable.PartitionPruneMode(sctx.GetSessionVars().PartitionPruneMode.Load())
 	if !r.jobs.IsInitialized() {
@@ -120,6 +112,20 @@ func (r *Refresher) AnalyzeHighestPriorityTables(sctx sessionctx.Context) bool {
 				return false
 			}
 		}
+	}
+
+	// NOTE: This check must be done after initializing/rebuilding the queue.
+	// For example, if TiDB instances restart outside the time window, the queue will not be initialized.
+	// This means the DDL events are not being processed. This would prevent the DDL notifier from moving forward.
+	// Although this won't cause a correctness issue and it does not affect other handlers, it is still better to avoid this situation.
+	// We should make sure the queue is always initialized when the current instance is the owner.
+	err := r.setAutoAnalysisTimeWindow(parameters)
+	if err != nil {
+		statslogutil.StatsErrVerboseSampleLogger().Error("Set auto analyze time window failed", zap.Error(err))
+		return false
+	}
+	if !r.isWithinTimeWindow() {
+		return false
 	}
 
 	// Update the concurrency to the latest value.

--- a/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
+++ b/pkg/statistics/handle/autoanalyze/refresher/refresher_test.go
@@ -49,25 +49,20 @@ func TestTurnOffAndOnAutoAnalyze(t *testing.T) {
 	tk.MustExec("insert into t values (5, 4), (5, 5), (6, 6)")
 	require.NoError(t, handle.DumpStatsDeltaToKV(true))
 	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
-	sysProcTracker := dom.SysProcTracker()
-	r := refresher.NewRefresher(context.Background(), handle, sysProcTracker, dom.DDLNotifier())
-	defer r.Close()
+
+	// This would initialize the auto analyze queue.
+	require.True(t, handle.HandleAutoAnalyze())
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
-		require.True(t, handle.HandleAutoAnalyze())
 		return nil
 	}))
-	r.WaitAutoAnalyzeFinishedForTest()
 
+	// Disable auto analyze.
 	tk.MustExec("set @@global.tidb_enable_auto_analyze = 0;")
-
 	// Add a new index to generate DDL event.
 	tk.MustExec("alter table t add index idx_b(b);")
 	// Make sure the mysql.tidb_ddl_notifier is not empty.
 	rows := tk.MustQuery("select * from mysql.tidb_ddl_notifier").Rows()
 	require.Greater(t, len(rows), 0)
-	require.Eventually(t, func() bool {
-		return !r.IsQueueInitializedForTest()
-	}, time.Second*5, time.Millisecond*100)
 
 	// Make sure the mysql.tidb_ddl_notifier table is empty.
 	require.Eventually(t, func() bool {
@@ -75,12 +70,51 @@ func TestTurnOffAndOnAutoAnalyze(t *testing.T) {
 		return len(rows) == 0
 	}, time.Second*5, time.Millisecond*100)
 
-	// Enable auto analyze again to make sure the queue is re-initialized and handles the DDL event correctly.
+	// Make sure the table is added to the auto analyze queue.
+	snapshot, err := handle.GetPriorityQueueSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(snapshot.CurrentJobs), "The queue should have one job for table t with the new index idx_b")
+
+	// Enable auto analyze again to make sure the queue works.
 	tk.MustExec("set @@global.tidb_enable_auto_analyze = 1;")
+	require.True(t, handle.HandleAutoAnalyze())
+}
+
+func TestQueueInitializesOutsideTimeWindow(t *testing.T) {
+	statistics.AutoAnalyzeMinCnt = 0
+	defer func() {
+		statistics.AutoAnalyzeMinCnt = 1000
+	}()
+
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+
+	handle := dom.StatsHandle()
+	now := time.Now()
+	// Set the auto-analyze time window to a future time.
+	tk.MustExec("set @@global.tidb_auto_analyze_start_time = ?", now.Add(time.Hour).Format("15:04"))
+	tk.MustExec("set @@global.tidb_auto_analyze_end_time = ?", now.Add(2*time.Hour).Format("15:04"))
+
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int, index idx(a))")
+	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3)")
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+	tk.MustExec("analyze table t")
+
+	r := refresher.NewRefresher(context.Background(), handle, dom.SysProcTracker(), dom.DDLNotifier())
+	defer r.Close()
+
+	tk.MustExec("insert into t values (5, 4), (5, 5), (6, 6)")
+	require.NoError(t, handle.DumpStatsDeltaToKV(true))
+	require.NoError(t, handle.Update(context.Background(), dom.InfoSchema()))
+
 	require.NoError(t, util.CallWithSCtx(handle.SPool(), func(sctx sessionctx.Context) error {
-		require.True(t, handle.HandleAutoAnalyze())
+		require.False(t, r.AnalyzeHighestPriorityTables(sctx), "Because it's out of time window, no jobs should be executed")
 		return nil
 	}))
+	r.WaitAutoAnalyzeFinishedForTest()
+	require.Equal(t, 1, r.Len(), "The job queue should be initialized even if it is out of the time window")
 }
 
 func TestChangePruneMode(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/pull/65147

Problem Summary:

### What changed and how does it work?

Split from https://github.com/pingcap/tidb/pull/65147

Previously, the DDL handler would close the priority queue when auto analyze was disabled. This could cause issues with queue state management and DDL notifier cleanup.

This patch changes the behavior to ignore DDL events when the queue is not initialized and auto analyze is disabled, instead of closing the queue. When the queue is already initialized, it continues processing normally regardless of the auto analyze setting.

In this patch, I propose moving the time window after the queue initialization. This change would allow the queue to be initialized normally. For example, if the instance restarts and becomes the owner outside the auto-analyze time window, the DDL notifier cannot proceed because the queue hasn't been initialized. This wouldn't cause any correctness issues, but it may delay the DDL notifier in processing and cleaning up handled events. By moving it after the stats initialization and rebuilding, it will no longer block the DDL notifier. Once it enters the time window, we can pop items from the queue immediately instead of waiting for DDL event handling.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
