### PR TITLE
dumpling/dump: Fallback to LOCK TABLES when FTWRL is stuck

### DIFF
--- a/dumpling/export/dump.go
+++ b/dumpling/export/dump.go
@@ -1424,7 +1424,9 @@ func resolveAutoConsistency(d *Dumper) error {
 		//nolint: errcheck
 		defer conn.Close()
 
-		err = FlushTableWithReadLock(d.tctx, conn)
+		ftwrlCtx, ftwrlCancel := context.WithTimeout(d.tctx.Context, timeout)
+		defer ftwrlCancel()
+		err = FlushTableWithReadLock(ftwrlCtx, conn)
 		//nolint: errcheck
 		defer UnlockTables(d.tctx, conn)
 		if err != nil {

--- a/dumpling/export/dump_test.go
+++ b/dumpling/export/dump_test.go
@@ -68,6 +68,48 @@ func TestDumpExit(t *testing.T) {
 	require.ErrorIs(t, d.dumpDatabases(writerCtx, baseConn, taskChan), sqlmock.ErrCancelled)
 }
 
+func TestResolveAutoConsistencyFallback(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	tctx, cancel := tcontext.Background().WithLogger(appLogger).WithCancel()
+	defer cancel()
+
+	conf := DefaultConfig()
+	conf.ServerInfo.ServerType = version.ServerTypeMySQL
+	conf.Consistency = ConsistencyTypeAuto
+
+	d := &Dumper{
+		tctx:      tctx,
+		conf:      conf,
+		cancelCtx: cancel,
+		dbHandle:  db,
+	}
+
+	// resolveAutoConsistency will:
+	// 1. Get a connection from the pool.
+	// 2. Attempt FLUSH TABLES WITH READ LOCK (which we delay to trigger timeout).
+	// 3. Attempt UNLOCK TABLES (due to defer).
+	// 4. Close the connection (due to defer).
+
+	// We don't need to mock Conn() explicitly as sqlmock handles pool connections,
+	// but we must mock the SQL executed on it.
+	mock.ExpectExec("FLUSH TABLES WITH READ LOCK").
+		WillDelayFor(6 * time.Second).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UNLOCK TABLES").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	err = resolveAutoConsistency(d)
+	require.NoError(t, err)
+
+	// Verify fallback happened to 'lock'
+	require.Equal(t, ConsistencyTypeLock, d.conf.Consistency)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestDumpTableMeta(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. dumpling/dump: Fallback to LOCK TABLES when FTWRL is stuck due to upstream operations
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/56838

Problem Summary:

### What changed and how does it work?

Added a 5-second context timeout to FTWRL execution. Triggers automatic fallback to LOCK TABLES if the timeout is reached.
Added unit test to verify the fallback logic during slow operation.



### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
