### PR TITLE
importer: fix flaky test

### DIFF
--- a/lightning/pkg/importer/table_import_test.go
+++ b/lightning/pkg/importer/table_import_test.go
@@ -417,8 +417,9 @@ func (s *tableRestoreSuite) TestRestoreEngineFailed() {
 	mockBackend.EXPECT().OpenEngine(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockBackend.EXPECT().CloseEngine(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockEncBuilder.EXPECT().NewEncoder(gomock.Any(), gomock.Any()).
-		Return(realEncBuilder.NewEncoder(ctx, &encode.EncodingConfig{Table: tbl})).
-		AnyTimes()
+		DoAndReturn(func(_ context.Context, _ *encode.EncodingConfig) (encode.Encoder, error) {
+			return realEncBuilder.NewEncoder(ctx, &encode.EncodingConfig{Table: tbl})
+		}).AnyTimes()
 	mockEncBuilder.EXPECT().MakeEmptyRows().Return(realEncBuilder.MakeEmptyRows()).AnyTimes()
 	mockBackend.EXPECT().LocalWriter(gomock.Any(), gomock.Any(), dataUUID).Return(mockEngineWriter, nil)
 	mockBackend.EXPECT().LocalWriter(gomock.Any(), gomock.Any(), indexUUID).


### PR DESCRIPTION
Issue Number: close #53820

<!--

Thank you for contributing to TiDB!

PR Title Format:

-->

### What problem does this PR solve?
<!--


Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

In the mock encoder expectations we were returning the same encoder instance for different chunk processor in the test. Reproducing the flaky test in isolation is hard but I  was able to recreate it by adding artifical sleep in the test. Changed it to return a new encoder instance everytime so that state is not shared.

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test 
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- 
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
