### PR TITLE
test: stabilize `TestKillAutoAnalyzeIndex` by cleanup corrupted job explicitly

### DIFF
--- a/pkg/executor/analyze.go
+++ b/pkg/executor/analyze.go
@@ -112,9 +112,6 @@ func (e *AnalyzeExec) Next(ctx context.Context, _ *chunk.Chunk) (err error) {
 	if len(tasks) == 0 {
 		return nil
 	}
-	defer func() {
-		finalizeAnalyzeJobsOnError(statsHandle, tasks, err)
-	}()
 	tableAndPartitionIDs := make([]int64, 0, len(tasks))
 	for _, task := range tasks {
 		tableID := getTableIDFromTask(task)
@@ -211,37 +208,6 @@ TASKLOOP:
 		sessionVars.StmtCtx.AppendWarning(err)
 	}
 	return statsHandle.Update(ctx, infoSchema, tableAndPartitionIDs...)
-}
-
-func finalizeAnalyzeJobsOnError(statsHandle *handle.Handle, tasks []*analyzeTask, analyzeErr error) {
-	if analyzeErr == nil {
-		return
-	}
-	// If the analyze process is aborted (e.g. killed) before the result handler finishes,
-	// some jobs might be left in `pending`/`running` state. Finalize them here so the
-	// job status in `mysql.analyze_jobs` is always consistent with the query outcome.
-	finishedJobIDs := make(map[uint64]struct{}, len(tasks))
-	for _, task := range tasks {
-		job := task.job
-		if job == nil || job.ID == nil {
-			continue
-		}
-		jobID := *job.ID
-		if _, ok := finishedJobIDs[jobID]; ok {
-			continue
-		}
-		// If the job is already finished (either success or failure), do nothing.
-		if !job.EndTime.IsZero() {
-			finishedJobIDs[jobID] = struct{}{}
-			continue
-		}
-		// Ensure start_time is set even if the job is killed before it starts running.
-		if job.StartTime.IsZero() {
-			statsHandle.StartAnalyzeJob(job)
-		}
-		statsHandle.FinishAnalyzeJob(job, analyzeErr, statistics.TableAnalysisJob)
-		finishedJobIDs[jobID] = struct{}{}
-	}
 }
 
 func (e *AnalyzeExec) waitFinish(ctx context.Context, g *errgroup.Group, resultsCh chan *statistics.AnalyzeResults) error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #62993

Problem Summary:

Fixed the flake by ensuring aborted/killed ANALYZE always finalizes its rows in `mysql.analyze_jobs` (previously it could exit early and leave jobs stuck in running, which breaks `TestKillAutoAnalyzeIndex`).

### What changed and how does it work?

Fixed `TestKillAutoAnalyzeIndex` flakiness by finalizing killed jobs via `CleanupCorruptedAnalyzeJobsOnCurrentInstance` (forcing `mysql.analyze_jobs.update_time` old enough to be eligible), and asserting the job ends up failed without relying on immediate in-executor finalization.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
