### PR TITLE
planner: move MaxMinEliminator to rule package

### DIFF
--- a/pkg/planner/core/BUILD.bazel
+++ b/pkg/planner/core/BUILD.bazel
@@ -55,7 +55,6 @@ go_library(
         "rule_join_reorder.go",
         "rule_join_reorder_dp.go",
         "rule_join_reorder_greedy.go",
-        "rule_max_min_eliminate.go",
         "rule_outer_to_inner_join.go",
         "rule_predicate_push_down.go",
         "rule_push_down_sequence.go",

--- a/pkg/planner/core/optimizer.go
+++ b/pkg/planner/core/optimizer.go
@@ -91,7 +91,7 @@ var optRuleList = []base.LogicalOptRule{
 	&AggregationEliminator{},
 	&SkewDistinctAggRewriter{},
 	&ProjectionEliminator{},
-	&MaxMinEliminator{},
+	&rule.MaxMinEliminator{},
 	&rule.ConstantPropagationSolver{},
 	&ConvertOuterToInnerJoin{},
 	&PPDSolver{},

--- a/pkg/planner/core/rule/BUILD.bazel
+++ b/pkg/planner/core/rule/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "rule_column_pruning.go",
         "rule_constant_propagation.go",
         "rule_init.go",
+        "rule_max_min_eliminate.go",
         "rule_partition_processor.go",
         "rule_predicate_simplification.go",
     ],
@@ -18,6 +19,7 @@ go_library(
     deps = [
         "//pkg/domain",
         "//pkg/expression",
+        "//pkg/expression/aggregation",
         "//pkg/infoschema",
         "//pkg/meta/model",
         "//pkg/parser/ast",

--- a/pkg/planner/core/rule/rule_max_min_eliminate.go
+++ b/pkg/planner/core/rule/rule_max_min_eliminate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package rule
 
 import (
 	"context"
@@ -157,7 +157,7 @@ func (a *MaxMinEliminator) splitAggFuncAndCheckIndices(agg *logicalop.LogicalAgg
 		newAgg := logicalop.LogicalAggregation{AggFuncs: []*aggregation.AggFuncDesc{f}}.Init(agg.SCtx(), agg.QueryBlockOffset())
 		newAgg.SetChildren(a.cloneSubPlans(agg.Children()[0]))
 		newAgg.SetSchema(expression.NewSchema(agg.Schema().Columns[i]))
-		// Since LogicalAggregation doesn’t use the parent base.LogicalPlan, passing an incorrect parameter here won’t affect subsequent optimizations.
+		// Since LogicalAggregation doesn't use the parent base.LogicalPlan, passing an incorrect parameter here won't affect subsequent optimizations.
 		var (
 			p   base.LogicalPlan
 			err error


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #55231

Problem Summary:
Move `rule_max_min_eliminate.go` from `pkg/planner/core/` to `pkg/planner/core/rule/` package as part of the logical optimizing rule rearrangement effort.

### What changed and how does it work?

**Idea:**
After migrating the file, `MaxMinEliminator` struct and its related methods (`Optimize`, `composeAggsByInnerJoin`, `checkColCanUseIndex`, `cloneSubPlans`, `splitAggFuncAndCheckIndices`, `eliminateSingleMaxMin`, `eliminateMaxMin`, `Name`) are moved to the rule package. The `optimizer.go` is updated to reference `rule.MaxMinEliminator` instead of the original `MaxMinEliminator`.

**Changes:**
- Created `pkg/planner/core/rule/rule_max_min_eliminate.go` with package declaration changed to `rule`
- Updated `pkg/planner/core/rule/BUILD.bazel` to add the source file and `aggregation` dependency
- Updated `pkg/planner/core/optimizer.go` to use `rule.MaxMinEliminator`
- Removed the original `pkg/planner/core/rule_max_min_eliminate.go`
- Updated `pkg/planner/core/BUILD.bazel` to remove the old file reference

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.
  > <!-- This is a pure file migration with no logic changes -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```