### PR TITLE
lightning: skip TestLocalTempKVDirCheckBasic in nextgen

### DIFF
--- a/lightning/pkg/importer/BUILD.bazel
+++ b/lightning/pkg/importer/BUILD.bazel
@@ -132,6 +132,7 @@ go_test(
         "//lightning/pkg/importer/opts",
         "//lightning/pkg/precheck",
         "//lightning/pkg/web",
+        "//pkg/config/kerneltype",
         "//pkg/ddl",
         "//pkg/errno",
         "//pkg/kv",

--- a/lightning/pkg/importer/precheck_impl_test.go
+++ b/lightning/pkg/importer/precheck_impl_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/lightning/pkg/importer/mock"
 	ropts "github.com/pingcap/tidb/lightning/pkg/importer/opts"
 	"github.com/pingcap/tidb/lightning/pkg/precheck"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
 	"github.com/pingcap/tidb/pkg/lightning/checkpoints"
 	"github.com/pingcap/tidb/pkg/lightning/config"
 	"github.com/pingcap/tidb/pkg/lightning/log"
@@ -375,6 +376,9 @@ func (s *precheckImplSuite) TestLocalDiskPlacementCheckBasic() {
 }
 
 func (s *precheckImplSuite) TestLocalTempKVDirCheckBasic() {
+	if kerneltype.IsNextGen() {
+		s.T().Skip("we only support global sort in nextgen kernel, this is for local-sort")
+	}
 	var (
 		err    error
 		ci     precheck.Checker


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65224

Problem Summary:

### What changed and how does it work?
we only support global sort in nextgen kernel, this case is for local-sort
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
