### PR TITLE
test: add non_transaction_dml test for active-active table | tidb-test=feature/active-active tikv=feature/active-active

### DIFF
--- a/tests/integrationtest/r/active_active/non_transaction_dml.result
+++ b/tests/integrationtest/r/active_active/non_transaction_dml.result
@@ -1,0 +1,50 @@
+create table t (id int primary key, v int) active_active='on' softdelete retention 7 day;
+insert into t values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6);
+batch on t.id limit 2 delete from t where v < 6;
+number of jobs	job status
+3	all succeeded
+select * from t;
+id	v
+6	6
+set @@tidb_translate_softdelete_sql = true;
+select id, v, _tidb_softdelete_time from t;
+Error 1815 (HY000): column '_tidb_softdelete_time' cannot be referenced when tidb_translate_softdelete_sql is enabled
+set @@tidb_translate_softdelete_sql = false;
+select id, v, _tidb_softdelete_time from t;
+id	v	_tidb_softdelete_time
+1	1	TIME
+2	2	TIME
+3	3	TIME
+4	4	TIME
+5	5	TIME
+6	6	NULL
+create table t1 (id int primary key, v int);
+insert into t1 values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7);
+set @@tidb_translate_softdelete_sql = true;
+batch on t1.id limit 2 insert ignore into t select * from t1;
+number of jobs	job status
+4	all succeeded
+set @@tidb_translate_softdelete_sql = false;
+select id, v, _tidb_softdelete_time from t;
+id	v	_tidb_softdelete_time
+1	1	NULL
+2	2	NULL
+3	3	NULL
+4	4	NULL
+5	5	NULL
+6	6	NULL
+7	7	NULL
+set @@tidb_translate_softdelete_sql = true;
+batch on t.id limit 3 update t set v =  v + 1;
+number of jobs	job status
+3	all succeeded
+set @@tidb_translate_softdelete_sql = false;
+select id, v, _tidb_softdelete_time from t;
+id	v	_tidb_softdelete_time
+1	2	NULL
+2	3	NULL
+3	4	NULL
+4	5	NULL
+5	6	NULL
+6	7	NULL
+7	8	NULL

--- a/tests/integrationtest/t/active_active/non_transaction_dml.test
+++ b/tests/integrationtest/t/active_active/non_transaction_dml.test
@@ -1,0 +1,29 @@
+create table t (id int primary key, v int) active_active='on' softdelete retention 7 day;
+insert into t values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6);
+batch on t.id limit 2 delete from t where v < 6;
+select * from t;
+
+set @@tidb_translate_softdelete_sql = true;
+--error 1815
+select id, v, _tidb_softdelete_time from t;
+
+set @@tidb_translate_softdelete_sql = false;
+--replace_regex /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}$/TIME/
+select id, v, _tidb_softdelete_time from t;
+
+# create another table for temporary data
+create table t1 (id int primary key, v int);
+insert into t1 values (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7);
+
+set @@tidb_translate_softdelete_sql = true;
+batch on t1.id limit 2 insert ignore into t select * from t1;
+set @@tidb_translate_softdelete_sql = false;
+--replace_regex /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}$/TIME/
+select id, v, _tidb_softdelete_time from t;
+
+
+set @@tidb_translate_softdelete_sql = true;
+batch on t.id limit 3 update t set v =  v + 1;
+set @@tidb_translate_softdelete_sql = false;
+--replace_regex /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}$/TIME/
+select id, v, _tidb_softdelete_time from t;


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65427

Problem Summary:

### What changed and how does it work?

Subtask for https://github.com/pingcap/tidb/issues/64281

Confirm non-transaction DML can work with softdelete or active-active tables.
In theory non-transaction DML just spilt the statement, it's using the same Insert/Update/Delete executor, which handles softdelete already, so nothing needs to change.

Just add test to cover it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
