### PR TITLE
*: ignore failpoint stash files to improve gopls performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ coverage.dat
 go.work
 go.work.sum
 .cursor
+*__failpoint_stash__


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65490

Problem Summary:
When running unit tests with `make failpoint-enable`, the failpoint tool creates `*__failpoint_stash__` files as temporary backups. These files can cause issues with gopls (Go language server) by:
- Being indexed as valid Go files
- Causing duplicate symbol definitions
- Consuming unnecessary memory and CPU resources
- Slowing down IDE features like code completion and navigation

### What changed and how does it work?

Added `*__failpoint_stash__` pattern to `.gitignore` to:
1. Prevent accidental commits of these temporary files
2. Signal to developers that these files should be ignored
3. Work with editors/IDEs that respect `.gitignore` for file watching

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > - [x] I checked and no code files have been changed.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```