### PR TITLE
lightning: fix logged content of "Sample source data"

### DIFF
--- a/lightning/pkg/importer/get_pre_info.go
+++ b/lightning/pkg/importer/get_pre_info.go
@@ -783,7 +783,7 @@ outloop:
 	if rowSize > 0 && kvSize > rowSize {
 		resultIndexRatio = float64(kvSize) / float64(rowSize)
 	}
-	logutil.Logger(ctx).Info("Sample source data", zap.String("table", tableMeta.Name), zap.Float64("IndexRatio", tableMeta.IndexRatio), zap.Bool("IsSourceOrder", tableMeta.IsRowOrdered))
+	logutil.Logger(ctx).Info("Sample source data", zap.String("table", tableMeta.Name), zap.Float64("IndexRatio", resultIndexRatio), zap.Bool("IsSourceOrder", isRowOrdered))
 	return resultIndexRatio, isRowOrdered, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65337

Problem Summary: the "Sample source data" line always printed the default values.

### What changed and how does it work?

Make it logs the actual computed values.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

```console
$ make build_lightning
$ tiup bench tpcc prepare -D test65537 --warehouses 0 --parts 0 --tables customer
$ tiup bench tpcc prepare --output-type csv --output-dir ./d -D test65537 -T 8 --tables customer
$ bin/tidb-lightning -d ./d -backend local -tidb-port 4000 -sorted-kv-dir /tmp/lskd/ -log-file ./l.log -no-schema -config <( echo 'mydumper.csv.header=false' )
$ grep Sample l.log
[2025/12/30 14:28:23.103 +08:00] [INFO] [get_pre_info.go:786] ["Sample source data"] [table=customer] [IndexRatio=1.3367036280139557] [IsSourceOrder=true]
[2025/12/30 14:28:23.127 +08:00] [INFO] [get_pre_info.go:786] ["Sample source data"] [table=order_line] [IndexRatio=1.7710732339222421] [IsSourceOrder=true]
[2025/12/30 14:28:23.160 +08:00] [INFO] [get_pre_info.go:786] ["Sample source data"] [table=stock] [IndexRatio=1.257260933749925] [IsSourceOrder=true]
[2025/12/30 14:30:47.859 +08:00] [INFO] [get_pre_info.go:786] ["Sample source data"] [table=customer] [IndexRatio=1.3368721476569196] [IsSourceOrder=true]
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
