### PR TITLE
test: avoid to query DNS and port name for lsof in run-test.sh to avoid block

### DIFF
--- a/tests/integrationtest/run-tests.sh
+++ b/tests/integrationtest/run-tests.sh
@@ -74,7 +74,7 @@ function find_available_port() {
             echo "Error: No available ports found below 65536." >&2
             exit 1
         fi
-        if ! lsof -i :"$port" &> /dev/null; then
+        if ! lsof -nP -i :"$port" &> /dev/null; then
             echo $port
             return 0
         fi

--- a/tests/integrationtest2/run-tests.sh
+++ b/tests/integrationtest2/run-tests.sh
@@ -97,7 +97,7 @@ function find_available_port() {
             echo "Error: No available ports found below 65536." >&2
             exit 1
         fi
-        if ! lsof -i :"$port" &> /dev/null; then
+        if ! lsof -nP -i :"$port" &> /dev/null; then
             echo $port
             return 0
         fi


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #56556

### What changed and how does it work?

Use `lsof -nP -i :port` to check whether port is available. `-nP` will forbd to query DNS for domain name and port service name. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
