### PR TITLE
pkg/store/driver: bound store pool for background tasks

### DIFF
--- a/pkg/store/driver/store_pool.go
+++ b/pkg/store/driver/store_pool.go
@@ -1,0 +1,60 @@
+package driver
+
+import (
+	"errors"
+	"sync"
+)
+
+var errStorePoolClosed = errors.New("store pool is closed")
+
+type storePool struct {
+	sem       chan struct{}
+	closeCh   chan struct{}
+	closeOnce sync.Once
+}
+
+func newStorePool(concurrency int) *storePool {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	return &storePool{
+		sem:     make(chan struct{}, concurrency),
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (p *storePool) Run(fn func()) error {
+	if fn == nil {
+		return nil
+	}
+	select {
+	case <-p.closeCh:
+		return errStorePoolClosed
+	default:
+	}
+
+	select {
+	case p.sem <- struct{}{}:
+	case <-p.closeCh:
+		return errStorePoolClosed
+	}
+
+	select {
+	case <-p.closeCh:
+		<-p.sem
+		return errStorePoolClosed
+	default:
+	}
+
+	go func() {
+		defer func() { <-p.sem }()
+		fn()
+	}()
+	return nil
+}
+
+func (p *storePool) Close() {
+	p.closeOnce.Do(func() {
+		close(p.closeCh)
+	})
+}

--- a/pkg/store/driver/store_pool.go
+++ b/pkg/store/driver/store_pool.go
@@ -1,3 +1,17 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package driver
 
 import (

--- a/pkg/store/driver/store_pool_test.go
+++ b/pkg/store/driver/store_pool_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package driver
 
 import (

--- a/pkg/store/driver/store_pool_test.go
+++ b/pkg/store/driver/store_pool_test.go
@@ -1,0 +1,72 @@
+package driver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorePoolBlocksWhenFull(t *testing.T) {
+	p := newStorePool(1)
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	require.NoError(t, p.Run(func() {
+		close(firstStarted)
+		<-releaseFirst
+	}))
+	<-firstStarted
+
+	secondRunReturned := make(chan error, 1)
+	secondTaskStarted := make(chan struct{})
+	go func() {
+		secondRunReturned <- p.Run(func() {
+			close(secondTaskStarted)
+		})
+	}()
+
+	select {
+	case err := <-secondRunReturned:
+		require.Failf(t, "expected Run to block", "unexpectedly returned: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	require.NoError(t, <-secondRunReturned)
+
+	select {
+	case <-secondTaskStarted:
+	case <-time.After(time.Second):
+		require.Fail(t, "expected second task to start")
+	}
+}
+
+func TestStorePoolCloseUnblocksRun(t *testing.T) {
+	p := newStorePool(1)
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	require.NoError(t, p.Run(func() {
+		close(firstStarted)
+		<-releaseFirst
+	}))
+	<-firstStarted
+
+	runReturned := make(chan error, 1)
+	go func() {
+		runReturned <- p.Run(func() {})
+	}()
+
+	select {
+	case err := <-runReturned:
+		require.Failf(t, "expected Run to block", "unexpectedly returned: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	p.Close()
+	err := <-runReturned
+	require.ErrorIs(t, err, errStorePoolClosed)
+
+	close(releaseFirst)
+}

--- a/pkg/store/driver/tikv_driver.go
+++ b/pkg/store/driver/tikv_driver.go
@@ -222,6 +222,7 @@ func (d *TiKVDriver) OpenWithOptions(path string, options ...Option) (resStore k
 	)
 
 	s, err = tikv.NewKVStore(uuid, pdClient, spkv, &injectTraceClient{Client: rpcClient},
+		tikv.WithPool(newStorePool(config.GetGlobalConfig().CommitterConcurrency)),
 		tikv.WithPDHTTPClient("tikv-driver", etcdAddrs, pdhttp.WithTLSConfig(tlsConfig), pdhttp.WithMetrics(metrics.PDAPIRequestCounter, metrics.PDAPIExecutionHistogram)))
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65517

Problem Summary:

TiDB can schedule 2PC background tasks (e.g. committing secondaries via `spawnWithStorePool`) onto client-go's store goroutine pool. The default pool is backed by `github.com/tiancaiamao/gp`, which does not provide backpressure and can spawn extra goroutines under load.

When secondaries commit becomes slow, a large number of in-flight background tasks can accumulate and keep transaction state reachable for longer, contributing to memory growth.

### What changed and how does it work?

- Configure TiKV store with a bounded pool via `tikv.WithPool(...)` in `pkg/store/driver/tikv_driver.go`.
- Add a simple semaphore-based pool implementation to cap the number of in-flight background tasks.
- Add unit tests to ensure the pool blocks when saturated and unblocks/returns error after `Close()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `go test ./pkg/store/driver -run TestStorePool -count=1`
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Bound TiKV store background goroutine pool to avoid unbounded 2PC background tasks under load.
```