### PR TITLE
copr: Reduce the max sleep time for TopoFetcherBackoff test to reduce the total run time of the test

### DIFF
--- a/pkg/store/copr/batch_coprocessor_test.go
+++ b/pkg/store/copr/batch_coprocessor_test.go
@@ -266,7 +266,7 @@ func TestDispatchPolicyRR(t *testing.T) {
 }
 
 func TestTopoFetcherBackoff(t *testing.T) {
-	fetchTopoBo := backoff.NewBackofferWithVars(context.Background(), fetchTopoMaxBackoff, nil)
+	fetchTopoBo := backoff.NewBackofferWithVars(context.Background(), 5000, nil)
 	expectErr := errors.New("Cannot find proper topo from AutoScaler")
 	var retryNum int
 	start := time.Now()
@@ -279,9 +279,9 @@ func TestTopoFetcherBackoff(t *testing.T) {
 	}
 	dura := time.Since(start)
 	// fetchTopoMaxBackoff is milliseconds.
-	require.GreaterOrEqual(t, dura, time.Duration(fetchTopoMaxBackoff*1000))
-	require.GreaterOrEqual(t, dura, 30*time.Second)
-	require.LessOrEqual(t, dura, 50*time.Second)
+	require.GreaterOrEqual(t, dura, 5*time.Second)
+	require.GreaterOrEqual(t, dura, 8*time.Second)
+	require.LessOrEqual(t, dura, 14*time.Second)
 }
 
 func TestGetAllUsedTiFlashStores(t *testing.T) {


### PR DESCRIPTION
… 
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #52798

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
