### PR TITLE
pkg/executor, pkg/util/admin: close SnapshotIter to avoid memory growth

### DIFF
--- a/pkg/executor/mem_reader_close_test.go
+++ b/pkg/executor/mem_reader_close_test.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/kv"
+	"github.com/pingcap/tidb/pkg/util/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type closeCountingIter struct {
+	keys   []kv.Key
+	values [][]byte
+	idx    int
+	closed *int32
+}
+
+func (it *closeCountingIter) Valid() bool {
+	return it.idx < len(it.keys)
+}
+
+func (it *closeCountingIter) Key() kv.Key {
+	return it.keys[it.idx]
+}
+
+func (it *closeCountingIter) Value() []byte {
+	return it.values[it.idx]
+}
+
+func (it *closeCountingIter) Next() error {
+	it.idx++
+	return nil
+}
+
+func (it *closeCountingIter) Close() {
+	atomic.AddInt32(it.closed, 1)
+}
+
+type testSnapshotIterer struct {
+	iters []kv.Iterator
+	idx   int
+}
+
+func (m *testSnapshotIterer) SnapshotIter(_ kv.Key, _ kv.Key) kv.Iterator {
+	it := m.iters[m.idx]
+	m.idx++
+	return it
+}
+
+func (m *testSnapshotIterer) SnapshotIterReverse(_ kv.Key, _ kv.Key) kv.Iterator {
+	it := m.iters[m.idx]
+	m.idx++
+	return it
+}
+
+func TestTxnMemBufferIterClosesIteratorOnRangeSwitch(t *testing.T) {
+	sctx := mock.NewContext()
+
+	var closed1 int32
+	iter1 := &closeCountingIter{
+		keys:   []kv.Key{kv.Key("k1")},
+		values: [][]byte{[]byte("v1")},
+		closed: &closed1,
+	}
+
+	var closed2 int32
+	iter2 := &closeCountingIter{
+		keys:   nil,
+		values: nil,
+		closed: &closed2,
+	}
+
+	memBuf := &testSnapshotIterer{iters: []kv.Iterator{iter1, iter2}}
+	it := &txnMemBufferIter{
+		sctx:       sctx,
+		kvRanges:   []kv.KeyRange{{StartKey: kv.Key("a"), EndKey: kv.Key("b")}, {StartKey: kv.Key("c"), EndKey: kv.Key("d")}},
+		cacheTable: nil,
+		memBuf:     memBuf,
+		reverse:    false,
+	}
+
+	require.True(t, it.Valid())
+	require.Equal(t, kv.Key("k1"), it.Key())
+	require.NoError(t, it.Next())
+
+	require.False(t, it.Valid())
+	require.Equal(t, int32(1), atomic.LoadInt32(&closed1))
+	require.Equal(t, int32(1), atomic.LoadInt32(&closed2))
+}
+
+func TestIterMemBufferSnapshotClosesIterators(t *testing.T) {
+	sctx := mock.NewContext()
+	ranges := []kv.KeyRange{{StartKey: kv.Key("a"), EndKey: kv.Key("z")}}
+
+	t.Run("close on completion", func(t *testing.T) {
+		var closed int32
+		iter := &closeCountingIter{
+			keys:   []kv.Key{kv.Key("k1"), kv.Key("k2")},
+			values: [][]byte{[]byte("v1"), []byte("v2")},
+			closed: &closed,
+		}
+		memBuf := &testSnapshotIterer{iters: []kv.Iterator{iter}}
+
+		seen := 0
+		err := iterMemBufferSnapshot(sctx, memBuf, nil, ranges, false, func(_ []byte, _ []byte) error {
+			seen++
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, seen)
+		require.Equal(t, int32(1), atomic.LoadInt32(&closed))
+	})
+
+	t.Run("close on error", func(t *testing.T) {
+		var closed int32
+		iter := &closeCountingIter{
+			keys:   []kv.Key{kv.Key("k1"), kv.Key("k2")},
+			values: [][]byte{[]byte("v1"), []byte("v2")},
+			closed: &closed,
+		}
+		memBuf := &testSnapshotIterer{iters: []kv.Iterator{iter}}
+
+		sentinel := errors.New("sentinel")
+		seen := 0
+		err := iterMemBufferSnapshot(sctx, memBuf, nil, ranges, false, func(_ []byte, _ []byte) error {
+			seen++
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, 1, seen)
+		require.Equal(t, int32(1), atomic.LoadInt32(&closed))
+	})
+}

--- a/pkg/util/admin/admin_integration_test.go
+++ b/pkg/util/admin/admin_integration_test.go
@@ -36,6 +36,7 @@ func TestAdminCheckTableCorrupted(t *testing.T) {
 	memBuffer := txn.GetMemBuffer()
 	handle := memBuffer.Staging()
 	it := memBuffer.SnapshotIter(nil, nil)
+	defer it.Close()
 	require.NoError(t, err)
 	for it.Valid() {
 		if tablecodec.IsRecordKey(it.Key()) && len(it.Value()) > 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65514

Problem Summary:

`pkg/executor/mem_reader.go` creates MemBuffer snapshot iterators (`SnapshotIter` / `SnapshotIterReverse`) without always closing them.

With client-go's ART-based MemDB implementation, not closing snapshot iterators can keep the snapshot ref-count > 0, preventing old-version nodes from being reclaimed/reused and potentially leading to continuous memory growth under repeated workloads.

### What changed and how does it work?

- Fix iterator lifecycle when scanning MemBuffer snapshots:
  - `txnMemBufferIter.Valid()` now closes the current per-range iterator when it becomes exhausted before switching to the next range, and closes iterators on all error paths.
  - `iterTxnMemBuffer()` centralizes the per-range snapshot iteration in `iterMemBufferSnapshot()` so each created iterator is always closed on normal completion and on early exits/errors.
  - `txnMemBufferIter` stores a `MemBuffer` snapshot-iter interface (`memBufferSnapshotIterer`) instead of a `kv.Transaction`, making it easier to test the close semantics.
- Add regression tests:
  - `pkg/executor/mem_reader_close_test.go` uses close-counting iterators to assert snapshot iterators are closed on range switch and when the consumer returns an error.
- Fix a test iterator leak:
  - `pkg/util/admin/admin_integration_test.go` adds `defer it.Close()` for `SnapshotIter`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `go test ./pkg/executor -run TestTxnMemBufferIterClosesIteratorOnRangeSwitch -count=1 -tags=intest`
  - `go test ./pkg/executor -run TestIterMemBufferSnapshotClosesIterators -count=1 -tags=intest`
  - `go test ./pkg/executor -run TestUnionScanForMemBufferReader -count=1 -tags=intest`
  - `go test ./pkg/util/admin -run TestAdminCheckTableCorrupted -count=1 -tags=intest`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix potential memory growth caused by not closing MemBuffer snapshot iterators during union scan.
```