### PR TITLE
types: print argument as hex literal if non-printable

### DIFF
--- a/pkg/sessionctx/variable/session.go
+++ b/pkg/sessionctx/variable/session.go
@@ -2133,7 +2133,7 @@ func (p *PlanCacheParamList) String() string {
 		p.forNonPrepCache { // hide non-prep parameter values by default
 		return ""
 	}
-	return " [arguments: " + types.DatumsToStrNoErr(p.paramValues) + "]"
+	return " [arguments: " + types.DatumsToStrNoErrSmart(p.paramValues) + "]"
 }
 
 // Append appends a parameter value to the PlanCacheParams.

--- a/pkg/types/datum.go
+++ b/pkg/types/datum.go
@@ -2440,6 +2440,15 @@ func isPrintable(s string) bool {
 
 // DatumsToString converts several datums to formatted string.
 func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
+	return datumsToString(datums, handleSpecialValue, false)
+}
+
+// DatumsToStringSmart is like DatumsToString, but with smart detection of non-printable data
+func DatumsToStringSmart(datums []Datum, handleSpecialValue bool) (string, error) {
+	return datumsToString(datums, handleSpecialValue, true)
+}
+
+func datumsToString(datums []Datum, handleSpecialValue bool, binaryAsHex bool) (string, error) {
 	n := len(datums)
 	builder := &strings.Builder{}
 	builder.Grow(8 * n)
@@ -2474,7 +2483,7 @@ func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 			str = str[:logDatumLen]
 		}
 		if datum.Kind() == KindString {
-			if isPrintable(str) {
+			if !binaryAsHex || isPrintable(str) {
 				builder.WriteString(`"`)
 				builder.WriteString(str)
 				builder.WriteString(`"`)
@@ -2501,6 +2510,15 @@ func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 // If an error occurs, it will print a log instead of returning an error.
 func DatumsToStrNoErr(datums []Datum) string {
 	str, err := DatumsToString(datums, true)
+	terror.Log(errors.Trace(err))
+	return str
+}
+
+// DatumsToStrNoErrSmart converts some datums to a formatted string.
+// If an error occurs, it will print a log instead of returning an error.
+// It also enables detection of non-pritable arguments
+func DatumsToStrNoErrSmart(datums []Datum) string {
+	str, err := DatumsToStringSmart(datums, true)
 	terror.Log(errors.Trace(err))
 	return str
 }

--- a/pkg/types/datum_test.go
+++ b/pkg/types/datum_test.go
@@ -808,3 +808,20 @@ func TestIsPrintable(t *testing.T) {
 			tc.input, tc.input, tc.valid, r)
 	}
 }
+
+func BenchmarkIsPrintable(b *testing.B) {
+	inputs := []string{
+		"abc",
+		"abcé",
+		string([]byte{0x61, 0x0, 0x62, 0x63}), // broken: contains NUL
+		string([]byte{0x61, 0x62, 0x63, 0xc3, 0xa9}), // broken: contains half char
+		strings.Repeat("abc", 1000),                  // longer string
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, input := range inputs {
+			isPrintable(input)
+		}
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65383 

Problem Summary:

### What changed and how does it work?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Non printable arguments for prepared statements are now printed in hex in the slow query log
```


### Alternatives

1. Looping over the string and checking for `< 0x20` (non printable ASCII and `0x7f` (DEL). However that doesn't check any multi-byte non-BMP runes (e.g. `\u2060` (SWJ).
2. Using `datum.GetStringWithCheck()`. Probably heavier and might only check if a string is valid, not if it is printable as well.