### PR TITLE
planner: add the prefix index as candidate for topn optimization

### DIFF
--- a/pkg/planner/core/core_init.go
+++ b/pkg/planner/core/core_init.go
@@ -180,7 +180,4 @@ func init() {
 	// for physical index merge reader.
 	utilfuncp.GetPlanCostVer14PhysicalIndexMergeReader = GetPlanCostVer14PhysicalIndexMergeReader
 	utilfuncp.GetPlanCostVer24PhysicalIndexMergeReader = GetPlanCostVer24PhysicalIndexMergeReader
-
-	// for util functions.
-	utilfuncp.TableHasDirtyContent = TableHasDirtyContent
 }

--- a/pkg/planner/core/logical_plan_builder.go
+++ b/pkg/planner/core/logical_plan_builder.go
@@ -4697,7 +4697,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 	}
 
 	var result base.LogicalPlan = ds
-	dirty := TableHasDirtyContent(b.ctx, tableInfo)
+	dirty := tableHasDirtyContent(b.ctx, tableInfo)
 	if dirty || tableInfo.TempTableType == model.TempTableLocal || tableInfo.TableCacheStatusType == model.TableCacheStatusEnable {
 		us := logicalop.LogicalUnionScan{HandleCols: handleCols}.Init(b.ctx, b.getSelectOffset())
 		us.SetChildren(ds)

--- a/pkg/planner/core/plan_cache.go
+++ b/pkg/planner/core/plan_cache.go
@@ -173,7 +173,7 @@ func planCachePreprocess(ctx context.Context, sctx sessionctx.Context, isNonPrep
 	// step 6: initialize the tableInfo2UnionScan, which indicates which tables are dirty.
 	for _, tbl := range stmt.tbls {
 		tblInfo := tbl.Meta()
-		if TableHasDirtyContent(sctx.GetPlanCtx(), tblInfo) {
+		if tableHasDirtyContent(sctx.GetPlanCtx(), tblInfo) {
 			sctx.GetSessionVars().StmtCtx.TblInfo2UnionScan[tblInfo] = true
 		}
 	}

--- a/pkg/planner/core/util.go
+++ b/pkg/planner/core/util.go
@@ -152,8 +152,8 @@ func extractStringFromBoolSlice(slice []bool) string {
 	return strings.Join(l, ",")
 }
 
-// TableHasDirtyContent checks whether the table or its partitions have dirty content in the current transaction.
-func TableHasDirtyContent(ctx base.PlanContext, tableInfo *model.TableInfo) bool {
+// tableHasDirtyContent checks whether the table or its partitions have dirty content in the current transaction.
+func tableHasDirtyContent(ctx base.PlanContext, tableInfo *model.TableInfo) bool {
 	pi := tableInfo.GetPartitionInfo()
 	if pi == nil {
 		return ctx.HasDirtyContent(tableInfo.ID)

--- a/pkg/planner/util/utilfuncp/BUILD.bazel
+++ b/pkg/planner/util/utilfuncp/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/expression",
-        "//pkg/meta/model",
         "//pkg/parser/ast",
         "//pkg/planner/core/base",
         "//pkg/planner/property",

--- a/pkg/planner/util/utilfuncp/func_pointer_misc.go
+++ b/pkg/planner/util/utilfuncp/func_pointer_misc.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pingcap/tidb/pkg/expression"
-	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/planner/core/base"
 	"github.com/pingcap/tidb/pkg/planner/property"
@@ -569,8 +568,3 @@ var DoOptimize func(
 	flag uint64,
 	logic base.LogicalPlan,
 ) (base.LogicalPlan, base.PhysicalPlan, float64, error)
-
-// ****************************************** util function related ****************************************
-
-// TableHasDirtyContent checks whether the table or its partitions have dirty content in the current transaction.
-var TableHasDirtyContent func(ctx base.PlanContext, tableInfo *model.TableInfo) bool


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: Fix #65813

Problem Summary:

### What changed and how does it work?

The planner part 1 of the partial order by enhancement
1. The new physical property 
    -  PartialOrderInfo: save the order by columns info
2. The exhaust physical plan of TopN will add a new path with this new physical property 
    -  the scope will be limited, and it will only affect the **available query patterns** when the **OptPartialOrderedIndexForTopN is turned on**.  
3.  The new match property function "matchPartialOrderProperty" is used to check if prefix index can be used for TopN query
    - The restrictions on match properties with new physical properties will be relaxed.
    - Allows prefix index to match ORDER BY columns.
    - The index can **completely match** the **prefix** of the order by column.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test
  > I will add more test after finish the part2 of this enhancement

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
