### PR TITLE
server/tests: fix flaky test TestIssue57531

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3485,16 +3485,16 @@ func TestIssue57531(t *testing.T) {
 			netConn.Close()
 		})
 
-		time.Sleep(10 * time.Millisecond)
-
 		// the `select sleep(300)` is killed
 		ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
-			rsCnt = 0
-			rs := dbt.MustQuery("show processlist")
-			for rs.Next() {
-				rsCnt++
-			}
-			require.Equal(t, rsCnt, 1)
+			require.Eventually(t, func() bool {
+				rs := dbt.MustQuery("show processlist")
+				cnt := 0
+				for rs.Next() {
+					cnt++
+				}
+				return cnt == 1
+			}, 5*time.Second, 50*time.Millisecond)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65228

Problem Summary:

### What changed and how does it work?

In [TestIssue57531](https://github.com/pingcap/tidb/blob/c51109cbbdec00619066e8afaf5347f926d77eea/pkg/server/tests/commontest/tidb_test.go#L3441), a time-based assertion was introduced to check if the killed session is not shown:

```
		time.Sleep(10 * time.Millisecond)

		// the `select sleep(300)` is killed
		ts.RunTests(t, nil, func(dbt *testkit.DBTestKit) {
			rsCnt = 0
			rs := dbt.MustQuery("show processlist")
			for rs.Next() {
				rsCnt++
			}
			require.Equal(t, rsCnt, 1)
		})
```

When there's a high workload, a sleep of 10 ms is not enough (I can always reproduce the failure when running with 100% CPU usage). I think it is reasonable to loosen this time to 5s for such a situation and still treat it as 'immediate' compared with `select sleep(300)`. 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- None(test only)

Documentation

- None(test only)

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
