### PR TITLE
variable: fix internal/poll.runtime_pollWait in the goleak with TestSetTiDBCloudStorageURI

### DIFF
--- a/pkg/sessionctx/variable/tests/session_test.go
+++ b/pkg/sessionctx/variable/tests/session_test.go
@@ -917,4 +917,5 @@ func TestSetTiDBCloudStorageURI(t *testing.T) {
 	require.NoError(t, err1)
 	require.Len(t, val, 0)
 	cancel()
+	<-ctx.Done()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #65526

Problem Summary:

### What changed and how does it work?

```
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 68 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
internal/poll.runtime_pollWait(0x79d4b9c5ba00, 0x72)
	GOROOT/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc000f0d080?, 0xc000ed8000?, 0x0)
	GOROOT/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
	GOROOT/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000f0d080, {0xc000ed8000, 0x1000, 0x1000})
	GOROOT/src/internal/poll/fd_unix.go:165 +0x279
net.(*netFD).Read(0xc000f0d080, {0xc000ed8000?, 0x769f194?, 0x0?})
	GOROOT/src/net/fd_posix.go:68 +0x25
net.(*conn).Read(0xc0009925f0, {0xc000ed8000?, 0x769ef85?, 0xc000f05680?})
	GOROOT/src/net/net.go:196 +0x45
net/http.(*persistConn).Read(0xc000f147e0, {0xc000ed8000?, 0x7b2e9c5?, 0x3fe4f40?})
	GOROOT/src/net/http/transport.go:2125 +0x47
bufio.(*Reader).fill(0xc0005d7c80)
	GOROOT/src/bufio/bufio.go:113 +0x103
bufio.(*Reader).Peek(0xc0005d7c80, 0x1)
	GOROOT/src/bufio/bufio.go:152 +0x53
net/http.(*persistConn).readLoop(0xc000f147e0)
	GOROOT/src/net/http/transport.go:2278 +0x172
created by net/http.(*Transport).dialConn in goroutine 84
	GOROOT/src/net/http/transport.go:1947 +0x174f
 Goroutine 69 in state select, with net/http.(*persistConn).writeLoop on top of the stack:
net/http.(*persistConn).writeLoop(0xc000f147e0)
	GOROOT/src/net/http/transport.go:2600 +0xe7
created by net/http.(*Transport).dialConn in goroutine 84
	GOROOT/src/net/http/transport.go:1948 +0x17a5
]
-- 
```

It has two goleak stack. Now, we close the server first and then cancel the client. so client is busy with a retry and cannot cancel the client as soon as possible.
We should cancel the context first and then close the background task.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test
  > - [ ] I checked and no code files have been changed.
  > <!-- Or your custom  "No need to test" reasons -->

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
