### PR TITLE
expression: Use lazy copy in resolve indices for scalar function

### DIFF
--- a/pkg/executor/sample.go
+++ b/pkg/executor/sample.go
@@ -269,7 +269,7 @@ func (s *tableRegionSampler) buildSampleColAndDecodeColMap() ([]*table.Column, m
 			// indices of column(Column.Index) needs to be resolved against full column's schema.
 			if schemaCol.VirtualExpr != nil {
 				var err error
-				schemaCol.VirtualExpr, err = schemaCol.VirtualExpr.ResolveIndices(s.fullSchema)
+				schemaCol.VirtualExpr, _, err = schemaCol.VirtualExpr.ResolveIndices(s.fullSchema, true)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/executor/sample.go
+++ b/pkg/executor/sample.go
@@ -269,7 +269,7 @@ func (s *tableRegionSampler) buildSampleColAndDecodeColMap() ([]*table.Column, m
 			// indices of column(Column.Index) needs to be resolved against full column's schema.
 			if schemaCol.VirtualExpr != nil {
 				var err error
-				schemaCol.VirtualExpr, _, err = schemaCol.VirtualExpr.ResolveIndices(s.fullSchema, true)
+				schemaCol.VirtualExpr, _, err = schemaCol.VirtualExpr.ResolveIndices(s.fullSchema)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -66,7 +66,7 @@ func (col *CorrelatedColumn) CloneAndClearIndexResolvedFlag() Expression {
 }
 
 // ClearIndexResolvedFlag implements Expression interface.
-func (_ *CorrelatedColumn) ClearIndexResolvedFlag() {
+func (*CorrelatedColumn) ClearIndexResolvedFlag() {
 }
 
 // VecEvalInt evaluates this expression in a vectorized manner.

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -699,24 +699,19 @@ func (col *Column) CleanHashCode() {
 	col.hashcode = make([]byte, 0, 9)
 }
 
-func (col *Column) getIndex(schema *Schema) (int, error) {
-	index := schema.ColumnIndex(col)
-	if index == -1 {
-		return index, errors.Errorf("Can't find column %s in schema %s", col, schema)
-	}
-	return index, nil
-}
-
 // ResolveIndices implements Expression interface.
 func (col *Column) ResolveIndices(schema *Schema) (Expression, bool, error) {
 	newCol := col.Clone()
-	newCol.resolveIndices(schema)
-	return newCol, true, nil
+	err := newCol.resolveIndices(schema)
+	return newCol, true, err
 }
 
 func (col *Column) resolveIndices(schema *Schema) (err error) {
-	col.Index, err = col.getIndex(schema)
-	return err
+	col.Index = schema.ColumnIndex(col)
+	if col.Index == -1 {
+		return errors.Errorf("Can't find column %s in schema %s", col, schema)
+	}
+	return nil
 }
 
 // ResolveIndicesByVirtualExpr implements Expression interface.

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -220,12 +220,12 @@ func (col *CorrelatedColumn) Decorrelate(schema *Schema) Expression {
 }
 
 // ResolveIndices implements Expression interface.
-func (col *CorrelatedColumn) ResolveIndices(_ *Schema, _ bool) (Expression, bool, error) {
+func (col *CorrelatedColumn) ResolveIndices(_ *Schema) (Expression, bool, error) {
 	// todo in order to follow the original behavior, maybe we should always clone a new correlated column here
 	return col, false, nil
 }
 
-func (col *CorrelatedColumn) resolveIndices(_ *Schema, _ bool) error {
+func (col *CorrelatedColumn) resolveIndices(_ *Schema) error {
 	return nil
 }
 
@@ -708,13 +708,13 @@ func (col *Column) getIndex(schema *Schema) (int, error) {
 }
 
 // ResolveIndices implements Expression interface.
-func (col *Column) ResolveIndices(schema *Schema, allowLazyCopy bool) (Expression, bool, error) {
+func (col *Column) ResolveIndices(schema *Schema) (Expression, bool, error) {
 	newCol := col.Clone()
-	newCol.resolveIndices(schema, allowLazyCopy)
+	newCol.resolveIndices(schema)
 	return newCol, true, nil
 }
 
-func (col *Column) resolveIndices(schema *Schema, _ bool) (err error) {
+func (col *Column) resolveIndices(schema *Schema) (err error) {
 	col.Index, err = col.getIndex(schema)
 	return err
 }

--- a/pkg/expression/column.go
+++ b/pkg/expression/column.go
@@ -221,7 +221,7 @@ func (col *CorrelatedColumn) Decorrelate(schema *Schema) Expression {
 
 // ResolveIndices implements Expression interface.
 func (col *CorrelatedColumn) ResolveIndices(_ *Schema) (Expression, bool, error) {
-	// todo in order to follow the original behavior, maybe we should always clone a new correlated column here
+	// todo in order to follow the original behavior, maybe we should always clone a new correlated column here?
 	return col, false, nil
 }
 

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -225,10 +225,12 @@ func (c *Constant) Clone() Expression {
 	return &con
 }
 
+// CloneAndClearIndexResolvedFlag implements Expression interface.
 func (c *Constant) CloneAndClearIndexResolvedFlag() Expression {
 	return c.Clone()
 }
 
+// ClearIndexResolvedFlag implements Expression interface.
 func (_ *Constant) ClearIndexResolvedFlag() {
 }
 

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -225,6 +225,13 @@ func (c *Constant) Clone() Expression {
 	return &con
 }
 
+func (c *Constant) CloneAndClearIndexResolvedFlag() Expression {
+	return c.Clone()
+}
+
+func (_ *Constant) ClearIndexResolvedFlag() {
+}
+
 // GetType implements Expression interface.
 func (c *Constant) GetType(ctx EvalContext) *types.FieldType {
 	if c.ParamMarker != nil {
@@ -619,11 +626,11 @@ func (c *Constant) getHashCode(canonical bool) []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (c *Constant) ResolveIndices(_ *Schema) (Expression, error) {
-	return c, nil
+func (c *Constant) ResolveIndices(_ *Schema, _ bool) (Expression, bool, error) {
+	return c, false, nil
 }
 
-func (c *Constant) resolveIndices(_ *Schema) error {
+func (c *Constant) resolveIndices(_ *Schema, _ bool) error {
 	return nil
 }
 

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -626,11 +626,11 @@ func (c *Constant) getHashCode(canonical bool) []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (c *Constant) ResolveIndices(_ *Schema, _ bool) (Expression, bool, error) {
+func (c *Constant) ResolveIndices(_ *Schema) (Expression, bool, error) {
 	return c, false, nil
 }
 
-func (c *Constant) resolveIndices(_ *Schema, _ bool) error {
+func (c *Constant) resolveIndices(_ *Schema) error {
 	return nil
 }
 

--- a/pkg/expression/constant.go
+++ b/pkg/expression/constant.go
@@ -231,7 +231,7 @@ func (c *Constant) CloneAndClearIndexResolvedFlag() Expression {
 }
 
 // ClearIndexResolvedFlag implements Expression interface.
-func (_ *Constant) ClearIndexResolvedFlag() {
+func (*Constant) ClearIndexResolvedFlag() {
 }
 
 // GetType implements Expression interface.

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -235,9 +235,9 @@ type Expression interface {
 	Decorrelate(schema *Schema) Expression
 
 	// ResolveIndices resolves indices by the given schema.
-	// It uses lazy copy, if the current Expression is not resolved, then it will resolve inplace,
-	// otherwise, it will copy the original expression and return the copied one.
-	// the second return value indicates whether the returned expression is a cloned one or not.
+	// Each implementation can choose to support lazy copy or not. If it uses
+	// lazy copy, and resolve the index inplace, it should return false as
+	// the second return value, otherwise return true.
 	ResolveIndices(schema *Schema) (Expression, bool, error)
 
 	// resolveIndices is called inside the `ResolveIndices` It will perform on the expression itself.

--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -238,10 +238,10 @@ type Expression interface {
 	// It uses lazy copy, if the current Expression is not resolved, then it will resolve inplace,
 	// otherwise, it will copy the original expression and return the copied one.
 	// the second return value indicates whether the returned expression is a cloned one or not.
-	ResolveIndices(schema *Schema, allowLazyCopy bool) (Expression, bool, error)
+	ResolveIndices(schema *Schema) (Expression, bool, error)
 
 	// resolveIndices is called inside the `ResolveIndices` It will perform on the expression itself.
-	resolveIndices(schema *Schema, allowLazyCopy bool) error
+	resolveIndices(schema *Schema) error
 
 	// ResolveIndicesByVirtualExpr resolves indices by the given schema in terms of virtual expression. It will copy the original expression and return the copied one.
 	ResolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) (Expression, bool)
@@ -1152,7 +1152,7 @@ func ColumnInfos2ColumnsAndNames(ctx BuildContext, dbName, tblName ast.CIStr, co
 			if e != nil {
 				columns[i].VirtualExpr = e.Clone()
 			}
-			columns[i].VirtualExpr, _, err = columns[i].VirtualExpr.ResolveIndices(mockSchema, true)
+			columns[i].VirtualExpr, _, err = columns[i].VirtualExpr.ResolveIndices(mockSchema)
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -17,6 +17,7 @@ package expression
 import (
 	"bytes"
 	"slices"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/pingcap/errors"
@@ -32,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
-	"sync/atomic"
 )
 
 var _ base.HashEquals = &ScalarFunction{}

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -800,8 +800,8 @@ func ReHashCode(sf *ScalarFunction) {
 func (sf *ScalarFunction) ResolveIndices(schema *Schema) (Expression, bool, error) {
 	if sf.indexResolved.CompareAndSwap(false, true) {
 		// don't need copy
-		sf.resolveIndices(schema)
-		return sf, false, nil
+		err := sf.resolveIndices(schema)
+		return sf, false, err
 	}
 	// need copy
 	newSf := sf.CloneAndClearIndexResolvedFlag()

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -817,7 +817,7 @@ func (sf *ScalarFunction) resolveIndices(schema *Schema, allowLazyCopy bool) err
 			return err
 		}
 		if cloned {
-			// if cloned is false, then continue to use the original arg
+			// if cloned is true, then update the arg, otherwise keep the original arg
 			sf.GetArgs()[index] = newArg
 		}
 	}

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -799,11 +799,11 @@ func ReHashCode(sf *ScalarFunction) {
 // ResolveIndices implements Expression interface.
 func (sf *ScalarFunction) ResolveIndices(schema *Schema) (Expression, bool, error) {
 	if sf.indexResolved.CompareAndSwap(false, true) {
-		// don't need to copy
+		// don't need copy
 		sf.resolveIndices(schema)
 		return sf, false, nil
 	}
-	// need to copy
+	// need copy
 	newSf := sf.CloneAndClearIndexResolvedFlag()
 	err := newSf.resolveIndices(schema)
 	newSf.(*ScalarFunction).indexResolved.Store(true)

--- a/pkg/expression/scalar_function.go
+++ b/pkg/expression/scalar_function.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbterror/plannererrors"
 	"github.com/pingcap/tidb/pkg/util/hack"
 	"github.com/pingcap/tidb/pkg/util/intest"
-	"go.uber.org/atomic"
+	"sync/atomic"
 )
 
 var _ base.HashEquals = &ScalarFunction{}
@@ -356,6 +356,7 @@ func (sf *ScalarFunction) Clone() Expression {
 		Function:      sf.Function.Clone(),
 		indexResolved: sf.indexResolved,
 	}
+	//c.indexResolved.Store(sf.indexResolved.Load())
 	// An implicit assumption: ScalarFunc.RetType == ScalarFunc.builtinFunc.RetType
 	if sf.canonicalhashcode != nil {
 		c.canonicalhashcode = slices.Clone(sf.canonicalhashcode)

--- a/pkg/expression/util_test.go
+++ b/pkg/expression/util_test.go
@@ -630,12 +630,12 @@ func (m *MockExpr) Clone() Expression {
 	return cloned
 }
 
-func (m *MockExpr) Equal(ctx EvalContext, e Expression) bool          { return false }
-func (m *MockExpr) IsCorrelated() bool                                { return false }
-func (m *MockExpr) ConstLevel() ConstLevel                            { return ConstNone }
-func (m *MockExpr) Decorrelate(schema *Schema) Expression             { return m }
-func (m *MockExpr) ResolveIndices(schema *Schema) (Expression, error) { return m, nil }
-func (m *MockExpr) resolveIndices(schema *Schema) error               { return nil }
+func (m *MockExpr) Equal(ctx EvalContext, e Expression) bool                { return false }
+func (m *MockExpr) IsCorrelated() bool                                      { return false }
+func (m *MockExpr) ConstLevel() ConstLevel                                  { return ConstNone }
+func (m *MockExpr) Decorrelate(schema *Schema) Expression                   { return m }
+func (m *MockExpr) ResolveIndices(schema *Schema) (Expression, bool, error) { return m, false, nil }
+func (m *MockExpr) resolveIndices(schema *Schema) error                     { return nil }
 func (m *MockExpr) ResolveIndicesByVirtualExpr(ctx EvalContext, schema *Schema) (Expression, bool) {
 	return m, true
 }
@@ -656,6 +656,8 @@ func (m *MockExpr) Repertoire() Repertoire                              { return
 func (m *MockExpr) SetRepertoire(Repertoire)                            {}
 func (m *MockExpr) IsExplicitCharset() bool                             { return false }
 func (m *MockExpr) SetExplicitCharset(bool)                             {}
+func (m *MockExpr) ClearIndexResolvedFlag()                             {}
+func (m *MockExpr) CloneAndClearIndexResolvedFlag() Expression          { return m.Clone() }
 
 func (m *MockExpr) CharsetAndCollation() (string, string) {
 	return "", ""

--- a/pkg/planner/core/operator/physicalop/base_physical_agg.go
+++ b/pkg/planner/core/operator/physicalop/base_physical_agg.go
@@ -910,20 +910,20 @@ func (p *BasePhysicalAgg) ResolveIndices() (err error) {
 	}
 	for _, aggFun := range p.AggFuncs {
 		for i, arg := range aggFun.Args {
-			aggFun.Args[i], err = arg.ResolveIndices(p.Children()[0].Schema())
+			aggFun.Args[i], _, err = arg.ResolveIndices(p.Children()[0].Schema(), true)
 			if err != nil {
 				return err
 			}
 		}
 		for _, byItem := range aggFun.OrderByItems {
-			byItem.Expr, err = byItem.Expr.ResolveIndices(p.Children()[0].Schema())
+			byItem.Expr, _, err = byItem.Expr.ResolveIndices(p.Children()[0].Schema(), true)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	for i, item := range p.GroupByItems {
-		p.GroupByItems[i], err = item.ResolveIndices(p.Children()[0].Schema())
+		p.GroupByItems[i], _, err = item.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/base_physical_agg.go
+++ b/pkg/planner/core/operator/physicalop/base_physical_agg.go
@@ -910,20 +910,20 @@ func (p *BasePhysicalAgg) ResolveIndices() (err error) {
 	}
 	for _, aggFun := range p.AggFuncs {
 		for i, arg := range aggFun.Args {
-			aggFun.Args[i], _, err = arg.ResolveIndices(p.Children()[0].Schema(), true)
+			aggFun.Args[i], _, err = arg.ResolveIndices(p.Children()[0].Schema())
 			if err != nil {
 				return err
 			}
 		}
 		for _, byItem := range aggFun.OrderByItems {
-			byItem.Expr, _, err = byItem.Expr.ResolveIndices(p.Children()[0].Schema(), true)
+			byItem.Expr, _, err = byItem.Expr.ResolveIndices(p.Children()[0].Schema())
 			if err != nil {
 				return err
 			}
 		}
 	}
 	for i, item := range p.GroupByItems {
-		p.GroupByItems[i], _, err = item.ResolveIndices(p.Children()[0].Schema(), true)
+		p.GroupByItems[i], _, err = item.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_apply.go
+++ b/pkg/planner/core/operator/physicalop/physical_apply.go
@@ -126,7 +126,7 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	}
 	p.OuterSchema = make([]*expression.CorrelatedColumn, 0, len(dedupCols))
 	for _, col := range dedupCols {
-		newCol, _, err := col.Column.ResolveIndices(p.Children()[0].Schema(), false)
+		newCol, _, err := col.Column.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -140,14 +140,14 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	joinedSchema := expression.MergeSchema(p.Children()[0].Schema(), p.Children()[1].Schema())
 	for i, cond := range p.PhysicalHashJoin.EqualConditions {
 		// todo double check if it can allowLazyCopy?
-		newSf, _, err := cond.ResolveIndices(joinedSchema, false)
+		newSf, _, err := cond.ResolveIndices(joinedSchema, true)
 		if err != nil {
 			return err
 		}
 		p.PhysicalHashJoin.EqualConditions[i] = newSf.(*expression.ScalarFunction)
 	}
 	for i, cond := range p.PhysicalHashJoin.NAEqualConditions {
-		newSf, _, err := cond.ResolveIndices(joinedSchema, false)
+		newSf, _, err := cond.ResolveIndices(joinedSchema, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_apply.go
+++ b/pkg/planner/core/operator/physicalop/physical_apply.go
@@ -139,7 +139,6 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	// single child's schema.
 	joinedSchema := expression.MergeSchema(p.Children()[0].Schema(), p.Children()[1].Schema())
 	for i, cond := range p.PhysicalHashJoin.EqualConditions {
-		// todo double check if it can allowLazyCopy?
 		newSf, _, err := cond.ResolveIndices(joinedSchema)
 		if err != nil {
 			return err

--- a/pkg/planner/core/operator/physicalop/physical_apply.go
+++ b/pkg/planner/core/operator/physicalop/physical_apply.go
@@ -126,7 +126,7 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	}
 	p.OuterSchema = make([]*expression.CorrelatedColumn, 0, len(dedupCols))
 	for _, col := range dedupCols {
-		newCol, _, err := col.Column.ResolveIndices(p.Children()[0].Schema(), true)
+		newCol, _, err := col.Column.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
@@ -140,14 +140,14 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	joinedSchema := expression.MergeSchema(p.Children()[0].Schema(), p.Children()[1].Schema())
 	for i, cond := range p.PhysicalHashJoin.EqualConditions {
 		// todo double check if it can allowLazyCopy?
-		newSf, _, err := cond.ResolveIndices(joinedSchema, true)
+		newSf, _, err := cond.ResolveIndices(joinedSchema)
 		if err != nil {
 			return err
 		}
 		p.PhysicalHashJoin.EqualConditions[i] = newSf.(*expression.ScalarFunction)
 	}
 	for i, cond := range p.PhysicalHashJoin.NAEqualConditions {
-		newSf, _, err := cond.ResolveIndices(joinedSchema, true)
+		newSf, _, err := cond.ResolveIndices(joinedSchema)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_apply.go
+++ b/pkg/planner/core/operator/physicalop/physical_apply.go
@@ -126,7 +126,7 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	}
 	p.OuterSchema = make([]*expression.CorrelatedColumn, 0, len(dedupCols))
 	for _, col := range dedupCols {
-		newCol, err := col.Column.ResolveIndices(p.Children()[0].Schema())
+		newCol, _, err := col.Column.ResolveIndices(p.Children()[0].Schema(), false)
 		if err != nil {
 			return err
 		}
@@ -139,14 +139,15 @@ func (p *PhysicalApply) ResolveIndices() (err error) {
 	// single child's schema.
 	joinedSchema := expression.MergeSchema(p.Children()[0].Schema(), p.Children()[1].Schema())
 	for i, cond := range p.PhysicalHashJoin.EqualConditions {
-		newSf, err := cond.ResolveIndices(joinedSchema)
+		// todo double check if it can allowLazyCopy?
+		newSf, _, err := cond.ResolveIndices(joinedSchema, false)
 		if err != nil {
 			return err
 		}
 		p.PhysicalHashJoin.EqualConditions[i] = newSf.(*expression.ScalarFunction)
 	}
 	for i, cond := range p.PhysicalHashJoin.NAEqualConditions {
-		newSf, err := cond.ResolveIndices(joinedSchema)
+		newSf, _, err := cond.ResolveIndices(joinedSchema, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_common_plans.go
+++ b/pkg/planner/core/operator/physicalop/physical_common_plans.go
@@ -346,12 +346,12 @@ func (p *Update) ResolveIndices() (err error) {
 	}
 	schema := p.SelectPlan.Schema()
 	for _, assign := range p.OrderedList {
-		newCol, _, err := assign.Col.ResolveIndices(schema, true)
+		newCol, _, err := assign.Col.ResolveIndices(schema)
 		if err != nil {
 			return err
 		}
 		assign.Col = newCol.(*expression.Column)
-		assign.Expr, _, err = assign.Expr.ResolveIndices(schema, true)
+		assign.Expr, _, err = assign.Expr.ResolveIndices(schema)
 		if err != nil {
 			return err
 		}
@@ -366,32 +366,32 @@ func (p *Insert) ResolveIndices() (err error) {
 		return err
 	}
 	for _, asgn := range p.OnDuplicate {
-		newCol, _, err := asgn.Col.ResolveIndices(p.TableSchema, true)
+		newCol, _, err := asgn.Col.ResolveIndices(p.TableSchema)
 		if err != nil {
 			return err
 		}
 		asgn.Col = newCol.(*expression.Column)
 		// Once the asgn.lazyErr exists, asgn.Expr here is nil.
 		if asgn.Expr != nil {
-			asgn.Expr, _, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate, true)
+			asgn.Expr, _, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	for i, expr := range p.GenCols.Exprs {
-		p.GenCols.Exprs[i], _, err = expr.ResolveIndices(p.TableSchema, true)
+		p.GenCols.Exprs[i], _, err = expr.ResolveIndices(p.TableSchema)
 		if err != nil {
 			return err
 		}
 	}
 	for _, asgn := range p.GenCols.OnDuplicates {
-		newCol, _, err := asgn.Col.ResolveIndices(p.TableSchema, true)
+		newCol, _, err := asgn.Col.ResolveIndices(p.TableSchema)
 		if err != nil {
 			return err
 		}
 		asgn.Col = newCol.(*expression.Column)
-		asgn.Expr, _, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate, true)
+		asgn.Expr, _, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_common_plans.go
+++ b/pkg/planner/core/operator/physicalop/physical_common_plans.go
@@ -346,12 +346,12 @@ func (p *Update) ResolveIndices() (err error) {
 	}
 	schema := p.SelectPlan.Schema()
 	for _, assign := range p.OrderedList {
-		newCol, err := assign.Col.ResolveIndices(schema)
+		newCol, _, err := assign.Col.ResolveIndices(schema, true)
 		if err != nil {
 			return err
 		}
 		assign.Col = newCol.(*expression.Column)
-		assign.Expr, err = assign.Expr.ResolveIndices(schema)
+		assign.Expr, _, err = assign.Expr.ResolveIndices(schema, true)
 		if err != nil {
 			return err
 		}
@@ -366,32 +366,32 @@ func (p *Insert) ResolveIndices() (err error) {
 		return err
 	}
 	for _, asgn := range p.OnDuplicate {
-		newCol, err := asgn.Col.ResolveIndices(p.TableSchema)
+		newCol, _, err := asgn.Col.ResolveIndices(p.TableSchema, true)
 		if err != nil {
 			return err
 		}
 		asgn.Col = newCol.(*expression.Column)
 		// Once the asgn.lazyErr exists, asgn.Expr here is nil.
 		if asgn.Expr != nil {
-			asgn.Expr, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate)
+			asgn.Expr, _, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate, true)
 			if err != nil {
 				return err
 			}
 		}
 	}
 	for i, expr := range p.GenCols.Exprs {
-		p.GenCols.Exprs[i], err = expr.ResolveIndices(p.TableSchema)
+		p.GenCols.Exprs[i], _, err = expr.ResolveIndices(p.TableSchema, true)
 		if err != nil {
 			return err
 		}
 	}
 	for _, asgn := range p.GenCols.OnDuplicates {
-		newCol, err := asgn.Col.ResolveIndices(p.TableSchema)
+		newCol, _, err := asgn.Col.ResolveIndices(p.TableSchema, true)
 		if err != nil {
 			return err
 		}
 		asgn.Col = newCol.(*expression.Column)
-		asgn.Expr, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate)
+		asgn.Expr, _, err = asgn.Expr.ResolveIndices(p.Schema4OnDuplicate, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_expand.go
+++ b/pkg/planner/core/operator/physicalop/physical_expand.go
@@ -165,7 +165,7 @@ func (p *PhysicalExpand) ResolveIndicesItself() (err error) {
 	for _, gs := range p.GroupingSets {
 		for _, groupingExprs := range gs {
 			for k, groupingExpr := range groupingExprs {
-				gExpr, _, err := groupingExpr.ResolveIndices(p.Children()[0].Schema(), true)
+				gExpr, _, err := groupingExpr.ResolveIndices(p.Children()[0].Schema())
 				if err != nil {
 					return err
 				}
@@ -177,7 +177,7 @@ func (p *PhysicalExpand) ResolveIndicesItself() (err error) {
 	for i, oneLevel := range p.LevelExprs {
 		for j, expr := range oneLevel {
 			// expr in expand level-projections only contains column ref and literal constant projection.
-			p.LevelExprs[i][j], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
+			p.LevelExprs[i][j], _, err = expr.ResolveIndices(p.Children()[0].Schema())
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_expand.go
+++ b/pkg/planner/core/operator/physicalop/physical_expand.go
@@ -165,7 +165,7 @@ func (p *PhysicalExpand) ResolveIndicesItself() (err error) {
 	for _, gs := range p.GroupingSets {
 		for _, groupingExprs := range gs {
 			for k, groupingExpr := range groupingExprs {
-				gExpr, err := groupingExpr.ResolveIndices(p.Children()[0].Schema())
+				gExpr, _, err := groupingExpr.ResolveIndices(p.Children()[0].Schema(), true)
 				if err != nil {
 					return err
 				}
@@ -177,7 +177,7 @@ func (p *PhysicalExpand) ResolveIndicesItself() (err error) {
 	for i, oneLevel := range p.LevelExprs {
 		for j, expr := range oneLevel {
 			// expr in expand level-projections only contains column ref and literal constant projection.
-			p.LevelExprs[i][j], err = expr.ResolveIndices(p.Children()[0].Schema())
+			p.LevelExprs[i][j], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_hash_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_hash_join.go
@@ -381,12 +381,12 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 	rSchema := p.Children()[1].Schema()
 	ctx := p.SCtx()
 	for i, fun := range p.EqualConditions {
-		lArg, err := fun.GetArgs()[0].ResolveIndices(lSchema)
+		lArg, _, err := fun.GetArgs()[0].ResolveIndices(lSchema, true)
 		if err != nil {
 			return err
 		}
 		p.LeftJoinKeys[i] = lArg.(*expression.Column)
-		rArg, err := fun.GetArgs()[1].ResolveIndices(rSchema)
+		rArg, _, err := fun.GetArgs()[1].ResolveIndices(rSchema, true)
 		if err != nil {
 			return err
 		}
@@ -394,12 +394,12 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 		p.EqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetStaticType(), lArg, rArg).(*expression.ScalarFunction)
 	}
 	for i, fun := range p.NAEqualConditions {
-		lArg, err := fun.GetArgs()[0].ResolveIndices(lSchema)
+		lArg, _, err := fun.GetArgs()[0].ResolveIndices(lSchema, true)
 		if err != nil {
 			return err
 		}
 		p.LeftNAJoinKeys[i] = lArg.(*expression.Column)
-		rArg, err := fun.GetArgs()[1].ResolveIndices(rSchema)
+		rArg, _, err := fun.GetArgs()[1].ResolveIndices(rSchema, true)
 		if err != nil {
 			return err
 		}
@@ -407,13 +407,13 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 		p.NAEqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetStaticType(), lArg, rArg).(*expression.ScalarFunction)
 	}
 	for i, expr := range p.LeftConditions {
-		p.LeftConditions[i], err = expr.ResolveIndices(lSchema)
+		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema, true)
 		if err != nil {
 			return err
 		}
 	}
 	for i, expr := range p.RightConditions {
-		p.RightConditions[i], err = expr.ResolveIndices(rSchema)
+		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema, true)
 		if err != nil {
 			return err
 		}
@@ -422,7 +422,7 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 	mergedSchema := expression.MergeSchema(lSchema, rSchema)
 
 	for i, expr := range p.OtherConditions {
-		p.OtherConditions[i], err = expr.ResolveIndices(mergedSchema)
+		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_hash_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_hash_join.go
@@ -381,12 +381,12 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 	rSchema := p.Children()[1].Schema()
 	ctx := p.SCtx()
 	for i, fun := range p.EqualConditions {
-		lArg, _, err := fun.GetArgs()[0].ResolveIndices(lSchema, true)
+		lArg, _, err := fun.GetArgs()[0].ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
 		p.LeftJoinKeys[i] = lArg.(*expression.Column)
-		rArg, _, err := fun.GetArgs()[1].ResolveIndices(rSchema, true)
+		rArg, _, err := fun.GetArgs()[1].ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
@@ -394,12 +394,12 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 		p.EqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetStaticType(), lArg, rArg).(*expression.ScalarFunction)
 	}
 	for i, fun := range p.NAEqualConditions {
-		lArg, _, err := fun.GetArgs()[0].ResolveIndices(lSchema, true)
+		lArg, _, err := fun.GetArgs()[0].ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
 		p.LeftNAJoinKeys[i] = lArg.(*expression.Column)
-		rArg, _, err := fun.GetArgs()[1].ResolveIndices(rSchema, true)
+		rArg, _, err := fun.GetArgs()[1].ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
@@ -407,13 +407,13 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 		p.NAEqualConditions[i] = expression.NewFunctionInternal(ctx.GetExprCtx(), fun.FuncName.L, fun.GetStaticType(), lArg, rArg).(*expression.ScalarFunction)
 	}
 	for i, expr := range p.LeftConditions {
-		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema, true)
+		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
 	}
 	for i, expr := range p.RightConditions {
-		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema, true)
+		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
@@ -422,7 +422,7 @@ func (p *PhysicalHashJoin) ResolveIndicesItself() (err error) {
 	mergedSchema := expression.MergeSchema(lSchema, rSchema)
 
 	for i, expr := range p.OtherConditions {
-		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema, true)
+		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_index_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_join.go
@@ -300,7 +300,7 @@ func (cwc *ColWithCmpFuncManager) BuildRangesByRow(ctx *rangerctx.RangerContext,
 
 func (cwc *ColWithCmpFuncManager) resolveIndices(schema *expression.Schema) (err error) {
 	for i := range cwc.opArg {
-		cwc.opArg[i], err = cwc.opArg[i].ResolveIndices(schema)
+		cwc.opArg[i], _, err = cwc.opArg[i].ResolveIndices(schema, true)
 		if err != nil {
 			return err
 		}
@@ -370,32 +370,32 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 	lSchema := p.Children()[0].Schema()
 	rSchema := p.Children()[1].Schema()
 	for i := range p.InnerJoinKeys {
-		newOuterKey, err := p.OuterJoinKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema())
+		newOuterKey, _, err := p.OuterJoinKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema(), true)
 		if err != nil {
 			return err
 		}
 		p.OuterJoinKeys[i] = newOuterKey.(*expression.Column)
-		newInnerKey, err := p.InnerJoinKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema())
+		newInnerKey, _, err := p.InnerJoinKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema(), true)
 		if err != nil {
 			return err
 		}
 		p.InnerJoinKeys[i] = newInnerKey.(*expression.Column)
 	}
 	for i, expr := range p.LeftConditions {
-		p.LeftConditions[i], err = expr.ResolveIndices(lSchema)
+		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema, true)
 		if err != nil {
 			return err
 		}
 	}
 	for i, expr := range p.RightConditions {
-		p.RightConditions[i], err = expr.ResolveIndices(rSchema)
+		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema, true)
 		if err != nil {
 			return err
 		}
 	}
 	mergedSchema := expression.MergeSchema(lSchema, rSchema)
 	for i, expr := range p.OtherConditions {
-		p.OtherConditions[i], err = expr.ResolveIndices(mergedSchema)
+		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema, true)
 		if err != nil {
 			return err
 		}
@@ -406,7 +406,7 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 			return err
 		}
 		for i := range p.CompareFilters.AffectedColSchema.Columns {
-			resolvedCol, err1 := p.CompareFilters.AffectedColSchema.Columns[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema())
+			resolvedCol, _, err1 := p.CompareFilters.AffectedColSchema.Columns[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema(), true)
 			if err1 != nil {
 				return err1
 			}
@@ -414,11 +414,11 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 		}
 	}
 	for i := range p.OuterHashKeys {
-		outerKey, err := p.OuterHashKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema())
+		outerKey, _, err := p.OuterHashKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema(), true)
 		if err != nil {
 			return err
 		}
-		innerKey, err := p.InnerHashKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema())
+		innerKey, _, err := p.InnerHashKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema(), true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_index_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_join.go
@@ -300,7 +300,7 @@ func (cwc *ColWithCmpFuncManager) BuildRangesByRow(ctx *rangerctx.RangerContext,
 
 func (cwc *ColWithCmpFuncManager) resolveIndices(schema *expression.Schema) (err error) {
 	for i := range cwc.opArg {
-		cwc.opArg[i], _, err = cwc.opArg[i].ResolveIndices(schema, true)
+		cwc.opArg[i], _, err = cwc.opArg[i].ResolveIndices(schema)
 		if err != nil {
 			return err
 		}
@@ -370,32 +370,32 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 	lSchema := p.Children()[0].Schema()
 	rSchema := p.Children()[1].Schema()
 	for i := range p.InnerJoinKeys {
-		newOuterKey, _, err := p.OuterJoinKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema(), true)
+		newOuterKey, _, err := p.OuterJoinKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}
 		p.OuterJoinKeys[i] = newOuterKey.(*expression.Column)
-		newInnerKey, _, err := p.InnerJoinKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema(), true)
+		newInnerKey, _, err := p.InnerJoinKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}
 		p.InnerJoinKeys[i] = newInnerKey.(*expression.Column)
 	}
 	for i, expr := range p.LeftConditions {
-		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema, true)
+		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
 	}
 	for i, expr := range p.RightConditions {
-		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema, true)
+		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
 	}
 	mergedSchema := expression.MergeSchema(lSchema, rSchema)
 	for i, expr := range p.OtherConditions {
-		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema, true)
+		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema)
 		if err != nil {
 			return err
 		}
@@ -406,7 +406,7 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 			return err
 		}
 		for i := range p.CompareFilters.AffectedColSchema.Columns {
-			resolvedCol, _, err1 := p.CompareFilters.AffectedColSchema.Columns[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema(), true)
+			resolvedCol, _, err1 := p.CompareFilters.AffectedColSchema.Columns[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema())
 			if err1 != nil {
 				return err1
 			}
@@ -414,11 +414,11 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 		}
 	}
 	for i := range p.OuterHashKeys {
-		outerKey, _, err := p.OuterHashKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema(), true)
+		outerKey, _, err := p.OuterHashKeys[i].ResolveIndices(p.Children()[1-p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}
-		innerKey, _, err := p.InnerHashKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema(), true)
+		innerKey, _, err := p.InnerHashKeys[i].ResolveIndices(p.Children()[p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_index_reader.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_reader.go
@@ -190,7 +190,7 @@ func (p *PhysicalIndexReader) ResolveIndices() (err error) {
 		return err
 	}
 	for i, col := range p.OutputColumns {
-		newCol, err := col.ResolveIndices(p.IndexPlan.Schema())
+		newCol, _, err := col.ResolveIndices(p.IndexPlan.Schema(), true)
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
 			sctx := p.SCtx()

--- a/pkg/planner/core/operator/physicalop/physical_index_reader.go
+++ b/pkg/planner/core/operator/physicalop/physical_index_reader.go
@@ -190,7 +190,7 @@ func (p *PhysicalIndexReader) ResolveIndices() (err error) {
 		return err
 	}
 	for i, col := range p.OutputColumns {
-		newCol, _, err := col.ResolveIndices(p.IndexPlan.Schema(), true)
+		newCol, _, err := col.ResolveIndices(p.IndexPlan.Schema())
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
 			sctx := p.SCtx()

--- a/pkg/planner/core/operator/physicalop/physical_merge_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_merge_join.go
@@ -354,27 +354,27 @@ func (p *PhysicalMergeJoin) ResolveIndices() (err error) {
 	lSchema := p.Children()[0].Schema()
 	rSchema := p.Children()[1].Schema()
 	for i, col := range p.LeftJoinKeys {
-		newKey, _, err := col.ResolveIndices(lSchema, true)
+		newKey, _, err := col.ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
 		p.LeftJoinKeys[i] = newKey.(*expression.Column)
 	}
 	for i, col := range p.RightJoinKeys {
-		newKey, _, err := col.ResolveIndices(rSchema, true)
+		newKey, _, err := col.ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
 		p.RightJoinKeys[i] = newKey.(*expression.Column)
 	}
 	for i, expr := range p.LeftConditions {
-		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema, true)
+		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
 	}
 	for i, expr := range p.RightConditions {
-		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema, true)
+		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
@@ -383,7 +383,7 @@ func (p *PhysicalMergeJoin) ResolveIndices() (err error) {
 	mergedSchema := expression.MergeSchema(lSchema, rSchema)
 
 	for i, expr := range p.OtherConditions {
-		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema, true)
+		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_merge_join.go
+++ b/pkg/planner/core/operator/physicalop/physical_merge_join.go
@@ -354,27 +354,27 @@ func (p *PhysicalMergeJoin) ResolveIndices() (err error) {
 	lSchema := p.Children()[0].Schema()
 	rSchema := p.Children()[1].Schema()
 	for i, col := range p.LeftJoinKeys {
-		newKey, err := col.ResolveIndices(lSchema)
+		newKey, _, err := col.ResolveIndices(lSchema, true)
 		if err != nil {
 			return err
 		}
 		p.LeftJoinKeys[i] = newKey.(*expression.Column)
 	}
 	for i, col := range p.RightJoinKeys {
-		newKey, err := col.ResolveIndices(rSchema)
+		newKey, _, err := col.ResolveIndices(rSchema, true)
 		if err != nil {
 			return err
 		}
 		p.RightJoinKeys[i] = newKey.(*expression.Column)
 	}
 	for i, expr := range p.LeftConditions {
-		p.LeftConditions[i], err = expr.ResolveIndices(lSchema)
+		p.LeftConditions[i], _, err = expr.ResolveIndices(lSchema, true)
 		if err != nil {
 			return err
 		}
 	}
 	for i, expr := range p.RightConditions {
-		p.RightConditions[i], err = expr.ResolveIndices(rSchema)
+		p.RightConditions[i], _, err = expr.ResolveIndices(rSchema, true)
 		if err != nil {
 			return err
 		}
@@ -383,7 +383,7 @@ func (p *PhysicalMergeJoin) ResolveIndices() (err error) {
 	mergedSchema := expression.MergeSchema(lSchema, rSchema)
 
 	for i, expr := range p.OtherConditions {
-		p.OtherConditions[i], err = expr.ResolveIndices(mergedSchema)
+		p.OtherConditions[i], _, err = expr.ResolveIndices(mergedSchema, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_shuffle.go
+++ b/pkg/planner/core/operator/physicalop/physical_shuffle.go
@@ -113,7 +113,7 @@ func (p *PhysicalShuffle) ResolveIndices() (err error) {
 		// Each DataSource has an array of HashByItems
 		for j := range p.ByItemArrays[i] {
 			// "Shuffle" get value of items from `DataSource`, other than children[0].
-			p.ByItemArrays[i][j], _, err = p.ByItemArrays[i][j].ResolveIndices(p.DataSources[i].Schema(), true)
+			p.ByItemArrays[i][j], _, err = p.ByItemArrays[i][j].ResolveIndices(p.DataSources[i].Schema())
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_shuffle.go
+++ b/pkg/planner/core/operator/physicalop/physical_shuffle.go
@@ -113,7 +113,7 @@ func (p *PhysicalShuffle) ResolveIndices() (err error) {
 		// Each DataSource has an array of HashByItems
 		for j := range p.ByItemArrays[i] {
 			// "Shuffle" get value of items from `DataSource`, other than children[0].
-			p.ByItemArrays[i][j], err = p.ByItemArrays[i][j].ResolveIndices(p.DataSources[i].Schema())
+			p.ByItemArrays[i][j], _, err = p.ByItemArrays[i][j].ResolveIndices(p.DataSources[i].Schema(), true)
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_sort.go
+++ b/pkg/planner/core/operator/physicalop/physical_sort.go
@@ -295,7 +295,7 @@ func resolveIndicesForSort(pp base.PhysicalPlan) (err error) {
 		return errors.Errorf("expect PhysicalSort or NominalSort, but got %s", p.TP())
 	}
 	for _, item := range byItems {
-		item.Expr, _, err = item.Expr.ResolveIndices(p.Children()[0].Schema(), true)
+		item.Expr, _, err = item.Expr.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_sort.go
+++ b/pkg/planner/core/operator/physicalop/physical_sort.go
@@ -295,7 +295,7 @@ func resolveIndicesForSort(pp base.PhysicalPlan) (err error) {
 		return errors.Errorf("expect PhysicalSort or NominalSort, but got %s", p.TP())
 	}
 	for _, item := range byItems {
-		item.Expr, err = item.Expr.ResolveIndices(p.Children()[0].Schema())
+		item.Expr, _, err = item.Expr.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/operator/physicalop/physical_table_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_scan.go
@@ -658,7 +658,7 @@ func (p *PhysicalTableScan) ResolveIndicesItself() (err error) {
 		column.Index = i
 	}
 	for i, expr := range p.LateMaterializationFilterCondition {
-		p.LateMaterializationFilterCondition[i], _, err = expr.ResolveIndices(p.Schema(), true)
+		p.LateMaterializationFilterCondition[i], _, err = expr.ResolveIndices(p.Schema())
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
 			newCond, isOk := expr.ResolveIndicesByVirtualExpr(p.SCtx().GetExprCtx().GetEvalCtx(), p.Schema())

--- a/pkg/planner/core/operator/physicalop/physical_table_scan.go
+++ b/pkg/planner/core/operator/physicalop/physical_table_scan.go
@@ -658,7 +658,7 @@ func (p *PhysicalTableScan) ResolveIndicesItself() (err error) {
 		column.Index = i
 	}
 	for i, expr := range p.LateMaterializationFilterCondition {
-		p.LateMaterializationFilterCondition[i], err = expr.ResolveIndices(p.Schema())
+		p.LateMaterializationFilterCondition[i], _, err = expr.ResolveIndices(p.Schema(), true)
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
 			newCond, isOk := expr.ResolveIndicesByVirtualExpr(p.SCtx().GetExprCtx().GetEvalCtx(), p.Schema())

--- a/pkg/planner/core/operator/physicalop/physical_utils.go
+++ b/pkg/planner/core/operator/physicalop/physical_utils.go
@@ -175,7 +175,7 @@ func GetDynamicAccessPartition(sctx base.PlanContext, tblInfo *model.TableInfo, 
 func ResolveIndicesForVirtualColumn(result []*expression.Column, schema *expression.Schema) error {
 	for _, col := range result {
 		if col.VirtualExpr != nil {
-			newExpr, err := col.VirtualExpr.ResolveIndices(schema)
+			newExpr, _, err := col.VirtualExpr.ResolveIndices(schema, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_utils.go
+++ b/pkg/planner/core/operator/physicalop/physical_utils.go
@@ -175,7 +175,7 @@ func GetDynamicAccessPartition(sctx base.PlanContext, tblInfo *model.TableInfo, 
 func ResolveIndicesForVirtualColumn(result []*expression.Column, schema *expression.Schema) error {
 	for _, col := range result {
 		if col.VirtualExpr != nil {
-			newExpr, _, err := col.VirtualExpr.ResolveIndices(schema, true)
+			newExpr, _, err := col.VirtualExpr.ResolveIndices(schema)
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_window.go
+++ b/pkg/planner/core/operator/physicalop/physical_window.go
@@ -234,21 +234,21 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 	}
 	for i := range len(p.Schema().Columns) - len(p.WindowFuncDescs) {
 		col := p.Schema().Columns[i]
-		newCol, err := col.ResolveIndices(p.Children()[0].Schema())
+		newCol, _, err := col.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
 		p.Schema().Columns[i] = newCol.(*expression.Column)
 	}
 	for i, item := range p.PartitionBy {
-		newCol, err := item.Col.ResolveIndices(p.Children()[0].Schema())
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
 		p.PartitionBy[i].Col = newCol.(*expression.Column)
 	}
 	for i, item := range p.OrderBy {
-		newCol, err := item.Col.ResolveIndices(p.Children()[0].Schema())
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 	}
 	for _, desc := range p.WindowFuncDescs {
 		for i, arg := range desc.Args {
-			desc.Args[i], err = arg.ResolveIndices(p.Children()[0].Schema())
+			desc.Args[i], _, err = arg.ResolveIndices(p.Children()[0].Schema(), true)
 			if err != nil {
 				return err
 			}
@@ -264,13 +264,13 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 	}
 	if p.Frame != nil {
 		for i := range p.Frame.Start.CalcFuncs {
-			p.Frame.Start.CalcFuncs[i], err = p.Frame.Start.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema())
+			p.Frame.Start.CalcFuncs[i], _, err = p.Frame.Start.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema(), true)
 			if err != nil {
 				return err
 			}
 		}
 		for i := range p.Frame.End.CalcFuncs {
-			p.Frame.End.CalcFuncs[i], err = p.Frame.End.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema())
+			p.Frame.End.CalcFuncs[i], _, err = p.Frame.End.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema(), true)
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/operator/physicalop/physical_window.go
+++ b/pkg/planner/core/operator/physicalop/physical_window.go
@@ -234,21 +234,21 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 	}
 	for i := range len(p.Schema().Columns) - len(p.WindowFuncDescs) {
 		col := p.Schema().Columns[i]
-		newCol, _, err := col.ResolveIndices(p.Children()[0].Schema(), true)
+		newCol, _, err := col.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
 		p.Schema().Columns[i] = newCol.(*expression.Column)
 	}
 	for i, item := range p.PartitionBy {
-		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
 		p.PartitionBy[i].Col = newCol.(*expression.Column)
 	}
 	for i, item := range p.OrderBy {
-		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 	}
 	for _, desc := range p.WindowFuncDescs {
 		for i, arg := range desc.Args {
-			desc.Args[i], _, err = arg.ResolveIndices(p.Children()[0].Schema(), true)
+			desc.Args[i], _, err = arg.ResolveIndices(p.Children()[0].Schema())
 			if err != nil {
 				return err
 			}
@@ -264,13 +264,13 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 	}
 	if p.Frame != nil {
 		for i := range p.Frame.Start.CalcFuncs {
-			p.Frame.Start.CalcFuncs[i], _, err = p.Frame.Start.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema(), true)
+			p.Frame.Start.CalcFuncs[i], _, err = p.Frame.Start.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema())
 			if err != nil {
 				return err
 			}
 		}
 		for i := range p.Frame.End.CalcFuncs {
-			p.Frame.End.CalcFuncs[i], _, err = p.Frame.End.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema(), true)
+			p.Frame.End.CalcFuncs[i], _, err = p.Frame.End.CalcFuncs[i].ResolveIndices(p.Children()[0].Schema())
 			if err != nil {
 				return err
 			}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1286,7 +1286,8 @@ func buildOrderedList(ctx base.PlanContext, plan base.Plan, list []*ast.Assignme
 			allAssignmentsAreConstant = isConst
 		}
 
-		newAssign.Expr, err = expr.ResolveIndices(plan.Schema())
+		// todo check if can enable lazycopy
+		newAssign.Expr, _, err = expr.ResolveIndices(plan.Schema(), false)
 		if err != nil {
 			return nil, true
 		}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1286,7 +1286,7 @@ func buildOrderedList(ctx base.PlanContext, plan base.Plan, list []*ast.Assignme
 			allAssignmentsAreConstant = isConst
 		}
 
-		newAssign.Expr, _, err = expr.ResolveIndices(plan.Schema(), true)
+		newAssign.Expr, _, err = expr.ResolveIndices(plan.Schema())
 		if err != nil {
 			return nil, true
 		}

--- a/pkg/planner/core/point_get_plan.go
+++ b/pkg/planner/core/point_get_plan.go
@@ -1286,8 +1286,7 @@ func buildOrderedList(ctx base.PlanContext, plan base.Plan, list []*ast.Assignme
 			allAssignmentsAreConstant = isConst
 		}
 
-		// todo check if can enable lazycopy
-		newAssign.Expr, _, err = expr.ResolveIndices(plan.Schema(), false)
+		newAssign.Expr, _, err = expr.ResolveIndices(plan.Schema(), true)
 		if err != nil {
 			return nil, true
 		}

--- a/pkg/planner/core/resolve_indices.go
+++ b/pkg/planner/core/resolve_indices.go
@@ -25,7 +25,7 @@ import (
 // resolveIndicesItself resolve indices for PhysicalPlan itself
 func resolveIndicesItself4PhysicalProjection(p *physicalop.PhysicalProjection) (err error) {
 	for i, expr := range p.Exprs {
-		p.Exprs[i], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
+		p.Exprs[i], _, err = expr.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func resolveIndices4PhysicalUnionScan(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for i, expr := range p.Conditions {
-		p.Conditions[i], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
+		p.Conditions[i], _, err = expr.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
@@ -118,14 +118,14 @@ func resolveIndices4PhysicalIndexLookUpReader(pp base.PhysicalPlan) (err error) 
 		return err
 	}
 	if p.ExtraHandleCol != nil {
-		newCol, _, err := p.ExtraHandleCol.ResolveIndices(p.TablePlan.Schema(), true)
+		newCol, _, err := p.ExtraHandleCol.ResolveIndices(p.TablePlan.Schema())
 		if err != nil {
 			return err
 		}
 		p.ExtraHandleCol = newCol.(*expression.Column)
 	}
 	for i, commonHandleCol := range p.CommonHandleCols {
-		newCol, _, err := commonHandleCol.ResolveIndices(p.TablePlans[0].Schema(), true)
+		newCol, _, err := commonHandleCol.ResolveIndices(p.TablePlans[0].Schema())
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func resolveIndices4PhysicalSelection(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for i, expr := range p.Conditions {
-		p.Conditions[i], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
+		p.Conditions[i], _, err = expr.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
 			newCond, isOk := expr.ResolveIndicesByVirtualExpr(p.SCtx().GetExprCtx().GetEvalCtx(), p.Children()[0].Schema())
@@ -194,13 +194,13 @@ func resolveIndices4PhysicalTopN(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for _, item := range p.ByItems {
-		item.Expr, _, err = item.Expr.ResolveIndices(p.Children()[0].Schema(), true)
+		item.Expr, _, err = item.Expr.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
 	}
 	for i, item := range p.PartitionBy {
-		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ func resolveIndices4PhysicalLimit(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for i, item := range p.PartitionBy {
-		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema())
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/resolve_indices.go
+++ b/pkg/planner/core/resolve_indices.go
@@ -25,7 +25,7 @@ import (
 // resolveIndicesItself resolve indices for PhysicalPlan itself
 func resolveIndicesItself4PhysicalProjection(p *physicalop.PhysicalProjection) (err error) {
 	for i, expr := range p.Exprs {
-		p.Exprs[i], err = expr.ResolveIndices(p.Children()[0].Schema())
+		p.Exprs[i], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func resolveIndices4PhysicalUnionScan(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for i, expr := range p.Conditions {
-		p.Conditions[i], err = expr.ResolveIndices(p.Children()[0].Schema())
+		p.Conditions[i], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -118,14 +118,14 @@ func resolveIndices4PhysicalIndexLookUpReader(pp base.PhysicalPlan) (err error) 
 		return err
 	}
 	if p.ExtraHandleCol != nil {
-		newCol, err := p.ExtraHandleCol.ResolveIndices(p.TablePlan.Schema())
+		newCol, _, err := p.ExtraHandleCol.ResolveIndices(p.TablePlan.Schema(), true)
 		if err != nil {
 			return err
 		}
 		p.ExtraHandleCol = newCol.(*expression.Column)
 	}
 	for i, commonHandleCol := range p.CommonHandleCols {
-		newCol, err := commonHandleCol.ResolveIndices(p.TablePlans[0].Schema())
+		newCol, _, err := commonHandleCol.ResolveIndices(p.TablePlans[0].Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func resolveIndices4PhysicalSelection(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for i, expr := range p.Conditions {
-		p.Conditions[i], err = expr.ResolveIndices(p.Children()[0].Schema())
+		p.Conditions[i], _, err = expr.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			// Check if there is duplicate virtual expression column matched.
 			newCond, isOk := expr.ResolveIndicesByVirtualExpr(p.SCtx().GetExprCtx().GetEvalCtx(), p.Children()[0].Schema())
@@ -194,13 +194,13 @@ func resolveIndices4PhysicalTopN(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for _, item := range p.ByItems {
-		item.Expr, err = item.Expr.ResolveIndices(p.Children()[0].Schema())
+		item.Expr, _, err = item.Expr.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
 	}
 	for i, item := range p.PartitionBy {
-		newCol, err := item.Col.ResolveIndices(p.Children()[0].Schema())
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ func resolveIndices4PhysicalLimit(pp base.PhysicalPlan) (err error) {
 		return err
 	}
 	for i, item := range p.PartitionBy {
-		newCol, err := item.Col.ResolveIndices(p.Children()[0].Schema())
+		newCol, _, err := item.Col.ResolveIndices(p.Children()[0].Schema(), true)
 		if err != nil {
 			return err
 		}

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -191,8 +191,8 @@ func (s *ScalarSubQueryExpr) Decorrelate(*expression.Schema) expression.Expressi
 }
 
 // ResolveIndices implements the Expression interface.
-func (s *ScalarSubQueryExpr) ResolveIndices(_ *expression.Schema) (expression.Expression, error) {
-	return s, nil
+func (s *ScalarSubQueryExpr) ResolveIndices(_ *expression.Schema, _ bool) (expression.Expression, bool, error) {
+	return s, false, nil
 }
 
 // ResolveIndicesByVirtualExpr implements the Expression interface.

--- a/pkg/planner/core/scalar_subq_expression.go
+++ b/pkg/planner/core/scalar_subq_expression.go
@@ -191,7 +191,7 @@ func (s *ScalarSubQueryExpr) Decorrelate(*expression.Schema) expression.Expressi
 }
 
 // ResolveIndices implements the Expression interface.
-func (s *ScalarSubQueryExpr) ResolveIndices(_ *expression.Schema, _ bool) (expression.Expression, bool, error) {
+func (s *ScalarSubQueryExpr) ResolveIndices(_ *expression.Schema) (expression.Expression, bool, error) {
 	return s, false, nil
 }
 

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -139,7 +139,7 @@ type MPPPartitionColumn struct {
 
 // ResolveIndices resolve index for MPPPartitionColumn
 func (partitionCol *MPPPartitionColumn) ResolveIndices(schema *expression.Schema) (*MPPPartitionColumn, error) {
-	newColExpr, err := partitionCol.Col.ResolveIndices(schema)
+	newColExpr, _, err := partitionCol.Col.ResolveIndices(schema, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/planner/property/physical_property.go
+++ b/pkg/planner/property/physical_property.go
@@ -139,7 +139,7 @@ type MPPPartitionColumn struct {
 
 // ResolveIndices resolve index for MPPPartitionColumn
 func (partitionCol *MPPPartitionColumn) ResolveIndices(schema *expression.Schema) (*MPPPartitionColumn, error) {
-	newColExpr, _, err := partitionCol.Col.ResolveIndices(schema, true)
+	newColExpr, _, err := partitionCol.Col.ResolveIndices(schema)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -225,7 +225,7 @@ func (cb *CommonHandleCols) ResolveIndices(schema *expression.Schema) (HandleCol
 		columns: make([]*expression.Column, len(cb.columns)),
 	}
 	for i, col := range cb.columns {
-		newCol, _, err := col.ResolveIndices(schema, false)
+		newCol, _, err := col.ResolveIndices(schema)
 		if err != nil {
 			return nil, err
 		}
@@ -398,7 +398,7 @@ func (ib *IntHandleCols) BuildHandleByDatums(_ *stmtctx.StatementContext, row []
 
 // ResolveIndices implements the kv.HandleCols interface.
 func (ib *IntHandleCols) ResolveIndices(schema *expression.Schema) (HandleCols, error) {
-	newCol, _, err := ib.col.ResolveIndices(schema, false)
+	newCol, _, err := ib.col.ResolveIndices(schema)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/planner/util/handle_cols.go
+++ b/pkg/planner/util/handle_cols.go
@@ -225,7 +225,7 @@ func (cb *CommonHandleCols) ResolveIndices(schema *expression.Schema) (HandleCol
 		columns: make([]*expression.Column, len(cb.columns)),
 	}
 	for i, col := range cb.columns {
-		newCol, err := col.ResolveIndices(schema)
+		newCol, _, err := col.ResolveIndices(schema, false)
 		if err != nil {
 			return nil, err
 		}
@@ -398,7 +398,7 @@ func (ib *IntHandleCols) BuildHandleByDatums(_ *stmtctx.StatementContext, row []
 
 // ResolveIndices implements the kv.HandleCols interface.
 func (ib *IntHandleCols) ResolveIndices(schema *expression.Schema) (HandleCols, error) {
-	newCol, err := ib.col.ResolveIndices(schema)
+	newCol, _, err := ib.col.ResolveIndices(schema, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65003

Problem Summary:

### What changed and how does it work?
Currently, `ScalarFunction::ResolveIndices` will always clone itself first, which may introduce too many meaningless clone, and it is a waste of both cpu and memory. In this pr, `ScalarFunction::ResolveIndices` will use a lazy copy stragety, if current ScalarFunction is already resolved index, it will clone itself otherwise, it will resolve index inplace.

For the pure insert workload described in https://github.com/pingcap/tidb/issues/65003
Before this pr
![20251230-140733](https://github.com/user-attachments/assets/39f683db-c844-410d-9a4a-63acf104865f)
After this pr
<img width="1140" height="358" alt="Screenshot 2025-12-30 at 14 01 29" src="https://github.com/user-attachments/assets/421e4c0f-2e43-4fd5-9b3d-9fa0c37d0037" />

As you can see, `ScalarFunction.Clone` and `baseBuiltinFunc.cloneFrom` disappears, which means we can save ~18% allocations


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
