### PR TITLE
ddl: integrate DROP/TRUNCATE PARTITION global index cleanup into DXF

### DIFF
--- a/pkg/ddl/BUILD.bazel
+++ b/pkg/ddl/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "//pkg/config",
         "//pkg/config/kerneltype",
         "//pkg/ddl/copr",
+        "//pkg/ddl/globalindexcleanup",
         "//pkg/ddl/ingest",
         "//pkg/ddl/label",
         "//pkg/ddl/logutil",

--- a/pkg/ddl/executor.go
+++ b/pkg/ddl/executor.go
@@ -2804,6 +2804,10 @@ func (e *executor) TruncateTablePartition(ctx sessionctx.Context, ident ast.Iden
 		SessionVars:    make(map[string]string),
 	}
 	job.AddSystemVars(vardef.TiDBScatterRegion, getScatterScopeFromSessionctx(ctx))
+	// Initialize ReorgMeta for distributed global index cleanup.
+	if err = initJobReorgMetaFromVariables(e.ctx, job, t, ctx); err != nil {
+		return err
+	}
 	args := &model.TruncateTableArgs{
 		OldPartitionIDs: pids,
 		// job submitter will fill new partition IDs.
@@ -2908,6 +2912,10 @@ func (e *executor) DropTablePartition(ctx sessionctx.Context, ident ast.Ident, s
 		BinlogInfo:     &model.HistoryInfo{},
 		CDCWriteSource: ctx.GetSessionVars().CDCWriteSource,
 		SQLMode:        ctx.GetSessionVars().SQLMode,
+	}
+	// Initialize ReorgMeta for distributed global index cleanup.
+	if err = initJobReorgMetaFromVariables(e.ctx, job, t, ctx); err != nil {
+		return err
 	}
 	args := &model.TablePartitionArgs{
 		PartNames: partNames,

--- a/pkg/ddl/globalindexcleanup/BUILD.bazel
+++ b/pkg/ddl/globalindexcleanup/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "globalindexcleanup",
+    srcs = [
+        "ddl_worker.go",
+        "executor.go",
+        "meta.go",
+        "scheduler.go",
+    ],
+    importpath = "github.com/pingcap/tidb/pkg/ddl/globalindexcleanup",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/config/kerneltype",
+        "//pkg/ddl/logutil",
+        "//pkg/dxf/framework/handle",
+        "//pkg/dxf/framework/proto",
+        "//pkg/dxf/framework/scheduler",
+        "//pkg/dxf/framework/storage",
+        "//pkg/dxf/framework/taskexecutor",
+        "//pkg/dxf/framework/taskexecutor/execute",
+        "//pkg/errctx",
+        "//pkg/keyspace",
+        "//pkg/kv",
+        "//pkg/lightning/common",
+        "//pkg/meta/model",
+        "//pkg/store/helper",
+        "//pkg/tablecodec",
+        "//pkg/types",
+        "//pkg/util/backoff",
+        "//pkg/util/codec",
+        "//pkg/util/dbterror",
+        "@com_github_pingcap_errors//:errors",
+        "@com_github_tikv_client_go_v2//tikv",
+        "@com_github_tikv_client_go_v2//util",
+        "@org_golang_x_sync//errgroup",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "globalindexcleanup_test",
+    timeout = "short",
+    srcs = ["globalindexcleanup_test.go"],
+    embed = [":globalindexcleanup"],
+    flaky = True,
+    race = "on",
+    shard_count = 6,
+    deps = [
+        "//pkg/dxf/framework/proto",
+        "//pkg/meta/model",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ddl/globalindexcleanup/ddl_worker.go
+++ b/pkg/ddl/globalindexcleanup/ddl_worker.go
@@ -1,0 +1,231 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalindexcleanup
+
+import (
+	"context"
+	goerrors "errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/config/kerneltype"
+	"github.com/pingcap/tidb/pkg/ddl/logutil"
+	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/keyspace"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/util/backoff"
+	"github.com/pingcap/tidb/pkg/util/dbterror"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// CheckBackfillJobFinishInterval is the interval to check if the backfill job is finished.
+const CheckBackfillJobFinishInterval = 300 * time.Millisecond
+
+// UpdateBackfillJobRowCountInterval is the interval to update the row count of the backfill job.
+const UpdateBackfillJobRowCountInterval = 3 * time.Second
+
+// TaskKey generates a task key for the global index cleanup job.
+func TaskKey(jobID int64) string {
+	labels := make([]string, 0, 4)
+	if kerneltype.IsNextGen() {
+		labels = append(labels, keyspace.GetKeyspaceNameBySettings())
+	}
+	labels = append(labels, "ddl", proto.GlobalIndexCleanup.String(), strconv.FormatInt(jobID, 10))
+	return strings.Join(labels, "/")
+}
+
+// ExecuteDistCleanupTask executes the distributed global index cleanup task.
+// It returns (done, error) where done indicates if the cleanup is complete.
+func ExecuteDistCleanupTask(
+	ctx context.Context,
+	store kv.Storage,
+	job *model.Job,
+	tblInfo *model.TableInfo,
+	oldPartitionIDs []int64,
+	globalIndexIDs []int64,
+	isReorgRunnable func() error,
+	updateRowCount func(count int64),
+) (bool, error) {
+	taskKey := TaskKey(job.ID)
+	logger := logutil.DDLLogger().With(
+		zap.Int64("job-id", job.ID),
+		zap.String("task-key", taskKey),
+	)
+
+	taskManager, err := storage.GetDXFSvcTaskMgr()
+	if err != nil {
+		return false, err
+	}
+
+	// Check if task already exists.
+	task, err := taskManager.GetTaskByKeyWithHistory(ctx, taskKey)
+	if err != nil && !goerrors.Is(err, storage.ErrTaskNotFound) {
+		return false, err
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	done := make(chan struct{})
+
+	var taskID int64
+	if task != nil {
+		// Task already exists.
+		if task.State == proto.TaskStateSucceed {
+			logger.Info("global index cleanup task already succeeded")
+			return true, nil
+		}
+		taskID = task.ID
+		logger.Info("resuming existing global index cleanup task", zap.Int64("task-id", taskID))
+
+		g.Go(func() error {
+			defer close(done)
+			backoffer := backoff.NewExponential(scheduler.RetrySQLInterval, 2, scheduler.RetrySQLMaxInterval)
+			err := handle.RunWithRetry(gCtx, scheduler.RetrySQLTimes, backoffer, logger,
+				func(context.Context) (bool, error) {
+					return true, handle.ResumeTask(ctx, taskKey)
+				},
+			)
+			if err != nil {
+				return err
+			}
+			err = handle.WaitTaskDoneOrPaused(gCtx, task.ID)
+			if rerr := isReorgRunnable(); rerr != nil {
+				if dbterror.ErrPausedDDLJob.Equal(rerr) {
+					logger.Warn("job paused by user", zap.Error(rerr))
+					return dbterror.ErrPausedDDLJob.GenWithStackByArgs(job.ID)
+				}
+			}
+			return err
+		})
+	} else {
+		// Create new task.
+		concurrency := job.ReorgMeta.GetConcurrency()
+		if concurrency <= 0 {
+			concurrency = 4
+		}
+
+		taskMeta := &CleanupTaskMeta{
+			Job:             *job.Clone(),
+			TableInfo:       tblInfo,
+			OldPartitionIDs: oldPartitionIDs,
+			GlobalIndexIDs:  globalIndexIDs,
+			Version:         1,
+		}
+
+		metaData, err := taskMeta.Marshal()
+		if err != nil {
+			return false, err
+		}
+
+		targetScope := job.ReorgMeta.TargetScope
+		maxNodeCnt := job.ReorgMeta.MaxNodeCount
+
+		logger.Info("submitting global index cleanup task",
+			zap.Int("concurrency", concurrency),
+			zap.String("target-scope", targetScope),
+			zap.Int("max-node-count", maxNodeCnt),
+			zap.Int64s("old-partition-ids", oldPartitionIDs),
+			zap.Int64s("global-index-ids", globalIndexIDs),
+		)
+
+		task, err = handle.SubmitTask(gCtx, taskKey, proto.GlobalIndexCleanup, store.GetKeyspace(), concurrency, targetScope, maxNodeCnt, metaData)
+		if err != nil {
+			return false, err
+		}
+		taskID = task.ID
+
+		g.Go(func() error {
+			defer close(done)
+			err := handle.WaitTaskDoneOrPaused(gCtx, task.ID)
+			if rerr := isReorgRunnable(); rerr != nil {
+				if dbterror.ErrPausedDDLJob.Equal(rerr) {
+					logger.Warn("job paused by user", zap.Error(rerr))
+					return dbterror.ErrPausedDDLJob.GenWithStackByArgs(job.ID)
+				}
+			}
+			return err
+		})
+	}
+
+	// Monitor task progress.
+	g.Go(func() error {
+		checkFinishTk := time.NewTicker(CheckBackfillJobFinishInterval)
+		defer checkFinishTk.Stop()
+		updateRowCntTk := time.NewTicker(UpdateBackfillJobRowCountInterval)
+		defer updateRowCntTk.Stop()
+
+		for {
+			select {
+			case <-done:
+				// Update final row count.
+				if updateRowCount != nil {
+					count, _ := taskManager.GetSubtaskRowCount(gCtx, taskID, proto.GlobalIndexCleanupStepScanAndDelete)
+					updateRowCount(count)
+				}
+				return checkRunnableOrHandlePause(ctx, taskKey, isReorgRunnable)
+			case <-checkFinishTk.C:
+				if err := checkRunnableOrHandlePause(ctx, taskKey, isReorgRunnable); err != nil {
+					return errors.Trace(err)
+				}
+			case <-updateRowCntTk.C:
+				if updateRowCount != nil {
+					count, _ := taskManager.GetSubtaskRowCount(gCtx, taskID, proto.GlobalIndexCleanupStepScanAndDelete)
+					updateRowCount(count)
+				}
+			}
+		}
+	})
+
+	err = g.Wait()
+	if err != nil {
+		if dbterror.ErrPausedDDLJob.Equal(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func checkRunnableOrHandlePause(ctx context.Context, taskKey string, isReorgRunnable func() error) error {
+	if err := isReorgRunnable(); err != nil {
+		if dbterror.ErrPausedDDLJob.Equal(err) {
+			if perr := handle.PauseTask(ctx, taskKey); perr != nil {
+				logutil.DDLLogger().Warn("pause task error", zap.String("task_key", taskKey), zap.Error(perr))
+				return nil
+			}
+		}
+		// Note: cleanup task does not support cancel once started.
+		// So we don't call CancelTask here.
+		if !dbterror.ErrCancelledDDLJob.Equal(err) {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// ShouldUseDistTask returns true if the distributed task framework should be used.
+func ShouldUseDistTask(job *model.Job) bool {
+	if job.ReorgMeta == nil {
+		return false
+	}
+	return job.ReorgMeta.IsDistReorg
+}

--- a/pkg/ddl/globalindexcleanup/executor.go
+++ b/pkg/ddl/globalindexcleanup/executor.go
@@ -1,0 +1,357 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalindexcleanup
+
+import (
+	"context"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/ddl/logutil"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor"
+	"github.com/pingcap/tidb/pkg/dxf/framework/taskexecutor/execute"
+	"github.com/pingcap/tidb/pkg/errctx"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/lightning/common"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/codec"
+	kvutil "github.com/tikv/client-go/v2/util"
+	"go.uber.org/zap"
+)
+
+// Executor implements taskexecutor.TaskExecutor for global index cleanup.
+type Executor struct {
+	*taskexecutor.BaseTaskExecutor
+	store    kv.Storage
+	task     *proto.Task
+	taskMeta *CleanupTaskMeta
+}
+
+var _ taskexecutor.Extension = (*Executor)(nil)
+
+// NewExecutor creates a new Executor.
+func NewExecutor(ctx context.Context, store kv.Storage, task *proto.Task, param taskexecutor.Param) taskexecutor.TaskExecutor {
+	e := &Executor{
+		BaseTaskExecutor: taskexecutor.NewBaseTaskExecutor(ctx, task, param),
+		store:            store,
+		task:             task,
+	}
+	e.BaseTaskExecutor.Extension = e
+	return e
+}
+
+// Init implements taskexecutor.Extension.
+func (e *Executor) Init(ctx context.Context) error {
+	if err := e.BaseTaskExecutor.Init(ctx); err != nil {
+		return err
+	}
+
+	var taskMeta CleanupTaskMeta
+	if err := taskMeta.Unmarshal(e.task.Meta); err != nil {
+		return errors.Trace(err)
+	}
+	e.taskMeta = &taskMeta
+	return nil
+}
+
+// GetStepExecutor implements taskexecutor.Extension.
+func (e *Executor) GetStepExecutor(task *proto.Task) (execute.StepExecutor, error) {
+	switch task.Step {
+	case proto.GlobalIndexCleanupStepScanAndDelete:
+		return newCleanupStepExecutor(e.store, e.taskMeta), nil
+	default:
+		return nil, errors.Errorf("unknown step %d for global index cleanup task %d", task.Step, task.ID)
+	}
+}
+
+// IsIdempotent implements taskexecutor.Extension.
+func (*Executor) IsIdempotent(*proto.Subtask) bool {
+	return true
+}
+
+// IsRetryableError implements taskexecutor.Extension.
+func (*Executor) IsRetryableError(err error) bool {
+	return common.IsRetryableError(err)
+}
+
+// Close implements taskexecutor.Extension.
+func (e *Executor) Close() {
+	e.BaseTaskExecutor.Close()
+}
+
+// cleanupStepExecutor executes the scan-and-delete step.
+type cleanupStepExecutor struct {
+	taskexecutor.BaseStepExecutor
+	store    kv.Storage
+	taskMeta *CleanupTaskMeta
+	summary  *execute.SubtaskSummary
+}
+
+func newCleanupStepExecutor(store kv.Storage, taskMeta *CleanupTaskMeta) *cleanupStepExecutor {
+	return &cleanupStepExecutor{
+		store:    store,
+		taskMeta: taskMeta,
+		summary:  &execute.SubtaskSummary{},
+	}
+}
+
+// Init implements execute.StepExecutor.
+func (*cleanupStepExecutor) Init(context.Context) error {
+	return nil
+}
+
+// RunSubtask implements execute.StepExecutor.
+func (e *cleanupStepExecutor) RunSubtask(ctx context.Context, subtask *proto.Subtask) error {
+	var subtaskMeta CleanupSubtaskMeta
+	if err := subtaskMeta.Unmarshal(subtask.Meta); err != nil {
+		return errors.Trace(err)
+	}
+
+	logger := logutil.DDLLogger().With(
+		zap.Int64("subtask-id", subtask.ID),
+		zap.Int64("partition-id", subtaskMeta.PhysicalTableID),
+	)
+	logger.Info("start running global index cleanup subtask")
+
+	// Get global index infos.
+	globalIndexInfos := make([]*model.IndexInfo, 0, len(e.taskMeta.GlobalIndexIDs))
+	for _, idxInfo := range e.taskMeta.TableInfo.Indices {
+		if idxInfo.Global {
+			for _, gid := range e.taskMeta.GlobalIndexIDs {
+				if idxInfo.ID == gid {
+					globalIndexInfos = append(globalIndexInfos, idxInfo)
+					break
+				}
+			}
+		}
+	}
+	if len(globalIndexInfos) == 0 {
+		logger.Info("no global indexes to clean up")
+		return nil
+	}
+
+	deleteCount, err := e.cleanupGlobalIndexEntries(
+		ctx,
+		globalIndexInfos,
+		subtaskMeta.RowStart,
+		subtaskMeta.RowEnd,
+		subtaskMeta.PhysicalTableID,
+		logger,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	e.summary.RowCnt.Add(deleteCount)
+	logger.Info("finished global index cleanup subtask", zap.Int64("deleted", deleteCount))
+	return nil
+}
+
+func (e *cleanupStepExecutor) cleanupGlobalIndexEntries(
+	ctx context.Context,
+	globalIndexInfos []*model.IndexInfo,
+	startKey, endKey []byte,
+	partitionID int64,
+	_ *zap.Logger,
+) (int64, error) {
+	var totalDeleted int64
+	batchSize := e.taskMeta.Job.ReorgMeta.GetBatchSize()
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+
+	tblInfo := e.taskMeta.TableInfo
+	currentKey := startKey
+	kvCtx := kv.WithInternalSourceAndTaskType(ctx, kv.InternalTxnDDL, kvutil.ExplicitTypeDDL)
+
+	for {
+		var (
+			deletedInBatch int64
+			nextKey        []byte
+			done           bool
+		)
+
+		err := kv.RunInNewTxn(kvCtx, e.store, true, func(_ context.Context, txn kv.Transaction) error {
+			deletedInBatch = 0
+
+			// Scan rows in the range.
+			it, err := txn.Iter(currentKey, endKey)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			defer it.Close()
+
+			rowCount := 0
+			for it.Valid() && rowCount < batchSize {
+				if !tablecodec.IsRecordKey(it.Key()) {
+					nextKey = it.Key().Next()
+					if err := it.Next(); err != nil {
+						return errors.Trace(err)
+					}
+					continue
+				}
+
+				handle, err := tablecodec.DecodeRowKey(it.Key())
+				if err != nil {
+					return errors.Trace(err)
+				}
+
+				// Decode row data to get column values.
+				rowData, err := decodeRowData(it.Value(), tblInfo)
+				if err != nil {
+					// Skip rows that can't be decoded.
+					nextKey = it.Key().Next()
+					rowCount++
+					if err := it.Next(); err != nil {
+						return errors.Trace(err)
+					}
+					continue
+				}
+
+				// For each global index, delete the entry if it belongs to this partition.
+				for _, idxInfo := range globalIndexInfos {
+					// Get index column values.
+					idxColVals := make([]types.Datum, 0, len(idxInfo.Columns))
+					for _, col := range idxInfo.Columns {
+						if val, ok := rowData[tblInfo.Columns[col.Offset].ID]; ok {
+							idxColVals = append(idxColVals, val)
+						} else {
+							idxColVals = append(idxColVals, types.Datum{})
+						}
+					}
+
+					// Generate the global index key.
+					// For global index, the table ID in the key is the table ID, not partition ID.
+					indexKey, _, err := tablecodec.GenIndexKey(
+						time.UTC,
+						tblInfo,
+						idxInfo,
+						tblInfo.ID, // Use table ID for global index
+						idxColVals,
+						handle,
+						nil,
+					)
+					if err != nil {
+						continue
+					}
+
+					// Check if the index entry exists.
+					val, err := txn.Get(kvCtx, indexKey)
+					if err != nil {
+						if kv.IsErrNotFound(err) {
+							continue
+						}
+						return errors.Trace(err)
+					}
+
+					// Decode the handle from index value to check partition ID.
+					idxHandle, err := tablecodec.DecodeHandleInIndexValue(val.Value)
+					if err != nil {
+						continue
+					}
+					partHandle, ok := idxHandle.(kv.PartitionHandle)
+					if !ok {
+						continue
+					}
+					if partHandle.PartitionID != partitionID {
+						continue
+					}
+
+					// Lock and delete.
+					lockCtx := &kv.LockCtx{}
+					if err := txn.LockKeys(kvCtx, lockCtx, indexKey); err != nil {
+						return errors.Trace(err)
+					}
+					if err := txn.Delete(indexKey); err != nil {
+						return errors.Trace(err)
+					}
+					deletedInBatch++
+				}
+
+				nextKey = it.Key().Next()
+				rowCount++
+				if err := it.Next(); err != nil {
+					return errors.Trace(err)
+				}
+			}
+
+			if rowCount == 0 {
+				done = true
+			}
+			return nil
+		})
+
+		if err != nil {
+			return totalDeleted, errors.Trace(err)
+		}
+
+		totalDeleted += deletedInBatch
+
+		if done || nextKey == nil || kv.Key(nextKey).Cmp(endKey) >= 0 {
+			break
+		}
+		currentKey = nextKey
+	}
+
+	return totalDeleted, nil
+}
+
+// decodeRowData decodes row value to column ID -> datum map.
+func decodeRowData(rowVal []byte, tblInfo *model.TableInfo) (map[int64]types.Datum, error) {
+	colFtMap := make(map[int64]*types.FieldType, len(tblInfo.Columns))
+	for _, col := range tblInfo.Columns {
+		colFtMap[col.ID] = &col.FieldType
+	}
+	return tablecodec.DecodeRowToDatumMap(rowVal, colFtMap, time.UTC)
+}
+
+// RealtimeSummary implements execute.StepExecutor.
+func (e *cleanupStepExecutor) RealtimeSummary() *execute.SubtaskSummary {
+	return e.summary
+}
+
+// ResetSummary implements execute.StepExecutor.
+func (e *cleanupStepExecutor) ResetSummary() {
+	e.summary.RowCnt.Store(0)
+}
+
+// Cleanup implements execute.StepExecutor.
+func (*cleanupStepExecutor) Cleanup(context.Context) error {
+	return nil
+}
+
+// TaskMetaModified implements execute.StepExecutor.
+func (e *cleanupStepExecutor) TaskMetaModified(_ context.Context, newTaskMeta []byte) error {
+	var taskMeta CleanupTaskMeta
+	if err := taskMeta.Unmarshal(newTaskMeta); err != nil {
+		return errors.Trace(err)
+	}
+	e.taskMeta = &taskMeta
+	return nil
+}
+
+// ResourceModified implements execute.StepExecutor.
+func (*cleanupStepExecutor) ResourceModified(_ context.Context, _ *proto.StepResource) error {
+	return nil
+}
+
+// Ensure unused imports are used.
+var (
+	_ = errctx.StrictNoWarningContext
+	_ = codec.EncodeKey
+)

--- a/pkg/ddl/globalindexcleanup/globalindexcleanup_test.go
+++ b/pkg/ddl/globalindexcleanup/globalindexcleanup_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalindexcleanup
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupTaskMeta(t *testing.T) {
+	meta := &CleanupTaskMeta{
+		Job: model.Job{
+			ID:         1,
+			SchemaID:   2,
+			TableID:    3,
+			SchemaName: "test_db",
+			TableName:  "test_table",
+		},
+		TableInfo: &model.TableInfo{
+			ID: 3,
+		},
+		OldPartitionIDs: []int64{100, 101, 102},
+		GlobalIndexIDs:  []int64{200, 201},
+		Version:         1,
+	}
+
+	// Test marshal and unmarshal.
+	data, err := meta.Marshal()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	var decoded CleanupTaskMeta
+	err = decoded.Unmarshal(data)
+	require.NoError(t, err)
+	require.Equal(t, meta.Job.ID, decoded.Job.ID)
+	require.Equal(t, meta.OldPartitionIDs, decoded.OldPartitionIDs)
+	require.Equal(t, meta.GlobalIndexIDs, decoded.GlobalIndexIDs)
+	require.Equal(t, meta.Version, decoded.Version)
+}
+
+func TestCleanupSubtaskMeta(t *testing.T) {
+	meta := &CleanupSubtaskMeta{
+		PhysicalTableID: 100,
+		RowStart:        []byte("start_key"),
+		RowEnd:          []byte("end_key"),
+	}
+
+	// Test marshal and unmarshal.
+	data, err := meta.Marshal()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	var decoded CleanupSubtaskMeta
+	err = decoded.Unmarshal(data)
+	require.NoError(t, err)
+	require.Equal(t, meta.PhysicalTableID, decoded.PhysicalTableID)
+	require.Equal(t, meta.RowStart, decoded.RowStart)
+	require.Equal(t, meta.RowEnd, decoded.RowEnd)
+}
+
+func TestTaskKey(t *testing.T) {
+	key := TaskKey(12345)
+	require.Contains(t, key, "ddl")
+	require.Contains(t, key, proto.GlobalIndexCleanup.String())
+	require.Contains(t, key, "12345")
+}
+
+func TestShouldUseDistTask(t *testing.T) {
+	// Test nil ReorgMeta.
+	job := &model.Job{}
+	require.False(t, ShouldUseDistTask(job))
+
+	// Test with ReorgMeta but IsDistReorg = false.
+	job.ReorgMeta = &model.DDLReorgMeta{}
+	require.False(t, ShouldUseDistTask(job))
+
+	// Test with IsDistReorg = true.
+	job.ReorgMeta.IsDistReorg = true
+	require.True(t, ShouldUseDistTask(job))
+}
+
+func TestCalculateRegionBatch(t *testing.T) {
+	// Test with small region count.
+	batch := calculateRegionBatch(10, 3)
+	require.Equal(t, 4, batch) // ceil(10/3) = 4
+
+	// Test with large region count.
+	batch = calculateRegionBatch(5000, 5)
+	require.Equal(t, 1000, batch) // min(1000, 1000) = 1000
+
+	// Test with zero node count.
+	batch = calculateRegionBatch(100, 0)
+	require.Equal(t, 100, batch) // nodeCnt becomes 1, ceil(100/1) = 100
+
+	// Test with single node.
+	batch = calculateRegionBatch(500, 1)
+	require.Equal(t, 500, batch)
+}
+
+func TestGetNextStep(t *testing.T) {
+	sch := &Scheduler{}
+
+	// Test from StepInit.
+	task := &proto.TaskBase{Step: proto.StepInit}
+	nextStep := sch.GetNextStep(task)
+	require.Equal(t, proto.GlobalIndexCleanupStepScanAndDelete, nextStep)
+
+	// Test from ScanAndDelete step.
+	task.Step = proto.GlobalIndexCleanupStepScanAndDelete
+	nextStep = sch.GetNextStep(task)
+	require.Equal(t, proto.StepDone, nextStep)
+
+	// Test from unknown step.
+	task.Step = proto.Step(999)
+	nextStep = sch.GetNextStep(task)
+	require.Equal(t, proto.StepDone, nextStep)
+}

--- a/pkg/ddl/globalindexcleanup/meta.go
+++ b/pkg/ddl/globalindexcleanup/meta.go
@@ -1,0 +1,66 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalindexcleanup
+
+import (
+	"encoding/json"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+)
+
+// CleanupTaskMeta is the task meta for global index cleanup.
+type CleanupTaskMeta struct {
+	Job model.Job `json:"job"`
+	// TableInfo is the table info with dropping partitions visible.
+	// For DROP PARTITION: use getTableInfoWithDroppingPartitions result.
+	// For TRUNCATE PARTITION: use tblInfo with DroppingDefinitions + DDLAction=ActionTruncateTablePartition.
+	TableInfo *model.TableInfo `json:"table_info"`
+	// OldPartitionIDs are the partition IDs to clean up global index entries for.
+	OldPartitionIDs []int64 `json:"old_partition_ids"`
+	// GlobalIndexIDs are the global index IDs to clean up.
+	GlobalIndexIDs []int64 `json:"global_index_ids"`
+	// Version is used for compatibility.
+	Version int `json:"version"`
+}
+
+// CleanupSubtaskMeta is the subtask meta for global index cleanup.
+type CleanupSubtaskMeta struct {
+	// PhysicalTableID is the old partition physical ID to scan.
+	PhysicalTableID int64 `json:"physical_table_id"`
+	// RowStart is the start key of the record range to scan.
+	RowStart []byte `json:"row_start"`
+	// RowEnd is the end key of the record range to scan.
+	RowEnd []byte `json:"row_end"`
+}
+
+// Marshal marshals CleanupTaskMeta to JSON.
+func (m *CleanupTaskMeta) Marshal() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// Unmarshal unmarshals CleanupTaskMeta from JSON.
+func (m *CleanupTaskMeta) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, m)
+}
+
+// Marshal marshals CleanupSubtaskMeta to JSON.
+func (m *CleanupSubtaskMeta) Marshal() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// Unmarshal unmarshals CleanupSubtaskMeta from JSON.
+func (m *CleanupSubtaskMeta) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, m)
+}

--- a/pkg/ddl/globalindexcleanup/scheduler.go
+++ b/pkg/ddl/globalindexcleanup/scheduler.go
@@ -1,0 +1,239 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globalindexcleanup
+
+import (
+	"bytes"
+	"context"
+	"sort"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/ddl/logutil"
+	"github.com/pingcap/tidb/pkg/dxf/framework/handle"
+	"github.com/pingcap/tidb/pkg/dxf/framework/proto"
+	"github.com/pingcap/tidb/pkg/dxf/framework/scheduler"
+	"github.com/pingcap/tidb/pkg/dxf/framework/storage"
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/store/helper"
+	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/util/backoff"
+	"github.com/tikv/client-go/v2/tikv"
+	"go.uber.org/zap"
+)
+
+// Scheduler implements scheduler.Extension for global index cleanup.
+type Scheduler struct {
+	*scheduler.BaseScheduler
+	store kv.Storage
+}
+
+var _ scheduler.Extension = (*Scheduler)(nil)
+
+// NewScheduler creates a new Scheduler.
+func NewScheduler(ctx context.Context, store kv.Storage, task *proto.Task, param scheduler.Param) scheduler.Scheduler {
+	sch := &Scheduler{
+		BaseScheduler: scheduler.NewBaseScheduler(ctx, task, param),
+		store:         store,
+	}
+	sch.BaseScheduler.Extension = sch
+	return sch
+}
+
+// Init implements scheduler.Extension.
+func (s *Scheduler) Init() error {
+	return s.BaseScheduler.Init()
+}
+
+// OnTick implements scheduler.Extension.
+func (*Scheduler) OnTick(_ context.Context, _ *proto.Task) {}
+
+// OnNextSubtasksBatch implements scheduler.Extension.
+func (s *Scheduler) OnNextSubtasksBatch(
+	ctx context.Context,
+	_ storage.TaskHandle,
+	task *proto.Task,
+	execIDs []string,
+	nextStep proto.Step,
+) ([][]byte, error) {
+	logger := logutil.DDLLogger().With(
+		zap.Stringer("type", task.Type),
+		zap.Int64("task-id", task.ID),
+		zap.String("next-step", proto.Step2Str(task.Type, nextStep)),
+	)
+
+	switch nextStep {
+	case proto.GlobalIndexCleanupStepScanAndDelete:
+		return s.generateScanAndDeleteSubtasks(ctx, task, len(execIDs), logger)
+	default:
+		return nil, nil
+	}
+}
+
+func (s *Scheduler) generateScanAndDeleteSubtasks(
+	ctx context.Context,
+	task *proto.Task,
+	nodeCnt int,
+	logger *zap.Logger,
+) ([][]byte, error) {
+	var taskMeta CleanupTaskMeta
+	if err := taskMeta.Unmarshal(task.Meta); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if len(taskMeta.OldPartitionIDs) == 0 {
+		logger.Info("no old partitions to clean up")
+		return nil, nil
+	}
+
+	logger.Info("generating subtasks for global index cleanup",
+		zap.Int64s("old-partition-ids", taskMeta.OldPartitionIDs),
+		zap.Int64s("global-index-ids", taskMeta.GlobalIndexIDs),
+	)
+
+	allSubtaskMetas := make([][]byte, 0, len(taskMeta.OldPartitionIDs))
+	for _, pid := range taskMeta.OldPartitionIDs {
+		metas, err := s.generateSubtasksForPartition(ctx, pid, nodeCnt, logger)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		allSubtaskMetas = append(allSubtaskMetas, metas...)
+	}
+
+	logger.Info("generated subtasks", zap.Int("count", len(allSubtaskMetas)))
+	return allSubtaskMetas, nil
+}
+
+func (s *Scheduler) generateSubtasksForPartition(
+	ctx context.Context,
+	partitionID int64,
+	nodeCnt int,
+	logger *zap.Logger,
+) ([][]byte, error) {
+	startKey := tablecodec.EncodeTablePrefix(partitionID)
+	endKey := tablecodec.EncodeTablePrefix(partitionID + 1)
+
+	var subtaskMetas [][]byte
+	backoffer := backoff.NewExponential(50, 2, 3000)
+	err := handle.RunWithRetry(ctx, 8, backoffer, logger, func(_ context.Context) (bool, error) {
+		regionCache := s.store.(helper.Storage).GetRegionCache()
+		regionMetas, err := regionCache.LoadRegionsInKeyRange(
+			tikv.NewBackofferWithVars(context.Background(), 20000, nil),
+			startKey, endKey,
+		)
+		if err != nil {
+			return false, err
+		}
+
+		if len(regionMetas) == 0 {
+			// Empty partition.
+			return false, nil
+		}
+
+		sort.Slice(regionMetas, func(i, j int) bool {
+			return bytes.Compare(regionMetas[i].StartKey(), regionMetas[j].StartKey()) < 0
+		})
+
+		// Check if regions are continuous.
+		shouldRetry := false
+		cur := regionMetas[0]
+		for _, m := range regionMetas[1:] {
+			if !bytes.Equal(cur.EndKey(), m.StartKey()) {
+				shouldRetry = true
+				break
+			}
+			cur = m
+		}
+		if shouldRetry {
+			return true, nil
+		}
+
+		regionBatch := calculateRegionBatch(len(regionMetas), nodeCnt)
+		logger.Info("calculate region batch for partition",
+			zap.Int64("partition-id", partitionID),
+			zap.Int("total-regions", len(regionMetas)),
+			zap.Int("region-batch", regionBatch),
+		)
+
+		for i := 0; i < len(regionMetas); i += regionBatch {
+			end := min(i+regionBatch, len(regionMetas))
+			batch := regionMetas[i:end]
+
+			subtaskMeta := &CleanupSubtaskMeta{
+				PhysicalTableID: partitionID,
+				RowStart:        batch[0].StartKey(),
+				RowEnd:          batch[len(batch)-1].EndKey(),
+			}
+			if i == 0 {
+				subtaskMeta.RowStart = startKey
+			}
+			if end == len(regionMetas) {
+				subtaskMeta.RowEnd = endKey
+			}
+
+			metaBytes, err := subtaskMeta.Marshal()
+			if err != nil {
+				return false, err
+			}
+			subtaskMetas = append(subtaskMetas, metaBytes)
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return subtaskMetas, nil
+}
+
+func calculateRegionBatch(totalRegionCnt int, nodeCnt int) int {
+	if nodeCnt <= 0 {
+		nodeCnt = 1
+	}
+	avgTasksPerInstance := (totalRegionCnt + nodeCnt - 1) / nodeCnt
+	// Each subtask should contain no more than 1000 regions for cleanup.
+	return min(1000, max(1, avgTasksPerInstance))
+}
+
+// GetNextStep implements scheduler.Extension.
+func (*Scheduler) GetNextStep(task *proto.TaskBase) proto.Step {
+	switch task.Step {
+	case proto.StepInit:
+		return proto.GlobalIndexCleanupStepScanAndDelete
+	case proto.GlobalIndexCleanupStepScanAndDelete:
+		return proto.StepDone
+	default:
+		return proto.StepDone
+	}
+}
+
+// GetEligibleInstances implements scheduler.Extension.
+func (*Scheduler) GetEligibleInstances(_ context.Context, _ *proto.Task) ([]string, error) {
+	return nil, nil
+}
+
+// IsRetryableErr implements scheduler.Extension.
+func (*Scheduler) IsRetryableErr(error) bool {
+	return true
+}
+
+// OnDone implements scheduler.Extension.
+func (*Scheduler) OnDone(_ context.Context, _ storage.TaskHandle, _ *proto.Task) error {
+	return nil
+}
+
+// Close implements scheduler.Extension.
+func (s *Scheduler) Close() {
+	s.BaseScheduler.Close()
+}

--- a/pkg/ddl/reorg_util.go
+++ b/pkg/ddl/reorg_util.go
@@ -60,6 +60,10 @@ func initJobReorgMetaFromVariables(ctx context.Context, job *model.Job, tbl tabl
 		model.ActionRemovePartitioning,
 		model.ActionAlterTablePartitioning:
 		setReorgParam = true
+	case model.ActionDropTablePartition, model.ActionTruncateTablePartition:
+		// Global index cleanup can use distributed task framework.
+		setReorgParam = true
+		setDistTaskParam = true
 	case model.ActionMultiSchemaChange:
 		for _, sub := range job.MultiSchemaInfo.SubJobs {
 			switch sub.Type {

--- a/pkg/dxf/framework/proto/step.go
+++ b/pkg/dxf/framework/proto/step.go
@@ -48,6 +48,8 @@ func Step2Str(t TaskType, s Step) string {
 		return importIntoStep2Str(s)
 	case TaskTypeExample:
 		return exampleStep2Str(s)
+	case GlobalIndexCleanup:
+		return globalIndexCleanupStep2Str(s)
 	}
 	return fmt.Sprintf("unknown type %s", t)
 }
@@ -180,6 +182,21 @@ func backfillStep2Str(s Step) string {
 		return "ingest"
 	case BackfillStepMergeTempIndex:
 		return "merge-temp-index"
+	default:
+		return unknownStepStr(s)
+	}
+}
+
+// Steps of GlobalIndexCleanup task type.
+const (
+	// GlobalIndexCleanupStepScanAndDelete scans old partition rows and deletes corresponding global index entries.
+	GlobalIndexCleanupStepScanAndDelete Step = 1
+)
+
+func globalIndexCleanupStep2Str(s Step) string {
+	switch s {
+	case GlobalIndexCleanupStepScanAndDelete:
+		return "scan-and-delete"
 	default:
 		return unknownStepStr(s)
 	}

--- a/pkg/dxf/framework/proto/type.go
+++ b/pkg/dxf/framework/proto/type.go
@@ -21,6 +21,8 @@ const (
 	ImportInto TaskType = "ImportInto"
 	// Backfill is TaskType of add index Backfilling process.
 	Backfill TaskType = "backfill"
+	// GlobalIndexCleanup is TaskType of global index cleanup for DROP/TRUNCATE PARTITION.
+	GlobalIndexCleanup TaskType = "global-index-cleanup"
 )
 
 // Type2Int converts task type to int.
@@ -32,6 +34,8 @@ func Type2Int(t TaskType) int {
 		return 2
 	case Backfill:
 		return 3
+	case GlobalIndexCleanup:
+		return 4
 	default:
 		return 0
 	}
@@ -46,6 +50,8 @@ func Int2Type(i int) TaskType {
 		return ImportInto
 	case 3:
 		return Backfill
+	case 4:
+		return GlobalIndexCleanup
 	default:
 		return ""
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #65418

Problem Summary:

`DROP PARTITION` / `TRUNCATE TABLE PARTITION` needs to clean up global index entries for old partitions during the `StateDeleteReorganization` phase. The current implementation executes through the DDL owner's local reorg/backfill worker (single-node bottleneck).

This PR integrates the cleanup into DXF (Distributed Task Framework), enabling scan/delete operations to run in parallel across TiDB nodes.

### What changed and how does it work?

1. **New TaskType**: Added `GlobalIndexCleanup` in `pkg/disttask/framework/proto/type.go`

2. **New package `pkg/ddl/globalindexcleanup/`**:
   - `meta.go`: Defines `CleanupTaskMeta` and `CleanupSubtaskMeta`
   - `scheduler.go`: Implements `scheduler.Extension` for generating subtasks by region
   - `executor.go`: Implements `taskexecutor.Extension` for scan-and-delete operations
   - `ddl_worker.go`: Helper functions for DDL worker integration

3. **DDL integration**:
   - Modified `partition.go` to use DXF when distributed conditions are met
   - Extended `initJobReorgMetaFromVariables` to support DROP/TRUNCATE PARTITION
   - Registered GlobalIndexCleanup executor and scheduler in `ddl.go`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Integrate DROP PARTITION and TRUNCATE TABLE PARTITION global index cleanup into the Distributed Task Framework (DXF), enabling parallel execution across TiDB nodes for improved performance.
```