### PR TITLE
planner: optimize NewPlanCacheKey

### DIFF
--- a/pkg/planner/core/plan_cache_utils.go
+++ b/pkg/planner/core/plan_cache_utils.go
@@ -285,6 +285,13 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 	if stmt.SchemaVersion == 0 && !intest.InTest {
 		return "", "", false, "", errors.New("Schema version uninitialized")
 	}
+	if stmt.hasSubquery && !vars.EnablePlanCacheForSubquery {
+		return "", "", false, "the switch 'tidb_enable_plan_cache_for_subquery' is off", nil
+	}
+	if len(stmt.limits) > 0 && !vars.EnablePlanCacheForParamLimit {
+		return "", "", false, "the switch 'tidb_enable_plan_cache_for_param_limit' is off", nil
+	}
+
 	stmtDB := stmt.StmtDB
 	if stmtDB == "" {
 		stmtDB = vars.CurrentDB
@@ -305,18 +312,36 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 	// the user might switch the prune mode dynamically
 	pruneMode := sctx.GetSessionVars().PartitionPruneMode.Load()
 
-	// Get buffer from pool and ensure it has enough capacity
-	hash := planCacheKeyBufPool.Get()[:0]
-	if cap(hash) < len(stmt.StmtText)*2 {
-		hash = make([]byte, 0, len(stmt.StmtText)*2)
+	// precalculate the length of the hash buffer, note each time add an element to the buffer, need
+	// to update hashLen accordingly
+	// basic informations
+	hashLen := len(userName) + len(hostName) + len(stmtDB) + len(stmt.StmtText)
+	// schemaVersion + relateVersion + pruneMode
+	hashLen += 8 + len(stmt.RelateVersion)*16 + len(pruneMode)
+	// latestSchemaVersion + sqlMode + timeZoneOffset + isolationReadEngines + selectLimit
+	hashLen += 8 + 8 + 8 + 4 /*len(kv.TiDB.Name())*/ + 4 /*len(kv.TiKV.Name())*/ + 7 /*len(kv.TiFlash.Name())*/ + 8
+	// binding + connCharset + connCollation + inRestrictedSQL + readOnly + superReadOnly + exprPushdownBlacklistReloadTimeStamp + hasSubquery + foreignKeyChecks
+	hashLen += len(binding) + len(connCharset) + len(connCollation) + 3 + 8 + 2
+	if len(stmt.limits) > 0 {
+		// '|' + each limit count/offset takes 8 bytes + '|'
+		hashLen += 2 + len(stmt.limits)*2*8
 	}
-	defer func() {
-		planCacheKeyBufPool.Put(hash)
-	}()
-	hash = append(hash, hack.Slice(userName)...)
-	hash = append(hash, hack.Slice(hostName)...)
-	hash = append(hash, hack.Slice(stmtDB)...)
-	hash = append(hash, hack.Slice(stmt.StmtText)...)
+	if vars.GetSessionVars().PlanCacheInvalidationOnFreshStats {
+		// statsVerHash
+		hashLen += 8
+	}
+	// dirty tables
+	hashLen += 8 * len(vars.StmtCtx.TblInfo2UnionScan)
+	// txn status
+	hashLen += 6
+
+	hash := make([]byte, 0, hashLen)
+	// hashInitCap is not used, just for test purposes
+	hashInitCap := cap(hash)
+	hash = append(hash, userName...)
+	hash = append(hash, hostName...)
+	hash = append(hash, stmtDB...)
+	hash = append(hash, stmt.StmtText...)
 	hash = codec.EncodeInt(hash, stmt.SchemaVersion)
 	hash = hashInt64Uint64Map(hash, stmt.RelateVersion)
 	hash = append(hash, pruneMode...)
@@ -337,9 +362,9 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 		hash = append(hash, kv.TiFlash.Name()...)
 	}
 	hash = codec.EncodeInt(hash, int64(vars.SelectLimit))
-	hash = append(hash, hack.Slice(binding)...)
-	hash = append(hash, hack.Slice(connCharset)...)
-	hash = append(hash, hack.Slice(connCollation)...)
+	hash = append(hash, binding...)
+	hash = append(hash, connCharset...)
+	hash = append(hash, connCollation...)
 	hash = append(hash, bool2Byte(vars.InRestrictedSQL))
 	hash = append(hash, bool2Byte(vardef.RestrictedReadOnly.Load()))
 	hash = append(hash, bool2Byte(vardef.VarTiDBSuperReadOnly.Load()))
@@ -347,23 +372,13 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 	hash = codec.EncodeInt(hash, expression.ExprPushDownBlackListReloadTimeStamp.Load())
 
 	// whether this query has sub-query
-	if stmt.hasSubquery {
-		if !vars.EnablePlanCacheForSubquery {
-			return "", "", false, "the switch 'tidb_enable_plan_cache_for_subquery' is off", nil
-		}
-		hash = append(hash, '1')
-	} else {
-		hash = append(hash, '0')
-	}
+	hash = append(hash, bool2Byte(stmt.hasSubquery))
 
 	// this variable might affect the plan
 	hash = append(hash, bool2Byte(vars.ForeignKeyChecks))
 
 	// "limit ?" can affect the cached plan: "limit 1" and "limit 10000" should use different plans.
 	if len(stmt.limits) > 0 {
-		if !vars.EnablePlanCacheForParamLimit {
-			return "", "", false, "the switch 'tidb_enable_plan_cache_for_param_limit' is off", nil
-		}
 		hash = append(hash, '|')
 		for _, node := range stmt.limits {
 			for _, valNode := range []ast.ExprNode{node.Count, node.Offset} {
@@ -424,7 +439,13 @@ func NewPlanCacheKey(sctx sessionctx.Context, stmt *PlanCacheStmt) (key, binding
 	hash = append(hash, bool2Byte(vars.StmtCtx.ForShareLockEnabledByNoop))
 	hash = append(hash, bool2Byte(vars.SharedLockPromotion))
 
-	return string(hash), binding, true, "", nil
+	if intest.InTest {
+		if cap(hash) != hashInitCap {
+			panic("unexpected hash buffer realloc in NewPlanCacheKey")
+		}
+	}
+
+	return string(hack.String(hash)), binding, true, "", nil
 }
 
 func bool2Byte(flag bool) byte {
@@ -535,11 +556,6 @@ var planCacheHasherPool = sync.Pool{
 		return sha256.New()
 	},
 }
-
-// planCacheKeyBufPool is a pool for byte slices used in NewPlanCacheKey.
-var planCacheKeyBufPool = zeropool.New[[]byte](func() []byte {
-	return make([]byte, 0, 512)
-})
 
 // dirtyTableIDsPool is a pool for int64 slices used in NewPlanCacheKey.
 var dirtyTableIDsPool = zeropool.New[[]int64](func() []int64 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #65117

Problem Summary:
#65072 try to optimize NewPlanCacheKey using sync.Pool, however, there is still some shortcomings
1. after using sync.Pool, the return statement `return string(hash), binding, true, "", nil` still need an allocation and a copy to convert `hash` to `string(hash)`
2. planCacheKeyBufPool is a global pool, since a system contains both long sql and short sql, it is hard to say `[]byte` get from the pool is enough for most sql's
3. `len(stmt.StmtText)*2` is just an estimate of the length of `PlanCacheKey`, especially for short sql, the real length maybe large than `len(stmt.StmtText)*2`

This pr remove `planCacheKeyBufPool`, and 
1. use `return string(hack.String(hash)), binding, true, "", nil` to remove the largest memory allocation in `NewPlanCacheKey`
2. precaculate length of `NewPlanCacheKey`, so it can be sure that cap(`hash`) enough once it is allocated.

Benchmark
before this pr:
```
BenchmarkNewPlanCacheKey-16      853314      1475 ns/op     193 B/op       2 allocs/op
BenchmarkNewPlanCacheKeyInTxn-16      967374      1264 ns/op     176 B/op       2 allocs/op
```
After this pr
```
BenchmarkNewPlanCacheKey-16      913701      1401 ns/op     209 B/op       2 allocs/op
BenchmarkNewPlanCacheKeyInTxn-16     1000000      1218 ns/op     176 B/op       2 allocs/op
```
### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
