### PR TITLE
test: stabilize `TestAuditPluginRetrying`

### DIFF
--- a/pkg/server/tests/commontest/tidb_test.go
+++ b/pkg/server/tests/commontest/tidb_test.go
@@ -3681,6 +3681,11 @@ func TestAuditPluginRetrying(t *testing.T) {
 		testResultsMu.Unlock()
 		return l
 	}
+	appendTestResult := func(res normalTest) {
+		testResultsMu.Lock()
+		testResults = append(testResults, res)
+		testResultsMu.Unlock()
+	}
 
 	onGeneralEvent := func(ctx context.Context, sctx *variable.SessionVars, event plugin.GeneralEvent, cmd string) {
 		// Only consider the Completed event
@@ -3693,9 +3698,7 @@ func TestAuditPluginRetrying(t *testing.T) {
 			audit.retrying = retrying.(bool)
 		}
 		audit.sql = sctx.StmtCtx.OriginalSQL
-		testResultsMu.Lock()
-		testResults = append(testResults, audit)
-		testResultsMu.Unlock()
+		appendTestResult(audit)
 	}
 	plugin.LoadPluginForTest(t, onGeneralEvent)
 	defer plugin.Shutdown(context.Background())


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65222

Problem Summary:

- `require.Eventually` with the predicate "we observed more audit events than issued statements" checks `len(testResults) > concurrency`, which only becomes true if at least one statement was retried (extra audit events).
- Before the change, `testResults` was a shared slice appended by many server goroutines (audit callbacks) while the test goroutine concurrently reset/read it, with no synchronization. Under load this can lose/corrupt entries, so `len(testResults)` can stay <= `concurrency` even if retries happened.

### What changed and how does it work?

- The change makes `testResults` thread-safe (mutex + snapshot helpers), and also removes DB usage patterns that make the loop less reliable: it switches from `Conn().QueryContext()` (no `Rows`/`Conn` close, error asserts in goroutines) to `db.ExecContext()` with a sized pool (`SetMaxOpenConns`/`SetMaxIdleConns`) and collects errors back in the main goroutine.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
