### PR TITLE
ddl: fix affinity idempotency problem

### DIFF
--- a/pkg/ddl/affinity_test.go
+++ b/pkg/ddl/affinity_test.go
@@ -173,9 +173,12 @@ func checkAffinityGroupsInPD(t *testing.T, do *domain.Domain, dbName, tbName str
 func TestAffinityPDInteraction(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
-
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t1, t2, tp1, tp2")
+	dropTable := func() {
+		tk.MustExec("drop table if exists t1, t2, t3, tp1, tp2, tp3")
+	}
+	dropTable()
+	defer dropTable()
 
 	// Test 1: Create table with affinity='table'
 	tk.MustExec("create table t1(a int) affinity = 'table'")
@@ -237,8 +240,19 @@ func TestAffinityPDInteraction(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, groups, "old partition's affinity group should be deleted after truncate partition")
 
-	// Cleanup
-	tk.MustExec("drop table if exists t2, tp1, tp2")
+	// Test 8: ALTER TABLE AFFINITY idempotency - partition -> partition
+	tk.MustExec("create table tp3(a int) affinity = 'partition' partition by hash(a) partitions 3")
+	checkAffinityGroupsInPD(t, dom, "test", "tp3", true)
+	// Set affinity to partition again (idempotent operation)
+	tk.MustExec("alter table tp3 affinity = 'partition'")
+	checkAffinityGroupsInPD(t, dom, "test", "tp3", true)
+
+	// Test 9: ALTER TABLE AFFINITY idempotency - table -> table
+	tk.MustExec("create table t3(a int) affinity = 'table'")
+	checkAffinityGroupsInPD(t, dom, "test", "t3", true)
+	// Set affinity to table again (idempotent operation)
+	tk.MustExec("alter table t3 affinity = 'table'")
+	checkAffinityGroupsInPD(t, dom, "test", "t3", true)
 }
 
 func TestAffinityDropDatabase(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/64938

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)
Set affinity multi times and found affinity group in pd is empty
Before:
<img width="2877" height="1634" alt="image" src="https://github.com/user-attachments/assets/4a7d0688-c1c5-464c-bb7c-c48184e0766c" />
After:
<img width="2854" height="1626" alt="image" src="https://github.com/user-attachments/assets/619e08be-4e02-498b-bc58-26ce4aeb2cf6" />

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reapplying an unchanged table or partition affinity setting is now handled safely and consistently.
  * Existing affinity groups are preserved when the affinity level remains unchanged.
  * Affinity groups are still removed correctly when affinity is cleared or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->